### PR TITLE
fix: limit name length of metrics resource names

### DIFF
--- a/dev-infrastructure/modules/metrics/aks-azure-monitor-metrics.bicep
+++ b/dev-infrastructure/modules/metrics/aks-azure-monitor-metrics.bicep
@@ -4,8 +4,8 @@ param clusterResourceId string
 param clusterLocation string
 
 var clusterName = split(clusterResourceId, '/')[8]
-var dceName = 'MSProm-${azureMonitorWorkspaceLocation}-${clusterName}'
-var dcrName = 'MSProm-${azureMonitorWorkspaceLocation}-${clusterName}'
+var dceName = take('MSProm-${azureMonitorWorkspaceLocation}-${clusterName}', 44)
+var dcrName = take('MSProm-${azureMonitorWorkspaceLocation}-${clusterName}', 44)
 var dcraName = 'MSProm-${clusterLocation}-${clusterName}'
 var nodeRecordingRuleGroupPrefix = 'NodeRecordingRulesRuleGroup-'
 var nodeRecordingRuleGroupName = '${nodeRecordingRuleGroupPrefix}${clusterName}'


### PR DESCRIPTION
### What this PR does

datacollectionendpoint has a max length of 44, these aren't advertised well though in ARM API contracts. Should hopefully allow dev infra to be deployed.  