### PR TITLE
feat: add workload identity pod label in CS Deployment

### DIFF
--- a/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
+++ b/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
@@ -405,6 +405,7 @@ objects:
       metadata:
         labels:
           app: clusters-service
+          azure.workload.identity/use: "true"
       spec:
         serviceAccount: clusters-service
         serviceAccountName: clusters-service


### PR DESCRIPTION
### What this PR does

Add the `azure.workload.identity/use` K8s label with the value `"true"` in the pod template spec of the CS Deployment. This label is one of the requirements to enable the Azure workload identity usage in the CS pod.

Important note: Even though we are adding the annotation to enable the CS workload identity, CS will still *not* leverage the workload identity. This is because in CS currently we are overriding the authentication to leverage other credentials through environment variables. Because of this, merging this MR should not have any effect for now. It is preparation work. In the near future we will do the following work:
* Removal of the credential setting through envvars in CS
* Update the CS image tag including the changes specified in the previous point. This will automatically make the change effective once CS is deployed with the new image.

Jira: https://issues.redhat.com/browse/ARO-10792
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
