### PR TITLE
fix parallel SC/MC provisioning bug

### DIFF
--- a/dev-infrastructure/modules/maestro/maestro-consumer.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-consumer.bicep
@@ -10,7 +10,7 @@ param maestroKeyVaultCertificateDomain string
 param location string
 
 module evengGridAccess './maestro-eventgrid-access.bicep' = {
-  name: '${deployment().name}-event-grid-access'
+  name: 'event-grid-access-${maestroConsumerName}'
   scope: resourceGroup(maestroInfraResourceGroup)
   params: {
     eventGridNamespaceName: maestroEventGridNamespaceName


### PR DESCRIPTION
### What this PR does

due to a static deploymentname for the deployment that handles event grid, access multiple concurrent MC/SC provisionings would fail, as these deployments all run in the regional RG.

this PR makes the deployment name unique by leveraging the consumer name as part of the name

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
