### PR TITLE
Isolate  `api` as a standalone component in this monorepo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
                 "editorconfig.editorconfig",
                 "ms-azuretools.vscode-bicep",
                 "ms-vscode.azurecli",
-                "arjun.swagger-viewer"      
+                "arjun.swagger-viewer",
+                "typespec.typespec-vscode"
             ],
 
             "settings": {

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -7,9 +7,15 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'api/**'
+      - 'package.json'
+      - 'package-lock.json'
 
 jobs:
   typescript_api_spec_validation:
+    permissions:
+      contents: 'read'
     runs-on: ubuntu-latest
 
     steps:
@@ -22,24 +28,21 @@ jobs:
       uses: actions/setup-node@c2ac33f2c62f978d6c944d9648125a294e56dc0b # v4.0.2
       with:
         node-version: 'v20.12.0'
-    
+
     - name: Install tsp
       run: npm install -g @typespec/compiler@0.55.0
 
     - name: Install dependencies
-      run: npm ci 
+      run: npm ci
 
-    - name: Install autorest 
+    - name: Install autorest
       run: npm install -g autorest@3.7.1
-        
-    - name: Compile tsp
-      run: tsp compile ./api/redhatopenshift/HcpCluster --warn-as-error
 
-    - name: Generate OpenAPI
-      run: autorest api/autorest-config.yaml
-     
+    - name: make generate
+      run: make generate
+      working-directory: './api'
+
     - name: Check for Uncommitted Changes
       run: |
         git diff --exit-code || (echo "::error::Uncommitted changes detected in OpenAPI spec. Please regenerate and commit them." && exit 1)
-
 

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,3 @@ deploy-frontend:
 
 undeploy-frontend:
 	oc process -f ./deploy/aro-hcp-frontend.yml -p ARO_HCP_FRONTEND_IMAGE=${ARO_HCP_FRONTEND_IMAGE} | oc delete -f -
-
-.PHONY: api
-api: 
-	tsp compile api/redhatopenshift/HcpCluster/
-	autorest api/autorest-config.yaml 
-

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,0 +1,6 @@
+SHELL = /bin/bash
+
+.PHONY: generate
+generate: 
+	tsp compile redhatopenshift/HcpCluster --warn-as-error
+	autorest autorest-config.yaml 


### PR DESCRIPTION
### What this PR does
Moves all of the pieces that `api` needs into `api/`, namely:
* `package.json`/`package-lock.json` utilizing npm workspaces
* Its own make targets

and then conditionalizes CI for the `api` component so that it only runs on relevant changes
