### PR TITLE
add helm linter github action

### DIFF
--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -379,7 +379,7 @@
             chmod +x /usr/local/bin/oc
 
         # Used to deploy Maestro Server, Frontend
-        - uses: azure/setup-helm@v4.2.0
+        - uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
           with:
             version: 'v3.13.3'
 
@@ -473,7 +473,7 @@
           chmod +x /usr/local/bin/oc
 
       # Used to deploy Maestro Agent
-      - uses: azure/setup-helm@v4.2.0
+      - uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
           version: 'v3.13.3'
 

--- a/.github/workflows/cs-integration-env-cd.yml
+++ b/.github/workflows/cs-integration-env-cd.yml
@@ -254,7 +254,7 @@
             chmod +x /usr/local/bin/oc
 
         # Used to deploy Maestro Server
-        - uses: azure/setup-helm@v4.2.0
+        - uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
           with:
             version: 'v3.13.3'
 

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,55 @@
+---
+# Helm chart lint
+# More info at https://github.com/helm/chart-testing-action
+name: Lint Helm Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.13.3
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Collect chart directories
+        id: collect-chart-dirs
+        run: |
+          # Find all parent directories of directories containing 'Chart.yaml', output via csv without the leading './'
+          CHART_DIRS=$(find . -type f -name 'Chart.yaml' -printf '%h\n' |sed 's|^\./||' | xargs -I {} dirname {} | sort -u | tr '\n' ',' | sed 's/,$//' )
+          echo "found charts in the following directories ${CHART_DIRS}"
+          echo "CHART_DIRS=$CHART_DIRS" >> "$GITHUB_ENV"
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --chart-dirs=${CHART_DIRS} --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Run chart-testing (lint)
+        id: lint-helm
+        if: env.changed == 'true'
+        run: |
+          echo "Running helm linter on charts in the following directories: $CHART_DIRS"
+          ct lint \
+            --chart-dirs=$CHART_DIRS \
+            --all \
+            --validate-maintainers=false \
+            --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -15,17 +15,17 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
           version: v3.13.3
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: '3.x'
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
 
       - name: Collect chart directories
         id: collect-chart-dirs


### PR DESCRIPTION
### What this PR does

Adds a Helm chart linter to CI checks.  The step to run the lint is conditional, running only if there are changes to any of the detected charts.

This uses default installed lint / schema configuration, if/when Charts become more defined we can update.
Jira: https://issues.redhat.com/browse/ARO-10414

Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

Testing involved making a change to an existing chart and ensuring that the lint step actually ran and output was similar to what I experienced running ct locally.
<!-- optional -->
