### PR TITLE
Minor database API refactoring

### DIFF
--- a/frontend/pkg/frontend/context.go
+++ b/frontend/pkg/frontend/context.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
@@ -96,12 +94,12 @@ func VersionFromContext(ctx context.Context) (api.Version, error) {
 	return version, nil
 }
 
-func ContextWithResourceID(ctx context.Context, resourceID *azcorearm.ResourceID) context.Context {
+func ContextWithResourceID(ctx context.Context, resourceID *arm.ResourceID) context.Context {
 	return context.WithValue(ctx, contextKeyResourceID, resourceID)
 }
 
-func ResourceIDFromContext(ctx context.Context) (*azcorearm.ResourceID, error) {
-	resourceID, ok := ctx.Value(contextKeyResourceID).(*azcorearm.ResourceID)
+func ResourceIDFromContext(ctx context.Context) (*arm.ResourceID, error) {
+	resourceID, ok := ctx.Value(contextKeyResourceID).(*arm.ResourceID)
 	if !ok {
 		err := &ContextError{
 			got: resourceID,

--- a/frontend/pkg/frontend/middleware_resourceid.go
+++ b/frontend/pkg/frontend/middleware_resourceid.go
@@ -33,7 +33,7 @@ func MiddlewareResourceID(w http.ResponseWriter, r *http.Request, next http.Hand
 
 	resourceID, err := azcorearm.ParseResourceID(originalPath)
 	if err == nil {
-		ctx := ContextWithResourceID(r.Context(), resourceID)
+		ctx := ContextWithResourceID(r.Context(), &arm.ResourceID{ResourceID: *resourceID})
 		r = r.WithContext(ctx)
 	} else {
 		logger.Warn(fmt.Sprintf("Failed to parse '%s' as resource ID: %v", originalPath, err))

--- a/frontend/pkg/frontend/middleware_resourceid_test.go
+++ b/frontend/pkg/frontend/middleware_resourceid_test.go
@@ -99,7 +99,7 @@ func TestMiddlewareResourceID(t *testing.T) {
 			resourceTypes := []string{}
 			for resourceID != nil {
 				resourceTypes = append(resourceTypes, resourceID.ResourceType.String())
-				resourceID = resourceID.Parent
+				resourceID = resourceID.GetParent()
 			}
 
 			if !reflect.DeepEqual(resourceTypes, tt.resourceTypes) {

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	cmv2alpha1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v2alpha1"
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -42,7 +41,7 @@ func convertVisibilityToListening(visibility api.Visibility) (listening cmv2alph
 }
 
 // ConvertCStoHCPOpenShiftCluster converts a CS Cluster object into HCPOpenShiftCluster object
-func ConvertCStoHCPOpenShiftCluster(resourceID *azcorearm.ResourceID, cluster *cmv2alpha1.Cluster) *api.HCPOpenShiftCluster {
+func ConvertCStoHCPOpenShiftCluster(resourceID *arm.ResourceID, cluster *cmv2alpha1.Cluster) *api.HCPOpenShiftCluster {
 	hcpcluster := &api.HCPOpenShiftCluster{
 		TrackedResource: arm.TrackedResource{
 			Location: cluster.Region().ID(),
@@ -226,7 +225,7 @@ func (f *Frontend) BuildCSCluster(ctx context.Context, hcpCluster *api.HCPOpenSh
 }
 
 // ConvertCStoNodePool converts a CS Node Pool object into HCPOpenShiftClusterNodePool object
-func ConvertCStoNodePool(resourceID *azcorearm.ResourceID, np *cmv2alpha1.NodePool) *api.HCPOpenShiftClusterNodePool {
+func ConvertCStoNodePool(resourceID *arm.ResourceID, np *cmv2alpha1.NodePool) *api.HCPOpenShiftClusterNodePool {
 	nodePool := &api.HCPOpenShiftClusterNodePool{
 		TrackedResource: arm.TrackedResource{
 			Resource: arm.Resource{

--- a/internal/api/arm/error.go
+++ b/internal/api/arm/error.go
@@ -112,7 +112,7 @@ func WriteCloudError(w http.ResponseWriter, err *CloudError) {
 	_ = encoder.Encode(err)
 }
 
-func WriteResourceNotFoundError(w http.ResponseWriter, resourceID *azcorearm.ResourceID) {
+func WriteResourceNotFoundError(w http.ResponseWriter, resourceID *ResourceID) {
 	var code string
 	var message string
 

--- a/internal/api/arm/resource.go
+++ b/internal/api/arm/resource.go
@@ -6,7 +6,39 @@ package arm
 import (
 	"maps"
 	"time"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 )
+
+// ResourceID is a wrappered ResourceID from azcore with text marshaling and unmarshaling methods.
+type ResourceID struct {
+	azcorearm.ResourceID
+}
+
+// GetParent returns the parent resource ID, if any. Handles the
+// type-casting necessary to access the parent as a wrapper type.
+func (id *ResourceID) GetParent() *ResourceID {
+	var parent *ResourceID
+	if id.Parent != nil {
+		parent = &ResourceID{ResourceID: *id.Parent}
+	}
+	return parent
+}
+
+// MarshalText returns a textual representation of the ResourceID.
+func (id *ResourceID) MarshalText() ([]byte, error) {
+	return []byte(id.String()), nil
+}
+
+// UnmarshalText decodes the textual representation of a ResourceID.
+func (id *ResourceID) UnmarshalText(text []byte) error {
+	newId, err := azcorearm.ParseResourceID(string(text))
+	if err != nil {
+		return err
+	}
+	id.ResourceID = *newId
+	return nil
+}
 
 // Resource represents a basic ARM resource
 type Resource struct {

--- a/internal/database/cache.go
+++ b/internal/database/cache.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
 
 var _ DBClient = &Cache{}
@@ -30,7 +30,7 @@ func (c *Cache) DBConnectionTest(ctx context.Context) error {
 	return nil
 }
 
-func (c *Cache) GetResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) (*ResourceDocument, error) {
+func (c *Cache) GetResourceDoc(ctx context.Context, resourceID *arm.ResourceID) (*ResourceDocument, error) {
 	// Make sure lookup keys are lowercase.
 	key := strings.ToLower(resourceID.String())
 
@@ -43,13 +43,13 @@ func (c *Cache) GetResourceDoc(ctx context.Context, resourceID *azcorearm.Resour
 
 func (c *Cache) SetResourceDoc(ctx context.Context, doc *ResourceDocument) error {
 	// Make sure lookup keys are lowercase.
-	key := strings.ToLower(doc.Key)
+	key := strings.ToLower(doc.Key.String())
 
 	c.resource[key] = doc
 	return nil
 }
 
-func (c *Cache) DeleteResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) error {
+func (c *Cache) DeleteResourceDoc(ctx context.Context, resourceID *arm.ResourceID) error {
 	// Make sure lookup keys are lowercase.
 	key := strings.ToLower(resourceID.String())
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -8,11 +8,11 @@ import (
 	"net/http"
 	"strings"
 
-	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
 
 const (
@@ -32,11 +32,11 @@ type DBClient interface {
 
 	// GetResourceDoc retrieves a ResourceDocument from the database given its resourceID.
 	// ErrNotFound is returned if an associated ResourceDocument cannot be found.
-	GetResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) (*ResourceDocument, error)
+	GetResourceDoc(ctx context.Context, resourceID *arm.ResourceID) (*ResourceDocument, error)
 	SetResourceDoc(ctx context.Context, doc *ResourceDocument) error
 	// DeleteResourceDoc deletes a ResourceDocument from the database given the resourceID
 	// of a Microsoft.RedHatOpenShift/HcpOpenShiftClusters resource or NodePools child resource.
-	DeleteResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) error
+	DeleteResourceDoc(ctx context.Context, resourceID *arm.ResourceID) error
 
 	GetOperationDoc(ctx context.Context, operationID string) (*OperationDocument, error)
 	SetOperationDoc(ctx context.Context, doc *OperationDocument) error
@@ -109,7 +109,7 @@ func (d *CosmosDBClient) DBConnectionTest(ctx context.Context) error {
 }
 
 // GetResourceDoc retrieves a resource document from the "resources" DB using resource ID
-func (d *CosmosDBClient) GetResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) (*ResourceDocument, error) {
+func (d *CosmosDBClient) GetResourceDoc(ctx context.Context, resourceID *arm.ResourceID) (*ResourceDocument, error) {
 	// Make sure partition key is lowercase.
 	pk := azcosmos.NewPartitionKeyString(strings.ToLower(resourceID.SubscriptionID))
 
@@ -155,7 +155,7 @@ func (d *CosmosDBClient) GetResourceDoc(ctx context.Context, resourceID *azcorea
 		// normalize or return a toupper or tolower form of the resource
 		// group or resource name. The resource group name and resource
 		// name must come from the URL and not the request body.
-		doc.Key = resourceID.String()
+		doc.Key = resourceID
 		return doc, nil
 	}
 	return nil, ErrNotFound
@@ -185,7 +185,7 @@ func (d *CosmosDBClient) SetResourceDoc(ctx context.Context, doc *ResourceDocume
 }
 
 // DeleteResourceDoc removes a resource document from the "resources" DB using resource ID
-func (d *CosmosDBClient) DeleteResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) error {
+func (d *CosmosDBClient) DeleteResourceDoc(ctx context.Context, resourceID *arm.ResourceID) error {
 	// Make sure partition key is lowercase.
 	pk := azcosmos.NewPartitionKeyString(strings.ToLower(resourceID.SubscriptionID))
 

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -10,7 +10,7 @@ import (
 // ARM-specific metadata for the resource.
 type ResourceDocument struct {
 	ID           string            `json:"id,omitempty"`
-	Key          string            `json:"key,omitempty"`
+	Key          *arm.ResourceID   `json:"key,omitempty"`
 	PartitionKey string            `json:"partitionKey,omitempty"`
 	InternalID   ocm.InternalID    `json:"internalId,omitempty"`
 	SystemData   *arm.SystemData   `json:"systemData,omitempty"`
@@ -31,7 +31,7 @@ type OperationDocument struct {
 	// Request is the type of operation requested; one of Create, Update or Delete
 	Request string `json:"request,omitempty"`
 	// ExternalID is the Azure resource ID of the cluster or node pool
-	ExternalID string `json:"externalId,omitempty"`
+	ExternalID *arm.ResourceID `json:"externalId,omitempty"`
 	// InternalID is the Cluster Service resource identifier in the form of a URL path
 	// "/cluster/{cluster_id}" or "/cluster/{cluster_id}/node_pools/{node_pool_id}"
 	InternalID string `json:"internalId,omitempty"`


### PR DESCRIPTION
### What this PR does

1. Use case-insensitive search for `ResourceDocument`
 \
 The [StringEquals function](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/stringequals) can do case-insensitive comparisons. This means resource IDs no longer have to be lowercased prior to reading from or writing to the Resources container.

2. Add `ResourceID` wrapper type
 \
 This is a thinly wrappered [azcorearm.ResourceID](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore@v1.14.0/arm/internal/resource#ResourceID) that implements the [encoding.TextMarshaler](https://pkg.go.dev/encoding#TextMarshaler) and [encoding.TextUnmarshaler](https://pkg.go.dev/encoding#TextUnmarshaler) interfaces, so that `ResourceID` can be used directly in structs that get built from JSON data.
 \
 I proposed this for [azcorearm.ResourceID](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore@v1.14.0/arm/internal/resource#ResourceID) in [Azure/azure-sdk-for-go#23381](https://github.com/Azure/azure-sdk-for-go/pull/23381).  If accepted, we can eventually remove this wrapper type.

<!-- optional -->
