### PR TITLE
Block requests based on provisioning state

### DIFF
--- a/frontend/pkg/frontend/helpers.go
+++ b/frontend/pkg/frontend/helpers.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
@@ -16,6 +17,57 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 )
+
+// CheckForProvisioningStateConflict returns a "409 Conflict" error response if the
+// provisioning state of the resource is non-terminal, or any of its parent resources
+// within the same provider namespace are in a "Deleting" state.
+func (f *Frontend) CheckForProvisioningStateConflict(ctx context.Context, operationRequest database.OperationRequest, doc *database.ResourceDocument) *arm.CloudError {
+	switch operationRequest {
+	case database.OperationRequestCreate:
+		// Resource must already exist for there to be a conflict.
+	case database.OperationRequestDelete:
+		if doc.ProvisioningState == arm.ProvisioningStateDeleting {
+			return arm.NewCloudError(
+				http.StatusConflict,
+				arm.CloudErrorCodeConflict,
+				doc.Key.String(),
+				"Resource is already deleting")
+		}
+	case database.OperationRequestUpdate:
+		if !doc.ProvisioningState.IsTerminal() {
+			return arm.NewCloudError(
+				http.StatusConflict,
+				arm.CloudErrorCodeConflict,
+				doc.Key.String(),
+				"Cannot update resource while resource is %s",
+				strings.ToLower(string(doc.ProvisioningState)))
+		}
+	}
+
+	parent := doc.Key.GetParent()
+
+	// ResourceType casing is preserved for parents in the same namespace.
+	for parent.ResourceType.Namespace == doc.Key.ResourceType.Namespace {
+		parentDoc, err := f.dbClient.GetResourceDoc(ctx, parent)
+		if err != nil {
+			f.logger.Error(err.Error())
+			return arm.NewInternalServerError()
+		}
+
+		if parentDoc.ProvisioningState == arm.ProvisioningStateDeleting {
+			return arm.NewCloudError(
+				http.StatusConflict,
+				arm.CloudErrorCodeConflict,
+				doc.Key.String(),
+				"Cannot %s resource while parent resource is deleting",
+				strings.ToLower(string(operationRequest)))
+		}
+
+		parent = parent.GetParent()
+	}
+
+	return nil
+}
 
 func (f *Frontend) MarshalResource(ctx context.Context, resourceID *arm.ResourceID, versionedInterface api.Version) ([]byte, *arm.CloudError) {
 	var responseBody []byte

--- a/frontend/pkg/frontend/helpers_test.go
+++ b/frontend/pkg/frontend/helpers_test.go
@@ -1,0 +1,223 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+)
+
+func TestCheckForProvisioningStateConflict(t *testing.T) {
+	const clusterResourceID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/testCluster"
+	const nodePoolResourceID = clusterResourceID + "/nodePools/testNodePool"
+
+	tests := []struct {
+		name             string
+		resourceID       string
+		operationRequest database.OperationRequest
+		directConflicts  map[arm.ProvisioningState]bool
+		parentConflicts  map[arm.ProvisioningState]bool
+	}{
+		{
+			name:             "Create cluster",
+			resourceID:       clusterResourceID,
+			operationRequest: database.OperationRequestCreate,
+			directConflicts: map[arm.ProvisioningState]bool{
+				arm.ProvisioningStateSucceeded:    false,
+				arm.ProvisioningStateFailed:       false,
+				arm.ProvisioningStateCanceled:     false,
+				arm.ProvisioningStateAccepted:     false,
+				arm.ProvisioningStateDeleting:     false,
+				arm.ProvisioningStateProvisioning: false,
+				arm.ProvisioningStateUpdating:     false,
+			},
+		},
+		{
+			name:             "Delete cluster",
+			resourceID:       clusterResourceID,
+			operationRequest: database.OperationRequestDelete,
+			directConflicts: map[arm.ProvisioningState]bool{
+				arm.ProvisioningStateSucceeded:    false,
+				arm.ProvisioningStateFailed:       false,
+				arm.ProvisioningStateCanceled:     false,
+				arm.ProvisioningStateAccepted:     false,
+				arm.ProvisioningStateDeleting:     true,
+				arm.ProvisioningStateProvisioning: false,
+				arm.ProvisioningStateUpdating:     false,
+			},
+		},
+		{
+			name:             "Update cluster",
+			resourceID:       clusterResourceID,
+			operationRequest: database.OperationRequestUpdate,
+			directConflicts: map[arm.ProvisioningState]bool{
+				arm.ProvisioningStateSucceeded:    false,
+				arm.ProvisioningStateFailed:       false,
+				arm.ProvisioningStateCanceled:     false,
+				arm.ProvisioningStateAccepted:     true,
+				arm.ProvisioningStateDeleting:     true,
+				arm.ProvisioningStateProvisioning: true,
+				arm.ProvisioningStateUpdating:     true,
+			},
+		},
+		{
+			name:             "Create node pool",
+			resourceID:       nodePoolResourceID,
+			operationRequest: database.OperationRequestCreate,
+			directConflicts: map[arm.ProvisioningState]bool{
+				arm.ProvisioningStateSucceeded:    false,
+				arm.ProvisioningStateFailed:       false,
+				arm.ProvisioningStateCanceled:     false,
+				arm.ProvisioningStateAccepted:     false,
+				arm.ProvisioningStateDeleting:     false,
+				arm.ProvisioningStateProvisioning: false,
+				arm.ProvisioningStateUpdating:     false,
+			},
+			parentConflicts: map[arm.ProvisioningState]bool{
+				arm.ProvisioningStateSucceeded:    false,
+				arm.ProvisioningStateFailed:       false,
+				arm.ProvisioningStateCanceled:     false,
+				arm.ProvisioningStateAccepted:     false,
+				arm.ProvisioningStateDeleting:     true,
+				arm.ProvisioningStateProvisioning: false,
+				arm.ProvisioningStateUpdating:     false,
+			},
+		},
+		{
+			name:             "Delete node pool",
+			resourceID:       nodePoolResourceID,
+			operationRequest: database.OperationRequestDelete,
+			directConflicts: map[arm.ProvisioningState]bool{
+				arm.ProvisioningStateSucceeded:    false,
+				arm.ProvisioningStateFailed:       false,
+				arm.ProvisioningStateCanceled:     false,
+				arm.ProvisioningStateAccepted:     false,
+				arm.ProvisioningStateDeleting:     true,
+				arm.ProvisioningStateProvisioning: false,
+				arm.ProvisioningStateUpdating:     false,
+			},
+			parentConflicts: map[arm.ProvisioningState]bool{
+				arm.ProvisioningStateSucceeded:    false,
+				arm.ProvisioningStateFailed:       false,
+				arm.ProvisioningStateCanceled:     false,
+				arm.ProvisioningStateAccepted:     false,
+				arm.ProvisioningStateDeleting:     true,
+				arm.ProvisioningStateProvisioning: false,
+				arm.ProvisioningStateUpdating:     false,
+			},
+		},
+		{
+			name:             "Update node pool",
+			resourceID:       nodePoolResourceID,
+			operationRequest: database.OperationRequestUpdate,
+			directConflicts: map[arm.ProvisioningState]bool{
+				arm.ProvisioningStateSucceeded:    false,
+				arm.ProvisioningStateFailed:       false,
+				arm.ProvisioningStateCanceled:     false,
+				arm.ProvisioningStateAccepted:     true,
+				arm.ProvisioningStateDeleting:     true,
+				arm.ProvisioningStateProvisioning: true,
+				arm.ProvisioningStateUpdating:     true,
+			},
+			parentConflicts: map[arm.ProvisioningState]bool{
+				arm.ProvisioningStateSucceeded:    false,
+				arm.ProvisioningStateFailed:       false,
+				arm.ProvisioningStateCanceled:     false,
+				arm.ProvisioningStateAccepted:     false,
+				arm.ProvisioningStateDeleting:     true,
+				arm.ProvisioningStateProvisioning: false,
+				arm.ProvisioningStateUpdating:     false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		var name string
+
+		resourceID, err := arm.ParseResourceID(tt.resourceID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for directState, directConflict := range tt.directConflicts {
+			name = fmt.Sprintf("%s (directState=%s)", tt.name, directState)
+			t.Run(name, func(t *testing.T) {
+				ctx := context.Background()
+
+				frontend := &Frontend{
+					logger:   slog.Default(),
+					dbClient: database.NewCache(),
+				}
+
+				doc := database.NewResourceDocument(resourceID)
+				doc.ProvisioningState = directState
+
+				parentResourceID := resourceID.GetParent()
+				if parentResourceID.ResourceType.Namespace == resourceID.ResourceType.Namespace {
+					parentDoc := database.NewResourceDocument(parentResourceID)
+					// Hold the provisioning state to something benign.
+					parentDoc.ProvisioningState = arm.ProvisioningStateSucceeded
+					_ = frontend.dbClient.CreateResourceDoc(ctx, parentDoc)
+				}
+
+				cloudError := frontend.CheckForProvisioningStateConflict(ctx, tt.operationRequest, doc)
+
+				if cloudError == nil {
+					if directConflict {
+						t.Errorf("Expected %d %s but got no error", http.StatusConflict, http.StatusText(http.StatusConflict))
+					}
+				} else {
+					if !directConflict || cloudError.StatusCode != http.StatusConflict {
+						t.Errorf("Got unexpected error: %d %s", cloudError.StatusCode, http.StatusText(cloudError.StatusCode))
+					}
+				}
+			})
+		}
+
+		for parentState, parentConflict := range tt.parentConflicts {
+			name = fmt.Sprintf("%s (parentState=%s)", tt.name, parentState)
+			t.Run(name, func(t *testing.T) {
+				ctx := context.Background()
+
+				frontend := &Frontend{
+					logger:   slog.Default(),
+					dbClient: database.NewCache(),
+				}
+
+				doc := database.NewResourceDocument(resourceID)
+				// Hold the provisioning state to something benign.
+				doc.ProvisioningState = arm.ProvisioningStateSucceeded
+
+				parentResourceID := resourceID.GetParent()
+				if parentResourceID.ResourceType.Namespace == resourceID.ResourceType.Namespace {
+					parentDoc := database.NewResourceDocument(parentResourceID)
+					parentDoc.ProvisioningState = parentState
+					_ = frontend.dbClient.CreateResourceDoc(ctx, parentDoc)
+				} else {
+					t.Fatalf("Parent resource type namespace (%s) differs from child namespace (%s)",
+						parentResourceID.ResourceType.Namespace,
+						resourceID.ResourceType.Namespace)
+				}
+
+				cloudError := frontend.CheckForProvisioningStateConflict(ctx, tt.operationRequest, doc)
+
+				if cloudError == nil {
+					if parentConflict {
+						t.Errorf("Expected %d %s but got no error", http.StatusConflict, http.StatusText(http.StatusConflict))
+					}
+				} else {
+					if !parentConflict || cloudError.StatusCode != http.StatusConflict {
+						t.Errorf("Got unexpected error: %d %s", cloudError.StatusCode, http.StatusText(cloudError.StatusCode))
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/database/cache.go
+++ b/internal/database/cache.go
@@ -114,6 +114,17 @@ func (c *Cache) CreateOperationDoc(ctx context.Context, doc *OperationDocument) 
 	return nil
 }
 
+func (c *Cache) UpdateOperationDoc(ctx context.Context, operationID string, callback func(*OperationDocument) bool) (bool, error) {
+	// Make sure lookup keys are lowercase.
+	key := strings.ToLower(operationID)
+
+	if doc, ok := c.operation[key]; ok {
+		return callback(doc), nil
+	}
+
+	return false, ErrNotFound
+}
+
 func (c *Cache) DeleteOperationDoc(ctx context.Context, operationID string) error {
 	// Make sure lookup keys are lowercase.
 	key := strings.ToLower(operationID)

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -97,7 +97,7 @@ type OperationDocument struct {
 func NewOperationDocument(request OperationRequest) *OperationDocument {
 	now := time.Now().UTC()
 
-	return &OperationDocument{
+	doc := &OperationDocument{
 		BaseDocument:       newBaseDocument(),
 		PartitionKey:       operationsPartitionKey,
 		Request:            request,
@@ -105,6 +105,14 @@ func NewOperationDocument(request OperationRequest) *OperationDocument {
 		LastTransitionTime: now,
 		Status:             arm.ProvisioningStateAccepted,
 	}
+
+	// When deleting, set Status directly to ProvisioningStateDeleting
+	// so any further deletion requests are rejected with 409 Conflict.
+	if request == OperationRequestDelete {
+		doc.Status = arm.ProvisioningStateDeleting
+	}
+
+	return doc
 }
 
 // ToStatus converts an OperationDocument to the ARM operation status format.


### PR DESCRIPTION
### What this PR does

This pull request builds upon [#749 Implement operations status polling in backend pod](https://github.com/Azure/ARO-HCP/pull/749), so its commits are duplicated here until that pull request is merged. (The last two commits are unique to this PR.)

**Update:** Instead of reproducing all the commits from #749 here I just cherry-picked the one this PR actually needs.

This should complete the ARM contract for asynchronous operations by blocking requests on a resource based on its provisioning state and – for child resources – its parent resource's provisioning state.  The semantics for this are not covered in the [Resource Provider Contract on GitHub](https://github.com/cloud-and-ai-microsoft/resource-provider-contract/) ([though they should be](https://github.com/cloud-and-ai-microsoft/resource-provider-contract/issues/192)), so it has been derived from a number of other sources: [RPaaS behavior](https://eng.ms/docs/products/arm/rpaas/async), [ARO Classic behavior](https://github.com/Azure/ARO-RP/tree/master/pkg/frontend), and the [Resource Provider Contract Guidelines on eng.ms](https://eng.ms/docs/products/arm/api_contracts/guidelines/rpc).

Note: Until the new **/api/aro_hcp/v1** OCM endpoint becomes available, asynchronous operation statuses for node pools will not be accurate.  But we can still fulfill the high-level ARM requirements.

Jira: I don't think we have a JIRA Story specifically for this, but it falls under [XCMSTRAT-627 - ARO HCP - Async Operations](https://issues.redhat.com/browse/XCMSTRAT-627)
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
