### PR TITLE
add namespace to azure-runtime-config cm

### DIFF
--- a/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
+++ b/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
@@ -363,6 +363,7 @@ objects:
   kind: ConfigMap
   metadata:
     name: azure-runtime-config
+    namespace: ${NAMESPACE}
   data:
     config.json: |
       {


### PR DESCRIPTION
### What this PR does
Adds the ${NAMESPACE} to deploy the azure-runtime-config configmap to the cluster-service namespace.  Previously it was deployed to the default namespace and the clusters-service pods were failing to start.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
