### PR TITLE
prevent duplicate DNS zone for GH action driven region creation

### DIFF
--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -84,6 +84,7 @@
                 --template-file templates/region.bicep \
                 --parameters configurations/mvp-region.bicepparam \
                 --parameters currentUserId="${GITHUB_ACTOR}" \
+                --parameters regionalDNSSubdomain="${REGION}"
 
               # service cluster
               az deployment group create \

--- a/.github/workflows/bicep-what-if.yml
+++ b/.github/workflows/bicep-what-if.yml
@@ -59,7 +59,8 @@ jobs:
               --name "region-${GITHUB_RUN_ID}" \
               --resource-group "${REGIONAL_RESOURCEGROUP}" \
               --template-file templates/region.bicep \
-              --parameters configurations/mvp-region.bicepparam
+              --parameters configurations/mvp-region.bicepparam \
+              --parameters regionalDNSSubdomain="${REGION}"
 
             # service cluster
             az deployment group what-if \

--- a/dev-infrastructure/templates/region.bicep
+++ b/dev-infrastructure/templates/region.bicep
@@ -26,6 +26,8 @@ param baseDNSZoneName string
 @description('The resource group to deploy the base DNS zone to')
 param baseDNSZoneResourceGroup string = 'global'
 
+param regionalDNSSubdomain string = empty(currentUserId) ? location : '${location}-${take(uniqueString(currentUserId), 5)}'
+
 // Tags the resource group
 resource subscriptionTags 'Microsoft.Resources/tags@2024-03-01' = {
   name: 'default'
@@ -41,8 +43,6 @@ resource subscriptionTags 'Microsoft.Resources/tags@2024-03-01' = {
 //
 // R E G I O N A L   D N S   Z O N E
 //
-
-var regionalDNSSubdomain = empty(currentUserId) ? location : '${location}-${take(uniqueString(currentUserId), 5)}'
 
 resource regionalZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   name: '${regionalDNSSubdomain}.${baseDNSZoneName}'

--- a/dev-infrastructure/templates/region.bicep
+++ b/dev-infrastructure/templates/region.bicep
@@ -26,7 +26,9 @@ param baseDNSZoneName string
 @description('The resource group to deploy the base DNS zone to')
 param baseDNSZoneResourceGroup string = 'global'
 
-param regionalDNSSubdomain string = empty(currentUserId) ? location : '${location}-${take(uniqueString(currentUserId), 5)}'
+param regionalDNSSubdomain string = empty(currentUserId)
+  ? location
+  : '${location}-${take(uniqueString(currentUserId), 5)}'
 
 // Tags the resource group
 resource subscriptionTags 'Microsoft.Resources/tags@2024-03-01' = {


### PR DESCRIPTION
### What this PR does

the additional zone appears because of currentUserId being passed into the region.bicep template [here](https://github.com/Azure/ARO-HCP/blob/aec16617b5eb1705c872efc5962b943244480bda/.github/workflows/aro-hcp-dev-env-cd.yml#L86) and being consumed like [this](https://github.com/Azure/ARO-HCP/blob/aec16617b5eb1705c872efc5962b943244480bda/dev-infrastructure/templates/region.bicep#L45)

fix by providing an explicit `regionalDNSSubdomain`

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
