### PR TITLE
Group typespec dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,9 @@ updates:
       interval: 'daily'
   - package-ecosystem: 'npm'
     directory: /
+    groups:
+      typespec:
+        patterns:
+          - '@typespec/*'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
### What this PR does
ARO-6276

After merging #27, dependabot opened many PRs, but these typespec packages follow the same versioning scheme. This change would group #29 #30 #31 #32 into a single PR moving forward.