### PR TITLE
Remove invalid field anonymousPullEnabled

### DIFF
--- a/dev-infrastructure/templates/dev-acr.bicep
+++ b/dev-infrastructure/templates/dev-acr.bicep
@@ -23,7 +23,6 @@ resource acrResource 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
   }
   properties: {
     adminUserEnabled: false
-    anonymousPullEnabled: false
     // Premium-only feature
     // https://azure.microsoft.com/en-us/blog/azure-container-registry-mitigating-data-exfiltration-with-dedicated-data-endpoints/
     dataEndpointEnabled: false


### PR DESCRIPTION
### What this PR does
```
Warning BCP037: The property "anonymousPullEnabled" is not allowed on objects of type "RegistryProperties". Permissible properties include "networkRuleBypassOptions", "networkRuleSet", "policies", "publicNetworkAccess", "zoneRedundancy". If this is an inaccuracy in the documentation, please report it to the Bicep Team. [https://aka.ms/bicep-type-issues]
```

`anonymousPullEnabled` is an invalid field, taking it out