### PR TITLE
Enable azure monitor metrics in persistent dev envs

### DIFF
--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -177,7 +177,10 @@
               AZ_MONITOR_RESOURCE_ID=$(az deployment group show --resource-group "${REGIONAL_RESOURCEGROUP}" --name "metrics-infra-${GITHUB_RUN_ID}" --output tsv --query properties.outputs.monitorId.value)
               GRAFANA_RESOURCE_ID=$(az deployment group show --resource-group "${REGIONAL_RESOURCEGROUP}" --name "metrics-infra-${GITHUB_RUN_ID}" --output tsv --query properties.outputs.grafanaId.value)
 
-              az aks update --name "${SVC_CLUSTER_NAME}" --resource-group "${SC_RESOURCEGROUP}" \
+              az aks update \
+                --name "${SVC_CLUSTER_NAME}" \
+                --enable-azure-monitor-metrics \
+                --resource-group "${SC_RESOURCEGROUP}" \
                 --azure-monitor-workspace-resource-id "${AZ_MONITOR_RESOURCE_ID}" \
                 --grafana-resource-id "${GRAFANA_RESOURCE_ID}"
 
@@ -234,7 +237,10 @@
               AZ_MONITOR_RESOURCE_ID=$(az deployment group show --resource-group "${REGIONAL_RESOURCEGROUP}" --name "metrics-infra-${GITHUB_RUN_ID}" --output tsv --query properties.outputs.monitorId.value)
               GRAFANA_RESOURCE_ID=$(az deployment group show --resource-group "${REGIONAL_RESOURCEGROUP}" --name "metrics-infra-${GITHUB_RUN_ID}" --output tsv --query properties.outputs.grafanaId.value)
 
-              az aks update --name "${MGMT_CLUSTER_NAME}" --resource-group "${MC_RESOURCEGROUP}" \
+              az aks update \
+                --name "${MGMT_CLUSTER_NAME}" \
+                --enable-azure-monitor-metrics \
+                --resource-group "${MC_RESOURCEGROUP}" \
                 --azure-monitor-workspace-resource-id "${AZ_MONITOR_RESOURCE_ID}" \
                 --grafana-resource-id "${GRAFANA_RESOURCE_ID}"
 

--- a/.github/workflows/cs-integration-env-cd.yml
+++ b/.github/workflows/cs-integration-env-cd.yml
@@ -151,7 +151,10 @@
               AZ_MONITOR_RESOURCE_ID=$(az deployment group show --resource-group "${REGIONAL_RESOURCEGROUP}" --name "metrics-infra-${GITHUB_RUN_ID}" --output tsv --query properties.outputs.monitorId.value)
               GRAFANA_RESOURCE_ID=$(az deployment group show --resource-group "${REGIONAL_RESOURCEGROUP}" --name "metrics-infra-${GITHUB_RUN_ID}" --output tsv --query properties.outputs.grafanaId.value)
 
-              az aks update --name "${SVC_CLUSTER_NAME}" --resource-group "${SC_RESOURCEGROUP}" \
+              az aks update \
+                --name "${SVC_CLUSTER_NAME}" \
+                --enable-azure-monitor-metrics \
+                --resource-group "${SC_RESOURCEGROUP}" \
                 --azure-monitor-workspace-resource-id "${AZ_MONITOR_RESOURCE_ID}" \
                 --grafana-resource-id "${GRAFANA_RESOURCE_ID}"
 
@@ -208,7 +211,10 @@
               AZ_MONITOR_RESOURCE_ID=$(az deployment group show --resource-group "${REGIONAL_RESOURCEGROUP}" --name "metrics-infra-${GITHUB_RUN_ID}" --output tsv --query properties.outputs.monitorId.value)
               GRAFANA_RESOURCE_ID=$(az deployment group show --resource-group "${REGIONAL_RESOURCEGROUP}" --name "metrics-infra-${GITHUB_RUN_ID}" --output tsv --query properties.outputs.grafanaId.value)
 
-              az aks update --name "${MGMT_CLUSTER_NAME}" --resource-group "${MC_RESOURCEGROUP}" \
+              az aks update \
+                --name "${MGMT_CLUSTER_NAME}" \
+                --enable-azure-monitor-metrics \
+                --resource-group "${MC_RESOURCEGROUP}" \
                 --azure-monitor-workspace-resource-id "${AZ_MONITOR_RESOURCE_ID}" \
                 --grafana-resource-id "${GRAFANA_RESOURCE_ID}"
 


### PR DESCRIPTION
### What this PR does
Fixes deployment of bare AKS cluster due to missing metrics addon enablement.  

