### PR TITLE
Aro 8285 deploy frontend kustomize

### DIFF
--- a/.github/workflows/build-deploy-frontend.yml
+++ b/.github/workflows/build-deploy-frontend.yml
@@ -94,7 +94,9 @@ jobs:
           cluster-name: ${{ steps.find_service_cluster.outputs.name }}
           use-kubelogin: 'true'
 
-      - name: Deploy Frontend
+      - name: 'Deploy Frontend'
+        env:
+          RESOURCEGROUP: aro-hcp-dev
         run: |
           cd frontend/
           make kustomize-deploy

--- a/.github/workflows/build-deploy-frontend.yml
+++ b/.github/workflows/build-deploy-frontend.yml
@@ -94,6 +94,7 @@ jobs:
           cluster-name: ${{ steps.find_service_cluster.outputs.name }}
           use-kubelogin: 'true'
 
-      - name: List namespaces
+      - name: Deploy Frontend
         run: |
-          kubectl get namespaces
+          cd frontend/
+          make kustomize-deploy

--- a/.github/workflows/build-dev-infra.yml
+++ b/.github/workflows/build-dev-infra.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  when_merged:
+  deploy_update_infra:
     if: github.event.pull_request.merged == true
     permissions:
       id-token: 'write'

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -33,7 +33,6 @@ push: image
 
 
 kustomize-update:
-	@test "${RESOURCEGROUP}" != "" || (echo "RESOURCEGROUP must be defined" && exit 1)
 	pushd deploy/overlays/dev;\
 	FRONTEND_MI_CLIENT_ID=$(shell az deployment group show \
 			-g ${RESOURCEGROUP} \


### PR DESCRIPTION
### What this PR does
* updates `build-deploy-frontend` to deploy frontend to cluster now that we know RBAC is working
* renames the infra deploy/update job name to make more sense
* removes test portion of kustomize make target, since we are explicitly setting RESOURCEGROUP, and there is already a default value for local testing

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
