### PR TITLE
update guid with acrName so roleAssignment is unique across all ACRs

### DIFF
--- a/dev-infrastructure/templates/dev-acr.bicep
+++ b/dev-infrastructure/templates/dev-acr.bicep
@@ -79,7 +79,7 @@ resource secretAccessPermission 'Microsoft.Authorization/roleAssignments@2022-04
       acr
     ]
     scope: keyVault
-    name: guid(keyVault.id, 'quayPullSecrets', 'read', repo.ruleName)
+    name: guid(keyVault.id, 'quayPullSecrets', 'read', repo.ruleName, acrName)
     properties: {
       roleDefinitionId: subscriptionResourceId(
         'Microsoft.Authorization/roleDefinitions/',


### PR DESCRIPTION
### What this PR does
Follow up to #724 
Update the roleAssignment name guid function so that the name generated for role assignments is unique across all ACRs.  This *should* fix the MVP CD [deployment error ](https://github.com/Azure/ARO-HCP/actions/runs/11464161433/job/31899726740#step:5:452).

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
