### PR TITLE
Add CI for `go test`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: /
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -1,0 +1,28 @@
+name: 'ci-go'
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - '**.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - 'go.work'
+jobs:
+  test:
+    permissions:
+      contents: 'read'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          fetch-depth: 1
+
+      - name: 'Set up Go'
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: 'go.work'
+          check-latest: true
+
+      - name: 'Test'
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+SHELL = /bin/bash
+
+# There is currently no convenient way to run tests against a whole Go workspace
+# https://github.com/golang/go/issues/50745
+test:
+	go list -f '{{.Dir}}/...' -m | xargs go test -cover

--- a/frontend/middleware_systemdata.go
+++ b/frontend/middleware_systemdata.go
@@ -21,7 +21,7 @@ func MiddlewareSystemData(w http.ResponseWriter, r *http.Request, next http.Hand
 		err := json.Unmarshal([]byte(data), &systemData)
 		if err != nil {
 			if logger, ok := r.Context().Value(ContextKeyLogger).(*slog.Logger); ok {
-				logger.Warn(fmt.Sprintf("Failed to parse %s header: %w", arm.HeaderNameARMResourceSystemData, err))
+				logger.Warn(fmt.Sprintf("Failed to parse %s header: %v", arm.HeaderNameARMResourceSystemData, err))
 			}
 		}
 		r = r.WithContext(context.WithValue(r.Context(), ContextKeySystemData, systemData))


### PR DESCRIPTION
This PR adds Go unit testing CI for this repo and fixes a failure. It does not address linting which is also part of the done criteria of this card, that will be done in a follow up PR.

ARO-5976