### PR TITLE
Add configmap

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -38,7 +38,12 @@ deploy:
 	  -p IMAGE_TAG=9da687c | oc apply -f -
 
 deploy-integ:
-	oc process --local -f deploy/integration/cluster-service-namespace.yaml | oc apply -f -
+	AZURE_CS_MI_CLIENT_ID=$(shell az identity show \
+			-g ${RESOURCEGROUP} \
+			-n clusters-service \
+			--query clientId) && \
+	oc process --local -f deploy/integration/cluster-service-namespace.yaml \
+	-p CLIENT_ID=$${AZURE_CS_MI_CLIENT_ID} | oc apply -f -
 
 # for local development
 provision-shard:

--- a/cluster-service/deploy/integration/cluster-service-namespace.yaml
+++ b/cluster-service/deploy/integration/cluster-service-namespace.yaml
@@ -8,6 +8,9 @@ parameters:
   description: The namespace to create
   required: true
   value: cluster-service-admin
+- name: CLIENT_ID
+  description: The Azure Client ID used for federation
+  required: true
 
 objects:
   - apiVersion: v1
@@ -62,3 +65,10 @@ objects:
         kubernetes.io/service-account.name: cluster-service-mgmt
       namespace: ${NAMESPACE}
     type: kubernetes.io/service-account-token
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cluster-service-config
+      namespace: ${NAMESPACE}
+    data:
+      cs-client-id: ${CLIENT_ID}


### PR DESCRIPTION
Adds a configmap containing the Azure Client ID of the cluster-service managed identity. Used in PR for configuring Cluser Service Service Accounts

### What this PR does


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
