### PR TITLE
bump cluster-service image and provide mock provisioning shard

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -4,10 +4,11 @@ deploy:
 	oc process --local -f deploy/openshift-templates/arohcp-namespace-template.yml \
 	  -p ISTIO_VERSION=asm-1-20 | oc apply -f -
 	oc process --local -f deploy/openshift-templates/arohcp-db-template.yml | oc apply -f -
-	oc process --local -f deploy/openshift-templates/arohcp-secrets-template.yml | oc apply -f -
+	oc process --local -f deploy/openshift-templates/arohcp-secrets-template.yml \
+	  -p PROVISION_SHARDS_CONFIG="cHJvdmlzaW9uX3NoYXJkczoKLSBpZDogMQogIGh5cGVyc2hpZnRfY29uZmlnOiB8CiAgICBhcGlWZXJzaW9uOiB2MQogICAga2luZDogQ29uZmlnCiAgICBjbHVzdGVyczoKICAgIC0gbmFtZTogZGVmYXVsdAogICAgICBjbHVzdGVyOgogICAgICAgIHNlcnZlcjogaHR0cDovL2xvY2FsaG9zdAogICAgdXNlcnM6CiAgICAtIG5hbWU6IGRlZmF1bHQKICAgICAgdXNlcjoKICAgICAgICB0b2tlbjogZm9vCiAgICBjb250ZXh0czoKICAgIC0gbmFtZTogZGVmYXVsdAogICAgICBjb250ZXh0OgogICAgICAgIGNsdXN0ZXI6IGRlZmF1bHQKICAgICAgICB1c2VyOiBkZWZhdWx0CiAgICBjdXJyZW50LWNvbnRleHQ6IGRlZmF1bHQKICBzdGF0dXM6IGFjdGl2ZQogIHJlZ2lvbjogZWFzdHVzCiAgY2xvdWRfcHJvdmlkZXI6IGF6dXJlCiAgdG9wb2xvZ3k6IGRlZGljYXRlZAo=" | oc apply -f -
 	oc process --local -f deploy/openshift-templates/arohcp-service-template.yml \
 	  -p IMAGE_REGISTRY=devarohcp.azurecr.io \
-	  -p IMAGE_REPOSITORY=uhc-clusters-service \
-	  -p IMAGE_TAG=1718894633 | oc apply -f -
+	  -p IMAGE_REPOSITORY=cluster-service/uhc-clusters-service \
+	  -p IMAGE_TAG=1719430575 | oc apply -f -
 
 .PHONY: deploy

--- a/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
+++ b/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
@@ -82,7 +82,7 @@ parameters:
 
 - name: GATEWAY_URL
   description: URL of the gateway.
-  value: "http://localhost"
+  value: "http://127.0.0.1:9090"
 
 - name: CLIENT_SCOPES
   description: Level of access that an app can request to a resource
@@ -91,10 +91,6 @@ parameters:
 - name: ENVIRONMENT
   description: Environment associated with this instance.
   value: "aro-hcp-dev"
-
-- name: FEDRAMP
-  description: Whether this environment runs in FedRAMP mode.
-  value: "true"
 
 - name: BACKPLANE_URL
   description: |-
@@ -482,7 +478,6 @@ objects:
           - --healthcheck-listener-network=tcp
           - --healthcheck-listener-address=:8083
           - --environment=${ENVIRONMENT}
-          - --fedramp=${FEDRAMP}
           - --backplane-url=${BACKPLANE_URL}
           - --provision-shards-config=/secrets/shards/config
           - --install-config-file=/configs/service/install-config.yaml


### PR DESCRIPTION
### What this PR does

CS requires at least one provisioning shard to start up correctly this PR provides such a mock provisioning shard. once the MCP MC is ready to act as a provisining shard, we can update this

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
