### PR TITLE
updates some values to ensure local testing works

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -15,7 +15,7 @@ frontend:
 	go build -o aro-hcp-frontend .
 
 run:
-	./aro-hcp-frontend --use-cache --region ${REGION} --clusters-service-url http://localhost:8000
+	./aro-hcp-frontend --use-cache --region eastus --clusters-service-url http://localhost:8000
 
 clean:
 	rm -f aro-hcp-frontend

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -82,19 +82,19 @@ curl -X GET "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/p
 
 Get a HcpOpenShiftClusterResource
 ```bash
-curl -X GET "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dev-test-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/YOUR_CLUSTER_NAME?api-version=2024-06-10-preview"
+curl -X GET "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dev-test-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/dev-test-cluster?api-version=2024-06-10-preview"
 ```
 
 Create or Update a HcpOpenShiftClusterResource
 ```bash
-curl -X PUT "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dev-test-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/YOUR_CLUSTER_NAME?api-version=2024-06-10-preview" \
+curl -X PUT "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dev-test-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/dev-test-cluster?api-version=2024-06-10-preview" \
   -H "X-Ms-Arm-Resource-System-Data: {\"createdBy\": \"aro-hcp-local-testing\", \"createdByType\": \"User\", \"createdAt\": \"2024-06-06T19:26:56+00:00\"}" \
   --json @cluster.json
 ```
 
 Delete a HcpOpenShiftClusterResource
 ```bash
-curl -X DELETE "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dev-test-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/YOUR_CLUSTER_NAME?api-version=2024-06-10-preview"
+curl -X DELETE "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dev-test-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/dev-test-cluster?api-version=2024-06-10-preview"
 ```
 
 Execute deployment preflight checks


### PR DESCRIPTION
### What this PR does
* the updated REGION global variable doesnt work great with local testing, so `run` target is now hardcoded for eastus to local testing since all other configs/setup is using that region
* updates RP calls to set a valid cluster name (`YOUR_CLUSTER_NAME` throws errors)


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
