### PR TITLE
Add dockerfile for OC-Mirror

### DIFF
--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -183,7 +183,7 @@
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}
             subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-        - name: Push frontend container image
+        - name: Push image-sync container image
           if: github.event.pull_request.merged == true
           env:
             ARO_HCP_IMAGE_ACR: devarohcp

--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -170,7 +170,7 @@
 
         - name: Build frontend container image
           env:
-            ARO_HCP_IMAGE_ACR: devarohcp
+            ARO_HCP_IMAGE_ACR: arohcpdev
           run: |
             cd image-sync/oc-mirror
             make image
@@ -186,10 +186,10 @@
         - name: Push image-sync container image
           if: github.event.pull_request.merged == true
           env:
-            ARO_HCP_IMAGE_ACR: devarohcp
+            ARO_HCP_IMAGE_ACR: arohcpdev
           run: |
             cd image-sync/oc-mirror/
-            az acr login --name devarohcp
+            az acr login --name arohcpdev
             make push
 
     deploy_to_service_cluster:

--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -15,6 +15,7 @@
         - 'pko/**'
         - 'acm/**'
         - 'hypershiftoperator/**'
+        - 'image-sync/**/'
       types:
         - opened
         - synchronize
@@ -154,6 +155,40 @@
             ARO_HCP_IMAGE_ACR: devarohcp
           run: |
             cd frontend/
+            az acr login --name devarohcp
+            make push
+
+    build_push_oc-mirror:
+      permissions:
+        id-token: 'write'
+        contents: 'read'
+      runs-on: 'ubuntu-latest'
+      steps:
+        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+          with:
+            fetch-depth: 1
+
+        - name: Build frontend container image
+          env:
+            ARO_HCP_IMAGE_ACR: devarohcp
+          run: |
+            cd image-sync/oc-mirror
+            make image
+
+        - name: 'Az CLI login'
+          if: github.event.pull_request.merged == true
+          uses: azure/login@v2
+          with:
+            client-id: ${{ secrets.AZURE_CLIENT_ID }}
+            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+        - name: Push frontend container image
+          if: github.event.pull_request.merged == true
+          env:
+            ARO_HCP_IMAGE_ACR: devarohcp
+          run: |
+            cd image-sync/oc-mirror/
             az acr login --name devarohcp
             make push
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
 * @ulrichschlueter @bennerv @zgalor @jharrington22 @mjlshen @tonytheleg
 /dev-infrastructure/ @bennerv @petrkotas @ulrichschlueter @mjlshen @tonytheleg @whober0521 @nwnt @jonathan34c @weinong @niontive @geoberle @janboll @jmelis
+/image-sync/ @bennerv @petrkotas @ulrichschlueter @mjlshen @tonytheleg @whober0521 @nwnt @jonathan34c @weinong @niontive @geoberle @janboll @jmelis
 /api/ @petrkotas @mbarnes @AldoFusterTurpin @bennerv @mjlshen @tonytheleg
 /frontend/ @petrkotas @mbarnes @AldoFusterTurpin @bennerv @mjlshen @tonytheleg
 /internal/ @petrkotas @mbarnes @AldoFusterTurpin @bennerv @mjlshen @tonytheleg

--- a/image-sync/oc-mirror/Dockerfile
+++ b/image-sync/oc-mirror/Dockerfile
@@ -1,9 +1,8 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.8 AS downloader
-
-ENV OC_VERSION=4.16.0
+FROM registry.access.redhat.com/ubi9/ubi:9.4-1123.1719560047 AS downloader
 
 RUN dnf -y install unzip glibc-langpack-en
 
+ENV OC_VERSION=4.16.3
 
 RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz \
     -o oc.tar.gz && \
@@ -15,8 +14,7 @@ RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VER
     tar -zvxf oc-mirror.tar.gz && \
     mv oc-mirror /usr/local/bin
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
-
+FROM registry.access.redhat.com/ubi9/ubi:9.4-1123.1719560047
 
 COPY --chown=0:0 --chmod=755 --from=downloader \
     /usr/local/bin/oc-mirror \

--- a/image-sync/oc-mirror/Dockerfile
+++ b/image-sync/oc-mirror/Dockerfile
@@ -2,9 +2,9 @@ FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS downloader
 
 RUN set -eux; \
 # Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating
-	tdnf update -y; \
+    tdnf update -y; \
     tdnf -y install unzip wget tar ca-certificates; \ 
-	tdnf clean all
+    tdnf clean all
 
 ENV OC_VERSION=4.16.3
 

--- a/image-sync/oc-mirror/Dockerfile
+++ b/image-sync/oc-mirror/Dockerfile
@@ -1,11 +1,14 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.4-1123.1719560047 AS downloader
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS downloader
 
-RUN dnf -y install unzip glibc-langpack-en
+RUN set -eux; \
+# Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating
+	tdnf update -y; \
+    tdnf -y install unzip wget tar ca-certificates; \ 
+	tdnf clean all
 
 ENV OC_VERSION=4.16.3
 
-RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz \
-    -o oc.tar.gz && \
+RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz -o oc.tar.gz  && \
     tar -zvxf oc.tar.gz && \
     mv oc kubectl /usr/local/bin
 
@@ -14,7 +17,14 @@ RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VER
     tar -zvxf oc-mirror.tar.gz && \
     mv oc-mirror /usr/local/bin
 
-FROM registry.access.redhat.com/ubi9/ubi:9.4-1123.1719560047
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+
+RUN mkdir --mode=777 /workspace; \
+    tdnf update -y; \
+    tdnf -y install ca-certificates; \
+    tdnf clean all
+
+WORKDIR /workspace
 
 COPY --chown=0:0 --chmod=755 --from=downloader \
     /usr/local/bin/oc-mirror \

--- a/image-sync/oc-mirror/Dockerfile
+++ b/image-sync/oc-mirror/Dockerfile
@@ -1,0 +1,25 @@
+FROM registry.access.redhat.com/ubi8/ubi:8.8 AS downloader
+
+ENV OC_VERSION=4.16.0
+
+RUN dnf -y install unzip glibc-langpack-en
+
+
+RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz \
+    -o oc.tar.gz && \
+    tar -zvxf oc.tar.gz && \
+    mv oc kubectl /usr/local/bin
+
+RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/oc-mirror.tar.gz \
+    -o oc-mirror.tar.gz && \
+    tar -zvxf oc-mirror.tar.gz && \
+    mv oc-mirror /usr/local/bin
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
+
+
+COPY --chown=0:0 --chmod=755 --from=downloader \
+    /usr/local/bin/oc-mirror \
+    /usr/local/bin/oc \
+    /usr/local/bin/kubectl \
+    /usr/local/bin/

--- a/image-sync/oc-mirror/Makefile
+++ b/image-sync/oc-mirror/Makefile
@@ -1,7 +1,7 @@
 SHELL = /bin/bash
 COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]])
-ARO_HCP_BASE_IMAGE ?= devarohcp.azurecr.io
-OC_MIRROR_IMAGE ?= $(ARO_HCP_BASE_IMAGE)/image-sync/ocmirror:$(COMMIT)
+ARO_HCP_IMAGE_ACR ?= arohcpdev.azurecr.io
+OC_MIRROR_IMAGE ?= $(ARO_HCP_IMAGE_ACR)/image-sync/ocmirror:$(COMMIT)
 
 build-push: image push
 

--- a/image-sync/oc-mirror/Makefile
+++ b/image-sync/oc-mirror/Makefile
@@ -1,0 +1,14 @@
+SHELL = /bin/bash
+COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]])
+ARO_HCP_BASE_IMAGE ?= devarohcp.azurecr.io
+OC_MIRROR_IMAGE ?= $(ARO_HCP_BASE_IMAGE)/image-sync/ocmirror:$(COMMIT)
+
+build-push: image push
+
+image:
+	docker build -f "./Dockerfile" -t ${OC_MIRROR_IMAGE} .
+
+push: image
+	docker push ${OC_MIRROR_IMAGE}
+
+.PHONY: image deploy

--- a/image-sync/oc-mirror/README.md
+++ b/image-sync/oc-mirror/README.md
@@ -4,16 +4,16 @@ This container contains oc-mirror end required dependencies.
 
 ## Example usage for devarohcp
 
- * Build the container image ```docker build -t oc-mirror .```
+ * Build the container image ```podman build -t oc-mirror .```
  * Get credentials for Openshift registries https://console.redhat.com/openshift/install/pull-secret
  * Get Azure registry credentials ```az acr login -n devarohcp```
  * Run the sync using the built container
 ```BASH
-docker run -it --rm --tmpfs /oc-mirror-workspace \
+podman run -it --rm --tmpfs /oc-mirror-workspace \
   -e XDG_RUNTIME_DIR=/ \
-  -v $PWD/imageset-config.yml:/imageset-config.yml \
-  -v $HOME/.docker/config.json:/containers/auth.json \
-  docker.io/library/oc-mirror \
+  -v $PWD/imageset-config.yml:/imageset-config.yml:Z \
+  -v $HOME/.docker/config.json:/containers/auth.json:Z \
+  oc-mirror \
   oc mirror --config=/imageset-config.yml docker://devarohcp.azurecr.io --dry-run
 ```
 

--- a/image-sync/oc-mirror/README.md
+++ b/image-sync/oc-mirror/README.md
@@ -4,9 +4,10 @@ This container contains oc-mirror end required dependencies.
 
 ## Example usage for devarohcp
 
- * Build the container image ```podman build -t oc-mirror .```
+ * Build the container image `podman build -t oc-mirror .`
+ * Alternatively, use `make image`
  * Get credentials for Openshift registries https://console.redhat.com/openshift/install/pull-secret
- * Get Azure registry credentials ```az acr login -n devarohcp```
+ * Get Azure registry credentials `az acr login -n devarohcp`
  * Run the sync using the built container
 ```BASH
 podman run -it --rm --tmpfs /oc-mirror-workspace \

--- a/image-sync/oc-mirror/README.md
+++ b/image-sync/oc-mirror/README.md
@@ -2,12 +2,12 @@
 
 This container contains oc-mirror end required dependencies.
 
-## Usage
+## Example usage for devarohcp
 
  * Build the container image ```docker build -t oc-mirror .```
  * Get credentials for Openshift registries https://console.redhat.com/openshift/install/pull-secret
- * Get Azure registry credentials ```az acr login -n <<registry>>```
- * Run the sync using the build container
+ * Get Azure registry credentials ```az acr login -n devarohcp```
+ * Run the sync using the built container
 ```BASH
 docker run -it --rm --tmpfs /oc-mirror-workspace \
   -e XDG_RUNTIME_DIR=/ \

--- a/image-sync/oc-mirror/README.md
+++ b/image-sync/oc-mirror/README.md
@@ -1,0 +1,41 @@
+# oc-mirror
+
+This container contains oc-mirror end required dependencies.
+
+## Usage
+
+ * Build the container image ```docker build -t oc-mirror .```
+ * Get credentials for Openshift registries https://console.redhat.com/openshift/install/pull-secret
+ * Get Azure registry credentials ```az acr login -n <<registry>>```
+ * Run the sync using the build container
+```BASH
+docker run -it --rm --tmpfs /oc-mirror-workspace \
+  -e XDG_RUNTIME_DIR=/ \
+  -v $PWD/imageset-config.yml:/imageset-config.yml \
+  -v $HOME/.docker/config.json:/containers/auth.json \
+  docker.io/library/oc-mirror \
+  oc mirror --config=/imageset-config.yml docker://devarohcp.azurecr.io --dry-run
+```
+
+Note, the above command will run the sync in dry-run mode. To run the sync, remove the `--dry-run` flag.
+
+## Example configuration
+
+The following is an example of the configuration file `imageset-config.yml`.
+
+This exact configuration was used in the initial testing of the `oc-mirror` tool.
+
+```YAML
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v1alpha2
+storageConfig:
+  registry:
+    imageURL: devarohcp.azurecr.io/mirror/oc-mirror-metadata
+    skipTLS: false
+mirror:
+  platform:
+    channels:
+      - name: stable-4.16
+        type: ocp
+    graph: true
+```

--- a/image-sync/oc-mirror/imageset-config.yml
+++ b/image-sync/oc-mirror/imageset-config.yml
@@ -9,4 +9,5 @@ mirror:
     channels:
       - name: stable-4.16
         type: ocp
+        full: true
     graph: true

--- a/image-sync/oc-mirror/imageset-config.yml
+++ b/image-sync/oc-mirror/imageset-config.yml
@@ -1,0 +1,12 @@
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v1alpha2
+storageConfig:
+  registry:
+    imageURL: devarohcp.azurecr.io/mirror/oc-mirror-metadata
+    skipTLS: false
+mirror:
+  platform:
+    channels:
+      - name: stable-4.16
+        type: ocp
+    graph: true


### PR DESCRIPTION
This creates a Dockerfile containing oc-mirror end required dependencies.

Additionally it adds some documentation on how to use/sync images using oc-mirror

Solves: https://issues.redhat.com/browse/ARO-8968