### PR TITLE
Validate database connectivity in health probe

### DIFF
--- a/frontend/cmd/cmd.go
+++ b/frontend/cmd/cmd.go
@@ -72,10 +72,8 @@ func (opts *FrontendOpts) Run() error {
 	prometheusEmitter := frontend.NewPrometheusEmitter()
 
 	// Configure database configuration and client
-	var dbClient database.DBClient
-	if opts.useCache {
-		dbClient = database.NewCache()
-	} else {
+	dbClient := database.NewCache()
+	if !opts.useCache {
 		var err error
 
 		dbConfig := database.NewCosmosDBConfig(opts.cosmosName, opts.cosmosURL)
@@ -102,15 +100,6 @@ func (opts *FrontendOpts) Run() error {
 	}
 
 	f := frontend.NewFrontend(logger, listener, prometheusEmitter, dbClient, opts.region, conn)
-
-	// Verify the Async DB is available and accessible
-	logger.Info("Testing DB Access")
-	result, err := dbClient.DBConnectionTest(context.Background())
-	if err != nil {
-		logger.Error(fmt.Sprintf("Database test failed to fetch properties: %v", err))
-	} else {
-		logger.Info(fmt.Sprintf("Database check completed - %s", result))
-	}
 
 	stop := make(chan struct{})
 	signalChannel := make(chan os.Signal, 1)


### PR DESCRIPTION
### What this PR does
* Makes /healthz/ready fail if the frontend cannot reach the database
* The binary doesn't crash or panic, but this would allow Kubernetes to get good signal from the configured liveness/readiness Probes https://github.com/Azure/ARO-HCP/blob/bb1805bd8917c0bb4df9bece4b35097085014a1a/frontend/deploy/aro-hcp-frontend.yml#L91-L103

```bash
❯ make frontend
❯ ./aro-hcp-frontend --clusters-service-url "http://localhost:8000" --use-cache # Don't need to have CS running locally, we're just health-checking the database

# In another terminal
❯ curl -I -X GET "http://localhost:8443/healthz/ready"
HTTP/1.1 200 OK
Date: Thu, 30 May 2024 20:22:37 GMT
Content-Length: 0
```

```bash
❯ ./aro-hcp-frontend --clusters-service-url "http://localhost:8000" --cosmos-name test --cosmos-url test # Simulating unable to reach CosmosDB

# In another terminal
❯ curl -I -X GET "http://localhost:8443/healthz/ready"
HTTP/1.1 500 Internal Server Error
Date: Thu, 30 May 2024 20:23:14 GMT
Content-Length: 0
```
