### PR TITLE
frontend: Set Content-Type header in LoggingResponseWriter

### DIFF
--- a/frontend/pkg/frontend/middleware_logging.go
+++ b/frontend/pkg/frontend/middleware_logging.go
@@ -34,6 +34,8 @@ type LoggingResponseWriter struct {
 }
 
 func (w *LoggingResponseWriter) Write(b []byte) (int, error) {
+	// All response body content is application/json.
+	w.Header().Set("Content-Type", "application/json")
 	n, err := w.ResponseWriter.Write(b)
 	w.bytesWritten += n
 	return n, err


### PR DESCRIPTION
### What this PR does

All resource provider response content is JSON formatted.

The `LoggingResponseWriter.Write` method is a good centralized place to set the "Content-Type" header when there is response content.

### Special notes for your reviewer

No Jira, this is just for RPC compliance.  Noticed while testing.