### PR TITLE
adds a basic map backed cache, includes a workaround for api-version

### DIFF
--- a/frontend/cache.go
+++ b/frontend/cache.go
@@ -1,0 +1,30 @@
+package main
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "github.com/Azure/ARO-HCP/internal/api"
+
+type cache struct {
+	cluster map[string]api.HCPOpenShiftCluster
+}
+
+// NewCache returns a new cache.
+func NewCache() *cache {
+	return &cache{
+		cluster: make(map[string]api.HCPOpenShiftCluster),
+	}
+}
+
+func (c *cache) GetCluster(id string) (api.HCPOpenShiftCluster, bool) {
+	cluster, found := c.cluster[id]
+	return cluster, found
+}
+
+func (c *cache) SetCluster(id string, cluster api.HCPOpenShiftCluster) {
+	c.cluster[id] = cluster
+}
+
+func (c *cache) DeleteCluster(id string) {
+	delete(c.cluster, id)
+}

--- a/frontend/middleware_validateapi.go
+++ b/frontend/middleware_validateapi.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -19,6 +20,9 @@ func MiddlewareValidateAPIVersion(w http.ResponseWriter, r *http.Request, next h
 			arm.CloudErrorCodeInvalidParameter, "",
 			"The request is missing required parameter '%s'.",
 			APIVersionKey)
+	} else if strings.EqualFold(apiVersion, "cache") {
+		r = r.WithContext(context.WithValue(r.Context(), ContextKeyVersion, "cache"))
+		next(w, r)
 	} else if version, ok := api.Lookup(apiVersion); !ok {
 		arm.WriteError(
 			w, http.StatusBadRequest,


### PR DESCRIPTION
This adds a basic map based cache to store 'non versioned' cluster structs. The api-version must be 'cache' in order for the cache to be set. We currently do not have 'versioned' structs, which are required by the 'middleware_apiversion'.