### PR TITLE
Fix Management cluster parallelism issue

### DIFF
--- a/dev-infrastructure/modules/maestro/maestro-consumer.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-consumer.bicep
@@ -3,6 +3,7 @@ param maestroServerManagedIdentityPrincipalId string
 param maestroServerManagedIdentityClientId string
 param namespace string
 
+@minLength(1)
 param maestroConsumerName string
 param maestroInfraResourceGroup string
 param maestroEventGridNamespaceName string

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -60,6 +60,8 @@ param maestroInfraResourceGroup string
 @description('The name of the eventgrid namespace for Maestro.')
 param maestroEventGridNamespacesName string
 
+func isValidMaestroConsumerName(input string) bool => length(input) <= 90 && contains(input, '[^a-zA-Z0-9_-]') == false
+
 module mgmtCluster '../modules/aks-cluster-base.bicep' = {
   name: 'aks_base_cluster'
   scope: resourceGroup()
@@ -101,7 +103,7 @@ module maestroConsumer '../modules/maestro/maestro-consumer.bicep' = if (deployM
     )[0].uamiClientID
     namespace: maestroNamespace
     maestroInfraResourceGroup: maestroInfraResourceGroup
-    maestroConsumerName: resourceGroup().name
+    maestroConsumerName: isValidMaestroConsumerName(resourceGroup().name)?resourceGroup().name:''
     maestroEventGridNamespaceName: maestroEventGridNamespacesName
     maestroKeyVaultName: maestroKeyVaultName
     maestroKeyVaultOfficerManagedIdentityName: maestroKeyVaultCertOfficerMSIName

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -8,7 +8,7 @@ param persist bool = false
 param currentUserId string
 
 @description('AKS cluster name')
-param aksClusterName string = 'aro-hcp-mgmt-aks1'
+param aksClusterName string = 'aro-hcp-mgmt-1'
 
 @description('Name of the resource group for the AKS nodes')
 param aksNodeResourceGroupName string = '${resourceGroup().name}-aks1'

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -103,7 +103,7 @@ module maestroConsumer '../modules/maestro/maestro-consumer.bicep' = if (deployM
     )[0].uamiClientID
     namespace: maestroNamespace
     maestroInfraResourceGroup: maestroInfraResourceGroup
-    maestroConsumerName: isValidMaestroConsumerName(resourceGroup().name) ? resourceGroup().name:''
+    maestroConsumerName: isValidMaestroConsumerName(resourceGroup().name) ? resourceGroup().name : ''
     maestroEventGridNamespaceName: maestroEventGridNamespacesName
     maestroKeyVaultName: maestroKeyVaultName
     maestroKeyVaultOfficerManagedIdentityName: maestroKeyVaultCertOfficerMSIName

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -8,7 +8,7 @@ param persist bool = false
 param currentUserId string
 
 @description('AKS cluster name')
-param aksClusterName string
+param aksClusterName string = 'aro-hcp-mgmt-aks1'
 
 @description('Name of the resource group for the AKS nodes')
 param aksNodeResourceGroupName string = '${resourceGroup().name}-aks1'
@@ -101,7 +101,7 @@ module maestroConsumer '../modules/maestro/maestro-consumer.bicep' = if (deployM
     )[0].uamiClientID
     namespace: maestroNamespace
     maestroInfraResourceGroup: maestroInfraResourceGroup
-    maestroConsumerName: mgmtCluster.outputs.aksClusterName
+    maestroConsumerName: resourceGroup().name
     maestroEventGridNamespaceName: maestroEventGridNamespacesName
     maestroKeyVaultName: maestroKeyVaultName
     maestroKeyVaultOfficerManagedIdentityName: maestroKeyVaultCertOfficerMSIName

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -8,7 +8,7 @@ param persist bool = false
 param currentUserId string
 
 @description('AKS cluster name')
-param aksClusterName string = 'aro-hcp-mgmt-1'
+param aksClusterName string = 'aro-hcp-aks'
 
 @description('Name of the resource group for the AKS nodes')
 param aksNodeResourceGroupName string = '${resourceGroup().name}-aks1'
@@ -103,7 +103,7 @@ module maestroConsumer '../modules/maestro/maestro-consumer.bicep' = if (deployM
     )[0].uamiClientID
     namespace: maestroNamespace
     maestroInfraResourceGroup: maestroInfraResourceGroup
-    maestroConsumerName: isValidMaestroConsumerName(resourceGroup().name)?resourceGroup().name:''
+    maestroConsumerName: isValidMaestroConsumerName(resourceGroup().name) ? resourceGroup().name:''
     maestroEventGridNamespaceName: maestroEventGridNamespacesName
     maestroKeyVaultName: maestroKeyVaultName
     maestroKeyVaultOfficerManagedIdentityName: maestroKeyVaultCertOfficerMSIName


### PR DESCRIPTION
… group

### What this PR does
Currently, the management cluster can't deploy parallelly. The main reason was due to the overlapping of the eventgrid certificate name. The current code uses the aks cluster name as the certificate name, we suggest using the Resource group name due to it's unique nature(```hcp-underlay-${region}-mgmt-${stamp number}```), and we would like to keep the aks cluster name the same throughout all resource group. 

Explanation: 
![Screenshot 2024-07-01 160714](https://github.com/Azure/ARO-HCP/assets/8307131/8c1982c8-c193-480a-a565-65cf43f1d96b)
When the aks cluster name was unique, I was able to deploy parallel, but not when all cluster share the same name. 

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
