### PR TITLE
Fix error updating agentpool version

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -237,7 +237,6 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-04-02-previ
         osType: 'Linux'
         osSKU: 'AzureLinux'
         mode: 'System'
-        orchestratorVersion: kubernetesVersion
         enableAutoScaling: true
         enableEncryptionAtHost: true
         enableFIPS: true
@@ -373,7 +372,6 @@ resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2
       osType: 'Linux'
       osSKU: 'AzureLinux'
       mode: 'User'
-      orchestratorVersion: kubernetesVersion
       enableAutoScaling: true
       enableEncryptionAtHost: true
       enableFIPS: true


### PR DESCRIPTION
### What this PR does
Fixes this apply failure from https://github.com/Azure/ARO-HCP/actions/runs/11072845830 by unspecifying all agent pool orchestrator versions. This is happening because our user pools are not explicitly configured in the AKS cluster resource and are defined as separate nodepool resources:

> Using managed cluster api, all Agent pools' OrchestratorVersion must be all specified or all unspecified. If all specified, they must be stay unchanged or the same with control plane. For agent pool specific change, please use per agent pool operations