### PR TITLE
increment AKS version to 1.29.7

### DIFF
--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -1,6 +1,6 @@
 using '../templates/mgmt-cluster.bicep'
 
-param kubernetesVersion = '1.29.5'
+param kubernetesVersion = '1.29.7'
 param vnetAddressPrefix = '10.132.0.0/14'
 param subnetPrefix = '10.132.8.0/21'
 param podSubnetPrefix = '10.132.64.0/18'

--- a/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
@@ -1,6 +1,6 @@
 using '../templates/mgmt-cluster.bicep'
 
-param kubernetesVersion = '1.29.5'
+param kubernetesVersion = '1.29.7'
 param vnetAddressPrefix = '10.132.0.0/14'
 param subnetPrefix = '10.132.8.0/21'
 param podSubnetPrefix = '10.132.64.0/18'

--- a/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
@@ -1,6 +1,6 @@
 using '../templates/svc-cluster.bicep'
 
-param kubernetesVersion = '1.29.5'
+param kubernetesVersion = '1.29.7'
 param istioVersion = ['asm-1-20']
 param vnetAddressPrefix = '10.128.0.0/14'
 param subnetPrefix = '10.128.8.0/21'

--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -1,6 +1,6 @@
 using '../templates/svc-cluster.bicep'
 
-param kubernetesVersion = '1.29.5'
+param kubernetesVersion = '1.29.7'
 param istioVersion = ['asm-1-20']
 param vnetAddressPrefix = '10.128.0.0/14'
 param subnetPrefix = '10.128.8.0/21'


### PR DESCRIPTION
### What this PR does

freshly created 1.29.5 clusters will upgrade anyways to .7 shortly after

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
