### PR TITLE
Pass location and tenantID when creating CS cluster

### DIFF
--- a/frontend/cmd/cmd.go
+++ b/frontend/cmd/cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -99,6 +100,9 @@ func (opts *FrontendOpts) Run() error {
 		return err
 	}
 
+	if len(opts.region) == 0 {
+		return errors.New("region is required")
+	}
 	f := frontend.NewFrontend(logger, listener, prometheusEmitter, dbClient, opts.region, conn)
 
 	stop := make(chan struct{})


### PR DESCRIPTION
* Makes `region` a required parameter for frontend to run
* Passes `tenantID` and `region` to CS with the expected values
* Sets `SystemData` correctly when returning a `Microsoft.RedHatOpenShift/HcpOpenShiftClusters` from a CS cluster