### PR TITLE
change grafana admin group

### DIFF
--- a/dev-infrastructure/modules/metrics/metrics.bicep
+++ b/dev-infrastructure/modules/metrics/metrics.bicep
@@ -12,7 +12,7 @@ param msiName string = take('metrics-admin-${uniqueString(currentUserId)}', 4)
 param grafanaName string = take('aro-hcp-grafana-${uniqueString(currentUserId)}', 23)
 
 var grafanaAdmin = {
-  principalId: '366b619c-e72e-4278-8aaf-9af7851c601f' // aro-hcp-engineering
+  principalId: '6b6d3adf-8476-4727-9812-20ffdef2b85c' // aro-hcp-engineering-App Developer
   principalType: 'group'
 }
 


### PR DESCRIPTION
### What this PR does

use `aro-hcp-engineering-App Developer` as grafana admin group

breadcrumbs: https://redhat-internal.slack.com/archives/CBUT43E94/p1726857476937179

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
