### PR TITLE
add serviceKeyVaultLocation bicep parameter

### DIFF
--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -27,6 +27,7 @@ param clusterServicePostgresPrivate = false
 
 param serviceKeyVaultName = 'aro-hcp-dev-svc-kv'
 param serviceKeyVaultResourceGroup = 'global'
+param serviceKeyVaultLocation = 'westus3'
 param serviceKeyVaultSoftDelete = true
 param serviceKeyVaultPrivate = false
 

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -93,6 +93,9 @@ param serviceKeyVaultName string
 @description('The name of the resourcegroup for the service keyvault')
 param serviceKeyVaultResourceGroup string = resourceGroup().name
 
+@description('The location of the resourcegroup for the service keyvault')
+param serviceKeyVaultLocation string = resourceGroup().location
+
 @description('Soft delete setting for service keyvault')
 param serviceKeyVaultSoftDelete bool = true
 
@@ -242,7 +245,7 @@ module serviceKeyVault '../modules/keyvault/keyvault.bicep' = {
   name: 'service-keyvault'
   scope: resourceGroup(serviceKeyVaultResourceGroup)
   params: {
-    location: location
+    location: serviceKeyVaultLocation
     keyVaultName: serviceKeyVaultName
     private: serviceKeyVaultPrivate
     enableSoftDelete: serviceKeyVaultSoftDelete


### PR DESCRIPTION
### What this PR does
Add a parameter to set the location of the shared serviceKeyvault.  This fixes resourceGroup/location conflicts as bicep tries to deploy the keyvault to the wrong location when deploying aks clusters to locations other than `westus3` and using the shared serviceKeyvault.
For personal development environments the location will point to westus3, for all other environments the location of the deployment resource group will be used.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
