### PR TITLE
Add concurrency controls around Cosmos DB

### DIFF
--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -27,6 +27,11 @@ var containers = [
   {
     name: 'Billing'
   }
+  {
+    name: 'Locks'
+    defaultTtl: 10
+    partitionKeyPaths: ['/id']
+  }
 ]
 
 param roleDefinitionId string = '00000000-0000-0000-0000-000000000002'

--- a/frontend/cmd/cmd.go
+++ b/frontend/cmd/cmd.go
@@ -118,7 +118,7 @@ func (opts *FrontendOpts) Run() error {
 			return err
 		}
 
-		dbClient, err = database.NewCosmosDBClient(cosmosDatabaseClient)
+		dbClient, err = database.NewCosmosDBClient(context.Background(), cosmosDatabaseClient)
 		if err != nil {
 			return fmt.Errorf("creating the database client failed: %v", err)
 		}

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -104,7 +104,10 @@ func TestSubscriptionsGET(t *testing.T) {
 
 			ts := httptest.NewServer(f.routes())
 			ts.Config.BaseContext = func(net.Listener) context.Context {
-				return ContextWithLogger(context.Background(), f.logger)
+				ctx := context.Background()
+				ctx = ContextWithLogger(ctx, f.logger)
+				ctx = ContextWithDBClient(ctx, f.dbClient)
+				return ctx
 			}
 
 			rs, err := ts.Client().Get(ts.URL + "/subscriptions/00000000-0000-0000-0000-000000000000?api-version=2.0")
@@ -224,7 +227,10 @@ func TestSubscriptionsPUT(t *testing.T) {
 
 			ts := httptest.NewServer(f.routes())
 			ts.Config.BaseContext = func(net.Listener) context.Context {
-				return ContextWithLogger(context.Background(), f.logger)
+				ctx := context.Background()
+				ctx = ContextWithLogger(ctx, f.logger)
+				ctx = ContextWithDBClient(ctx, f.dbClient)
+				return ctx
 			}
 
 			req, err := http.NewRequest(http.MethodPut, ts.URL+test.urlPath, bytes.NewReader(body))

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -96,7 +96,7 @@ func TestSubscriptionsGET(t *testing.T) {
 			}
 
 			if test.subDoc != nil {
-				err := f.dbClient.SetSubscriptionDoc(context.TODO(), test.subDoc)
+				err := f.dbClient.CreateSubscriptionDoc(context.TODO(), test.subDoc)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -216,7 +216,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 			}
 
 			if test.subDoc != nil {
-				err := f.dbClient.SetSubscriptionDoc(context.TODO(), test.subDoc)
+				err := f.dbClient.CreateSubscriptionDoc(context.TODO(), test.subDoc)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/frontend/pkg/frontend/middleware_locksubscription.go
+++ b/frontend/pkg/frontend/middleware_locksubscription.go
@@ -1,0 +1,87 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/ARO-HCP/frontend/pkg/config"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+)
+
+func MiddlewareLockSubscription(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	var lockClient *database.LockClient
+
+	ctx := r.Context()
+
+	logger, err := LoggerFromContext(ctx)
+	if err != nil {
+		config.DefaultLogger().Error(err.Error())
+		arm.WriteInternalServerError(w)
+		return
+	}
+
+	dbClient, err := DBClientFromContext(ctx)
+	if err != nil {
+		logger.Error(err.Error())
+		arm.WriteInternalServerError(w)
+		return
+	}
+
+	subscriptionID := r.PathValue(PathSegmentSubscriptionID)
+
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+		// These methods are read-only and don't require locking.
+	default:
+		lockClient = dbClient.GetLockClient()
+	}
+
+	if lockClient == nil {
+		next(w, r)
+	} else {
+		// Wait for the default TTL to acquire lock.
+		timeout := lockClient.GetDefaultTimeToLive()
+		lock, err := lockClient.AcquireLock(ctx, subscriptionID, &timeout)
+		if err != nil {
+			message := fmt.Sprintf("Failed to acquire lock for subscription '%s': ", subscriptionID)
+			if errors.Is(err, context.DeadlineExceeded) {
+				message += "timed out"
+				lockClient.SetRetryAfterHeader(w.Header())
+				arm.WriteError(
+					w, http.StatusConflict, arm.CloudErrorCodeConflict,
+					"/subscriptions/"+subscriptionID, "%s", message)
+			} else {
+				message += err.Error()
+				arm.WriteInternalServerError(w)
+			}
+			logger.Error(message)
+			return
+		}
+		logger.Info(fmt.Sprintf("Acquired lock for subscription '%s'", subscriptionID))
+
+		// Hold the lock until the remaining handlers complete.
+		// If we lose the lock the context will be cancelled.
+		lockedCtx, stop := lockClient.HoldLock(ctx, lock)
+		r = r.WithContext(lockedCtx)
+
+		next(w, r)
+
+		lock = stop()
+		if lock != nil {
+			err = lockClient.ReleaseLock(ctx, lock)
+			if err == nil {
+				logger.Info(fmt.Sprintf("Released lock for subscription '%s'", subscriptionID))
+			} else {
+				// Failure here is non-fatal but still log the error.
+				// The lock's TTL ensures it will be released eventually.
+				logger.Error(fmt.Sprintf("Failed to release lock for subscription '%s': %v", subscriptionID, err))
+			}
+		}
+	}
+}

--- a/frontend/pkg/frontend/middleware_validatesubscription_test.go
+++ b/frontend/pkg/frontend/middleware_validatesubscription_test.go
@@ -157,7 +157,7 @@ func TestMiddlewareValidateSubscription(t *testing.T) {
 			dbClient := database.NewCache()
 
 			if tt.cachedState != "" {
-				if err := dbClient.SetSubscriptionDoc(context.Background(), &database.SubscriptionDocument{
+				if err := dbClient.CreateSubscriptionDoc(context.Background(), &database.SubscriptionDocument{
 					BaseDocument: database.BaseDocument{
 						ID: subscriptionId,
 					},

--- a/frontend/pkg/frontend/operations.go
+++ b/frontend/pkg/frontend/operations.go
@@ -104,7 +104,7 @@ func (f *Frontend) StartOperation(writer http.ResponseWriter, request *http.Requ
 	doc.OperationID = operationID
 	doc.NotificationURI = request.Header.Get(arm.HeaderNameAsyncNotificationURI)
 
-	err = f.dbClient.SetOperationDoc(ctx, doc)
+	err = f.dbClient.CreateOperationDoc(ctx, doc)
 	if err != nil {
 		return err
 	}

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -75,6 +75,7 @@ func (f *Frontend) routes() *MiddlewareMux {
 		MiddlewareResourceID,
 		MiddlewareLoggingPostMux,
 		MiddlewareValidateAPIVersion,
+		MiddlewareLockSubscription,
 		MiddlewareValidateSubscriptionState)
 	mux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
@@ -122,7 +123,8 @@ func (f *Frontend) routes() *MiddlewareMux {
 	// Subscription management endpoints
 	postMuxMiddleware = NewMiddleware(
 		MiddlewareResourceID,
-		MiddlewareLoggingPostMux)
+		MiddlewareLoggingPostMux,
+		MiddlewareLockSubscription)
 	mux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions),
 		postMuxMiddleware.HandlerFunc(f.ArmSubscriptionGet))

--- a/internal/api/arm/error.go
+++ b/internal/api/arm/error.go
@@ -20,6 +20,7 @@ const (
 	CloudErrorCodeInvalidResourceType    = "InvalidResourceType"
 	CloudErrorCodeMultipleErrorsOccurred = "MultipleErrorsOccurred"
 	CloudErrorCodeUnsupportedMediaType   = "UnsupportedMediaType"
+	CloudErrorCodeConflict               = "Conflict"
 	CloudErrorCodeNotFound               = "NotFound"
 	CloudErrorInvalidSubscriptionState   = "InvalidSubscriptionState"
 	CloudErrorCodeSubscriptionNotFound   = "SubscriptionNotFound"

--- a/internal/database/cache.go
+++ b/internal/database/cache.go
@@ -47,12 +47,23 @@ func (c *Cache) GetResourceDoc(ctx context.Context, resourceID *arm.ResourceID) 
 	return nil, ErrNotFound
 }
 
-func (c *Cache) SetResourceDoc(ctx context.Context, doc *ResourceDocument) error {
+func (c *Cache) CreateResourceDoc(ctx context.Context, doc *ResourceDocument) error {
 	// Make sure lookup keys are lowercase.
 	key := strings.ToLower(doc.Key.String())
 
 	c.resource[key] = doc
 	return nil
+}
+
+func (c *Cache) UpdateResourceDoc(ctx context.Context, resourceID *arm.ResourceID, callback func(*ResourceDocument) bool) (bool, error) {
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(resourceID.String())
+
+	if doc, ok := c.resource[key]; ok {
+		return callback(doc), nil
+	}
+
+	return false, ErrNotFound
 }
 
 func (c *Cache) DeleteResourceDoc(ctx context.Context, resourceID *arm.ResourceID) error {
@@ -91,7 +102,7 @@ func (c *Cache) GetOperationDoc(ctx context.Context, operationID string) (*Opera
 	return nil, ErrNotFound
 }
 
-func (c *Cache) SetOperationDoc(ctx context.Context, doc *OperationDocument) error {
+func (c *Cache) CreateOperationDoc(ctx context.Context, doc *OperationDocument) error {
 	// Make sure lookup keys are lowercase.
 	key := strings.ToLower(doc.ID)
 
@@ -118,10 +129,21 @@ func (c *Cache) GetSubscriptionDoc(ctx context.Context, subscriptionID string) (
 	return nil, ErrNotFound
 }
 
-func (c *Cache) SetSubscriptionDoc(ctx context.Context, doc *SubscriptionDocument) error {
+func (c *Cache) CreateSubscriptionDoc(ctx context.Context, doc *SubscriptionDocument) error {
 	// Make sure lookup keys are lowercase.
 	key := strings.ToLower(doc.ID)
 
 	c.subscription[key] = doc
 	return nil
+}
+
+func (c *Cache) UpdateSubscriptionDoc(ctx context.Context, subscriptionID string, callback func(*SubscriptionDocument) bool) (bool, error) {
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(subscriptionID)
+
+	if doc, ok := c.subscription[key]; ok {
+		return callback(doc), nil
+	}
+
+	return false, ErrNotFound
 }

--- a/internal/database/cache.go
+++ b/internal/database/cache.go
@@ -36,6 +36,10 @@ func (c *Cache) DBConnectionTest(ctx context.Context) error {
 	return nil
 }
 
+func (c *Cache) GetLockClient() *LockClient {
+	return nil
+}
+
 func (c *Cache) GetResourceDoc(ctx context.Context, resourceID *arm.ResourceID) (*ResourceDocument, error) {
 	// Make sure lookup keys are lowercase.
 	key := strings.ToLower(resourceID.String())

--- a/internal/database/lock.go
+++ b/internal/database/lock.go
@@ -1,0 +1,248 @@
+package database
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+// Copied from azcore/internal/shared/shared.go
+func Delay(ctx context.Context, delay time.Duration) error {
+	select {
+	case <-time.After(delay):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type LockClient struct {
+	name              string
+	containerClient   *azcosmos.ContainerClient
+	defaultTimeToLive int32
+}
+
+// lockDocument implements a global distributed lock.
+// Its contents should be opaque outside of LockClient.
+type lockDocument struct {
+	BaseDocument
+	Owner string `json:"owner,omitempty"`
+	TTL   int32  `json:"ttl,omitempty"`
+}
+
+// NewLockClient creates a LockClient around a ContainerClient. It attempts to
+// read container properties to extract a default TTL. If this fails or if the
+// container does not define a default TTL, the function returns an error.
+func NewLockClient(ctx context.Context, containerClient *azcosmos.ContainerClient) (*LockClient, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+
+	c := &LockClient{
+		name:            hostname,
+		containerClient: containerClient,
+	}
+
+	response, err := containerClient.Read(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.ContainerProperties != nil && response.ContainerProperties.DefaultTimeToLive != nil {
+		c.defaultTimeToLive = *response.ContainerProperties.DefaultTimeToLive
+	} else {
+		return nil, fmt.Errorf("Container '%s' does not have a default TTL", containerClient.ID())
+	}
+
+	return c, nil
+}
+
+// SetName overrides how a lock item identifies the owner. This is for
+// informational purposes only. LockClient uses the hostname by default.
+func (c *LockClient) SetName(name string) {
+	c.name = name
+}
+
+// GetDefaultTimeToLive returns the default time-to-live value of the
+// container as a time.Duration.
+func (c *LockClient) GetDefaultTimeToLive() time.Duration {
+	return time.Duration(c.defaultTimeToLive) * time.Second
+}
+
+// SetRetryAfterHeader sets a "Retry-After" header to the default TTL value.
+func (c *LockClient) SetRetryAfterHeader(header http.Header) {
+	header.Set("Retry-After", strconv.Itoa(int(c.defaultTimeToLive)))
+}
+
+// AcquireLock persistently tries to acquire a lock for the given ID. If a
+// timeout is provided, the function will cease after the timeout duration
+// and return a context.DeadlineExceeded error.
+func (c *LockClient) AcquireLock(ctx context.Context, id string, timeout *time.Duration) (*azcosmos.ItemResponse, error) {
+	var lock *azcosmos.ItemResponse
+
+	if timeout != nil {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	for lock == nil {
+		var err error
+
+		lock, err = c.TryAcquireLock(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if lock == nil {
+			// TTL values are in whole seconds,
+			// so wait one second before retrying.
+			err = Delay(ctx, time.Second)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return lock, nil
+}
+
+// TryAcquireLock tries once to acquire a lock for the given ID. If the lock
+// is already taken, it returns a nil azcosmos.ItemResponse and no error.
+func (c *LockClient) TryAcquireLock(ctx context.Context, id string) (*azcosmos.ItemResponse, error) {
+	doc := &lockDocument{
+		BaseDocument: BaseDocument{ID: id},
+		Owner:        c.name,
+		TTL:          c.defaultTimeToLive,
+	}
+
+	data, err := json.Marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	pk := azcosmos.NewPartitionKeyString(doc.ID)
+	options := &azcosmos.ItemOptions{
+		EnableContentResponseOnWrite: true,
+	}
+	response, err := c.containerClient.CreateItem(ctx, pk, data, options)
+	if isResponseError(err, http.StatusPreconditionFailed) {
+		return nil, nil // lock already acquired by someone else
+	} else if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+type StopHoldLock func() *azcosmos.ItemResponse
+
+// HoldLock tries to hold an acquired lock by renewing it periodically from a
+// goroutine until the returned stop function is called. The function also returns
+// a new context which is cancelled if the lock is lost or some other error occurs.
+// The stop function terminates the goroutine and returns the current lock, or nil
+// if the lock was lost.
+func (c *LockClient) HoldLock(ctx context.Context, item *azcosmos.ItemResponse) (cancelCtx context.Context, stop StopHoldLock) {
+	cancelCtx, cancelCause := context.WithCancelCause(ctx)
+	done := make(chan struct{})
+
+	stop = func() *azcosmos.ItemResponse {
+		cancelCause(nil)
+		<-done // wait for goroutine to finish
+		return item
+	}
+
+	go func() {
+		defer close(done)
+		for {
+			var doc *lockDocument
+
+			err := json.Unmarshal(item.Value, &doc)
+			if err != nil {
+				cancelCause(fmt.Errorf("Failed to unmarshal lock: %w", err))
+				return
+			}
+
+			// Aim to renew one second before TTL expires.
+			timeToRenew := time.Unix(int64(doc.Timestamp), 0)
+			if doc.TTL > 0 {
+				timeToRenew = timeToRenew.Add(time.Duration(doc.TTL-1) * time.Second)
+			}
+
+			select {
+			case <-time.After(time.Until(timeToRenew)):
+				item, err = c.RenewLock(cancelCtx, item)
+				if err != nil {
+					cancelCause(fmt.Errorf("Failed to renew lock: %w", err))
+					return
+				}
+				if item == nil {
+					// We lost the lock, cancel the context.
+					cancelCause(nil)
+					return
+				}
+			case <-cancelCtx.Done():
+				return
+			}
+		}
+	}()
+
+	return
+}
+
+// RenewLock attempts to renew an acquired lock. If successful it returns a new lock.
+// If the lock was somehow lost, it returns a nil azcosmos.ItemResponse and no error.
+func (c *LockClient) RenewLock(ctx context.Context, item *azcosmos.ItemResponse) (*azcosmos.ItemResponse, error) {
+	var doc *lockDocument
+
+	err := json.Unmarshal(item.Value, &doc)
+	if err != nil {
+		return nil, err
+	}
+
+	pk := azcosmos.NewPartitionKeyString(doc.ID)
+	options := &azcosmos.ItemOptions{
+		EnableContentResponseOnWrite: true,
+		IfMatchEtag:                  &item.Response.ETag,
+	}
+	response, err := c.containerClient.UpsertItem(ctx, pk, item.Value, options)
+	if isResponseError(err, http.StatusPreconditionFailed) {
+		return nil, nil // lock already acquired by someone else
+	} else if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// ReleaseLock attempts to release an acquired lock. Errors should be logged but not
+// treated as fatal, since the container item's TTL value guarantees that it will be
+// released eventually.
+func (c *LockClient) ReleaseLock(ctx context.Context, item *azcosmos.ItemResponse) error {
+	var doc *lockDocument
+
+	err := json.Unmarshal(item.Value, &doc)
+	if err != nil {
+		return err
+	}
+
+	pk := azcosmos.NewPartitionKeyString(doc.ID)
+	options := &azcosmos.ItemOptions{
+		IfMatchEtag: &item.Response.ETag,
+	}
+	_, err = c.containerClient.DeleteItem(ctx, pk, doc.ID, options)
+	if isResponseError(err, http.StatusPreconditionFailed) {
+		return nil // lock already acquired by someone else
+	}
+
+	return err
+}


### PR DESCRIPTION
### What this PR does

In anticipation of running [multiple RP replicas](https://issues.redhat.com/browse/ARO-9674) as well as introducing a [polling backend for asynchronous operations](https://issues.redhat.com/browse/ARO-8598), we need to add concurrency controls around our Cosmos DB containers to ensure data integrity in the presence of multiple writers.

This PR takes a two-fold approach:

1. The first and simplest approach is to utilize [Optimistic Concurrency Control](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/database-transactions-optimistic-concurrency#optimistic-concurrency-control) when updating container items by setting the [IfMatchEtag option](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos#ItemOptions) and allowing for retries in the event of a **412 Precondition Failed** error.
   (covered in the 1st commit)

3. The second approach is to adapt Brian Dunnington[^1]'s [Cloud Distributed Lock pattern for Cosmos DB](https://github.com/briandunnington/CloudDistributedLock/) (see also [this YouTube video](https://www.youtube.com/live/Hreew-l5rCQ?si=F1DkRXHu3Tq4zeEk) of Brian demoing the pattern) to protect critical sections in request handlers. A critical section that requires protection through locks would involve the sequence of checking Cosmos for ongoing asynchronous operations that would block the current request, initiating a create, update, or delete operation through Cluster Service, and writing operation data, resource tags and system metadata to Cosmos.

   The [GitHub link](https://github.com/briandunnington/CloudDistributedLock/) explains the pattern best but I'll try to summarize:

   The pattern is somewhat similar to the leasing pattern ARO Classic uses to protect cluster documents, where all the data that needs protection is in one document and the lock (or lease) is built into the same document as the data.  The difference here is the lock is its own document, and leverages two built-in features of Cosmos:

   1. The lock container sets a short default time-to-live (TTL) as a fail safe in case the RP crashes or otherwise fails to release a lock.  Locks are only held briefly -- like a mutex -- so the TTL should only be a few seconds.
   1. Once a lock is acquired by creating a new container item, the RP uses [Optimistic Concurrency Control](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/database-transactions-optimistic-concurrency#optimistic-concurrency-control) to renew or release (delete) the lock.  Because of the short TTL, the RP must periodically renew the lock if it needs to hold it for longer periods.  This is done from a goroutine.

   For our purposes, we introduce a new Cosmos container named "Locks" and the IDs for items in this container are subscription IDs. So effectively the entire subscription is locked for the duration of a PUT, PATCH, or DELETE request (GET requests will not use locking).  If a PUT, PATCH, or DELETE request arrives while the subscription is locked, the caller gets a **409 Conflict** response with a **Retry-After** header set to the container's TTL value.

[^1]: Brian is a principal software engineering manager at Microsoft.

Jira: [ARO-10822 - Add concurrency controls around Cosmos DB](https://issues.redhat.com/browse/ARO-10822)
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

I think this is working well enough to merge, but it's not foolproof.

Because this is a cloud environment, weird things can happen and the RP can potentially lose the subscription lock it acquired.  This should be rare but is still possible.  When the lock is lost, the `context.Context` passed to the request handler is cancelled.  Depending on when the context is cancelled, the RP can potentially end up in an inconsistent state.

For example, suppose Cluster Service is taking a really long time to respond to a create cluster request.  During that time, the RP somehow loses its subscription lock and the context is cancelled.  Cluster Service eventually returns a response, but the context cancellation prevents the RP from recording the new cluster in Cosmos DB.
