### PR TITLE
Pin OutboundType to LoadBalancer as it is the only valid option

### DIFF
--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -84,7 +84,7 @@ func (f *Frontend) ConvertCStoHCPOpenShiftCluster(ctx context.Context, systemDat
 				Platform: api.PlatformProfile{
 					ManagedResourceGroup:   cluster.Azure().ManagedResourceGroupName(),
 					SubnetID:               cluster.Azure().SubnetResourceID(),
-					OutboundType:           "",
+					OutboundType:           api.OutboundTypeLoadBalancer,
 					NetworkSecurityGroupID: cluster.Azure().NetworkSecurityGroupResourceID(),
 					EtcdEncryptionSetID:    "",
 				},


### PR DESCRIPTION
### What this PR does
Currently this is the only valid value for this field: https://github.com/Azure/ARO-HCP/blob/683f939a2b23282796b2f91065e4ea20463e7c07/internal/api/enums.go#L14-L19

Jira: [ARO-7958](https://issues.redhat.com/browse/ARO-7958)