### PR TITLE
chore: update cs commit to b16f630

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -53,8 +53,3 @@ provision-shard:
 	sed -e "s#ZONE_RESOURCE_ID#$${ZONE_RESOURCE_ID}#g" -e "s/REGION/${REGION}/g" -e "s/CONSUMER_NAME/${CONSUMER_NAME}/g" deploy/dev-provisioning-shards.yml
 
 .PHONY: deploy deploy-integ provision-shard
-
-copy-fpc:
-	@FPC_SECRET=$(shell az keyvault secret show --vault-name "service-kv-aro-hcp-dev" --name ${FPA_CERT_NAME} --query "value" -o tsv) && \
- 	../dev-infrastructure/scripts/kv-add-secret.sh ${KEYVAULT_NAME} ${RESOURCEGROUP} ${FPA_CERT_NAME} $${FPC_SECRET}
-.PHONY: copy-fpc

--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -37,7 +37,7 @@ deploy:
 	  -p IMAGE_REPOSITORY=app-sre/uhc-clusters-service \
 	  -p AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID=$${AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID} \
 	  -p FPA_CERT_NAME=${FPA_CERT_NAME} \
-	  -p IMAGE_TAG=9da687c | oc apply -f -
+	  -p IMAGE_TAG=b16f630 | oc apply -f -
 
 deploy-integ:
 	AZURE_CS_MI_CLIENT_ID=$(shell az identity show \

--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -171,12 +171,7 @@ To access the HTTP and GRPC endpoints of maestro, run
 
 ### Cluster Service
 
-To make use of the first party certificate it is needed to copy the cert into the service-kv.
-   ```bash
-   cd cluster-service/
-   make copy-fpc
-   ```
-Then deploy CS:
+Deploy CS:
    ```bash
    cd cluster-service/
    make deploy


### PR DESCRIPTION
### What this PR does
Updates the CS commit to [b16f630](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/tree/b16f630b0e076c99449806ccbd29eb7e61a52a80) which has the changes from https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/8610. 

```
{
  ...
  "createdTime": "2024-10-01T09:10:18.5913806Z",
  "digest": "sha256:6332d4b4fc1524d45d9f2671e0f6b22ec87e7b3cf21c38447e0d620e197f6194",
  "lastUpdateTime": "2024-10-01T09:10:18.5913806Z",
  "name": "b16f630",
}
```

Also removes the copy-fpc make target from the cluster service makefile as the first party application certificate has been moved to a global kv. We no longer need to copy over the cert to a private kv. 

Jira: https://issues.redhat.com/browse/ARO-7387
Link to demo recording: N/A

### Special notes for your reviewer

<!-- optional -->
