### PR TITLE
dns zone refactor followup

### DIFF
--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -86,7 +86,7 @@
                 --parameters configurations/mvp-mgmt-cluster.bicepparam \
                 --parameters currentUserId="${GITHUB_ACTOR}" \
                 --parameters maestroInfraResourceGroup="${SC_RESOURCEGROUP}" \
-                --parameters zoneResourceGroup="${SC_RESOURCEGROUP}"
+                --parameters regionalZoneResourceGroup="${SC_RESOURCEGROUP}"
 
               MGMT_CLUSTER_NAME=$(az deployment group show --resource-group "${MC_RESOURCEGROUP}" --name "mgmt-cluster-${GITHUB_RUN_ID}" --output tsv --query properties.outputs.aksClusterName.value)
               SVC_CLUSTER_NAME=$(az deployment group show --resource-group "${SC_RESOURCEGROUP}" --name "svc-cluster-${GITHUB_RUN_ID}" --output tsv --query properties.outputs.aksClusterName.value)

--- a/.github/workflows/bicep-what-if.yml
+++ b/.github/workflows/bicep-what-if.yml
@@ -66,4 +66,4 @@ jobs:
               --parameters configurations/mvp-mgmt-cluster.bicepparam \
               --parameters currentUserId="${GITHUB_ACTOR}" \
               --parameters maestroInfraResourceGroup="${SC_RESOURCEGROUP}" \
-              --parameters zoneResourceGroup="${SC_RESOURCEGROUP}"
+              --parameters regionalZoneResourceGroup="${SC_RESOURCEGROUP}"

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -49,9 +49,7 @@ endif
 			configurations/$(AKSCONFIG).bicepparam \
 		--parameters \
 			currentUserId=$(CURRENTUSER) \
-			maestroInfraResourceGroup=$(MAESTRO_INFRA_RESOURCEGROUP) \
-			zoneResourceGroup=$(DNS_RESOURCEGROUP)
-
+			maestroInfraResourceGroup=$(MAESTRO_INFRA_RESOURCEGROUP)
 cluster-what-if: rg
 ifndef AKSCONFIG
 	$(error "Must set AKSCONFIG")

--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -36,4 +36,4 @@ param workloadIdentities = items({
 // This parameter is always overriden in the Makefile
 param currentUserId = ''
 param maestroInfraResourceGroup = ''
-param zoneResourceGroup = ''
+param regionalZoneResourceGroup = maestroInfraResourceGroup

--- a/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
@@ -34,4 +34,4 @@ param workloadIdentities = items({
 // This parameter is always overriden in the Makefile
 param currentUserId = ''
 param maestroInfraResourceGroup = ''
-param zoneResourceGroup = ''
+param regionalZoneResourceGroup = ''

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -73,7 +73,7 @@ param baseDNSZoneName string = ''
 param regionalDNSSubdomain string = resourceGroup().location
 
 @description('The resource group that hosts the regional zone')
-param zoneResourceGroup string
+param regionalZoneResourceGroup string
 
 func isValidMaestroConsumerName(input string) bool => length(input) <= 90 && contains(input, '[^a-zA-Z0-9_-]') == false
 
@@ -142,7 +142,7 @@ var externalDnsManagedIdentityPrincipalId = filter(
 
 module dnsZoneContributor '../modules/dns/zone-contributor.bicep' = {
   name: guid(regionalDNSSubdomain, mgmtCluster.name, 'external-dns')
-  scope: resourceGroup(zoneResourceGroup)
+  scope: resourceGroup(regionalZoneResourceGroup)
   params: {
     zoneName: '${regionalDNSSubdomain}.${baseDNSZoneName}'
     zoneContributerManagedIdentityPrincipalId: externalDnsManagedIdentityPrincipalId


### PR DESCRIPTION
### What this PR does

follows up on https://github.com/Azure/ARO-HCP/pull/324

- `regionalZoneResourceGroup` as param name for the regional DNS zone RG name on mgmt cluster side
- `regionalZoneResourceGroup` defaults to the maestro infra RG for DEV envs. still explicit for MVP env.
   - in a second step we can combine the regional zone RG name and maestro infra RG name into a parameter `regionalInfraResourceGroup`
- fix a leftover bug on make cluster for mgmt clusters

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
