### PR TITLE
restrict ACR purge job to RP image

### DIFF
--- a/dev-infrastructure/templates/dev-acr.bicep
+++ b/dev-infrastructure/templates/dev-acr.bicep
@@ -43,7 +43,7 @@ resource acrPurgeTask 'Microsoft.ContainerRegistry/registries/tasks@2019-04-01' 
       os: 'Linux'
     }
     step: {
-      encodedTaskContent: base64('acr purge --ago 7d')
+      encodedTaskContent: base64('acr purge --filter "arohcpfrontend:.*" --keep 3 --ago 7d')
       type: 'EncodedTask'
     }
     timeout: 3600


### PR DESCRIPTION
### What this PR does

the RP image is the only one right now that is continously deployed to our clusters. as such purging older images while retaining newer ones is a meaningful practice.

we can add more service images to the list once we implement continous delivery for them as well.

images like the OCP payloads or the operator catalog images should never be purged automatically for now.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
