### PR TITLE
adds cosmos role to gh principal for smoke test cleanup

### DIFF
--- a/.github/workflows/build-dev-infra.yml
+++ b/.github/workflows/build-dev-infra.yml
@@ -63,6 +63,7 @@ jobs:
               --parameters persist="true"
 
             SVC_CLUSTER_NAME=$(az deployment group show --resource-group "${RESOURCEGROUP}" --name "svc-cluster-${GITHUB_RUN_ID}" --output tsv --query properties.outputs.aksClusterName.value)
+            COSMOS_DB_NAME=$(az deployment group show --resource-group "${RESOURCEGROUP}" --name "svc-cluster-${GITHUB_RUN_ID}" --output tsv --query properties.outputs.cosmosDBName.value)
 
             # service cluster rolebindings
             az deployment group create \
@@ -70,4 +71,5 @@ jobs:
               --resource-group "${RESOURCEGROUP}" \
               --template-file templates/dev-aks-roleassignments.bicep \
               --parameters aksClusterName=${SVC_CLUSTER_NAME} \
+              --parameters cosmosDBName=$(COSMOS_DB_NAME)
               --parameters githubActionsPrincipalID=${{ secrets.GHA_PRINCIPAL_ID }}

--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -187,3 +187,5 @@ resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignm
     scope: cosmosDbAccount.id
   }
 }
+
+output cosmosDBName string = name


### PR DESCRIPTION
### What this PR does
* updates necessary bicep configs to grant GH access to cosmos in order to clean up test documents as part of smoke tests
  * note the role definition uses a built-in role since it needs read/write but has more permissions than it needs
  * we can create a more granular role if needed but i believe custom roles are limted?


Jira: ARO-8287
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer
Im guessing we don't have a great way to test the role assignments bicep right now since they rely on values that we pull from the deployment. Possibly in near future we add them as GH variables since DEV objects should be static names? 

<!-- optional -->
