### PR TITLE
dev-infrastructure: Update option for clusters-service demo mode

### DIFF
--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -346,7 +346,7 @@ make db/setup
 3) Start CS:
 
 ```bash
-./clusters-service serve --config-file development.yml --demo-mode
+./clusters-service serve --config-file development.yml --runtime-mode demo
 ```
 
 You now have a running, functioning local CS deployment

--- a/dev-infrastructure/local_CS.sh
+++ b/dev-infrastructure/local_CS.sh
@@ -86,4 +86,4 @@ make db/setup
 ./clusters-service init --config-file ./development.yml
 
 # Start CS
-./clusters-service serve --config-file development.yml --demo-mode
+./clusters-service serve --config-file development.yml --runtime-mode demo


### PR DESCRIPTION
Demo mode is now selected by `--runtime-mode demo`.

https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/commit/cfd954f35ccd088296a3f50705f4e9eb1e1b40b2