### PR TITLE
Add more validation for node pool autoscaling

### DIFF
--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -252,16 +252,22 @@ func ConvertCStoNodePool(resourceID *arm.ResourceID, np *cmv1.NodePool) *api.HCP
 					DiskEncryptionSetID:    "", // TODO: Not implemented in OCM
 					EphemeralOSDisk:        np.AzureNodePool().EphemeralOSDiskEnabled(),
 				},
-				Replicas:   int32(np.Replicas()),
-				AutoRepair: np.AutoRepair(),
-				AutoScaling: api.NodePoolAutoScaling{
-					Min: int32(np.Autoscaling().MinReplica()),
-					Max: int32(np.Autoscaling().MaxReplica()),
-				},
+				AutoRepair:    np.AutoRepair(),
 				Labels:        np.Labels(),
 				TuningConfigs: np.TuningConfigs(),
 			},
 		},
+	}
+
+	if replicas, ok := np.GetReplicas(); ok {
+		nodePool.Properties.Spec.Replicas = int32(replicas)
+	}
+
+	if autoscaling, ok := np.GetAutoscaling(); ok {
+		nodePool.Properties.Spec.AutoScaling = &api.NodePoolAutoScaling{
+			Min: int32(autoscaling.MinReplica()),
+			Max: int32(autoscaling.MaxReplica()),
+		}
 	}
 
 	taints := make([]*api.Taint, len(np.Taints()))
@@ -308,13 +314,12 @@ func (f *Frontend) BuildCSNodePool(ctx context.Context, nodePool *api.HCPOpenShi
 		Labels(nodePool.Properties.Spec.Labels).
 		TuningConfigs(nodePool.Properties.Spec.TuningConfigs...)
 
-	// from CS API: "Only one of 'replicas' and 'autoscaling' can be provided.
-	if nodePool.Properties.Spec.Replicas != 0 {
-		npBuilder.Replicas(int(nodePool.Properties.Spec.Replicas))
-	} else {
+	if nodePool.Properties.Spec.AutoScaling != nil {
 		npBuilder.Autoscaling(cmv1.NewNodePoolAutoscaling().
 			MinReplica(int(nodePool.Properties.Spec.AutoScaling.Min)).
 			MaxReplica(int(nodePool.Properties.Spec.AutoScaling.Max)))
+	} else {
+		npBuilder.Replicas(int(nodePool.Properties.Spec.Replicas))
 	}
 
 	for _, t := range nodePool.Properties.Spec.Taints {

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -254,7 +254,7 @@ func ConvertCStoNodePool(resourceID *arm.ResourceID, np *cmv1.NodePool) *api.HCP
 				},
 				Replicas:   int32(np.Replicas()),
 				AutoRepair: np.AutoRepair(),
-				Autoscaling: api.NodePoolAutoscaling{
+				AutoScaling: api.NodePoolAutoScaling{
 					Min: int32(np.Autoscaling().MinReplica()),
 					Max: int32(np.Autoscaling().MaxReplica()),
 				},
@@ -313,8 +313,8 @@ func (f *Frontend) BuildCSNodePool(ctx context.Context, nodePool *api.HCPOpenShi
 		npBuilder.Replicas(int(nodePool.Properties.Spec.Replicas))
 	} else {
 		npBuilder.Autoscaling(cmv1.NewNodePoolAutoscaling().
-			MinReplica(int(nodePool.Properties.Spec.Autoscaling.Min)).
-			MaxReplica(int(nodePool.Properties.Spec.Autoscaling.Max)))
+			MinReplica(int(nodePool.Properties.Spec.AutoScaling.Min)).
+			MaxReplica(int(nodePool.Properties.Spec.AutoScaling.Max)))
 	}
 
 	for _, t := range nodePool.Properties.Spec.Taints {

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -24,9 +24,9 @@ type HCPOpenShiftClusterNodePoolProperties struct {
 type NodePoolSpec struct {
 	Version       VersionProfile          `json:"version,omitempty" visibility:"read create"`
 	Platform      NodePoolPlatformProfile `json:"platform,omitempty" visibility:"read create"`
-	Replicas      int32                   `json:"replicas,omitempty" visibility:"read create update"`
+	Replicas      int32                   `json:"replicas,omitempty" visibility:"read create update" validate:"min=0,excluded_with=AutoScaling"`
 	AutoRepair    bool                    `json:"autoRepair,omitempty" visibility:"read create"`
-	AutoScaling   NodePoolAutoScaling     `json:"autoScaling,omitempty" visibility:"read create update"`
+	AutoScaling   *NodePoolAutoScaling    `json:"autoScaling,omitempty" visibility:"read create update"`
 	Labels        map[string]string       `json:"labels,omitempty" visibility:"read create update"`
 	Taints        []*Taint                `json:"taints,omitempty" visibility:"read create update"`
 	TuningConfigs []string                `json:"tuningConfigs,omitempty" visibility:"read create update"`
@@ -48,8 +48,8 @@ type NodePoolPlatformProfile struct {
 // NodePoolAutoScaling represents a node pool autoscaling configuration.
 // Visibility for the entire struct is "read create update".
 type NodePoolAutoScaling struct {
-	Min int32 `json:"min,omitempty"`
-	Max int32 `json:"max,omitempty"`
+	Min int32 `json:"min,omitempty" validate:"min=0"`
+	Max int32 `json:"max,omitempty" validate:"min=0,gtefield=Min"`
 }
 
 type Taint struct {

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -26,7 +26,7 @@ type NodePoolSpec struct {
 	Platform      NodePoolPlatformProfile `json:"platform,omitempty" visibility:"read create"`
 	Replicas      int32                   `json:"replicas,omitempty" visibility:"read create update"`
 	AutoRepair    bool                    `json:"autoRepair,omitempty" visibility:"read create"`
-	Autoscaling   NodePoolAutoscaling     `json:"autoScaling,omitempty" visibility:"read create update"`
+	AutoScaling   NodePoolAutoScaling     `json:"autoScaling,omitempty" visibility:"read create update"`
 	Labels        map[string]string       `json:"labels,omitempty" visibility:"read create update"`
 	Taints        []*Taint                `json:"taints,omitempty" visibility:"read create update"`
 	TuningConfigs []string                `json:"tuningConfigs,omitempty" visibility:"read create update"`
@@ -45,9 +45,9 @@ type NodePoolPlatformProfile struct {
 	EphemeralOSDisk        bool   `json:"ephemeralOsDisk,omitempty"`
 }
 
-// NodePoolAutoscaling represents a node pool autoscaling configuration.
+// NodePoolAutoScaling represents a node pool autoscaling configuration.
 // Visibility for the entire struct is "read create update".
-type NodePoolAutoscaling struct {
+type NodePoolAutoScaling struct {
 	Min int32 `json:"min,omitempty"`
 	Max int32 `json:"max,omitempty"`
 }

--- a/internal/api/hcpopenshiftclusternodepool_test.go
+++ b/internal/api/hcpopenshiftclusternodepool_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"testing"
 
+	"dario.cat/mergo"
+
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
 
@@ -51,7 +53,7 @@ func TestNodePoolRequiredForPut(t *testing.T) {
 			resource: &HCPOpenShiftClusterNodePool{
 				Properties: HCPOpenShiftClusterNodePoolProperties{
 					Spec: NodePoolSpec{
-						AutoRepair: true,
+						Replicas: int32(1),
 					},
 				},
 			},
@@ -82,6 +84,106 @@ func TestNodePoolRequiredForPut(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actualErrors := ValidateRequest(validate, http.MethodPut, tt.resource)
+
+			// from hcpopenshiftcluster_test.go
+			diff := compareErrors(tt.expectErrors, actualErrors)
+			if diff != "" {
+				t.Fatalf("Expected error mismatch:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNodePoolValidateTags(t *testing.T) {
+	// Note "required_for_put" validation tests are above.
+	// This function tests all the other validators in use.
+	tests := []struct {
+		name         string
+		tweaks       *HCPOpenShiftClusterNodePool
+		expectErrors []arm.CloudErrorBody
+	}{
+		{
+			name: "Min=0 not satisfied",
+			tweaks: &HCPOpenShiftClusterNodePool{
+				Properties: HCPOpenShiftClusterNodePoolProperties{
+					Spec: NodePoolSpec{
+						Replicas: int32(-1),
+					},
+				},
+			},
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Invalid value '-1' for field 'replicas' (must be non-negative)",
+					Target:  "properties.spec.replicas",
+				},
+			},
+		},
+		{
+			name: "Both Replicas and AutoScaling present",
+			tweaks: &HCPOpenShiftClusterNodePool{
+				Properties: HCPOpenShiftClusterNodePoolProperties{
+					Spec: NodePoolSpec{
+						Replicas: int32(1),
+						AutoScaling: &NodePoolAutoScaling{
+							Min: 1,
+							Max: 2,
+						},
+					},
+				},
+			},
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Field 'replicas' must be 0 when 'autoScaling' is specified",
+					Target:  "properties.spec.replicas",
+				},
+			},
+		},
+		{
+			name: "Only AutoScaling present with zero-values",
+			tweaks: &HCPOpenShiftClusterNodePool{
+				Properties: HCPOpenShiftClusterNodePoolProperties{
+					Spec: NodePoolSpec{
+						AutoScaling: &NodePoolAutoScaling{
+							Min: 0,
+							Max: 0,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "AutoScaling max is less than min",
+			tweaks: &HCPOpenShiftClusterNodePool{
+				Properties: HCPOpenShiftClusterNodePoolProperties{
+					Spec: NodePoolSpec{
+						AutoScaling: &NodePoolAutoScaling{
+							Min: 1,
+							Max: 0,
+						},
+					},
+				},
+			},
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Invalid value '0' for field 'max' (must be at least the value of 'min')",
+					Target:  "properties.spec.autoScaling.max",
+				},
+			},
+		},
+	}
+
+	// from hcpopenshiftcluster_test.go
+	validate := newTestValidator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := minimumValidNodePool()
+			err := mergo.Merge(resource, tt.tweaks, mergo.WithOverride)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actualErrors := ValidateRequest(validate, http.MethodPut, resource)
 
 			// from hcpopenshiftcluster_test.go
 			diff := compareErrors(tt.expectErrors, actualErrors)

--- a/internal/api/v20240610preview/nodepools_methods.go
+++ b/internal/api/v20240610preview/nodepools_methods.go
@@ -185,10 +185,16 @@ func newNodePoolPlatformProfile(from *api.NodePoolPlatformProfile) *generated.No
 }
 
 func newNodePoolAutoScaling(from *api.NodePoolAutoScaling) *generated.NodePoolAutoScaling {
-	return &generated.NodePoolAutoScaling{
-		Max: api.Ptr(from.Max),
-		Min: api.Ptr(from.Min),
+	var autoScaling *generated.NodePoolAutoScaling
+
+	if from != nil {
+		autoScaling = &generated.NodePoolAutoScaling{
+			Max: api.Ptr(from.Max),
+			Min: api.Ptr(from.Min),
+		}
 	}
+
+	return autoScaling
 }
 
 func newNodePoolTaint(from *api.Taint) *generated.Taint {
@@ -217,7 +223,7 @@ func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNod
 					Platform:      newNodePoolPlatformProfile(&from.Properties.Spec.Platform),
 					Version:       newVersionProfile(&from.Properties.Spec.Version),
 					AutoRepair:    api.Ptr(from.Properties.Spec.AutoRepair),
-					AutoScaling:   newNodePoolAutoScaling(&from.Properties.Spec.AutoScaling),
+					AutoScaling:   newNodePoolAutoScaling(from.Properties.Spec.AutoScaling),
 					Labels:        []*generated.Label{},
 					Replicas:      api.Ptr(from.Properties.Spec.Replicas),
 					Taints:        make([]*generated.Taint, len(from.Properties.Spec.Taints)),

--- a/internal/api/v20240610preview/nodepools_methods.go
+++ b/internal/api/v20240610preview/nodepools_methods.go
@@ -64,10 +64,10 @@ func (h *HcpOpenShiftClusterNodePoolResource) Normalize(out *api.HCPOpenShiftClu
 		}
 		if h.Properties.Spec.AutoScaling != nil {
 			if h.Properties.Spec.AutoScaling.Max != nil {
-				out.Properties.Spec.Autoscaling.Max = *h.Properties.Spec.AutoScaling.Max
+				out.Properties.Spec.AutoScaling.Max = *h.Properties.Spec.AutoScaling.Max
 			}
 			if h.Properties.Spec.AutoScaling.Min != nil {
-				out.Properties.Spec.Autoscaling.Min = *h.Properties.Spec.AutoScaling.Min
+				out.Properties.Spec.AutoScaling.Min = *h.Properties.Spec.AutoScaling.Min
 			}
 		}
 		out.Properties.Spec.Labels = make(map[string]string)
@@ -184,7 +184,7 @@ func newNodePoolPlatformProfile(from *api.NodePoolPlatformProfile) *generated.No
 	}
 }
 
-func newNodePoolAutoscaling(from *api.NodePoolAutoscaling) *generated.NodePoolAutoScaling {
+func newNodePoolAutoScaling(from *api.NodePoolAutoScaling) *generated.NodePoolAutoScaling {
 	return &generated.NodePoolAutoScaling{
 		Max: api.Ptr(from.Max),
 		Min: api.Ptr(from.Min),
@@ -217,7 +217,7 @@ func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNod
 					Platform:      newNodePoolPlatformProfile(&from.Properties.Spec.Platform),
 					Version:       newVersionProfile(&from.Properties.Spec.Version),
 					AutoRepair:    api.Ptr(from.Properties.Spec.AutoRepair),
-					AutoScaling:   newNodePoolAutoscaling(&from.Properties.Spec.Autoscaling),
+					AutoScaling:   newNodePoolAutoScaling(&from.Properties.Spec.AutoScaling),
 					Labels:        []*generated.Label{},
 					Replicas:      api.Ptr(from.Properties.Spec.Replicas),
 					Taints:        make([]*generated.Taint, len(from.Properties.Spec.Taints)),


### PR DESCRIPTION
### What this PR does

Followup to [#613](https://github.com/Azure/ARO-HCP/pull/613)...

Uses the new validation test framework to add and test additional validation for node pool replicas and autoscaling.

- If `autoScaling` is specified, `replicas` must be 0.
- The values for `replicas`, `autoScaling.min`, and `autoScaling.max` must be non-negative.
- The value for `autoScaling.max` must be greather than or equal to `autoScaling.min`.


Jira: none, just addressing a [Slack thread](https://redhat-external.slack.com/archives/C075PHEFZKQ/p1726249159120609)
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
