### PR TITLE
use the resourcegroup ID of a mgmt cluster as EDO txt owner ID

### DIFF
--- a/hypershiftoperator/Makefile
+++ b/hypershiftoperator/Makefile
@@ -26,7 +26,10 @@ create-edo-sa-patch:
 create-domain-file:
 	@echo "${ZONE_NAME}" > deploy/overlays/dev/domain.txt
 
-deploy: create-edo-azure-creds create-edo-sa-patch create-domain-file
+create-txt-owner-id-file:
+	@echo "${RESOURCEGROUP}" > deploy/overlays/dev/txt_owner_id.txt
+
+deploy: create-edo-azure-creds create-edo-sa-patch create-domain-file create-txt-owner-id-file
 	kubectl apply --server-side --force-conflicts -k deploy/crds
 	kubectl apply --server-side --force-conflicts -k deploy/overlays/dev
 
@@ -46,7 +49,7 @@ prepare-ho-manifests:
 		--external-dns-secret external-dns-azure \
 		--external-dns-domain-filter \$$\(DOMAIN\) \
 		--external-dns-image ${EDO_IMAGE} \
-		--external-dns-txt-owner-id ARO-HCP \
+		--external-dns-txt-owner-id \$$\(TXT_OWNER_ID\) \
 		--managed-service ARO-HCP | ./kubectl-slice -f - -o deploy/base
 	@rm deploy/crds/*
 	@mkdir -p deploy/crds

--- a/hypershiftoperator/deploy/base/deployment-external-dns.yaml
+++ b/hypershiftoperator/deploy/base/deployment-external-dns.yaml
@@ -26,7 +26,7 @@ spec:
         - --provider=azure
         - --registry=txt
         - --txt-suffix=-external-dns
-        - --txt-owner-id=ARO-HCP
+        - --txt-owner-id=$(TXT_OWNER_ID)
         - --label-filter=hypershift.openshift.io/route-visibility!=private
         - --interval=1m
         - --txt-cache-interval=1h

--- a/hypershiftoperator/deploy/overlays/dev/kustomization.yml
+++ b/hypershiftoperator/deploy/overlays/dev/kustomization.yml
@@ -27,3 +27,4 @@ secretGenerator:
   files:
   - credentials=edo-azure-credentials.json
   - domain=domain.txt
+  - txt_owner_id=txt_owner_id.txt

--- a/hypershiftoperator/deploy/overlays/dev/patch-deployment-external-dns.json
+++ b/hypershiftoperator/deploy/overlays/dev/patch-deployment-external-dns.json
@@ -21,6 +21,15 @@
                         "name": "external-dns-azure"
                     }
                 }
+            },
+            {
+                "name": "TXT_OWNER_ID",
+                "valueFrom": {
+                    "secretKeyRef": {
+                        "key": "txt_owner_id",
+                        "name": "external-dns-azure"
+                    }
+                }
             }
         ]
     },


### PR DESCRIPTION
### What this PR does

when multiple external DNS operators act in a zone (e.g. multiple MCs acting in the regional zone), they only touch records they own. since an ARO-HCP region will be represented by a subscription and each MC by a RG, the RG is unique within the region and can be used as identifier for ownership in EDO.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
