### PR TITLE
Update GitHub Action to use typespec/compiler v0.57.0 like devcontainer

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: 'v20.12.0'
 
       - name: Install tsp
-        run: npm install -g @typespec/compiler@0.55.0
+        run: npm install -g @typespec/compiler@0.57.0
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
### What this PR does
Aligns with what we install in our devcontainer: https://github.com/Azure/ARO-HCP/blob/3704f6ff98dfc5daa78e30a196f26e095f799a2c/.devcontainer/postCreate.sh#L17-L19
