### PR TITLE
limit the name length of the maestro eventgrid access deployment

### DIFF
--- a/dev-infrastructure/modules/maestro/maestro-consumer.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-consumer.bicep
@@ -10,7 +10,7 @@ param maestroKeyVaultCertificateDomain string
 param location string
 
 module evengGridAccess './maestro-eventgrid-access.bicep' = {
-  name: 'event-grid-access-${maestroConsumerName}'
+  name: 'event-grid-access-${uniqueString(maestroConsumerName)}'
   scope: resourceGroup(maestroInfraResourceGroup)
   params: {
     eventGridNamespaceName: maestroEventGridNamespaceName


### PR DESCRIPTION
### What this PR does

the current name can occasionally be longer depending on the resourcegroup name of the AKS cluster
`uniqueString` generates a 13 char string, which is short enough for the deployment and subdeployments.

fixes https://github.com/Azure/ARO-HCP/pull/465

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
