### PR TITLE
Increased OsDiskSize

### DIFF
--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -11,8 +11,8 @@ param systemAgentMinCount = 2
 param systemAgentMaxCount = 3
 param systemAgentVMSize = 'Standard_D2s_v3'
 param userAgentMinCount = 1
-param userAgentMaxCount = 3
-param userAgentVMSize = 'Standard_D2s_v3'
+param userAgentMaxCount = 6
+param userAgentVMSize = 'Standard_D4s_v3'
 param userAgentPoolAZCount = 3
 param persist = false
 

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -42,8 +42,8 @@ param dnsPrefix string = aksClusterName
 @description('Disk size (in GB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize.')
 @minValue(0)
 @maxValue(1023)
-param systemOsDiskSizeGB int = 32
-param userOsDiskSizeGB int = 32
+param systemOsDiskSizeGB int = 128
+param userOsDiskSizeGB int = 128
 
 param acrPullResourceGroups array = []
 


### PR DESCRIPTION
### What this PR does

During performance test on AKS, few nodes when they get freshly added(by autoscaler event) the node experiencing  `DiskPressure` within few minutes. Based on this [study](https://learn.microsoft.com/en-us/samples/azure-samples/aks-ephemeral-os-disk/aks-ephemeral-os-disk/), its recommended to have better disk size in general to have a performant worker node.

> The recommended configuration is using the osDiskType equal to Ephemeral, kubeletDiskType equal to OS, and the osDiskSize equal to the maximum VM cache or temporary storage size, depending on the VM series selected for the agent nodes.

So referring to [this](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dsv3-series?tabs=sizestoragelocal#sizes-in-series) table, increasing it to much larger size. 

`DiskPressure` was [seen](https://redhat-external.slack.com/archives/C075PHEFZKQ/p1728993565504419) on the CI cluster as well, so better increase it.

### Special notes for your reviewer

<!-- optional -->
