### PR TITLE
Update to K8s 1.30.3

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -10,7 +10,7 @@ deploy:
 	ZONE_RESOURCE_ID=$(shell az network dns zone list -g ${REGIONAL_RESOURCEGROUP} --query "[?zoneType=='Public'].id" -o tsv) && \
 	sed -e "s#ZONE_RESOURCE_ID#$${ZONE_RESOURCE_ID}#g" -e "s/REGION/${REGION}/g" -e "s/CONSUMER_NAME/${CONSUMER_NAME}/g" deploy/mvp-provisioning-shards.yml > deploy/tmp-provisioning-shard.yml
 	oc process --local -f deploy/openshift-templates/arohcp-namespace-template.yml \
-	  -p ISTIO_VERSION=asm-1-20 | oc apply -f -
+	  -p ISTIO_VERSION=asm-1-21 | oc apply -f -
 	kubectl apply -f deploy/istio.yml
 	oc process --local -f deploy/openshift-templates/arohcp-db-template.yml | oc apply -f -
 	oc process --local -f deploy/openshift-templates/arohcp-secrets-template.yml \

--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -1,6 +1,6 @@
 using '../templates/mgmt-cluster.bicep'
 
-param kubernetesVersion = '1.29.7'
+param kubernetesVersion = '1.30.3'
 param vnetAddressPrefix = '10.132.0.0/14'
 param subnetPrefix = '10.132.8.0/21'
 param podSubnetPrefix = '10.132.64.0/18'

--- a/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
@@ -1,6 +1,6 @@
 using '../templates/mgmt-cluster.bicep'
 
-param kubernetesVersion = '1.29.7'
+param kubernetesVersion = '1.30.3'
 param vnetAddressPrefix = '10.132.0.0/14'
 param subnetPrefix = '10.132.8.0/21'
 param podSubnetPrefix = '10.132.64.0/18'

--- a/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
@@ -1,7 +1,7 @@
 using '../templates/svc-cluster.bicep'
 
-param kubernetesVersion = '1.29.7'
-param istioVersion = ['asm-1-20']
+param kubernetesVersion = '1.30.3'
+param istioVersion = ['asm-1-21']
 param vnetAddressPrefix = '10.128.0.0/14'
 param subnetPrefix = '10.128.8.0/21'
 param podSubnetPrefix = '10.128.64.0/18'

--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -1,7 +1,7 @@
 using '../templates/svc-cluster.bicep'
 
-param kubernetesVersion = '1.29.7'
-param istioVersion = ['asm-1-20']
+param kubernetesVersion = '1.30.3'
+param istioVersion = ['asm-1-21']
 param vnetAddressPrefix = '10.128.0.0/14'
 param subnetPrefix = '10.128.8.0/21'
 param podSubnetPrefix = '10.128.64.0/18'

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -25,7 +25,7 @@ param persist bool = false
 
 param kubernetesVersion string
 param deployIstio bool
-param istioVersion array = ['asm-1-20']
+param istioVersion array = ['asm-1-21']
 param vnetAddressPrefix string
 param subnetPrefix string
 param podSubnetPrefix string

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -260,7 +260,10 @@ module csServiceKeyVaultAccess '../modules/keyvault/keyvault-secret-access.bicep
 //   I M A G E   S Y N C
 //
 
-var imageSyncManagedIdentityPrincipalId = filter(svcCluster.outputs.userAssignedIdentities, id => id.uamiName == 'image-sync')[0].uamiPrincipalID
+var imageSyncManagedIdentityPrincipalId = filter(
+  svcCluster.outputs.userAssignedIdentities,
+  id => id.uamiName == 'image-sync'
+)[0].uamiPrincipalID
 
 module imageServiceKeyVaultAccess '../modules/keyvault/keyvault-secret-access.bicep' = {
   name: guid(serviceKeyVaultName, 'imagesync', 'read')

--- a/frontend/deploy/overlays/dev/kustomization.yml
+++ b/frontend/deploy/overlays/dev/kustomization.yml
@@ -11,7 +11,7 @@ patches:
     - op: add
       # "~1" is an escaped "/"
       path: /metadata/labels/istio.io~1rev
-      value: asm-1-20
+      value: asm-1-21
   target:
     kind: Namespace
     name: aro-hcp


### PR DESCRIPTION
### What this PR does
* Updates all our K8s clusters to v1.30.3
* Requires Istio `asm-1-21`
* Fixes a `bicep fmt` issue

Uwubernetes has no breaking changes from v1.29 https://kubernetes.io/blog/2024/04/17/kubernetes-v1-30-release/