### PR TITLE
Update DBConnectionTest to only return an error

### DIFF
--- a/frontend/pkg/database/cache.go
+++ b/frontend/pkg/database/cache.go
@@ -16,8 +16,8 @@ func NewCache() DBClient {
 	}
 }
 
-func (c *Cache) DBConnectionTest(ctx context.Context) (string, error) {
-	return "using cache", nil
+func (c *Cache) DBConnectionTest(ctx context.Context) error {
+	return nil
 }
 
 func (c *Cache) GetClusterDoc(ctx context.Context, resourceID string, partitionKey string) (*HCPOpenShiftClusterDocument, error) {

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -167,12 +167,11 @@ func (f *Frontend) Join() {
 
 func (f *Frontend) CheckReady(ctx context.Context) bool {
 	// Verify the DB is available and accessible
-	result, err := f.dbClient.DBConnectionTest(ctx)
-	if err != nil {
-		f.logger.Error(fmt.Sprintf("Database test failed to fetch properties: %v", err))
+	if err := f.dbClient.DBConnectionTest(ctx); err != nil {
+		f.logger.Error(fmt.Sprintf("Database test failed: %v", err))
 		return false
 	}
-	f.logger.Debug(fmt.Sprintf("Database check completed - %s", result))
+	f.logger.Debug("Database check completed")
 
 	return f.ready.Load().(bool)
 }


### PR DESCRIPTION
### What this PR does
Change
```go
DBConnectionTest(ctx context.Context) (string, error)
```

to

```go
DBConnectionTest(ctx context.Context) error
```

since the string is not really a useful return parameter 

https://github.com/Azure/ARO-HCP/pull/158#discussion_r1622735117