### PR TITLE
Add additional configurable options to the RP --> CS integration

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -14,7 +14,11 @@ frontend:
 	go build -o aro-hcp-frontend .
 
 run:
-	./aro-hcp-frontend --use-cache --region eastus --clusters-service-url http://localhost:8000
+	./aro-hcp-frontend --use-cache --region eastus \
+		--clusters-service-url http://localhost:8000 \
+		--cluster-service-provision-shard 1 \
+		--cluster-service-noop-provision \
+		--cluster-service-noop-deprovision
 
 clean:
 	rm -f aro-hcp-frontend


### PR DESCRIPTION
### What this PR does
Adds three new configurable options for the RP --> CS integration:
* `--cluster-service-provision-shard`
* `--cluster-service-noop-provision`
* `--cluster-service-noop-deprovision`

by creating a new `ClusterServiceConfig` field in the Frontend struct. These flags are only needed during development - in production they shouldn't be set. I'm not tied to the name and open to other ideas.

This handles this comment from https://github.com/Azure/ARO-HCP/pull/243/files#diff-dca68281d465331f001c419bfd49e4cbd190aba28906c7592f393b3056cce8dcR169-R172