### PR TITLE
multiple agentpool for usergroup

### DIFF
--- a/dev-infrastructure/configurations/cs-integ-mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/cs-integ-mgmt-cluster.bicepparam
@@ -9,9 +9,10 @@ param aksKeyVaultName = 'aks-kv-cs-integ-mc-1'
 param systemAgentMinCount = 2
 param systemAgentMaxCount = 3
 param systemAgentVMSize = 'Standard_D2s_v3'
-param userAgentMinCount = 3
-param userAgentMaxCount = 9
+param userAgentMinCount = 1
+param userAgentMaxCount = 3
 param userAgentVMSize = 'Standard_D2s_v3'
+param userAgentPoolAZCount = 3
 param persist = true
 
 param deployMaestroConsumer = true

--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -10,9 +10,10 @@ param aksEtcdKVEnableSoftDelete = false
 param systemAgentMinCount = 2
 param systemAgentMaxCount = 3
 param systemAgentVMSize = 'Standard_D2s_v3'
-param userAgentMinCount = 2
-param userAgentMaxCount = 5
+param userAgentMinCount = 1
+param userAgentMaxCount = 3
 param userAgentVMSize = 'Standard_D2s_v3'
+param userAgentPoolAZCount = 3
 param persist = false
 
 param deployMaestroConsumer = true

--- a/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
@@ -9,9 +9,10 @@ param aksKeyVaultName = 'aks-kv-aro-hcp-dev-mc-1'
 param systemAgentMinCount = 2
 param systemAgentMaxCount = 3
 param systemAgentVMSize = 'Standard_D2s_v3'
-param userAgentMinCount = 3
-param userAgentMaxCount = 9
+param userAgentMinCount = 1
+param userAgentMaxCount = 3
 param userAgentVMSize = 'Standard_D2s_v3'
+param userAgentPoolAZCount = 3
 param persist = true
 
 param deployMaestroConsumer = true

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -20,13 +20,16 @@ param aksNodeResourceGroupName string = '${resourceGroup().name}-aks1'
 param vnetAddressPrefix string
 
 @description('Min replicas for the worker nodes')
-param userAgentMinCount int = 2
+param userAgentMinCount int = 1
 
 @description('Max replicas for the worker nodes')
 param userAgentMaxCount int = 3
 
 @description('VM instance type for the worker nodes')
 param userAgentVMSize string = 'Standard_D2s_v3'
+
+@description('Availability Zone count for worker nodes')
+param userAgentPoolAZCount int = 3
 
 @description('Min replicas for the system nodes')
 param systemAgentMinCount int = 2
@@ -122,9 +125,9 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
       }
     })
     aksKeyVaultName: aksKeyVaultName
-    deployUserAgentPool: true
     acrPullResourceGroups: acrPullResourceGroups
     userAgentMinCount: userAgentMinCount
+    userAgentPoolAZCount: userAgentPoolAZCount
     userAgentMaxCount: userAgentMaxCount
     userAgentVMSize: userAgentVMSize
     systemAgentMinCount: systemAgentMinCount

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -153,7 +153,6 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
       }
     })
     aksKeyVaultName: aksKeyVaultName
-    deployUserAgentPool: true
     acrPullResourceGroups: acrPullResourceGroups
   }
 }


### PR DESCRIPTION
Autoscaler may not scale up evenly across multiple AZ that affects the node distribution, so pods with zone anti-affinity(like etcd) stuck at pending until it finds a node on the right zone.
AKS autoscaler profile does not enable this by default, it can be enabled by `--balance-similar-node-group` to maintain the node distribution.

This PR make this AKS autoscaler profile change as well as create multiple user agent pool - 1 per AZ.

PR: #590 
