### PR TITLE
Add MiddlewareResourceID and other refactoring

### DIFF
--- a/frontend/pkg/frontend/context.go
+++ b/frontend/pkg/frontend/context.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
@@ -28,6 +30,7 @@ const (
 	contextKeyBody
 	contextKeyLogger
 	contextKeyVersion
+	contextKeyResourceID
 	contextKeyCorrelationData
 	contextKeySystemData
 	contextKeySubscription
@@ -91,6 +94,21 @@ func VersionFromContext(ctx context.Context) (api.Version, error) {
 		return version, err
 	}
 	return version, nil
+}
+
+func ContextWithResourceID(ctx context.Context, resourceID *azcorearm.ResourceID) context.Context {
+	return context.WithValue(ctx, contextKeyResourceID, resourceID)
+}
+
+func ResourceIDFromContext(ctx context.Context) (*azcorearm.ResourceID, error) {
+	resourceID, ok := ctx.Value(contextKeyResourceID).(*azcorearm.ResourceID)
+	if !ok {
+		err := &ContextError{
+			got: resourceID,
+		}
+		return resourceID, err
+	}
+	return resourceID, nil
 }
 
 func ContextWithCorrelationData(ctx context.Context, correlationData *arm.CorrelationData) context.Context {

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -14,10 +14,8 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"sync/atomic"
 
-	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/google/uuid"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -829,28 +827,24 @@ func (f *Frontend) CreateNodePool(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
+	nodePoolResourceID, err := ResourceIDFromContext(ctx)
+	if err != nil {
+		f.logger.Error(err.Error())
+		arm.WriteInternalServerError(writer)
+		return
+	}
+
 	f.logger.Info(fmt.Sprintf("%s: CreateNodePool", versionedInterface))
 
-	// URL path is already lowercased by middleware.
-	nodePoolResourceID := request.URL.Path
-
-	nodePoolResourceIDObject, err := azcorearm.ParseResourceID(nodePoolResourceID)
-	if err != nil {
-		f.logger.Error(fmt.Sprintf("could not parse resource ID: %v", err))
+	clusterResourceID := nodePoolResourceID.Parent
+	if clusterResourceID == nil {
+		f.logger.Error(fmt.Sprintf("failed to obtain Azure parent resourceID for nodepool %s", nodePoolResourceID))
 		arm.WriteInternalServerError(writer)
 		return
 	}
-
-	clusterResourceIDObject := nodePoolResourceIDObject.Parent
-	if clusterResourceIDObject == nil {
-		f.logger.Error(fmt.Sprintf("failed to obtain Azure parent resourceID for nodepool %v", nodePoolResourceID))
-		arm.WriteInternalServerError(writer)
-		return
-	}
-	clusterResourceID := strings.ToLower(clusterResourceIDObject.String())
 
 	subscriptionID := request.PathValue(PathSegmentSubscriptionID)
-	clusterDoc, err := f.dbClient.GetClusterDoc(ctx, clusterResourceID, subscriptionID)
+	clusterDoc, err := f.dbClient.GetClusterDoc(ctx, clusterResourceID.String(), subscriptionID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Error(fmt.Sprintf("existing document not found for cluster %s when creating node pool", clusterResourceID))
@@ -870,19 +864,19 @@ func (f *Frontend) CreateNodePool(writer http.ResponseWriter, request *http.Requ
 	}
 
 	if csResp.Body().State() == cmv1.ClusterStateUninstalling {
-		f.logger.Error(fmt.Sprintf("failed to create nodepool for cluster %v as it is in %v state", clusterResourceID, cmv1.ClusterStateUninstalling))
+		f.logger.Error(fmt.Sprintf("failed to create nodepool for cluster %s as it is in %v state", clusterResourceID, cmv1.ClusterStateUninstalling))
 		arm.WriteInternalServerError(writer)
 		return
 	}
 
-	nodePoolDoc, err := f.dbClient.GetNodePoolDoc(ctx, nodePoolResourceID)
+	nodePoolDoc, err := f.dbClient.GetNodePoolDoc(ctx, nodePoolResourceID.String())
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Info(fmt.Sprintf("creating nodepool document for %s", nodePoolResourceID))
 
 			nodePoolDoc = &database.NodePoolDocument{
 				ID:           uuid.New().String(),
-				Key:          nodePoolResourceID,
+				Key:          nodePoolResourceID.String(),
 				PartitionKey: subscriptionID,
 				SystemData:   systemData,
 			}
@@ -974,28 +968,24 @@ func (f *Frontend) GetNodePool(writer http.ResponseWriter, request *http.Request
 		return
 	}
 
+	nodePoolResourceID, err := ResourceIDFromContext(ctx)
+	if err != nil {
+		f.logger.Error(err.Error())
+		arm.WriteInternalServerError(writer)
+		return
+	}
+
 	f.logger.Info(fmt.Sprintf("%s: GetNodePools", versionedInterface))
 
-	// URL path is already lowercased by middleware.
-	nodePoolResourceID := request.URL.Path
-
-	nodePoolResourceIDObject, err := azcorearm.ParseResourceID(nodePoolResourceID)
-	if err != nil {
-		f.logger.Error(fmt.Sprintf("could not parse resource ID: %v", err))
+	clusterResourceID := nodePoolResourceID.Parent
+	if clusterResourceID == nil {
+		f.logger.Error(fmt.Sprintf("failed to obtain Azure parent resourceID for nodepool %s", nodePoolResourceID))
 		arm.WriteInternalServerError(writer)
 		return
 	}
-
-	clusterResourceIDObject := nodePoolResourceIDObject.Parent
-	if clusterResourceIDObject == nil {
-		f.logger.Error(fmt.Sprintf("failed to obtain Azure parent resourceID for nodepool %v", nodePoolResourceID))
-		arm.WriteInternalServerError(writer)
-		return
-	}
-	clusterResourceID := strings.ToLower(clusterResourceIDObject.String())
 
 	subscriptionID := request.PathValue(PathSegmentSubscriptionID)
-	clusterDoc, err := f.dbClient.GetClusterDoc(ctx, clusterResourceID, subscriptionID)
+	clusterDoc, err := f.dbClient.GetClusterDoc(ctx, clusterResourceID.String(), subscriptionID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Error(fmt.Sprintf("existing cluster document not found for cluster: %s on GET node pool by name", clusterResourceID))
@@ -1008,7 +998,7 @@ func (f *Frontend) GetNodePool(writer http.ResponseWriter, request *http.Request
 		return
 	}
 
-	nodePoolDoc, err := f.dbClient.GetNodePoolDoc(ctx, nodePoolResourceID)
+	nodePoolDoc, err := f.dbClient.GetNodePoolDoc(ctx, nodePoolResourceID.String())
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Error(fmt.Sprintf("existing node pool document not found for node pool: %s on GET node pool by name", nodePoolResourceID))
@@ -1066,28 +1056,24 @@ func (f *Frontend) DeleteNodePool(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
+	nodePoolResourceID, err := ResourceIDFromContext(ctx)
+	if err != nil {
+		f.logger.Error(err.Error())
+		arm.WriteInternalServerError(writer)
+		return
+	}
+
 	f.logger.Info(fmt.Sprintf("%s: DeleteNodePool", versionedInterface))
 
-	// URL path is already lowercased by middleware.
-	nodePoolResourceID := request.URL.Path
-
-	nodePoolResourceIDObject, err := azcorearm.ParseResourceID(nodePoolResourceID)
-	if err != nil {
-		f.logger.Error(fmt.Sprintf("could not parse resource ID: %v", err))
+	clusterResourceID := nodePoolResourceID.Parent
+	if clusterResourceID == nil {
+		f.logger.Error(fmt.Sprintf("failed to obtain Azure parent resourceID for nodepool %s", nodePoolResourceID))
 		arm.WriteInternalServerError(writer)
 		return
 	}
-
-	clusterResourceIDObject := nodePoolResourceIDObject.Parent
-	if clusterResourceIDObject == nil {
-		f.logger.Error(fmt.Sprintf("failed to obtain Azure parent resourceID for nodepool %v", nodePoolResourceID))
-		arm.WriteInternalServerError(writer)
-		return
-	}
-	clusterResourceID := strings.ToLower(clusterResourceIDObject.String())
 
 	subscriptionID := request.PathValue(PathSegmentSubscriptionID)
-	clusterDoc, err := f.dbClient.GetClusterDoc(ctx, clusterResourceID, subscriptionID)
+	clusterDoc, err := f.dbClient.GetClusterDoc(ctx, clusterResourceID.String(), subscriptionID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Error(fmt.Sprintf("existing document not found for cluster %s when deleting node pool", clusterResourceID))
@@ -1099,7 +1085,7 @@ func (f *Frontend) DeleteNodePool(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	doc, err := f.dbClient.GetNodePoolDoc(ctx, nodePoolResourceID)
+	doc, err := f.dbClient.GetNodePoolDoc(ctx, nodePoolResourceID.String())
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Error(fmt.Sprintf("nodepool document cannot be deleted -- nodepool document not found for %s", nodePoolResourceID))
@@ -1125,7 +1111,7 @@ func (f *Frontend) DeleteNodePool(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	err = f.dbClient.DeleteNodePoolDoc(ctx, nodePoolResourceID)
+	err = f.dbClient.DeleteNodePoolDoc(ctx, nodePoolResourceID.String())
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Error(fmt.Sprintf("nodepool document cannot be deleted -- nodepool document not found for %s", nodePoolResourceID))

--- a/frontend/pkg/frontend/middleware_resourceid.go
+++ b/frontend/pkg/frontend/middleware_resourceid.go
@@ -1,0 +1,43 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"fmt"
+	"net/http"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/frontend/pkg/config"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+// This middleware only applies to endpoints whose path form a valid Azure
+// resource ID. It should follow the MiddlewareLowercase function.
+
+func MiddlewareResourceID(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	logger, err := LoggerFromContext(r.Context())
+	if err != nil {
+		config.DefaultLogger().Error(err.Error())
+		arm.WriteInternalServerError(w)
+		return
+	}
+
+	originalPath, _ := OriginalPathFromContext(r.Context())
+	if originalPath == "" {
+		// MiddlewareLowercase has not run; fall back to the request path.
+		logger.Warn("Middleware dependency error: MiddlewareResourceID ran before MiddlewareLowercase")
+		originalPath = r.URL.Path
+	}
+
+	resourceID, err := azcorearm.ParseResourceID(originalPath)
+	if err == nil {
+		ctx := ContextWithResourceID(r.Context(), resourceID)
+		r = r.WithContext(ctx)
+	} else {
+		logger.Warn(fmt.Sprintf("Failed to parse '%s' as resource ID: %v", originalPath, err))
+	}
+
+	next(w, r)
+}

--- a/frontend/pkg/frontend/middleware_resourceid_test.go
+++ b/frontend/pkg/frontend/middleware_resourceid_test.go
@@ -1,0 +1,110 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMiddlewareResourceID(t *testing.T) {
+	tests := []struct {
+		name          string
+		path          string
+		resourceTypes []string
+	}{
+		{
+			name: "subscription resource",
+			path: "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000",
+			resourceTypes: []string{
+				"Microsoft.Resources/subscriptions",
+				"Microsoft.Resources/tenants",
+			},
+		},
+		{
+			name: "cluster resource",
+			path: "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/MyResourceGroup/PROVIDERS/MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS/myCluster",
+			resourceTypes: []string{
+				"MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS",
+				"Microsoft.Resources/resourceGroups",
+				"Microsoft.Resources/subscriptions",
+				"Microsoft.Resources/tenants",
+			},
+		},
+		{
+			// Parser treats the action name as a subtype
+			name: "cluster resource with action",
+			path: "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/MyResourceGroup/PROVIDERS/MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS/myCluster/myAction",
+			resourceTypes: []string{
+				"MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS/myAction",
+				"MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS",
+				"Microsoft.Resources/resourceGroups",
+				"Microsoft.Resources/subscriptions",
+				"Microsoft.Resources/tenants",
+			},
+		},
+		{
+			name: "node pool resource",
+			path: "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/MyResourceGroup/PROVIDERS/MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS/myCluster/NODEPOOLS/myNodePool",
+			resourceTypes: []string{
+				"MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS/NODEPOOLS",
+				"MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS",
+				"Microsoft.Resources/resourceGroups",
+				"Microsoft.Resources/subscriptions",
+				"Microsoft.Resources/tenants",
+			},
+		},
+		{
+			name: "preflight deployment",
+			path: "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/MyResourceGroup/PROVIDERS/MICROSOFT.REDHATOPENSHIFT/DEPLOYMENTS/preflight",
+			resourceTypes: []string{
+				"MICROSOFT.REDHATOPENSHIFT/DEPLOYMENTS",
+				"Microsoft.Resources/resourceGroups",
+				"Microsoft.Resources/subscriptions",
+				"Microsoft.Resources/tenants",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := httptest.NewRecorder()
+
+			// Convert path to simulate MiddlewareLowercase
+			url := "http://example.com" + strings.ToLower(tt.path)
+
+			request := httptest.NewRequest("GET", url, nil)
+			request = request.WithContext(ContextWithLogger(request.Context(), slog.Default()))
+			request = request.WithContext(ContextWithOriginalPath(request.Context(), tt.path))
+
+			next := func(w http.ResponseWriter, r *http.Request) {
+				request = r // capture modified request
+				w.WriteHeader(http.StatusOK)
+			}
+
+			MiddlewareResourceID(writer, request, next)
+
+			resourceID, err := ResourceIDFromContext(request.Context())
+			if err != nil {
+				t.Error(err)
+			}
+
+			resourceTypes := []string{}
+			for resourceID != nil {
+				resourceTypes = append(resourceTypes, resourceID.ResourceType.String())
+				resourceID = resourceID.Parent
+			}
+
+			if !reflect.DeepEqual(resourceTypes, tt.resourceTypes) {
+				t.Error(cmp.Diff(resourceTypes, tt.resourceTypes))
+			}
+		})
+	}
+}

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -103,13 +102,9 @@ func (f *Frontend) ConvertCStoHCPOpenShiftCluster(systemData *arm.SystemData, cl
 
 // BuildCSCluster creates a CS Cluster object from an HCPOpenShiftCluster object
 func (f *Frontend) BuildCSCluster(ctx context.Context, hcpCluster *api.HCPOpenShiftCluster) (*cmv1.Cluster, error) {
-	originalPath, err := OriginalPathFromContext(ctx)
+	resourceID, err := ResourceIDFromContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("could not get original path: %w", err)
-	}
-	resourceID, err := azcorearm.ParseResourceID(originalPath)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse resource ID: %w", err)
+		return nil, fmt.Errorf("could not get parsed resource ID: %w", err)
 	}
 	tenantID, err := TenantIDFromContext(ctx)
 	if err != nil {
@@ -180,17 +175,9 @@ func (f *Frontend) BuildCSCluster(ctx context.Context, hcpCluster *api.HCPOpenSh
 
 // ConvertCStoNodepool converts a CS Node Pool object into HCPOpenShiftClusterNodePool object
 func (f *Frontend) ConvertCStoNodepool(ctx context.Context, systemData *arm.SystemData, np *cmv1.NodePool) (*api.HCPOpenShiftClusterNodePool, error) {
-	originalPath, err := OriginalPathFromContext(ctx)
+	resourceID, err := ResourceIDFromContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("could not get original path: %w", err)
-	}
-	resourceID, err := azcorearm.ParseResourceID(originalPath)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse resource ID: %w", err)
-	}
-	resourceType, err := azcorearm.ParseResourceType(originalPath)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse resource type: %w", err)
+		return nil, fmt.Errorf("could not get parsed resource ID: %w", err)
 	}
 
 	nodePool := &api.HCPOpenShiftClusterNodePool{
@@ -198,7 +185,7 @@ func (f *Frontend) ConvertCStoNodepool(ctx context.Context, systemData *arm.Syst
 			Resource: arm.Resource{
 				ID:         resourceID.String(),
 				Name:       resourceID.Name,
-				Type:       resourceType.String(),
+				Type:       resourceID.ResourceType.String(),
 				SystemData: systemData,
 			},
 		},

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -55,7 +55,7 @@ func (f *Frontend) routes() *MiddlewareMux {
 	// Expose Prometheus metrics endpoint
 	mux.Handle(MuxPattern(http.MethodGet, "metrics"), promhttp.Handler())
 
-	// Authenticated routes
+	// List endpoints
 	postMuxMiddleware := NewMiddleware(
 		MiddlewareLoggingPostMux,
 		MiddlewareValidateAPIVersion,
@@ -69,6 +69,14 @@ func (f *Frontend) routes() *MiddlewareMux {
 	mux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceList))
+
+	// Resource ID endpoints
+	// Request context holds an azcorearm.ResourceID
+	postMuxMiddleware = NewMiddleware(
+		MiddlewareResourceID,
+		MiddlewareLoggingPostMux,
+		MiddlewareValidateAPIVersion,
+		subscriptionStateMuxValidator.MiddlewareValidateSubscriptionState)
 	mux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceRead))
@@ -84,8 +92,6 @@ func (f *Frontend) routes() *MiddlewareMux {
 	mux.Handle(
 		MuxPattern(http.MethodPost, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName, PatternActionName),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceAction))
-
-	// node pools
 	mux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName, PatternNodepoolResource),
 		postMuxMiddleware.HandlerFunc(f.GetNodePool))

--- a/internal/database/cache.go
+++ b/internal/database/cache.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"strings"
 )
 
 var _ DBClient = &Cache{}
@@ -30,7 +31,10 @@ func (c *Cache) DBConnectionTest(ctx context.Context) error {
 }
 
 func (c *Cache) GetClusterDoc(ctx context.Context, resourceID string, subscriptionID string) (*HCPOpenShiftClusterDocument, error) {
-	if doc, ok := c.cluster[resourceID]; ok {
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(resourceID)
+
+	if doc, ok := c.cluster[key]; ok {
 		return doc, nil
 	}
 
@@ -38,17 +42,26 @@ func (c *Cache) GetClusterDoc(ctx context.Context, resourceID string, subscripti
 }
 
 func (c *Cache) SetClusterDoc(ctx context.Context, doc *HCPOpenShiftClusterDocument) error {
-	c.cluster[doc.Key] = doc
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(doc.Key)
+
+	c.cluster[key] = doc
 	return nil
 }
 
 func (c *Cache) DeleteClusterDoc(ctx context.Context, resourceID string, subscriptionID string) error {
-	delete(c.cluster, resourceID)
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(resourceID)
+
+	delete(c.cluster, key)
 	return nil
 }
 
 func (c *Cache) GetNodePoolDoc(ctx context.Context, resourceID string) (*NodePoolDocument, error) {
-	if doc, ok := c.nodePool[resourceID]; ok {
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(resourceID)
+
+	if doc, ok := c.nodePool[key]; ok {
 		return doc, nil
 	}
 
@@ -56,17 +69,26 @@ func (c *Cache) GetNodePoolDoc(ctx context.Context, resourceID string) (*NodePoo
 }
 
 func (c *Cache) SetNodePoolDoc(ctx context.Context, doc *NodePoolDocument) error {
-	c.nodePool[doc.Key] = doc
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(doc.Key)
+
+	c.nodePool[key] = doc
 	return nil
 }
 
 func (c *Cache) DeleteNodePoolDoc(ctx context.Context, resourceID string) error {
-	delete(c.nodePool, resourceID)
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(resourceID)
+
+	delete(c.nodePool, key)
 	return nil
 }
 
 func (c *Cache) GetOperationDoc(ctx context.Context, operationID string) (*OperationDocument, error) {
-	if doc, ok := c.operation[operationID]; ok {
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(operationID)
+
+	if doc, ok := c.operation[key]; ok {
 		return doc, nil
 	}
 
@@ -74,17 +96,26 @@ func (c *Cache) GetOperationDoc(ctx context.Context, operationID string) (*Opera
 }
 
 func (c *Cache) SetOperationDoc(ctx context.Context, doc *OperationDocument) error {
-	c.operation[doc.ID] = doc
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(doc.ID)
+
+	c.operation[key] = doc
 	return nil
 }
 
 func (c *Cache) DeleteOperationDoc(ctx context.Context, operationID string) error {
-	delete(c.operation, operationID)
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(operationID)
+
+	delete(c.operation, key)
 	return nil
 }
 
 func (c *Cache) GetSubscriptionDoc(ctx context.Context, subscriptionID string) (*SubscriptionDocument, error) {
-	if doc, ok := c.subscription[subscriptionID]; ok {
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(subscriptionID)
+
+	if doc, ok := c.subscription[key]; ok {
 		return doc, nil
 	}
 
@@ -92,6 +123,9 @@ func (c *Cache) GetSubscriptionDoc(ctx context.Context, subscriptionID string) (
 }
 
 func (c *Cache) SetSubscriptionDoc(ctx context.Context, doc *SubscriptionDocument) error {
-	c.subscription[doc.PartitionKey] = doc
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(doc.PartitionKey)
+
+	c.subscription[key] = doc
 	return nil
 }

--- a/internal/database/cache.go
+++ b/internal/database/cache.go
@@ -30,8 +30,8 @@ func (c *Cache) DBConnectionTest(ctx context.Context) error {
 }
 
 func (c *Cache) GetClusterDoc(ctx context.Context, resourceID string, subscriptionID string) (*HCPOpenShiftClusterDocument, error) {
-	if _, ok := c.cluster[resourceID]; ok {
-		return c.cluster[resourceID], nil
+	if doc, ok := c.cluster[resourceID]; ok {
+		return doc, nil
 	}
 
 	return nil, ErrNotFound
@@ -48,8 +48,8 @@ func (c *Cache) DeleteClusterDoc(ctx context.Context, resourceID string, subscri
 }
 
 func (c *Cache) GetNodePoolDoc(ctx context.Context, resourceID string) (*NodePoolDocument, error) {
-	if _, ok := c.nodePool[resourceID]; ok {
-		return c.nodePool[resourceID], nil
+	if doc, ok := c.nodePool[resourceID]; ok {
+		return doc, nil
 	}
 
 	return nil, ErrNotFound
@@ -66,8 +66,8 @@ func (c *Cache) DeleteNodePoolDoc(ctx context.Context, resourceID string) error 
 }
 
 func (c *Cache) GetOperationDoc(ctx context.Context, operationID string) (*OperationDocument, error) {
-	if _, ok := c.operation[operationID]; ok {
-		return c.operation[operationID], nil
+	if doc, ok := c.operation[operationID]; ok {
+		return doc, nil
 	}
 
 	return nil, ErrNotFound
@@ -84,8 +84,8 @@ func (c *Cache) DeleteOperationDoc(ctx context.Context, operationID string) erro
 }
 
 func (c *Cache) GetSubscriptionDoc(ctx context.Context, subscriptionID string) (*SubscriptionDocument, error) {
-	if _, ok := c.subscription[subscriptionID]; ok {
-		return c.subscription[subscriptionID], nil
+	if doc, ok := c.subscription[subscriptionID]; ok {
+		return doc, nil
 	}
 
 	return nil, ErrNotFound

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -112,6 +113,10 @@ func (d *CosmosDBClient) DBConnectionTest(ctx context.Context) error {
 
 // GetClusterDoc retrieves a cluster document from async DB using resource ID
 func (d *CosmosDBClient) GetClusterDoc(ctx context.Context, resourceID string, subscriptionID string) (*HCPOpenShiftClusterDocument, error) {
+	// Make sure lookup keys are lowercase.
+	resourceID = strings.ToLower(resourceID)
+	subscriptionID = strings.ToLower(subscriptionID)
+
 	container, err := d.client.NewContainer(clustersContainer)
 	if err != nil {
 		return nil, err
@@ -148,6 +153,10 @@ func (d *CosmosDBClient) GetClusterDoc(ctx context.Context, resourceID string, s
 
 // SetClusterDoc creates/updates a cluster document in the async DB during cluster creation/patching
 func (d *CosmosDBClient) SetClusterDoc(ctx context.Context, doc *HCPOpenShiftClusterDocument) error {
+	// Make sure lookup keys are lowercase.
+	doc.Key = strings.ToLower(doc.Key)
+	doc.PartitionKey = strings.ToLower(doc.PartitionKey)
+
 	data, err := json.Marshal(doc)
 	if err != nil {
 		return err
@@ -168,6 +177,10 @@ func (d *CosmosDBClient) SetClusterDoc(ctx context.Context, doc *HCPOpenShiftClu
 
 // DeleteClusterDoc removes a cluster document from the async DB using resource ID
 func (d *CosmosDBClient) DeleteClusterDoc(ctx context.Context, resourceID string, subscriptionID string) error {
+	// Make sure lookup keys are lowercase.
+	resourceID = strings.ToLower(resourceID)
+	subscriptionID = strings.ToLower(subscriptionID)
+
 	doc, err := d.GetClusterDoc(ctx, resourceID, subscriptionID)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
@@ -204,6 +217,9 @@ func (d *CosmosDBClient) DeleteNodePoolDoc(ctx context.Context, resourceID strin
 // GetOperationDoc retrieves the asynchronous operation document for the given
 // operation ID from the "operations" container
 func (d *CosmosDBClient) GetOperationDoc(ctx context.Context, operationID string) (*OperationDocument, error) {
+	// Make sure lookup keys are lowercase.
+	operationID = strings.ToLower(operationID)
+
 	container, err := d.client.NewContainer(operationsContainer)
 	if err != nil {
 		return nil, err
@@ -233,6 +249,9 @@ func (d *CosmosDBClient) GetOperationDoc(ctx context.Context, operationID string
 // SetOperationDoc writes an asynchronous operation document to the "operations"
 // container
 func (d *CosmosDBClient) SetOperationDoc(ctx context.Context, doc *OperationDocument) error {
+	// Make sure lookup keys are lowercase.
+	doc.ID = strings.ToLower(doc.ID)
+
 	container, err := d.client.NewContainer(operationsContainer)
 	if err != nil {
 		return err
@@ -256,6 +275,9 @@ func (d *CosmosDBClient) SetOperationDoc(ctx context.Context, doc *OperationDocu
 // DeleteOperationDoc deletes the asynchronous operation document for the given
 // operation ID from the "operations" container
 func (d *CosmosDBClient) DeleteOperationDoc(ctx context.Context, operationID string) error {
+	// Make sure lookup keys are lowercase.
+	operationID = strings.ToLower(operationID)
+
 	container, err := d.client.NewContainer(operationsContainer)
 	if err != nil {
 		return err
@@ -278,6 +300,9 @@ func (d *CosmosDBClient) DeleteOperationDoc(ctx context.Context, operationID str
 
 // GetSubscriptionDoc retreives a subscription document from async DB using the subscription ID
 func (d *CosmosDBClient) GetSubscriptionDoc(ctx context.Context, subscriptionID string) (*SubscriptionDocument, error) {
+	// Make sure lookup keys are lowercase.
+	subscriptionID = strings.ToLower(subscriptionID)
+
 	container, err := d.client.NewContainer(subsContainer)
 	if err != nil {
 		return nil, err
@@ -314,6 +339,9 @@ func (d *CosmosDBClient) GetSubscriptionDoc(ctx context.Context, subscriptionID 
 
 // SetSubscriptionDoc creates/updates a subscription document in the async DB during cluster creation/patching
 func (d *CosmosDBClient) SetSubscriptionDoc(ctx context.Context, doc *SubscriptionDocument) error {
+	// Make sure lookup keys are lowercase.
+	doc.PartitionKey = strings.ToLower(doc.PartitionKey)
+
 	data, err := json.Marshal(doc)
 	if err != nil {
 		return err


### PR DESCRIPTION
### What this PR does

Introduce a new middleware function and some light refactoring of the `DBClient` interface.

- Cosmos DB partition key and document ID strings are case-sensitive.  Convert these strings to lowercase in all `DBClient`  methods so callers don't have to remember to.  Reduces the chance of lookup failures due to case sensitivity.

- Introduce a new `MiddlewareResourceID` function for endpoints that form a valid Azure resource ID.  Creates a [ResourceID](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore@v1.13.0/arm/internal/resource#ResourceID) instance from the original (non-lowercased) URL path and stores it in the HTTP request context.

Jira: Loosely related to [ARO-5737 : Implement Async API ARM Requirements for Long-Running Operations](https://issues.redhat.com/browse/ARO-5737)
Link to demo recording: <!-- optional: link to a demo recording -->
