### PR TITLE
initial addition of svc-cluster Prometheus scrape config 

### DIFF
--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -425,6 +425,10 @@
           run: |
             cd image-sync/deployment
             make deploy
+        - name: 'Deploy Prometheus Config'
+          run: |
+            cd metrics/
+            make deploy-config
 
     deploy_to_management_cluster:
       if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'

--- a/cluster-service/deploy/istio.yml
+++ b/cluster-service/deploy/istio.yml
@@ -1,3 +1,32 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: cluster-service
+spec:
+  selector:
+    matchLabels:
+      app: clusters-service
+  portLevelMtls:
+    8080:
+      mode: PERMISSIVE
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-metrics
+  namespace: cluster-service
+spec:
+  action: "ALLOW"
+  rules:
+    - to:
+      - operation:
+          paths: ["/metrics"]
+          methods: ["GET"]
+          ports: ["8080"]
+  selector:
+    matchLabels:
+      app: "clusters-service"
 ---
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy

--- a/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
+++ b/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
@@ -592,3 +592,22 @@ objects:
       targetPort: 8083
       name: healthcheck
       protocol: TCP
+
+- apiVersion: azmonitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    name: clusters-service-service-monitor
+    namespace: ${NAMESPACE}
+  spec:
+    endpoints:
+    - interval: 30s
+      path: /metrics
+      port: metrics
+      scheme: http
+    namespaceSelector:
+      matchNames:
+      - cluster-service
+    selector:
+      matchLabels:
+        app: clusters-service
+        port: metrics

--- a/frontend/deploy/base/allow-metrics.authorizationpolicy.yml
+++ b/frontend/deploy/base/allow-metrics.authorizationpolicy.yml
@@ -1,0 +1,16 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-metrics
+  namespace: aro-hcp
+spec:
+  action: "ALLOW"
+  rules:
+    - to:
+      - operation:
+          paths: ["/metrics"]
+          methods: ["GET"]
+          ports: ["8081"]
+  selector:
+    matchLabels:
+      app: "aro-hcp-frontend"

--- a/frontend/deploy/base/kustomization.yml
+++ b/frontend/deploy/base/kustomization.yml
@@ -4,3 +4,7 @@ resources:
 - serviceaccount.yml
 - deployment.yml
 - service.yml
+- metrics.service.yml
+- allow-metrics.authorizationpolicy.yml
+- peerauthentication.yml
+- servicemonitor.yml

--- a/frontend/deploy/base/metrics.service.yml
+++ b/frontend/deploy/base/metrics.service.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: aro-hcp-frontend
+    port: metrics
+  name: aro-hcp-frontend-metrics
+spec:
+  ports:
+  - port: 8081
+    protocol: TCP
+    targetPort: 8081
+    name: metrics
+  selector:
+    app: aro-hcp-frontend

--- a/frontend/deploy/base/peerauthentication.yml
+++ b/frontend/deploy/base/peerauthentication.yml
@@ -1,0 +1,12 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: aro-hcp
+spec:
+  selector:
+    matchLabels:
+      app: aro-hcp-frontend
+  portLevelMtls:
+    "8081":
+      mode: PERMISSIVE

--- a/frontend/deploy/base/servicemonitor.yml
+++ b/frontend/deploy/base/servicemonitor.yml
@@ -1,0 +1,18 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-frontend-service-monitor
+  namespace: aro-hcp
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - aro-hcp
+  selector:
+    matchLabels:
+      app: aro-hcp-frontend
+      port: metrics

--- a/maestro/deploy/helm/server/templates/allow-metrics.authorizationpolicy.yaml
+++ b/maestro/deploy/helm/server/templates/allow-metrics.authorizationpolicy.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-metrics
+  namespace: {{ .Release.Namespace }}
+spec:
+  action: "ALLOW"
+  rules:
+    - to:
+      - operation:
+          paths: ["/metrics"]
+          methods: ["GET"]
+          ports: ["8080"]
+  selector:
+    matchLabels:
+      app: "maestro"

--- a/maestro/deploy/helm/server/templates/maestro.peerauthentication.yaml
+++ b/maestro/deploy/helm/server/templates/maestro.peerauthentication.yaml
@@ -1,0 +1,12 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: maestro
+  portLevelMtls:
+    8080:
+      mode: PERMISSIVE

--- a/maestro/deploy/helm/server/templates/maestro.servicemonitor.yaml
+++ b/maestro/deploy/helm/server/templates/maestro.servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: maestro-service-monitor
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: maestro
+      port: metrics

--- a/metrics/Makefile
+++ b/metrics/Makefile
@@ -1,0 +1,7 @@
+deploy-config:
+	kubectl apply -k overlays/svc-cluster
+
+undeploy-config:
+	kubectl delete -k overlays/svc-cluster
+
+.PHONY: deploy-config undeploy-config

--- a/metrics/overlays/svc-cluster/kustomization.yml
+++ b/metrics/overlays/svc-cluster/kustomization.yml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - prometheus-config.yml
+namespace: kube-system

--- a/metrics/overlays/svc-cluster/prometheus-config.yml
+++ b/metrics/overlays/svc-cluster/prometheus-config.yml
@@ -1,0 +1,30 @@
+kind: ConfigMap
+apiVersion: v1
+data:
+  prometheus-config: |-
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+    # scrape sidecar proxies and gateway proxies
+    - job_name: 'envoy-stats'
+      metrics_path: /stats/prometheus
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_container_port_name]
+        action: keep
+        regex: '.*-envoy-prom'
+
+    - job_name: 'istiod'
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - aks-istio-system
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_endpoints_label_app, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istiod;http-monitoring
+metadata:
+  name: ama-metrics-prometheus-config
+  namespace: kube-system


### PR DESCRIPTION
### What this PR does
Adds Prometheus configuration for scraping istiod and envoy proxies.  
Adds a ServiceMonitor for scraping clusters-service pods.  
Adds a ServiceMonitor for scraping maestro-server pods.  
Adds a ServiceMonitor for scraping aro-hcp-frontend pods.

In order to scrape pod metrics Istio mTLS is set to PERMISSIVE mode for port `8080` and an authorization policy is added to allow http on port `8080/metrics`.

Jira: 
- https://issues.redhat.com/browse/ARO-9336 
- https://issues.redhat.com/browse/ARO-9701
- https://issues.redhat.com/browse/ARO-9702
- https://issues.redhat.com/browse/ARO-9700

Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
