### PR TITLE
remove additional NSG 

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -62,16 +62,6 @@ resource subscriptionTags 'Microsoft.Resources/tags@2024-03-01' = {
   }
 }
 
-resource aks_nsg 'Microsoft.Network/networkSecurityGroups@2023-11-01' = {
-  name: 'aks-nsg'
-  location: location
-}
-
-resource aks_pod_nsg 'Microsoft.Network/networkSecurityGroups@2023-11-01' = {
-  name: 'aks-pod-nsg'
-  location: location
-}
-
 resource aks_keyvault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   location: location
   name: take('aks-kv-${clusterType}-${uniqueString(currentUserId)}', 24)
@@ -155,9 +145,6 @@ resource aksNodeSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = 
   name: 'ClusterSubnet-001'
   properties: {
     addressPrefix: subnetPrefix
-    networkSecurityGroup: {
-      id: aks_nsg.id
-    }
     privateEndpointNetworkPolicies: 'Disabled'
     serviceEndpoints: [
       {
@@ -181,9 +168,6 @@ resource aksPodSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = {
   name: 'PodSubnet-001'
   properties: {
     addressPrefix: podSubnetPrefix
-    networkSecurityGroup: {
-      id: aks_pod_nsg.id
-    }
     privateEndpointNetworkPolicies: 'Disabled'
     serviceEndpoints: [
       {


### PR DESCRIPTION
### What this PR does
**Before this PR:**
There are 2 addition NSGs(`aks-nsg` and `aks-pod-nsg`) for the cluster subnet and pod subnet respectively with default DenyAll policies and it blocks all the communication to/from external DNS and k8s-services, this affects the HostedCluster communication as well as nodes to reach API/ignition services.

```
On the HC node VM console
[ ***  ] A start job is running for Ignitio[ 2401.612345] ignition[885]: GET error: Get "https://ignition-aks-hosted-cp-3.akshcp.hyp.azure.rhperfscale.org/ignition": dial tcp 57.152.2.170:443: connect: connection refused
[**    ] A start job is running for Ignition (fetch) (40min 4s / no limit)

Manual curl
# curl -H "Authorization: Bearer ZjNkMGQ3ZTItZmQyYy00MTkzLWI4ZDgtNDZiMTFiOGNkOTZm" https://ignition-aks-hosted-cp-3.akshcp.hyp.azure.rhperfscale.org/ignition  -k
curl: (28) Failed to connect to ignition-aks-hosted-cp-3.akshcp.hyp.azure.rhperfscale.org port 443: Connection timed out

Works from internal network
# k exec -n clusters-aks-hosted-cp-3 ignition-server-76d64dcd6-4wljr -- curl -H "Authorization: Bearer ZjNkMGQ3ZTItZmQyYy00MTkzLWI4ZDgtNDZiMTFiOGNkOTZm" https://10.130.123.193/ignition -k 
Defaulted container "ignition-server" out of: ignition-server, fetch-feature-gate (init)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0{"ignition":{"version":"3.2.0"},
  .....
```

**After this PR:**
By default AKS cluster has a security group that protects the VMs(`aks-agentpool-*`), HO doesn't control the other 2 created by this bicep template so it is static with default DenyAll rules.
It works as expected without these groups.


If those extra groups are required and kept intentionally then we have to add/remove security group rules dynamically for HCs(or statically for known ports) to allow pods from expected source to destination. 

