### PR TITLE
updates kustomize deployment for DB use and client id fetch

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -34,10 +34,10 @@ push: image
 
 kustomize-update:
 	pushd deploy/overlays/dev;\
-	FRONTEND_MI_CLIENT_ID=$(shell az deployment group show \
+	FRONTEND_MI_CLIENT_ID=$(shell az identity show \
 			-g ${RESOURCEGROUP} \
-			-n ${DEPLOYMENTNAME} \
-			--query properties.outputs.frontend_mi_client_id.value);\
+			-n frontend-${REGION} \
+			--query clientId);\
 	DB_NAME=$(shell az cosmosdb list -g ${RESOURCEGROUP} | jq -r '.[].name') DB_NAME=$${DB_NAME:-"none"};\
 	kustomize edit set configmap frontend-config \
 		--from-literal=DB_NAME="$${DB_NAME}" \

--- a/frontend/deploy/base/deployment.yml
+++ b/frontend/deploy/base/deployment.yml
@@ -27,10 +27,7 @@ spec:
         - name: aro-hcp-frontend
           image: IMAGE_NAME
           imagePullPolicy: Always
-          args: [
-            "--use-cache",
-            "--clusters-service-url", "http://localhost:8000"
-          ]
+          args: ["--clusters-service-url", "http://localhost:8000"]
           env:
           - name: DB_NAME
             valueFrom:


### PR DESCRIPTION
### What this PR does
* fetching the managed identity client ID fails because of an expected deployment name. Changed how the client id is fetched to be agnostic to any deployments
* updated the deployment.yml to use cosmos DB instead of cache, which will get its config from env vars in configmap


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
