### PR TITLE
Towards updating hosted cluster resources

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -399,7 +399,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 	versionedRequestCluster.Normalize(hcpCluster)
 
 	hcpCluster.Name = request.PathValue(PathSegmentResourceName)
-	csCluster, err := f.BuildCSCluster(ctx, hcpCluster)
+	csCluster, err := f.BuildCSCluster(ctx, hcpCluster, updating)
 	if err != nil {
 		f.logger.Error(err.Error())
 		arm.WriteInternalServerError(writer)

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	csFlavourId        string = "osd-4" // managed cluster
 	csCloudProvider    string = "azure"
 	csProductId        string = "aro"
 	csHypershifEnabled bool   = true
@@ -155,7 +156,7 @@ func (f *Frontend) BuildCSCluster(ctx context.Context, hcpCluster *api.HCPOpenSh
 		clusterBuilder = clusterBuilder.
 			Name(hcpCluster.Name).
 			Flavour(cmv1.NewFlavour().
-				ID(hcpCluster.Type)).
+				ID(csFlavourId)).
 			Region(cmv1.NewCloudRegion().
 				ID(f.location)).
 			CloudProvider(cmv1.NewCloudProvider().

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -80,7 +80,7 @@ func (f *Frontend) routes() *MiddlewareMux {
 		postMuxMiddleware.HandlerFunc(f.ArmResourceCreateOrUpdate))
 	mux.Handle(
 		MuxPattern(http.MethodPatch, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceUpdate))
+		postMuxMiddleware.HandlerFunc(f.ArmResourceCreateOrUpdate))
 	mux.Handle(
 		MuxPattern(http.MethodDelete, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternResourceName),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceDelete))

--- a/frontend/utils/create.go
+++ b/frontend/utils/create.go
@@ -45,11 +45,6 @@ func main() {
 // CreateJSONFile creates a base cluster JSON file for use with testing frontend to create clusters
 func CreateJSONFile() error {
 	cluster := api.HCPOpenShiftCluster{
-		TrackedResource: arm.TrackedResource{
-			Resource: arm.Resource{
-				Type: "osd-4",
-			},
-		},
 		Properties: api.HCPOpenShiftClusterProperties{
 			Spec: api.ClusterSpec{
 				Version: api.VersionProfile{
@@ -99,11 +94,6 @@ func CreateJSONFile() error {
 
 func CreateNodePool() error {
 	nodePool := api.HCPOpenShiftClusterNodePool{
-		TrackedResource: arm.TrackedResource{
-			Resource: arm.Resource{
-				Type: "osd-4",
-			},
-		},
 		Properties: api.HCPOpenShiftClusterNodePoolProperties{
 			ProvisioningState: arm.ProvisioningState(""),
 			Spec: api.NodePoolSpec{

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -75,10 +75,10 @@ type APIProfile struct {
 // ProxyProfile represents the cluster proxy configuration.
 // Visibility for the entire struct is "read create update".
 type ProxyProfile struct {
-	HTTPProxy  string `json:"httpProxy,omitempty"`
-	HTTPSProxy string `json:"httpsProxy,omitempty"`
+	HTTPProxy  string `json:"httpProxy,omitempty"  validate:"omitempty,url,startswith=http:"`
+	HTTPSProxy string `json:"httpsProxy,omitempty" validate:"omitempty,url"`
 	NoProxy    string `json:"noProxy,omitempty"`
-	TrustedCA  string `json:"trustedCa,omitempty"`
+	TrustedCA  string `json:"trustedCa,omitempty"  validate:"omitempty,pem_certificates"`
 }
 
 // PlatformProfile represents the Azure platform configuration.

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -47,7 +47,7 @@ type VersionProfile struct {
 // DNSProfile represents the DNS configuration of the cluster.
 type DNSProfile struct {
 	BaseDomain       string `json:"baseDomain,omitempty"       visibility:"read"`
-	BaseDomainPrefix string `json:"baseDomainPrefix,omitempty" visibility:"read create"`
+	BaseDomainPrefix string `json:"baseDomainPrefix,omitempty" visibility:"read create" validate:"omitempty,dns_rfc1035_label"`
 }
 
 // NetworkProfile represents a cluster network configuration.

--- a/internal/api/validate.go
+++ b/internal/api/validate.go
@@ -134,6 +134,8 @@ func ValidateRequest(validate *validator.Validate, method string, resource any) 
 					message = fmt.Sprintf("Missing required field '%s'", fieldErr.Field())
 				case "cidrv4":
 					message += " (must be a v4 CIDR range)"
+				case "dns_rfc1035_label":
+					message += " (must be a valid DNS RFC 1035 label)"
 				case "ipv4":
 					message += " (must be an IPv4 address)"
 				case "url":


### PR DESCRIPTION
### What this PR does

This started with the observation that updates to existing clusters through PUT were not being handled correctly and kinda spiraled from there.  It's by no means complete, but the changes here allow the RP to submit cluster update requests via PUT or PATCH to Cluster Service and _for the most part_ pass Cluster Service's static validation (though gaps remain).

As an aside, I think we should set the goal of never tripping Cluster Service's static validation.  For one thing, we're able to return multiple validation errors at once whereas Cluster Service stops on the first one.  Also, ARO-HCP users should get consistent looking error responses when validation fails.  If something slips through our validation, users will most likely either get an unhelpful "500 Internal Server Error" response or at best a 4xx response containing the raw error message returned by Cluster Service.  This PR doesn't meet that goal but inches us closer.

Jira: Partially addresses:
- [ARO-7593 - Frontend can Update/Patch a HostedCluster CR in CS](https://issues.redhat.com/browse/ARO-7593)
- [ARO-7958 - Validate cluster conversion objects are completed in Frontend](https://issues.redhat.com/browse/ARO-7958)
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

There's a lot here.  I suggest reviewing one commit at a time.
