### PR TITLE
Introduce a DBClient interface

### DIFF
--- a/frontend/cmd/cmd.go
+++ b/frontend/cmd/cmd.go
@@ -24,8 +24,9 @@ type FrontendOpts struct {
 	region string
 	port   int
 
-	databaseName string
-	databaseURL  string
+	useCache   bool
+	cosmosName string
+	cosmosURL  string
 }
 
 func NewRootCmd() *cobra.Command {
@@ -39,7 +40,7 @@ func NewRootCmd() *cobra.Command {
 	This command runs the ARO HCP Frontend. It communicates with Clusters Service and a CosmosDB
 
 	# Run ARO HCP Frontend locally to connect to a local Clusters Service at http://localhost:8000
-	./aro-hcp-frontend --database-name ${DB_NAME} --database-url ${DB_URL} --region ${REGION} \
+	./aro-hcp-frontend --cosmos-name ${DB_NAME} --cosmos-url ${DB_URL} --region ${REGION} \
 		--clusters-service-url "http://localhost:8000"
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -47,13 +48,18 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 
-	rootCmd.Flags().StringVar(&opts.databaseName, "database-name", os.Getenv("DB_NAME"), "database name")
-	rootCmd.Flags().StringVar(&opts.databaseURL, "database-url", os.Getenv("DB_URL"), "database url")
+	rootCmd.Flags().BoolVar(&opts.useCache, "use-cache", false, "leverage a local cache instead of reaching out to a database")
+	rootCmd.Flags().StringVar(&opts.cosmosName, "cosmos-name", os.Getenv("DB_NAME"), "Cosmos database name")
+	rootCmd.Flags().StringVar(&opts.cosmosURL, "cosmos-url", os.Getenv("DB_URL"), "Cosmos database url")
 	rootCmd.Flags().StringVar(&opts.region, "region", os.Getenv("REGION"), "Azure region")
 	rootCmd.Flags().IntVar(&opts.port, "port", 8443, "port to listen on")
 
 	rootCmd.Flags().StringVar(&opts.clustersServiceURL, "clusters-service-url", "https://api.openshift.com", "URL of the OCM API gateway.")
 	rootCmd.Flags().BoolVar(&opts.insecure, "insecure", false, "Skip validating TLS for clusters-service.")
+
+	rootCmd.MarkFlagsMutuallyExclusive("use-cache", "cosmos-name")
+	rootCmd.MarkFlagsMutuallyExclusive("use-cache", "cosmos-url")
+	rootCmd.MarkFlagsRequiredTogether("cosmos-name", "cosmos-url")
 
 	return rootCmd
 }
@@ -76,10 +82,17 @@ func (opts *FrontendOpts) Run() error {
 	prometheusEmitter := frontend.NewPrometheusEmitter()
 
 	// Configure database configuration and client
-	dbConfig := database.NewDatabaseConfig(opts.databaseName, opts.databaseURL)
-	dbClient, err := database.NewDatabaseClient(dbConfig)
-	if err != nil {
-		return fmt.Errorf("creating the database client failed: %v", err)
+	var dbClient database.DBClient
+	if opts.useCache {
+		dbClient = database.NewCache()
+	} else {
+		var err error
+
+		dbConfig := database.NewCosmosDBConfig(opts.cosmosName, opts.cosmosURL)
+		dbClient, err = database.NewCosmosDBClient(dbConfig)
+		if err != nil {
+			return fmt.Errorf("creating the database client failed: %v", err)
+		}
 	}
 
 	listener, err := net.Listen("tcp4", fmt.Sprintf(":%d", opts.port))

--- a/frontend/pkg/database/cache.go
+++ b/frontend/pkg/database/cache.go
@@ -1,0 +1,52 @@
+package database
+
+import "context"
+
+var _ DBClient = &Cache{}
+
+type Cache struct {
+	cluster      map[string]*HCPOpenShiftClusterDocument
+	subscription map[string]*SubscriptionDocument
+}
+
+func NewCache() DBClient {
+	return &Cache{
+		cluster:      make(map[string]*HCPOpenShiftClusterDocument),
+		subscription: make(map[string]*SubscriptionDocument),
+	}
+}
+
+func (c *Cache) DBConnectionTest(ctx context.Context) (string, error) {
+	return "using cache", nil
+}
+
+func (c *Cache) GetClusterDoc(ctx context.Context, resourceID string, partitionKey string) (*HCPOpenShiftClusterDocument, error) {
+	if _, ok := c.cluster[resourceID]; ok {
+		return c.cluster[resourceID], nil
+	}
+
+	return nil, ErrNotFound
+}
+
+func (c *Cache) SetClusterDoc(ctx context.Context, doc *HCPOpenShiftClusterDocument) error {
+	c.cluster[doc.ResourceID] = doc
+	return nil
+}
+
+func (c *Cache) DeleteClusterDoc(ctx context.Context, resourceID string, partitionKey string) error {
+	delete(c.cluster, resourceID)
+	return nil
+}
+
+func (c *Cache) GetSubscriptionDoc(ctx context.Context, partitionKey string) (*SubscriptionDocument, error) {
+	if _, ok := c.subscription[partitionKey]; ok {
+		return c.subscription[partitionKey], nil
+	}
+
+	return nil, ErrNotFound
+}
+
+func (c *Cache) SetSubscriptionDoc(ctx context.Context, doc *SubscriptionDocument) error {
+	c.subscription[doc.PartitionKey] = doc
+	return nil
+}

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -40,7 +40,7 @@ type Frontend struct {
 	logger   *slog.Logger
 	listener net.Listener
 	server   http.Server
-	cache    Cache
+	cache    Cache // TODO: Delete
 	dbClient database.DBClient
 	ready    atomic.Value
 	done     chan struct{}
@@ -55,7 +55,7 @@ func MuxPattern(method string, segments ...string) string {
 	return fmt.Sprintf("%s /%s", method, strings.ToLower(path.Join(segments...)))
 }
 
-func NewFrontend(logger *slog.Logger, listener net.Listener, emitter Emitter, dbClient *database.DBClient, region string, conn *sdk.Connection) *Frontend {
+func NewFrontend(logger *slog.Logger, listener net.Listener, emitter Emitter, dbClient database.DBClient, region string, conn *sdk.Connection) *Frontend {
 	f := &Frontend{
 		conn:     conn,
 		logger:   logger,
@@ -68,7 +68,7 @@ func NewFrontend(logger *slog.Logger, listener net.Listener, emitter Emitter, db
 			},
 		},
 		cache:    *NewCache(),
-		dbClient: *dbClient,
+		dbClient: dbClient,
 		done:     make(chan struct{}),
 		region:   region,
 	}


### PR DESCRIPTION
Should not be merged before #149

* Added CosmosDBClient and CacheClient to implement the DBClient
  interface
* Allows for easier local testing
* Added a --use-cache flag to the CLI to leverage CacheClient
* TODO: In the future, we can remove the previous cache

Local testing:
```bash
make frontend

# Run Frontend locally backed by a local cache instead of CosmosDB
./aro-hcp-frontend --clusters-service-url "http://localhost:8000" --use-auth-code --use-cache # doesn't matter if you're really running clusters-service or not at this point

# Generate a dummy cluster.json
go run frontend/utils/create.go   

curl -X PUT "http://localhost:8443/subscriptions/YOUR_SUBSCRIPTION_ID?api-version=2.0" --json '{"state":"Registered"}'
curl -X GET "http://localhost:8443/subscriptions/YOUR_SUBSCRIPTION_ID?api-version=2.0"
curl -X PUT "localhost:8443/subscriptions/YOUR_SUBSCRIPTION_ID/resourceGroups/YOUR_RESOURCE_GROUP_NAME/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/YOUR_CLUSTER_NAME?api-version=2024-06-10-preview" --json @cluster.json
curl -X GET "localhost:8443/subscriptions/YOUR_SUBSCRIPTION_ID/resourceGroups/YOUR_RESOURCE_GROUP_NAME/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/YOUR_CLUSTER_NAME?api-version=2024-06-10-preview"
curl -X DELETE "localhost:8443/subscriptions/YOUR_SUBSCRIPTION_ID/resourceGroups/YOUR_RESOURCE_GROUP_NAME/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/YOUR_CLUSTER_NAME?api-version=2024-06-10-preview"

```