### PR TITLE
Update NodePool provisioning state type to ProvisioningState

### DIFF
--- a/api/redhatopenshift/HcpCluster/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster/hcpCluster-models.tsp
@@ -129,6 +129,18 @@ model ClusterSpec {
 union ProvisioningState {
   string,
   ResourceProvisioningState,
+
+  /** Non-terminal state indicating the resource has been accepted */
+  "Accepted",
+
+  /** Non-terminal state indicating the resource is deleting */
+  "Deleting",
+
+  /** Non-terminal state indicating the resource is provisioning */
+  "Provisioning",
+
+  /** Non-terminal state indicating the resource is updating */
+  "Updating",
 }
 
 /** Versions represents an OpenShift version. */
@@ -434,7 +446,7 @@ model IngressProfile {
 model NodePoolProperties {
   /** Provisioning state */
   @visibility("read")
-  provisioningState?: ResourceProvisioningState;
+  provisioningState?: ProvisioningState;
 
   /** The node pool resource specification */
   spec: NodePoolSpec;

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/openapi.json
@@ -1881,7 +1881,7 @@
       "description": "Represents the node pool properties",
       "properties": {
         "provisioningState": {
-          "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",
+          "$ref": "#/definitions/ProvisioningState",
           "description": "Provisioning state",
           "readOnly": true
         },
@@ -2044,7 +2044,11 @@
       "enum": [
         "Succeeded",
         "Failed",
-        "Canceled"
+        "Canceled",
+        "Accepted",
+        "Deleting",
+        "Provisioning",
+        "Updating"
       ],
       "x-ms-enum": {
         "name": "ProvisioningState",
@@ -2064,6 +2068,26 @@
             "name": "Canceled",
             "value": "Canceled",
             "description": "Resource creation was canceled."
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "Non-terminal state indicating the resource has been accepted"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Non-terminal state indicating the resource is deleting"
+          },
+          {
+            "name": "Provisioning",
+            "value": "Provisioning",
+            "description": "Non-terminal state indicating the resource is provisioning"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Non-terminal state indicating the resource is updating"
           }
         ]
       },

--- a/internal/api/v20240610preview/generated/constants.go
+++ b/internal/api/v20240610preview/generated/constants.go
@@ -143,20 +143,32 @@ func PossibleOutboundTypeValues() []OutboundType {
 type ProvisioningState string
 
 const (
+	// ProvisioningStateAccepted - Non-terminal state indicating the resource has been accepted
+	ProvisioningStateAccepted ProvisioningState = "Accepted"
 	// ProvisioningStateCanceled - Resource creation was canceled.
 	ProvisioningStateCanceled ProvisioningState = "Canceled"
+	// ProvisioningStateDeleting - Non-terminal state indicating the resource is deleting
+	ProvisioningStateDeleting ProvisioningState = "Deleting"
 	// ProvisioningStateFailed - Resource creation failed.
 	ProvisioningStateFailed ProvisioningState = "Failed"
+	// ProvisioningStateProvisioning - Non-terminal state indicating the resource is provisioning
+	ProvisioningStateProvisioning ProvisioningState = "Provisioning"
 	// ProvisioningStateSucceeded - Resource has been created.
 	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
+	// ProvisioningStateUpdating - Non-terminal state indicating the resource is updating
+	ProvisioningStateUpdating ProvisioningState = "Updating"
 )
 
 // PossibleProvisioningStateValues returns the possible values for the ProvisioningState const type.
 func PossibleProvisioningStateValues() []ProvisioningState {
 	return []ProvisioningState{	
+		ProvisioningStateAccepted,
 		ProvisioningStateCanceled,
+		ProvisioningStateDeleting,
 		ProvisioningStateFailed,
+		ProvisioningStateProvisioning,
 		ProvisioningStateSucceeded,
+		ProvisioningStateUpdating,
 	}
 }
 

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -482,7 +482,7 @@ type NodePoolProperties struct {
 	Spec *NodePoolSpec
 
 	// READ-ONLY; Provisioning state
-	ProvisioningState *ResourceProvisioningState
+	ProvisioningState *ProvisioningState
 }
 
 // NodePoolSpec - Worker node pool profile


### PR DESCRIPTION
* This allows for a nodepool to be represented with non-terminal states
* Also, update ProvisioningState to include specific non-terminal states

Now matches https://github.com/Azure/ARO-HCP/blob/a23f1e139cbd4121a59b1fba7b2c05b86ad8e0a7/internal/api/arm/resource.go#L96-L104