### PR TITLE
increase max user nodepool size for personal MGMT AKS cluster

### DIFF
--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -12,7 +12,7 @@ param systemAgentMinCount = 2
 param systemAgentMaxCount = 3
 param systemAgentVMSize = 'Standard_D2s_v3'
 param userAgentMinCount = 2
-param userAgentMaxCount = 3
+param userAgentMaxCount = 5
 param userAgentVMSize = 'Standard_D2s_v3'
 param persist = false
 


### PR DESCRIPTION
### What this PR does

the previous value of `3` resulted in issues during nodepool k8s upgrades. in some scenarios HCP pods with anti-affinity did not find a place to be rescheduled on and the nodepool upgrade came to a halt.

increasing the max pool size to `5` gives more wiggle room for such scenarios

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
