### PR TITLE
determine maestro region from resource group

### DIFF
--- a/maestro/Makefile
+++ b/maestro/Makefile
@@ -1,7 +1,7 @@
 SHELL = /bin/bash
 
 RESOURCEGROUP ?= aro-hcp-${AKSCONFIG}-$(USER)
-REGION ?= eastus
+REGION ?= $(shell az group show -n ${RESOURCEGROUP} --query location)
 
 deploy-server:
 	MAESTRO_MI_CLIENT_ID=$(shell az identity show \


### PR DESCRIPTION
### What this PR does
Currently, maestro is failing to deploy because
```
Message: The Resource 'Microsoft.ManagedIdentity/userAssignedIdentities/maestro-server-eastus' under resource group 'aro-hcp-dev' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix
```
Because we recently changed the region to westus3 in #274