### PR TITLE
GitHub Actions improvements

### DIFF
--- a/.github/workflows/dev-infrastructure.yml
+++ b/.github/workflows/dev-infrastructure.yml
@@ -2,9 +2,6 @@
 name: Validate dev-infrastructure
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/needs-rebase.yml
+++ b/.github/workflows/needs-rebase.yml
@@ -1,5 +1,5 @@
 ---
-name: Maintenance
+name: needs-rebase
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check if prs are dirty
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@1b1b1fcde06a9b3d089f3464c96417961dde1168 #v3.0.2
         with:
           dirtyLabel: needs-rebase
           removeOnDirtyLabel: ready-for-review


### PR DESCRIPTION
### What this PR does
* Skips validating bicep post-merge, we're already applying bicep post-merge which will catch this - it only makes sense to run on open PRs before merge
* Updates and pins `eps1lon/actions-label-merge-conflict` - we were running an old version with dependencies that were going to be deprecated: https://github.com/Azure/ARO-HCP/actions/runs/9840459003
* Renames the `Maintenance` GitHub Action to `needs-rebase` for clarity