### PR TITLE
Update frontend to Go 1.23

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -21,7 +21,7 @@ npm install -g oav@3.3.4
 
 # Install the golang-lint
 # binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.60.3
 
 golangci-lint --version
 

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -45,5 +45,5 @@ jobs:
       - name: 'Lint'
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
-          version: 'v1.59.1'
+          version: 'v1.60.3'
           args: '-v --build-tags=containers_image_openpgp $(go list -f ''{{.Dir}}/...'' -m | xargs)'

--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -1,8 +1,8 @@
 module github.com/Azure/ARO-HCP/frontend
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.2
+toolchain go1.23.0
 
 require (
 	github.com/Azure/ARO-HCP/internal v0.0.0-00010101000000-000000000000
@@ -15,8 +15,6 @@ require (
 	golang.org/x/exp v0.0.0-20240707233637-46b078467d37
 	golang.org/x/sync v0.8.0
 )
-
-require github.com/klauspost/compress v1.17.9 // indirect
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
@@ -41,6 +39,7 @@ require (
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.2
+toolchain go1.23.0
 
 use (
 	./frontend

--- a/internal/api/arm/error.go
+++ b/internal/api/arm/error.go
@@ -148,7 +148,7 @@ func NewResourceNotFoundError(resourceID *ResourceID) *CloudError {
 			resourceID.ResourceType.Type, resourceID.Name, resourceID.ResourceGroupName)
 	}
 
-	return NewCloudError(http.StatusNotFound, code, resourceID.String(), message)
+	return NewCloudError(http.StatusNotFound, code, resourceID.String(), "%s", message)
 }
 
 // WriteResourceNotFoundError writes a nonexistent resource error to the given ResponseWriter


### PR DESCRIPTION
### What this PR does
* We're not using any Go 1.23 features yet, but why not I guess?
* Also update golangci-lint to v1.60.3 and fix new linter findings

### Special notes for your reviewer

To double-check I'm not making up a SHA :D
```bash
❯ skopeo inspect --format "{{ .Digest }}" "docker://mcr.microsoft.com/oss/go/microsoft/golang:1.23.0-fips-cbl-mariner2.0" --override-arch amd64 --override-os linux
sha256:f182cc18fc741e51cb131d21a7f023a374c120e0ff49627238cefb719acc813d
```
