### PR TITLE
api: Remove IngressProfile from cluster API

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
@@ -44,12 +44,7 @@
           },
           "externalAuth": {
             "enabled": true
-          },
-          "ingress": [
-            {
-              "visibility": "public"
-            }
-          ]
+          }
         }
       },
       "identity": {

--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -155,11 +155,6 @@ model ClusterSpec {
    */
   @visibility("create", "read")
   externalAuth?: ExternalAuthConfigProfile;
-
-  /** Configures the default cluster ingress */
-  @visibility("create", "read")
-  @OpenAPI.extension("x-ms-identifiers", ["url", "visibility"])
-  ingress: IngressProfile;
 }
 
 /** The patchable cluster specification */
@@ -471,31 +466,6 @@ model TokenClaimValidationRuleProfile {
 /*
  * =======================================
  *  End ExternalAuth resources
- * =======================================
- */
-
-/*
- * =======================================
- *  Ingress resources
- * =======================================
- */
-
-/** Configuration of the default cluster ingress */
-model IngressProfile {
-  /** The ingress url */
-  @visibility("read")
-  url: string;
-
-  /** The visibility of the ingress
-   * determines if the ingress is visible from the internet
-   */
-  @visibility("create", "read")
-  visibility: Visibility;
-}
-
-/*
- * =======================================
- *  End Ingress resources
  * =======================================
  */
 

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
@@ -44,12 +44,7 @@
           },
           "externalAuth": {
             "enabled": true
-          },
-          "ingress": [
-            {
-              "visibility": "public"
-            }
-          ]
+          }
         }
       },
       "identity": {

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1114,26 +1114,13 @@
             "read",
             "create"
           ]
-        },
-        "ingress": {
-          "$ref": "#/definitions/IngressProfile",
-          "description": "Configures the default cluster ingress",
-          "x-ms-identifiers": [
-            "url",
-            "visibility"
-          ],
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ]
         }
       },
       "required": [
         "version",
         "console",
         "api",
-        "issuerUrl",
-        "ingress"
+        "issuerUrl"
       ]
     },
     "ConsoleProfile": {
@@ -1572,29 +1559,6 @@
       },
       "required": [
         "clusterVersion"
-      ]
-    },
-    "IngressProfile": {
-      "type": "object",
-      "description": "Configuration of the default cluster ingress",
-      "properties": {
-        "url": {
-          "type": "string",
-          "description": "The ingress url",
-          "readOnly": true
-        },
-        "visibility": {
-          "$ref": "#/definitions/Visibility",
-          "description": "The visibility of the ingress\ndetermines if the ingress is visible from the internet",
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ]
-        }
-      },
-      "required": [
-        "url",
-        "visibility"
       ]
     },
     "Label": {

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -85,10 +85,6 @@ func (f *Frontend) ConvertCStoHCPOpenShiftCluster(systemData *arm.SystemData, cl
 					Enabled:       false,
 					ExternalAuths: []*configv1.OIDCProvider{},
 				},
-				Ingress: api.IngressProfile{
-					URL:        "",
-					Visibility: "",
-				},
 			},
 		},
 	}

--- a/frontend/utils/create.go
+++ b/frontend/utils/create.go
@@ -80,9 +80,6 @@ func CreateJSONFile() error {
 				},
 				IssuerURL:    "",
 				ExternalAuth: api.ExternalAuthConfigProfile{},
-				Ingress: api.IngressProfile{
-					Visibility: api.Visibility("public"),
-				},
 			},
 		},
 	}

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -35,7 +35,6 @@ type ClusterSpec struct {
 	Platform                      PlatformProfile           `json:"platform,omitempty"                      visibility:"read create"        validate:"required_for_put"`
 	IssuerURL                     string                    `json:"issuerUrl,omitempty"                     visibility:"read"               validate:"omitempty,url"`
 	ExternalAuth                  ExternalAuthConfigProfile `json:"externalAuth,omitempty"                  visibility:"read create"`
-	Ingress                       IngressProfile            `json:"ingress,omitempty"                       visibility:"read create"        validate:"required_for_put"`
 }
 
 // VersionProfile represents the cluster control plane version.
@@ -97,12 +96,6 @@ type PlatformProfile struct {
 type ExternalAuthConfigProfile struct {
 	Enabled       bool                     `json:"enabled,omitempty"       visibility:"read create"`
 	ExternalAuths []*configv1.OIDCProvider `json:"externalAuths,omitempty" visibility:"read"`
-}
-
-// IngressProfile represents a cluster ingress configuration.
-type IngressProfile struct {
-	URL        string     `json:"url,omitempty"        visibility:"read"        validate:"omitempty,url"`
-	Visibility Visibility `json:"visibility,omitempty" visibility:"read create" validate:"required_for_put,enum_visibility"`
 }
 
 // Creates an HCPOpenShiftCluster with any non-zero default values.

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -44,9 +44,6 @@ type ClusterPatchSpec struct {
 
 // ClusterSpec - The cluster resource specification
 type ClusterSpec struct {
-	// REQUIRED; Configures the default cluster ingress
-	Ingress *IngressProfile
-
 	// REQUIRED; Version of the control plane components
 	Version *VersionProfile
 
@@ -358,15 +355,6 @@ type HcpOpenShiftVersionsProperties struct {
 
 	// READ-ONLY; The provisioning state of the resource.
 	ProvisioningState *ResourceProvisioningState
-}
-
-// IngressProfile - Configuration of the default cluster ingress
-type IngressProfile struct {
-	// REQUIRED; The visibility of the ingress determines if the ingress is visible from the internet
-	Visibility *Visibility
-
-	// READ-ONLY; The ingress url
-	URL *string
 }
 
 // Label represents the k8s label

--- a/internal/api/v20240610preview/generated/models_serde.go
+++ b/internal/api/v20240610preview/generated/models_serde.go
@@ -131,7 +131,6 @@ func (c ClusterSpec) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "etcdEncryption", c.EtcdEncryption)
 	populate(objectMap, "externalAuth", c.ExternalAuth)
 	populate(objectMap, "fips", c.Fips)
-	populate(objectMap, "ingress", c.Ingress)
 	populate(objectMap, "issuerUrl", c.IssuerURL)
 	populate(objectMap, "network", c.Network)
 	populate(objectMap, "platform", c.Platform)
@@ -169,9 +168,6 @@ func (c *ClusterSpec) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "fips":
 				err = unpopulate(val, "Fips", &c.Fips)
-			delete(rawMsg, key)
-		case "ingress":
-				err = unpopulate(val, "Ingress", &c.Ingress)
 			delete(rawMsg, key)
 		case "issuerUrl":
 				err = unpopulate(val, "IssuerURL", &c.IssuerURL)
@@ -1061,39 +1057,6 @@ func (h *HcpOpenShiftVersionsProperties) UnmarshalJSON(data []byte) error {
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", h, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type IngressProfile.
-func (i IngressProfile) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "url", i.URL)
-	populate(objectMap, "visibility", i.Visibility)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type IngressProfile.
-func (i *IngressProfile) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", i, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "url":
-				err = unpopulate(val, "URL", &i.URL)
-			delete(rawMsg, key)
-		case "visibility":
-				err = unpopulate(val, "Visibility", &i.Visibility)
-			delete(rawMsg, key)
-		default:
-			err = fmt.Errorf("unmarshalling type %T, unknown field %q", i, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", i, err)
 		}
 	}
 	return nil

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -49,10 +49,6 @@ type ExternalAuthConfigProfile struct {
 	generated.ExternalAuthConfigProfile
 }
 
-type IngressProfile struct {
-	generated.IngressProfile
-}
-
 func newVersionProfile(from *api.VersionProfile) *generated.VersionProfile {
 	return &generated.VersionProfile{
 		ID:                api.Ptr(from.ID),
@@ -107,13 +103,6 @@ func newPlatformProfile(from *api.PlatformProfile) *generated.PlatformProfile {
 		OutboundType:           api.Ptr(generated.OutboundType(from.OutboundType)),
 		NetworkSecurityGroupID: api.Ptr(from.NetworkSecurityGroupID),
 		EtcdEncryptionSetID:    api.Ptr(from.EtcdEncryptionSetID),
-	}
-}
-
-func newIngressProfile(from *api.IngressProfile) *generated.IngressProfile {
-	return &generated.IngressProfile{
-		URL:        api.Ptr(from.URL),
-		Visibility: api.Ptr(generated.Visibility(from.Visibility)),
 	}
 }
 
@@ -209,7 +198,6 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 					DisableUserWorkloadMonitoring: api.Ptr(from.Properties.Spec.DisableUserWorkloadMonitoring),
 					Proxy:                         newProxyProfile(&from.Properties.Spec.Proxy),
 					Platform:                      newPlatformProfile(&from.Properties.Spec.Platform),
-					Ingress:                       newIngressProfile(&from.Properties.Spec.Ingress),
 					IssuerURL:                     api.Ptr(from.Properties.Spec.IssuerURL),
 					ExternalAuth: &generated.ExternalAuthConfigProfile{
 						Enabled:       api.Ptr(from.Properties.Spec.ExternalAuth.Enabled),
@@ -320,9 +308,6 @@ func (c *HcpOpenShiftClusterResource) Normalize(out *api.HCPOpenShiftCluster) {
 			}
 			if c.Properties.Spec.ExternalAuth != nil {
 				normalizeExternalAuthConfig(c.Properties.Spec.ExternalAuth, &out.Properties.Spec.ExternalAuth)
-			}
-			if c.Properties.Spec.Ingress != nil {
-				normalizeIngress(c.Properties.Spec.Ingress, &out.Properties.Spec.Ingress)
 			}
 		}
 	}
@@ -572,18 +557,5 @@ func normalizeExternalAuthConfig(p *generated.ExternalAuthConfigProfile, out *ap
 		}
 
 		out.ExternalAuths = append(out.ExternalAuths, provider)
-	}
-}
-
-func (p *IngressProfile) Normalize(out *api.IngressProfile) {
-	normalizeIngress(&p.IngressProfile, out)
-}
-
-func normalizeIngress(p *generated.IngressProfile, out *api.IngressProfile) {
-	if p.URL != nil {
-		out.URL = *p.URL
-	}
-	if p.Visibility != nil {
-		out.Visibility = api.Visibility(*p.Visibility)
 	}
 }


### PR DESCRIPTION
### What this PR does

Cluster Service does not accept default ingress attributes when creating a cluster, nor does it expose the default ingress thru its "ingresses" cluster API. So drop default ingress parameters (as least for now) from our ARM API.

Jira: [ARO-9678 - Remove IngressProfile from API](https://issues.redhat.com/browse/ARO-9678)
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
