### PR TITLE
Makefile: Explicitly name "all" as the default goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ SHELL = /bin/bash
 GOTAGS?='containers_image_openpgp'
 TOOLS_BIN_DIR := tooling/bin
 
+.DEFAULT_GOAL := all
+
 all: test lint
 
 # There is currently no convenient way to run tests against a whole Go workspace


### PR DESCRIPTION
### What this PR does

`.bingo/Variables.mk` is included before "all" is defined and because we were not explicitly naming a default goal, the 1st target in `.bingo/Variables.mk` became the default goal.
