### PR TITLE
define required managed identities within cluster templates

### DIFF
--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -22,19 +22,6 @@ param maestroCertDomain = 'selfsigned.maestro.keyvault.aro-int.azure.com'
 
 param baseDNSZoneName = 'hcp.osadev.cloud'
 
-param workloadIdentities = items({
-  maestro_wi: {
-    uamiName: 'maestro-consumer'
-    namespace: 'maestro'
-    serviceAccountName: 'maestro'
-  }
-  external_dns_wi: {
-    uamiName: 'external-dns'
-    namespace: 'hypershift'
-    serviceAccountName: 'external-dns'
-  }
-})
-
 param acrPullResourceGroups = ['global']
 
 // These parameters are always overriden in the Makefile

--- a/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
@@ -22,19 +22,6 @@ param maestroCertDomain = 'selfsigned.maestro.keyvault.aro-dev.azure.com'
 param baseDNSZoneName = 'hcp.osadev.cloud'
 param regionalDNSSubdomain = 'westus3'
 
-param workloadIdentities = items({
-  maestro_wi: {
-    uamiName: 'maestro-consumer'
-    namespace: 'maestro'
-    serviceAccountName: 'maestro'
-  }
-  external_dns_wi: {
-    uamiName: 'external-dns'
-    namespace: 'hypershift'
-    serviceAccountName: 'external-dns'
-  }
-})
-
 param acrPullResourceGroups = [regionalResourceGroup, 'global']
 
 // These parameters are always overridden in the Makefile

--- a/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
@@ -26,29 +26,6 @@ param serviceKeyVaultName = 'service-kv-aro-hcp-dev'
 param serviceKeyVaultSoftDelete = true
 param serviceKeyVaultPrivate = false
 
-param workloadIdentities = items({
-  frontend_wi: {
-    uamiName: 'frontend'
-    namespace: 'aro-hcp'
-    serviceAccountName: 'frontend'
-  }
-  maestro_wi: {
-    uamiName: 'maestro-server'
-    namespace: 'maestro'
-    serviceAccountName: 'maestro'
-  }
-  cs_wi: {
-    uamiName: 'clusters-service'
-    namespace: 'cluster-service'
-    serviceAccountName: 'clusters-service'
-  }
-  image_sync_wi: {
-    uamiName: 'image-sync'
-    namespace: 'image-sync'
-    serviceAccountName: 'image-sync'
-  }
-})
-
 param acrPullResourceGroups = ['global']
 param clustersServiceAcrResourceGroupNames = ['global']
 

--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -27,29 +27,6 @@ param serviceKeyVaultName = take('service-kv-${uniqueString(currentUserId)}', 24
 param serviceKeyVaultSoftDelete = false
 param serviceKeyVaultPrivate = false
 
-param workloadIdentities = items({
-  frontend_wi: {
-    uamiName: 'frontend'
-    namespace: 'aro-hcp'
-    serviceAccountName: 'frontend'
-  }
-  maestro_wi: {
-    uamiName: 'maestro-server'
-    namespace: 'maestro'
-    serviceAccountName: 'maestro'
-  }
-  cs_wi: {
-    uamiName: 'clusters-service'
-    namespace: 'cluster-service'
-    serviceAccountName: 'clusters-service'
-  }
-  image_sync_wi: {
-    uamiName: 'image-sync'
-    namespace: 'image-sync'
-    serviceAccountName: 'image-sync'
-  }
-})
-
 param acrPullResourceGroups = ['global']
 param imageSyncAcrResourceGroupNames = ['global']
 param clustersServiceAcrResourceGroupNames = ['global']

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -53,9 +53,6 @@ param aksKeyVaultName string
 @description('Manage soft delete setting for AKS etcd key-value store')
 param aksEtcdKVEnableSoftDelete bool = true
 
-@description('List of workload identities to create and their required values')
-param workloadIdentities array
-
 @description('Deploys a Maestro Consumer to the management cluster if set to true.')
 param deployMaestroConsumer bool
 
@@ -115,7 +112,18 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     subnetPrefix: subnetPrefix
     podSubnetPrefix: podSubnetPrefix
     clusterType: 'mgmt-cluster'
-    workloadIdentities: workloadIdentities
+    workloadIdentities: items({
+      maestro_wi: {
+        uamiName: 'maestro-consumer'
+        namespace: 'maestro'
+        serviceAccountName: 'maestro'
+      }
+      external_dns_wi: {
+        uamiName: 'external-dns'
+        namespace: 'hypershift'
+        serviceAccountName: 'external-dns'
+      }
+    })
     aksKeyVaultName: aksKeyVaultName
     deployUserAgentPool: true
     acrPullResourceGroups: acrPullResourceGroups

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -45,9 +45,6 @@ param disableLocalAuth bool
 @description('Deploy ARO HCP RP Azure Cosmos DB if true')
 param deployFrontendCosmos bool
 
-@description('List of workload identities to create and their required values')
-param workloadIdentities array
-
 @description('The resourcegroup for regional infrastructure')
 param regionalResourceGroup string
 
@@ -130,7 +127,28 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     subnetPrefix: subnetPrefix
     podSubnetPrefix: podSubnetPrefix
     clusterType: 'svc-cluster'
-    workloadIdentities: workloadIdentities
+    workloadIdentities: items({
+      frontend_wi: {
+        uamiName: 'frontend'
+        namespace: 'aro-hcp'
+        serviceAccountName: 'frontend'
+      }
+      maestro_wi: {
+        uamiName: 'maestro-server'
+        namespace: 'maestro'
+        serviceAccountName: 'maestro'
+      }
+      cs_wi: {
+        uamiName: 'clusters-service'
+        namespace: 'cluster-service'
+        serviceAccountName: 'clusters-service'
+      }
+      image_sync_wi: {
+        uamiName: 'image-sync'
+        namespace: 'image-sync'
+        serviceAccountName: 'image-sync'
+      }
+    })
     aksKeyVaultName: aksKeyVaultName
     deployUserAgentPool: true
     acrPullResourceGroups: acrPullResourceGroups


### PR DESCRIPTION
### What this PR does

the set of required managed identities per cluster type were defined within the bicepparm files up until now. to get rid of the coordination efforts between various bicepparam files in DEV and MSFT envs, the list of managed identities are now part of the cluster template, so `svc-cluster.bicep` and `mgmt-cluster.bicep`

part of https://issues.redhat.com/browse/ARO-9361

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
