### PR TITLE
configure ACM addons to run in hosted mode

### DIFF
--- a/acm/deploy/mch/addondeployconfig.yaml
+++ b/acm/deploy/mch/addondeployconfig.yaml
@@ -1,0 +1,8 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: addon-hosted-config
+spec:
+  customizedVariables:
+    - name: managedKubeConfigSecret
+      value: external-managed-kubeconfig

--- a/acm/scripts/install-acm.sh
+++ b/acm/scripts/install-acm.sh
@@ -72,6 +72,13 @@ kubectl wait --for=condition=Established crds manifestworks.work.open-cluster-ma
 wait_resource crds managedclusters.cluster.open-cluster-management.io
 kubectl wait --for=condition=Established crds managedclusters.cluster.open-cluster-management.io --timeout=600s
 
+# config MCE addons to run in hosted mode
+# https://github.com/stolostron/hypershift-addon-operator/blob/2c2794d5b773dfb1e5210c804faf22747dc003be/docs/advanced/running_mce_acm_addons_hostedmode.md#configuring-the-hub-cluster
+kubectl apply -f deploy/mch/addondeployconfig.yaml -n multicluster-engine
+kubectl patch clustermanagementaddon work-manager --type merge -p '{"spec":{"supportedConfigs":[{"defaultConfig":{"name":"addon-hosted-config","namespace":"multicluster-engine"},"group":"addon.open-cluster-management.io","resource":"addondeploymentconfigs"}]}}'
+kubectl patch clustermanagementaddon config-policy-controller --type merge -p '{"spec":{"supportedConfigs":[{"defaultConfig":{"name":"addon-hosted-config","namespace":"multicluster-engine"},"group":"addon.open-cluster-management.io","resource":"addondeploymentconfigs"}]}}'
+kubectl patch clustermanagementaddon cert-policy-controller --type merge -p '{"spec":{"supportedConfigs":[{"defaultConfig":{"name":"addon-hosted-config","namespace":"multicluster-engine"},"group":"addon.open-cluster-management.io","resource":"addondeploymentconfigs"}]}}'
+
 # apply klusterletconfig to enroll local cluster
 kubectl apply -f deploy/mch/klusterletconfig.yaml
 


### PR DESCRIPTION
### What this PR does

this is required when imported ManagedClusters are HCPs without nodes, so that the addons are scheduled on the MC and use a specific kube secret for CP access

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
