### PR TITLE
Set restart policy on ocmirror cronjob

### DIFF
--- a/image-sync/oc-mirror/deploy/image-sync-template.yml
+++ b/image-sync/oc-mirror/deploy/image-sync-template.yml
@@ -96,6 +96,7 @@ objects:
                   readOnly: true
                   volumeAttributes:
                     secretProviderClass: "ocmirror-pullsecret"
+              restartPolicy: Never
               serviceAccountName: image-sync
     status: {}
   - apiVersion: v1


### PR DESCRIPTION
### What this PR does
Fix deploy CI.  Set restart policy = Never on ocmirror cronjob.  Since it runs every hour, no need to restart it, unless @janboll or @geoberle disagree :) 