### PR TITLE
Write out only subscription content on ARM GET

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -57,7 +57,7 @@ make undeploy-private
 
 Update a subscription state (Must be **Registered** for other calls to function)
 ```bash
-curl -X PUT localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000?api-version=2.0 --json '{"state":"Registered"}'
+curl -X PUT localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000?api-version=2.0 --json '{"state":"Registered", "properties": { "tenantId": "00000000-0000-0000-0000-000000000000"}}'
 ```
 
 List the Operations for the Provider

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -530,7 +530,7 @@ func (f *Frontend) ArmSubscriptionGet(writer http.ResponseWriter, request *http.
 		}
 	}
 
-	resp, err := json.Marshal(&doc)
+	resp, err := json.Marshal(&doc.Subscription)
 	if err != nil {
 		f.logger.Error(err.Error())
 		writer.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Previously it was writing the whole subscription document on Arm get subscription.  Now it's only outputting the content.  