### PR TITLE
Ensure local golangci-lint version mirrors CI

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -19,12 +19,6 @@ cd api && npm ci
 # TODO: if we need to, we should move this out of here and into `api/package.json`
 npm install -g oav@3.3.4
 
-# Install the golang-lint
-# binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0
-
-golangci-lint --version
-
 # Setup the welcome screen
 echo "cat .devcontainer/motd" >> ~/.bashrc
 echo "cat .devcontainer/motd" >> ~/.zshrc

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -45,5 +45,6 @@ jobs:
       - name: 'Lint'
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
-          version: 'v1.61.0'
+          # The repo's top-level Makefile parses the version of golangci-lint from here
+          version: v1.61.0
           args: '-v --build-tags=containers_image_openpgp $(go list -f ''{{.Dir}}/...'' -m | xargs)'

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules
 .idea
 env
 frontend/archive.tar.gz
+tooling/bin

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL = /bin/bash
 # This build tag is currently leveraged by tooling/image-sync
 # https://github.com/containers/image?tab=readme-ov-file#building
 GOTAGS?='containers_image_openpgp'
+TOOLS_BIN_DIR := tooling/bin
 
 all: test lint
 
@@ -14,7 +15,15 @@ test:
 # There is currently no convenient way to run golangci-lint against a whole Go workspace
 # https://github.com/golang/go/issues/50745
 MODULES := $(shell go list -f '{{.Dir}}/...' -m | xargs)
-lint:
-	golangci-lint run -v --build-tags=$(GOTAGS) $(MODULES)
+lint: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) run -v --build-tags=$(GOTAGS) $(MODULES)
 
 .PHONY: all clean lint test
+
+GOLANGCI_LINT_BIN := golangci-lint
+GOLANGCI_LINT_VER := $(shell cat .github/workflows/ci-go.yml | grep [[:space:]]version: | sed 's/.*version: //')
+GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER))
+
+$(GOLANGCI_LINT): # Setup a repo-local golangci-lint in $(GOLANGCI_LINT)
+	$(shell curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) $(GOLANGCI_LINT_VER))
+	$(shell mv $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN) $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER))


### PR DESCRIPTION
### What this PR does
This commit sets up a repo-local `tooling/bin/golangci-lint` that will use the same version as CI instead of using whatever local version of golangci-lint is available on a developer's device.
