### PR TITLE
control maestro server istio ingress restriction via helm value

### DIFF
--- a/.github/workflows/cs-integration-env-cd.yml
+++ b/.github/workflows/cs-integration-env-cd.yml
@@ -282,7 +282,7 @@
         - name: 'Deploy Maestro Server'
           run: |
             cd maestro/
-            make deploy-server
+            RESTRICT_ISTIO_INGRESS=false make deploy-server
 
         - name: 'Register Maestro Agent'
           env:

--- a/maestro/Makefile
+++ b/maestro/Makefile
@@ -6,6 +6,7 @@ include ../dev-infrastructure/configurations/$(CONFIG_PROFILE).mk
 CONSUMER_NAME ?= $(shell az aks list --query "[?tags.clusterType == 'mgmt-cluster' && starts_with(resourceGroup, '$(REGIONAL_RESOURCEGROUP)')].resourceGroup" -o tsv)
 EVENTGRID_ID = $(shell az resource list -g ${REGIONAL_RESOURCEGROUP} --resource-type "Microsoft.EventGrid/namespaces" --query "[].id" -o tsv)
 
+RESTRICT_ISTIO_INGRESS ?= true
 
 MAESTRO_BASE_IMAGE ?= quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
 MAESTRO_TAG ?= ea066c250a002f0cc458711945165591bc9f6d3f
@@ -28,6 +29,7 @@ deploy-server:
 		--set credsKeyVault.name=$${MAESTRO_KV_NAME} \
 		--set azure.clientId=$${MAESTRO_MI_CLIENT_ID} \
 		--set azure.tenantId=$${TENANT_ID} \
+		--set istio.restrictIngress=${RESTRICT_ISTIO_INGRESS} \
 		--set image.base=${MAESTRO_BASE_IMAGE} \
 		--set image.tag=${MAESTRO_TAG} \
 		--set database.containerizedDb=true \

--- a/maestro/deploy/helm/server/templates/allow-cluster-service.authorizationpolicy.yaml
+++ b/maestro/deploy/helm/server/templates/allow-cluster-service.authorizationpolicy.yaml
@@ -6,14 +6,19 @@ metadata:
 spec:
   action: "ALLOW"
   rules:
-    - from:
-      - source:
-          principals: ["cluster.local/ns/{{ .Values.clusterService.namespace }}/sa/{{ .Values.clusterService.serviceAccount }}"]
-      to:
+    - to:
       - operation:
           ports:
             - "{{ .Values.maestro.httpBindPort }}"
             - "{{ .Values.maestro.grpcBindPort }}"
+      from:
+      - source:
+          principals:
+            {{- if .Values.istio.restrictIngress }}
+            - "cluster.local/ns/{{ .Values.clusterService.namespace }}/sa/{{ .Values.clusterService.serviceAccount }}"
+            {{- else }}
+            - "*"
+            {{- end }}
   selector:
     matchLabels:
       app: "maestro"

--- a/maestro/deploy/helm/server/values.yaml
+++ b/maestro/deploy/helm/server/values.yaml
@@ -33,6 +33,8 @@ maestro:
 clusterService:
   namespace: cluster-service
   serviceAccount: clusters-service
+istio:
+  restrictIngress: true
 azure:
   clientId: ""
   tenantId: ""


### PR DESCRIPTION
### What this PR does

for the CS integration environment, we require the maestro istio policy to not restrict ingress sources because the source namespace name is dynamically generated during CS PR checks.

the RESTRICT_ISTIO_INGRESS var controls if ingress is restricted from the well known CS namespace in prod, or not restricted at all

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
