### PR TITLE
configurable name for AKS nodepool resource group

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -1,5 +1,6 @@
 // Constants
 param aksClusterName string = take('aro-hcp-${clusterType}-${uniqueString(clusterType)}', 63)
+param aksNodeResourceGroupName string
 
 // System agentpool spec(Infra)
 param systemAgentMinCount int = 2
@@ -245,7 +246,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
       managed: true
       enableAzureRBAC: true
     }
-    nodeResourceGroup: '${resourceGroup().name}-aks1'
+    nodeResourceGroup: aksNodeResourceGroupName
     apiServerAccessProfile: {
       enablePrivateCluster: enablePrivateCluster
     }

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -7,6 +7,9 @@ param persist bool = false
 @description('Captures logged in users UID')
 param currentUserId string
 
+@description('Name of the resource group for the AKS nodes')
+param aksNodeResourceGroupName string = '${resourceGroup().name}-aks1'
+
 @description('VNET address prefix')
 param vnetAddressPrefix string
 
@@ -61,6 +64,7 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     location: location
     persist: persist
     currentUserId: currentUserId
+    aksNodeResourceGroupName: aksNodeResourceGroupName
     enablePrivateCluster: enablePrivateCluster
     istioVersion: istioVersion
     kubernetesVersion: kubernetesVersion

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -7,6 +7,9 @@ param persist bool = false
 @description('Captures logged in users UID')
 param currentUserId string
 
+@description('Name of the resource group for the AKS nodes')
+param aksNodeResourceGroupName string = '${resourceGroup().name}-aks1'
+
 @description('VNET address prefix')
 param vnetAddressPrefix string
 
@@ -80,6 +83,7 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
   params: {
     location: location
     persist: persist
+    aksNodeResourceGroupName: aksNodeResourceGroupName
     currentUserId: currentUserId
     enablePrivateCluster: enablePrivateCluster
     kubernetesVersion: kubernetesVersion


### PR DESCRIPTION
### What this PR does

the resource group name for the AKS node pools is now configurable via the `aksNodeResourceGroupName` parameter. if unspecified, it defaults to `${aks_rg_name}-aks1` as before.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

cc @whober0521 @jonathan34c 

<!-- optional -->
