### PR TITLE
api: Do not require a boolean field

### DIFF
--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -89,7 +89,7 @@ type PlatformProfile struct {
 	ManagedResourceGroup string       `json:"managedResourceGroup,omitempty" validate:"required_for_put"`
 	SubnetID             string       `json:"subnetId,omitempty"             validate:"required_for_put"`
 	OutboundType         OutboundType `json:"outboundType,omitempty"         validate:"omitempty,enum_outboundtype"`
-	PreconfiguredNSGs    bool         `json:"preconfiguredNsgs,omitempty"    validate:"required_for_put"`
+	PreconfiguredNSGs    bool         `json:"preconfiguredNsgs,omitempty"`
 	EtcdEncryptionSetID  string       `json:"etcdEncryptionSetId,omitempty"`
 }
 


### PR DESCRIPTION
Need to be careful about requiring fields with native types like `bool` where the zero value (e.g. `false`) is valid.

See https://pkg.go.dev/github.com/go-playground/validator/v10#hdr-Required