### PR TITLE
Etcd Encryption Profile Changes

### DIFF
--- a/api/redhatopenshift/HcpCluster/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster/hcpCluster-models.tsp
@@ -80,17 +80,13 @@ model ClusterSpec {
   @visibility("read")
   api: ApiProfile;
 
-  /** Enable FIPS mode for the cluster
-   * When set to true, `etcdEncryption` must be set to true
-  */
+  /** Enable FIPS mode for the cluster */
   @visibility("create")
   fips?: boolean = false;
 
-  /** Enables customer ETCD encryption, set during creation
-   * When set to true, `platform.etcdEncryptionSetId` must be set
-  */
-  @visibility("create")
-  etcdEncryption?: boolean = false;
+  /** Enables customer ETCD encryption, set during creation */
+  @visibility("create", "update")
+  etcdEncryption?: EtcdEncryptionProfile;
 
   /** Disable user workload monitoring */
   @visibility("create", "update")
@@ -190,7 +186,7 @@ model NetworkProfile {
 union NetworkType {
   string,
 
-  /** THE OVN network plugin for the OpenShift cluster */
+  /** The OVN network plugin for the OpenShift cluster */
   OVNKubernetes: "OVNKubernetes",
   /** Other network plugins */
   Other:         "Other",
@@ -216,6 +212,21 @@ model ApiProfile {
   /** should the API server be accessible from the internet */
   @visibility("create")
   visibility: Visibility;
+}
+
+/** Information about how Etcd is Encrypted. */
+model EtcdEncryptionProfile {
+  /** The name of the keyvault used for etcd encryption */
+  @visibility("create", "update")
+  keyvaultName: string;
+
+  /** The key within the keyvault used for etcd encryption */
+  @visibility("create", "update")
+  keyName: string;
+
+  /** The version of the key used for etcd encryption */
+  @visibility("create", "update")
+  keyVersion: string;
 }
 
 /** The visibility of the API server */
@@ -256,13 +267,7 @@ model PlatformProfile {
   outboundType?: OutboundType = OutboundType.loadBalancer;
 
   /** Specifies whether subnets are pre-attached with an NSG */
-  preconfiguredNsgs: boolean;
-
-  /** The id of the disk encryption set to be used for etcd.
-   * Configure this when `etcdEncryption` is set to true
-   * Is used the https://learn.microsoft.com/en-us/azure/storage/common/customer-managed-keys-overview
-  */
-  etcdEncryptionSetId?: string;
+  preconfiguredNsg: boolean;
 }
 
 /** The outbound routing strategy used to provide your cluster egress to the internet. */
@@ -501,7 +506,7 @@ model NodePoolPlatformProfile {
   /** Whether the worker machines should be encrypted at host */
   encryptionAtHost?: boolean;
 
-  /** Disk Encryption Set ID that will be used for ecnryption the Nodes disks
+  /** Disk Encryption Set ID that will be used for encryption the Nodes disks
    * - https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption-overview
    * - https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption
    */

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/openapi.json
@@ -1043,17 +1043,17 @@
         },
         "fips": {
           "type": "boolean",
-          "description": "Enable FIPS mode for the cluster\nWhen set to true, `etcdEncryption` must be set to true",
+          "description": "Enable FIPS mode for the cluster",
           "default": false,
           "x-ms-mutability": [
             "create"
           ]
         },
         "etcdEncryption": {
-          "type": "boolean",
-          "description": "Enables customer ETCD encryption, set during creation\nWhen set to true, `platform.etcdEncryptionSetId` must be set",
-          "default": false,
+          "$ref": "#/definitions/EtcdEncryptionProfile",
+          "description": "Enables customer ETCD encryption, set during creation",
           "x-ms-mutability": [
+            "update",
             "create"
           ]
         },
@@ -1133,6 +1133,14 @@
           "$ref": "#/definitions/DnsProfileUpdate",
           "description": "Cluster DNS configuration"
         },
+        "etcdEncryption": {
+          "$ref": "#/definitions/EtcdEncryptionProfileUpdate",
+          "description": "Enables customer ETCD encryption, set during creation",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
         "disableUserWorkloadMonitoring": {
           "type": "boolean",
           "description": "Disable user workload monitoring",
@@ -1191,6 +1199,71 @@
     "DnsProfileUpdate": {
       "type": "object",
       "description": "DNS contains the DNS settings of the cluster"
+    },
+    "EtcdEncryptionProfile": {
+      "type": "object",
+      "description": "Information about how Etcd is Encrypted.",
+      "properties": {
+        "keyvaultName": {
+          "type": "string",
+          "description": "The name of the keyvault used for etcd encryption",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "keyName": {
+          "type": "string",
+          "description": "The key within the keyvault used for etcd encryption",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "keyVersion": {
+          "type": "string",
+          "description": "The version of the key used for etcd encryption",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        }
+      },
+      "required": [
+        "keyvaultName",
+        "keyName",
+        "keyVersion"
+      ]
+    },
+    "EtcdEncryptionProfileUpdate": {
+      "type": "object",
+      "description": "Information about how Etcd is Encrypted.",
+      "properties": {
+        "keyvaultName": {
+          "type": "string",
+          "description": "The name of the keyvault used for etcd encryption",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "keyName": {
+          "type": "string",
+          "description": "The key within the keyvault used for etcd encryption",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "keyVersion": {
+          "type": "string",
+          "description": "The version of the key used for etcd encryption",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        }
+      }
     },
     "ExternalAuthClaimProfile": {
       "type": "object",
@@ -1685,7 +1758,7 @@
               {
                 "name": "OVNKubernetes",
                 "value": "OVNKubernetes",
-                "description": "THE OVN network plugin for the OpenShift cluster"
+                "description": "The OVN network plugin for the OpenShift cluster"
               },
               {
                 "name": "Other",
@@ -1749,7 +1822,7 @@
           {
             "name": "OVNKubernetes",
             "value": "OVNKubernetes",
-            "description": "THE OVN network plugin for the OpenShift cluster"
+            "description": "The OVN network plugin for the OpenShift cluster"
           },
           {
             "name": "Other",
@@ -1830,7 +1903,7 @@
         },
         "discEncryptionSetId": {
           "type": "string",
-          "description": "Disk Encryption Set ID that will be used for ecnryption the Nodes disks\n- https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption-overview\n- https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption"
+          "description": "Disk Encryption Set ID that will be used for encryption the Nodes disks\n- https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption-overview\n- https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption"
         },
         "ephemeralOsDisk": {
           "type": "boolean",
@@ -1984,19 +2057,15 @@
             ]
           }
         },
-        "preconfiguredNsgs": {
+        "preconfiguredNsg": {
           "type": "boolean",
           "description": "Specifies whether subnets are pre-attached with an NSG"
-        },
-        "etcdEncryptionSetId": {
-          "type": "string",
-          "description": "The id of the disk encryption set to be used for etcd.\nConfigure this when `etcdEncryption` is set to true\nIs used the https://learn.microsoft.com/en-us/azure/storage/common/customer-managed-keys-overview"
         }
       },
       "required": [
         "managedResourceGroup",
         "subnetId",
-        "preconfiguredNsgs"
+        "preconfiguredNsg"
       ]
     },
     "ProvisioningState": {

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -29,7 +29,7 @@ type ClusterSpec struct {
 	Console                       ConsoleProfile            `json:"console,omitempty"                       visibility:"read"`
 	API                           APIProfile                `json:"api,omitempty"                           visibility:"read,create"        validate:"required_for_put"`
 	FIPS                          bool                      `json:"fips,omitempty"                          visibility:"read,create"`
-	EtcdEncryption                bool                      `json:"etcdEncryption,omitempty"                visibility:"read,create"`
+	EtcdEncryption                EtcdEncryptionProfile     `json:"etcdEncryptionProfile,omitempty"         visibility:"read,create,update"`
 	DisableUserWorkloadMonitoring bool                      `json:"disableUserWorkloadMonitoring,omitempty" visibility:"read,create,update"`
 	Proxy                         ProxyProfile              `json:"proxy,omitempty"                         visibility:"read,create,update"`
 	Platform                      PlatformProfile           `json:"platform,omitempty"                      visibility:"read,create"        validate:"required_for_put"`
@@ -74,6 +74,13 @@ type APIProfile struct {
 	Visibility Visibility `json:"visibility,omitempty" visibility:"read,create" validate:"required_for_put,enum_visibility"`
 }
 
+// EtcdEncryptionProfile represents etcd encryption with customer-managed keys
+type EtcdEncryptionProfile struct {
+	KeyvaultName string `json:"keyvaultName,omitempty" visibility:"read,create,update"`
+	KeyName      string `json:"keyName,omitempty"      visibility:"read,create,update"`
+	KeyVersion   string `json:"keyVersion,omitempty"   visibility:"read,create,update"`
+}
+
 // ProxyProfile represents the cluster proxy configuration.
 // Visibility for the entire struct is "read,create,update".
 type ProxyProfile struct {
@@ -89,8 +96,7 @@ type PlatformProfile struct {
 	ManagedResourceGroup string       `json:"managedResourceGroup,omitempty" validate:"required_for_put"`
 	SubnetID             string       `json:"subnetId,omitempty"             validate:"required_for_put"`
 	OutboundType         OutboundType `json:"outboundType,omitempty"         validate:"omitempty,enum_outboundtype"`
-	PreconfiguredNSGs    bool         `json:"preconfiguredNsgs,omitempty"    validate:"required_for_put"`
-	EtcdEncryptionSetID  string       `json:"etcdEncryptionSetId,omitempty"`
+	PreconfiguredNSG     bool         `json:"preconfiguredNsg,omitempty"    validate:"required_for_put"`
 }
 
 // ExternalAuthConfigProfile represents the external authentication configuration.

--- a/internal/api/v20240610preview/generated_constants.go
+++ b/internal/api/v20240610preview/generated_constants.go
@@ -70,7 +70,7 @@ func PossibleManagedServiceIdentityTypeValues() []ManagedServiceIdentityType {
 type NetworkType string
 
 const (
-	// NetworkTypeOVNKubernetes - THE OVN network plugin for the OpenShift cluster
+	// NetworkTypeOVNKubernetes - The OVN network plugin for the OpenShift cluster
 	NetworkTypeOVNKubernetes NetworkType = "OVNKubernetes"
 	// NetworkTypeOther - Other network plugins
 	NetworkTypeOther NetworkType = "Other"

--- a/internal/api/v20240610preview/generated_models.go
+++ b/internal/api/v20240610preview/generated_models.go
@@ -50,14 +50,14 @@ type ClusterSpec struct {
 	// Disable user workload monitoring
 	DisableUserWorkloadMonitoring *bool
 
-	// Enables customer ETCD encryption, set during creation When set to true, platform.etcdEncryptionSetId must be set
-	EtcdEncryption *bool
+	// Enables customer ETCD encryption, set during creation
+	EtcdEncryption *EtcdEncryptionProfile
 
 	// Configuration to override the openshift-oauth-apiserver inside cluster This changes user login into the cluster to external
 // provider
 	ExternalAuth *ExternalAuthConfigProfile
 
-	// Enable FIPS mode for the cluster When set to true, etcdEncryption must be set to true
+	// Enable FIPS mode for the cluster
 	Fips *bool
 
 	// Configures the cluster ingresses
@@ -83,6 +83,9 @@ type ClusterSpecUpdate struct {
 
 	// Disable user workload monitoring
 	DisableUserWorkloadMonitoring *bool
+
+	// Enables customer ETCD encryption, set during creation
+	EtcdEncryption *EtcdEncryptionProfileUpdate
 
 	// Openshift cluster proxy configuration
 	Proxy *ProxyProfile
@@ -139,6 +142,30 @@ type ErrorDetail struct {
 type ErrorResponse struct {
 	// The error object.
 	Error *ErrorDetail
+}
+
+// EtcdEncryptionProfile - Information about how Etcd is Encrypted.
+type EtcdEncryptionProfile struct {
+	// REQUIRED; The key within the keyvault used for etcd encryption
+	KeyName *string
+
+	// REQUIRED; The version of the key used for etcd encryption
+	KeyVersion *string
+
+	// REQUIRED; The name of the keyvault used for etcd encryption
+	KeyvaultName *string
+}
+
+// EtcdEncryptionProfileUpdate - Information about how Etcd is Encrypted.
+type EtcdEncryptionProfileUpdate struct {
+	// The key within the keyvault used for etcd encryption
+	KeyName *string
+
+	// The version of the key used for etcd encryption
+	KeyVersion *string
+
+	// The name of the keyvault used for etcd encryption
+	KeyvaultName *string
 }
 
 // ExternalAuthClaimProfile - External auth claim profile
@@ -457,7 +484,7 @@ type NodePoolPlatformProfile struct {
 // * https://learn.microsoft.com/en-us/azure/availability-zones/az-overview
 	AvailabilityZone *string
 
-	// Disk Encryption Set ID that will be used for ecnryption the Nodes disks
+	// Disk Encryption Set ID that will be used for encryption the Nodes disks
 // * https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption-overview
 // * https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption
 	DiscEncryptionSetID *string
@@ -570,14 +597,10 @@ type PlatformProfile struct {
 	ManagedResourceGroup *string
 
 	// REQUIRED; Specifies whether subnets are pre-attached with an NSG
-	PreconfiguredNsgs *bool
+	PreconfiguredNsg *bool
 
 	// REQUIRED; ResourceId for the subnet used by the control plane
 	SubnetID *string
-
-	// The id of the disk encryption set to be used for etcd. Configure this when etcdEncryption is set to true Is used the
-// https://learn.microsoft.com/en-us/azure/storage/common/customer-managed-keys-overview
-	EtcdEncryptionSetID *string
 
 	// The core outgoing configuration
 	OutboundType *OutboundType

--- a/internal/api/v20240610preview/generated_models_serde.go
+++ b/internal/api/v20240610preview/generated_models_serde.go
@@ -164,6 +164,7 @@ func (c ClusterSpecUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populateAny(objectMap, "dns", c.DNS)
 	populate(objectMap, "disableUserWorkloadMonitoring", c.DisableUserWorkloadMonitoring)
+	populate(objectMap, "etcdEncryption", c.EtcdEncryption)
 	populate(objectMap, "proxy", c.Proxy)
 	populate(objectMap, "version", c.Version)
 	return json.Marshal(objectMap)
@@ -183,6 +184,9 @@ func (c *ClusterSpecUpdate) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "disableUserWorkloadMonitoring":
 				err = unpopulate(val, "DisableUserWorkloadMonitoring", &c.DisableUserWorkloadMonitoring)
+			delete(rawMsg, key)
+		case "etcdEncryption":
+				err = unpopulate(val, "EtcdEncryption", &c.EtcdEncryption)
 			delete(rawMsg, key)
 		case "proxy":
 				err = unpopulate(val, "Proxy", &c.Proxy)
@@ -348,6 +352,76 @@ func (e *ErrorResponse) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "error":
 				err = unpopulate(val, "Error", &e.Error)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", e, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type EtcdEncryptionProfile.
+func (e EtcdEncryptionProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "keyName", e.KeyName)
+	populate(objectMap, "keyVersion", e.KeyVersion)
+	populate(objectMap, "keyvaultName", e.KeyvaultName)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type EtcdEncryptionProfile.
+func (e *EtcdEncryptionProfile) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", e, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "keyName":
+				err = unpopulate(val, "KeyName", &e.KeyName)
+			delete(rawMsg, key)
+		case "keyVersion":
+				err = unpopulate(val, "KeyVersion", &e.KeyVersion)
+			delete(rawMsg, key)
+		case "keyvaultName":
+				err = unpopulate(val, "KeyvaultName", &e.KeyvaultName)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", e, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type EtcdEncryptionProfileUpdate.
+func (e EtcdEncryptionProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "keyName", e.KeyName)
+	populate(objectMap, "keyVersion", e.KeyVersion)
+	populate(objectMap, "keyvaultName", e.KeyvaultName)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type EtcdEncryptionProfileUpdate.
+func (e *EtcdEncryptionProfileUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", e, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "keyName":
+				err = unpopulate(val, "KeyName", &e.KeyName)
+			delete(rawMsg, key)
+		case "keyVersion":
+				err = unpopulate(val, "KeyVersion", &e.KeyVersion)
+			delete(rawMsg, key)
+		case "keyvaultName":
+				err = unpopulate(val, "KeyvaultName", &e.KeyvaultName)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -1462,10 +1536,9 @@ func (o *OperationListResult) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type PlatformProfile.
 func (p PlatformProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "etcdEncryptionSetId", p.EtcdEncryptionSetID)
 	populate(objectMap, "managedResourceGroup", p.ManagedResourceGroup)
 	populate(objectMap, "outboundType", p.OutboundType)
-	populate(objectMap, "preconfiguredNsgs", p.PreconfiguredNsgs)
+	populate(objectMap, "preconfiguredNsg", p.PreconfiguredNsg)
 	populate(objectMap, "subnetId", p.SubnetID)
 	return json.Marshal(objectMap)
 }
@@ -1479,17 +1552,14 @@ func (p *PlatformProfile) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "etcdEncryptionSetId":
-				err = unpopulate(val, "EtcdEncryptionSetID", &p.EtcdEncryptionSetID)
-			delete(rawMsg, key)
 		case "managedResourceGroup":
 				err = unpopulate(val, "ManagedResourceGroup", &p.ManagedResourceGroup)
 			delete(rawMsg, key)
 		case "outboundType":
 				err = unpopulate(val, "OutboundType", &p.OutboundType)
 			delete(rawMsg, key)
-		case "preconfiguredNsgs":
-				err = unpopulate(val, "PreconfiguredNsgs", &p.PreconfiguredNsgs)
+		case "preconfiguredNsg":
+				err = unpopulate(val, "PreconfiguredNsg", &p.PreconfiguredNsg)
 			delete(rawMsg, key)
 		case "subnetId":
 				err = unpopulate(val, "SubnetID", &p.SubnetID)

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -51,6 +51,14 @@ func newAPIProfile(from *api.APIProfile) *APIProfile {
 	}
 }
 
+func newEtcdEncryptionProfile(from *api.EtcdEncryptionProfile) *EtcdEncryptionProfile {
+	return &EtcdEncryptionProfile{
+		KeyName:      api.Ptr(from.KeyName),
+		KeyVersion:   api.Ptr(from.KeyVersion),
+		KeyvaultName: api.Ptr(from.KeyvaultName),
+	}
+}
+
 func newProxyProfile(from *api.ProxyProfile) *ProxyProfile {
 	return &ProxyProfile{
 		HTTPProxy:  api.Ptr(from.HTTPProxy),
@@ -65,8 +73,7 @@ func newPlatformProfile(from *api.PlatformProfile) *PlatformProfile {
 		ManagedResourceGroup: api.Ptr(from.ManagedResourceGroup),
 		SubnetID:             api.Ptr(from.SubnetID),
 		OutboundType:         api.Ptr(OutboundType(from.OutboundType)),
-		PreconfiguredNsgs:    api.Ptr(from.PreconfiguredNSGs),
-		EtcdEncryptionSetID:  api.Ptr(from.EtcdEncryptionSetID),
+		PreconfiguredNsg:     api.Ptr(from.PreconfiguredNSG),
 	}
 }
 
@@ -161,7 +168,7 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 				Console:                       newConsoleProfile(&from.Properties.Spec.Console),
 				API:                           newAPIProfile(&from.Properties.Spec.API),
 				Fips:                          api.Ptr(from.Properties.Spec.FIPS),
-				EtcdEncryption:                api.Ptr(from.Properties.Spec.EtcdEncryption),
+				EtcdEncryption:                newEtcdEncryptionProfile(&from.Properties.Spec.EtcdEncryption),
 				DisableUserWorkloadMonitoring: api.Ptr(from.Properties.Spec.DisableUserWorkloadMonitoring),
 				Proxy:                         newProxyProfile(&from.Properties.Spec.Proxy),
 				Platform:                      newPlatformProfile(&from.Properties.Spec.Platform),
@@ -278,7 +285,7 @@ func (c *HcpOpenShiftClusterResource) Normalize(out *api.HCPOpenShiftCluster) {
 				out.Properties.Spec.FIPS = *c.Properties.Spec.Fips
 			}
 			if c.Properties.Spec.EtcdEncryption != nil {
-				out.Properties.Spec.EtcdEncryption = *c.Properties.Spec.EtcdEncryption
+				c.Properties.Spec.EtcdEncryption.Normalize(&out.Properties.Spec.EtcdEncryption)
 			}
 			if c.Properties.Spec.DisableUserWorkloadMonitoring != nil {
 				out.Properties.Spec.DisableUserWorkloadMonitoring = *c.Properties.Spec.DisableUserWorkloadMonitoring
@@ -364,6 +371,18 @@ func (p *APIProfile) Normalize(out *api.APIProfile) {
 	}
 }
 
+func (e *EtcdEncryptionProfile) Normalize(out *api.EtcdEncryptionProfile) {
+	if e.KeyvaultName != nil {
+		out.KeyvaultName = *e.KeyvaultName
+	}
+	if e.KeyName != nil {
+		out.KeyName = *e.KeyName
+	}
+	if e.KeyVersion != nil {
+		out.KeyVersion = *e.KeyVersion
+	}
+}
+
 func (p *ProxyProfile) Normalize(out *api.ProxyProfile) {
 	if p.HTTPProxy != nil {
 		out.HTTPProxy = *p.HTTPProxy
@@ -389,11 +408,8 @@ func (p *PlatformProfile) Normalize(out *api.PlatformProfile) {
 	if p.OutboundType != nil {
 		out.OutboundType = api.OutboundType(*p.OutboundType)
 	}
-	if p.PreconfiguredNsgs != nil {
-		out.PreconfiguredNSGs = *p.PreconfiguredNsgs
-	}
-	if p.EtcdEncryptionSetID != nil {
-		out.EtcdEncryptionSetID = *p.EtcdEncryptionSetID
+	if p.PreconfiguredNsg != nil {
+		out.PreconfiguredNSG = *p.PreconfiguredNsg
 	}
 }
 


### PR DESCRIPTION
### What this PR does
**Before this PR:**
- etcd encryption was a disk encryption set 
- preconfigured nsg was plural

**After this PR:**
- etcd profile adheres to hypershift's KMS [etcd encryption](https://github.com/openshift/hypershift/blob/252e43f8ff644a4da20608eb4cdbce5bd93a85b9/api/hypershift/v1alpha1/hostedcluster_types.go#L1784-L1797) 
- preconfigured nsg field is singular

Jira: https://issues.redhat.com/browse/ARO-6225
### Special notes for your reviewer
You rock!

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Deployment: The deployment process was considered and addressed if required
- [ ] Testing: New code requires new unit tests.
- [ ] Documentation: Is the documentation updated? Either in the doc located in focus area, in the README or in the code itself.
- [ ] Customers: Is this change affecting customers? Is the release plan considered?
