### PR TITLE
Remove AFEC permissions on mock 1p service role definition

### DIFF
--- a/dev-infrastructure/scripts/mock-dev-role-definition.json
+++ b/dev-infrastructure/scripts/mock-dev-role-definition.json
@@ -3,8 +3,6 @@
     "Actions": [
         "Microsoft.Resources/subscriptions/resourceGroups/read",
         "Microsoft.Resources/subscriptions/resourceGroups/write",
-        "Microsoft.Features/features/read",
-        "Microsoft.Features/providers/features/read",
         "Microsoft.Authorization/*/action"
     ]
 }


### PR DESCRIPTION
We recently removed permissions over the 1p service role definition because they were unused.  

This PR removes them from our mock 1p service role definition.

```bash
$ az provider permission list --namespace Microsoft.RedHatOpenShift
{
  "nextLink": null,
  "value": [
    {
      "applicationId": "f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875",
      "managedByRoleDefinition": {
        "id": "9e3af657a8ff583ca75c2fe7c4bcb635",
        "idAsGuid": "9e3af657-a8ff-583c-a75c-2fe7c4bcb635",
        "isServiceRole": true,
        "name": "Service Owner role",
        "permissions": [
          {
            "actions": [
              "*"
            ],
            "dataActions": [],
            "notActions": [],
            "notDataActions": []
          }
        ],
        "scopes": [
          "/"
        ]
      },
      "providerAuthorizationConsentState": null,
      "roleDefinition": {
        "id": "640c5ac96f32489194f4d20f7aa9a7e6",
        "idAsGuid": "640c5ac9-6f32-4891-94f4-d20f7aa9a7e6",
        "isServiceRole": true,
        "name": "AzureRedHatOpenShiftRP Service Role",
        "permissions": [
          {
            "actions": [
              "Microsoft.Authorization/denyAssignments/read",
              "Microsoft.Authorization/denyAssignments/write",
              "Microsoft.Authorization/denyAssignments/delete",
              "Microsoft.Resources/subscriptions/resourceGroups/write",
              "Microsoft.Resources/subscriptions/resourceGroups/read",
              "Microsoft.Authorization/checkAccess/action",
              "Microsoft.Authorization/checkAccess/read"
            ],
            "dataActions": [],
            "notActions": [],
            "notDataActions": []
          }
        ],
        "scopes": [
          "/"
        ]
      }
    }
  ]
}
