### PR TITLE
postgres database for maestro

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -72,6 +72,12 @@ ifndef AKSCONFIG
 endif
 	@scripts/current-user-pg-access.sh $(RESOURCEGROUP) "cs-"
 
+maestro-out-of-cluster-db-access: rg
+ifndef AKSCONFIG
+	$(error "Must set AKSCONFIG")
+endif
+	@scripts/current-user-pg-access.sh $(RESOURCEGROUP) "maestro-"
+
 aks.kubeconfig:
 ifndef AKSCONFIG
 	$(error "Must set AKSCONFIG")

--- a/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
@@ -11,12 +11,17 @@ param aksClusterName = take('aro-hcp-svc-cluster-${uniqueString('svc-cluster')}'
 param aksKeyVaultName = 'aks-kv-aro-hcp-dev-sc'
 param disableLocalAuth = false
 param deployFrontendCosmos = true
+
 param deployMaestroInfra = true
 param maestroNamespace = 'maestro'
 param maestroKeyVaultName = 'maestro-kv-aro-hcp-dev'
 param maestroEventGridNamespacesName = 'maestro-eventgrid-aro-hcp-dev'
 param maestroCertDomain = 'selfsigned.maestro.keyvault.aro-dev.azure.com'
 param maxClientSessionsPerAuthName = 2
+param maestroPostgresServerName = 'maestro-pg-aro-hcp-dev'
+param maestroPostgresServerVersion = '15'
+param maestroPostgresServerStorageSizeGB = 32
+
 param deployCsInfra = false
 param csNamespace = 'cluster-service'
 param csPostgresServerName = 'cs-pg-aro-hcp-dev'

--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -11,12 +11,17 @@ param aksClusterName = 'aro-hcp-svc-cluster'
 param aksKeyVaultName = take('aks-kv-svc-cluster-${uniqueString(currentUserId)}', 24)
 param disableLocalAuth = false
 param deployFrontendCosmos = false
+
 param deployMaestroInfra = false
 param maestroNamespace = 'maestro'
 param maestroKeyVaultName = take('maestro-kv-${uniqueString(currentUserId)}', 24)
 param maestroEventGridNamespacesName = '${maestroInfraResourceGroup}-eventgrid'
 param maestroCertDomain = 'selfsigned.maestro.keyvault.aro-int.azure.com'
 param maxClientSessionsPerAuthName = 2
+param maestroPostgresServerName = take('maestro-pg-${uniqueString(currentUserId)}', 60)
+param maestroPostgresServerVersion = '15'
+param maestroPostgresServerStorageSizeGB = 32
+
 param deployCsInfra = false
 param csNamespace = 'cluster-service'
 param csPostgresServerName = take('cs-pg-${uniqueString(currentUserId)}', 60)

--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -128,6 +128,17 @@ KUBECONFIG=svc-cluster.kubeconfig kubectl port-forward svc/maestro 8000 -n maest
 
 At this point `localhost:8000` forwards traffic to the Maestro server running on the SC.
 
+### Access the database from outside of the AKS cluster
+
+The connection parameters for the database can be aquired via `AKSCONFIG=svc-cluster make maestro-out-of-cluster-db-access`.
+
+The output are in ENV var format for the `psql` tool, so this works to get a connection into the DB#
+
+```sh
+eval $(AKSCONFIG=svc-cluster make maestro-out-of-cluster-db-access)
+psql -d maestro
+```
+
 ## Maestro consumer
 
 Before setting up a Maestro consumer, make sure that

--- a/dev-infrastructure/modules/maestro/maestro-infra.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-infra.bicep
@@ -35,6 +35,101 @@ param maestroKeyVaultName string
 @description('The name for the Managed Identity that will be created for Key Vault Certificate management.')
 param kvCertOfficerManagedIdentityName string
 
+@description('The name of the Postgres server for Maestro')
+param postgresServerName string
+
+@description('The version of the Postgres server for Maestro')
+param postgresServerVersion string
+
+@description('The size of the Postgres server storage for Maestro')
+@allowed([
+  32
+  64
+  128
+  256
+  512
+  1024
+  2048
+  4096
+  8192
+  16384
+  32768
+])
+param postgresServerStorageSizeGB int
+
+@description('The name of the database to create for Maestro')
+param maestroDatabaseName string = 'maestro'
+
+@description('The name of the Managed Identity for the Maestro cluster service')
+param maestroServerManagedIdentityName string
+
+@description('The principal ID of the Managed Identity for the Maestro cluster service')
+param maestroServerManagedIdentityPrincipalId string
+
+//
+//   P O S T G R E S
+//
+
+resource postgresAdminManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: '${postgresServerName}-db-admin-msi'
+  location: location
+}
+
+module postgres '../postgres/postgres.bicep' = {
+  name: '${deployment().name}-postgres'
+  params: {
+    name: postgresServerName
+    databaseAdministrators: [
+      // add the dedicated admin managed identity as administrator
+      // this one is going to be used to manage DB access
+      {
+        principalId: postgresAdminManagedIdentity.properties.principalId
+        principalName: postgresAdminManagedIdentity.name
+        principalType: 'ServicePrincipal'
+      }
+    ]
+    version: postgresServerVersion
+    configurations: [
+      {
+        source: 'log_min_duration_statement'
+        value: '3000'
+      }
+      {
+        source: 'log_statement'
+        value: 'all'
+      }
+    ]
+    databases: [
+      {
+        name: maestroDatabaseName
+        charset: 'UTF8'
+        collation: 'en_US.utf8'
+      }
+    ]
+    maintenanceWindow: {
+      customWindow: 'Enabled'
+      dayOfWeek: 0
+      startHour: 1
+      startMinute: 12
+    }
+    storageSizeGB: postgresServerStorageSizeGB
+  }
+}
+
+module csManagedIdentityDatabaseAccess '../postgres/postgres-access.bicep' = {
+  name: '${deployment().name}-maestro-db-access'
+  params: {
+    postgresServerName: postgresServerName
+    postgresAdminManagedIdentityName: postgresAdminManagedIdentity.name
+    databaseName: maestroDatabaseName
+    newUserName: maestroServerManagedIdentityName
+    newUserPrincipalId: maestroServerManagedIdentityPrincipalId
+  }
+  dependsOn: [
+    postgres
+  ]
+}
+
 //
 //   K E Y    V A U L T
 //

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -77,6 +77,16 @@ param csNamespace string
 @maxLength(60)
 param csPostgresServerName string
 
+@description('The name of the Postgres server for Maestro')
+@maxLength(60)
+param maestroPostgresServerName string
+
+@description('The version of the Postgres server for Maestro')
+param maestroPostgresServerVersion string
+
+@description('The size of the Postgres server for Maestro')
+param maestroPostgresServerStorageSizeGB int
+
 @description('The maximum client sessions per authentication name for the EventGrid MQTT broker')
 param maxClientSessionsPerAuthName int
 
@@ -143,6 +153,17 @@ module maestroInfra '../modules/maestro/maestro-infra.bicep' = if (deployMaestro
     maxClientSessionsPerAuthName: maxClientSessionsPerAuthName
     maestroKeyVaultName: maestroKeyVaultName
     kvCertOfficerManagedIdentityName: maestroKeyVaultCertOfficerMSIName
+    postgresServerName: maestroPostgresServerName
+    postgresServerVersion: maestroPostgresServerVersion
+    postgresServerStorageSizeGB: maestroPostgresServerStorageSizeGB
+    maestroServerManagedIdentityPrincipalId: filter(
+      svcCluster.outputs.userAssignedIdentities,
+      id => id.uamiName == 'maestro-server'
+    )[0].uamiPrincipalID
+    maestroServerManagedIdentityName: filter(
+      svcCluster.outputs.userAssignedIdentities,
+      id => id.uamiName == 'maestro-server'
+    )[0].uamiName
   }
 }
 


### PR DESCRIPTION
### What this PR does

this PR introduced postgres provisioning for maestro. this way the maestro team can start developing entra authentication support for the maestro server.

- adds a azure database service for postgres instance for maestro
- defines access controls for the maestro managed identity

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
