### PR TITLE
Store SystemData in frontend DBClient for now

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -83,7 +83,9 @@ curl -X GET "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/r
 
 Create or Update a HcpOpenShiftClusterResource
 ```bash
-curl -X PUT "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dev-test-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/YOUR_CLUSTER_NAME?api-version=2024-06-10-preview" --json @cluster.json
+curl -X PUT "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dev-test-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/YOUR_CLUSTER_NAME?api-version=2024-06-10-preview" \
+  -H "X-Ms-Arm-Resource-System-Data: {\"createdBy\": \"aro-hcp-local-testing\", \"createdByType\": \"User\", \"createdAt\": \"2024-06-06T19:26:56+00:00\"}" \
+  --json @cluster.json
 ```
 
 Delete a HcpOpenShiftClusterResource

--- a/frontend/pkg/database/document.go
+++ b/frontend/pkg/database/document.go
@@ -4,10 +4,11 @@ import "github.com/Azure/ARO-HCP/internal/api/arm"
 
 // HCPOpenShiftClusterDocument represents an HCP OpenShift cluster document.
 type HCPOpenShiftClusterDocument struct {
-	ID           string `json:"id,omitempty"`
-	Key          string `json:"key,omitempty"`
-	PartitionKey string `json:"partitionKey,omitempty"`
-	ClusterID    string `json:"clusterid,omitempty"`
+	ID           string          `json:"id,omitempty"`
+	Key          string          `json:"key,omitempty"`
+	PartitionKey string          `json:"partitionKey,omitempty"`
+	ClusterID    string          `json:"clusterid,omitempty"`
+	SystemData   *arm.SystemData `json:"systemData,omitempty"` // TODO: Should CS store this?
 
 	// Values provided by Cosmos after doc creation
 	ResourceID  string `json:"_rid,omitempty"`

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -21,11 +21,7 @@ const (
 )
 
 // ConvertCStoHCPOpenShiftCluster converts a CS Cluster object into HCPOpenShiftCluster object
-func (f *Frontend) ConvertCStoHCPOpenShiftCluster(ctx context.Context, cluster *cmv1.Cluster) (*api.HCPOpenShiftCluster, error) {
-	systemData, err := SystemDataFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
+func (f *Frontend) ConvertCStoHCPOpenShiftCluster(ctx context.Context, systemData *arm.SystemData, cluster *cmv1.Cluster) (*api.HCPOpenShiftCluster, error) {
 	originalPath, err := OriginalPathFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get original path: %w", err)

--- a/internal/api/arm/resource.go
+++ b/internal/api/arm/resource.go
@@ -54,12 +54,18 @@ const (
 // SystemData includes creation and modification metadata for resources
 // See https://eng.ms/docs/products/arm/api_contracts/resourcesystemdata
 type SystemData struct {
-	CreatedBy          string        `json:"createdBy,omitempty"`
-	CreatedByType      CreatedByType `json:"createdByType,omitempty"      validate:"omitempty,enum_createdbytype"`
-	CreatedAt          *time.Time    `json:"createdAt,omitempty"`
-	LastModifiedBy     string        `json:"lastModifiedBy,omitempty"`
+	// CreatedBy is a string identifier for the identity that created the resource
+	CreatedBy string `json:"createdBy,omitempty"`
+	// CreatedByType is the type of identity that created the resource: User, Application, ManagedIdentity
+	CreatedByType CreatedByType `json:"createdByType,omitempty"      validate:"omitempty,enum_createdbytype"`
+	// The timestamp of resource creation (UTC)
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	// LastModifiedBy is a string identifier for the identity that last modified the resource
+	LastModifiedBy string `json:"lastModifiedBy,omitempty"`
+	// LastModifiedByType is the type of identity that last modified the resource: User, Application, ManagedIdentity
 	LastModifiedByType CreatedByType `json:"lastModifiedByType,omitempty" validate:"omitempty,enum_createdbytype"`
-	LastModifiedAt     *time.Time    `json:"lastModifiedAt,omitempty"`
+	// LastModifiedAt is the timestamp of resource last modification (UTC)
+	LastModifiedAt *time.Time `json:"lastModifiedAt,omitempty"`
 }
 
 func (src *SystemData) Copy(dst *SystemData) {


### PR DESCRIPTION
According to https://eng.ms/docs/products/arm/api_contracts/resourcesystemdata

> For tracked resources, the header values that ARM passes on resource modification are authoritative and should be stored with the metadata for the resource.

However, we don't currently have a place to store this :( For now, this PR:

* Updates our frontend DBClient to store `arm.SystemData` when `Microsoft.RedHatOpenshift` resources are modified
* Updates frontend/README.md to document a sample cluster PUT call
* ConvertCStoHCPOpenShiftCluster now requires `arm.SystemData` as an input while we are not sure if CS will persist this data.

[ARO-6188](https://issues.redhat.com/browse/ARO-6188)