### PR TITLE
Specify BASE_DOMAIN to fix the dev CS deployment

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -7,7 +7,7 @@ include ../dev-infrastructure/configurations/$(CONFIG_PROFILE).mk
 CONSUMER_NAME ?= $(shell az aks list --query "[?tags.clusterType == 'mgmt-cluster' && starts_with(resourceGroup, '$(REGIONAL_RESOURCEGROUP)')].resourceGroup" -o tsv)
 
 deploy:
-	DOMAIN=$(shell az network dns zone list -g ${REGIONAL_RESOURCEGROUP} --query "[?zoneType=='Public'].name" -o tsv) && \
+	DOMAIN="${REGION}.${BASE_DOMAIN}" && \
 	sed -e "s/DOMAIN/$${DOMAIN}/g" -e "s/REGION/${REGION}/g" -e "s/CONSUMER_NAME/${CONSUMER_NAME}/g" deploy/mvp-provisioning-shards.yml > deploy/tmp-provisioning-shard.yml
 	oc process --local -f deploy/openshift-templates/arohcp-namespace-template.yml \
 	  -p ISTIO_VERSION=asm-1-20 | oc apply -f -

--- a/dev-infrastructure/configurations/dev.mk
+++ b/dev-infrastructure/configurations/dev.mk
@@ -4,3 +4,4 @@ REGIONAL_RESOURCEGROUP ?= aro-hcp-$(USER)-$(REGION)
 GLOBAL_RESOURCEGROUP ?= global
 ARO_HCP_IMAGE_ACR ?= arohcpdev
 REGIONAL_ACR_NAME ?= arohcpdev$(shell echo $(CURRENTUSER) | sha256sum  | head -c 24)
+BASE_DOMAIN ?= hcp.osadev.cloud


### PR DESCRIPTION
### What this PR does

The existing logic to list public zones in the provided resource group no longer works because both the long-lived dev environment and ephemeral environments create these zones in the same regional resource group. This commit does not fix the problem for ephemeral environments at this time, which still exists.

https://github.com/Azure/ARO-HCP/actions/runs/10165696447/job/28114914461