### PR TITLE
updates to agent pool settings to fix bicep idempotency bug

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -273,12 +273,17 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
         enableAutoScaling: true
         enableEncryptionAtHost: true
         enableFIPS: true
+        kubeletDiskType: 'OS'
         osDiskType: 'Ephemeral'
         osDiskSizeGB: systemOsDiskSizeGB
         count: systemAgentMinCount
         minCount: systemAgentMinCount
         maxCount: systemAgentMaxCount
         vmSize: systemAgentVMSize
+        type: 'VirtualMachineScaleSets'
+        upgradeSettings: {
+          maxSurge: '10%'
+        }
         vnetSubnetID: aksNodeSubnet.id
         podSubnetID: aksPodSubnet.id
         maxPods: 100
@@ -354,6 +359,7 @@ resource userPool 'Microsoft.ContainerService/managedClusters/agentPools@2024-02
   name: 'user'
   parent: aksCluster
   properties: {
+
     osType: 'Linux'
     osSKU: 'AzureLinux'
     mode: 'User'
@@ -361,12 +367,17 @@ resource userPool 'Microsoft.ContainerService/managedClusters/agentPools@2024-02
     enableAutoScaling: true
     enableEncryptionAtHost: true
     enableFIPS: true
+    kubeletDiskType: 'OS'
     osDiskType: 'Ephemeral'
     osDiskSizeGB: userOsDiskSizeGB
     count: userAgentMinCount
     minCount: userAgentMinCount
     maxCount: userAgentMaxCount
     vmSize: userAgentVMSize
+    type: 'VirtualMachineScaleSets'
+    upgradeSettings: {
+      maxSurge: '10%'
+    }
     vnetSubnetID: aksNodeSubnet.id
     podSubnetID: aksPodSubnet.id
     maxPods: 250


### PR DESCRIPTION
### What this PR does
* bicep apply is failing because:
"AgentPool 'user' has set auto scaling as enabled but is not on Virtual Machine Scale Sets

Although we are using VMSS, possibly because its not explicitly set there is a bug that is causing it to freak out and thinks it should change (based on bicep-what-if)

```
~ properties.agentPoolProfiles: [
      ~ 0:

        - kubeletDiskType: "OS"
        - powerState:

            code: "Running"

        - type:            "VirtualMachineScaleSets"  <--- notice the '-' symbol meaning removal
```

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
