### PR TITLE
make managed grafana name configurable

### DIFF
--- a/dev-infrastructure/configurations/mvp-region.bicepparam
+++ b/dev-infrastructure/configurations/mvp-region.bicepparam
@@ -11,5 +11,8 @@ param maestroKeyVaultName = 'maestro-kv-aro-hcp-dev'
 param maestroEventGridNamespacesName = 'maestro-eventgrid-aro-hcp-dev'
 param maestroEventGridMaxClientSessionsPerAuthName = 4
 
+// observability
+param managedGrafanaName= 'aro-hcp-grafana'
+
 // This parameter is always overriden in the Makefile
 param currentUserId = ''

--- a/dev-infrastructure/configurations/region.bicepparam
+++ b/dev-infrastructure/configurations/region.bicepparam
@@ -9,5 +9,8 @@ param maestroKeyVaultName = take('maestro-kv-${uniqueString(currentUserId)}', 24
 param maestroEventGridNamespacesName = take('maestro-eg-${uniqueString(currentUserId)}', 24)
 param maestroEventGridMaxClientSessionsPerAuthName = 4
 
+// observability
+param managedGrafanaName= take('aro-hcp-${uniqueString(currentUserId)}', 24)
+
 // This parameter is always overriden in the Makefile
 param currentUserId = ''

--- a/dev-infrastructure/modules/metrics/Metrics.bicep
+++ b/dev-infrastructure/modules/metrics/Metrics.bicep
@@ -1,6 +1,8 @@
 // This template is copied from https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/ARO-Pipelines?path=/metrics/infra/Templates/Metrics.bicep
 // Ideally this template is consumed from ACR.
 
+param managedGrafanaName string
+
 // api-version=2021-06-01-preview is the internal Microsoft API, and api-version=2021-06-03-preview is for external customer use.
 // The internal API version enables additional configurations options, including Geneva Metrics (MDM) stamp selection, and Geneva Metrics (MDM) ingestion configuration.
 // Internal Microsoft customers should use the internal API to be able to link their existing Geneva Metrics (MDM) accounts, or to create managed Geneva Metrics (MDM) accounts on the appropriate stamp.
@@ -11,7 +13,7 @@ resource monitor 'microsoft.monitor/accounts@2021-06-03-preview' = {
 }
 
 resource grafana 'Microsoft.Dashboard/grafana@2023-09-01' = {
-  name: 'aro-hcp-grafana'
+  name: managedGrafanaName
   location: resourceGroup().location
   sku: {
     name: 'Standard'

--- a/dev-infrastructure/templates/region.bicep
+++ b/dev-infrastructure/templates/region.bicep
@@ -17,6 +17,9 @@ param maestroEventGridNamespacesName string
 @description('The maximum client sessions per authentication name for the EventGrid MQTT broker')
 param maestroEventGridMaxClientSessionsPerAuthName int
 
+@description('A unique name for the managed Grafana instance')
+param managedGrafanaName string
+
 @description('Set to true to prevent resources from being pruned after 48 hours')
 param persist bool = false
 
@@ -82,4 +85,7 @@ module maestroInfra '../modules/maestro/maestro-infra.bicep' = {
 
 module metricsInfra '../modules/metrics/Metrics.bicep' = {
   name: 'metrics-infra'
+  params: {
+    managedGrafanaName: managedGrafanaName
+  }
 }


### PR DESCRIPTION
### What this PR does

the name for managed grafana needs to be unique, so making it configurable allows us to adapt in different environments. for personal dev environments our defaults ensure uniqueness

```
NameNotUnique - The Grafana Workspace name 'aro-hcp-grafana' is already being used. Please choose another name.
```

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
