### PR TITLE
Hypershift operator/external-dns prometheus scrape config

### DIFF
--- a/hypershiftoperator/deploy/base/podmonitor-external-dns.yaml
+++ b/hypershiftoperator/deploy/base/podmonitor-external-dns.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1
+apiVersion: azmonitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   creationTimestamp: null

--- a/hypershiftoperator/deploy/base/servicemonitor-operator.yaml
+++ b/hypershiftoperator/deploy/base/servicemonitor-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1
+apiVersion: azmonitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
### What this PR does
Updates external-dns PodMonitor and hypershift operator ServiceMonitor so Azure Managed Prometheus can scrape these metrics.

Jira: https://issues.redhat.com/browse/ARO-9704
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
