### PR TITLE
Refactor ARO HCP cluster ingress API 

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -12,7 +12,7 @@ git config --global core.editor "code --wait"
 source /usr/share/bash-completion/completions/git
 echo "source /usr/share/bash-completion/completions/git" >> ~/.bashrc
 
-npm ci
+cd api && npm ci
 
 # Install azure/oav for validation of openapi and swagger example generation
 # https://github.com/Azure/oav

--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -156,10 +156,10 @@ model ClusterSpec {
   @visibility("create", "read")
   externalAuth?: ExternalAuthConfigProfile;
 
-  /** Configures the cluster ingresses */
+  /** Configures the default cluster ingress */
   @visibility("create", "read")
   @OpenAPI.extension("x-ms-identifiers", ["ip", "url", "visibility"])
-  ingress?: IngressProfile[];
+  ingress?: IngressProfile;
 }
 
 /** The patchable cluster specification */
@@ -480,12 +480,8 @@ model TokenClaimValidationRuleProfile {
  * =======================================
  */
 
-/** Configuration of the cluster ingress */
+/** Configuration of the default cluster ingress */
 model IngressProfile {
-  /** The IP for the ingress */
-  @visibility("read")
-  ip: string;
-
   /** The ingress url */
   @visibility("read")
   url: string;

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1116,11 +1116,8 @@
           ]
         },
         "ingress": {
-          "type": "array",
-          "description": "Configures the cluster ingresses",
-          "items": {
-            "$ref": "#/definitions/IngressProfile"
-          },
+          "$ref": "#/definitions/IngressProfile",
+          "description": "Configures the default cluster ingress",
           "x-ms-identifiers": [
             "ip",
             "url",
@@ -1579,13 +1576,8 @@
     },
     "IngressProfile": {
       "type": "object",
-      "description": "Configuration of the cluster ingress",
+      "description": "Configuration of the default cluster ingress",
       "properties": {
-        "ip": {
-          "type": "string",
-          "description": "The IP for the ingress",
-          "readOnly": true
-        },
         "url": {
           "type": "string",
           "description": "The ingress url",
@@ -1601,7 +1593,6 @@
         }
       },
       "required": [
-        "ip",
         "url",
         "visibility"
       ]

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -85,12 +85,9 @@ func (f *Frontend) ConvertCStoHCPOpenShiftCluster(systemData *arm.SystemData, cl
 					Enabled:       false,
 					ExternalAuths: []*configv1.OIDCProvider{},
 				},
-				Ingress: []*api.IngressProfile{
-					{
-						IP:         "", // TODO: Unsure if OCM will support this field
-						URL:        "",
-						Visibility: "",
-					},
+				Ingress: api.IngressProfile{
+					URL:        "",
+					Visibility: "",
 				},
 			},
 		},

--- a/frontend/utils/create.go
+++ b/frontend/utils/create.go
@@ -80,7 +80,7 @@ func CreateJSONFile() error {
 				},
 				IssuerURL:    "",
 				ExternalAuth: api.ExternalAuthConfigProfile{},
-				Ingress:      nil,
+				Ingress:      api.IngressProfile{},
 			},
 		},
 	}

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -35,7 +35,7 @@ type ClusterSpec struct {
 	Platform                      PlatformProfile           `json:"platform,omitempty"                      visibility:"read create"        validate:"required_for_put"`
 	IssuerURL                     string                    `json:"issuerUrl,omitempty"                     visibility:"read"               validate:"omitempty,url"`
 	ExternalAuth                  ExternalAuthConfigProfile `json:"externalAuth,omitempty"                  visibility:"read create"`
-	Ingress                       []*IngressProfile         `json:"ingressProfile,omitempty"                visibility:"read create"`
+	Ingress                       IngressProfile            `json:"ingressProfile,omitempty"                visibility:"read create"`
 }
 
 // VersionProfile represents the cluster control plane version.
@@ -101,7 +101,6 @@ type ExternalAuthConfigProfile struct {
 
 // IngressProfile represents a cluster ingress configuration.
 type IngressProfile struct {
-	IP         string     `json:"ip,omitempty"         visibility:"read"        validate:"omitempty,ipv4"`
 	URL        string     `json:"url,omitempty"        visibility:"read"        validate:"omitempty,url"`
 	Visibility Visibility `json:"visibility,omitempty" visibility:"read create" validate:"required_for_put,enum_visibility"`
 }

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -66,8 +66,8 @@ type ClusterSpec struct {
 	// Enable FIPS mode for the cluster When set to true, etcdEncryption must be set to true
 	Fips *bool
 
-	// Configures the cluster ingresses
-	Ingress []*IngressProfile
+	// Configures the default cluster ingress
+	Ingress *IngressProfile
 
 	// Cluster network configuration
 	Network *NetworkProfile
@@ -360,13 +360,10 @@ type HcpOpenShiftVersionsProperties struct {
 	ProvisioningState *ResourceProvisioningState
 }
 
-// IngressProfile - Configuration of the cluster ingress
+// IngressProfile - Configuration of the default cluster ingress
 type IngressProfile struct {
 	// REQUIRED; The visibility of the ingress determines if the ingress is visible from the internet
 	Visibility *Visibility
-
-	// READ-ONLY; The IP for the ingress
-	IP *string
 
 	// READ-ONLY; The ingress url
 	URL *string

--- a/internal/api/v20240610preview/generated/models_serde.go
+++ b/internal/api/v20240610preview/generated/models_serde.go
@@ -1069,7 +1069,6 @@ func (h *HcpOpenShiftVersionsProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type IngressProfile.
 func (i IngressProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "ip", i.IP)
 	populate(objectMap, "url", i.URL)
 	populate(objectMap, "visibility", i.Visibility)
 	return json.Marshal(objectMap)
@@ -1084,9 +1083,6 @@ func (i *IngressProfile) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "ip":
-				err = unpopulate(val, "IP", &i.IP)
-			delete(rawMsg, key)
 		case "url":
 				err = unpopulate(val, "URL", &i.URL)
 			delete(rawMsg, key)

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -112,7 +112,6 @@ func newPlatformProfile(from *api.PlatformProfile) *generated.PlatformProfile {
 
 func newIngressProfile(from *api.IngressProfile) *generated.IngressProfile {
 	return &generated.IngressProfile{
-		IP:         api.Ptr(from.IP),
 		URL:        api.Ptr(from.URL),
 		Visibility: api.Ptr(generated.Visibility(from.Visibility)),
 	}
@@ -210,12 +209,12 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 					DisableUserWorkloadMonitoring: api.Ptr(from.Properties.Spec.DisableUserWorkloadMonitoring),
 					Proxy:                         newProxyProfile(&from.Properties.Spec.Proxy),
 					Platform:                      newPlatformProfile(&from.Properties.Spec.Platform),
+					Ingress:                       newIngressProfile(&from.Properties.Spec.Ingress),
 					IssuerURL:                     api.Ptr(from.Properties.Spec.IssuerURL),
 					ExternalAuth: &generated.ExternalAuthConfigProfile{
 						Enabled:       api.Ptr(from.Properties.Spec.ExternalAuth.Enabled),
 						ExternalAuths: make([]*generated.ExternalAuthProfile, len(from.Properties.Spec.ExternalAuth.ExternalAuths)),
 					},
-					Ingress: make([]*generated.IngressProfile, len(from.Properties.Spec.Ingress)),
 				},
 			},
 		},
@@ -238,10 +237,6 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 
 	for index, item := range from.Properties.Spec.ExternalAuth.ExternalAuths {
 		out.Properties.Spec.ExternalAuth.ExternalAuths[index] = newExternalAuthProfile(item)
-	}
-
-	for index, item := range from.Properties.Spec.Ingress {
-		out.Properties.Spec.Ingress[index] = newIngressProfile(item)
 	}
 
 	return out
@@ -326,11 +321,8 @@ func (c *HcpOpenShiftClusterResource) Normalize(out *api.HCPOpenShiftCluster) {
 			if c.Properties.Spec.ExternalAuth != nil {
 				normalizeExternalAuthConfig(c.Properties.Spec.ExternalAuth, &out.Properties.Spec.ExternalAuth)
 			}
-			ingressSequence := api.DeleteNilsFromPtrSlice(c.Properties.Spec.Ingress)
-			out.Properties.Spec.Ingress = make([]*api.IngressProfile, len(ingressSequence))
-			for index, item := range ingressSequence {
-				out.Properties.Spec.Ingress[index] = &api.IngressProfile{}
-				normalizeIngress(item, out.Properties.Spec.Ingress[index])
+			if c.Properties.Spec.Ingress != nil {
+				normalizeIngress(c.Properties.Spec.Ingress, &out.Properties.Spec.Ingress)
 			}
 		}
 	}
@@ -588,9 +580,6 @@ func (p *IngressProfile) Normalize(out *api.IngressProfile) {
 }
 
 func normalizeIngress(p *generated.IngressProfile, out *api.IngressProfile) {
-	if p.IP != nil {
-		out.IP = *p.IP
-	}
 	if p.URL != nil {
 		out.URL = *p.URL
 	}


### PR DESCRIPTION
### What this PR does
* Only the default ingress is configurable, previously a slice of
  ingresses could be provided.
* The IP field has been removed. It may be added back in the future if
  there is a compelling use-case.

### Special notes for your reviewer
* The devcontainer was no longer working since the top-level package-lock.json was moved under `api`
