### PR TITLE
use unique name for azure monitor workspace

### DIFF
--- a/dev-infrastructure/configurations/dev-metrics.bicepparam
+++ b/dev-infrastructure/configurations/dev-metrics.bicepparam
@@ -1,5 +1,6 @@
 using '../modules/metrics/metrics.bicep'
 
+param monitorName = 'aro-hcp-monitor-${take(uniqueString(readEnvironmentVariable('CURRENTUSER', '')), 5)}'
 param grafanaName = take('aro-hcp-grafana-${uniqueString(readEnvironmentVariable('CURRENTUSER', ''))}', 23)
 param msiName = 'aro-hcp-metrics-msi-${take(uniqueString(readEnvironmentVariable('CURRENTUSER', '')), 5)}'
 

--- a/dev-infrastructure/configurations/mvp-metrics.bicepparam
+++ b/dev-infrastructure/configurations/mvp-metrics.bicepparam
@@ -1,5 +1,6 @@
 using '../modules/metrics/metrics.bicep'
 
+param monitorName = 'aro-hcp-monitor'
 param grafanaName = 'aro-hcp-grafana'
 param msiName = 'aro-hcp-metrics-msi'
 

--- a/dev-infrastructure/modules/metrics/metrics.bicep
+++ b/dev-infrastructure/modules/metrics/metrics.bicep
@@ -6,7 +6,10 @@ param currentUserId string = ''
 param globalResourceGroup string
 
 @description('Metrics global MSI name')
-param msiName string = take('metrics-admin-${uniqueString(currentUserId)}', 4)
+param msiName string = take('metrics-admin-${uniqueString(currentUserId)}', 20)
+
+@description('Metrics regional monitor name')
+param monitorName string = take('aro-hcp-monitor-${uniqueString(currentUserId)}', 23)
 
 @description('Metrics global Grafana name')
 param grafanaName string = take('aro-hcp-grafana-${uniqueString(currentUserId)}', 23)
@@ -25,11 +28,12 @@ module grafana 'br:arointacr.azurecr.io/grafana.bicep:metrics.20240814.1' = {
   }
 }
 
-module monitor 'br:arointacr.azurecr.io/monitor.bicep:metrics.20240814.2' = {
+module monitor 'br:arointacr.azurecr.io/monitor.bicep:monitor.20241004.1' = {
   name: 'monitor'
   params: {
     globalResourceGroup: globalResourceGroup
     msiName: msiName
+    monitorName: monitorName
     grafanaName: grafanaName
   }
   dependsOn: [


### PR DESCRIPTION
### What this PR does
Allows passing a unique name for azure managed workspace to ensure the Azure Monitor Workspace's managed resource group is unique within the subscription.
MVP environments Azure Monitor Workspace's name will remain the same
Personal development environments Azure Monitor Workspace's name will have a random suffix added.

Jira: https://issues.redhat.com/browse/ARO-10947
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
