### PR TITLE
keyvault access requires MSI to exist

### DIFF
--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -269,6 +269,7 @@ module csServiceKeyVaultAccess '../modules/keyvault/keyvault-secret-access.bicep
   }
   dependsOn: [
     serviceKeyVault
+    svcCluster
   ]
 }
 
@@ -287,5 +288,6 @@ module imageServiceKeyVaultAccess '../modules/keyvault/keyvault-secret-access.bi
   }
   dependsOn: [
     serviceKeyVault
+    svcCluster
   ]
 }


### PR DESCRIPTION
This adds a missing dependency, where we try to grant access to MSI, that does not exist yet

### What this PR does

Fixes errors in pipeline: https://github.com/Azure/ARO-HCP/actions/runs/10139786138
