### PR TITLE
Revert "build(deps): bump azure/cli from 2.0.0 to 2.1.0"

### DIFF
--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -61,7 +61,7 @@
               subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
         - name: 'Deploy'
-          uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+          uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
           with:
             azcliversion: latest
             inlineScript: |
@@ -93,7 +93,7 @@
               subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
         - name: 'Deploy'
-          uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+          uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
           with:
             azcliversion: latest
             inlineScript: |
@@ -139,7 +139,7 @@
               subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
         - name: 'Deploy'
-          uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+          uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
           with:
             azcliversion: latest
             inlineScript: |
@@ -200,7 +200,7 @@
               subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
         - name: 'Deploy or Update'
-          uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+          uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
           with:
             azcliversion: latest
             inlineScript: |
@@ -361,7 +361,7 @@
 
         - name: 'Find service cluster'
           id: find_service_cluster
-          uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+          uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
           with:
             azcliversion: latest
             inlineScript: |
@@ -448,7 +448,7 @@
 
       - name: 'Find management cluster'
         id: find_management_cluster
-        uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+        uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
         with:
           azcliversion: latest
           inlineScript: |

--- a/.github/workflows/bicep-what-if.yml
+++ b/.github/workflows/bicep-what-if.yml
@@ -38,7 +38,7 @@ jobs:
       # TODO: We don't have `make` in the azure/cli task so a lot of this is duplicated in dev-infrastructure/Makefile
       # we should run our own container or find a solution to bring them closer
       - name: 'Deployment What If'
-        uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+        uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
         with:
           azcliversion: latest
           inlineScript: |

--- a/.github/workflows/cs-integ-bicep-what-if.yml
+++ b/.github/workflows/cs-integ-bicep-what-if.yml
@@ -37,7 +37,7 @@ jobs:
       # TODO: We don't have `make` in the azure/cli task so a lot of this is duplicated in dev-infrastructure/Makefile
       # we should run our own container or find a solution to bring them closer
       - name: 'Deployment What If'
-        uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+        uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
         with:
           azcliversion: latest
           inlineScript: |

--- a/.github/workflows/cs-integration-env-cd.yml
+++ b/.github/workflows/cs-integration-env-cd.yml
@@ -60,7 +60,7 @@
               subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
         - name: 'Deploy'
-          uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+          uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
           with:
             azcliversion: latest
             inlineScript: |
@@ -106,7 +106,7 @@
               subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
         - name: 'Deploy'
-          uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+          uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
           with:
             azcliversion: latest
             inlineScript: |
@@ -167,7 +167,7 @@
               subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
         - name: 'Deploy or Update'
-          uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+          uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
           with:
             azcliversion: latest
             inlineScript: |
@@ -229,7 +229,7 @@
 
         - name: 'Find service cluster'
           id: find_service_cluster
-          uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+          uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
           with:
             azcliversion: latest
             inlineScript: |
@@ -306,7 +306,7 @@
 
       - name: 'Find management cluster'
         id: find_management_cluster
-        uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+        uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
         with:
           azcliversion: latest
           inlineScript: |


### PR DESCRIPTION
Reverts Azure/ARO-HCP#552 due to https://github.com/Azure/azure-cli/issues/29828