### PR TITLE
api: Change VersionProfile.ID to be create-only

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -102,7 +102,7 @@ model HcpOpenShiftClusterNodePoolPatch
 /** The cluster resource specification */
 model ClusterSpec {
   /** Version of the control plane components */
-  @visibility("create", "update")
+  @visibility("create", "read")
   version: VersionProfile;
 
   /** Cluster DNS configuration */
@@ -159,10 +159,6 @@ model ClusterSpec {
 
 /** The patchable cluster specification */
 model ClusterPatchSpec {
-  /** Version of the control plane components */
-  @visibility("update")
-  version?: VersionProfile;
-
   /** Disable user workload monitoring */
   @visibility("update")
   disableUserWorkloadMonitoring?: boolean;
@@ -194,7 +190,7 @@ union ProvisioningState {
 /** Versions represents an OpenShift version. */
 model VersionProfile {
   /** ID is the unique identifier of the version. */
-  @visibility("create", "update")
+  @visibility("create", "read")
   id: string;
 
   /** ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set. */
@@ -526,7 +522,7 @@ union Effect {
 /** Worker node pool profile */
 model NodePoolSpec {
   /** OpenShift version for the nodepool */
-  @visibility("create", "update")
+  @visibility("create", "read")
   version: VersionProfile;
 
   /** Azure node pool platform configuration */
@@ -578,10 +574,6 @@ model NodePoolSpec {
 
 /** Worker node pool profile */
 model NodePoolPatchSpec {
-  /** OpenShift version for the nodepool */
-  @visibility("update")
-  version?: VersionProfile;
-
   /** The number of worker nodes, it cannot be used together with autoscaling */
   @visibility("update")
   replicas?: int32;

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1002,13 +1002,6 @@
       "type": "object",
       "description": "The patchable cluster specification",
       "properties": {
-        "version": {
-          "$ref": "#/definitions/VersionProfileUpdate",
-          "description": "Version of the control plane components",
-          "x-ms-mutability": [
-            "update"
-          ]
-        },
         "disableUserWorkloadMonitoring": {
           "type": "boolean",
           "description": "Disable user workload monitoring",
@@ -1033,7 +1026,7 @@
           "$ref": "#/definitions/VersionProfile",
           "description": "Version of the control plane components",
           "x-ms-mutability": [
-            "update",
+            "read",
             "create"
           ]
         },
@@ -1445,6 +1438,11 @@
       "type": "object",
       "description": "HCP patchable cluster properties",
       "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The status of the last operation.",
+          "readOnly": true
+        },
         "spec": {
           "$ref": "#/definitions/ClusterPatchSpec",
           "description": "The cluster resource specification."
@@ -1706,6 +1704,11 @@
       "type": "object",
       "description": "Represents the patchable node pool properties",
       "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",
+          "description": "Provisioning state",
+          "readOnly": true
+        },
         "spec": {
           "$ref": "#/definitions/NodePoolPatchSpec",
           "description": "The node pool resource specification"
@@ -1716,13 +1719,6 @@
       "type": "object",
       "description": "Worker node pool profile",
       "properties": {
-        "version": {
-          "$ref": "#/definitions/VersionProfileUpdate",
-          "description": "OpenShift version for the nodepool",
-          "x-ms-mutability": [
-            "update"
-          ]
-        },
         "replicas": {
           "type": "integer",
           "format": "int32",
@@ -1838,7 +1834,7 @@
           "$ref": "#/definitions/VersionProfile",
           "description": "OpenShift version for the nodepool",
           "x-ms-mutability": [
-            "update",
+            "read",
             "create"
           ]
         },
@@ -2138,7 +2134,7 @@
           "type": "string",
           "description": "ID is the unique identifier of the version.",
           "x-ms-mutability": [
-            "update",
+            "read",
             "create"
           ]
         },
@@ -2164,20 +2160,6 @@
         "channelGroup",
         "availableUpgrades"
       ]
-    },
-    "VersionProfileUpdate": {
-      "type": "object",
-      "description": "Versions represents an OpenShift version.",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "ID is the unique identifier of the version.",
-          "x-ms-mutability": [
-            "update",
-            "create"
-          ]
-        }
-      }
     },
     "Visibility": {
       "type": "string",

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -23,7 +23,7 @@ type HCPOpenShiftClusterProperties struct {
 
 // ClusterSpec represents a high level cluster configuration.
 type ClusterSpec struct {
-	Version                       VersionProfile            `json:"version,omitempty"                       visibility:"read create update" validate:"required_for_put"`
+	Version                       VersionProfile            `json:"version,omitempty"                       visibility:"read create"        validate:"required_for_put"`
 	DNS                           DNSProfile                `json:"dns,omitempty"                           visibility:"read create update"`
 	Network                       NetworkProfile            `json:"network,omitempty"                       visibility:"read create"`
 	Console                       ConsoleProfile            `json:"console,omitempty"                       visibility:"read"`
@@ -39,8 +39,8 @@ type ClusterSpec struct {
 
 // VersionProfile represents the cluster control plane version.
 type VersionProfile struct {
-	ID                string   `json:"id,omitempty"                visibility:"read create update" validate:"required_for_put"`
-	ChannelGroup      string   `json:"channelGroup,omitempty"      visibility:"read create"        validate:"required_for_put"`
+	ID                string   `json:"id,omitempty"                visibility:"read create" validate:"required_for_put"`
+	ChannelGroup      string   `json:"channelGroup,omitempty"      visibility:"read create" validate:"required_for_put"`
 	AvailableUpgrades []string `json:"availableUpgrades,omitempty" visibility:"read"`
 }
 

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -22,7 +22,7 @@ type HCPOpenShiftClusterNodePoolProperties struct {
 }
 
 type NodePoolSpec struct {
-	Version       VersionProfile          `json:"version,omitempty" visibility:"read create update" validate:"required_for_put"`
+	Version       VersionProfile          `json:"version,omitempty" visibility:"read create" validate:"required_for_put"`
 	Platform      NodePoolPlatformProfile `json:"platform,omitempty" visibility:"read create" validate:"required_for_put"`
 	Replicas      int32                   `json:"replicas,omitempty" visibility:"read create update"`
 	AutoRepair    bool                    `json:"autoRepair,omitempty" visibility:"read create"`

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -37,9 +37,6 @@ type ClusterPatchSpec struct {
 
 	// Openshift cluster proxy configuration
 	Proxy *ProxyProfile
-
-	// Version of the control plane components
-	Version *VersionProfileUpdate
 }
 
 // ClusterSpec - The cluster resource specification
@@ -274,6 +271,9 @@ type HcpOpenShiftClusterPatch struct {
 type HcpOpenShiftClusterPatchProperties struct {
 	// The cluster resource specification.
 	Spec *ClusterPatchSpec
+
+	// READ-ONLY; The status of the last operation.
+	ProvisioningState *ProvisioningState
 }
 
 // HcpOpenShiftClusterProperties - HCP cluster properties
@@ -426,6 +426,9 @@ type NodePoolAutoScaling struct {
 type NodePoolPatchProperties struct {
 	// The node pool resource specification
 	Spec *NodePoolPatchSpec
+
+	// READ-ONLY; Provisioning state
+	ProvisioningState *ResourceProvisioningState
 }
 
 // NodePoolPatchSpec - Worker node pool profile
@@ -447,9 +450,6 @@ type NodePoolPatchSpec struct {
 // in the NodePool. Each ConfigMap must have a single key named "tuned" whose value is the JSON or YAML of a serialized Tuned
 // or PerformanceProfile.
 	TuningConfigs []*string
-
-	// OpenShift version for the nodepool
-	Version *VersionProfileUpdate
 }
 
 // NodePoolPlatformProfile - Azure node pool platform configuration
@@ -741,11 +741,5 @@ type VersionProfile struct {
 
 	// READ-ONLY; AvailableUpgrades is a list of version names the current version can be upgraded to.
 	AvailableUpgrades []*string
-}
-
-// VersionProfileUpdate - Versions represents an OpenShift version.
-type VersionProfileUpdate struct {
-	// ID is the unique identifier of the version.
-	ID *string
 }
 

--- a/internal/api/v20240610preview/generated/models_serde.go
+++ b/internal/api/v20240610preview/generated/models_serde.go
@@ -89,7 +89,6 @@ func (c ClusterPatchSpec) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "disableUserWorkloadMonitoring", c.DisableUserWorkloadMonitoring)
 	populate(objectMap, "proxy", c.Proxy)
-	populate(objectMap, "version", c.Version)
 	return json.Marshal(objectMap)
 }
 
@@ -107,9 +106,6 @@ func (c *ClusterPatchSpec) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "proxy":
 				err = unpopulate(val, "Proxy", &c.Proxy)
-			delete(rawMsg, key)
-		case "version":
-				err = unpopulate(val, "Version", &c.Version)
 			delete(rawMsg, key)
 		default:
 			err = fmt.Errorf("unmarshalling type %T, unknown field %q", c, key)
@@ -802,6 +798,7 @@ func (h *HcpOpenShiftClusterPatch) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HcpOpenShiftClusterPatchProperties.
 func (h HcpOpenShiftClusterPatchProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "provisioningState", h.ProvisioningState)
 	populate(objectMap, "spec", h.Spec)
 	return json.Marshal(objectMap)
 }
@@ -815,6 +812,9 @@ func (h *HcpOpenShiftClusterPatchProperties) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "provisioningState":
+				err = unpopulate(val, "ProvisioningState", &h.ProvisioningState)
+			delete(rawMsg, key)
 		case "spec":
 				err = unpopulate(val, "Spec", &h.Spec)
 			delete(rawMsg, key)
@@ -1250,6 +1250,7 @@ func (n *NodePoolAutoScaling) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type NodePoolPatchProperties.
 func (n NodePoolPatchProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "provisioningState", n.ProvisioningState)
 	populate(objectMap, "spec", n.Spec)
 	return json.Marshal(objectMap)
 }
@@ -1263,6 +1264,9 @@ func (n *NodePoolPatchProperties) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "provisioningState":
+				err = unpopulate(val, "ProvisioningState", &n.ProvisioningState)
+			delete(rawMsg, key)
 		case "spec":
 				err = unpopulate(val, "Spec", &n.Spec)
 			delete(rawMsg, key)
@@ -1284,7 +1288,6 @@ func (n NodePoolPatchSpec) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "replicas", n.Replicas)
 	populate(objectMap, "taints", n.Taints)
 	populate(objectMap, "tuningConfigs", n.TuningConfigs)
-	populate(objectMap, "version", n.Version)
 	return json.Marshal(objectMap)
 }
 
@@ -1311,9 +1314,6 @@ func (n *NodePoolPatchSpec) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "tuningConfigs":
 				err = unpopulate(val, "TuningConfigs", &n.TuningConfigs)
-			delete(rawMsg, key)
-		case "version":
-				err = unpopulate(val, "Version", &n.Version)
 			delete(rawMsg, key)
 		default:
 			err = fmt.Errorf("unmarshalling type %T, unknown field %q", n, key)
@@ -2054,35 +2054,6 @@ func (v *VersionProfile) UnmarshalJSON(data []byte) error {
 		case "channelGroup":
 				err = unpopulate(val, "ChannelGroup", &v.ChannelGroup)
 			delete(rawMsg, key)
-		case "id":
-				err = unpopulate(val, "ID", &v.ID)
-			delete(rawMsg, key)
-		default:
-			err = fmt.Errorf("unmarshalling type %T, unknown field %q", v, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", v, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type VersionProfileUpdate.
-func (v VersionProfileUpdate) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "id", v.ID)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type VersionProfileUpdate.
-func (v *VersionProfileUpdate) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", v, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
 		case "id":
 				err = unpopulate(val, "ID", &v.ID)
 			delete(rawMsg, key)


### PR DESCRIPTION
### What this PR does

[Cluster Service does not allow patching the cluster version ID directly](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/blob/master/cmd/clusters-service/servecmd/apiserver/validation_helpers.go?ref_type=heads#L2830).
For now, make the field create-only until we get cluster and node pool upgrades figured out.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

`ID` was the only update-able field in `VersionProfile` so I adjusted the visibility attribute for the entire struct as well.
