### PR TITLE
Fix npm dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: 'daily'
   - package-ecosystem: 'npm'
-    directory: /
+    directory: /api
     groups:
       typespec:
         patterns:


### PR DESCRIPTION
### What this PR does
* Dependabot npm updates have been failing: https://github.com/Azure/ARO-HCP/network/updates
* We forgot about this in 917cb1f3c31b3cc75ec4c212a5fcc65f82e6fc8e