### PR TITLE
prevent resourcegroup tag loss

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -38,17 +38,21 @@ feature-registration: # hardcoded to eastus as this is a subscription deployment
 .PHONY: feature-registration
 
 rg:
-	az group create \
-  		--name $(RESOURCEGROUP)  \
-		--location $(REGION) \
-		--output none
+	@if ! az group exists --name $(RESOURCEGROUP) -o none; then \
+        @az group create \
+            --name $(RESOURCEGROUP)  \
+            --location $(REGION) \
+            --output none; \
+    fi
 .PHONY: rg
 
 regionalRg:
-	@az group create \
-		--name $(REGIONAL_RESOURCEGROUP)  \
-		--location $(REGION) \
-		--output none
+	@if ! az group exists --name $(REGIONAL_RESOURCEGROUP) -o none; then \
+        @az group create \
+            --name $(REGIONAL_RESOURCEGROUP)  \
+            --location $(REGION) \
+            --output none; \
+    fi
 .PHONY: regionalRg
 
 cleanup-orphaned-rolebindings:

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -39,20 +39,20 @@ feature-registration: # hardcoded to eastus as this is a subscription deployment
 
 rg:
 	@if ! az group exists --name $(RESOURCEGROUP) -o none; then \
-        @az group create \
-            --name $(RESOURCEGROUP)  \
-            --location $(REGION) \
-            --output none; \
-    fi
+		@az group create \
+			--name $(RESOURCEGROUP)  \
+			--location $(REGION) \
+			--output none; \
+	fi
 .PHONY: rg
 
 regionalRg:
 	@if ! az group exists --name $(REGIONAL_RESOURCEGROUP) -o none; then \
-        @az group create \
-            --name $(REGIONAL_RESOURCEGROUP)  \
-            --location $(REGION) \
-            --output none; \
-    fi
+		@az group create \
+			--name $(REGIONAL_RESOURCEGROUP)  \
+			--location $(REGION) \
+			--output none; \
+	fi
 .PHONY: regionalRg
 
 cleanup-orphaned-rolebindings:


### PR DESCRIPTION
### What this PR does

don't run `az group create` again if a resourcegroup already exists, as this wipes the existing tags.

loosing the `persist: true` tag was the reason for some RGs being cleaned.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
