### PR TITLE
Add missing NodePools CosmosDB container

### DIFF
--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -26,6 +26,9 @@ var containers = [
   {
     name: 'Billing'
   }
+  {
+    name: 'NodePools'
+  }
 ]
 
 param roleDefinitionId string = '00000000-0000-0000-0000-000000000002'


### PR DESCRIPTION
### What this PR does
In #513 CosmosDB Nodepool operations were implemented, but the `NodePools` container doesn't exist in CosmosDB yet!

https://github.com/Azure/ARO-HCP/blob/a4f244c3ea7239f20717e8480b550caab4bac509/internal/database/database.go#L20

Jira: [ARO-9686](https://issues.redhat.com/browse/ARO-9686)