### PR TITLE
parent zone for delegation must exist already

### DIFF
--- a/dev-infrastructure/modules/dns/zone-delegation.bicep
+++ b/dev-infrastructure/modules/dns/zone-delegation.bicep
@@ -6,9 +6,8 @@ param childZoneNameservers array
 
 param ttl int = 3600
 
-resource parentZone 'Microsoft.Network/dnsZones@2018-05-01' = {
+resource parentZone 'Microsoft.Network/dnsZones@2018-05-01' existing = {
   name: parentZoneName
-  location: 'global'
 }
 
 resource delegation 'Microsoft.Network/dnsZones/NS@2018-05-01' = {


### PR DESCRIPTION
### What this PR does

the parent zone from the `zone-delegation.bicep` module is supposed to exist already.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
