### PR TITLE
unique names for maestro consumer deployment names

### DIFF
--- a/dev-infrastructure/modules/aks-csi-secret-store.bicep
+++ b/dev-infrastructure/modules/aks-csi-secret-store.bicep
@@ -45,7 +45,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' exis
 }
 
 module maestroCSISecretStoreConfig '../modules/aks-manifest.bicep' = {
-  name: '${deployment().name}-${csiSecProviderClassName}-aks-manifest'
+  name: '${deployment().name}-${csiSecProviderClassName}-manifest'
   params: {
     aksClusterName: aksClusterName
     manifests: [

--- a/dev-infrastructure/modules/maestro/maestro-consumer.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-consumer.bicep
@@ -76,7 +76,7 @@ module maestroConfigMap '../aks-manifest.bicep' = {
 // access certificates stored in KeyVault
 
 module maestroCSISecretStoreConfig '../aks-csi-secret-store.bicep' = {
-  name: '${deployment().name}-csi-secret-store-manifest'
+  name: '${deployment().name}-csi-secret-store'
   params: {
     aksClusterName: aksClusterName
     clientId: maestroServerManagedIdentityClientId

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -78,7 +78,7 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
 //
 
 module maestroConsumer '../modules/maestro/maestro-consumer.bicep' = if (deployMaestroConsumer && maestroInfraResourceGroup != '') {
-  name: 'maestro-consumer'
+  name: 'maestro-consumer-${uniqueString(resourceGroup().name)}'
   scope: resourceGroup()
   params: {
     aksClusterName: mgmtCluster.outputs.aksClusterName


### PR DESCRIPTION
### What this PR does

the bicep deployment names for maestro consumer mqtt access management are now unique so multiple deployments can run at the same time in the RG of the maestro infrastructure.

### Special notes for your reviewer

<!-- optional -->
