### PR TITLE
reducing user agentpool maxpod limit to 225

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -393,7 +393,7 @@ resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2
       }
       vnetSubnetID: aksNodeSubnet.id
       podSubnetID: aksPodSubnet.id
-      maxPods: 250
+      maxPods: 225
       availabilityZones: [
         '${(i + 1)}'
       ]


### PR DESCRIPTION
As we often hit resource crisis on the worker nodes due to HCP burst, leads to containerd and kubelet being OOM killed when running 250 pods per node irrespective of total available resources(noticed in D16 as well as E16 types)

Limiting the pod space on worker would help this situation,  at least burst caused by HCP pods were not affecting those daemon during 50 HCP test on perfscale environments. 