### PR TITLE
Fix 1st party application credentials in dev

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -7,6 +7,7 @@ include ../dev-infrastructure/configurations/$(CONFIG_PROFILE).mk
 CONSUMER_NAME ?= $(shell az aks list --query "[?tags.clusterType == 'mgmt-cluster' && starts_with(resourceGroup, '$(REGIONAL_RESOURCEGROUP)')].resourceGroup" -o tsv)
 KEYVAULT_NAME ?= $(shell az keyvault list --query "[?starts_with(name, 'service-kv')].name" -g ${RESOURCEGROUP} --output tsv)
 FPA_CERT_NAME ?= firstPartyMock
+AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID ?= "ccf5339c-61d1-402f-9c9b-d463670191f9"
 
 deploy:
 	ZONE_RESOURCE_ID=$(shell az network dns zone list -g ${REGIONAL_RESOURCEGROUP} --query "[?zoneType=='Public'].id" -o tsv) && \
@@ -21,10 +22,7 @@ deploy:
 			-g ${RESOURCEGROUP} \
 			-n clusters-service \
 			--query clientId) && \
-	AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID=$(shell az ad app list \
-			--display-name aro-hcp-dev-first-party \
-			--query '[*]'.appId \
-			-o tsv) && \
+	AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID=${AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID} && \
 	CS_SERVICE_PRINCIPAL_CREDS_BASE64='$(shell az keyvault secret show --vault-name "service-kv-aro-hcp-dev" --name "aro-hcp-dev-sp-cs" | jq .value -r | base64 | tr -d '\n')' && \
 	TENANT_ID=$(shell az account show --query tenantId --output tsv) && \
 	oc process --local -f deploy/openshift-templates/arohcp-service-template.yml \


### PR DESCRIPTION
### What this PR does
This commit hardcodes the application ID of the mock first-party credentials for the dev environment. This is because the GitHub Actions entity does not have permissions to list applications at the tenant scope.

Fixes CD errors deploying CS, like https://github.com/Azure/ARO-HCP/actions/runs/10917480196/job/30436069484