### PR TITLE
database: Use subscription ID for SubscriptionDocument.ID

### DIFF
--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -14,6 +14,7 @@ param uamiPrincipalId string
 var containers = [
   {
     name: 'Subscriptions'
+    partitionKeyPaths: ['/id']
   }
   {
     name: 'Operations'

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -69,7 +69,7 @@ func TestSubscriptionsGET(t *testing.T) {
 		{
 			name: "GET Subscription - Doc Exists",
 			subDoc: &database.SubscriptionDocument{
-				PartitionKey: "00000000-0000-0000-0000-000000000000",
+				ID: "00000000-0000-0000-0000-000000000000",
 				Subscription: &arm.Subscription{
 					State:            arm.SubscriptionStateRegistered,
 					RegistrationDate: api.Ptr(time.Now().String()),
@@ -145,7 +145,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 				Properties:       nil,
 			},
 			subDoc: &database.SubscriptionDocument{
-				PartitionKey: "00000000-0000-0000-0000-000000000000",
+				ID: "00000000-0000-0000-0000-000000000000",
 				Subscription: &arm.Subscription{
 					State:            arm.SubscriptionStateRegistered,
 					RegistrationDate: api.Ptr(time.Now().String()),

--- a/frontend/pkg/frontend/middleware_validatesubscription_test.go
+++ b/frontend/pkg/frontend/middleware_validatesubscription_test.go
@@ -159,7 +159,7 @@ func TestMiddlewareValidateSubscription(t *testing.T) {
 
 			if tt.cachedState != "" {
 				if err := dbClient.SetSubscriptionDoc(context.Background(), &database.SubscriptionDocument{
-					PartitionKey: subscriptionId,
+					ID: subscriptionId,
 					Subscription: &arm.Subscription{
 						State: tt.cachedState,
 						Properties: &arm.SubscriptionProperties{

--- a/internal/database/cache.go
+++ b/internal/database/cache.go
@@ -117,7 +117,7 @@ func (c *Cache) GetSubscriptionDoc(ctx context.Context, subscriptionID string) (
 
 func (c *Cache) SetSubscriptionDoc(ctx context.Context, doc *SubscriptionDocument) error {
 	// Make sure lookup keys are lowercase.
-	key := strings.ToLower(doc.PartitionKey)
+	key := strings.ToLower(doc.ID)
 
 	c.subscription[key] = doc
 	return nil

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -115,7 +115,6 @@ func (doc *OperationDocument) ToStatus() *arm.Operation {
 // SubscriptionDocument represents an Azure Subscription document.
 type SubscriptionDocument struct {
 	ID           string            `json:"id,omitempty"`
-	PartitionKey string            `json:"partitionKey,omitempty"`
 	Subscription *arm.Subscription `json:"subscription,omitempty"`
 
 	// Values provided by Cosmos after doc creation
@@ -128,8 +127,7 @@ type SubscriptionDocument struct {
 
 func NewSubscriptionDocument(subscriptionID string, subscription *arm.Subscription) *SubscriptionDocument {
 	return &SubscriptionDocument{
-		ID:           uuid.New().String(),
-		PartitionKey: strings.ToLower(subscriptionID),
+		ID:           strings.ToLower(subscriptionID),
 		Subscription: subscription,
 	}
 }


### PR DESCRIPTION
### What this PR does

Eliminates the need for a separate `PartitionKey` field (partition key path is now `/id`). This allows subscriptions to be looked up directly by their ID, which is simpler and faster.

Jira: No specific Jira; this is a database optimization
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
