### PR TITLE
make multiple agentpool for usergroup

### DIFF
--- a/dev-infrastructure/configurations/cs-integ-mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/cs-integ-mgmt-cluster.bicepparam
@@ -9,9 +9,10 @@ param aksKeyVaultName = 'aks-kv-cs-integ-mc-1'
 param systemAgentMinCount = 2
 param systemAgentMaxCount = 3
 param systemAgentVMSize = 'Standard_D2s_v3'
-param userAgentMinCount = 3
-param userAgentMaxCount = 9
+param userAgentMinCount = 1
+param userAgentMaxCount = 3
 param userAgentVMSize = 'Standard_D2s_v3'
+param userAgentPoolAZCount = 3
 param persist = true
 
 param deployMaestroConsumer = true

--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -10,9 +10,10 @@ param aksEtcdKVEnableSoftDelete = false
 param systemAgentMinCount = 2
 param systemAgentMaxCount = 3
 param systemAgentVMSize = 'Standard_D2s_v3'
-param userAgentMinCount = 2
-param userAgentMaxCount = 5
+param userAgentMinCount = 1
+param userAgentMaxCount = 3
 param userAgentVMSize = 'Standard_D2s_v3'
+param userAgentPoolAZCount = 3
 param persist = false
 
 param deployMaestroConsumer = true

--- a/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
@@ -9,9 +9,10 @@ param aksKeyVaultName = 'aks-kv-aro-hcp-dev-mc-1'
 param systemAgentMinCount = 2
 param systemAgentMaxCount = 3
 param systemAgentVMSize = 'Standard_D2s_v3'
-param userAgentMinCount = 3
-param userAgentMaxCount = 9
+param userAgentMinCount = 1
+param userAgentMaxCount = 3
 param userAgentVMSize = 'Standard_D2s_v3'
+param userAgentPoolAZCount = 3
 param persist = true
 
 param deployMaestroConsumer = true

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -10,9 +10,10 @@ param systemAgentVMSize string = 'Standard_D2s_v3'
 
 // User agentpool spec (Worker)
 param deployUserAgentPool bool = false
-param userAgentMinCount int = 2
+param userAgentMinCount int = 1
 param userAgentMaxCount int = 3
 param userAgentVMSize string = 'Standard_D2s_v3'
+param userAgentPoolAZCount int = 3
 
 param serviceCidr string = '10.130.0.0/16'
 param dnsServiceIP string = '10.130.0.10'
@@ -103,9 +104,8 @@ var systemAgentPool = [
   }
 ]
 
-var userAgentPool = [
-  {
-    name: 'user'
+var userAgentPool = [for i in range(0, userAgentPoolAZCount): {
+    name: 'user-${(i + 1)}'
     osType: 'Linux'
     osSKU: 'AzureLinux'
     mode: 'User'
@@ -129,9 +129,7 @@ var userAgentPool = [
     podSubnetID: aksPodSubnet.id
     maxPods: 250
     availabilityZones: [
-      '1'
-      '2'
-      '3'
+      '${(i + 1)}'
     ]
     securityProfile: {
       enableSecureBoot: false
@@ -315,7 +313,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-04-02-previ
     }
     agentPoolProfiles: agentProfile
     autoScalerProfile: {
-      'balance-similar-node-groups': 'false'
+      'balance-similar-node-groups': 'true'
       'daemonset-eviction-for-occupied-nodes': true
       'scan-interval': '10s'
       'scale-down-delay-after-add': '10m'

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -20,13 +20,16 @@ param aksNodeResourceGroupName string = '${resourceGroup().name}-aks1'
 param vnetAddressPrefix string
 
 @description('Min replicas for the worker nodes')
-param userAgentMinCount int = 2
+param userAgentMinCount int = 1
 
 @description('Max replicas for the worker nodes')
 param userAgentMaxCount int = 3
 
 @description('VM instance type for the worker nodes')
 param userAgentVMSize string = 'Standard_D2s_v3'
+
+@description('Availability Zone count for worker nodes')
+param userAgentPoolAZCount int = 3
 
 @description('Min replicas for the system nodes')
 param systemAgentMinCount int = 2
@@ -127,6 +130,7 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     userAgentMinCount: userAgentMinCount
     userAgentMaxCount: userAgentMaxCount
     userAgentVMSize: userAgentVMSize
+    userAgentPoolAZCount: userAgentPoolAZCount
     systemAgentMinCount: systemAgentMinCount
     systemAgentMaxCount: systemAgentMaxCount
     systemAgentVMSize: systemAgentVMSize


### PR DESCRIPTION
Autoscaler may not scale up evenly across multiple AZ that affects the node distribution, so pods with zone anti-affinity(like etcd) stuck at pending until it finds a node on the right zone. 
AKS autoscaler profile does not enable this by default, it can be enabled by  `--balance-similar-node-group`  to maintain the node distribution.

This PR make this AKS autoscaler profile change as well as create multiple user agent pool - 1 per AZ.

