### PR TITLE
AKS cluster name parameter

### DIFF
--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -6,6 +6,7 @@ param vnetAddressPrefix = '10.132.0.0/14'
 param subnetPrefix = '10.132.8.0/21'
 param podSubnetPrefix = '10.132.64.0/18'
 param enablePrivateCluster = false
+param aksClusterName = 'aro-hcp-mgmt-cluster'
 param aksKeyVaultName = take('aks-kv-mgmt-cluster-${uniqueString(currentUserId)}', 24)
 param persist = false
 param deployMaestroConsumer = false

--- a/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
@@ -6,6 +6,7 @@ param vnetAddressPrefix = '10.132.0.0/14'
 param subnetPrefix = '10.132.8.0/21'
 param podSubnetPrefix = '10.132.64.0/18'
 param enablePrivateCluster = false
+param aksClusterName = take('aro-hcp-mgmt-cluster-${uniqueString('mgmt-cluster')}', 63)
 param aksKeyVaultName = 'aks-kv-aro-hcp-dev-mc-1'
 param persist = true
 param deployMaestroConsumer = true

--- a/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
@@ -7,6 +7,7 @@ param subnetPrefix = '10.128.8.0/21'
 param podSubnetPrefix = '10.128.64.0/18'
 param enablePrivateCluster = false
 param persist = true
+param aksClusterName = take('aro-hcp-svc-cluster-${uniqueString('svc-cluster')}', 63)
 param aksKeyVaultName = 'aks-kv-aro-hcp-dev-sc'
 param disableLocalAuth = false
 param deployFrontendCosmos = true

--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -7,6 +7,7 @@ param subnetPrefix = '10.128.8.0/21'
 param podSubnetPrefix = '10.128.64.0/18'
 param enablePrivateCluster = false
 param persist = false
+param aksClusterName = 'aro-hcp-svc-cluster'
 param aksKeyVaultName = take('aks-kv-svc-cluster-${uniqueString(currentUserId)}', 24)
 param disableLocalAuth = false
 param deployFrontendCosmos = false

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -1,5 +1,5 @@
 // Constants
-param aksClusterName string = take('aro-hcp-${clusterType}-${uniqueString(clusterType)}', 63)
+param aksClusterName string
 param aksNodeResourceGroupName string
 
 // System agentpool spec(Infra)

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -7,6 +7,9 @@ param persist bool = false
 @description('Captures logged in users UID')
 param currentUserId string
 
+@description('AKS cluster name')
+param aksClusterName string
+
 @description('Name of the resource group for the AKS nodes')
 param aksNodeResourceGroupName string = '${resourceGroup().name}-aks1'
 
@@ -64,6 +67,7 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     location: location
     persist: persist
     currentUserId: currentUserId
+    aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName
     enablePrivateCluster: enablePrivateCluster
     istioVersion: istioVersion

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -7,6 +7,9 @@ param persist bool = false
 @description('Captures logged in users UID')
 param currentUserId string
 
+@description('AKS cluster name')
+param aksClusterName string
+
 @description('Name of the resource group for the AKS nodes')
 param aksNodeResourceGroupName string = '${resourceGroup().name}-aks1'
 
@@ -83,6 +86,7 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
   params: {
     location: location
     persist: persist
+    aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName
     currentUserId: currentUserId
     enablePrivateCluster: enablePrivateCluster


### PR DESCRIPTION
### What this PR does

the new mandatory paramter `aksClusterName` can be used to define the name of the AKS cluster to be created. works on both SC and MC templates.

our bicepparam files for MVP keep backwards compatibility for now so the names of existing clusters don't change.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
