### PR TITLE
Add e2e test for /healthz/ready

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -19,7 +19,6 @@ import (
 	"github.com/google/uuid"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/Azure/ARO-HCP/frontend/pkg/database"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -73,84 +72,7 @@ func NewFrontend(logger *slog.Logger, listener net.Listener, emitter Emitter, db
 		region:   region,
 	}
 
-	subscriptionStateMuxValidator := NewSubscriptionStateMuxValidator(f.dbClient)
-
-	// Setup metrics middleware
-	metricsMiddleware := MetricsMiddleware{dbClient: dbClient, Emitter: emitter}
-
-	mux := NewMiddlewareMux(
-		MiddlewarePanic,
-		MiddlewareLogging,
-		MiddlewareBody,
-		MiddlewareLowercase,
-		MiddlewareSystemData,
-		MiddlewareValidateStatic,
-		metricsMiddleware.Metrics(),
-	)
-
-	// Unauthenticated routes
-	mux.HandleFunc("/", f.NotFound)
-	mux.HandleFunc(MuxPattern(http.MethodGet, "healthz", "ready"), f.HealthzReady)
-	// TODO: determine where in the auth chain we should allow for this endpoint to be called by ARM
-	mux.HandleFunc(MuxPattern(http.MethodGet, PatternSubscriptions), f.ArmSubscriptionGet)
-	mux.HandleFunc(MuxPattern(http.MethodPut, PatternSubscriptions), f.ArmSubscriptionPut)
-
-	// Expose Prometheus metrics endpoint
-	mux.Handle(MuxPattern(http.MethodGet, "metrics"), promhttp.Handler())
-
-	// Authenticated routes
-	postMuxMiddleware := NewMiddleware(
-		MiddlewareLoggingPostMux,
-		MiddlewareValidateAPIVersion,
-		subscriptionStateMuxValidator.MiddlewareValidateSubscriptionState)
-	mux.Handle(
-		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceListBySubscription))
-	mux.Handle(
-		MuxPattern(http.MethodGet, PatternSubscriptions, PatternLocations, PatternProviders),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceListByLocation))
-	mux.Handle(
-		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceListByResourceGroup))
-	mux.Handle(
-		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceRead))
-	mux.Handle(
-		MuxPattern(http.MethodPut, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceCreateOrUpdate))
-	mux.Handle(
-		MuxPattern(http.MethodPatch, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceCreateOrUpdate))
-	mux.Handle(
-		MuxPattern(http.MethodDelete, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceDelete))
-	mux.Handle(
-		MuxPattern(http.MethodPost, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName, PatternActionName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceAction))
-
-	// Nodepool Routes
-	mux.Handle(
-		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName, PatternNodepoolResource),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceRead))
-	mux.Handle(
-		MuxPattern(http.MethodPut, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName, PatternNodepoolResource),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceCreateOrUpdate))
-	mux.Handle(
-		MuxPattern(http.MethodPatch, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName, PatternNodepoolResource),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceCreateOrUpdate))
-	mux.Handle(
-		MuxPattern(http.MethodDelete, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName, PatternNodepoolResource),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceDelete))
-
-	// Exclude ARO-HCP API version validation for endpoints defined by ARM.
-	postMuxMiddleware = NewMiddleware(
-		MiddlewareLoggingPostMux,
-		subscriptionStateMuxValidator.MiddlewareValidateSubscriptionState)
-	mux.Handle(
-		MuxPattern(http.MethodPost, PatternSubscriptions, PatternResourceGroups, "providers", api.ProviderNamespace, PatternDeployments, "preflight"),
-		postMuxMiddleware.HandlerFunc(f.ArmDeploymentPreflight))
-
-	f.server.Handler = mux
+	f.server.Handler = f.routes()
 
 	return f
 }

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -1,0 +1,56 @@
+package frontend
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/ARO-HCP/frontend/pkg/database"
+)
+
+func TestReadiness(t *testing.T) {
+	tests := []struct {
+		name               string
+		ready              bool
+		expectedStatusCode int
+	}{
+		{
+			name:               "Not ready - returns 500",
+			ready:              false,
+			expectedStatusCode: http.StatusInternalServerError,
+		},
+		{
+			name:               "Ready - returns 200",
+			ready:              true,
+			expectedStatusCode: http.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := &Frontend{
+				dbClient: database.NewCache(),
+				logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+				metrics:  NewPrometheusEmitter(),
+			}
+			f.ready.Store(test.ready)
+			ts := httptest.NewServer(f.routes())
+			ts.Config.BaseContext = func(net.Listener) context.Context {
+				return ContextWithLogger(context.Background(), f.logger)
+			}
+
+			rs, err := ts.Client().Get(ts.URL + "/healthz/ready")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if rs.StatusCode != test.expectedStatusCode {
+				t.Errorf("expected status code %d, got %d", test.expectedStatusCode, rs.StatusCode)
+			}
+		})
+	}
+}

--- a/frontend/pkg/frontend/metrics.go
+++ b/frontend/pkg/frontend/metrics.go
@@ -24,12 +24,14 @@ type Emitter interface {
 type PrometheusEmitter struct {
 	gauges   map[string]*prometheus.GaugeVec
 	counters map[string]*prometheus.CounterVec
+	registry prometheus.Registerer
 }
 
 func NewPrometheusEmitter() *PrometheusEmitter {
 	return &PrometheusEmitter{
 		gauges:   make(map[string]*prometheus.GaugeVec),
 		counters: make(map[string]*prometheus.CounterVec),
+		registry: prometheus.NewRegistry(),
 	}
 }
 
@@ -38,7 +40,7 @@ func (pe *PrometheusEmitter) EmitGauge(name string, value float64, labels map[st
 	if !exists {
 		labelKeys := maps.Keys(labels)
 		vec = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: name}, labelKeys)
-		prometheus.MustRegister(vec)
+		pe.registry.MustRegister(vec)
 		pe.gauges[name] = vec
 	}
 	vec.With(labels).Set(value)

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -1,0 +1,76 @@
+package frontend
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+func (f *Frontend) routes() *MiddlewareMux {
+	subscriptionStateMuxValidator := NewSubscriptionStateMuxValidator(f.dbClient)
+
+	// Setup metrics middleware
+	metricsMiddleware := MetricsMiddleware{dbClient: f.dbClient, Emitter: f.metrics}
+
+	mux := NewMiddlewareMux(
+		MiddlewarePanic,
+		MiddlewareLogging,
+		MiddlewareBody,
+		MiddlewareLowercase,
+		MiddlewareSystemData,
+		MiddlewareValidateStatic,
+		metricsMiddleware.Metrics(),
+	)
+
+	// Unauthenticated routes
+	mux.HandleFunc("/", f.NotFound)
+	mux.HandleFunc(MuxPattern(http.MethodGet, "healthz", "ready"), f.HealthzReady)
+	// TODO: determine where in the auth chain we should allow for this endpoint to be called by ARM
+	mux.HandleFunc(MuxPattern(http.MethodGet, PatternSubscriptions), f.ArmSubscriptionGet)
+	mux.HandleFunc(MuxPattern(http.MethodPut, PatternSubscriptions), f.ArmSubscriptionPut)
+
+	// Expose Prometheus metrics endpoint
+	mux.Handle(MuxPattern(http.MethodGet, "metrics"), promhttp.Handler())
+
+	// Authenticated routes
+	postMuxMiddleware := NewMiddleware(
+		MiddlewareLoggingPostMux,
+		MiddlewareValidateAPIVersion,
+		subscriptionStateMuxValidator.MiddlewareValidateSubscriptionState)
+	mux.Handle(
+		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders),
+		postMuxMiddleware.HandlerFunc(f.ArmResourceListBySubscription))
+	mux.Handle(
+		MuxPattern(http.MethodGet, PatternSubscriptions, PatternLocations, PatternProviders),
+		postMuxMiddleware.HandlerFunc(f.ArmResourceListByLocation))
+	mux.Handle(
+		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders),
+		postMuxMiddleware.HandlerFunc(f.ArmResourceListByResourceGroup))
+	mux.Handle(
+		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName),
+		postMuxMiddleware.HandlerFunc(f.ArmResourceRead))
+	mux.Handle(
+		MuxPattern(http.MethodPut, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName),
+		postMuxMiddleware.HandlerFunc(f.ArmResourceCreateOrUpdate))
+	mux.Handle(
+		MuxPattern(http.MethodPatch, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName),
+		postMuxMiddleware.HandlerFunc(f.ArmResourceCreateOrUpdate))
+	mux.Handle(
+		MuxPattern(http.MethodDelete, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName),
+		postMuxMiddleware.HandlerFunc(f.ArmResourceDelete))
+	mux.Handle(
+		MuxPattern(http.MethodPost, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName, PatternActionName),
+		postMuxMiddleware.HandlerFunc(f.ArmResourceAction))
+
+	// Exclude ARO-HCP API version validation for endpoints defined by ARM.
+	postMuxMiddleware = NewMiddleware(
+		MiddlewareLoggingPostMux,
+		subscriptionStateMuxValidator.MiddlewareValidateSubscriptionState)
+	mux.Handle(
+		MuxPattern(http.MethodPost, PatternSubscriptions, PatternResourceGroups, "providers", api.ProviderNamespace, PatternDeployments, "preflight"),
+		postMuxMiddleware.HandlerFunc(f.ArmDeploymentPreflight))
+
+	return mux
+}


### PR DESCRIPTION
### What this PR does
* Initial "e2e" test for `/healthz/ready` - e2e in the sense that it goes through all the middleware.
* Shift our mux defintion out into a standalone method so it can be used in tests
* Uses a locally-scoped `prometheus.Registry` instead of the package-scoped one, which was causing conflicts when unit testing

Jira: [ARO-8287](https://issues.redhat.com/browse/ARO-8287)