### PR TITLE
database: Fix error code check in LockClient.TryAcquireLock

### DIFF
--- a/internal/database/lock.go
+++ b/internal/database/lock.go
@@ -135,7 +135,7 @@ func (c *LockClient) TryAcquireLock(ctx context.Context, id string) (*azcosmos.I
 		EnableContentResponseOnWrite: true,
 	}
 	response, err := c.containerClient.CreateItem(ctx, pk, data, options)
-	if isResponseError(err, http.StatusPreconditionFailed) {
+	if isResponseError(err, http.StatusConflict) {
 		return nil, nil // lock already acquired by someone else
 	} else if err != nil {
 		return nil, err


### PR DESCRIPTION
### What this PR does

Already found a boo boo in `database.LockClient`...

When attempting to create an item with an ID that already exists, Cosmos responds with **409 Conflict** not **412 Precondition Failed**.

Jira: Additional testing of [ARO-10822 - Add concurrency controls around Cosmos DB](https://issues.redhat.com/browse/ARO-10822)
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
