### PR TITLE
Unify DELETE request handling for clusters and node pools

### DIFF
--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -103,7 +103,7 @@ func (f *Frontend) routes() *MiddlewareMux {
 		postMuxMiddleware.HandlerFunc(f.CreateOrUpdateNodePool))
 	mux.Handle(
 		MuxPattern(http.MethodDelete, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, PatternNodePools),
-		postMuxMiddleware.HandlerFunc(f.DeleteNodePool))
+		postMuxMiddleware.HandlerFunc(f.ArmResourceDelete))
 
 	// Operation endpoints
 	postMuxMiddleware = NewMiddleware(


### PR DESCRIPTION
### What this PR does

Our DELETE request handlers for clusters and node pools were _nearly_ identical.  With the addition of a frontend helper method `DeleteResource` we can now unify the request handlers and eliminate a fair amount of duplicate code.

Jira: none; refactoring work
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
