### PR TITLE
The kind 'Template' is not recognized by oc-4.17.0

### DIFF
--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -129,6 +129,8 @@ To access the HTTP and GRPC endpoints of maestro, run
 
 ### Cluster Service
 
+> This might not work with oc 4.17.0, please use oc 4.16.x until this is fixed in 4.17
+> 
 Deploy CS:
    ```bash
    cd cluster-service/


### PR DESCRIPTION
This is caution message until the issue in oc 4.17.0 is fixed. https://redhat-external.slack.com/archives/C075PHEFZKQ/p1728656947447139
