### PR TITLE
Grant bicep-what-if action id-token write permissions as intended

### DIFF
--- a/.github/workflows/bicep-what-if.yml
+++ b/.github/workflows/bicep-what-if.yml
@@ -11,13 +11,10 @@ on:
     paths:
       - 'dev-infrastructure/**/*.bicep'
 
-permissions:
-      id-token: write
-      contents: read
-
 jobs:
   test:
     permissions:
+      id-token: 'write'
       contents: 'read'
     runs-on: 'ubuntu-latest'
     steps:


### PR DESCRIPTION
### What this PR does
Fixes the bicep-what-if GitHub Action from #134 - we were mistakenly overwriting the `id-token: write` permissions that it needs.