### PR TITLE
Store tracked resource tags in Cosmos

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -796,12 +796,7 @@ func (f *Frontend) GetNodePool(writer http.ResponseWriter, request *http.Request
 		return
 	}
 
-	hcpNodePool, err := f.ConvertCStoNodePool(ctx, csNodePool)
-	if err != nil {
-		f.logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
-	}
+	hcpNodePool := ConvertCStoNodePool(resourceID, csNodePool)
 
 	versionedNodePool := versionedInterface.NewHCPOpenShiftClusterNodePool(hcpNodePool)
 	resp, err := json.Marshal(versionedNodePool)
@@ -917,13 +912,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 			return
 		}
 
-		hcpNodePool, err := f.ConvertCStoNodePool(ctx, csNodePool)
-		if err != nil {
-			// Should never happen currently
-			f.logger.Error(err.Error())
-			arm.WriteInternalServerError(writer)
-			return
-		}
+		hcpNodePool := ConvertCStoNodePool(nodePoolResourceID, csNodePool)
 
 		// This is slightly repetitive for the sake of clarify on PUT vs PATCH.
 		switch request.Method {

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -335,6 +335,10 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 
 		hcpCluster := ConvertCStoHCPOpenShiftCluster(resourceID, csCluster)
 
+		// Do not set the TrackedResource.Tags field here. We need
+		// the Tags map to remain nil so we can see if the request
+		// body included a new set of resource tags.
+
 		// This is slightly repetitive for the sake of clarity on PUT vs PATCH.
 		switch request.Method {
 		case http.MethodPut:
@@ -426,6 +430,16 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 	// Record the latest system data values from ARM, if present.
 	if systemData != nil {
 		doc.SystemData = systemData
+		docUpdated = true
+	}
+
+	// Here the difference between a nil map and an empty map is significant.
+	// If the Tags map is nil, that means it was omitted from the request body,
+	// so we leave any existing tags alone. If the Tags map is non-nil, even if
+	// empty, that means it was specified in the request body and should fully
+	// replace any existing tags.
+	if hcpCluster.TrackedResource.Tags != nil {
+		doc.Tags = hcpCluster.TrackedResource.Tags
 		docUpdated = true
 	}
 
@@ -910,6 +924,10 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 
 		hcpNodePool := ConvertCStoNodePool(nodePoolResourceID, csNodePool)
 
+		// Do not set the TrackedResource.Tags field here. We need
+		// the Tags map to remain nil so we can see if the request
+		// body included a new set of resource tags.
+
 		// This is slightly repetitive for the sake of clarify on PUT vs PATCH.
 		switch request.Method {
 		case http.MethodPut:
@@ -1001,6 +1019,16 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 	// Record the latest system data values from ARM, if present.
 	if systemData != nil {
 		nodePoolDoc.SystemData = systemData
+		docUpdated = true
+	}
+
+	// Here the difference between a nil map and an empty map is significant.
+	// If the Tags map is nil, that means it was omitted from the request body,
+	// so we leave any existing tags alone. If the Tags map is non-nil, even if
+	// empty, that means it was specified in the request body and should fully
+	// replace any existing tags.
+	if hcpNodePool.TrackedResource.Tags != nil {
+		nodePoolDoc.Tags = hcpNodePool.TrackedResource.Tags
 		docUpdated = true
 	}
 

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -164,12 +164,11 @@ func (f *Frontend) ArmResourceList(writer http.ResponseWriter, request *http.Req
 		return
 	}
 
-	systemData := &arm.SystemData{}
 	var hcpCluster *api.HCPOpenShiftCluster
 	var versionedHcpClusters []*api.VersionedHCPOpenShiftCluster
 	clusters := clustersListResponse.Items().Slice()
 	for _, cluster := range clusters {
-		hcpCluster, err = f.ConvertCStoHCPOpenShiftCluster(systemData, cluster)
+		hcpCluster, err = f.ConvertCStoHCPOpenShiftCluster(cluster)
 		if err != nil {
 			f.logger.Error(err.Error())
 			arm.WriteInternalServerError(writer)
@@ -247,7 +246,7 @@ func (f *Frontend) ArmResourceRead(writer http.ResponseWriter, request *http.Req
 		return
 	}
 
-	hcpCluster, err := f.ConvertCStoHCPOpenShiftCluster(doc.SystemData, csCluster)
+	hcpCluster, err := f.ConvertCStoHCPOpenShiftCluster(csCluster)
 	if err != nil {
 		// Should never happen currently
 		f.logger.Error(err.Error())
@@ -336,7 +335,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 			return
 		}
 
-		hcpCluster, err := f.ConvertCStoHCPOpenShiftCluster(doc.SystemData, csCluster)
+		hcpCluster, err := f.ConvertCStoHCPOpenShiftCluster(csCluster)
 		if err != nil {
 			// Should never happen currently
 			f.logger.Error(err.Error())
@@ -866,7 +865,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 			return
 		}
 
-		hcpNodePool, err := f.ConvertCStoNodePool(ctx, nodePoolDoc.SystemData, csNodePool)
+		hcpNodePool, err := f.ConvertCStoNodePool(ctx, csNodePool)
 		if err != nil {
 			// Should never happen currently
 			f.logger.Error(err.Error())
@@ -1039,7 +1038,7 @@ func (f *Frontend) GetNodePool(writer http.ResponseWriter, request *http.Request
 		return
 	}
 
-	aroNodePool, err := f.ConvertCStoNodePool(ctx, nodePoolDoc.SystemData, nodePool)
+	aroNodePool, err := f.ConvertCStoNodePool(ctx, nodePool)
 	if err != nil {
 		f.logger.Error(err.Error())
 		arm.WriteInternalServerError(writer)

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -225,13 +225,8 @@ func (f *Frontend) BuildCSCluster(ctx context.Context, hcpCluster *api.HCPOpenSh
 	return cluster, nil
 }
 
-// ConvertCStoNodepool converts a CS Node Pool object into HCPOpenShiftClusterNodePool object
-func (f *Frontend) ConvertCStoNodePool(ctx context.Context, np *cmv2alpha1.NodePool) (*api.HCPOpenShiftClusterNodePool, error) {
-	resourceID, err := ResourceIDFromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("could not get parsed resource ID: %w", err)
-	}
-
+// ConvertCStoNodePool converts a CS Node Pool object into HCPOpenShiftClusterNodePool object
+func ConvertCStoNodePool(resourceID *azcorearm.ResourceID, np *cmv2alpha1.NodePool) *api.HCPOpenShiftClusterNodePool {
 	nodePool := &api.HCPOpenShiftClusterNodePool{
 		TrackedResource: arm.TrackedResource{
 			Resource: arm.Resource{
@@ -280,7 +275,7 @@ func (f *Frontend) ConvertCStoNodePool(ctx context.Context, np *cmv2alpha1.NodeP
 	}
 	nodePool.Properties.Spec.Taints = taints
 
-	return nodePool, nil
+	return nodePool
 }
 
 // BuildCSNodePool creates a CS Node Pool object from an HCPOpenShiftClusterNodePool object

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -41,7 +41,7 @@ func convertVisibilityToListening(visibility api.Visibility) (listening cmv2alph
 }
 
 // ConvertCStoHCPOpenShiftCluster converts a CS Cluster object into HCPOpenShiftCluster object
-func (f *Frontend) ConvertCStoHCPOpenShiftCluster(systemData *arm.SystemData, cluster *cmv2alpha1.Cluster) (*api.HCPOpenShiftCluster, error) {
+func (f *Frontend) ConvertCStoHCPOpenShiftCluster(cluster *cmv2alpha1.Cluster) (*api.HCPOpenShiftCluster, error) {
 	resourceGroupName := cluster.Azure().ResourceGroupName()
 	resourceName := cluster.Azure().ResourceName()
 	subID := cluster.Azure().SubscriptionID()
@@ -50,12 +50,10 @@ func (f *Frontend) ConvertCStoHCPOpenShiftCluster(systemData *arm.SystemData, cl
 	hcpcluster := &api.HCPOpenShiftCluster{
 		TrackedResource: arm.TrackedResource{
 			Location: cluster.Region().ID(),
-			Tags:     nil, // TODO: OCM should support cluster.Azure().Tags(),
 			Resource: arm.Resource{
-				ID:         resourceID,
-				Name:       resourceName,
-				Type:       api.ResourceType,
-				SystemData: systemData,
+				ID:   resourceID,
+				Name: resourceName,
+				Type: api.ResourceType,
 			},
 		},
 		Properties: api.HCPOpenShiftClusterProperties{
@@ -231,8 +229,8 @@ func (f *Frontend) BuildCSCluster(ctx context.Context, hcpCluster *api.HCPOpenSh
 	return cluster, nil
 }
 
-// ConvertCStoNodePool converts a CS Node Pool object into HCPOpenShiftClusterNodePool object
-func (f *Frontend) ConvertCStoNodePool(ctx context.Context, systemData *arm.SystemData, np *cmv2alpha1.NodePool) (*api.HCPOpenShiftClusterNodePool, error) {
+// ConvertCStoNodepool converts a CS Node Pool object into HCPOpenShiftClusterNodePool object
+func (f *Frontend) ConvertCStoNodePool(ctx context.Context, np *cmv2alpha1.NodePool) (*api.HCPOpenShiftClusterNodePool, error) {
 	resourceID, err := ResourceIDFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get parsed resource ID: %w", err)
@@ -241,10 +239,9 @@ func (f *Frontend) ConvertCStoNodePool(ctx context.Context, systemData *arm.Syst
 	nodePool := &api.HCPOpenShiftClusterNodePool{
 		TrackedResource: arm.TrackedResource{
 			Resource: arm.Resource{
-				ID:         resourceID.String(),
-				Name:       resourceID.Name,
-				Type:       resourceID.ResourceType.String(),
-				SystemData: systemData,
+				ID:   resourceID.String(),
+				Name: resourceID.Name,
+				Type: resourceID.ResourceType.String(),
 			},
 		},
 		Properties: api.HCPOpenShiftClusterNodePoolProperties{

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	cmv2alpha1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v2alpha1"
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -41,19 +42,14 @@ func convertVisibilityToListening(visibility api.Visibility) (listening cmv2alph
 }
 
 // ConvertCStoHCPOpenShiftCluster converts a CS Cluster object into HCPOpenShiftCluster object
-func (f *Frontend) ConvertCStoHCPOpenShiftCluster(cluster *cmv2alpha1.Cluster) (*api.HCPOpenShiftCluster, error) {
-	resourceGroupName := cluster.Azure().ResourceGroupName()
-	resourceName := cluster.Azure().ResourceName()
-	subID := cluster.Azure().SubscriptionID()
-	resourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/%s/%s", subID, resourceGroupName, api.ResourceType, resourceName)
-
+func ConvertCStoHCPOpenShiftCluster(resourceID *azcorearm.ResourceID, cluster *cmv2alpha1.Cluster) *api.HCPOpenShiftCluster {
 	hcpcluster := &api.HCPOpenShiftCluster{
 		TrackedResource: arm.TrackedResource{
 			Location: cluster.Region().ID(),
 			Resource: arm.Resource{
-				ID:   resourceID,
-				Name: resourceName,
-				Type: api.ResourceType,
+				ID:   resourceID.String(),
+				Name: resourceID.Name,
+				Type: resourceID.ResourceType.String(),
 			},
 		},
 		Properties: api.HCPOpenShiftClusterProperties{
@@ -107,7 +103,7 @@ func (f *Frontend) ConvertCStoHCPOpenShiftCluster(cluster *cmv2alpha1.Cluster) (
 		},
 	}
 
-	return hcpcluster, nil
+	return hcpcluster
 }
 
 // BuildCSCluster creates a CS Cluster object from an HCPOpenShiftCluster object

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -35,3 +35,31 @@ func StringPtrSliceToStringSlice(s []*string) []string {
 	}
 	return out
 }
+
+// StringMapToStringPtrMap converts a map of strings to a map of string pointers.
+func StringMapToStringPtrMap(m map[string]string) map[string]*string {
+	// Preserve nil in case it matters.
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]*string, len(m))
+	for key, val := range m {
+		out[key] = Ptr(val)
+	}
+	return out
+}
+
+// StringPtrMapToStringMap converts a map of string pointers to a map of strings.
+func StringPtrMapToStringMap(m map[string]*string) map[string]string {
+	// Preserve nil in case it matters.
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for key, val := range m {
+		if val != nil {
+			out[key] = *val
+		}
+	}
+	return out
+}

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -183,7 +183,7 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 			Name:     api.Ptr(from.Resource.Name),
 			Type:     api.Ptr(from.Resource.Type),
 			Location: api.Ptr(from.TrackedResource.Location),
-			Tags:     map[string]*string{},
+			Tags:     api.StringMapToStringPtrMap(from.TrackedResource.Tags),
 			// FIXME Skipping ManagedServiceIdentity
 			Properties: &generated.HcpOpenShiftClusterProperties{
 				ProvisioningState: api.Ptr(generated.ProvisioningState(from.Properties.ProvisioningState)),
@@ -217,10 +217,6 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 			LastModifiedByType: api.Ptr(generated.CreatedByType(from.Resource.SystemData.LastModifiedByType)),
 			LastModifiedAt:     from.Resource.SystemData.LastModifiedAt,
 		}
-	}
-
-	for key, val := range from.TrackedResource.Tags {
-		out.Tags[key] = api.Ptr(val)
 	}
 
 	for index, item := range from.Properties.Spec.ExternalAuth.ExternalAuths {
@@ -262,12 +258,7 @@ func (c *HcpOpenShiftClusterResource) Normalize(out *api.HCPOpenShiftCluster) {
 	if c.Location != nil {
 		out.TrackedResource.Location = *c.Location
 	}
-	out.Tags = make(map[string]string)
-	for k, v := range c.Tags {
-		if v != nil {
-			out.Tags[k] = *v
-		}
-	}
+	out.Tags = api.StringPtrMapToStringMap(c.Tags)
 	if c.Properties != nil {
 		if c.Properties.ProvisioningState != nil {
 			out.Properties.ProvisioningState = arm.ProvisioningState(*c.Properties.ProvisioningState)

--- a/internal/api/v20240610preview/nodepools_methods.go
+++ b/internal/api/v20240610preview/nodepools_methods.go
@@ -43,12 +43,7 @@ func (h *HcpOpenShiftClusterNodePoolResource) Normalize(out *api.HCPOpenShiftClu
 	if h.Location != nil {
 		out.TrackedResource.Location = *h.Location
 	}
-	out.Tags = make(map[string]string)
-	for k, v := range h.Tags {
-		if v != nil {
-			out.Tags[k] = *v
-		}
-	}
+	out.Tags = api.StringPtrMapToStringMap(h.Tags)
 	if h.Properties != nil {
 		if h.Properties.ProvisioningState != nil {
 			out.Properties.ProvisioningState = arm.ProvisioningState(*h.Properties.ProvisioningState)
@@ -214,8 +209,8 @@ func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNod
 			ID:       api.Ptr(from.Resource.ID),
 			Name:     api.Ptr(from.Resource.Name),
 			Type:     api.Ptr(from.Resource.Type),
-			Location: api.Ptr(from.Location),
-			Tags:     map[string]*string{},
+			Location: api.Ptr(from.TrackedResource.Location),
+			Tags:     api.StringMapToStringPtrMap(from.TrackedResource.Tags),
 			Properties: &generated.NodePoolProperties{
 				ProvisioningState: api.Ptr(generated.ProvisioningState(from.Properties.ProvisioningState)),
 				Spec: &generated.NodePoolSpec{
@@ -241,10 +236,6 @@ func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNod
 			LastModifiedByType: api.Ptr(generated.CreatedByType(from.Resource.SystemData.LastModifiedByType)),
 			LastModifiedAt:     from.Resource.SystemData.LastModifiedAt,
 		}
-	}
-
-	for k, v := range from.TrackedResource.Tags {
-		out.Tags[k] = api.Ptr(v)
 	}
 
 	for k, v := range from.Properties.Spec.Labels {

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -9,11 +9,12 @@ import (
 // to an internal resource ID (the OCM API path), as well as any
 // ARM-specific metadata for the resource.
 type ResourceDocument struct {
-	ID           string          `json:"id,omitempty"`
-	Key          string          `json:"key,omitempty"`
-	PartitionKey string          `json:"partitionKey,omitempty"`
-	InternalID   ocm.InternalID  `json:"internalId,omitempty"`
-	SystemData   *arm.SystemData `json:"systemData,omitempty"`
+	ID           string            `json:"id,omitempty"`
+	Key          string            `json:"key,omitempty"`
+	PartitionKey string            `json:"partitionKey,omitempty"`
+	InternalID   ocm.InternalID    `json:"internalId,omitempty"`
+	SystemData   *arm.SystemData   `json:"systemData,omitempty"`
+	Tags         map[string]string `json:"tags,omitempty"`
 
 	// Values provided by Cosmos after doc creation
 	ResourceID  string `json:"_rid,omitempty"`


### PR DESCRIPTION
### What this PR does

Devoted some brain cells to tracked resource tags, now that the [Cosmos cluster and node pool containers are merged](https://github.com/Azure/ARO-HCP/pull/537).  It was decided at the June face-to-face that the RP will store resource tags.  Both tags and system data need to be amended to response bodies.

Jira: Partially addresses [ARO-9523 - Persist and Return System Metadata and Tags from RP](https://issues.redhat.com/browse/ARO-9523)
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

I'm punting for now on adding tags and system data to list endpoint results, like "list clusters by subscription".  Need to work out how to do this efficiently: one Cluster Service query, one Cosmos query, and "join" the results.  That's a pull request for another day.
