### PR TITLE
feat: add azure runtime config flag to cs service template

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -37,7 +37,7 @@ deploy:
 	  -p IMAGE_REPOSITORY=app-sre/uhc-clusters-service \
 	  -p AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID=$${AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID} \
 	  -p FPA_CERT_NAME=${FPA_CERT_NAME} \
-	  -p IMAGE_TAG=3482df9 | oc apply -f -
+	  -p IMAGE_TAG=9da687c | oc apply -f -
 
 deploy-integ:
 	oc process --local -f deploy/integration/cluster-service-namespace.yaml | oc apply -f -

--- a/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
+++ b/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
@@ -360,6 +360,16 @@ objects:
               min_version: 4.11.0
 
 - apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: azure-runtime-config
+  data:
+    config.json: |
+      {
+        "cloudEnvironment": "AzurePublicCloud"
+      }
+
+- apiVersion: v1
   kind: ServiceAccount
   metadata:
     name: clusters-service
@@ -434,6 +444,9 @@ objects:
         - name: config
           configMap:
             name: clusters-service
+        - name: azure-runtime-config
+          configMap:
+            name: azure-runtime-config
         - name: mixin-pull-secret
           secret:
             secretName: hive-ci-global-pull-secret
@@ -506,6 +519,8 @@ objects:
           - name: keyvault
             mountPath: "/secrets/keyvault"
             readOnly: true
+          - name: azure-runtime-config
+            mountPath: /configs/azure-runtime-config
           env:
           - name: NAMESPACE
             valueFrom:
@@ -556,6 +571,7 @@ objects:
           - --azure-auth-config-path=/secrets/azure-credentials/azure-auth-config
           - --azure-first-party-application-client-id=${AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID}
           - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
+          - --azure-runtime-config-path=/configs/azure-runtime-config/config.json
           livenessProbe:
             httpGet:
               path: /api/clusters_mgmt/v1


### PR DESCRIPTION
### What this PR does
Adds a configmap containing the azure runtime configuration in the ARO HCP CS service template. This is used as value to the flag `azure-runtime-config` which has been added in https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/8478

Current configuration available to be set here is the cloud environment where CS is running on. For now, only the cloud environment is added there. Additional configuration will be added at a later time. 

CS image tag has been updated to [9da687c](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/tree/9da687cd0053da08b98c1a373080f122b9b99a66) which contains the changes in the MR linked above.

Jira: https://issues.redhat.com/browse/ARO-7653
Link to demo recording: N/A

### Special notes for your reviewer
Please note that this depends on https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/8478. The cs image in the makefile will be updated as soon as that's merged. 
