### PR TITLE
Allow creating both mgmt/svc cluster idempotently

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -4,9 +4,9 @@ HCPDEVSUBSCRIPTION="ARO Hosted Control Planes (EA Subscription 1)"
 HCPDEVSUBSCRIPTIONID=1d3378d3-5a3f-4712-85a1-2485495dfc4b
 
 CURRENTUSER=$(shell az ad signed-in-user show | jq -r '.id')
-DEPLOYMENTNAME=hcp-$(USER)-dev-infra
 LOCATION?=eastus
 RESOURCEGROUP=aro-hcp-${AKSCONFIG}-$(USER)
+DEPLOYMENTNAME=$(RESOURCEGROUP)
 
 list:
 	@grep '^[^#[:space:]].*:' Makefile
@@ -26,15 +26,6 @@ lint:
 	echo "az bicep lint --file $${file}"; \
 	az bicep lint --file $$file; \
 	done
-
-show:
-	@echo "Resource group      : $(RESOURCEGROUP)"
-	@echo "VPN resource group  : $(VPNRESOURCEGROUP)"
-	@echo "AddressSpace prefix : $(PREFIX)"
-	@echo "AKS version         : $(AKSVERSION)"
-	@echo "Location            : $(LOCATION)"
-	@echo "AKS VNet Name       : $(AKSVNETNAME)"
-	@echo "DNSZone/deployment  : $(DEPLOYMENTNAME)"
 
 setsubscription:
 ifndef AKSCONFIG
@@ -71,7 +62,8 @@ mgmt-cluster: setsubscription rg
 			currentUserId=$(CURRENTUSER)
 
 aks.kubeconfig: setsubscription
-	az aks get-credentials -n aro-hcp-cluster-001 -g $(RESOURCEGROUP) -a -f aks.kubeconfig
+	AKS_NAME="$$(az aks list --query "[?tags.clusterType == '$(AKSCONFIG)'].name" -ojson | jq -r '.[0]')"; \
+	az aks get-credentials -n "$${AKS_NAME}" -g $(RESOURCEGROUP) -a -f "$(AKSCONFIG).kubeconfig"
 
 secrets-download: setsubscription
 	@[ "${SECRET_SA_ACCOUNT_NAME}" ] || ( echo ">> SECRET_SA_ACCOUNT_NAME is not set"; exit 1 )

--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -1,9 +1,10 @@
 using '../templates/mgmt-cluster.bicep'
 
 param kubernetesVersion = '1.29.2'
-param vnetAddressPrefix = enablePrivateCluster ? '10.132.0.0/14' : '10.128.0.0/14'
-param subnetPrefix = enablePrivateCluster ? '10.132.8.0/21' : '10.128.8.0/21'
-param podSubnetPrefix = enablePrivateCluster ? '10.132.64.0/18' : '10.128.64.0/18'
+param istioVersion = 'asm-1-20'
+param vnetAddressPrefix = '10.132.0.0/14'
+param subnetPrefix = '10.132.8.0/21'
+param podSubnetPrefix = '10.132.64.0/18'
 param enablePrivateCluster = false
 param persist = false
 param workloadIdentities = []

--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -1,9 +1,10 @@
 using '../templates/svc-cluster.bicep'
 
 param kubernetesVersion = '1.29.2'
-param vnetAddressPrefix = enablePrivateCluster ? '10.132.0.0/14' : '10.128.0.0/14'
-param subnetPrefix = enablePrivateCluster ? '10.132.8.0/21' : '10.128.8.0/21'
-param podSubnetPrefix = enablePrivateCluster ? '10.132.64.0/18' : '10.128.64.0/18'
+param istioVersion = 'asm-1-20'
+param vnetAddressPrefix = '10.128.0.0/14'
+param subnetPrefix = '10.128.8.0/21'
+param podSubnetPrefix = '10.128.64.0/18'
 param enablePrivateCluster = false
 param persist = false
 param disableLocalAuth = false

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -22,6 +22,9 @@ param enablePrivateCluster bool
 @description('Kuberentes version to use with AKS')
 param kubernetesVersion string
 
+@description('Istio control plane version to use with AKS')
+param istioVersion string
+
 @description('List of workload identities to create and their required values')
 param workloadIdentities array
 
@@ -33,11 +36,12 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     persist: persist
     currentUserId: currentUserId
     enablePrivateCluster: enablePrivateCluster
+    istioVersion: istioVersion
     kubernetesVersion: kubernetesVersion
     vnetAddressPrefix: vnetAddressPrefix
     subnetPrefix: subnetPrefix
     podSubnetPrefix: podSubnetPrefix
-    clusterType: 'mgmt'
+    clusterType: 'mgmt-cluster'
     workloadIdentities: workloadIdentities
   }
 }

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -22,6 +22,9 @@ param enablePrivateCluster bool
 @description('Kuberentes version to use with AKS')
 param kubernetesVersion string
 
+@description('Istio control plane version to use with AKS')
+param istioVersion string
+
 // TODO: When the work around workload identity for the RP is finalized, change this to true
 @description('disableLocalAuth for the ARO HCP RP CosmosDB')
 param disableLocalAuth bool
@@ -41,10 +44,11 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     currentUserId: currentUserId
     enablePrivateCluster: enablePrivateCluster
     kubernetesVersion: kubernetesVersion
+    istioVersion: istioVersion
     vnetAddressPrefix: vnetAddressPrefix
     subnetPrefix: subnetPrefix
     podSubnetPrefix: podSubnetPrefix
-    clusterType: 'svc'
+    clusterType: 'svc-cluster'
     workloadIdentities: workloadIdentities
   }
 }


### PR DESCRIPTION
### What this PR does
**Before this PR:**
* Unable to create a mgmt and a svc cluster due to naming conflicts
* Unable to idempotently `make mgmt-cluster`/`make svc-cluster`

**After this PR:**
* Able to create a mgmt and svc cluster
* Able to idempotently `make mgmt-cluster`/`make svc-cluster`, making iterating on changes easier.

Applying the mgmt-cluster/svc-cluster targets again now results in:

```
Resource changes: 4 to modify, 10 no change.
```

Jira: [ARO-6158](https://issues.redhat.com/browse/ARO-6158)