### PR TITLE
uses lowercase path segment names 

### DIFF
--- a/frontend/const.go
+++ b/frontend/const.go
@@ -17,7 +17,7 @@ const (
 	ContextKeyCorrelationData
 	ContextKeySystemData
 
-	// Wildcard path segment names for request multiplexing, must be lowercase as we lowercase the request URL before pattern matching
+	// Wildcard path segment names for request multiplexing, must be lowercase as we lowercase the request URL pattern when registering handlers
 	PageSegmentLocation          = "location"
 	PathSegmentSubscriptionID    = "subscriptionid"
 	PathSegmentResourceGroupName = "resourcegroupname"

--- a/frontend/const.go
+++ b/frontend/const.go
@@ -17,10 +17,10 @@ const (
 	ContextKeyCorrelationData
 	ContextKeySystemData
 
-	// Wildcard path segment names for request multiplexing
+	// Wildcard path segment names for request multiplexing, must be lowercase as we lowercase the request URL before pattern matching
 	PageSegmentLocation          = "location"
-	PathSegmentSubscriptionID    = "subscriptionId"
-	PathSegmentResourceGroupName = "resourceGroupName"
-	PathSegmentResourceName      = "resourceName"
-	PathSegmentActionName        = "actionName"
+	PathSegmentSubscriptionID    = "subscriptionid"
+	PathSegmentResourceGroupName = "resourcegroupname"
+	PathSegmentResourceName      = "resourcename"
+	PathSegmentActionName        = "actionname"
 )

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -294,7 +294,7 @@ func (f *Frontend) ArmSubscriptionAction(writer http.ResponseWriter, request *ht
 		return
 	}
 
-	subId := request.PathValue(strings.ToLower(PathSegmentSubscriptionID))
+	subId := request.PathValue(PathSegmentSubscriptionID)
 	f.cache.SetSubscription(subId, &subscription)
 
 	resp, err := json.Marshal(subscription)


### PR DESCRIPTION


### What this PR does
**Before this PR:**
PathSegments would need to be lowercased before being used in request.PathValue

**After this PR:**
Now they don't 
