### PR TITLE
Revert "Revert "reducing user agentpool maxpod limit to 225""

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -391,7 +391,7 @@ resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2
       }
       vnetSubnetID: aksNodeSubnet.id
       podSubnetID: aksPodSubnet.id
-      maxPods: 250
+      maxPods: 225
       availabilityZones: [
         '${(i + 1)}'
       ]


### PR DESCRIPTION
Reverts Azure/ARO-HCP#628

This time, setting maxPods to 225 for real