### PR TITLE
Allow setting `persist: true` on resource groups

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -13,7 +13,6 @@ ifndef AKSCONFIG
 $(error "Must set AKSCONFIG")
 endif
 
-
 list:
 	@grep '^[^#[:space:]].*:' Makefile
 
@@ -33,10 +32,9 @@ setsubscription:
 rg: setsubscription
 	az group create \
   		--name $(RESOURCEGROUP)  \
-  		--location $(LOCATION) \
-		--tags "CreatedByConfig=${AKSCONFIG}"
+  		--location $(LOCATION)
 
-dev.svc-cluster: setsubscription rg
+svc-cluster: setsubscription rg
 	az deployment group create \
 		--name "$(DEPLOYMENTNAME)" \
 		--resource-group $(RESOURCEGROUP) \
@@ -47,11 +45,11 @@ dev.svc-cluster: setsubscription rg
 		--parameters \
 			currentUserId=$(CURRENTUSER)
 
-dev.mc-cluster: setsubscription rg
+mgmt-cluster: setsubscription rg
 	az deployment group create \
 		--name "$(DEPLOYMENTNAME)" \
 		--resource-group $(RESOURCEGROUP) \
-		--template-file templates/mc-cluster.bicep \
+		--template-file templates/mgmt-cluster.bicep \
 		--confirm-with-what-if \
 		--parameters \
 			configurations/${AKSCONFIG}.bicepparam \

--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -1,12 +1,11 @@
-using '../templates/mc-cluster.bicep'
-
+using '../templates/mgmt-cluster.bicep'
 
 param kubernetesVersion = '1.29.2'
 param vnetAddressPrefix = enablePrivateCluster ? '10.132.0.0/14' : '10.128.0.0/14'
 param subnetPrefix = enablePrivateCluster ? '10.132.8.0/21' : '10.128.8.0/21'
 param podSubnetPrefix = enablePrivateCluster ? '10.132.64.0/18' : '10.128.64.0/18'
 param enablePrivateCluster = false
-param createdByConfigTag = 'svc-cluster'
+param persist = false
 
 // This parameter is always overriden in the Makefile
 param currentUserId = ''

--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -5,7 +5,7 @@ param vnetAddressPrefix = enablePrivateCluster ? '10.132.0.0/14' : '10.128.0.0/1
 param subnetPrefix = enablePrivateCluster ? '10.132.8.0/21' : '10.128.8.0/21'
 param podSubnetPrefix = enablePrivateCluster ? '10.132.64.0/18' : '10.128.64.0/18'
 param enablePrivateCluster = false
-param createdByConfigTag = 'svc-cluster'
+param persist = false
 param disableLocalAuth = false
 param deployFrontendCosmos = false
 

--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -15,14 +15,18 @@ There are a few variants to chose from when creating an AKS cluster:
 * Service Cluster: Public AKS cluster with optional params that can be modified to include all Azure resources needed to run a Service cluster
 * Management Cluster: Public AKS cluster with optional params that can be modified to include all Azure resources needed to run a Management cluster (coming soon)
 
-1. Provision an AKS Cluster for each Variant 
+1. Decide on the variant and update the corresponding configuration file as desired
+
+  For example, you can toggle `deployFrontendCosmos` in configurations/svc-cluster.bicepparam to control whether or not to deploy a CosmosDB for frontend development.
+
+1. Provision an AKS Cluster for each Variant
 
    ```bash
    # Service Cluster
-   AKSCONFIG=svc-cluster make dev.svc-cluster
+   AKSCONFIG=svc-cluster make svc-cluster
 
    # Management Cluster
-   AKSCONFIG=mc-cluster make dev.mc-cluster
+   AKSCONFIG=mgmt-cluster make mgmt-cluster
    ```
 
 1. Access private AKS clusters with:
@@ -36,7 +40,7 @@ There are a few variants to chose from when creating an AKS cluster:
 1. Access public AKS clusters with:
 
    ```bash
-   make aks.kubeconfig
+   AKSCONFIG=svc-cluster make aks.kubeconfig
    KUBECONFIG=aks.kubeconfig kubectl get ns
    ```
 
@@ -94,5 +98,5 @@ This will delete:
 1. Setting the correct `AKSCONFIG`, this will cleanup all resources created in Azure
 
    ```bash
-   AKSCONFIG=private make clean
+   AKSCONFIG=svc-cluster make clean
    ```

--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -26,7 +26,7 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' = {
   identity: {
     type: 'UserAssigned'
     userAssignedIdentities: {
-    '${userAssignedMI}': {}
+      '${userAssignedMI}': {}
     }
   }
   name: name

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -1,8 +1,8 @@
 @description('Azure Region Location')
 param location string = resourceGroup().location
 
-@description('Captures the bicep template that created it')
-param createdByConfigTag string
+@description('Set to true to prevent resources from being pruned after 48 hours')
+param persist bool = false
 
 @description('Captures logged in users UID')
 param currentUserId string
@@ -22,20 +22,18 @@ param enablePrivateCluster bool
 @description('Kuberentes version to use with AKS')
 param kubernetesVersion string
 
-
-module aksBaseCluster '../modules/aks-cluster-base.bicep' = {
+module mgmtCluster '../modules/aks-cluster-base.bicep' = {
   name: 'aks_base_cluster'
-  scope: resourceGroup()  
+  scope: resourceGroup()
   params: {
     location: location
-    createdByConfigTag: createdByConfigTag
+    persist: persist
     currentUserId: currentUserId
     enablePrivateCluster: enablePrivateCluster
     kubernetesVersion: kubernetesVersion
     vnetAddressPrefix: vnetAddressPrefix
     subnetPrefix: subnetPrefix
     podSubnetPrefix: podSubnetPrefix
-    clusterType: 'mc'
+    clusterType: 'mgmt'
   }
 }
-


### PR DESCRIPTION
### What this PR does
* Adds a `persist` parameter to allow exempting resources from cleanup if desired. Defaults to false
* Renames `mc-cluster` --> `mgmt-cluster`
* Removes the `CreatedByConfig` tag that was sporadically set/not used
* `az bicep format`
* Updated docs

Jira: [ARO-7327](https://issues.redhat.com/browse/ARO-7327)

Trying it out:
```bash
AKSCONFIG=svc-cluster make svc-cluster
AKSCONFIG=svc-cluster make clean
AKSCONFIG=mgmt-cluster make mgmt-cluster
AKSCONFIG=mgmt-cluster make clean
```