### PR TITLE
align VM instance types and disk sizes

### DIFF
--- a/dev-infrastructure/configurations/cs-integ-mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/cs-integ-mgmt-cluster.bicepparam
@@ -9,9 +9,11 @@ param aksKeyVaultName = 'aks-kv-cs-integ-mc-1'
 param systemAgentMinCount = 2
 param systemAgentMaxCount = 6
 param systemAgentVMSize = 'Standard_D2s_v3'
+param aksSystemOsDiskSizeGB = 32
 param userAgentMinCount = 1
 param userAgentMaxCount = 12
-param userAgentVMSize = 'Standard_D2s_v3'
+param userAgentVMSize = 'Standard_D2s_v3' // todo bump later
+param aksUserOsDiskSizeGB = 32 // todo bump later
 param userAgentPoolAZCount = 3
 param persist = true
 

--- a/dev-infrastructure/configurations/mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.bicepparam
@@ -10,9 +10,11 @@ param aksEtcdKVEnableSoftDelete = false
 param systemAgentMinCount = 2
 param systemAgentMaxCount = 3
 param systemAgentVMSize = 'Standard_D2s_v3'
+param aksSystemOsDiskSizeGB = 32
 param userAgentMinCount = 1
 param userAgentMaxCount = 6
 param userAgentVMSize = 'Standard_D4s_v3'
+param aksUserOsDiskSizeGB = 100
 param userAgentPoolAZCount = 3
 param persist = false
 

--- a/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-mgmt-cluster.bicepparam
@@ -9,9 +9,11 @@ param aksKeyVaultName = 'aks-kv-aro-hcp-dev-mc-1'
 param systemAgentMinCount = 2
 param systemAgentMaxCount = 3
 param systemAgentVMSize = 'Standard_D2s_v3'
+param aksSystemOsDiskSizeGB = 32
 param userAgentMinCount = 1
-param userAgentMaxCount = 3
-param userAgentVMSize = 'Standard_D2s_v3'
+param userAgentMaxCount = 9
+param userAgentVMSize = 'Standard_D4s_v3'
+param aksUserOsDiskSizeGB = 100
 param userAgentPoolAZCount = 3
 param persist = true
 

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -42,8 +42,8 @@ param dnsPrefix string = aksClusterName
 @description('Disk size (in GB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize.')
 @minValue(0)
 @maxValue(1023)
-param systemOsDiskSizeGB int = 128
-param userOsDiskSizeGB int = 128
+param systemOsDiskSizeGB int
+param userOsDiskSizeGB int
 
 param acrPullResourceGroups array = []
 

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -10,6 +10,12 @@ param currentUserId string
 @description('AKS cluster name')
 param aksClusterName string = 'aro-hcp-aks'
 
+@description('Disk size for the AKS system nodes')
+param aksSystemOsDiskSizeGB int
+
+@description('Disk size for the AKS user nodes')
+param aksUserOsDiskSizeGB int
+
 @description('Names of additional resource group contains ACRs the AKS cluster will get pull permissions on')
 param acrPullResourceGroups array = []
 
@@ -133,6 +139,8 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     systemAgentMinCount: systemAgentMinCount
     systemAgentMaxCount: systemAgentMaxCount
     systemAgentVMSize: systemAgentVMSize
+    systemOsDiskSizeGB: aksSystemOsDiskSizeGB
+    userOsDiskSizeGB: aksUserOsDiskSizeGB
   }
 }
 

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -10,6 +10,12 @@ param currentUserId string
 @description('AKS cluster name')
 param aksClusterName string
 
+@description('Disk size for the AKS system nodes')
+param aksSystemOsDiskSizeGB int = 32
+
+@description('Disk size for the AKS user nodes')
+param aksUserOsDiskSizeGB int = 32
+
 @description('Names of additional resource group contains ACRs the AKS cluster will get pull permissions on')
 param acrPullResourceGroups array = []
 
@@ -152,6 +158,8 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     subnetPrefix: subnetPrefix
     podSubnetPrefix: podSubnetPrefix
     clusterType: 'svc-cluster'
+    systemOsDiskSizeGB: aksSystemOsDiskSizeGB
+    userOsDiskSizeGB: aksUserOsDiskSizeGB
     workloadIdentities: items({
       frontend_wi: {
         uamiName: 'frontend'


### PR DESCRIPTION
not every VM instance type and disk size can be combined when using ephemeral disks. this PR provides a config that is known to work

follows up on https://github.com/Azure/ARO-HCP/pull/728

### What this PR does


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
