### PR TITLE
empty pull secret for hypershift-sharedingress

### DIFF
--- a/hypershiftoperator/.gitignore
+++ b/hypershiftoperator/.gitignore
@@ -3,3 +3,4 @@ edo-azure-credentials.json
 domain.txt
 patch-serviceaccount-external-dns.json
 test
+deploy/overlays/dev/txt_owner_id.txt

--- a/hypershiftoperator/deploy/overlays/dev/kustomization.yml
+++ b/hypershiftoperator/deploy/overlays/dev/kustomization.yml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+- pull-secret.yaml
 patches:
 - target:
     version: v1

--- a/hypershiftoperator/deploy/overlays/dev/pull-secret.yaml
+++ b/hypershiftoperator/deploy/overlays/dev/pull-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: pull-secret
+  namespace: hypershift
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: e30K


### PR DESCRIPTION
### What this PR does

currently the hypershift operator expects a pullsecret in the hypershift namespace and otherwise refuses to reconcile the shared ingress. since we don't require a pullsecret to pull the respective images, we can resolve the situation by providing an empty pull secret.

the hypershift team will provide a fix, not requiring a pull-secret

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
