### PR TITLE
Management cluster resource group name is now aro-hcp-dev-mc

### DIFF
--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -90,8 +90,6 @@
 
         # Deploying Cluster Service and Maestro Server leverage OpenShift Templates
         - name: 'Install oc'
-          env:
-            RESOURCEGROUP: aro-hcp-dev
           run: |
             curl -sfLo - https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.15.9/openshift-client-linux.tar.gz | tar xzf -
             sudo mv oc /usr/local/bin/oc
@@ -154,7 +152,7 @@
         id: find_management_cluster
         uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
         env:
-          RESOURCEGROUP: aro-hcp-dev
+          RESOURCEGROUP: aro-hcp-dev-mc
         with:
           azcliversion: latest
           inlineScript: |
@@ -167,8 +165,6 @@
           kubelogin-version: 'v0.1.3'
 
       - name: 'Install oc'
-        env:
-          RESOURCEGROUP: aro-hcp-dev
         run: |
           curl -sfLo - https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.15.9/openshift-client-linux.tar.gz | tar xzf -
           sudo mv oc /usr/local/bin/oc
@@ -177,7 +173,7 @@
       - name: 'Setup kubectl for management cluster'
         uses: azure/aks-set-context@37037e33d3a2fc08abe40c887d81c3f6e1eb93b9 # v4.0.0
         with:
-          resource-group: 'aro-hcp-dev'
+          resource-group: 'aro-hcp-dev-mc'
           cluster-name: ${{ steps.find_management_cluster.outputs.name }}
           use-kubelogin: 'true'
 


### PR DESCRIPTION
### What this PR does
In #274 the management cluster was deployed into a resource group named `aro-hcp-dev-mc`. We are currently failing to deploy because the resource group is misnamed https://github.com/Azure/ARO-HCP/actions/runs/9783077404