### PR TITLE
frontend: Log error when recovering from a panic

### DIFF
--- a/frontend/middleware_panic.go
+++ b/frontend/middleware_panic.go
@@ -4,7 +4,10 @@ package main
 // Licensed under the Apache License 2.0.
 
 import (
+	"fmt"
+	"log/slog"
 	"net/http"
+	"runtime/debug"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
@@ -12,6 +15,9 @@ import (
 func MiddlewarePanic(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	defer func() {
 		if e := recover(); e != nil {
+			if logger, ok := r.Context().Value(ContextKeyLogger).(*slog.Logger); ok {
+				logger.Error(fmt.Sprintf("panic: %#v\n%s\n", e, string(debug.Stack())))
+			}
 			arm.WriteInternalServerError(w)
 		}
 	}()


### PR DESCRIPTION
Completes MiddlewarePanic, which was written before structured logging was added.