### PR TITLE
rename diskSizeGB to diskSizeGiB

### DIFF
--- a/api/redhatopenshift/HcpCluster/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster/hcpCluster-models.tsp
@@ -566,9 +566,8 @@ model NodePoolPlatformProfile {
    * - https://learn.microsoft.com/en-us/azure/virtual-machines/sizes */
   vmSize: string;
 
-  /** The OS disk size in GB */
-  #suppress "@azure-tools/typespec-azure-core/casing-style" "The field needs to be indicate size in GB not in Gb"
-  diskSizeGB?: int32;
+  /** The OS disk size in GiB */
+  diskSizeGiB?: int32;
 
   /** The type of the disk storage account
    * - https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/openapi.json
@@ -1846,10 +1846,10 @@
           "type": "string",
           "description": "The VM size according to the documentation:\n- https://learn.microsoft.com/en-us/azure/virtual-machines/sizes"
         },
-        "diskSizeGB": {
+        "diskSizeGiB": {
           "type": "integer",
           "format": "int32",
-          "description": "The OS disk size in GB"
+          "description": "The OS disk size in GiB"
         },
         "diskStorageAccountType": {
           "type": "string",

--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.0.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
-	github.com/openshift-online/ocm-sdk-go v0.1.423
+	github.com/openshift-online/ocm-sdk-go v0.1.424
 	github.com/prometheus/client_golang v1.19.1
 	github.com/segmentio/ksuid v1.0.4
 	github.com/spf13/cobra v1.8.0

--- a/frontend/go.sum
+++ b/frontend/go.sum
@@ -107,8 +107,8 @@ github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY
 github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
 github.com/onsi/gomega v1.31.0 h1:54UJxxj6cPInHS3a35wm6BK/F9nHYueZ1NVujHDrnXE=
 github.com/onsi/gomega v1.31.0/go.mod h1:DW9aCi7U6Yi40wNVAvT6kzFnEVEI5n3DloYBiKiT6zk=
-github.com/openshift-online/ocm-sdk-go v0.1.423 h1:meCUWEX57n+s2hKwTz5LaZ5RFPT5fQJ7V6J1vgE53l4=
-github.com/openshift-online/ocm-sdk-go v0.1.423/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
+github.com/openshift-online/ocm-sdk-go v0.1.424 h1:fTNC0qs/s3IZWym3g7R4aS0YtyEkKuoasKvru18iKAs=
+github.com/openshift-online/ocm-sdk-go v0.1.424/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/openshift/api v0.0.0-20240429104249-ac9356ba1784 h1:SmOZFMxuAH4d1Cj7dOftVyo4Wg/mEC4pwz6QIJJsAkc=
 github.com/openshift/api v0.0.0-20240429104249-ac9356ba1784/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -210,11 +210,11 @@ func (f *Frontend) ConvertCStoNodepool(ctx context.Context, systemData *arm.Syst
 	}
 
 	// TODO: Ask OCM if we can get OSDiskSizeGibibytes to an int
-	diskSizeGB, err := strconv.Atoi(np.AzureNodePool().OSDiskSizeGibibytes())
+	diskSizeGiB, err := strconv.Atoi(np.AzureNodePool().OSDiskSizeGibibytes())
 	if err != nil {
 		return nil, fmt.Errorf("could not convert node pool OSDiskSizeGibibytes %s: %w", np.AzureNodePool().OSDiskSizeGibibytes(), err)
 	}
-	nodePool.Properties.Spec.Platform.DiskSizeGB = int32(diskSizeGB)
+	nodePool.Properties.Spec.Platform.DiskSizeGiB = int32(diskSizeGiB)
 
 	taints := make([]*api.Taint, len(np.Taints()))
 	for i, t := range np.Taints() {
@@ -234,7 +234,7 @@ func (f *Frontend) BuildCSNodepool(ctx context.Context, nodepool *api.HCPOpenShi
 		VMSize(nodepool.Properties.Spec.Platform.VMSize).
 		ResourceName(nodepool.Name).
 		EphemeralOSDiskEnabled(nodepool.Properties.Spec.Platform.EphemeralOSDisk).
-		OSDiskSizeGibibytes(strconv.Itoa(int(nodepool.Properties.Spec.Platform.DiskSizeGB))).
+		OSDiskSizeGibibytes(strconv.Itoa(int(nodepool.Properties.Spec.Platform.DiskSizeGiB))).
 		OSDiskStorageAccountType(nodepool.Properties.Spec.Platform.DiskStorageAccountType)
 
 	npBuilder := cmv1.NewNodePool().

--- a/go.work.sum
+++ b/go.work.sum
@@ -76,6 +76,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/openshift-online/ocm-sdk-go v0.1.424 h1:fTNC0qs/s3IZWym3g7R4aS0YtyEkKuoasKvru18iKAs=
+github.com/openshift-online/ocm-sdk-go v0.1.424/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgcC4zIxODThtZNPirFr42+A=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
@@ -112,8 +114,6 @@ golang.org/x/term v0.21.0/go.mod h1:ooXLefLobQVslOqselCNF4SxFAaoS6KujMbsGzSDmX0=
 golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
 golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 h1:BZqlfIlq5YbRMFko6/PM7FjZpUb45WallggurYhKGag=
 k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340/go.mod h1:yD4MZYeKMBwQKVht279WycxKyM84kkAx2DPrTXaeb98=

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -37,7 +37,7 @@ type NodePoolSpec struct {
 type NodePoolPlatformProfile struct {
 	SubnetID               string `json:"subnetId,omitempty"`
 	VMSize                 string `json:"vmSize,omitempty" validate:"required_for_put"`
-	DiskSizeGB             int32  `json:"diskSizeGB,omitempty"`
+	DiskSizeGiB            int32  `json:"diskSizeGiB,omitempty"`
 	DiskStorageAccountType string `json:"diskStorageAccountType,omitempty"`
 	AvailabilityZone       string `json:"availabilityZone,omitempty"`
 	EncryptionAtHost       bool   `json:"encryptionAtHost,omitempty"`

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -459,8 +459,8 @@ type NodePoolPlatformProfile struct {
 // * https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption
 	DiskEncryptionSetID *string
 
-	// The OS disk size in GB
-	DiskSizeGB *int32
+	// The OS disk size in GiB
+	DiskSizeGiB *int32
 
 	// The type of the disk storage account
 // * https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types

--- a/internal/api/v20240610preview/generated/models_serde.go
+++ b/internal/api/v20240610preview/generated/models_serde.go
@@ -1276,7 +1276,7 @@ func (n NodePoolPlatformProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "availabilityZone", n.AvailabilityZone)
 	populate(objectMap, "diskEncryptionSetId", n.DiskEncryptionSetID)
-	populate(objectMap, "diskSizeGB", n.DiskSizeGB)
+	populate(objectMap, "diskSizeGiB", n.DiskSizeGiB)
 	populate(objectMap, "diskStorageAccountType", n.DiskStorageAccountType)
 	populate(objectMap, "encryptionAtHost", n.EncryptionAtHost)
 	populate(objectMap, "ephemeralOsDisk", n.EphemeralOsDisk)
@@ -1300,8 +1300,8 @@ func (n *NodePoolPlatformProfile) UnmarshalJSON(data []byte) error {
 		case "diskEncryptionSetId":
 				err = unpopulate(val, "DiskEncryptionSetID", &n.DiskEncryptionSetID)
 			delete(rawMsg, key)
-		case "diskSizeGB":
-				err = unpopulate(val, "DiskSizeGB", &n.DiskSizeGB)
+		case "diskSizeGiB":
+				err = unpopulate(val, "DiskSizeGiB", &n.DiskSizeGiB)
 			delete(rawMsg, key)
 		case "diskStorageAccountType":
 				err = unpopulate(val, "DiskStorageAccountType", &n.DiskStorageAccountType)

--- a/internal/api/v20240610preview/nodepools_methods.go
+++ b/internal/api/v20240610preview/nodepools_methods.go
@@ -110,8 +110,8 @@ func normalizeNodePoolPlatform(p *generated.NodePoolPlatformProfile, out *api.No
 	if p.DiskEncryptionSetID != nil {
 		out.DiskEncryptionSetID = *p.DiskEncryptionSetID
 	}
-	if p.DiskSizeGB != nil {
-		out.DiskSizeGB = *p.DiskSizeGB
+	if p.DiskSizeGiB != nil {
+		out.DiskSizeGiB = *p.DiskSizeGiB
 	}
 	if p.DiskStorageAccountType != nil {
 		out.DiskStorageAccountType = *p.DiskStorageAccountType
@@ -146,7 +146,7 @@ func newNodePoolPlatformProfile(from *api.NodePoolPlatformProfile) *generated.No
 		VMSize:                 api.Ptr(from.VMSize),
 		AvailabilityZone:       api.Ptr(from.AvailabilityZone),
 		DiskEncryptionSetID:    api.Ptr(from.DiskEncryptionSetID),
-		DiskSizeGB:             api.Ptr(from.DiskSizeGB),
+		DiskSizeGiB:            api.Ptr(from.DiskSizeGiB),
 		DiskStorageAccountType: api.Ptr(from.DiskStorageAccountType),
 		EncryptionAtHost:       api.Ptr(from.EncryptionAtHost),
 		EphemeralOsDisk:        api.Ptr(from.EphemeralOSDisk),


### PR DESCRIPTION
### What this PR does
Azure disks are measured in GiB
https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types

This also aligns us with ocm-sdk-go https://github.com/openshift-online/ocm-sdk-go/blob/5991978bab9cd8093d06e3d83bc90c29322e11f1/clustersmgmt/v1/azure_node_pool_type.go#L27 and gets rid of a TODO from #201 

Jira: [ARO-7592](https://issues.redhat.com/browse/ARO-7592)