### PR TITLE
Add dependabot updates for backend and image-sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,3 +46,11 @@ updates:
     directory: "/frontend"
     schedule:
       interval: 'weekly'
+  - package-ecosystem: docker
+    directory: "/backend"
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: docker
+    directory: "/tooling/image-sync"
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
### What this PR does

We should get dependabot updates for additional components now for their dockerfiles.  
