### PR TITLE
Combine "Clusters" and "NodePools" DB containers

### DIFF
--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -21,13 +21,10 @@ var containers = [
     partitionKeyPaths: ['/id']
   }
   {
-    name: 'Clusters'
+    name: 'Resources'
   }
   {
     name: 'Billing'
-  }
-  {
-    name: 'NodePools'
   }
 ]
 

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -227,7 +227,7 @@ func (f *Frontend) ArmResourceRead(writer http.ResponseWriter, request *http.Req
 
 	f.logger.Info(fmt.Sprintf("%s: ArmResourceRead", versionedInterface))
 
-	doc, err := f.dbClient.GetClusterDoc(ctx, resourceID)
+	doc, err := f.dbClient.GetResourceDoc(ctx, resourceID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Error(fmt.Sprintf("existing document not found for cluster: %s", resourceID))
@@ -308,7 +308,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 
 	f.logger.Info(fmt.Sprintf("%s: ArmResourceCreateOrUpdate", versionedInterface))
 
-	doc, err := f.dbClient.GetClusterDoc(ctx, resourceID)
+	doc, err := f.dbClient.GetResourceDoc(ctx, resourceID)
 	if err != nil && !errors.Is(err, database.ErrNotFound) {
 		f.logger.Error(fmt.Sprintf("failed to fetch document for %s: %v", resourceID, err))
 		arm.WriteInternalServerError(writer)
@@ -368,7 +368,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 			return
 		}
 
-		doc = &database.HCPOpenShiftClusterDocument{
+		doc = &database.ResourceDocument{
 			ID:           uuid.New().String(),
 			Key:          resourceID.String(),
 			PartitionKey: resourceID.SubscriptionID,
@@ -439,7 +439,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 	}
 
 	if docUpdated {
-		err = f.dbClient.SetClusterDoc(ctx, doc)
+		err = f.dbClient.SetResourceDoc(ctx, doc)
 		if err != nil {
 			f.logger.Error(fmt.Sprintf("failed to upsert document for %s: %v", resourceID, err))
 			arm.WriteInternalServerError(writer)
@@ -486,8 +486,8 @@ func (f *Frontend) ArmResourceDelete(writer http.ResponseWriter, request *http.R
 
 	f.logger.Info(fmt.Sprintf("%s: ArmResourceDelete", versionedInterface))
 
-	var doc *database.HCPOpenShiftClusterDocument
-	doc, err = f.dbClient.GetClusterDoc(ctx, resourceID)
+	var doc *database.ResourceDocument
+	doc, err = f.dbClient.GetResourceDoc(ctx, resourceID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Info(fmt.Sprintf("cluster document cannot be deleted -- document not found for %s", resourceID))
@@ -507,7 +507,7 @@ func (f *Frontend) ArmResourceDelete(writer http.ResponseWriter, request *http.R
 		return
 	}
 
-	err = f.dbClient.DeleteClusterDoc(ctx, resourceID)
+	err = f.dbClient.DeleteResourceDoc(ctx, resourceID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Info(fmt.Sprintf("cluster document cannot be deleted -- document not found for %s", resourceID))
@@ -800,7 +800,7 @@ func (f *Frontend) CreateNodePool(writer http.ResponseWriter, request *http.Requ
 	}
 
 	subscriptionID := request.PathValue(PathSegmentSubscriptionID)
-	clusterDoc, err := f.dbClient.GetClusterDoc(ctx, clusterResourceID)
+	clusterDoc, err := f.dbClient.GetResourceDoc(ctx, clusterResourceID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Error(fmt.Sprintf("existing document not found for cluster %s when creating node pool", clusterResourceID))
@@ -825,12 +825,12 @@ func (f *Frontend) CreateNodePool(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	nodePoolDoc, err := f.dbClient.GetNodePoolDoc(ctx, nodePoolResourceID)
+	nodePoolDoc, err := f.dbClient.GetResourceDoc(ctx, nodePoolResourceID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Info(fmt.Sprintf("creating nodepool document for %s", nodePoolResourceID))
 
-			nodePoolDoc = &database.NodePoolDocument{
+			nodePoolDoc = &database.ResourceDocument{
 				ID:           uuid.New().String(),
 				Key:          nodePoolResourceID.String(),
 				PartitionKey: subscriptionID,
@@ -887,7 +887,7 @@ func (f *Frontend) CreateNodePool(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	err = f.dbClient.SetNodePoolDoc(ctx, nodePoolDoc)
+	err = f.dbClient.SetResourceDoc(ctx, nodePoolDoc)
 	if err != nil {
 		f.logger.Error(fmt.Sprintf("failed to create nodepool document for resource %s: %v", nodePoolResourceID, err))
 		arm.WriteInternalServerError(writer)
@@ -938,7 +938,7 @@ func (f *Frontend) GetNodePool(writer http.ResponseWriter, request *http.Request
 		return
 	}
 
-	nodePoolDoc, err := f.dbClient.GetNodePoolDoc(ctx, nodePoolResourceID)
+	nodePoolDoc, err := f.dbClient.GetResourceDoc(ctx, nodePoolResourceID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Error(fmt.Sprintf("existing node pool document not found for node pool: %s on GET node pool by name", nodePoolResourceID))
@@ -1005,7 +1005,7 @@ func (f *Frontend) DeleteNodePool(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	doc, err := f.dbClient.GetNodePoolDoc(ctx, nodePoolResourceID)
+	doc, err := f.dbClient.GetResourceDoc(ctx, nodePoolResourceID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Error(fmt.Sprintf("nodepool document cannot be deleted -- nodepool document not found for %s", nodePoolResourceID))
@@ -1025,7 +1025,7 @@ func (f *Frontend) DeleteNodePool(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	err = f.dbClient.DeleteNodePoolDoc(ctx, nodePoolResourceID)
+	err = f.dbClient.DeleteResourceDoc(ctx, nodePoolResourceID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			f.logger.Error(fmt.Sprintf("nodepool document cannot be deleted -- nodepool document not found for %s", nodePoolResourceID))

--- a/internal/database/cache.go
+++ b/internal/database/cache.go
@@ -12,8 +12,7 @@ var _ DBClient = &Cache{}
 // Cache is a simple DBClient that allows us to perform simple tests without needing a real CosmosDB. For production,
 // use CosmosDBClient instead. Call NewCache() to initialize a Cache correctly.
 type Cache struct {
-	cluster      map[string]*HCPOpenShiftClusterDocument
-	nodePool     map[string]*NodePoolDocument
+	resource     map[string]*ResourceDocument
 	operation    map[string]*OperationDocument
 	subscription map[string]*SubscriptionDocument
 }
@@ -22,8 +21,7 @@ type Cache struct {
 // NewCosmosDBConfig instead.
 func NewCache() DBClient {
 	return &Cache{
-		cluster:      make(map[string]*HCPOpenShiftClusterDocument),
-		nodePool:     make(map[string]*NodePoolDocument),
+		resource:     make(map[string]*ResourceDocument),
 		subscription: make(map[string]*SubscriptionDocument),
 	}
 }
@@ -32,57 +30,30 @@ func (c *Cache) DBConnectionTest(ctx context.Context) error {
 	return nil
 }
 
-func (c *Cache) GetClusterDoc(ctx context.Context, resourceID *azcorearm.ResourceID) (*HCPOpenShiftClusterDocument, error) {
+func (c *Cache) GetResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) (*ResourceDocument, error) {
 	// Make sure lookup keys are lowercase.
 	key := strings.ToLower(resourceID.String())
 
-	if doc, ok := c.cluster[key]; ok {
+	if doc, ok := c.resource[key]; ok {
 		return doc, nil
 	}
 
 	return nil, ErrNotFound
 }
 
-func (c *Cache) SetClusterDoc(ctx context.Context, doc *HCPOpenShiftClusterDocument) error {
+func (c *Cache) SetResourceDoc(ctx context.Context, doc *ResourceDocument) error {
 	// Make sure lookup keys are lowercase.
 	key := strings.ToLower(doc.Key)
 
-	c.cluster[key] = doc
+	c.resource[key] = doc
 	return nil
 }
 
-func (c *Cache) DeleteClusterDoc(ctx context.Context, resourceID *azcorearm.ResourceID) error {
+func (c *Cache) DeleteResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) error {
 	// Make sure lookup keys are lowercase.
 	key := strings.ToLower(resourceID.String())
 
-	delete(c.cluster, key)
-	return nil
-}
-
-func (c *Cache) GetNodePoolDoc(ctx context.Context, resourceID *azcorearm.ResourceID) (*NodePoolDocument, error) {
-	// Make sure lookup keys are lowercase.
-	key := strings.ToLower(resourceID.String())
-
-	if doc, ok := c.nodePool[key]; ok {
-		return doc, nil
-	}
-
-	return nil, ErrNotFound
-}
-
-func (c *Cache) SetNodePoolDoc(ctx context.Context, doc *NodePoolDocument) error {
-	// Make sure lookup keys are lowercase.
-	key := strings.ToLower(doc.Key)
-
-	c.nodePool[key] = doc
-	return nil
-}
-
-func (c *Cache) DeleteNodePoolDoc(ctx context.Context, resourceID *azcorearm.ResourceID) error {
-	// Make sure lookup keys are lowercase.
-	key := strings.ToLower(resourceID.String())
-
-	delete(c.nodePool, key)
+	delete(c.resource, key)
 	return nil
 }
 

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -1,13 +1,16 @@
 package database
 
-import "github.com/Azure/ARO-HCP/internal/api/arm"
+import (
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+)
 
 // HCPOpenShiftClusterDocument represents an HCP OpenShift cluster document.
 type HCPOpenShiftClusterDocument struct {
 	ID           string          `json:"id,omitempty"`
 	Key          string          `json:"key,omitempty"`
 	PartitionKey string          `json:"partitionKey,omitempty"`
-	ClusterID    string          `json:"clusterId,omitempty"`
+	InternalID   ocm.InternalID  `json:"internalId,omitempty"`
 	SystemData   *arm.SystemData `json:"systemData,omitempty"`
 
 	// Values provided by Cosmos after doc creation
@@ -23,7 +26,7 @@ type NodePoolDocument struct {
 	ID           string          `json:"id,omitempty"`
 	Key          string          `json:"key,omitempty"`
 	PartitionKey string          `json:"partitionKey,omitempty"`
-	NodePoolID   string          `json:"nodePoolId,omitempty"`
+	InternalID   ocm.InternalID  `json:"internalId,omitempty"`
 	SystemData   *arm.SystemData `json:"systemData,omitempty"`
 
 	// Values provided by Cosmos after doc creation

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -8,7 +8,7 @@ type HCPOpenShiftClusterDocument struct {
 	Key          string          `json:"key,omitempty"`
 	PartitionKey string          `json:"partitionKey,omitempty"`
 	ClusterID    string          `json:"clusterId,omitempty"`
-	SystemData   *arm.SystemData `json:"systemData,omitempty"` // TODO: Should CS store this?
+	SystemData   *arm.SystemData `json:"systemData,omitempty"`
 
 	// Values provided by Cosmos after doc creation
 	ResourceID  string `json:"_rid,omitempty"`
@@ -24,7 +24,7 @@ type NodePoolDocument struct {
 	Key          string          `json:"key,omitempty"`
 	PartitionKey string          `json:"partitionKey,omitempty"`
 	NodePoolID   string          `json:"nodePoolId,omitempty"`
-	SystemData   *arm.SystemData `json:"systemData,omitempty"` // TODO: Should CS store this?
+	SystemData   *arm.SystemData `json:"systemData,omitempty"`
 
 	// Values provided by Cosmos after doc creation
 	ResourceID  string `json:"_rid,omitempty"`

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -5,24 +5,10 @@ import (
 	"github.com/Azure/ARO-HCP/internal/ocm"
 )
 
-// HCPOpenShiftClusterDocument represents an HCP OpenShift cluster document.
-type HCPOpenShiftClusterDocument struct {
-	ID           string          `json:"id,omitempty"`
-	Key          string          `json:"key,omitempty"`
-	PartitionKey string          `json:"partitionKey,omitempty"`
-	InternalID   ocm.InternalID  `json:"internalId,omitempty"`
-	SystemData   *arm.SystemData `json:"systemData,omitempty"`
-
-	// Values provided by Cosmos after doc creation
-	ResourceID  string `json:"_rid,omitempty"`
-	Self        string `json:"_self,omitempty"`
-	ETag        string `json:"_etag,omitempty"`
-	Attachments string `json:"_attachments,omitempty"`
-	Timestamp   int    `json:"_ts,omitempty"`
-}
-
-// NodePoolDocument represents an HCP OpenShift NodePool document.
-type NodePoolDocument struct {
+// ResourceDocument captures the mapping of an Azure resource ID
+// to an internal resource ID (the OCM API path), as well as any
+// ARM-specific metadata for the resource.
+type ResourceDocument struct {
 	ID           string          `json:"id,omitempty"`
 	Key          string          `json:"key,omitempty"`
 	PartitionKey string          `json:"partitionKey,omitempty"`

--- a/internal/ocm/internalid.go
+++ b/internal/ocm/internalid.go
@@ -1,0 +1,115 @@
+package ocm
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+
+	cmv2alpha1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v2alpha1"
+)
+
+const (
+	v2alpha1Pattern         = "/api/clusters_mgmt/v2alpha1"
+	v2alpha1ClusterPattern  = v2alpha1Pattern + "/clusters/*"
+	v2alpha1NodePoolPattern = v2alpha1ClusterPattern + "/node_pools/*"
+)
+
+// InternalID represents a Cluster Service resource.
+type InternalID struct {
+	path string
+}
+
+func (id *InternalID) validate() error {
+	var match bool
+
+	// This is where we will catch and convert any legacy API versions
+	// to the version the RP is actively using.
+	//
+	// For example, once the RP is using "v2" we will convert "v2alpha1"
+	// and any other legacy transitional versions we see to "v2".
+
+	if match, _ = path.Match(v2alpha1ClusterPattern, id.path); match {
+		return nil
+	}
+
+	if match, _ = path.Match(v2alpha1NodePoolPattern, id.path); match {
+		return nil
+	}
+
+	return fmt.Errorf("Invalid InternalID: %s", id.path)
+}
+
+// NewInternalID attempts to create a new InternalID from a Cluster Service
+// API path, returning an error if the API path is invalid or unsupported.
+func NewInternalID(path string) (InternalID, error) {
+	internalID := InternalID{path: strings.ToLower(path)}
+	if err := internalID.validate(); err != nil {
+		return InternalID{}, err
+	}
+	return internalID, nil
+}
+
+// String allows an InternalID to be used as a fmt.Stringer.
+func (id *InternalID) String() string {
+	return id.path
+}
+
+// MarshalText allows an InternalID to be used as an encoding.TextMarshaler.
+func (id InternalID) MarshalText() ([]byte, error) {
+	return []byte(id.path), nil
+}
+
+// UnmarshalText allows an InternalID to be used as an encoding.TextUnmarshaler.
+func (id *InternalID) UnmarshalText(text []byte) error {
+	id.path = strings.ToLower(string(text))
+	return id.validate()
+}
+
+// Kind returns the kind of resource described by InternalID, currently
+// limited to "Cluster" and "NodePool".
+func (id *InternalID) Kind() string {
+	var match bool
+	var kind string
+
+	if match, _ = path.Match(v2alpha1ClusterPattern, id.path); match {
+		kind = cmv2alpha1.ClusterKind
+	}
+
+	if match, _ = path.Match(v2alpha1NodePoolPattern, id.path); match {
+		kind = cmv2alpha1.NodePoolKind
+	}
+
+	return kind
+}
+
+// GetClusterClient returns a v1 ClusterClient from the InternalID.
+// This works for both cluster and node pool resources. The transport
+// is most likely to be a Connection object from the SDK.
+func (id *InternalID) GetClusterClient(transport http.RoundTripper) (*cmv2alpha1.ClusterClient, bool) {
+	var thisPath string = id.path
+	var lastPath string
+
+	for thisPath != lastPath {
+		if match, _ := path.Match(v2alpha1ClusterPattern, thisPath); match {
+			return cmv2alpha1.NewClusterClient(transport, thisPath), true
+		} else {
+			lastPath = thisPath
+			thisPath = path.Dir(thisPath)
+		}
+	}
+
+	return nil, false
+}
+
+// GetNodePoolClient returns a v1 NodePoolClient from the InternalID.
+// The transport is most likely to be a Connection object from the SDK.
+func (id *InternalID) GetNodePoolClient(transport http.RoundTripper) (*cmv2alpha1.NodePoolClient, bool) {
+	if match, _ := path.Match(v2alpha1NodePoolPattern, id.path); match {
+		return cmv2alpha1.NewNodePoolClient(transport, id.path), true
+	}
+	return nil, false
+}

--- a/internal/ocm/internalid_test.go
+++ b/internal/ocm/internalid_test.go
@@ -1,0 +1,94 @@
+package ocm
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the apache License 2.0.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cmv2alpha1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v2alpha1"
+)
+
+type FakeTransport struct{}
+
+func (t *FakeTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestInternalID(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		kind      string
+		expectErr bool
+	}{
+		{
+			name:      "parse invalid internal ID",
+			path:      "/invalid/internal/id",
+			kind:      "",
+			expectErr: true,
+		},
+		{
+			name:      "parse v2alpha1 cluster",
+			path:      "/api/clusters_mgmt/v2alpha1/clusters/abc",
+			kind:      cmv2alpha1.ClusterKind,
+			expectErr: false,
+		},
+		{
+			name:      "parse v2alpha1 node pool",
+			path:      "/api/clusters_mgmt/v2alpha1/clusters/abc/node_pools/def",
+			kind:      cmv2alpha1.NodePoolKind,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			internalID, err := NewInternalID(tt.path)
+			if err != nil {
+				if !tt.expectErr {
+					t.Error(err)
+				}
+				return
+			}
+
+			if tt.expectErr {
+				t.Error("expected unmarshaling to fail")
+				return
+			}
+
+			kind := internalID.Kind()
+			if kind != tt.kind {
+				t.Errorf("expected kind '%s', got '%s'", tt.kind, kind)
+			}
+
+			str := internalID.String()
+			if str != tt.path {
+				t.Errorf("expected string '%s', got '%s'", tt.path, str)
+			}
+
+			transport := &FakeTransport{}
+			if _, ok := internalID.GetClusterClient(transport); !ok {
+				t.Errorf("failed to get cluster client")
+			}
+			if kind == cmv2alpha1.NodePoolKind {
+				if _, ok := internalID.GetNodePoolClient(transport); !ok {
+					t.Errorf("failed to get node pool client")
+				}
+			}
+
+			bytes, err := json.Marshal(internalID)
+			if err != nil {
+				t.Error(err)
+			}
+			fmt.Printf("Bytes: %s\n", bytes)
+			err = json.Unmarshal(bytes, &internalID)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What this PR does

As the title states, this combines the "Clusters" and "NodePools" Cosmos DB containers into a single "Resources" container that can accommodate clusters, node pools, and any other Azure child resources we may add in the future. 

The `clusterId` and `nodePoolId` fields of the respective document types are replaced by what I call an `internalId`, which is the full OCM API path for the resource, rendering the two document types identical.

Additionally -- and this is something I originally wrote and intend to use for asynchronous operations -- is the `InternalID` type, which is analogous to [azcorearm.ResourceID](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore@v1.13.0/arm/internal/resource#ResourceID) but for OCM paths (limited to cluster and node pool paths).

The `InternalID` type provides a number of advantages over raw strings:

- Pattern-based validation when calling `NewInternalID` or unmarshaling from JSON.  Currently it's matching path strings that look like `/api/clusters_mgmt/v2alpha1/clusters/{clusterId}[/node_pools/{nodePoolId}]` but we'll eventually switch over to `/api/aro_hcp/v1/...` paths as per [OCM-DDR-104](https://docs.google.com/document/d/1pzKM2o3IHbJRbzy8KgQyV3mLG3fyukia2yVFzvMn9Uc/edit).

- Includes a `Kind()` method which returns the equivalent to [Cluster.Kind](https://pkg.go.dev/github.com/openshift-online/ocm-sdk-go@v0.1.433/clustersmgmt/v2alpha1#Cluster.Kind) or [NodePool.Kind](https://pkg.go.dev/github.com/openshift-online/ocm-sdk-go@v0.1.433/clustersmgmt/v2alpha1#NodePool.Kind).

- Includes `GetClusterClient(transport http.RoundTripper)` and `GetNodePoolClient(transport http.RoundTripper)` methods that return a [ClusterClient](https://pkg.go.dev/github.com/openshift-online/ocm-sdk-go@v0.1.433/clustersmgmt/v2alpha1#ClusterClient) and [NodePoolClient](https://pkg.go.dev/github.com/openshift-online/ocm-sdk-go@v0.1.433/clustersmgmt/v2alpha1#NodePoolClient) respectively.  (`GetClusterClient` even works for node pool resources, since the cluster ID is embedded in the OCM path.)

Together these methods further simplify the RP's endpoint handling and supporting logic.

Jira: Loosely related to [ARO-5737 - Implement Async API ARM Requirements for Long-Running Operations](https://issues.redhat.com/browse/ARO-5737)
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
