### PR TITLE
Define frontend namespace in kustomize manifests

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -9,7 +9,6 @@ RESOURCEGROUP ?= aro-hcp-${AKSCONFIG}-$(USER)
 CLUSTER_NAME ?=
 DEPLOYMENTNAME=$(RESOURCEGROUP)
 REGION ?= $(shell az group show -n ${RESOURCEGROUP} --query location)
-NAMESPACE ?= aro-hcp
 
 frontend:
 	go build -o aro-hcp-frontend .
@@ -32,7 +31,6 @@ endif
 push: image
 	docker push ${ARO_HCP_FRONTEND_IMAGE}
 
-
 kustomize-update:
 	pushd deploy/overlays/dev;\
 	FRONTEND_MI_CLIENT_ID=$(shell az identity show \
@@ -47,27 +45,11 @@ kustomize-update:
 		--from-literal=CURRENT_VERSION=${ARO_HCP_FRONTEND_IMAGE} \
 		--from-literal=REGION="${REGION}"
 
-kustomize-update-gha:
-	pushd deploy/overlays/dev;\
-	FRONTEND_MI_CLIENT_ID=$(shell az identity show \
-			-g ${RESOURCEGROUP} \
-			-n frontend-${REGION} \
-			--query clientId);\
-	kustomize edit set configmap frontend-config \
-		--from-literal=DB_NAME="${DB_NAME}" \
-		--from-literal=DB_URL="${DB_URL}" \
-		--from-literal=FRONTEND_MI_CLIENT_ID="$${FRONTEND_MI_CLIENT_ID}" \
-		--from-literal=CURRENT_VERSION=${ARO_HCP_FRONTEND_IMAGE} \
-		--from-literal=REGION="${REGION}"
-
 kustomize-deploy:
-	CHECK=$(shell kubectl get ns -o name ${NAMESPACE} 2>/dev/null);\
-	if [[ -z "$${CHECK}" ]]; then kubectl create ns ${NAMESPACE}; fi
-	kubectl apply -n ${NAMESPACE} -k deploy/overlays/dev
+	kubectl apply -k deploy/overlays/dev
 
 kustomize-undeploy:
-	kubectl delete -n ${NAMESPACE} -k deploy/overlays/dev && \
-	kubectl delete ns ${NAMESPACE}
+	kubectl delete -k deploy/overlays/dev
 
 deploy:
 	FRONTEND_MI_CLIENT_ID=$(shell az deployment group show \

--- a/frontend/deploy/overlays/dev/kustomization.yml
+++ b/frontend/deploy/overlays/dev/kustomization.yml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+- namespace.yml
+namespace: aro-hcp
 configMapGenerator:
 - behavior: create
   literals:

--- a/frontend/deploy/overlays/dev/namespace.yml
+++ b/frontend/deploy/overlays/dev/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aro-hcp


### PR DESCRIPTION
### What this PR does
Makes our kustomize template declarative for the namespace as well. For now, it's not so different, but in the future we may need to label our namespace, which this will enable: https://learn.microsoft.com/en-us/azure/aks/istio-deploy-addon#enable-sidecar-injection

You can view the result of this template with:
```bash
kubectl kustomize frontend/deploy/overlays/dev
```