### PR TITLE
added user agent pool

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -7,6 +7,7 @@ param systemAgentMaxCount int = 3
 param systemAgentVMSize string = 'Standard_D2s_v3'
 
 // User agentpool spec (Worker)
+param deployUserAgentPool bool = false
 param userAgentMinCount int = 2
 param userAgentMaxCount int = 3
 param userAgentVMSize string = 'Standard_D2s_v3'
@@ -348,7 +349,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
 }
 
 // additional agent pool for user workload
-resource userPool 'Microsoft.ContainerService/managedClusters/agentPools@2024-03-02-preview' = {
+resource userPool 'Microsoft.ContainerService/managedClusters/agentPools@2024-02-01' = if (deployUserAgentPool) {
   name: 'user'
   parent: aksCluster
   properties: {

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -279,7 +279,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
         vmSize: systemAgentVMSize
         vnetSubnetID: aksNodeSubnet.id
         podSubnetID: aksPodSubnet.id
-        maxPods: 250
+        maxPods: 100
         availabilityZones: [
           '1'
           '2'

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -286,30 +286,6 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
           '3'
         ]
       }
-      {
-        name: 'user'
-        osType: 'Linux'
-        osSKU: 'AzureLinux'
-        mode: 'User'
-        orchestratorVersion: kubernetesVersion
-        enableAutoScaling: true
-        enableEncryptionAtHost: true
-        enableFIPS: true
-        osDiskType: 'Ephemeral'
-        osDiskSizeGB: userOsDiskSizeGB
-        count: userAgentMinCount
-        minCount: userAgentMinCount
-        maxCount: userAgentMaxCount
-        vmSize: userAgentVMSize
-        vnetSubnetID: aksNodeSubnet.id
-        podSubnetID: aksPodSubnet.id
-        maxPods: 250
-        availabilityZones: [
-          '1'
-          '2'
-          '3'
-        ]
-      }
     ]
     networkProfile: {
       networkDataplane: 'cilium'
@@ -368,6 +344,35 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
         ]
       }
     }
+  }
+}
+
+// additional agent pool for user workload
+resource userPool 'Microsoft.ContainerService/managedClusters/agentPools@2024-03-02-preview' = {
+  name: 'user'
+  parent: aksCluster
+  properties: {
+    osType: 'Linux'
+    osSKU: 'AzureLinux'
+    mode: 'User'
+    orchestratorVersion: kubernetesVersion
+    enableAutoScaling: true
+    enableEncryptionAtHost: true
+    enableFIPS: true
+    osDiskType: 'Ephemeral'
+    osDiskSizeGB: userOsDiskSizeGB
+    count: userAgentMinCount
+    minCount: userAgentMinCount
+    maxCount: userAgentMaxCount
+    vmSize: userAgentVMSize
+    vnetSubnetID: aksNodeSubnet.id
+    podSubnetID: aksPodSubnet.id
+    maxPods: 250
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
   }
 }
 

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -70,6 +70,7 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     clusterType: 'mgmt-cluster'
     workloadIdentities: workloadIdentities
     aksKeyVaultName: aksKeyVaultName
+    deployUserAgentPool: true
   }
 }
 

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -90,6 +90,7 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     clusterType: 'svc-cluster'
     workloadIdentities: workloadIdentities
     aksKeyVaultName: aksKeyVaultName
+    deployUserAgentPool: false
   }
 }
 var frontendMI = filter(svcCluster.outputs.userAssignedIdentities, id => id.uamiName == 'frontend')[0]


### PR DESCRIPTION
### What this PR does

Included additional agentpool for application pods, these userpools are meant for application(HCP) pods and existing system pools are for hosting system critical pods only.  we can treat the system pools as Infra nodes in Openshift cluster.

This PR adds an additional agentpool to the cluster.

### Special notes for your reviewer
As recommended in [this](https://learn.microsoft.com/en-us/azure/aks/use-system-pools?tabs=azure-cli#system-and-user-node-pools) doc, system agent should be present as it has its benefits to host system critical pods.

They run operator pods on system pools,  ex - on installing and configuring Azure Managed Prometheus to collect metrics, `ama-metrics-operator-targets-6878d6665d-lb6rv` runs on system pool and leave the userpool for user application.

