### PR TITLE
Fix bug when validating subscription resources

### DIFF
--- a/frontend/pkg/frontend/middleware_validatestatic_test.go
+++ b/frontend/pkg/frontend/middleware_validatestatic_test.go
@@ -30,7 +30,12 @@ func TestMiddlewareValidateStatic(t *testing.T) {
 		expectedBody       string
 	}{
 		{
-			name:               "Valid request",
+			name:               "Valid request for a subscription resource",
+			path:               "/Subscriptions/42d9eac4-d29a-4d6e-9e26-3439758b1491",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Valid request for a HCPOpenShiftClusters resource",
 			path:               "/Subscriptions/42d9eac4-d29a-4d6e-9e26-3439758b1491/ResourceGroups/MyResourceGroup/Providers/Microsoft.RedHatOpenShift/HCPOpenShiftClusters/MyCluster",
 			expectedStatusCode: http.StatusOK,
 		},


### PR DESCRIPTION
### What this PR does
Fixes a bug introduced in #159 where we were mistakenly trying to validate subscription resource with our HcpOpenShiftCluster resource name regex.

Before:
```bash
❯ curl -X PUT "http://localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000?api-version=2.0" --json '{"state":"Registered", "properties": {"tenantId": "00000000-0000-0000-0000-000000000000"}}'
{
    "error": {
        "code": "InvalidResourceName",
        "message": "The Resource 'Microsoft.Resources/subscriptions/00000000-0000-0000-0000-000000000000' under resource group '' is invalid.",
        "target": "/subscriptions/00000000-0000-0000-0000-000000000000"
    }
}
```

After:
```bash
❯ curl -X PUT "http://localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000?api-version=2.0" --json '{"state":"Registered", "properties": {"tenantId": "00000000-0000-0000-0000-000000000000"}}'
{"state":"Registered","properties":{"tenantId":"00000000-0000-0000-0000-000000000000"}}
```