### PR TITLE
Make managedResourceGroup optional

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -316,7 +316,7 @@ model ProxyProfile {
 /** Azure specific configuration */
 model PlatformProfile {
   /** Resource group to put cluster resources */
-  managedResourceGroup: string;
+  managedResourceGroup?: string;
 
   /** ResourceId for the subnet used by the control plane */
   subnetId: SubnetResourceId;

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1992,7 +1992,6 @@
         }
       },
       "required": [
-        "managedResourceGroup",
         "subnetId",
         "networkSecurityGroupId"
       ]

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -85,7 +85,7 @@ type ProxyProfile struct {
 // PlatformProfile represents the Azure platform configuration.
 // Visibility for the entire struct is "read create".
 type PlatformProfile struct {
-	ManagedResourceGroup string       `json:"managedResourceGroup,omitempty" validate:"required_for_put"`
+	ManagedResourceGroup string       `json:"managedResourceGroup,omitempty"`
 	SubnetID             string       `json:"subnetId,omitempty"             validate:"required_for_put"`
 	OutboundType         OutboundType `json:"outboundType,omitempty"         validate:"omitempty,enum_outboundtype"`
 	//TODO: Is nsg required for PUT, or will we create if not specified?

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -586,9 +586,6 @@ type OperationListResult struct {
 
 // PlatformProfile - Azure specific configuration
 type PlatformProfile struct {
-	// REQUIRED; Resource group to put cluster resources
-	ManagedResourceGroup *string
-
 	// REQUIRED; ResourceId for the network security group attached to the cluster subnet
 	NetworkSecurityGroupID *string
 
@@ -598,6 +595,9 @@ type PlatformProfile struct {
 	// The id of the disk encryption set to be used for etcd. Configure this when etcdEncryption is set to true Is used the
 // https://learn.microsoft.com/en-us/azure/storage/common/customer-managed-keys-overview
 	EtcdEncryptionSetID *string
+
+	// Resource group to put cluster resources
+	ManagedResourceGroup *string
 
 	// The core outgoing configuration
 	OutboundType *OutboundType


### PR DESCRIPTION
## What:

This is a draft MR for https://issues.redhat.com/browse/ARO-9525. After discussing this with some members of the HCP team there was a weak preference to place the fallback logic in the CS rather than in the RP. Open to changing this but if this looks correct I'll add tests and we can go from there.
