### PR TITLE
Default the base DNS zone for cluster records to the region name

### DIFF
--- a/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
@@ -31,11 +31,8 @@ param serviceKeyVaultName = 'service-kv-aro-hcp-dev'
 param serviceKeyVaultSoftDelete = true
 param serviceKeyVaultPrivate = false
 
-param dnsZone = {
-  name: 'aro-hcp-dev'
-  parentZoneName: 'hcp.osadev.cloud'
-  parentZoneResourceGroup: 'global'
-}
+param baseDNSZoneName = 'hcp.osadev.cloud'
+param zoneResourceGroup = 'global'
 
 param workloadIdentities = items({
   frontend_wi: {

--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -31,11 +31,8 @@ param serviceKeyVaultName = take('service-kv-${uniqueString(currentUserId)}', 24
 param serviceKeyVaultSoftDelete = false
 param serviceKeyVaultPrivate = false
 
-param dnsZone = {
-  name: take('dev-${uniqueString(currentUserId)}', 10)
-  parentZoneName: 'hcp.osadev.cloud'
-  parentZoneResourceGroup: 'global'
-}
+param baseDNSZoneName = 'hcp.osadev.cloud'
+param baseDNSZoneResourceGroup = 'global'
 
 param workloadIdentities = items({
   frontend_wi: {

--- a/dev-infrastructure/modules/dns/zone-delegation.bicep
+++ b/dev-infrastructure/modules/dns/zone-delegation.bicep
@@ -1,6 +1,6 @@
 param parentZoneName string
 
-param childZoneName string
+param childZoneName string = resourceGroup().location
 
 param childZoneNameservers array
 


### PR DESCRIPTION
### What this PR does
* This will create a `${region}.hcp.osadev.cloud` DNS Zone per service cluster by default
* Developers are still able to override the subdomain as needed

From the what-if PR check:
```
Scope: /subscriptions/***/resourceGroups/global
  + Microsoft.Network/dnsZones/westus3.hcp.osadev.cloud [2018-05-01]
      apiVersion: "2018-05-01"
      id:         "/subscriptions/***/resourceGroups/global/providers/Microsoft.Network/dnsZones/westus3.hcp.osadev.cloud"
      location:   "global"
      name:       "westus3.hcp.osadev.cloud"
      type:       "Microsoft.Network/dnsZones"
```
