### PR TITLE
remove MinimumTlsVersionAllowed from eventgrid definition

### DIFF
--- a/dev-infrastructure/modules/maestro/maestro-infra.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-infra.bicep
@@ -110,7 +110,6 @@ resource eventGridNamespace 'Microsoft.EventGrid/namespaces@2024-06-01-preview' 
   }
   properties: {
     isZoneRedundant: true
-    minimumTlsVersionAllowed: '1.2'
     publicNetworkAccess: 'Enabled'
     topicSpacesConfiguration: {
       state: 'Enabled'


### PR DESCRIPTION
### What this PR does

the MinimumTlsVersionAllowed property can't be defined during resource creation.

```
The operation failed as MinimumTlsVersionAllowed is a read-only property and should not be present when creating or updating the resource. Please remove this property and try again.
```


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
