### PR TITLE
frontend: Add azcore event logging, disabled by default

### DIFF
--- a/frontend/cmd/cmd.go
+++ b/frontend/cmd/cmd.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -83,6 +84,11 @@ func NewRootCmd() *cobra.Command {
 func (opts *FrontendOpts) Run() error {
 	logger := config.DefaultLogger()
 	logger.Info(fmt.Sprintf("%s (%s) started", frontend.ProgramName, version()))
+
+	// Log SDK events by setting AZURE_SDK_GO_LOGGING="all"
+	azlog.SetListener(func(event azlog.Event, message string) {
+		logger.Info(message, "event", event)
+	})
 
 	// Init prometheus emitter
 	prometheusEmitter := frontend.NewPrometheusEmitter()

--- a/frontend/deploy/helm/frontend/templates/frontend.configmap.yaml
+++ b/frontend/deploy/helm/frontend/templates/frontend.configmap.yaml
@@ -8,3 +8,4 @@ data:
   FRONTEND_MI_CLIENT_ID: '{{ .Values.configMap.frontendMiClientId }}'
   CURRENT_VERSION: '{{ .Values.configMap.currentVersion }}'
   LOCATION: '{{ .Values.configMap.location }}'
+  AZURE_SDK_GO_LOGGING: ''

--- a/frontend/deploy/helm/frontend/templates/frontend.deployment.yaml
+++ b/frontend/deploy/helm/frontend/templates/frontend.deployment.yaml
@@ -44,6 +44,11 @@ spec:
               configMapKeyRef:
                 name: frontend-config
                 key: LOCATION
+          - name: AZURE_SDK_GO_LOGGING
+            valueFrom:
+              configMapKeyRef:
+                name: frontend-config
+                key: AZURE_SDK_GO_LOGGING
           ports:
             - containerPort: 8443
               protocol: TCP


### PR DESCRIPTION
### What this PR does

Debugging feature for [logging azcore events](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore/log).

Enable by setting `AZURE_SDK_GO_LOGGING` to "all" in the `frontend-config` ConfigMap ("all" is the only valid value at present, which logs events for all [azure-sdk-for-go](https://github.com/Azure/azure-sdk-for-go) clients).

Jira: Added this while working on [ARO-9674 - Frontend needs to run with at least two replicas](https://issues.redhat.com/browse/ARO-9674)
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
