### PR TITLE
devcontainer: Use "containerUser" instead of "removeUser"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
         "ghcr.io/devcontainers/features/dotnet:2": {}
     },
 
-    "remoteUser": "vscode",
+    "containerUser": "vscode",
 
     "mounts": [
         "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached"


### PR DESCRIPTION
This applies the suggested workaround in:

[Devcontainer fails with "remoteUser" with "mkdir: cannot create directory ‘/root’: Permission denied" #7657](https://github.com/microsoft/vscode-remote-release/issues/7657)

I encountered this error today while rebuilding the devcontainer.