### PR TITLE
Label aro-hcp namespace with Istio revision

### DIFF
--- a/frontend/deploy/overlays/dev/kustomization.yml
+++ b/frontend/deploy/overlays/dev/kustomization.yml
@@ -4,6 +4,17 @@ resources:
 - ../../base
 - namespace.yml
 namespace: aro-hcp
+
+patches:
+- patch: |-
+    - op: add
+      # "~1" is an escaped "/"
+      path: /metadata/labels/istio.io~1rev
+      value: asm-1-20
+  target:
+    kind: Namespace
+    name: aro-hcp
+
 configMapGenerator:
 - behavior: create
   literals:

--- a/frontend/deploy/overlays/dev/namespace.yml
+++ b/frontend/deploy/overlays/dev/namespace.yml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: aro-hcp
+  labels: {}


### PR DESCRIPTION
### What this PR does
For now, this labels our aro-hcp namespace with the currently deployed Istio revision, asm-1-20

This mirrors other places it is hardcoded in, like https://github.com/Azure/ARO-HCP/blob/1c6ae951a0ae1e176f2d855df9b73e254cb33bb6/cluster-service/Makefile#L12