### PR TITLE
ocm: Handle CS responses internally

### DIFF
--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -4,6 +4,8 @@ package ocm
 // Licensed under the Apache License 2.0.
 
 import (
+	"fmt"
+
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
@@ -26,61 +28,75 @@ type ClusterServiceConfig struct {
 }
 
 // GetCSCluster creates and sends a GET request to fetch a cluster from Clusters Service
-func (csc *ClusterServiceConfig) GetCSCluster(clusterID string) (*cmv1.ClusterGetResponse, error) {
-	cluster, err := csc.Conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).Get().Send()
+func (csc *ClusterServiceConfig) GetCSCluster(clusterID string) (*cmv1.Cluster, error) {
+	clusterGetResponse, err := csc.Conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).Get().Send()
 	if err != nil {
 		return nil, err
+	}
+	cluster, ok := clusterGetResponse.GetBody()
+	if !ok {
+		return nil, fmt.Errorf("empty response body")
 	}
 	return cluster, nil
 }
 
 // PostCSCluster creates and sends a POST request to create a cluster in Clusters Service
-func (csc *ClusterServiceConfig) PostCSCluster(cluster *cmv1.Cluster) (*cmv1.ClustersAddResponse, error) {
-	resp, err := csc.Conn.ClustersMgmt().V1().Clusters().Add().Body(cluster).Send()
+func (csc *ClusterServiceConfig) PostCSCluster(cluster *cmv1.Cluster) (*cmv1.Cluster, error) {
+	clustersAddResponse, err := csc.Conn.ClustersMgmt().V1().Clusters().Add().Body(cluster).Send()
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+	cluster, ok := clustersAddResponse.GetBody()
+	if !ok {
+		return nil, fmt.Errorf("empty response body")
+	}
+	return cluster, nil
 }
 
 // UpdateCSCluster sends a POST request to update a cluster in Clusters Service
-func (csc *ClusterServiceConfig) UpdateCSCluster(clusterID string, cluster *cmv1.Cluster) (*cmv1.ClusterUpdateResponse, error) {
-	resp, err := csc.Conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).Update().Body(cluster).Send()
+func (csc *ClusterServiceConfig) UpdateCSCluster(clusterID string, cluster *cmv1.Cluster) (*cmv1.Cluster, error) {
+	clusterUpdateResponse, err := csc.Conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).Update().Body(cluster).Send()
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+	cluster, ok := clusterUpdateResponse.GetBody()
+	if !ok {
+		return nil, fmt.Errorf("empty response body")
+	}
+	return cluster, nil
 }
 
 // DeleteCSCluster creates and sends a DELETE request to delete a cluster from Clusters Service
-func (csc *ClusterServiceConfig) DeleteCSCluster(clusterID string) (*cmv1.ClusterDeleteResponse, error) {
-	resp, err := csc.Conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).Delete().Send()
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+func (csc *ClusterServiceConfig) DeleteCSCluster(clusterID string) error {
+	_, err := csc.Conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).Delete().Send()
+	return err
 }
 
-func (csc *ClusterServiceConfig) GetCSNodePool(clusterID, nodePoolID string) (*cmv1.NodePoolGetResponse, error) {
+func (csc *ClusterServiceConfig) GetCSNodePool(clusterID, nodePoolID string) (*cmv1.NodePool, error) {
 	nodePoolGetResponse, err := csc.Conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).NodePools().NodePool(nodePoolID).Get().Send()
 	if err != nil {
 		return nil, err
 	}
-	return nodePoolGetResponse, nil
+	nodePool, ok := nodePoolGetResponse.GetBody()
+	if !ok {
+		return nil, fmt.Errorf("empty response body")
+	}
+	return nodePool, nil
 }
 
-func (csc *ClusterServiceConfig) CreateCSNodePool(clusterID string, nodePool *cmv1.NodePool) (*cmv1.NodePoolsAddResponse, error) {
-	resp, err := csc.Conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).NodePools().Add().Body(nodePool).Send()
+func (csc *ClusterServiceConfig) CreateCSNodePool(clusterID string, nodePool *cmv1.NodePool) (*cmv1.NodePool, error) {
+	nodePoolsAddResponse, err := csc.Conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).NodePools().Add().Body(nodePool).Send()
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+	nodePool, ok := nodePoolsAddResponse.GetBody()
+	if !ok {
+		return nil, fmt.Errorf("empty response body")
+	}
+	return nodePool, nil
 }
 
-func (csc *ClusterServiceConfig) DeleteCSNodePool(clusterID, nodePoolID string) (*cmv1.NodePoolDeleteResponse, error) {
-	resp, err := csc.Conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).NodePools().NodePool(nodePoolID).Delete().Send()
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+func (csc *ClusterServiceConfig) DeleteCSNodePool(clusterID, nodePoolID string) error {
+	_, err := csc.Conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).NodePools().NodePool(nodePoolID).Delete().Send()
+	return err
 }


### PR DESCRIPTION
### What this PR does

Simplifies the `ClusterServiceConfig` methods by hiding the raw response objects and instead returning the response body where applicable (or an error if an expected body is absent).

Jira: Loosely related to [ARO-5737 : Implement Async API ARM Requirements for Long-Running Operations](https://issues.redhat.com/browse/ARO-5737)
Link to demo recording: <!-- optional: link to a demo recording -->