### PR TITLE
devcontainer: Remove misleading message from motd

### DIFF
--- a/.devcontainer/motd
+++ b/.devcontainer/motd
@@ -10,6 +10,3 @@ Welcome to the devcontainer!
 
 To start working with azure-cli, you need to login to Azure account.
 $ az login --use-device-code
-
-To start working on typespec API, install the tsp extension
-$ tsp code install


### PR DESCRIPTION
### What this PR does

The command `tsp code install` no longer works, and installation is automatic now anyway via `devcontainer.json`.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
