### PR TITLE
Add unit tests for "validate" struct tags

### DIFF
--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -17,7 +17,7 @@ type HCPOpenShiftCluster struct {
 
 // HCPOpenShiftClusterProperties represents the property bag of a HCPOpenShiftCluster resource.
 type HCPOpenShiftClusterProperties struct {
-	ProvisioningState arm.ProvisioningState `json:"provisioningState,omitempty" visibility:"read"               validate:"omitempty,enum_provisioningstate"`
+	ProvisioningState arm.ProvisioningState `json:"provisioningState,omitempty" visibility:"read"`
 	Spec              ClusterSpec           `json:"spec,omitempty"              visibility:"read create update"`
 }
 
@@ -33,7 +33,7 @@ type ClusterSpec struct {
 	DisableUserWorkloadMonitoring bool                      `json:"disableUserWorkloadMonitoring,omitempty" visibility:"read create update"`
 	Proxy                         ProxyProfile              `json:"proxy,omitempty"                         visibility:"read create update"`
 	Platform                      PlatformProfile           `json:"platform,omitempty"                      visibility:"read create"`
-	IssuerURL                     string                    `json:"issuerUrl,omitempty"                     visibility:"read"               validate:"omitempty,url"`
+	IssuerURL                     string                    `json:"issuerUrl,omitempty"                     visibility:"read"`
 	ExternalAuth                  ExternalAuthConfigProfile `json:"externalAuth,omitempty"                  visibility:"read create"`
 }
 
@@ -63,12 +63,12 @@ type NetworkProfile struct {
 // ConsoleProfile represents a cluster web console configuration.
 // Visibility for the entire struct is "read".
 type ConsoleProfile struct {
-	URL string `json:"url,omitempty" validate:"omitempty,url"`
+	URL string `json:"url,omitempty"`
 }
 
 // APIProfile represents a cluster API server configuration.
 type APIProfile struct {
-	URL        string     `json:"url,omitempty"        visibility:"read"        validate:"omitempty,url"`
+	URL        string     `json:"url,omitempty"        visibility:"read"`
 	Visibility Visibility `json:"visibility,omitempty" visibility:"read create" validate:"required_for_put,enum_visibility"`
 }
 

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -18,21 +18,21 @@ type HCPOpenShiftCluster struct {
 // HCPOpenShiftClusterProperties represents the property bag of a HCPOpenShiftCluster resource.
 type HCPOpenShiftClusterProperties struct {
 	ProvisioningState arm.ProvisioningState `json:"provisioningState,omitempty" visibility:"read"               validate:"omitempty,enum_provisioningstate"`
-	Spec              ClusterSpec           `json:"spec,omitempty"              visibility:"read create update" validate:"required_for_put"`
+	Spec              ClusterSpec           `json:"spec,omitempty"              visibility:"read create update"`
 }
 
 // ClusterSpec represents a high level cluster configuration.
 type ClusterSpec struct {
-	Version                       VersionProfile            `json:"version,omitempty"                       visibility:"read create"        validate:"required_for_put"`
+	Version                       VersionProfile            `json:"version,omitempty"                       visibility:"read create"`
 	DNS                           DNSProfile                `json:"dns,omitempty"                           visibility:"read create update"`
 	Network                       NetworkProfile            `json:"network,omitempty"                       visibility:"read create"`
 	Console                       ConsoleProfile            `json:"console,omitempty"                       visibility:"read"`
-	API                           APIProfile                `json:"api,omitempty"                           visibility:"read create"        validate:"required_for_put"`
+	API                           APIProfile                `json:"api,omitempty"                           visibility:"read create"`
 	FIPS                          bool                      `json:"fips,omitempty"                          visibility:"read create"`
 	EtcdEncryption                bool                      `json:"etcdEncryption,omitempty"                visibility:"read create"`
 	DisableUserWorkloadMonitoring bool                      `json:"disableUserWorkloadMonitoring,omitempty" visibility:"read create update"`
 	Proxy                         ProxyProfile              `json:"proxy,omitempty"                         visibility:"read create update"`
-	Platform                      PlatformProfile           `json:"platform,omitempty"                      visibility:"read create"        validate:"required_for_put"`
+	Platform                      PlatformProfile           `json:"platform,omitempty"                      visibility:"read create"`
 	IssuerURL                     string                    `json:"issuerUrl,omitempty"                     visibility:"read"               validate:"omitempty,url"`
 	ExternalAuth                  ExternalAuthConfigProfile `json:"externalAuth,omitempty"                  visibility:"read create"`
 }

--- a/internal/api/hcpopenshiftcluster_test.go
+++ b/internal/api/hcpopenshiftcluster_test.go
@@ -1,0 +1,269 @@
+package api
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"net/http"
+	"testing"
+
+	"dario.cat/mergo"
+	validator "github.com/go-playground/validator/v10"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+func newTestValidator() *validator.Validate {
+	validate := NewValidator()
+
+	validate.RegisterAlias("enum_outboundtype", EnumValidateTag("loadBalancer"))
+	validate.RegisterAlias("enum_visibility", EnumValidateTag("private", "public"))
+
+	return validate
+}
+
+func compareErrors(x, y []arm.CloudErrorBody) string {
+	return cmp.Diff(x, y,
+		cmpopts.SortSlices(func(x, y arm.CloudErrorBody) bool { return x.Target < y.Target }),
+		cmpopts.IgnoreFields(arm.CloudErrorBody{}, "Code"))
+}
+
+func minimumValidCluster() *HCPOpenShiftCluster {
+	// Values are meaningless but need to pass validation.
+	return &HCPOpenShiftCluster{
+		Properties: HCPOpenShiftClusterProperties{
+			Spec: ClusterSpec{
+				Version: VersionProfile{
+					ID:           "openshift-v4.16.0",
+					ChannelGroup: "stable",
+				},
+				Network: NetworkProfile{
+					PodCIDR:     "10.128.0.0/14",
+					ServiceCIDR: "172.30.0.0/16",
+					MachineCIDR: "10.0.0.0/16",
+				},
+				API: APIProfile{
+					Visibility: "public",
+				},
+				Platform: PlatformProfile{
+					SubnetID:               "/something/something/virtualNetworks/subnets",
+					NetworkSecurityGroupID: "/something/something/networkSecurityGroups",
+				},
+			},
+		},
+	}
+}
+
+func TestClusterRequiredForPut(t *testing.T) {
+	tests := []struct {
+		name         string
+		resource     *HCPOpenShiftCluster
+		expectErrors []arm.CloudErrorBody
+	}{
+		{
+			name:     "Empty cluster",
+			resource: &HCPOpenShiftCluster{},
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Missing required field 'properties'",
+					Target:  "properties",
+				},
+			},
+		},
+		{
+			name:     "Default cluster",
+			resource: NewDefaultHCPOpenShiftCluster(),
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Missing required field 'id'",
+					Target:  "properties.spec.version.id",
+				},
+				{
+					Message: "Missing required field 'channelGroup'",
+					Target:  "properties.spec.version.channelGroup",
+				},
+				{
+					Message: "Missing required field 'podCidr'",
+					Target:  "properties.spec.network.podCidr",
+				},
+				{
+					Message: "Missing required field 'serviceCidr'",
+					Target:  "properties.spec.network.serviceCidr",
+				},
+				{
+					Message: "Missing required field 'machineCidr'",
+					Target:  "properties.spec.network.machineCidr",
+				},
+				{
+					Message: "Missing required field 'visibility'",
+					Target:  "properties.spec.api.visibility",
+				},
+				{
+					Message: "Missing required field 'subnetId'",
+					Target:  "properties.spec.platform.subnetId",
+				},
+				{
+					Message: "Missing required field 'networkSecurityGroupId'",
+					Target:  "properties.spec.platform.networkSecurityGroupId",
+				},
+			},
+		},
+		{
+			name:     "Minimum valid cluster",
+			resource: minimumValidCluster(),
+		},
+	}
+
+	validate := newTestValidator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualErrors := ValidateRequest(validate, http.MethodPut, tt.resource)
+
+			diff := compareErrors(tt.expectErrors, actualErrors)
+			if diff != "" {
+				t.Fatalf("Expected error mismatch:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestClusterValidateTags(t *testing.T) {
+	// Note "required_for_put" validation tests are above.
+	// This function tests all the other validators in use.
+	tests := []struct {
+		name         string
+		tweaks       *HCPOpenShiftCluster
+		expectErrors []arm.CloudErrorBody
+	}{
+		{
+			name: "Bad cidrv4",
+			tweaks: &HCPOpenShiftCluster{
+				Properties: HCPOpenShiftClusterProperties{
+					Spec: ClusterSpec{
+						Network: NetworkProfile{
+							PodCIDR: "Mmm... apple cider",
+						},
+					},
+				},
+			},
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Invalid value 'Mmm... apple cider' for field 'podCidr' (must be a v4 CIDR range)",
+					Target:  "properties.spec.network.podCidr",
+				},
+			},
+		},
+		{
+			name: "Bad dns_rfc1035_label",
+			tweaks: &HCPOpenShiftCluster{
+				Properties: HCPOpenShiftClusterProperties{
+					Spec: ClusterSpec{
+						DNS: DNSProfile{
+							BaseDomainPrefix: "0badlabel",
+						},
+					},
+				},
+			},
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Invalid value '0badlabel' for field 'baseDomainPrefix' (must be a valid DNS RFC 1035 label)",
+					Target:  "properties.spec.dns.baseDomainPrefix",
+				},
+			},
+		},
+		{
+			name: "Bad enum_outboundtype",
+			tweaks: &HCPOpenShiftCluster{
+				Properties: HCPOpenShiftClusterProperties{
+					Spec: ClusterSpec{
+						Platform: PlatformProfile{
+							OutboundType: "loadJuggler",
+						},
+					},
+				},
+			},
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Invalid value 'loadJuggler' for field 'outboundType' (must be loadBalancer)",
+					Target:  "properties.spec.platform.outboundType",
+				},
+			},
+		},
+		{
+			name: "Bad enum_visibility",
+			tweaks: &HCPOpenShiftCluster{
+				Properties: HCPOpenShiftClusterProperties{
+					Spec: ClusterSpec{
+						API: APIProfile{
+							Visibility: "it's a secret to everybody",
+						},
+					},
+				},
+			},
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Invalid value 'it's a secret to everybody' for field 'visibility' (must be one of: private public)",
+					Target:  "properties.spec.api.visibility",
+				},
+			},
+		},
+		{
+			name: "Bad startswith=http:",
+			tweaks: &HCPOpenShiftCluster{
+				Properties: HCPOpenShiftClusterProperties{
+					Spec: ClusterSpec{
+						Proxy: ProxyProfile{
+							HTTPProxy: "ftp://not_an_http_url",
+						},
+					},
+				},
+			},
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Invalid value 'ftp://not_an_http_url' for field 'httpProxy' (must start with 'http:')",
+					Target:  "properties.spec.proxy.httpProxy",
+				},
+			},
+		},
+		{
+			name: "Bad url",
+			tweaks: &HCPOpenShiftCluster{
+				Properties: HCPOpenShiftClusterProperties{
+					Spec: ClusterSpec{
+						Proxy: ProxyProfile{
+							HTTPProxy: "http_but_not_a_url",
+						},
+					},
+				},
+			},
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Invalid value 'http_but_not_a_url' for field 'httpProxy' (must be a URL)",
+					Target:  "properties.spec.proxy.httpProxy",
+				},
+			},
+		},
+	}
+
+	validate := newTestValidator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := minimumValidCluster()
+			err := mergo.Merge(resource, tt.tweaks, mergo.WithOverride)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actualErrors := ValidateRequest(validate, http.MethodPut, resource)
+
+			diff := compareErrors(tt.expectErrors, actualErrors)
+			if diff != "" {
+				t.Fatalf("Expected error mismatch:\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -18,12 +18,12 @@ type HCPOpenShiftClusterNodePool struct {
 // HCPOpenShiftClusterNodePool resource.
 type HCPOpenShiftClusterNodePoolProperties struct {
 	ProvisioningState arm.ProvisioningState `json:"provisioningState,omitempty" visibility:"read" validate:"omitempty,enum_provisioningstate"`
-	Spec              NodePoolSpec          `json:"spec,omitempty" visibility:"read create update" validate:"required_for_put"`
+	Spec              NodePoolSpec          `json:"spec,omitempty" visibility:"read create update"`
 }
 
 type NodePoolSpec struct {
-	Version       VersionProfile          `json:"version,omitempty" visibility:"read create" validate:"required_for_put"`
-	Platform      NodePoolPlatformProfile `json:"platform,omitempty" visibility:"read create" validate:"required_for_put"`
+	Version       VersionProfile          `json:"version,omitempty" visibility:"read create"`
+	Platform      NodePoolPlatformProfile `json:"platform,omitempty" visibility:"read create"`
 	Replicas      int32                   `json:"replicas,omitempty" visibility:"read create update"`
 	AutoRepair    bool                    `json:"autoRepair,omitempty" visibility:"read create"`
 	Autoscaling   NodePoolAutoscaling     `json:"autoScaling,omitempty" visibility:"read create update"`

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -17,7 +17,7 @@ type HCPOpenShiftClusterNodePool struct {
 // HCPOpenShiftClusterNodePoolProperties represents the property bag of a
 // HCPOpenShiftClusterNodePool resource.
 type HCPOpenShiftClusterNodePoolProperties struct {
-	ProvisioningState arm.ProvisioningState `json:"provisioningState,omitempty" visibility:"read" validate:"omitempty,enum_provisioningstate"`
+	ProvisioningState arm.ProvisioningState `json:"provisioningState,omitempty" visibility:"read"`
 	Spec              NodePoolSpec          `json:"spec,omitempty" visibility:"read create update"`
 }
 

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -48,8 +48,8 @@ type NodePoolPlatformProfile struct {
 // NodePoolAutoscaling represents a node pool autoscaling configuration.
 // Visibility for the entire struct is "read create update".
 type NodePoolAutoscaling struct {
-	Min int32 `json:"min,omitempty" validate:"required_for_put"`
-	Max int32 `json:"max,omitempty" validate:"required_for_put"`
+	Min int32 `json:"min,omitempty"`
+	Max int32 `json:"max,omitempty"`
 }
 
 type Taint struct {

--- a/internal/api/hcpopenshiftclusternodepool_test.go
+++ b/internal/api/hcpopenshiftclusternodepool_test.go
@@ -1,0 +1,93 @@
+package api
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+func minimumValidNodePool() *HCPOpenShiftClusterNodePool {
+	// Values are meaningless but need to pass validation.
+	return &HCPOpenShiftClusterNodePool{
+		Properties: HCPOpenShiftClusterNodePoolProperties{
+			Spec: NodePoolSpec{
+				Version: VersionProfile{
+					ID:           "openshift-v4.16.0",
+					ChannelGroup: "stable",
+				},
+				Platform: NodePoolPlatformProfile{
+					VMSize: "Standard_D8s_v3",
+				},
+			},
+		},
+	}
+}
+
+func TestNodePoolRequiredForPut(t *testing.T) {
+	tests := []struct {
+		name         string
+		resource     *HCPOpenShiftClusterNodePool
+		expectErrors []arm.CloudErrorBody
+	}{
+		{
+			name:     "Empty node pool",
+			resource: &HCPOpenShiftClusterNodePool{},
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Missing required field 'properties'",
+					Target:  "properties",
+				},
+			},
+		},
+		{
+			name: "Default node pool",
+			// NewDefaultHCPOpenShiftClusterNodePool does not currently have
+			// any non-zero defaults. We need a non-zero value somewhere to
+			// trigger required fields beyond just "properties".
+			resource: &HCPOpenShiftClusterNodePool{
+				Properties: HCPOpenShiftClusterNodePoolProperties{
+					Spec: NodePoolSpec{
+						AutoRepair: true,
+					},
+				},
+			},
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Missing required field 'id'",
+					Target:  "properties.spec.version.id",
+				},
+				{
+					Message: "Missing required field 'channelGroup'",
+					Target:  "properties.spec.version.channelGroup",
+				},
+				{
+					Message: "Missing required field 'vmSize'",
+					Target:  "properties.spec.platform.vmSize",
+				},
+			},
+		},
+		{
+			name:     "Minimum valid node pool",
+			resource: minimumValidNodePool(),
+		},
+	}
+
+	// from hcpopenshiftcluster_test.go
+	validate := newTestValidator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualErrors := ValidateRequest(validate, http.MethodPut, tt.resource)
+
+			// from hcpopenshiftcluster_test.go
+			diff := compareErrors(tt.expectErrors, actualErrors)
+			if diff != "" {
+				t.Fatalf("Expected error mismatch:\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/api/validate.go
+++ b/internal/api/validate.go
@@ -138,7 +138,11 @@ func ValidateRequest(validate *validator.Validate, method string, resource any) 
 			// Try to add a corrective suggestion to the message.
 			tag := fieldErr.Tag()
 			if strings.HasPrefix(tag, "enum_") {
-				message += fmt.Sprintf(" (must be one of: %s)", fieldErr.Param())
+				if len(strings.Split(fieldErr.Param(), " ")) == 1 {
+					message += fmt.Sprintf(" (must be %s)", fieldErr.Param())
+				} else {
+					message += fmt.Sprintf(" (must be one of: %s)", fieldErr.Param())
+				}
 			} else {
 				switch tag {
 				case "api_version": // custom tag


### PR DESCRIPTION
### What this PR does

Adds unit tests for the various "validate" struct tags in use, which leverage the [package validator](https://github.com/go-playground/validator) module.  I also added some tweaks and corrections to existing "validate" tags based on this testing.

Another benefit to this test framework is it allows us to easily try out new validators, or combinations of validators, without having to stand up a full test environment.

Jira: none, was inspired by a [Slack thread](https://redhat-external.slack.com/archives/C075PHEFZKQ/p1726249159120609)
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
