### PR TITLE
making multiaz agentpool for mgmt clusters

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -283,6 +283,11 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
         vnetSubnetID: aksNodeSubnet.id
         podSubnetID: aksPodSubnet.id
         maxPods: 100
+        availabilityZones: [
+          '1'
+          '2'
+          '3'
+        ]
       }
     ]
     networkProfile: {


### PR DESCRIPTION
### What this PR does
**Before this PR:**
The cluster workers nodes are running on the same availaiblity zone so multiAZ HCP pods wouldn't come up due to the builtin node anti-affinity


**After this PR:**
With this the AKS workers nodes are across multiple AZ, we can create HCP pods across zones for testing HighlyAvailable clusters

