### PR TITLE
Reduce changes needed on repeated applies of aks bicep

### DIFF
--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -4,7 +4,6 @@ param kubernetesVersion = '1.29.7'
 param vnetAddressPrefix = '10.132.0.0/14'
 param subnetPrefix = '10.132.8.0/21'
 param podSubnetPrefix = '10.132.64.0/18'
-param enablePrivateCluster = false
 param aksClusterName = 'aro-hcp-mgmt-cluster'
 param aksKeyVaultName = take('aks-kv-mgmt-cluster-${uniqueString(currentUserId)}', 24)
 param aksEtcdKVEnableSoftDelete = false

--- a/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
@@ -4,7 +4,6 @@ param kubernetesVersion = '1.29.7'
 param vnetAddressPrefix = '10.132.0.0/14'
 param subnetPrefix = '10.132.8.0/21'
 param podSubnetPrefix = '10.132.64.0/18'
-param enablePrivateCluster = false
 param aksClusterName = take('aro-hcp-mgmt-cluster-${uniqueString('mgmt-cluster')}', 63)
 param aksKeyVaultName = 'aks-kv-aro-hcp-dev-mc-1'
 param systemAgentMinCount = 2

--- a/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
@@ -5,7 +5,6 @@ param istioVersion = ['asm-1-20']
 param vnetAddressPrefix = '10.128.0.0/14'
 param subnetPrefix = '10.128.8.0/21'
 param podSubnetPrefix = '10.128.64.0/18'
-param enablePrivateCluster = false
 param persist = true
 param aksClusterName = take('aro-hcp-svc-cluster-${uniqueString('svc-cluster')}', 63)
 param aksKeyVaultName = 'aks-kv-aro-hcp-dev-sc'

--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -5,7 +5,6 @@ param istioVersion = ['asm-1-20']
 param vnetAddressPrefix = '10.128.0.0/14'
 param subnetPrefix = '10.128.8.0/21'
 param podSubnetPrefix = '10.128.64.0/18'
-param enablePrivateCluster = false
 param persist = false
 param aksClusterName = 'aro-hcp-svc-cluster'
 param aksKeyVaultName = take('aks-kv-svc-cluster-${uniqueString(currentUserId)}', 24)

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -292,7 +292,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-04-02-previ
   name: aksClusterName
   sku: {
     name: 'Base'
-    tier: 'Free'
+    tier: 'Standard'
   }
   tags: {
     persist: toLower(string(persist))

--- a/dev-infrastructure/modules/keyvault/keyvault.bicep
+++ b/dev-infrastructure/modules/keyvault/keyvault.bicep
@@ -14,7 +14,7 @@ param private bool
 // e.g. AKS KMS on a private KV will manage their own private endpoint setup in the nodepool RG
 param managedPrivateEndpoint bool = true
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-04-01-preview' = {
   location: location
   name: keyVaultName
   tags: {
@@ -26,7 +26,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
     enabledForDiskEncryption: false
     enabledForTemplateDeployment: false
     enableSoftDelete: enableSoftDelete
-    publicNetworkAccess: private ? 'disabled' : 'enabled'
+    publicNetworkAccess: private ? 'Disabled' : 'Enabled'
     sku: {
       name: 'standard'
       family: 'A'
@@ -41,7 +41,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
 
 var privateDnsZoneName = 'privatelink.vaultcore.azure.net'
 
-resource keyVaultPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = if (managedPrivateEndpoint) {
+resource keyVaultPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-01-01' = if (managedPrivateEndpoint) {
   name: '${keyVaultName}-pe'
   location: location
   properties: {

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -43,9 +43,6 @@ param subnetPrefix string
 @description('Specifies the address prefix of the subnet hosting the pods of the AKS cluster.')
 param podSubnetPrefix string
 
-@description('(Optional) boolean flag to configure public/private AKS Cluster')
-param enablePrivateCluster bool
-
 @description('Kuberentes version to use with AKS')
 param kubernetesVersion string
 
@@ -112,7 +109,6 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName
     aksEtcdKVEnableSoftDelete: aksEtcdKVEnableSoftDelete
-    enablePrivateCluster: enablePrivateCluster
     deployIstio: false
     kubernetesVersion: kubernetesVersion
     vnetAddressPrefix: vnetAddressPrefix

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -25,9 +25,6 @@ param subnetPrefix string
 @description('Specifies the address prefix of the subnet hosting the pods of the AKS cluster.')
 param podSubnetPrefix string
 
-@description('(Optional) boolean flag to configure public/private AKS Cluster')
-param enablePrivateCluster bool
-
 @description('Kuberentes version to use with AKS')
 param kubernetesVersion string
 
@@ -126,7 +123,6 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName
     aksEtcdKVEnableSoftDelete: aksEtcdKVEnableSoftDelete
-    enablePrivateCluster: enablePrivateCluster
     kubernetesVersion: kubernetesVersion
     deployIstio: true
     istioVersion: istioVersion


### PR DESCRIPTION
### What this PR does
In addition to making our bicep more declarative/reducing the amount of changes per bicep application:
 
* Removed the option of creating a private AKS cluster
* Changed AKS SKU to standard

Before: Honestly just way too many changes to show
After: Still not the best, but I can't seem to improve it further
```
The deployment will update the following scope:

Scope: /subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/aro-hcp-mshen-westus3-svc-cluster

  ~ Microsoft.ContainerService/managedClusters/aro-hcp-svc-cluster [2024-04-02-preview]
    - properties.aadProfile.tenantID:                      "64dc69e4-d083-49fc-9569-ebece1dd1408"
    - properties.controlPlanePluginProfiles:

        azure-monitor-metrics-ccp.enableV2: true
        karpenter.enableV2:                 true
        live-patching-controller.enableV2:  true

    - properties.identityProfile:

        kubeletidentity.clientId:   "5692b548-83b7-41aa-8378-3165c1d7ce88"
        kubeletidentity.objectId:   "0ad787f8-0de8-49a3-8303-9c786f96bd2c"
        kubeletidentity.resourceId: "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourcegroups/aro-hcp-mshen-westus3-svc-cluster-aks1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-hcp-svc-cluster-agentpool"

    - properties.networkProfile.loadBalancerProfile.effectiveOutboundIPs: [
        0: {}
      ]
    - properties.windowsProfile:

        adminUsername:  "azureuser"
        enableCSIProxy: true

    ~ properties.agentPoolProfiles: [
      ~ 0:

        - powerState:

            code: "Running"


      ~ 1:

        - powerState:

            code: "Running"


      ]
    ~ properties.securityProfile.azureKeyVaultKms.keyId:   "https://aks-kv-svc-cluster-75v2j.vault.azure.net/keys/aks-etcd-encryption/12ff10e978aa45569568f626e626e17d" => "[reference(resourceId('Microsoft.KeyVault/vaults/keys', parameters('aksKeyVaultName'), 'aks-etcd-encryption'), '2023-07-01').keyUriWithVersion]"
    ~ sku.tier:                                            "Free" => "Standard"
    x properties.agentPoolProfiles[0].orchestratorVersion: "1.29.7"
    x properties.agentPoolProfiles[1].orchestratorVersion: "1.29.7"

  ~ Microsoft.ContainerService/managedClusters/aro-hcp-svc-cluster/providers/Microsoft.Authorization/roleAssignments/b4cefd52-c596-5d47-a267-04e05025687a [2022-04-01]
    ~ properties.principalId:   "0467a689-7f11-4dd9-81c0-0830caf14f15" => "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-msi', parameters('aksClusterName'))), '2023-01-31').principalId]"
    x properties.principalType: "ServicePrincipal"

  ~ Microsoft.KeyVault/vaults/aks-kv-svc-cluster-75v2j/providers/Microsoft.Authorization/roleAssignments/231e68f4-c6e1-5310-860b-d8e00aaef0ee [2022-04-01]
    ~ properties.principalId:   "0467a689-7f11-4dd9-81c0-0830caf14f15" => "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-msi', parameters('aksClusterName'))), '2023-01-31').principalId]"
    x properties.principalType: "ServicePrincipal"

  ~ Microsoft.ManagedIdentity/userAssignedIdentities/clusters-service/federatedIdentityCredentials/clusters-service-westus3-fedcred [2023-01-31]
    ~ properties.issuer: "https://westus3.oic.prod-aks.azure.com/64dc69e4-d083-49fc-9569-ebece1dd1408/b7b34d5f-6230-4d37-8f51-992e8f791c6f/" => "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('aksClusterName')), '2024-04-02-preview').oidcIssuerProfile.issuerURL]"

  ~ Microsoft.ManagedIdentity/userAssignedIdentities/frontend/federatedIdentityCredentials/frontend-westus3-fedcred [2023-01-31]
    ~ properties.issuer: "https://westus3.oic.prod-aks.azure.com/64dc69e4-d083-49fc-9569-ebece1dd1408/b7b34d5f-6230-4d37-8f51-992e8f791c6f/" => "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('aksClusterName')), '2024-04-02-preview').oidcIssuerProfile.issuerURL]"

  ~ Microsoft.ManagedIdentity/userAssignedIdentities/image-sync/federatedIdentityCredentials/image-sync-westus3-fedcred [2023-01-31]
    ~ properties.issuer: "https://westus3.oic.prod-aks.azure.com/64dc69e4-d083-49fc-9569-ebece1dd1408/b7b34d5f-6230-4d37-8f51-992e8f791c6f/" => "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('aksClusterName')), '2024-04-02-preview').oidcIssuerProfile.issuerURL]"

  ~ Microsoft.ManagedIdentity/userAssignedIdentities/maestro-server/federatedIdentityCredentials/maestro-server-westus3-fedcred [2023-01-31]
    ~ properties.issuer: "https://westus3.oic.prod-aks.azure.com/64dc69e4-d083-49fc-9569-ebece1dd1408/b7b34d5f-6230-4d37-8f51-992e8f791c6f/" => "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('aksClusterName')), '2024-04-02-preview').oidcIssuerProfile.issuerURL]"

  ~ Microsoft.Network/privateEndpoints/service-kv-75v2j7yzgv2ri-pe [2024-01-01]
    - properties.isIPv6EnabledPrivateEndpoint: false

  ~ Microsoft.Network/privateEndpoints/service-kv-75v2j7yzgv2ri-pe/privateDnsZoneGroups/service-kv-75v2j7yzgv2ri-dns-group [2023-09-01]
    ~ properties.privateDnsZoneConfigs: [
      ~ 0:

        - etag:                         "W/"c86e4c61-93fc-497a-a424-7416d0d69113""
        - id:                           "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/aro-hcp-mshen-westus3-svc-cluster/providers/Microsoft.Network/privateEndpoints/service-kv-75v2j7yzgv2ri-pe/privateDnsZoneGroups/service-kv-75v2j7yzgv2ri-dns-group/privateDnsZoneConfigs/config1"
        - properties.provisioningState: "Succeeded"
        - type:                         "Microsoft.Network/privateEndpoints/privateDnsZoneGroups/privateDnsZoneConfigs"

      ]

  ~ Microsoft.Network/virtualNetworks/aks-net/providers/Microsoft.Authorization/roleAssignments/7779eee1-d9ce-5b95-85d1-5a474a56ab0e [2022-04-01]
    ~ properties.principalId:   "0467a689-7f11-4dd9-81c0-0830caf14f15" => "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-msi', parameters('aksClusterName'))), '2023-01-31').principalId]"
    x properties.principalType: "ServicePrincipal"

  ~ Microsoft.Resources/tags/default [2024-03-01]
    - properties.tags.createdAt: "2024-08-08T21:21:40.0744498Z"

  = Microsoft.KeyVault/vaults/aks-kv-svc-cluster-75v2j [2024-04-01-preview]
  = Microsoft.KeyVault/vaults/aks-kv-svc-cluster-75v2j/keys/aks-etcd-encryption [2023-07-01]
  = Microsoft.KeyVault/vaults/service-kv-75v2j7yzgv2ri [2024-04-01-preview]
  = Microsoft.ManagedIdentity/userAssignedIdentities/aro-hcp-svc-cluster-msi [2023-01-31]
  = Microsoft.ManagedIdentity/userAssignedIdentities/clusters-service [2023-01-31]
  = Microsoft.ManagedIdentity/userAssignedIdentities/frontend [2023-01-31]
  = Microsoft.ManagedIdentity/userAssignedIdentities/image-sync [2023-01-31]
  = Microsoft.ManagedIdentity/userAssignedIdentities/maestro-server [2023-01-31]
  = Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net [2020-06-01]
  = Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net/virtualNetworkLinks/2frpda47eiqhg [2020-06-01]
  = Microsoft.Network/virtualNetworks/aks-net [2023-11-01]
    x properties.subnets[0].type: "Microsoft.Network/virtualNetworks/subnets"
    x properties.subnets[1].type: "Microsoft.Network/virtualNetworks/subnets"

  = Microsoft.Network/virtualNetworks/aks-net/subnets/ClusterSubnet-001 [2023-11-01]
  = Microsoft.Network/virtualNetworks/aks-net/subnets/PodSubnet-001 [2023-11-01]
  * Microsoft.AlertsManagement/prometheusRuleGroups/KubernetesRecordingRulesRuleGroup-aro-hcp-svc-cluster
  * Microsoft.AlertsManagement/prometheusRuleGroups/NodeRecordingRulesRuleGroup-aro-hcp-svc-cluster
  * Microsoft.Insights/dataCollectionEndpoints/MSProm-westus3-aro-hcp-svc-cluster
  * Microsoft.Insights/dataCollectionRules/MSProm-westus3-aro-hcp-svc-cluster
  * Microsoft.ManagedIdentity/userAssignedIdentities/maestro-pg-75v2j7yzgv2ri-db-admin-msi
  * Microsoft.Network/networkInterfaces/service-kv-75v2j7yzgv2ri-pe.nic.47424ac4-0152-48cd-af88-294608d9dc7a

Resource changes: 11 to modify, 13 no change, 6 to ignore.
```