### PR TITLE
Use Standard Tier

### DIFF
--- a/dev-infrastructure/configurations/dev-acr.bicepparam
+++ b/dev-infrastructure/configurations/dev-acr.bicepparam
@@ -1,5 +1,5 @@
 using '../templates/dev-acr.bicep'
 
 param acrName = 'devarohcp'
-param acrSku = 'Basic'
+param acrSku = 'Standard'
 param persist = true


### PR DESCRIPTION
### What this PR does

Switch SKU of Dev ACR to standard. Need more storage to sync all OCP images.

