### PR TITLE
Add GitHub Action and make targets to validate bicep

### DIFF
--- a/.github/workflows/dev-infrastructure.yml
+++ b/.github/workflows/dev-infrastructure.yml
@@ -1,0 +1,36 @@
+---
+name: Validate dev-infrastructure
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'dev-infrastructure/**'
+
+jobs:
+  validate_bicep:
+    permissions:
+      contents: 'read'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+        with:
+          fetch-depth: 1
+          sparse-checkout: dev-infrastructure
+
+      - name: 'az bicep format and lint'
+        working-directory: './dev-infrastructure'
+        run: |
+          make fmt
+          make lint
+
+      - name: Check for uncommitted changes
+        working-directory: './dev-infrastructure'
+        run: |
+          git diff --exit-code || (echo "::error::Uncommitted changes detected in OpenAPI spec. Please regenerate and commit them." && exit 1)

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -1,4 +1,3 @@
-
 SHELL = /bin/bash
 
 HCPDEVSUBSCRIPTION="ARO Hosted Control Planes (EA Subscription 1)"
@@ -9,12 +8,24 @@ DEPLOYMENTNAME=hcp-$(USER)-dev-infra
 LOCATION?=eastus
 RESOURCEGROUP=aro-hcp-${AKSCONFIG}-$(USER)
 
-ifndef AKSCONFIG
-$(error "Must set AKSCONFIG")
-endif
-
 list:
 	@grep '^[^#[:space:]].*:' Makefile
+
+fmt:
+	set -e; \
+	FILES="$$(find . -type f -name "*.bicep*")"; \
+	for file in $$FILES; do \
+	echo "az bicep format --file $${file}"; \
+	az bicep format --file $$file; \
+	done
+
+lint:
+	set -e; \
+	FILES="$$(find . -type f -name "*.bicep*")"; \
+	for file in $$FILES; do \
+	echo "az bicep lint --file $${file}"; \
+	az bicep lint --file $$file; \
+	done
 
 show:
 	@echo "Resource group      : $(RESOURCEGROUP)"
@@ -26,6 +37,9 @@ show:
 	@echo "DNSZone/deployment  : $(DEPLOYMENTNAME)"
 
 setsubscription:
+	ifndef AKSCONFIG
+	$(error "Must set AKSCONFIG")
+	endif
 	az account set --subscription $(HCPDEVSUBSCRIPTION)
 	az account show
 
@@ -54,9 +68,9 @@ mgmt-cluster: setsubscription rg
 		--parameters \
 			configurations/${AKSCONFIG}.bicepparam \
 		--parameters \
-			currentUserId=$(CURRENTUSER)			
+			currentUserId=$(CURRENTUSER)
 
-aks.kubeconfig:
+aks.kubeconfig: setsubscription
 	az aks get-credentials -n aro-hcp-cluster-001 -g $(RESOURCEGROUP) -a -f aks.kubeconfig
 
 secrets-download: setsubscription

--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -10,9 +10,9 @@ param disableLocalAuth = false
 param deployFrontendCosmos = false
 param workloadIdentities = items({
   frontend_wi: {
-      uamiName: 'frontend'
-      namespace: 'aro-hcp'
-      serviceAccountName: 'frontend'
+    uamiName: 'frontend'
+    namespace: 'aro-hcp'
+    serviceAccountName: 'frontend'
   }
 })
 

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -21,7 +21,6 @@ param podSubnetPrefix string
 param clusterType string
 param workloadIdentities array
 
-
 // Local Params
 @description('Optional DNS prefix to use with hosted Kubernetes API server FQDN.')
 param dnsPrefix string = aksClusterName
@@ -341,23 +340,25 @@ resource currentUserAksRbacClusterAdmin 'Microsoft.Authorization/roleAssignments
   }
 
 resource uami 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = [
-for wi in workloadIdentities: {
-  location: location
-  name: '${wi.value.uamiName}-${location}'
-}]
+  for wi in workloadIdentities: {
+    location: location
+    name: '${wi.value.uamiName}-${location}'
+  }
+]
 
 resource uami_fedcred 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2023-01-31' = [
-for i in range(0, length(workloadIdentities)): {
-  parent: uami[i]
-  name: '${workloadIdentities[i].value.uamiName}-${location}-fedcred'
-  properties: {
-    audiences: [
-      'api://AzureADTokenExchange'
-    ]
-    issuer: aksCluster.properties.oidcIssuerProfile.issuerURL
-    subject: 'system:serviceaccount:${workloadIdentities[i].value.namespace}:${workloadIdentities[i].value.serviceAccountName}'
+  for i in range(0, length(workloadIdentities)): {
+    parent: uami[i]
+    name: '${workloadIdentities[i].value.uamiName}-${location}-fedcred'
+    properties: {
+      audiences: [
+        'api://AzureADTokenExchange'
+      ]
+      issuer: aksCluster.properties.oidcIssuerProfile.issuerURL
+      subject: 'system:serviceaccount:${workloadIdentities[i].value.namespace}:${workloadIdentities[i].value.serviceAccountName}'
+    }
   }
-}]
+]
 
 // Outputs
 output userAssignedIdentities array = [

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -50,18 +50,18 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
 }
 var frontendMI = filter(svcCluster.outputs.userAssignedIdentities, id => id.uamiName == 'frontend')[0]
 
-module rpCosmosDb '../modules/rp-cosmos.bicep' = 
-if (deployFrontendCosmos) {
-  name: 'rp_cosmos_db'
-  scope: resourceGroup()  
-  params: {
-    location: location
-    aksNodeSubnetId: svcCluster.outputs.aksNodeSubnetId
-    vnetId: svcCluster.outputs.aksVnetId
-    disableLocalAuth: disableLocalAuth
-    userAssignedMI: frontendMI.uamiID
-    uamiPrincipalId: frontendMI.uamiPrincipalID
+module rpCosmosDb '../modules/rp-cosmos.bicep' =
+  if (deployFrontendCosmos) {
+    name: 'rp_cosmos_db'
+    scope: resourceGroup()
+    params: {
+      location: location
+      aksNodeSubnetId: svcCluster.outputs.aksNodeSubnetId
+      vnetId: svcCluster.outputs.aksVnetId
+      disableLocalAuth: disableLocalAuth
+      userAssignedMI: frontendMI.uamiID
+      uamiPrincipalId: frontendMI.uamiPrincipalID
+    }
   }
-}
 
 output frontend_mi_client_id string = frontendMI.uamiClientID


### PR DESCRIPTION
### What this PR does
* Adds `dev-infrastructure` make targets to lint/format bicep files
  * Should be mostly a non-factor because, if you use the VSCode Bicep extension, these will be taken care of. Long term (in a future PR) it would be good to hook it up to a subscription to run a "what-if" or plan as well to ease PR reviews.
* Adds a GitHub Action to validate bicep file lint/formatting
* Moves `AKSCONFIG` inside make targets that require it