### PR TITLE
dev infra: use json output explicitly when needed

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash
 
-CURRENTUSER=$(shell az ad signed-in-user show | jq -r '.id')
+CURRENTUSER=$(shell az ad signed-in-user show -o json | jq -r '.id')
 LOCATION?=westus3
 RESOURCEGROUP?=aro-hcp-${AKSCONFIG}-$(USER)
 MAESTRO_INFRA_RESOURCEGROUP?=aro-hcp-svc-cluster-$(USER)

--- a/dev-infrastructure/modules/postgres/postgres-sql.bicep
+++ b/dev-infrastructure/modules/postgres/postgres-sql.bicep
@@ -37,7 +37,7 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
     retentionInterval: 'P1D'
     scriptContent: '''
       az login --identity
-      export PGPASSWORD=$(az account get-access-token --resource-type oss-rdbms | jq .accessToken -r)
+      export PGPASSWORD=$(az account get-access-token --resource-type oss-rdbms -o json | jq .accessToken -r)
       echo "${SQL_SCRIPT}" | base64 -d > script.sql
       apk add postgresql-client
       psql -f script.sql

--- a/dev-infrastructure/scripts/aks-admin-access.sh
+++ b/dev-infrastructure/scripts/aks-admin-access.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
+set -ex
 
 RESOURCEGROUP=$1
-CURRENTUSER_CLIENT_ID=$(az ad signed-in-user show | jq -r '.id')
-CLUSTER_ID=$(az aks list -g $RESOURCEGROUP | jq -r .[0].id)
+CURRENTUSER_CLIENT_ID=$(az ad signed-in-user show -o json | jq -r '.id')
+CLUSTER_ID=$(az aks list -g $RESOURCEGROUP -o json | jq -r .[0].id)
 
 az role assignment create --assignee $CURRENTUSER_CLIENT_ID --role "Azure Kubernetes Service RBAC Cluster Admin" --scope $CLUSTER_ID
 az role assignment create --assignee $CURRENTUSER_CLIENT_ID --role "Azure Kubernetes Service Cluster Admin Role" --scope $CLUSTER_ID

--- a/dev-infrastructure/scripts/cs-current-user-pg-connect.sh
+++ b/dev-infrastructure/scripts/cs-current-user-pg-connect.sh
@@ -3,17 +3,17 @@
 RESOURCEGROUP=$1
 DB_SERVER_NAME_PREFIX=$2
 
-CURRENTUSER=$(az ad signed-in-user show | jq -r '.id')
-CURRENTUSER_NAME=$(az ad signed-in-user show | jq -r '.userPrincipalName')
+CURRENTUSER=$(az ad signed-in-user show -o json | jq -r '.id')
+CURRENTUSER_NAME=$(az ad signed-in-user show -o json | jq -r '.userPrincipalName')
 
-CS_DB=$(az postgres flexible-server list -g ${RESOURCEGROUP} | jq --arg prefix "${DB_SERVER_NAME_PREFIX}" '.[] | select(.name | startswith($prefix))')
+CS_DB=$(az postgres flexible-server list -g ${RESOURCEGROUP} -o json | jq --arg prefix "${DB_SERVER_NAME_PREFIX}" '.[] | select(.name | startswith($prefix))')
 CS_DB_NAME=$(echo ${CS_DB} | jq -r .name)
 
-ALREADY_ADMIN=$(az postgres flexible-server ad-admin list -g  ${RESOURCEGROUP} -s ${CS_DB_NAME} | jq  --arg principalname "${CURRENTUSER_NAME}" '[.[] | select(.principalName == $principalname)] | length')
+ALREADY_ADMIN=$(az postgres flexible-server ad-admin list -g  ${RESOURCEGROUP} -s ${CS_DB_NAME} -o json | jq  --arg principalname "${CURRENTUSER_NAME}" '[.[] | select(.principalName == $principalname)] | length')
 if [ $ALREADY_ADMIN -eq 0 ]; then
     az postgres flexible-server ad-admin create --server-name ${CS_DB_NAME} --resource-group ${RESOURCEGROUP} --object-id ${CURRENTUSER} --display-name ${CURRENTUSER_NAME}
 fi
 
 echo export PGHOST=$(echo ${CS_DB} | jq -r .fullyQualifiedDomainName)
 echo export PGUSER=$CURRENTUSER_NAME
-echo export PGPASSWORD=$(az account get-access-token --resource='https://ossrdbms-aad.database.windows.net' | jq .accessToken -r)
+echo export PGPASSWORD=$(az account get-access-token --resource='https://ossrdbms-aad.database.windows.net' -o json | jq .accessToken -r)

--- a/dev-infrastructure/scripts/cs-miwi-pg-connect.sh
+++ b/dev-infrastructure/scripts/cs-miwi-pg-connect.sh
@@ -8,7 +8,7 @@ SA_NAME=$5
 
 # prep creds and configs
 PGHOST=$(az postgres flexible-server list --resource-group ${RESOURCEGROUP} --query "[?starts_with(name, '${DB_SERVER_NAME_PREFIX}')].fullyQualifiedDomainName" -o tsv)
-AZURE_TENANT_ID=$(az account show | jq .homeTenantId -r)
+AZURE_TENANT_ID=$(az account show -o json | jq .homeTenantId -r)
 AZURE_CLIENT_ID=$(az identity show -g ${RESOURCEGROUP} -n ${MANAGED_IDENTITY_NAME} --query clientId -o tsv)
 SA_TOKEN=$(kubectl create token ${SA_NAME} --namespace=${NAMESPACE} --audience api://AzureADTokenExchange)
 
@@ -18,7 +18,7 @@ rm -rf $AZURE_CONFIG_DIR
 az login --federated-token ${SA_TOKEN} --service-principal -u $AZURE_CLIENT_ID -t $AZURE_TENANT_ID > /dev/null 2>&1
 
 # get tmp DB password
-PGPASSWORD=$(az account get-access-token --resource='https://ossrdbms-aad.database.windows.net' | jq .accessToken -r)
+PGPASSWORD=$(az account get-access-token --resource='https://ossrdbms-aad.database.windows.net' -o json | jq .accessToken -r)
 rm -rf $AZURE_CONFIG_DIR
 
 echo export PGHOST=${PGHOST}


### PR DESCRIPTION
### What this PR does

In the deployment scripts of the dev infrastructure, it makes sure that `az` command explicitly uses json output when the result is piped into `jq` command. This is useful when one reconfigures the default output of az cli.