### PR TITLE
frontend: Preserve original casing in error messages

### DIFF
--- a/frontend/pkg/frontend/middleware_validatestatic_test.go
+++ b/frontend/pkg/frontend/middleware_validatestatic_test.go
@@ -22,58 +22,45 @@ func TestMiddlewareValidateStatic(t *testing.T) {
 	})
 
 	tests := []struct {
-		name              string
-		path              string
-		subscriptionID    string
-		resourceGroupName string
+		name string
+		path string
 
-		resourceType       string
-		resourceName       string
 		operationsId       string
 		expectedStatusCode int
 		expectedBody       string
 	}{
 		{
 			name:               "Valid request",
-			path:               "/subscriptions/42d9eac4-d29a-4d6e-9e26-3439758b1491",
-			subscriptionID:     "42d9eac4-d29a-4d6e-9e26-3439758b1491",
+			path:               "/Subscriptions/42d9eac4-d29a-4d6e-9e26-3439758b1491/ResourceGroups/MyResourceGroup/Providers/Microsoft.RedHatOpenShift/HCPOpenShiftClusters/MyCluster",
 			expectedStatusCode: http.StatusOK,
 		},
 		{
 			name:               "Invalid subscription ID",
-			path:               "/subscriptions/invalid!sub!id",
-			subscriptionID:     "invalid!sub!id",
+			path:               "/Subscriptions/invalid!sub!id",
 			expectedStatusCode: http.StatusBadRequest,
 			expectedBody:       "The provided subscription identifier 'invalid!sub!id' is malformed or invalid.",
 		},
 		{
 			name:               "Invalid resource group name",
-			path:               "/resourcegroups/resourcegroup!",
-			resourceGroupName:  "resourcegroup!",
+			path:               "/Subscriptions/00000000-0000-0000-0000-000000000000/ResourceGroups/ResourceGroup!",
 			expectedStatusCode: http.StatusBadRequest,
-			expectedBody:       "Resource group 'resourcegroup!' is invalid.",
+			expectedBody:       "Resource group 'ResourceGroup!' is invalid.",
 		},
 		{
 			name:               "Invalid resource name",
-			path:               "/resourcegroup/providers/microsoft.redhatopenshift/hcpopenshiftcluster/$",
-			resourceGroupName:  "resourcegroup",
-			resourceType:       "hcpOpenShiftClusters",
-			resourceName:       "$",
+			path:               "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/MyResourceGroup/PROVIDERS/MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS/$",
 			expectedStatusCode: http.StatusBadRequest,
-			expectedBody:       "The Resource 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters/$' under resource group 'resourcegroup' is invalid.",
+			expectedBody:       "The Resource 'MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS/$' under resource group 'MyResourceGroup' is invalid.",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest("GET", "http://example.com"+tc.path, nil)
+			req = req.WithContext(ContextWithOriginalPath(req.Context(), tc.path))
 
 			// Use httptest.ResponseRecorder to record the response
 			w := httptest.NewRecorder()
-
-			req.SetPathValue(PathSegmentSubscriptionID, tc.subscriptionID)
-			req.SetPathValue(PathSegmentResourceGroupName, tc.resourceGroupName)
-			req.SetPathValue(PathSegmentResourceName, tc.resourceName)
 
 			// Execute the middleware
 			MiddlewareValidateStatic(w, req, nextHandler)


### PR DESCRIPTION
Based on some Slack discussion yesterday I did a quick pass over the frontend for conformance with [OAPI012](https://eng.ms/docs/products/arm/api_contracts/guidelines/openapi):

> OAPI012: Resource IDs must not be case sensitive
> 
> Any entity name in the URL or resource ID (resource group names, resource names, resource provider names) must be treated case insensitively. RPs should also persist the casing provided by the user for tags, resource names, etc. and use that same casing in responses.

Preserving the original casing in responses is something we'll have to continue to be mindful of.  Only issue I spotted was the error messages in `middleware_validatestatic.go`.  I also varied the casing in the middleware's unit tests to make sure it's preserved.