### PR TITLE
Deploy ocp/svc ACRs to development mvp environment

### DIFF
--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -78,6 +78,21 @@
                 --template-file templates/dev-acr.bicep \
                 --parameters configurations/mvp-dev-acr.bicepparam
 
+              # OCP ACR
+              az deployment group create \
+                --name "dev-ocp-acr-${GITHUB_RUN_ID}" \
+                --resource-group ${GLOBAL_RESOURCEGROUP} \
+                --template-file templates/dev-acr.bicep \
+                --parameters configurations/mvp-dev-ocp-acr.bicepparam
+
+              # SVC ACR
+              az deployment group create \
+                --name "dev-svc-acr-${GITHUB_RUN_ID}" \
+                --resource-group ${GLOBAL_RESOURCEGROUP} \
+                --template-file templates/dev-acr.bicep \
+                --parameters configurations/mvp-dev-svc-acr.bicepparam
+
+
     deploy_image_sync_rg:
       if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
       permissions:

--- a/.github/workflows/bicep-what-if.yml
+++ b/.github/workflows/bicep-what-if.yml
@@ -65,6 +65,20 @@ jobs:
               --template-file templates/dev-acr.bicep \
               --parameters configurations/mvp-dev-acr.bicepparam
 
+            # OCP ACR
+            az deployment group what-if \
+              --name "dev-ocp-acr-${GITHUB_RUN_ID}" \
+              --resource-group ${GLOBAL_RESOURCEGROUP} \
+              --template-file templates/dev-acr.bicep \
+              --parameters configurations/mvp-dev-ocp-acr.bicepparam
+
+            # SVC ACR
+            az deployment group what-if \
+              --name "dev-svc-acr-${GITHUB_RUN_ID}" \
+              --resource-group ${GLOBAL_RESOURCEGROUP} \
+              --template-file templates/dev-acr.bicep \
+              --parameters configurations/mvp-dev-svc-acr.bicepparam
+
             # region infra
             az deployment group what-if \
               --name "region-${GITHUB_RUN_ID}" \

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -117,18 +117,6 @@ image-sync: imagesyncRg
 		--parameters \
 			configurations/mvp-image-sync.bicepparam
 
-acr: regionalRg
-	az deployment group create \
-		--name "$(DEPLOYMENTNAMEREGION)-ACR" \
-		--resource-group $(REGIONAL_RESOURCEGROUP) \
-		--template-file templates/dev-acr.bicep \
-		$(PROMPT_TO_CONFIRM) \
-		--parameters \
-			configurations/dev-acr.bicepparam \
-		--parameters \
-			acrName=$(REGIONAL_ACR_NAME)
-.PHONY: acr
-
 region: regionalRg
 	az deployment group create \
 		--name "$(DEPLOYMENTNAMEREGION)" \
@@ -141,7 +129,7 @@ region: regionalRg
 			currentUserId=$(CURRENTUSER)
 .PHONY: region
 
-cluster: rg cleanup-orphaned-rolebindings region acr
+cluster: rg cleanup-orphaned-rolebindings region
 ifndef AKSCONFIG
 	$(error "Must set AKSCONFIG")
 endif

--- a/dev-infrastructure/configurations/dev-acr.bicepparam
+++ b/dev-infrastructure/configurations/dev-acr.bicepparam
@@ -1,4 +1,0 @@
-using '../templates/dev-acr.bicep'
-
-param acrName = 'OVERWRITE VIA MAKEFILE'
-param acrSku = 'Standard'

--- a/dev-infrastructure/configurations/dev.mk
+++ b/dev-infrastructure/configurations/dev.mk
@@ -6,5 +6,4 @@ GLOBAL_RESOURCEGROUP ?= global
 IMAGE_SYNC_RESOURCEGROUP ?= aro-hcp-image-sync-$(USER)-$(REGION)
 IMAGE_SYNC_ENVIRONMENT ?= image-sync-env
 ARO_HCP_IMAGE_ACR ?= arohcpdev
-REGIONAL_ACR_NAME ?= arohcpdev$(shell echo $(CURRENTUSER) | sha256sum  | head -c 24)
 REPOSITORIES_TO_SYNC ?= '{registry.k8s.io/external-dns/external-dns,quay.io/acm-d/rhtap-hypershift-operator,quay.io/pstefans/controlplaneoperator,quay.io/app-sre/uhc-clusters-service}'

--- a/dev-infrastructure/configurations/mvp-dev-acr.bicepparam
+++ b/dev-infrastructure/configurations/mvp-dev-acr.bicepparam
@@ -9,9 +9,6 @@ param quayRepositoriesToCache = [
     ruleName: 'openshiftReleaseDev'
     sourceRepo: 'quay.io/openshift-release-dev/*'
     targetRepo: 'openshift-release-dev/*'
-    purgeFilter: 'quay.io/openshift-release-dev/.*:.*'
-    purgeAfter: '2d'
-    imagesToKeep: 1
     userIdentifier: 'quay-username'
     passwordIdentifier: 'quay-password'
   }
@@ -19,11 +16,29 @@ param quayRepositoriesToCache = [
     ruleName: 'csSandboxImages'
     sourceRepo: 'quay.io/app-sre/ocm-clusters-service-sandbox'
     targetRepo: 'app-sre/ocm-clusters-service-sandbox'
+    userIdentifier: 'quay-componentsync-username'
+    passwordIdentifier: 'quay-componentsync-password'
+  }
+]
+
+param purgeJobs = [
+  {
+    name: 'ocm-clusters-service-sandbox-purge'
     purgeFilter: 'quay.io/app-sre/ocm-clusters-service-sandbox:.*'
     purgeAfter: '2d'
     imagesToKeep: 1
-    userIdentifier: 'quay-componentsync-username'
-    passwordIdentifier: 'quay-componentsync-password'
+  }
+  {
+    name: 'openshift-release-dev-purge'
+    purgeFilter: 'quay.io/openshift-release-dev/.*:.*'
+    purgeAfter: '2d'
+    imagesToKeep: 1
+  }
+  {
+    name: 'arohcpfrontend-purge'
+    purgeFilter: 'arohcpfrontend:.*'
+    purgeAfter: '7d'
+    imagesToKeep: 3
   }
 ]
 

--- a/dev-infrastructure/configurations/mvp-dev-ocp-acr.bicepparam
+++ b/dev-infrastructure/configurations/mvp-dev-ocp-acr.bicepparam
@@ -1,0 +1,26 @@
+using '../templates/dev-acr.bicep'
+
+param acrName = 'arohcpocpdev'
+param acrSku = 'Premium'
+param location = 'westus3'
+
+param quayRepositoriesToCache = [
+  {
+    ruleName: 'openshiftReleaseDev'
+    sourceRepo: 'quay.io/openshift-release-dev/*'
+    targetRepo: 'openshift-release-dev/*'
+    userIdentifier: 'quay-username'
+    passwordIdentifier: 'quay-password'
+  }
+]
+
+param purgeJobs = [
+  {
+    name: 'openshift-release-dev-purge'
+    purgeFilter: 'quay.io/openshift-release-dev/.*:.*'
+    purgeAfter: '2d'
+    imagesToKeep: 1
+  }
+]
+
+param keyVaultName = 'aro-hcp-dev-global-kv'

--- a/dev-infrastructure/configurations/mvp-dev-svc-acr.bicepparam
+++ b/dev-infrastructure/configurations/mvp-dev-svc-acr.bicepparam
@@ -1,0 +1,32 @@
+using '../templates/dev-acr.bicep'
+
+param acrName = 'arohcpsvcdev'
+param acrSku = 'Premium'
+param location = 'westus3'
+
+param quayRepositoriesToCache = [
+  {
+    ruleName: 'csSandboxImages'
+    sourceRepo: 'quay.io/app-sre/ocm-clusters-service-sandbox'
+    targetRepo: 'app-sre/ocm-clusters-service-sandbox'
+    userIdentifier: 'quay-componentsync-username'
+    passwordIdentifier: 'quay-componentsync-password'
+  }
+]
+
+param purgeJobs = [
+  {
+    name: 'ocm-clusters-service-sandbox-purge'
+    purgeFilter: 'quay.io/app-sre/ocm-clusters-service-sandbox:.*'
+    purgeAfter: '2d'
+    imagesToKeep: 1
+  }
+  {
+    name: 'arohcpfrontend-purge'
+    purgeFilter: 'arohcpfrontend:.*'
+    purgeAfter: '7d'
+    imagesToKeep: 3
+  }
+]
+
+param keyVaultName = 'aro-hcp-dev-global-kv'

--- a/dev-infrastructure/modules/acr/acr.bicep
+++ b/dev-infrastructure/modules/acr/acr.bicep
@@ -1,0 +1,58 @@
+@minLength(5)
+@maxLength(40)
+@description('Globally unique name of the Azure Container Registry')
+param acrName string
+
+@description('Location of the registry.')
+param location string = resourceGroup().location
+
+@description('Service tier of the Azure Container Registry.')
+param acrSku string
+
+resource acrResource 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' = {
+  name: acrName
+  location: location
+  sku: {
+    name: acrSku
+  }
+  properties: {
+    adminUserEnabled: false
+    anonymousPullEnabled: false
+    // Premium-only feature
+    // https://azure.microsoft.com/en-us/blog/azure-container-registry-mitigating-data-exfiltration-with-dedicated-data-endpoints/
+    dataEndpointEnabled: false
+    encryption: {
+      // The naming of this field is misleading - it disables encryption with a customer-managed key.
+      // Data in Azure Container Registry is encrypted, just with an Azure-managed key.
+      // https://learn.microsoft.com/en-us/azure/container-registry/tutorial-enable-customer-managed-keys#show-encryption-status
+      status: 'disabled'
+    }
+    policies: {
+      azureADAuthenticationAsArmPolicy: {
+        status: 'enabled'
+      }
+      softDeletePolicy: {
+        retentionDays: 7
+        status: 'disabled'
+      }
+    }
+  }
+}
+
+// Assign the AcrPull Role to the ${acrName}-pull-identity
+var acrPullRoleId = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+
+resource acrMsi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: '${acrName}-pull-identity'
+  location: resourceGroup().location
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acrName, acrMsi.name, acrPullRoleId)
+  scope: acrResource
+  properties: {
+    principalId: acrMsi.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', acrPullRoleId)
+  }
+}


### PR DESCRIPTION
### What this PR does

- Refactors ACR deployment to use module and adds an identity for pulling images.
- Removes the personal development environment acr named `arohcpdev<randomstring>` as it is unused.  Personal development environments share the mvp registry.
- Deploys an "OCP" and "SVC" registry to the development environment.  The actual cutover to use these registries will be done in a follow up PR.

Jira: https://issues.redhat.com/browse/ARO-10905
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
