### PR TITLE
Remove cache from SubscriptionStateMuxValidator

### DIFF
--- a/frontend/pkg/frontend/cache.go
+++ b/frontend/pkg/frontend/cache.go
@@ -38,11 +38,3 @@ func (c *Cache) GetSubscription(id string) (*arm.Subscription, bool) {
 	subscription, found := c.subscription[id]
 	return subscription, found
 }
-
-func (c *Cache) SetSubscription(id string, subscription *arm.Subscription) {
-	c.subscription[id] = subscription
-}
-
-func (c *Cache) DeleteSubscription(id string) {
-	delete(c.subscription, id)
-}

--- a/frontend/pkg/frontend/context_test.go
+++ b/frontend/pkg/frontend/context_test.go
@@ -1,0 +1,55 @@
+package frontend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func TestTenantIDFromContext(t *testing.T) {
+	tests := []struct {
+		name      string
+		sub       arm.Subscription
+		expected  string
+		expectErr bool
+	}{
+		{
+			name: "Valid",
+			sub: arm.Subscription{
+				Properties: &arm.Properties{
+					TenantId: stringPtr("tenant-id"),
+				},
+			},
+			expected:  "tenant-id",
+			expectErr: false,
+		},
+		{
+			name:      "Missing tenantId",
+			sub:       arm.Subscription{},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		ctx := ContextWithSubscription(context.Background(), test.sub)
+		actual, err := TenantIDFromContext(ctx)
+		if err != nil {
+			if !test.expectErr {
+				t.Errorf("expected err to be nil, got %v", err)
+			}
+		} else {
+			if test.expectErr {
+				t.Error("expected err to be non-nil")
+			}
+
+			if actual != test.expected {
+				t.Errorf("expected %s, got %s", test.expected, actual)
+			}
+		}
+	}
+}

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -73,7 +73,7 @@ func NewFrontend(logger *slog.Logger, listener net.Listener, emitter Emitter, db
 		region:   region,
 	}
 
-	subscriptionStateMuxValidator := NewSubscriptionStateMuxValidator(&f.cache)
+	subscriptionStateMuxValidator := NewSubscriptionStateMuxValidator(f.dbClient)
 
 	// Setup metrics middleware
 	metricsMiddleware := MetricsMiddleware{cache: &f.cache, Emitter: emitter}
@@ -488,7 +488,6 @@ func (f *Frontend) ArmSubscriptionPut(writer http.ResponseWriter, request *http.
 	}
 
 	subscriptionID := request.PathValue(PathSegmentSubscriptionID)
-	f.cache.SetSubscription(subscriptionID, &subscription)
 
 	// Emit the subscription state metric
 	f.metrics.EmitGauge("subscription_lifecycle", 1, map[string]string{


### PR DESCRIPTION
### What this PR does
* Leverage DBClient instead
* Allows us to start deprecating this cache
* Allows us to add tenantID to our request context