### PR TITLE
chore: update cs version to cf23767

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -37,7 +37,7 @@ deploy:
 	  -p IMAGE_REPOSITORY=app-sre/uhc-clusters-service \
 	  -p AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID=$${AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID} \
 	  -p FPA_CERT_NAME=${FPA_CERT_NAME} \
-	  -p IMAGE_TAG=b16f630 | oc apply -f -
+	  -p IMAGE_TAG=cf23767 | oc apply -f -
 
 deploy-integ:
 	AZURE_CS_MI_CLIENT_ID=$(shell az identity show \


### PR DESCRIPTION
### What this PR does
Updates Cluster Service version to [cf23767](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/tree/cf23767a4edeee7817948e01abd1f2eb947f8787).

This updates the OpenShift version from `4.16.0` -> `4.17.0`

Jira: [ARO-10660](https://issues.redhat.com/browse/ARO-10660), [ARO-10662](https://issues.redhat.com/browse/ARO-10662)
Link to demo recording: N/A

### Special notes for your reviewer
Please note that the following must be completed before this is merged:
- [ ] All `4.16` clusters on the DEV environment should be deleted
- [ ] `4.16` version should be deleted from the Cluster Service database

This is scheduled to be merged for Wednesday, Oct 16 2024. 
