### PR TITLE
Explicitly write out ARO HCP paths

### DIFF
--- a/frontend/pkg/frontend/const.go
+++ b/frontend/pkg/frontend/const.go
@@ -8,13 +8,4 @@ const (
 
 	// APIVersionKey is the request parameter name for the API version.
 	APIVersionKey = "api-version"
-
-	// Wildcard path segment names for request multiplexing, must be lowercase as we lowercase the request URL pattern when registering handlers
-	PageSegmentLocation          = "location"
-	PathSegmentSubscriptionID    = "subscriptionid"
-	PathSegmentResourceGroupName = "resourcegroupname"
-	PathSegmentResourceName      = "resourcename"
-	PathSegmentDeploymentName    = "deploymentname"
-	PathSegmentActionName        = "actionname"
-	PathSegmentNodepoolName      = "nodepoolname"
 )

--- a/frontend/pkg/frontend/middleware_lowercase.go
+++ b/frontend/pkg/frontend/middleware_lowercase.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// This middleware helps comply with Azure OpenAPI Specifications Guidelines
+// MiddlewareLowercase helps comply with Azure OpenAPI Specifications Guidelines
 // around case sensitivity for resource IDs.  Specifically:
 //
 // OAPI012: Resource IDs must not be case sensitive
@@ -32,13 +32,9 @@ import (
 // The frontend uses ServeMux from Go's standard library (net/http), which
 // matches literal (that is, non-wildcarded) path segments case-sensitively.
 // For instance, in a resource ID, "subscriptions" and "resourcegroups" are
-// literal path segments and therefore are matched case-sensitvely.
-//
-// So this middleware saves the original path casing in the request context,
-// and then normalizes the casing for ServeMux by lowercasing it. At the same
-// time, when registering URL patterns with ServeMux in routes.go, we use the
-// helper function MuxPattern which also lowercases the path segments passed
-// to it to ensure their normalized casing agrees with this middleware.
+// literal path segments and therefore are matched case-sensitvely. So this
+// middleware saves the original path casing in the request context, and
+// then normalizes the casing for ServeMux by lowercasing it.
 //
 // When the resource ID, or parts of it, needs to be used in an HTTP response
 // (such as an error message), be sure to retrieve the original path from the


### PR DESCRIPTION
### What this PR does
Removes `MuxPattern()` in favor of explicitly writing out our paths

Pros:
* Readability

Cons:
* Need to manually ensure future added paths are all lowercase
* Easier to have typos

Both of the cons can be mitigated by integration tests, which we do not have yet at this point in the project.