### PR TITLE
New Go module "github.com/Azure/ARO-HCP/backend"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,15 @@ updates:
           - 'github.com/Azure/azure-sdk-for-go/*'
     open-pull-requests-limit: 3
   - package-ecosystem: gomod
+    directory: /backend
+    schedule:
+      interval: 'weekly'
+    groups:
+      azure-sdk-for-go:
+        patterns:
+          - 'github.com/Azure/azure-sdk-for-go/*'
+    open-pull-requests-limit: 3
+  - package-ecosystem: gomod
     directory: /internal
     schedule:
       interval: 'weekly'

--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -18,6 +18,7 @@
         - 'dev-infrastructure/**/*.bicepparam'
         - 'dev-infrastructure/configurations/*'
         - 'frontend/**'
+        - 'backend/**'
         - 'cluster-service/**'
         - 'internal/**'
         - 'maestro/**'
@@ -275,6 +276,36 @@
             az acr login --name ${ARO_HCP_IMAGE_ACR}
             make push
 
+    build_push_backend:
+      permissions:
+        id-token: 'write'
+        contents: 'read'
+      runs-on: 'ubuntu-latest'
+      steps:
+        - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+          with:
+            fetch-depth: 1
+
+        - name: Build backend container image
+          run: |
+            cd backend/
+            make image
+
+        - name: 'Az CLI login'
+          if: github.event.pull_request.merged == true
+          uses: azure/login@v2
+          with:
+            client-id: ${{ secrets.AZURE_CLIENT_ID }}
+            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+        - name: Push backend container image
+          if: github.event.pull_request.merged == true
+          run: |
+            cd backend/
+            az acr login --name ${ARO_HCP_IMAGE_ACR}
+            make push
+
     build_push_ocmirror:
       permissions:
         id-token: 'write'
@@ -343,6 +374,7 @@
       if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
       needs:
         - build_push_frontend
+        - build_push_backend
         - build_push_imagesync
         - build_push_ocmirror
         - deploy_service_cluster_rg
@@ -407,6 +439,11 @@
         - name: 'Deploy Frontend'
           run: |
             cd frontend/
+            make deploy
+
+        - name: 'Deploy Backend'
+          run: |
+            cd backend/
             make deploy
 
         - name: 'Deploy Cluster Service'

--- a/.github/workflows/cs-integration-env-cd.yml
+++ b/.github/workflows/cs-integration-env-cd.yml
@@ -18,6 +18,7 @@
         - 'dev-infrastructure/**/*.bicepparam'
         - 'dev-infrastructure/configurations/*'
         - 'frontend/**'
+        - 'backend/**'
         - 'cluster-service/**'
         - 'internal/**'
         - 'maestro/**'
@@ -284,6 +285,11 @@
         - name: 'Deploy Frontend'
           run: |
             cd frontend/
+            make deploy
+
+        - name: 'Deploy Backend'
+          run: |
+            cd backend/
             make deploy
 
         - name: 'Deploy Maestro Server'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/*.swp
 aro-hcp-frontend
+aro-hcp-backend
 localsecrets
 secrets
 node_modules
@@ -11,5 +12,5 @@ node_modules
 .DS_Store
 .idea
 env
-frontend/archive.tar.gz
+*/archive.tar.gz
 tooling/bin

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,5 +3,6 @@
 /image-sync/ @bennerv @geoberle @janboll @jmelis @jonathan34c @mjlshen @niontive @nwnt @ulrichschlueter @weinong @whober0521
 /api/ @bennerv @mbarnes @mjlshen
 /frontend/ @bennerv @mbarnes @mjlshen
+/backend/ @bennerv @mbarnes @mjlshen
 /internal/ @bennerv @mbarnes @mjlshen
 /tooling/ @bennerv @geoberle @janboll @weinong @whober0521

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,14 @@
+# Builder image installs tools needed to build aro-hcp-backend
+FROM --platform=${TARGETPLATFORM:-linux/amd64} mcr.microsoft.com/oss/go/microsoft/golang:1.23-fips-cbl-mariner2.0@sha256:c5685a5169d83829545f22c87e0fec84cfc075cbcfc57e0d744ef27b05923093 as builder
+WORKDIR /app
+ADD archive.tar.gz .
+# https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips#build-option-to-require-fips-mode
+ENV CGO_ENABLED=1 GOFLAGS='-tags=requirefips'
+RUN cd backend && make backend
+
+
+# Deployment image copies aro-hcp-backend from builder image
+FROM --platform=${TARGETPLATFORM:-linux/amd64} mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot@sha256:92275882d3b3f18da5ed51ab0b3bf0c5e5255390fe86f00414fca5007c377a11
+WORKDIR /
+COPY --from=builder /app/backend/aro-hcp-backend .
+ENTRYPOINT ["/aro-hcp-backend"]

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -33,4 +33,27 @@ image:
 push: image
 	docker push ${ARO_HCP_BACKEND_IMAGE}
 
-.PHONY: backend run clean image push
+deploy:
+	BACKEND_MI_CLIENT_ID=$(shell az identity show \
+			-g ${RESOURCEGROUP} \
+			-n backend \
+			--query clientId);\
+	DB_NAME=$(shell az cosmosdb list -g ${RESOURCEGROUP} | jq -r '.[].name') DB_NAME=$${DB_NAME:-"none"};\
+	ISTO_VERSION=$(shell az aks list --query "[?tags.clusterType == 'svc-cluster' && starts_with(resourceGroup, '${RESOURCEGROUP}')].serviceMeshProfile.istio.revisions[-1]" -o tsv) && \
+	kubectl create namespace aro-hcp --dry-run=client -o json | kubectl apply -f - && \
+	kubectl label namespace aro-hcp "istio.io/rev=$${ISTO_VERSION}" --overwrite=true && \
+	helm upgrade --install aro-hcp-backend-dev \
+		deploy/helm/backend/ \
+		--set configMap.databaseName=$${DB_NAME} \
+		--set configMap.databaseUrl="https://$${DB_NAME}.documents.azure.com:443/" \
+		--set configMap.backendMiClientId="$${BACKEND_MI_CLIENT_ID}" \
+		--set serviceAccount.workloadIdentityClientId="$${BACKEND_MI_CLIENT_ID}" \
+		--set configMap.currentVersion=${ARO_HCP_BACKEND_IMAGE} \
+		--set configMap.location=${LOCATION} \
+		--set deployment.imageName=${ARO_HCP_BACKEND_IMAGE} \
+		--namespace aro-hcp
+
+undeploy:
+	helm uninstall aro-hcp-backend-dev --namespace aro-hcp
+
+.PHONY: backend run clean image push deploy undeploy

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,36 @@
+SHELL = /bin/bash
+
+# for deploying backend into private aks cluster via invoke command
+# these values must be set
+AKSCONFIG ?= svc-cluster
+CONFIG_PROFILE ?= dev
+include ../dev-infrastructure/configurations/$(CONFIG_PROFILE).mk
+
+COMMIT = $(shell git rev-parse --short=7 HEAD)
+ARO_HCP_BASE_IMAGE ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
+ARO_HCP_BACKEND_IMAGE ?= $(ARO_HCP_BASE_IMAGE)/arohcpbackend:$(COMMIT)
+CLUSTER_NAME ?=
+DEPLOYMENTNAME=$(RESOURCEGROUP)
+
+# dev-infrastructure defines this as REGION
+LOCATION ?= ${REGION}
+
+backend:
+	go build -o aro-hcp-backend .
+
+run:
+	./aro-hcp-backend --location ${LOCATION} \
+		--clusters-service-url http://localhost:8000
+
+clean:
+	rm -f aro-hcp-backend
+
+image:
+	pushd .. && git archive --output backend/archive.tar.gz HEAD && popd
+	docker build -f "./Dockerfile" -t ${ARO_HCP_BACKEND_IMAGE} .
+	rm -f archive.tar.gz
+
+push: image
+	docker push ${ARO_HCP_BACKEND_IMAGE}
+
+.PHONY: backend run clean image push

--- a/backend/deploy/helm/backend/Chart.yaml
+++ b/backend/deploy/helm/backend/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: backend
+description: A Helm chart for RP Backend
+type: application
+
+version: 0.1.0
+appVersion: "1.0.0"

--- a/backend/deploy/helm/backend/templates/allow-metrics.authorizationpolicy.yaml
+++ b/backend/deploy/helm/backend/templates/allow-metrics.authorizationpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: allow-metrics-frontend
+  name: allow-metrics-backend
 spec:
   action: "ALLOW"
   rules:
@@ -12,4 +12,4 @@ spec:
           ports: ["8081"]
   selector:
     matchLabels:
-      app: "aro-hcp-frontend"
+      app: "aro-hcp-backend"

--- a/backend/deploy/helm/backend/templates/backend.configmap.yaml
+++ b/backend/deploy/helm/backend/templates/backend.configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend-config
+data:
+  DB_NAME: '{{ .Values.configMap.databaseName }}'
+  DB_URL: '{{ .Values.configMap.databaseUrl }}'
+  BACKEND_MI_CLIENT_ID: '{{ .Values.configMap.backendMiClientId }}'
+  CURRENT_VERSION: '{{ .Values.configMap.currentVersion }}'
+  LOCATION: '{{ .Values.configMap.location }}'

--- a/backend/deploy/helm/backend/templates/backend.deployment.yaml
+++ b/backend/deploy/helm/backend/templates/backend.deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: aro-hcp-backend
+  name: aro-hcp-backend
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: aro-hcp-backend
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: aro-hcp-backend
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: backend
+      containers:
+        - name: aro-hcp-backend
+          image: '{{ .Values.deployment.imageName }}'
+          imagePullPolicy: Always
+          args: ["--clusters-service-url", "http://clusters-service.cluster-service.svc.cluster.local:8000"]
+          env:
+          - name: DB_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: backend-config
+                key: DB_NAME
+          - name: DB_URL
+            valueFrom:
+              configMapKeyRef:
+                name: backend-config
+                key: DB_URL
+          - name: LOCATION
+            valueFrom:
+              configMapKeyRef:
+                name: backend-config
+                key: LOCATION
+          ports:
+            - containerPort: 8081
+              protocol: TCP
+          resources:
+            limits:
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 500Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/backend/deploy/helm/backend/templates/metrics.service.yaml
+++ b/backend/deploy/helm/backend/templates/metrics.service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: aro-hcp-backend
+    port: metrics
+  name: aro-hcp-backend-metrics
+spec:
+  ports:
+  - port: 8081
+    protocol: TCP
+    targetPort: 8081
+    name: metrics
+  selector:
+    app: aro-hcp-backend

--- a/backend/deploy/helm/backend/templates/serviceaccount.yaml
+++ b/backend/deploy/helm/backend/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    azure.workload.identity/client-id: '{{ .Values.serviceAccount.workloadIdentityClientId }}'
+  name: backend

--- a/backend/deploy/helm/backend/templates/servicemonitor.yaml
+++ b/backend/deploy/helm/backend/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-backend-service-monitor
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - aro-hcp
+  selector:
+    matchLabels:
+      app: aro-hcp-backend
+      port: metrics

--- a/backend/deploy/helm/backend/values.yaml
+++ b/backend/deploy/helm/backend/values.yaml
@@ -1,0 +1,10 @@
+configMap:
+  location: ""
+  currentVersion: ""
+  backendMiClientId: ""
+  databaseUrl: ""
+  databaseName: ""
+deployment:
+  imageName: ""
+serviceAccount:
+  workloadIdentityClientId: ""

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,11 @@
+module github.com/Azure/ARO-HCP/backend
+
+go 1.23.0
+
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.1.0
+	github.com/openshift-online/ocm-sdk-go v0.1.444
+	github.com/spf13/cobra v1.8.1
+)
+
+replace github.com/Azure/ARO-HCP/internal => ../internal

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,91 @@
+package main
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime/debug"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	argLocation           string
+	argCosmosName         string
+	argCosmosURL          string
+	argClustersServiceURL string
+	argInsecure           bool
+
+	processName = filepath.Base(os.Args[0])
+
+	rootCmd = &cobra.Command{
+		Use:   processName,
+		Args:  cobra.NoArgs,
+		Short: "ARO HCP Backend",
+		Long: fmt.Sprintf(`ARO HCP Backend
+
+	The command runs the ARO HCP Backend. It executes background processing that
+	communicates with Clusters Service and CosmosDB.
+
+	# Run ARO HCP Backend locally to connect to a local Clusters Service at http://localhost:8000
+	%s --cosmos-name ${DB_NAME} --cosmos-url ${DB_URL} --location ${LOCATION} \
+		--clusters-service-url "http://localhost:8000"
+`, processName),
+		Version:       "unknown", // overridden by build info below
+		RunE:          Run,
+		SilenceErrors: true, // errors are printed after Execute
+	}
+)
+
+func init() {
+	rootCmd.SetErrPrefix(rootCmd.Short + " error:")
+
+	rootCmd.Flags().StringVar(&argLocation, "location", os.Getenv("LOCATION"), "Azure location")
+	rootCmd.Flags().StringVar(&argCosmosName, "cosmos-name", os.Getenv("DB_NAME"), "Cosmos database name")
+	rootCmd.Flags().StringVar(&argCosmosURL, "cosmos-url", os.Getenv("DB_URL"), "Cosmos database URL")
+	rootCmd.Flags().StringVar(&argClustersServiceURL, "clusters-service-url", "https://api.openshift.com", "URL of the OCM API gateway")
+	rootCmd.Flags().BoolVar(&argInsecure, "insecure", false, "Skip validating TLS for clusters-service")
+
+	rootCmd.MarkFlagsRequiredTogether("cosmos-name", "cosmos-url")
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				rootCmd.Version = setting.Value
+				break
+			}
+		}
+	}
+}
+
+func Run(cmd *cobra.Command, args []string) error {
+	handler := slog.NewJSONHandler(os.Stdout, nil)
+	logger := slog.New(handler)
+
+	logger.Info(fmt.Sprintf("%s (%s) started", cmd.Short, cmd.Version))
+
+	stop := make(chan struct{})
+	signalChannel := make(chan os.Signal, 1)
+	signal.Notify(signalChannel, syscall.SIGINT, syscall.SIGTERM)
+
+	sig := <-signalChannel
+	logger.Info(fmt.Sprintf("caught %s signal", sig))
+	close(stop)
+
+	logger.Info(fmt.Sprintf("%s (%s) stopped", cmd.Short, cmd.Version))
+
+	return nil
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		rootCmd.PrintErrln(rootCmd.ErrPrefix(), err.Error())
+		os.Exit(1)
+	}
+}

--- a/cluster-service/deploy/istio.yml
+++ b/cluster-service/deploy/istio.yml
@@ -45,7 +45,9 @@ spec:
   rules:
     - from:
       - source:
-          principals: ["cluster.local/ns/aro-hcp/sa/frontend"]
+          principals:
+            - "cluster.local/ns/aro-hcp/sa/frontend"
+            - "cluster.local/ns/aro-hcp/sa/backend"
       to:
       - operation:
           ports:

--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -179,10 +179,17 @@ Deploy CS:
 
 To validate, have a look at the `cluster-service` namespace.
 
-### Frontend
+### Resource Provider
+
+The ARO-HCP resource provider consists of independent frontend and backend components.
 
   ```bash
   cd frontend/
+  make deploy
+  ```
+
+  ```bash
+  cd backend/
   make deploy
   ```
 

--- a/dev-infrastructure/templates/dev-acr.bicep
+++ b/dev-infrastructure/templates/dev-acr.bicep
@@ -69,6 +69,9 @@ steps:
   - cmd: acr purge --filter "arohcpfrontend:.*" --keep 3 --ago 7d
     disableWorkingDirectoryOverride: true
     timeout: 3600
+  - cmd: acr purge --filter "arohcpbackend:.*" --keep 3 --ago 7d
+    disableWorkingDirectoryOverride: true
+    timeout: 3600
 ''')
       type: 'EncodedTask'
     }

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -158,6 +158,11 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
         namespace: 'aro-hcp'
         serviceAccountName: 'frontend'
       }
+      backend_wi: {
+        uamiName: 'backend'
+        namespace: 'aro-hcp'
+        serviceAccountName: 'backend'
+      }
       maestro_wi: {
         uamiName: 'maestro-server'
         namespace: 'maestro'
@@ -181,6 +186,7 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
 
 output aksClusterName string = svcCluster.outputs.aksClusterName
 var frontendMI = filter(svcCluster.outputs.userAssignedIdentities, id => id.uamiName == 'frontend')[0]
+var backendMI = filter(svcCluster.outputs.userAssignedIdentities, id => id.uamiName == 'backend')[0]
 
 module rpCosmosDb '../modules/rp-cosmos.bicep' = if (deployFrontendCosmos) {
   name: 'rp_cosmos_db'
@@ -190,8 +196,7 @@ module rpCosmosDb '../modules/rp-cosmos.bicep' = if (deployFrontendCosmos) {
     aksNodeSubnetId: svcCluster.outputs.aksNodeSubnetId
     vnetId: svcCluster.outputs.aksVnetId
     disableLocalAuth: disableLocalAuth
-    userAssignedMI: frontendMI.uamiID
-    uamiPrincipalId: frontendMI.uamiPrincipalID
+    userAssignedMIs: [frontendMI, backendMI]
   }
 }
 

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -47,7 +47,7 @@ deploy:
 	ISTO_VERSION=$(shell az aks list --query "[?tags.clusterType == 'svc-cluster' && starts_with(resourceGroup, '${RESOURCEGROUP}')].serviceMeshProfile.istio.revisions[-1]" -o tsv) && \
 	kubectl create namespace aro-hcp --dry-run=client -o json | kubectl apply -f - && \
 	kubectl label namespace aro-hcp "istio.io/rev=$${ISTO_VERSION}" --overwrite=true && \
-	helm upgrade --install aro-hcp-dev \
+	helm upgrade --install aro-hcp-frontend-dev \
 		deploy/helm/frontend/ \
 		--set configMap.databaseName=$${DB_NAME} \
 		--set configMap.databaseUrl="https://$${DB_NAME}.documents.azure.com:443/" \
@@ -59,7 +59,7 @@ deploy:
 		--namespace aro-hcp
 
 undeploy:
-	helm uninstall aro-hcp-dev --namespace aro-hcp
+	helm uninstall aro-hcp-frontend-dev --namespace aro-hcp
 
 smoke-tests:
 	go test -v -count 1 ./utils/frontend_smoke_test.go

--- a/go.work
+++ b/go.work
@@ -4,6 +4,7 @@ toolchain go1.23.0
 
 use (
 	./frontend
+	./backend
 	./internal
 	./tooling/image-sync
 	./tooling/templatize


### PR DESCRIPTION
### What this PR does

Establishes a new "**github.com/Azure/ARO-HCP/backend**" Go module and a new "**aro-hcp-backend**" deployment with a single-instance backend pod.  The purpose of the backend pod is to periodically update Cosmos DB containers owned by the ARO-HCP resource provider.

The pod itself currently does nothing; just sits and waits for a termination signal.  The purpose of this pull request is to get all the infrastructure crud in place: Helm chart, Bicep templates, GitHub workflows, dependabot, etc.

Jira: Related to [ARO-8598 - Prototype async op status notification mechanism for RP](https://issues.redhat.com/browse/ARO-8598)
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

- The deployment commit is largely a "copy-and-tweak" job.  I went through all the files in the repo that mention "frontend" and added equivalent files/items for "backend".  But be on the lookout for anything I missed.

- This adds a new workload identity named "backend".  I had to make some fairly significant changes to `rp-cosmos.bicep` to allow both "frontend" and "backend" workload identities to access Cosmos.

- I renamed the frontend's Helm release from `aro-hcp-dev` to `aro-hcp-frontend-dev`.  Not sure if this will disrupt the shared dev/int environments at all.  If it does, the old release name just needs to be uninstalled.

- I assume we'll eventually want to collect metrics from the backend so I added a metrics service, though nothing is currently listening on the metrics port.
