### PR TITLE
fix orphaned roleassignment cleanup

### DIFF
--- a/dev-infrastructure/scripts/cleanup-orphaned-rolebindings.sh
+++ b/dev-infrastructure/scripts/cleanup-orphaned-rolebindings.sh
@@ -8,7 +8,7 @@ roleAssignments=$(az role assignment list -g ${RESOURCEGROUP} --query "[?princip
 if [ -n "$roleAssignments" ]; then
     while IFS=$'\t' read -r id principalId; do
         # Check if the Managed Identity exists
-        identityExists=$(az identity show --ids $principalId --query id -o tsv 2>/dev/null)
+        identityExists=$(az ad sp show --id $principalId --query id -o tsv 2>/dev/null)
 
         if [ -z "$identityExists" ]; then
             echo "Role Assignment ID $id is bound to a non-existent Managed Identity $principalId... deleting"


### PR DESCRIPTION
### What this PR does

the previous [PR](https://github.com/Azure/ARO-HCP/pull/320) was only handling managed identities correctly and was deleting and recreating roleassignments for service principals (SPs) like the ones on AKS nodepools during `make cluster`

this PR handles now SPs correctly as well.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
