### PR TITLE
oc mirror 4.17 version ranges for sync

### DIFF
--- a/image-sync/deployment/ocmirrorCronjob/templates/configmap.yaml
+++ b/image-sync/deployment/ocmirrorCronjob/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
             type: ocp
           - name: stable-4.17
             minVersion: 4.17.0
-            maxVersion: 4.17.3
+            maxVersion: 4.17.0
             type: ocp
         graph: true
       additionalImages:


### PR DESCRIPTION
### What this PR does

sync limits result in failed jobs if a max version is specified that does not exist yet.
let's sync only 4.17.0 for now

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
