### PR TITLE
Increment install-time K8s version to v1.29.5

### DIFF
--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -1,6 +1,6 @@
 using '../templates/mgmt-cluster.bicep'
 
-param kubernetesVersion = '1.29.2'
+param kubernetesVersion = '1.29.5'
 param vnetAddressPrefix = '10.132.0.0/14'
 param subnetPrefix = '10.132.8.0/21'
 param podSubnetPrefix = '10.132.64.0/18'

--- a/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
@@ -1,6 +1,6 @@
 using '../templates/mgmt-cluster.bicep'
 
-param kubernetesVersion = '1.29.2'
+param kubernetesVersion = '1.29.5'
 param vnetAddressPrefix = '10.132.0.0/14'
 param subnetPrefix = '10.132.8.0/21'
 param podSubnetPrefix = '10.132.64.0/18'
@@ -29,7 +29,7 @@ param workloadIdentities = items({
   }
 })
 
-// This parameter is always overriden in the Makefile
+// These parameters are always overridden in the Makefile
 param currentUserId = ''
 param maestroInfraResourceGroup = ''
 param regionalZoneResourceGroup = ''

--- a/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
@@ -1,6 +1,6 @@
 using '../templates/svc-cluster.bicep'
 
-param kubernetesVersion = '1.29.2'
+param kubernetesVersion = '1.29.5'
 param istioVersion = 'asm-1-20'
 param vnetAddressPrefix = '10.128.0.0/14'
 param subnetPrefix = '10.128.8.0/21'
@@ -50,6 +50,7 @@ param workloadIdentities = items({
     serviceAccountName: 'clusters-service'
   }
 })
-// This parameter is always overriden in the Makefile
+
+// These parameters are always overridden in the Makefile
 param currentUserId = ''
 param maestroInfraResourceGroup = ''

--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -1,6 +1,6 @@
 using '../templates/svc-cluster.bicep'
 
-param kubernetesVersion = '1.29.2'
+param kubernetesVersion = '1.29.5'
 param istioVersion = 'asm-1-20'
 param vnetAddressPrefix = '10.128.0.0/14'
 param subnetPrefix = '10.128.8.0/21'


### PR DESCRIPTION
### What this PR does
Currently, the AKS clusters are installing at v1.29.2 and then immediately auto-upgrading to v1.29.5, which is taking time and preventing other modifications in the meantime.