### PR TITLE
Bump istioVersion param to 1-22

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -12,8 +12,9 @@ AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID ?= "57e54810-3138-4f38-bd3b-29cb33f4c358
 deploy:
 	ZONE_RESOURCE_ID=$(shell az network dns zone list -g ${REGIONAL_RESOURCEGROUP} --query "[?zoneType=='Public'].id" -o tsv) && \
 	sed -e "s#ZONE_RESOURCE_ID#$${ZONE_RESOURCE_ID}#g" -e "s/REGION/${REGION}/g" -e "s/CONSUMER_NAME/${CONSUMER_NAME}/g" deploy/mvp-provisioning-shards.yml > deploy/tmp-provisioning-shard.yml
+	ISTO_VERSION=$(shell az aks list --query "[?tags.clusterType == 'svc-cluster' && starts_with(resourceGroup, '${RESOURCEGROUP}')].serviceMeshProfile.istio.revisions[-1]" -o tsv)
 	oc process --local -f deploy/openshift-templates/arohcp-namespace-template.yml \
-	  -p ISTIO_VERSION=asm-1-21 | oc apply -f -
+	  -p ISTIO_VERSION=$${ISTO_VERSION} | oc apply -f -
 	kubectl apply -f deploy/istio.yml
 	oc process --local -f deploy/openshift-templates/arohcp-db-template.yml | oc apply -f -
 	oc process --local -f deploy/openshift-templates/arohcp-secrets-template.yml \

--- a/dev-infrastructure/configurations/cs-integ-svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/cs-integ-svc-cluster.bicepparam
@@ -1,7 +1,7 @@
 using '../templates/svc-cluster.bicep'
 
 param kubernetesVersion = '1.30.4'
-param istioVersion = ['asm-1-21']
+param istioVersion = ['asm-1-22']
 param vnetAddressPrefix = '10.128.0.0/14'
 param subnetPrefix = '10.128.8.0/21'
 param podSubnetPrefix = '10.128.64.0/18'

--- a/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
@@ -1,7 +1,7 @@
 using '../templates/svc-cluster.bicep'
 
 param kubernetesVersion = '1.30.4'
-param istioVersion = ['asm-1-21']
+param istioVersion = ['asm-1-22']
 param vnetAddressPrefix = '10.128.0.0/14'
 param subnetPrefix = '10.128.8.0/21'
 param podSubnetPrefix = '10.128.64.0/18'

--- a/dev-infrastructure/configurations/svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.bicepparam
@@ -1,7 +1,7 @@
 using '../templates/svc-cluster.bicep'
 
 param kubernetesVersion = '1.30.4'
-param istioVersion = ['asm-1-21']
+param istioVersion = ['asm-1-22']
 param vnetAddressPrefix = '10.128.0.0/14'
 param subnetPrefix = '10.128.8.0/21'
 param podSubnetPrefix = '10.128.64.0/18'

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -25,7 +25,7 @@ param persist bool = false
 
 param kubernetesVersion string
 param deployIstio bool
-param istioVersion array = ['asm-1-21']
+param istioVersion array = ['asm-1-22']
 param vnetAddressPrefix string
 param subnetPrefix string
 param podSubnetPrefix string


### PR DESCRIPTION
### What this PR does


Bump istioVersion version to 1-22 to resolve the error while deploying svc-cluster -
`Message: Requested change in revisions is not allowed. Reason: Revision asm-1-21 is not supported by the service mesh add-on..`


### Special notes for your reviewer
Verified the changes in local setup.
