### PR TITLE
enable hypershift-addon on ACM

### DIFF
--- a/acm/deploy/mch/mce-overrides.yml
+++ b/acm/deploy/mch/mce-overrides.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mce-overrides
+data:
+  manifest.json: |-
+    [
+      {
+        "image-name": "hypershift-addon-operator",
+        "image-tag": "0725b",
+        "image-remote": "quay.io/rokejungrh",
+        "image-key": "hypershift_addon_operator"
+      }
+    ]


### PR DESCRIPTION
### What this PR does

hypershift-addon is required to be enabled in order for HCP based `ManagedClusters` to work. for the time being, we use an image override for the hypershift-addon, until it is compatible with AKS

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
