### PR TITLE
Revert "reducing user agentpool maxpod limit to 225"

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -393,7 +393,7 @@ resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2
       }
       vnetSubnetID: aksNodeSubnet.id
       podSubnetID: aksPodSubnet.id
-      maxPods: 225
+      maxPods: 250
       availabilityZones: [
         '${(i + 1)}'
       ]


### PR DESCRIPTION
Reverts Azure/ARO-HCP#626

This is to temporarily clean up the service/management clusters before recreating