### PR TITLE
Resolve missing-x-ms-identifiers

### DIFF
--- a/api/redhatopenshift/HcpCluster/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster/hcpCluster-models.tsp
@@ -118,6 +118,7 @@ model ClusterSpec {
 
   /** Configures the cluster ingresses */
   @visibility("create")
+  @OpenAPI.extension("x-ms-identifiers", ["ip", "url", "visibility"])
   ingress?: IngressProfile[];
 }
 
@@ -292,6 +293,7 @@ model ExternalAuthConfigProfile {
 
   /** This can only be set as a day-2 resource on a separate endpoint to provide a self-managed auth service */
   @visibility("read")
+  @OpenAPI.extension("x-ms-identifiers", ["issuer", "clients", "claim"])
   externalAuths: ExternalAuthProfile[];
 }
 
@@ -345,6 +347,7 @@ model ExternalAuthClaimProfile {
   mappings: TokenClaimMappingsProfile;
 
   /** The claim validation rules */
+  @OpenAPI.extension("x-ms-identifiers", ["claim", "requiredValue"])
   validationRules: TokenClaimValidationRuleProfile[];
 }
 

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/examples/NodePools_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/examples/NodePools_CreateOrUpdate_MaximumSet_Gen.json
@@ -1,0 +1,147 @@
+{
+  "title": "NodePools_CreateOrUpdate",
+  "operationId": "NodePools_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2024-06-10-preview",
+    "subscriptionId": "F64FF5E2-2AD0-4E4D-A9D5-6E88511247A7",
+    "resourceGroupName": "rgopenapi",
+    "hcpOpenShiftClusterName": "Replace this value with a string matching RegExp ^[a-zA-Z0-9-]{3,24}$",
+    "nodePoolName": "Replace this value with a string matching RegExp ^[a-zA-Z0-9-]{3,24}$",
+    "resource": {
+      "properties": {
+        "spec": {
+          "version": {
+            "id": "tbg",
+            "channelGroup": "rhhchgarryftdwzbadtwrzcbighms"
+          },
+          "platform": {
+            "subnetId": "afapulyhvjjg",
+            "vmSize": "hfdapwwtchingr",
+            "diskSizeGB": 12,
+            "diskStorageAccountType": "cyfacrhebgxccilnjsgozmqge",
+            "availabilityZone": "mssxcjzxagdxoeuqydthwc",
+            "encryptionAtHost": true,
+            "discEncryptionSetId": "rjasgujgzleldjwp",
+            "ephemeralOsDisk": true
+          },
+          "replicas": 18,
+          "autoRepair": true,
+          "autoScaling": {
+            "min": 6,
+            "max": 29
+          },
+          "labels": [
+            "ufrvhxdwltr"
+          ],
+          "taints": [
+            "yzmuazkxmfhksrjm"
+          ],
+          "tuningConfigs": [
+            "m"
+          ]
+        }
+      },
+      "tags": {
+        "key7212": "uufkzlwqnoxdfihpqz"
+      },
+      "location": "mqewzbuvnyxnwbmir"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "spec": {
+            "version": {
+              "availableUpgrades": [
+                "jlufyoivqzyxnqzwijozipxmgux"
+              ]
+            },
+            "platform": {
+              "subnetId": "afapulyhvjjg",
+              "vmSize": "hfdapwwtchingr",
+              "diskSizeGB": 12,
+              "diskStorageAccountType": "cyfacrhebgxccilnjsgozmqge",
+              "availabilityZone": "mssxcjzxagdxoeuqydthwc",
+              "encryptionAtHost": true,
+              "discEncryptionSetId": "rjasgujgzleldjwp",
+              "ephemeralOsDisk": true
+            },
+            "autoScaling": {
+              "min": 6,
+              "max": 29
+            },
+            "tuningConfigs": [
+              "m"
+            ]
+          }
+        },
+        "tags": {
+          "key7212": "uufkzlwqnoxdfihpqz"
+        },
+        "location": "mqewzbuvnyxnwbmir",
+        "id": "ogtjdgogxemijejkai",
+        "name": "riywfucwvfwoepzliopnphdfjw",
+        "type": "znmdhkzcopsephiyom",
+        "systemData": {
+          "createdBy": "iiqgrciyremxtwbrkjqtvcjkn",
+          "createdByType": "User",
+          "createdAt": "2024-03-25T11:14:17.555Z",
+          "lastModifiedBy": "ylhwjaq",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-25T11:14:17.555Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "spec": {
+            "version": {
+              "availableUpgrades": [
+                "jlufyoivqzyxnqzwijozipxmgux"
+              ]
+            },
+            "platform": {
+              "subnetId": "afapulyhvjjg",
+              "vmSize": "hfdapwwtchingr",
+              "diskSizeGB": 12,
+              "diskStorageAccountType": "cyfacrhebgxccilnjsgozmqge",
+              "availabilityZone": "mssxcjzxagdxoeuqydthwc",
+              "encryptionAtHost": true,
+              "discEncryptionSetId": "rjasgujgzleldjwp",
+              "ephemeralOsDisk": true
+            },
+            "autoScaling": {
+              "min": 6,
+              "max": 29
+            },
+            "tuningConfigs": [
+              "m"
+            ]
+          }
+        },
+        "tags": {
+          "key7212": "uufkzlwqnoxdfihpqz"
+        },
+        "location": "mqewzbuvnyxnwbmir",
+        "id": "ogtjdgogxemijejkai",
+        "name": "riywfucwvfwoepzliopnphdfjw",
+        "type": "znmdhkzcopsephiyom",
+        "systemData": {
+          "createdBy": "iiqgrciyremxtwbrkjqtvcjkn",
+          "createdByType": "User",
+          "createdAt": "2024-03-25T11:14:17.555Z",
+          "lastModifiedBy": "ylhwjaq",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-25T11:14:17.555Z"
+        }
+      }
+    }
+  }
+}

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/examples/NodePools_Delete_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/examples/NodePools_Delete_MaximumSet_Gen.json
@@ -1,0 +1,19 @@
+{
+  "title": "NodePools_Delete",
+  "operationId": "NodePools_Delete",
+  "parameters": {
+    "api-version": "2024-06-10-preview",
+    "subscriptionId": "F64FF5E2-2AD0-4E4D-A9D5-6E88511247A7",
+    "resourceGroupName": "rgopenapi",
+    "hcpOpenShiftClusterName": "Replace this value with a string matching RegExp ^[a-zA-Z0-9-]{3,24}$",
+    "nodePoolName": "Replace this value with a string matching RegExp ^[a-zA-Z0-9-]{3,24}$"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/examples/NodePools_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/examples/NodePools_Get_MaximumSet_Gen.json
@@ -1,0 +1,59 @@
+{
+  "title": "NodePools_Get",
+  "operationId": "NodePools_Get",
+  "parameters": {
+    "api-version": "2024-06-10-preview",
+    "subscriptionId": "F64FF5E2-2AD0-4E4D-A9D5-6E88511247A7",
+    "resourceGroupName": "rgopenapi",
+    "hcpOpenShiftClusterName": "Replace this value with a string matching RegExp ^[a-zA-Z0-9-]{3,24}$",
+    "nodePoolName": "Replace this value with a string matching RegExp ^[a-zA-Z0-9-]{3,24}$"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "spec": {
+            "version": {
+              "availableUpgrades": [
+                "jlufyoivqzyxnqzwijozipxmgux"
+              ]
+            },
+            "platform": {
+              "subnetId": "afapulyhvjjg",
+              "vmSize": "hfdapwwtchingr",
+              "diskSizeGB": 12,
+              "diskStorageAccountType": "cyfacrhebgxccilnjsgozmqge",
+              "availabilityZone": "mssxcjzxagdxoeuqydthwc",
+              "encryptionAtHost": true,
+              "discEncryptionSetId": "rjasgujgzleldjwp",
+              "ephemeralOsDisk": true
+            },
+            "autoScaling": {
+              "min": 6,
+              "max": 29
+            },
+            "tuningConfigs": [
+              "m"
+            ]
+          }
+        },
+        "tags": {
+          "key7212": "uufkzlwqnoxdfihpqz"
+        },
+        "location": "mqewzbuvnyxnwbmir",
+        "id": "ogtjdgogxemijejkai",
+        "name": "riywfucwvfwoepzliopnphdfjw",
+        "type": "znmdhkzcopsephiyom",
+        "systemData": {
+          "createdBy": "iiqgrciyremxtwbrkjqtvcjkn",
+          "createdByType": "User",
+          "createdAt": "2024-03-25T11:14:17.555Z",
+          "lastModifiedBy": "ylhwjaq",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-25T11:14:17.555Z"
+        }
+      }
+    }
+  }
+}

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/examples/NodePools_ListByHcpOpenShiftClusterResource_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/examples/NodePools_ListByHcpOpenShiftClusterResource_MaximumSet_Gen.json
@@ -1,0 +1,63 @@
+{
+  "title": "NodePools_ListByHcpOpenShiftClusterResource",
+  "operationId": "NodePools_ListByHcpOpenShiftClusterResource",
+  "parameters": {
+    "api-version": "2024-06-10-preview",
+    "subscriptionId": "F64FF5E2-2AD0-4E4D-A9D5-6E88511247A7",
+    "resourceGroupName": "rgopenapi",
+    "hcpOpenShiftClusterName": "Replace this value with a string matching RegExp ^[a-zA-Z0-9-]{3,24}$"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded",
+              "spec": {
+                "version": {
+                  "availableUpgrades": [
+                    "jlufyoivqzyxnqzwijozipxmgux"
+                  ]
+                },
+                "platform": {
+                  "subnetId": "afapulyhvjjg",
+                  "vmSize": "hfdapwwtchingr",
+                  "diskSizeGB": 12,
+                  "diskStorageAccountType": "cyfacrhebgxccilnjsgozmqge",
+                  "availabilityZone": "mssxcjzxagdxoeuqydthwc",
+                  "encryptionAtHost": true,
+                  "discEncryptionSetId": "rjasgujgzleldjwp",
+                  "ephemeralOsDisk": true
+                },
+                "autoScaling": {
+                  "min": 6,
+                  "max": 29
+                },
+                "tuningConfigs": [
+                  "m"
+                ]
+              }
+            },
+            "tags": {
+              "key7212": "uufkzlwqnoxdfihpqz"
+            },
+            "location": "mqewzbuvnyxnwbmir",
+            "id": "ogtjdgogxemijejkai",
+            "name": "riywfucwvfwoepzliopnphdfjw",
+            "type": "znmdhkzcopsephiyom",
+            "systemData": {
+              "createdBy": "iiqgrciyremxtwbrkjqtvcjkn",
+              "createdByType": "User",
+              "createdAt": "2024-03-25T11:14:17.555Z",
+              "lastModifiedBy": "ylhwjaq",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-03-25T11:14:17.555Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/examples/NodePools_Update_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/examples/NodePools_Update_MaximumSet_Gen.json
@@ -1,0 +1,88 @@
+{
+  "title": "NodePools_Update",
+  "operationId": "NodePools_Update",
+  "parameters": {
+    "api-version": "2024-06-10-preview",
+    "subscriptionId": "F64FF5E2-2AD0-4E4D-A9D5-6E88511247A7",
+    "resourceGroupName": "rgopenapi",
+    "hcpOpenShiftClusterName": "Replace this value with a string matching RegExp ^[a-zA-Z0-9-]{3,24}$",
+    "nodePoolName": "Replace this value with a string matching RegExp ^[a-zA-Z0-9-]{3,24}$",
+    "properties": {
+      "tags": {
+        "key3313": "aciaohrpspozhrvwvbdtpqliezchbn"
+      },
+      "properties": {
+        "version": {
+          "id": "chh"
+        },
+        "replicas": 7,
+        "autoScaling": {
+          "min": 29,
+          "max": 2
+        },
+        "labels": [
+          "qptpzhtgcqsofgvlahww"
+        ],
+        "taints": [
+          "fzmckrigt"
+        ],
+        "tuningConfigs": [
+          "dvoeaysltfusyb"
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "spec": {
+            "version": {
+              "availableUpgrades": [
+                "jlufyoivqzyxnqzwijozipxmgux"
+              ]
+            },
+            "platform": {
+              "subnetId": "afapulyhvjjg",
+              "vmSize": "hfdapwwtchingr",
+              "diskSizeGB": 12,
+              "diskStorageAccountType": "cyfacrhebgxccilnjsgozmqge",
+              "availabilityZone": "mssxcjzxagdxoeuqydthwc",
+              "encryptionAtHost": true,
+              "discEncryptionSetId": "rjasgujgzleldjwp",
+              "ephemeralOsDisk": true
+            },
+            "autoScaling": {
+              "min": 6,
+              "max": 29
+            },
+            "tuningConfigs": [
+              "m"
+            ]
+          }
+        },
+        "tags": {
+          "key7212": "uufkzlwqnoxdfihpqz"
+        },
+        "location": "mqewzbuvnyxnwbmir",
+        "id": "ogtjdgogxemijejkai",
+        "name": "riywfucwvfwoepzliopnphdfjw",
+        "type": "znmdhkzcopsephiyom",
+        "systemData": {
+          "createdBy": "iiqgrciyremxtwbrkjqtvcjkn",
+          "createdByType": "User",
+          "createdAt": "2024-03-25T11:14:17.555Z",
+          "lastModifiedBy": "ylhwjaq",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-25T11:14:17.555Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/openapi.json
@@ -79,6 +79,14 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Operations_List_Maximum": {
+            "$ref": "./examples/Operations_List_MaximumSet_Gen.json"
+          },
+          "Operations_List_Minimum": {
+            "$ref": "./examples/Operations_List_MinimumSet_Gen.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -116,6 +124,14 @@
             }
           }
         },
+        "x-ms-examples": {
+          "HcpClusterVersionOperations_ListByLocation_Maximum": {
+            "$ref": "./examples/HcpClusterVersionOperations_ListByLocation_MaximumSet_Gen.json"
+          },
+          "HcpClusterVersionOperations_ListByLocation_Minimum": {
+            "$ref": "./examples/HcpClusterVersionOperations_ListByLocation_MinimumSet_Gen.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -148,6 +164,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "HcpOpenShiftClusters_ListBySubscription": {
+            "$ref": "./examples/HcpOpenShiftClusters_ListBySubscription_MaximumSet_Gen.json"
           }
         },
         "x-ms-pageable": {
@@ -185,6 +206,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "HcpOpenShiftClusters_ListByResourceGroup": {
+            "$ref": "./examples/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json"
           }
         },
         "x-ms-pageable": {
@@ -232,6 +258,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "HcpOpenShiftClusters_Get": {
+            "$ref": "./examples/HcpOpenShiftClusters_Get_MaximumSet_Gen.json"
           }
         }
       },
@@ -296,6 +327,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "HcpOpenShiftClusters_CreateOrUpdate": {
+            "$ref": "./examples/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -367,6 +403,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "HcpOpenShiftClusters_Update": {
+            "$ref": "./examples/HcpOpenShiftClusters_Update_MaximumSet_Gen.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -424,6 +465,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "HcpOpenShiftClusters_Delete": {
+            "$ref": "./examples/HcpOpenShiftClusters_Delete_MaximumSet_Gen.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -471,6 +517,11 @@
               "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "HcpOpenShiftClusters_AdminCredentials": {
+            "$ref": "./examples/HcpOpenShiftClusters_AdminCredentials_MaximumSet_Gen.json"
+          }
         }
       }
     },
@@ -515,6 +566,11 @@
               "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "HcpOpenShiftClusters_KubeConfig": {
+            "$ref": "./examples/HcpOpenShiftClusters_KubeConfig_MaximumSet_Gen.json"
+          }
         }
       }
     },
@@ -558,6 +614,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "NodePools_ListByHcpOpenShiftClusterResource": {
+            "$ref": "./examples/NodePools_ListByHcpOpenShiftClusterResource_MaximumSet_Gen.json"
           }
         },
         "x-ms-pageable": {
@@ -615,6 +676,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "NodePools_Get": {
+            "$ref": "./examples/NodePools_Get_MaximumSet_Gen.json"
           }
         }
       },
@@ -689,6 +755,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "NodePools_CreateOrUpdate": {
+            "$ref": "./examples/NodePools_CreateOrUpdate_MaximumSet_Gen.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -770,6 +841,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "NodePools_Update": {
+            "$ref": "./examples/NodePools_Update_MaximumSet_Gen.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -835,6 +911,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "NodePools_Delete": {
+            "$ref": "./examples/NodePools_Delete_MaximumSet_Gen.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -1018,7 +1099,11 @@
           "items": {
             "$ref": "#/definitions/IngressProfile"
           },
-          "x-ms-identifiers": [],
+          "x-ms-identifiers": [
+            "ip",
+            "url",
+            "visibility"
+          ],
           "x-ms-mutability": [
             "create"
           ]
@@ -1121,7 +1206,10 @@
           "items": {
             "$ref": "#/definitions/TokenClaimValidationRuleProfile"
           },
-          "x-ms-identifiers": []
+          "x-ms-identifiers": [
+            "claim",
+            "requiredValue"
+          ]
         }
       },
       "required": [
@@ -1199,7 +1287,11 @@
             "$ref": "#/definitions/ExternalAuthProfile"
           },
           "readOnly": true,
-          "x-ms-identifiers": []
+          "x-ms-identifiers": [
+            "issuer",
+            "clients",
+            "claim"
+          ]
         }
       },
       "required": [


### PR DESCRIPTION
https://azure.github.io/typespec-azure/docs/libraries/azure-resource-manager/rules/missing-x-ms-identifiers

Remediates:
```
$ tsp compile api/redhatopenshift/HcpCluster/ --warn-as-error
TypeSpec compiler v0.55.0

Diagnostics were reported during compilation:

/workspaces/ARO-HCP/api/redhatopenshift/HcpCluster/hcpCluster-models.tsp:121:3 - error @azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers: Missing identifying properties of objects in the array item, please add @extension("x-ms-identifiers", [<prop>]) to specify it. If there are no appropriate identifying properties, please add @extension("x-ms-identifiers",[]).
> 121 |   ingress?: IngressProfile[];
      |   ^^^^^^^

Found 1 error.
```

Jira: ARO-6276