### PR TITLE
Remove dirty suffix while building locally

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/bash
-COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
+COMMIT = $(shell git rev-parse --short=7 HEAD)
 ARO_HCP_BASE_IMAGE ?= devarohcp.azurecr.io
 ARO_HCP_FRONTEND_IMAGE ?= $(ARO_HCP_BASE_IMAGE)/arohcpfrontend:$(COMMIT)
 


### PR DESCRIPTION
### What this PR does
Removes the `-dirty` suffix, it's currently causing issues in CD and we don't have a need for this