### PR TITLE
cleanup rolebindings towards non-existant managed identities

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -32,7 +32,11 @@ rg:
   		--location $(LOCATION) \
 		--output none
 
-cluster: rg
+cleanup-orgphaned-rolebindings:
+	@scripts/cleanup-orphaned-rolebindings.sh $(RESOURCEGROUP)
+	@scripts/cleanup-orphaned-rolebindings.sh aro-hcp-dev
+
+cluster: rg cleanup-orgphaned-rolebindings
 ifndef AKSCONFIG
 	$(error "Must set AKSCONFIG")
 endif

--- a/dev-infrastructure/scripts/cleanup-orphaned-rolebindings.sh
+++ b/dev-infrastructure/scripts/cleanup-orphaned-rolebindings.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+RESOURCEGROUP=$1
+
+# List all role assignments and filter for 'ServicePrincipal'
+roleAssignments=$(az role assignment list -g ${RESOURCEGROUP} --query "[?principalType=='ServicePrincipal'].{id:id, principalId:principalId}" -o tsv)
+
+if [ -n "$roleAssignments" ]; then
+    while IFS=$'\t' read -r id principalId; do
+        # Check if the Managed Identity exists
+        identityExists=$(az identity show --ids $principalId --query id -o tsv 2>/dev/null)
+
+        if [ -z "$identityExists" ]; then
+            echo "Role Assignment ID $id is bound to a non-existent Managed Identity $principalId... deleting"
+            az role assignment delete --ids "$id"
+        fi
+    done <<< "$roleAssignments"
+fi


### PR DESCRIPTION
### What this PR does

when managed identities are deleted, potential rolebindings referencing them are not. we have several such situations:
- external-dns MI in the MC RG with contributer permissions on a zone in the SC RG
- kubelet MI of an AKS cluster with pull permissions on the permanent ACR

since such RGs and their MIs are deleted and recreated on a regular basis, we have orphaned rolebindings. that is bad because
* they count into the 4k limit (not a huge issue right now)
* they prevent successful recreations of such rolebindings

an additional make target dependency on `make cluster` cleans up such orphaned rolebindings

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
