### PR TITLE
WIP: feat: redesign etcd encryption API for ARO-HCP clusters

### DIFF
--- a/api/redhatopenshift/HcpCluster/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster/hcpCluster-models.tsp
@@ -83,16 +83,13 @@ model ClusterSpec {
   api: ApiProfile;
 
   /** Enable FIPS mode for the cluster
-   * When set to true, `etcdEncryption` must be set to true
+   * When set to true, `etcdProfile.encryptionProfile.kms` must be set
    */
   @visibility("create")
   fips?: boolean = false;
 
-  /** Enables customer ETCD encryption, set during creation
-   * When set to true, `platform.etcdEncryptionSetId` must be set
-   */
-  @visibility("create")
-  etcdEncryption?: boolean = false;
+  /** Cluster etcd configuration */
+  etcd?: EtcdProfile;
 
   /** Disable user workload monitoring */
   @visibility("create", "update")
@@ -260,12 +257,43 @@ model PlatformProfile {
 
   /** Specifies whether subnets are pre-attached with an NSG */
   preconfiguredNsgs: boolean;
+}
 
-  /** The id of the disk encryption set to be used for etcd.
-   * Configure this when `etcdEncryption` is set to true
-   * Is used the https://learn.microsoft.com/en-us/azure/storage/common/customer-managed-keys-overview
-   */
-  etcdEncryptionSetId?: string;
+/** etcd specific configuration */
+model EtcdProfile {
+  encryption?: EtcdEncryptionProfile;
+}
+
+/** etcd encryption specific configuration */
+model EtcdEncryptionProfile {
+  dataEncryption?: EtcdDataEncryption;
+}
+
+/** etcd data-level encryption specific configuration.
+ * At least one of its attributes is required. At most
+ * one attribute can be specified.
+ */
+model EtcdDataEncryption {
+  kms?: EtcdDataEncryptionKms;
+}
+
+/** etcd KMS-based data-level encryption specific configuration */
+model EtcdDataEncryptionKms {
+	/** The name of the Azure Key Vault vault containing encryption
+	 * keys used to perform etcd data-level encryption.
+	 */
+  keyVaultName: string;
+
+	/** The name of the Azure Key Vault key containing the encryption
+	 * keys used to perform etcd data-level encryptiion. The key
+	 * has to exist in the Azure Key Vault keyVaultName.
+	 */
+  keyVaultKeyName: string;
+
+	/** The key version of the Azure Key Vault key keyVaultKeyName
+	 * used to perform etcd data-level encryption.
+	 */
+  keyVaultKeyVersion: string;
 }
 
 /** The outbound routing strategy used to provide your cluster egress to the internet. */


### PR DESCRIPTION
# Summary

This commit redesigns the etcd encryption related API fields for ARO-HCP clusters.

The reason of this change is that the current attributes did not reflect what is needed for etcd encryption and how it will work in ARO-HCP.

For the ARO-HCP offering etcd encryption will *always* be enabled. Therefore, having an EtcdEncryption boolean to control etcd encryption enablement is not of use anymore.

Additionally, the etcd encryption keys related data is not going to be provided through an Azure Disk Encryption Set but through references to Azure Key vault. Because of this, the `.platform.etcdEncryptionSetId?` attribute has been removed.

 A new etcd section has been added containing relevant etcd encryption configuration elements. The section with all of its attributes expanded looks like this:
```
etcd:
  encryption:
    data_encryption:
      kms:
        key_vault_name: "<key_vault_name>"
        key_vault_key_name: "<key_vault_key_name>"
        key_vault_key_version: "<key_vault_key_version>"
```

# Details

The new design is the following:

A new `etcd` top-level map in the ClusterSpec has been added. This map is optional. If not specified then etcd data-level encryption is performed using Red Hat managed encryption keys.

An attribute  named `encryption` is introduced within the `etcd` map. This map contains etcd encryption settings for the Cluster. This map is optional. If not specified then etcd data-level encryption is performed using Red Hat managed encryption keys. This map has been intentionally placed within the `.etcd` map being the only element for now and it has also been intentionally named `encryption`. The reason for this organization and name is that this map is intended to configure etcd encryption. By placing it within the `etcd` map we also give space to add etcd non encryption related attributes in the future.

An attribute named `data_encryption` is introduced within the `.etcd.encryption` map. This map contains etcd data-level encryption settings for the Cluster. This map is optional. If not specified then etcd data-level encryption is performed using Red Hat managed encryption keys. This map has been intentionally placed within the `.etcd.encryption` map. The reason for this organization and name is that
this map is intended to configure etcd date-level encryption. By pkacing it within the `.etcd.encryption` map we also give space to add etcd encryption attributes that are not data-level encryption attributes. For example, in the future we might be interested in having disk-level etcd encryption.

An attribute named `kms` is introduced within the
`.etcd.encryption.data_encryption` map. The purpose of this map is to specify that the encryption strategy to be used to perform etcd data-level encryption is to perform encryption using customer provided encryption keys located in an Azure-based Key Management Service(KMS). The Azure-based KMS service implementation is Azure Key Vault. The reason `kms` is within the `.etcd.encryption.data_encryption` section is also intentional. It allows growth other strategies of etcd data-level encryption in the future. If `data_encryption` is set then `kms` is mandatory.

Three attribues have been added within the
`kms` map: `key_vault_name`, `key_vault_key_name` and `key_vault_key_version`. They contain the information to be able to locate customer provided keys in Azure Key Vault. This keys are then used to perform etcd data level encryption.

# TODO

- [ ] Add more details in descriptions of the fields
- [ ] Add the appropriate visibilities in the fields

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft, for early feedback ping code owners
2. Structure your PR accordingly to the focus areas, e.g. `api` containing all exposed API specs
3. Write meaningful commit messages and PR description

For more details, please check the [CONTRIBUTING](../CONTRIBUTING.md) guide.
-->

### What this PR does
**Before this PR:**

**After this PR:**

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Deployment: The deployment process was considered and addressed if required
- [ ] Testing: New code requires new unit tests.
- [ ] Documentation: Is the documentation updated? Either in the doc located in focus area, in the README or in the code itself.
- [ ] Customers: Is this change affecting customers? Is the release plan considered?
