### PR TITLE
Leverage the armResourceIdentifier type for resourceIds

### DIFF
--- a/api/redhatopenshift/HcpCluster/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster/hcpCluster-models.tsp
@@ -267,13 +267,13 @@ model PlatformProfile {
   managedResourceGroup: string;
 
   /** ResourceId for the subnet used by the control plane */
-  subnetId: string;
+  subnetId: SubnetResourceId;
 
   /** The core outgoing configuration */
   outboundType?: OutboundType = OutboundType.loadBalancer;
 
   /** ResourceId for the network security group attached to the cluster subnet */
-  networkSecurityGroupId: string;
+  networkSecurityGroupId: NetworkSecurityGroupResourceId;
 
   /** The id of the disk encryption set to be used for etcd.
    * Configure this when `etcdEncryption` is set to true
@@ -282,11 +282,24 @@ model PlatformProfile {
   etcdEncryptionSetId?: string;
 }
 
+scalar SubnetResourceId
+  extends Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Network/virtualNetworks/subnets",
+    }
+  ]>;
+
+scalar NetworkSecurityGroupResourceId
+  extends Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Network/networkSecurityGroups",
+    }
+  ]>;
 /** The outbound routing strategy used to provide your cluster egress to the internet. */
 union OutboundType {
   string,
 
-  /** The loadbalancer configuration */
+  /** The load balancer configuration */
   loadBalancer: "loadBalancer",
 }
 

--- a/api/redhatopenshift/HcpCluster/main.tsp
+++ b/api/redhatopenshift/HcpCluster/main.tsp
@@ -16,7 +16,7 @@ using Azure.ResourceManager;
 /** Microsoft.RedHatOpenshift Resource Provider management API. */
 @armProviderNamespace
 @service({
-  title: "Microsoft.RedHatOpenshift management service",
+  title: "Azure Red Hat OpenShift Hosted Control Planes Service",
 })
 @versioned(Microsoft.RedHatOpenshift.Versions)
 namespace Microsoft.RedHatOpenshift;

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenshift/preview/2024-06-10-preview/openapi.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "Microsoft.RedHatOpenshift management service",
+    "title": "Azure Red Hat OpenShift Hosted Control Planes Service",
     "version": "2024-06-10-preview",
     "description": "Microsoft.RedHatOpenshift Resource Provider management API.",
     "x-typespec-generated": [
@@ -1762,6 +1762,18 @@
         "machineCidr"
       ]
     },
+    "NetworkSecurityGroupResourceId": {
+      "type": "string",
+      "format": "arm-id",
+      "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+      "x-ms-arm-id-details": {
+        "allowedResources": [
+          {
+            "type": "Microsoft.Network/networkSecurityGroups"
+          }
+        ]
+      }
+    },
     "NetworkType": {
       "type": "string",
       "description": "The cluster network type",
@@ -1979,7 +1991,7 @@
           {
             "name": "loadBalancer",
             "value": "loadBalancer",
-            "description": "The loadbalancer configuration"
+            "description": "The load balancer configuration"
           }
         ]
       }
@@ -1993,7 +2005,7 @@
           "description": "Resource group to put cluster resources"
         },
         "subnetId": {
-          "type": "string",
+          "$ref": "#/definitions/SubnetResourceId",
           "description": "ResourceId for the subnet used by the control plane"
         },
         "outboundType": {
@@ -2010,13 +2022,13 @@
               {
                 "name": "loadBalancer",
                 "value": "loadBalancer",
-                "description": "The loadbalancer configuration"
+                "description": "The load balancer configuration"
               }
             ]
           }
         },
         "networkSecurityGroupId": {
-          "type": "string",
+          "$ref": "#/definitions/NetworkSecurityGroupResourceId",
           "description": "ResourceId for the network security group attached to the cluster subnet"
         },
         "etcdEncryptionSetId": {
@@ -2105,6 +2117,18 @@
           "type": "string",
           "description": "The trusted CA for the proxy"
         }
+      }
+    },
+    "SubnetResourceId": {
+      "type": "string",
+      "format": "arm-id",
+      "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+      "x-ms-arm-id-details": {
+        "allowedResources": [
+          {
+            "type": "Microsoft.Network/virtualNetworks/subnets"
+          }
+        ]
       }
     },
     "Taint": {

--- a/internal/api/v20240610preview/generated/constants.go
+++ b/internal/api/v20240610preview/generated/constants.go
@@ -128,7 +128,7 @@ func PossibleOriginValues() []Origin {
 type OutboundType string
 
 const (
-	// OutboundTypeLoadBalancer - The loadbalancer configuration
+	// OutboundTypeLoadBalancer - The load balancer configuration
 	OutboundTypeLoadBalancer OutboundType = "loadBalancer"
 )
 


### PR DESCRIPTION
Refactor types that leverage a resourceId according to best practices, and a couple more clarifications.

https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type#the-provisioningstate-property-for-tracked-resources