### PR TITLE
Run ARO HCP frontend with 2 replicas

### DIFF
--- a/frontend/deploy/helm/frontend/templates/frontend.deployment.yaml
+++ b/frontend/deploy/helm/frontend/templates/frontend.deployment.yaml
@@ -6,15 +6,15 @@ metadata:
   name: aro-hcp-frontend
 spec:
   progressDeadlineSeconds: 600
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: aro-hcp-frontend
   strategy:
     rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
+      maxSurge: 50%
+      maxUnavailable: 50%
     type: RollingUpdate
   template:
     metadata:

--- a/frontend/deploy/helm/frontend/templates/frontend.poddisruptionbudget.yaml
+++ b/frontend/deploy/helm/frontend/templates/frontend.poddisruptionbudget.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: aro-hcp-frontend
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: aro-hcp-frontend


### PR DESCRIPTION
### What this PR does
With the completion of https://github.com/Azure/ARO-HCP/pull/680 this PR adds a PodDisruptionBudget to ensure 1 replica is running, but by default 2 replicas will be running at all times.

Jira: [ARO-9674](https://issues.redhat.com/browse/ARO-9674)