### PR TITLE
Lock down network traffic between frontend and CS

### DIFF
--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -210,6 +210,11 @@
             cluster-name: ${{ steps.find_service_cluster.outputs.name }}
             use-kubelogin: 'true'
 
+        - name: 'Deploy Istio Configuration'
+          run: |
+            cd istio
+            make deploy-service
+
         - name: 'Deploy Frontend'
           env:
             RESOURCEGROUP: aro-hcp-dev

--- a/cluster-service/deploy/istio.yml
+++ b/cluster-service/deploy/istio.yml
@@ -1,0 +1,46 @@
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-nothing
+  namespace: cluster-service
+spec: {}
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-frontend
+  namespace: cluster-service
+spec:
+  action: "ALLOW"
+  rules:
+    - from:
+      - source:
+          principals: ["cluster.local/ns/aro-hcp/sa/frontend"]
+      to:
+      - operation:
+          ports:
+            - "8000"
+  selector:
+    matchLabels:
+      app: "clusters-service"
+---
+# TODO: Remove when migration to Azure Postgres completes
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-intra-namespace
+  namespace: cluster-service
+spec:
+  action: "ALLOW"
+  rules:
+    - from:
+      - source:
+          principals: ["cluster.local/ns/cluster-service/sa/clusters-service"]
+      to:
+      - operation:
+          ports:
+            - "5432"
+  selector:
+    matchLabels:
+      name: "ocm-cs-db"

--- a/frontend/deploy/overlays/dev/authorizationpolicy.yml
+++ b/frontend/deploy/overlays/dev/authorizationpolicy.yml
@@ -1,0 +1,5 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-nothing
+spec: {}

--- a/frontend/deploy/overlays/dev/kustomization.yml
+++ b/frontend/deploy/overlays/dev/kustomization.yml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../../base
 - namespace.yml
+- authorizationpolicy.yml
 namespace: aro-hcp
 
 patches:

--- a/istio/Makefile
+++ b/istio/Makefile
@@ -1,0 +1,7 @@
+deploy-service:
+	kubectl apply -k overlays/svc
+
+undeploy-service:
+	kubectl delete -k overlays/svc
+
+.PHONY: deploy-service undeploy-service

--- a/istio/overlays/svc/kustomization.yml
+++ b/istio/overlays/svc/kustomization.yml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - strict_mtls.yml
+namespace: aks-istio-system

--- a/istio/overlays/svc/strict_mtls.yml
+++ b/istio/overlays/svc/strict_mtls.yml
@@ -1,0 +1,7 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+spec:
+  mtls:
+    mode: STRICT


### PR DESCRIPTION
### What this PR does
* Configure strict mTLS inside the service cluster
* Set a default-deny AuthorizationPolicy for the aro-hcp namespace
* Set a default-deny AuthorizationPolicy for the cluster-service namespace
* Allow workloads with the frontend serviceaccount to communicate with port 8000 of clusters-service

Jira: [ARO-6380](https://issues.redhat.com/browse/ARO-6380)