### PR TITLE
Add missing aks cluster name output to mgmt Bicep

### DIFF
--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -101,6 +101,8 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
   }
 }
 
+output aksClusterName string = mgmtCluster.outputs.aksClusterName
+
 //
 //   M A E S T R O
 //


### PR DESCRIPTION
### What this PR does
* Resolve mgmt-roleassign failures due to a missing output https://github.com/Azure/ARO-HCP/actions/runs/9843750785/job/27179070358 which is used https://github.com/Azure/ARO-HCP/blob/c2fa95cd3af471f1dd34f6e90968567bb9aa402c/.github/workflows/aro-hcp-dev-env-cd.yml#L91