### PR TITLE
Continue removing IP from IngressProfile

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -158,8 +158,8 @@ model ClusterSpec {
 
   /** Configures the default cluster ingress */
   @visibility("create", "read")
-  @OpenAPI.extension("x-ms-identifiers", ["ip", "url", "visibility"])
-  ingress?: IngressProfile;
+  @OpenAPI.extension("x-ms-identifiers", ["url", "visibility"])
+  ingress: IngressProfile;
 }
 
 /** The patchable cluster specification */

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1119,7 +1119,6 @@
           "$ref": "#/definitions/IngressProfile",
           "description": "Configures the default cluster ingress",
           "x-ms-identifiers": [
-            "ip",
             "url",
             "visibility"
           ],
@@ -1133,7 +1132,8 @@
         "version",
         "console",
         "api",
-        "issuerUrl"
+        "issuerUrl",
+        "ingress"
       ]
     },
     "ConsoleProfile": {

--- a/frontend/utils/create.go
+++ b/frontend/utils/create.go
@@ -80,7 +80,9 @@ func CreateJSONFile() error {
 				},
 				IssuerURL:    "",
 				ExternalAuth: api.ExternalAuthConfigProfile{},
-				Ingress:      api.IngressProfile{},
+				Ingress: api.IngressProfile{
+					Visibility: api.Visibility("public"),
+				},
 			},
 		},
 	}

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -35,7 +35,7 @@ type ClusterSpec struct {
 	Platform                      PlatformProfile           `json:"platform,omitempty"                      visibility:"read create"        validate:"required_for_put"`
 	IssuerURL                     string                    `json:"issuerUrl,omitempty"                     visibility:"read"               validate:"omitempty,url"`
 	ExternalAuth                  ExternalAuthConfigProfile `json:"externalAuth,omitempty"                  visibility:"read create"`
-	Ingress                       IngressProfile            `json:"ingressProfile,omitempty"                visibility:"read create"`
+	Ingress                       IngressProfile            `json:"ingress,omitempty"                       visibility:"read create"        validate:"required_for_put"`
 }
 
 // VersionProfile represents the cluster control plane version.

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -44,6 +44,9 @@ type ClusterPatchSpec struct {
 
 // ClusterSpec - The cluster resource specification
 type ClusterSpec struct {
+	// REQUIRED; Configures the default cluster ingress
+	Ingress *IngressProfile
+
 	// REQUIRED; Version of the control plane components
 	Version *VersionProfile
 
@@ -65,9 +68,6 @@ type ClusterSpec struct {
 
 	// Enable FIPS mode for the cluster When set to true, etcdEncryption must be set to true
 	Fips *bool
-
-	// Configures the default cluster ingress
-	Ingress *IngressProfile
 
 	// Cluster network configuration
 	Network *NetworkProfile


### PR DESCRIPTION
### What this PR does
* Forgot to update `x-ms-identifiers`
* Generates a valid cluster.json defaulting to a public IngressProfile
* Make IngressProfile a required field to align with APIProfile
* Rename json struct tag to ingress to align with generated code

Currently the existing helper code results in:
```
❯ curl -i -X PUT "localhost:8443/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/mshen-p1-temp/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/mshen2?api-version=2024-06-10-preview" \
  -H "X-Ms-Arm-Resource-System-Data: {\"createdBy\": \"mshen\", \"createdByType\": \"User\", \"createdAt\": \"2024-07-31T19:26:56+00:00\"}" \
  --json @cluster.json
HTTP/1.1 400 Bad Request
Content-Type: application/json
X-Ms-Error-Code: InvalidRequestContent
X-Ms-Request-Id: 86567206-2296-4eaf-ae05-a80e1d169de7
Date: Wed, 07 Aug 2024 20:26:10 GMT
Content-Length: 186

{
    "error": {
        "code": "InvalidRequestContent",
        "message": "Missing required field 'visibility'",
        "target": "properties.spec.ingressProfile.visibility"
    }
}
```