### PR TITLE
Lock down network traffic between CS and Maestro

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -8,6 +8,7 @@ REGION ?= $(shell az group show -n ${RESOURCEGROUP} --query location -o tsv)
 deploy:
 	DOMAIN=$(shell az network dns zone list -g ${RESOURCEGROUP} --query "[?zoneType=='Public'].name" -o tsv) && \
 	sed -e "s/DOMAIN/$${DOMAIN}/g" -e "s/REGION/${REGION}/g" -e "s/CONSUMER_NAME/${CONSUMER_NAME}/g" deploy/mvp-provisioning-shards.yml > deploy/tmp-provisioning-shard.yml
+	kubectl apply -f deploy/istio.yml
 	oc process --local -f deploy/openshift-templates/arohcp-namespace-template.yml \
 	  -p ISTIO_VERSION=asm-1-20 | oc apply -f -
 	oc process --local -f deploy/openshift-templates/arohcp-db-template.yml | oc apply -f -

--- a/maestro/Makefile
+++ b/maestro/Makefile
@@ -8,6 +8,7 @@ EVENTGRID_ID = $(shell az resource list -g ${MAESTRO_INFRA_RESOURCEGROUP} --reso
 
 
 deploy-server:
+	kubectl apply -f deploy/istio.yml
 	MAESTRO_MI_CLIENT_ID=$(shell az identity show \
 			-g ${RESOURCEGROUP} \
 			-n maestro-server \

--- a/maestro/deploy/istio.yml
+++ b/maestro/deploy/istio.yml
@@ -1,0 +1,46 @@
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-nothing
+  namespace: maestro
+spec: {}
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-cluster-service
+  namespace: maestro
+spec:
+  action: "ALLOW"
+  rules:
+    - from:
+      - source:
+          principals: ["cluster.local/ns/cluster-service/sa/clusters-service"]
+      to:
+      - operation:
+          ports:
+            - "8000"
+            - "8090"
+  selector:
+    matchLabels:
+      app: "maestro"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-maestro-to-db
+  namespace: maestro
+spec:
+  action: "ALLOW"
+  rules:
+    - from:
+      - source:
+          principals: ["cluster.local/ns/maestro/sa/maestro"]
+      to:
+      - operation:
+          ports:
+            - "5432"
+  selector:
+    matchLabels:
+      name: "maestro-db"


### PR DESCRIPTION
### What this PR does
* Add a default-deny AuthorizationPolicy in the maestro namespace
* Allow workloads with the clusters-service serviceaccount to
  communicate with ports 8000 and 8090 of Maestro
* Deploy AuthorizationPolicies for Cluster Service 

Jira: [ARO-6380](https://issues.redhat.com/browse/ARO-6380)
