### PR TITLE
database: Store all Operations items in a single partition

### DIFF
--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -18,7 +18,6 @@ var containers = [
   {
     name: 'Operations'
     defaultTtl: 604800 // 7 days
-    partitionKeyPaths: ['/id']
   }
   {
     name: 'Resources'

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -64,6 +64,7 @@ const (
 type OperationDocument struct {
 	BaseDocument
 
+	PartitionKey string `json:"partitionKey,omitempty"`
 	// TenantID is the tenant ID of the client that requested the operation
 	TenantID string `json:"tenantId,omitempty"`
 	// ClientID is the object ID of the client that requested the operation
@@ -96,6 +97,7 @@ func NewOperationDocument(request OperationRequest) *OperationDocument {
 
 	return &OperationDocument{
 		BaseDocument:       newBaseDocument(),
+		PartitionKey:       operationsPartitionKey,
 		Request:            request,
 		StartTime:          now,
 		LastTransitionTime: now,


### PR DESCRIPTION
### What this PR does

The [azcosmos SDK ](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos) currently only supports single-partition queries, so there's no way to list all items in a container unless you know all the partition keys. The backend needs to list all items in the Operations container so to work around this limitation we keep all items in a single partition with a well-known name: "workaround".

Once [this SDK issue](https://github.com/Azure/azure-sdk-for-go/issues/18578) is fixed we could transition the Operations container to using subscription IDs as the partition key like other containers. The items are transient thanks to the container's default TTL, so `GetOperationDoc` would just need temporary fallback logic to check the "workaround" partition.

Jira: Blocking progress on [ARO-8598 - Prototype async op status notification mechanism for RP](https://issues.redhat.com/browse/ARO-8598)
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
