### PR TITLE
disable softdelete for AKS etcd KV in personal dev envs

### DIFF
--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -9,6 +9,7 @@ param enablePrivateCluster = false
 param aksClusterName = 'aro-hcp-mgmt-cluster'
 param additionalAcrResourceGroups = ['aro-hcp-dev']
 param aksKeyVaultName = take('aks-kv-mgmt-cluster-${uniqueString(currentUserId)}', 24)
+param aksEtcdKVEnableSoftDelete = false
 param persist = false
 param deployMaestroConsumer = false
 param maestroNamespace = 'maestro'

--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -10,6 +10,7 @@ param persist = false
 param aksClusterName = 'aro-hcp-svc-cluster'
 param additionalAcrResourceGroups = ['aro-hcp-dev']
 param aksKeyVaultName = take('aks-kv-svc-cluster-${uniqueString(currentUserId)}', 24)
+param aksEtcdKVEnableSoftDelete = false
 param disableLocalAuth = false
 param deployFrontendCosmos = false
 

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -38,6 +38,9 @@ param istioVersion string
 @maxLength(24)
 param aksKeyVaultName string
 
+@description('Manage soft delete setting for AKS etcd key-value store')
+param aksEtcdKVEnableSoftDelete bool = true
+
 @description('List of workload identities to create and their required values')
 param workloadIdentities array
 
@@ -80,6 +83,7 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     currentUserId: currentUserId
     aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName
+    aksEtcdKVEnableSoftDelete: aksEtcdKVEnableSoftDelete
     enablePrivateCluster: enablePrivateCluster
     istioVersion: istioVersion
     kubernetesVersion: kubernetesVersion

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -38,6 +38,9 @@ param istioVersion string
 @maxLength(24)
 param aksKeyVaultName string
 
+@description('Manage soft delete setting for AKS etcd key-value store')
+param aksEtcdKVEnableSoftDelete bool = true
+
 // TODO: When the work around workload identity for the RP is finalized, change this to true
 @description('disableLocalAuth for the ARO HCP RP CosmosDB')
 param disableLocalAuth bool
@@ -122,6 +125,7 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     persist: persist
     aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName
+    aksEtcdKVEnableSoftDelete: aksEtcdKVEnableSoftDelete
     currentUserId: currentUserId
     enablePrivateCluster: enablePrivateCluster
     kubernetesVersion: kubernetesVersion


### PR DESCRIPTION
### What this PR does

personal DEV clusters are deleted on a regular basis and recreating them when there are still soft-deleted KVs around involves manual purging. to prevent that and make the develeoper experience better, the soft-delete for such KVs is not configurable, enabled by default and overwritten to disable for personal dev envs

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
