### PR TITLE
database: Preserve resource ID casing in GetResourceDoc

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -142,6 +142,21 @@ func (d *CosmosDBClient) GetResourceDoc(ctx context.Context, resourceID *azcorea
 		}
 	}
 	if doc != nil {
+		// Replace the lowercased key field from Cosmos with the given
+		// resource ID, which typically comes from the URL. This helps
+		// preserve the casing of the resource group and resource name
+		// from the URL to meet RPC requirements:
+		//
+		// Put Resource | Arguments
+		//
+		// The resource group names and resource names should be matched
+		// case insensitively. ... Additionally, the Resource Provier must
+		// preserve the casing provided by the user. The service must return
+		// the most recently specified casing to the client and must not
+		// normalize or return a toupper or tolower form of the resource
+		// group or resource name. The resource group name and resource
+		// name must come from the URL and not the request body.
+		doc.Key = resourceID.String()
 		return doc, nil
 	}
 	return nil, ErrNotFound


### PR DESCRIPTION
### What this PR does

This small tweak should help us meet the [RPC requirement to preserve the most recent resource group name and resource name casing from the URL](https://github.com/cloud-and-ai-microsoft/resource-provider-contract/blob/master/v1.0/put-resource.md#put-resource).

In all current use cases of GetResourceDoc, the resource ID comes from MiddlewareResourceID, which preserves the casing from the URL.

The returned ResourceDocument is then passed to marshalCSCluster or marshalCSNodePool, which uses the ResourceDocument's resource ID to populate the top-level resource fields in the JSON output.


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
