### PR TITLE
remove current user AKS cluster admin permissions from bicep

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -59,6 +59,12 @@ endif
 			currentUserId=$(CURRENTUSER) \
 			maestroInfraResourceGroup=$(MAESTRO_INFRA_RESOURCEGROUP)
 
+aks.admin-access: rg
+ifndef AKSCONFIG
+	$(error "Must set AKSCONFIG")
+endif
+	@scripts/aks-admin-access.sh $(RESOURCEGROUP)
+
 aks.kubeconfig:
 ifndef AKSCONFIG
 	$(error "Must set AKSCONFIG")

--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -44,6 +44,13 @@ There are a few variants to chose from when creating an AKS cluster:
    KUBECONFIG=aks.kubeconfig kubectl get ns
    ```
 
+1. Access cluter via the Azure portal or via `az aks command invoke`
+
+  ```bash
+  AKSCONFIG=svc-cluster make aks.admin-access  # one time
+  az aks command invoke ...
+  ```
+
 ## Creating your own "First Party Application"
 In order for a resource provider to interact with a customers tenant, we create a special type of Application + Service Principal called a First Party Application. This applications' service principal is then granted permissions over certain resources / resource groups within the customers tenant. In the dev tenant we do not need nor can create a First Party Application (they are tied to AME). Instead, we create a Third Party Application, and grant it permissions over our dev subscription so the RP can then interact and create the required resources.
 
@@ -336,5 +343,3 @@ To create a cluster in CS using a locally running Frontend, see the frontend [RE
 To tear down your CS setup:
 1) Kill the running clusters-service process
 2) Clean up the database `make db/teardown`
-
-

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -41,10 +41,6 @@ var aksClusterAdminRoleId = subscriptionResourceId(
   'Microsoft.Authorization/roleDefinitions/',
   '0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8'
 )
-var aksClusterRbacClusterAdminRoleId = subscriptionResourceId(
-  'Microsoft.Authorization/roleDefinitions/',
-  'b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b'
-)
 var networkContributorRoleId = subscriptionResourceId(
   'Microsoft.Authorization/roleDefinitions/',
   '4d97b98b-1d4f-4787-a291-c67834d212e7'
@@ -347,28 +343,6 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
         ]
       }
     }
-  }
-}
-
-// az aks command invoke --resource-group hcp-standalone-mshen --name aro-hcp-cluster-001 --command "kubectl get ns"
-resource currentUserAksClusterAdmin 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (length(currentUserId) > 0) {
-  scope: aksCluster
-  name: guid(location, aksClusterName, aksClusterAdminRoleId, currentUserId)
-  properties: {
-    roleDefinitionId: aksClusterAdminRoleId
-    principalId: currentUserId
-    principalType: 'User'
-  }
-}
-
-// az aks command invoke --resource-group hcp-standalone-mshen --name aro-hcp-cluster-001 --command "kubectl get ns"
-resource currentUserAksRbacClusterAdmin 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (length(currentUserId) > 0) {
-  scope: aksCluster
-  name: guid(location, aksClusterName, aksClusterRbacClusterAdminRoleId, currentUserId)
-  properties: {
-    roleDefinitionId: aksClusterRbacClusterAdminRoleId
-    principalId: currentUserId
-    principalType: 'User'
   }
 }
 

--- a/dev-infrastructure/scripts/aks-admin-access.sh
+++ b/dev-infrastructure/scripts/aks-admin-access.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+RESOURCEGROUP=$1
+CURRENTUSER_CLIENT_ID=$(az ad signed-in-user show | jq -r '.id')
+CLUSTER_ID=$(az aks list -g aro-hcp-svc-cluster-goberlec | jq -r .[0].id)
+
+az role assignment create --assignee $CURRENTUSER_CLIENT_ID --role "Azure Kubernetes Service Cluster Admin Role" --scope $CLUSTER_ID
+echo "It might take a couple of minutes for the permissions to take effect"


### PR DESCRIPTION
### What this PR does
**Before this PR:**
the AKS cluster admin permissions in the aks-cluster-base.bicep file are used during development only and are not required for anything beyond dev

**After this PR:**
granting access has been moved from "upfront during cluster provisioning" to "on-demand after cluster provisioning" and is now available via the `aks.admin-access` make target
