### PR TITLE
Add CI for `golangci-lint`

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -26,3 +26,23 @@ jobs:
 
       - name: 'Test'
         run: make test
+  lint:
+    permissions:
+      contents: 'read'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          fetch-depth: 1
+
+      - name: 'Set up Go'
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: 'go.work'
+          check-latest: true
+
+      - name: 'Lint'
+        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
+        with:
+          version: 'v1.56.2'
+          args: '-v $(go list -f ''{{.Dir}}/...'' -m | xargs)'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+run:
+  timeout: 10m
+  skip-dirs-use-default: true
+  modules-download-mode: readonly
+
+issues:
+  # We want to make sure we get a full report every time. Setting these
+  # to zero disables the limit.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 SHELL = /bin/bash
 
+all: test lint
+
 # There is currently no convenient way to run tests against a whole Go workspace
 # https://github.com/golang/go/issues/50745
 test:
 	go list -f '{{.Dir}}/...' -m | xargs go test -cover
+
+# There is currently no convenient way to run golangci-lint against a whole Go workspace
+# https://github.com/golang/go/issues/50745
+MODULES := $(shell go list -f '{{.Dir}}/...' -m | xargs)
+lint:
+	golangci-lint run -v $(MODULES)

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -91,7 +91,7 @@ func (f *Frontend) Run(ctx context.Context, stop <-chan struct{}) {
 		go func() {
 			<-stop
 			f.ready.Store(false)
-			f.server.Shutdown(ctx)
+			_ = f.server.Shutdown(ctx)
 		}()
 	}
 

--- a/internal/api/arm/error.go
+++ b/internal/api/arm/error.go
@@ -60,7 +60,7 @@ func (body *CloudErrorBody) String() string {
 	if len(body.Details) > 0 {
 		details = " Details: "
 		for i, innerErr := range body.Details {
-			details := innerErr.String()
+			details += innerErr.String()
 			if i < len(body.Details)-1 {
 				details += ", "
 			}

--- a/internal/api/arm/error_test.go
+++ b/internal/api/arm/error_test.go
@@ -1,0 +1,60 @@
+package arm
+
+import "testing"
+
+func TestCloudErrorBody_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     *CloudErrorBody
+		expected string
+	}{
+		{
+			name: "One detail",
+			body: &CloudErrorBody{
+				Code:    "code",
+				Message: "message",
+				Target:  "target",
+				Details: []CloudErrorBody{
+					{
+						Code:    "innercode",
+						Message: "innermessage",
+						Target:  "innertarget",
+						Details: []CloudErrorBody{},
+					},
+				},
+			},
+			expected: "code: target: message Details: innercode: innertarget: innermessage",
+		},
+		{
+			name: "Two details",
+			body: &CloudErrorBody{
+				Code:    "code",
+				Message: "message",
+				Target:  "target",
+				Details: []CloudErrorBody{
+					{
+						Code:    "innercode",
+						Message: "innermessage",
+						Target:  "innertarget",
+						Details: []CloudErrorBody{},
+					},
+					{
+						Code:    "innercode2",
+						Message: "innermessage2",
+						Target:  "innertarget2",
+						Details: []CloudErrorBody{},
+					},
+				},
+			},
+			expected: "code: target: message Details: innercode: innertarget: innermessage, innercode2: innertarget2: innermessage2",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.body.String()
+			if test.expected != actual {
+				t.Errorf("expected: %v\ngot: %v", test.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -81,8 +81,8 @@ type NetworkProfile struct {
 // NodePoolAutoscaling represents a node pool autoscaling configuration.
 // Visibility for the entire struct is "read".
 type NodePoolAutoscaling struct {
-	MinReplicas int32 `json:minReplicas,omitempty"`
-	MaxReplicas int32 `json:maxReplicas,omitempty"`
+	MinReplicas int32 `json:"minReplicas,omitempty"`
+	MaxReplicas int32 `json:"maxReplicas,omitempty"`
 }
 
 // NodePoolProfile represents a worker node pool configuration.

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -18,5 +18,5 @@ type HCPOpenShiftClusterNodePool struct {
 // HCPOpenShiftClusterNodePool resource.
 type HCPOpenShiftClusterNodePoolProperties struct {
 	ProvisioningState arm.ProvisioningState `json:"provisioningState,omitempty" visibility:"read"`
-	Profile           NodePoolProfile       `json:profile,omitempty" visibility:"read,create,update"`
+	Profile           NodePoolProfile       `json:"profile,omitempty" visibility:"read,create,update"`
 }

--- a/internal/api/v20240610preview/hcpopenshiftclusternodepool.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusternodepool.go
@@ -19,5 +19,5 @@ type HCPOpenShiftClusterNodePool struct {
 // HCPOpenShiftClusterNodePool resource.
 type HCPOpenShiftClusterNodePoolProperties struct {
 	ProvisioningState arm.ProvisioningState        `json:"provisioningState,omitempty" visibility:"read"`
-	Profile           api.VersionedNodePoolProfile `json:profile,omitempty" visibility:"read,create,update"`
+	Profile           api.VersionedNodePoolProfile `json:"profile,omitempty" visibility:"read,create,update"`
 }

--- a/internal/api/v20240610preview/nodepoolprofile.go
+++ b/internal/api/v20240610preview/nodepoolprofile.go
@@ -6,8 +6,8 @@ package v20240610preview
 // NodePoolAutoscaling represents a node pool autoscaling configuration.
 // Visibility for the entire struct is "read".
 type NodePoolAutoscaling struct {
-	MinReplicas int32 `json:minReplicas,omitempty"`
-	MaxReplicas int32 `json:maxReplicas,omitempty"`
+	MinReplicas int32 `json:"minReplicas,omitempty"`
+	MaxReplicas int32 `json:"maxReplicas,omitempty"`
 }
 
 // NodePoolProfile represents a worker node pool configuration.


### PR DESCRIPTION
As an extension of https://github.com/Azure/ARO-HCP/pull/10 this PR adds a CI check for golangci-lint and fixes existing linter errors.

ARO-5976