### PR TITLE
Enable usage of workload identity and azure DB in CS (including P1 environment)

### DIFF
--- a/.github/workflows/aro-hcp-dev-env-cd.yml
+++ b/.github/workflows/aro-hcp-dev-env-cd.yml
@@ -500,7 +500,7 @@
         - name: 'Deploy Cluster Service'
           run: |
             cd cluster-service/
-            make deploy
+            make deploy-using-azure-db
 
         - name: 'Deploy Maestro Server'
           run: |

--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -41,12 +41,7 @@ deploy: configure-tmp-provision-shard deploy-namespace-template deploy-istio-con
 # be redesigned when we move to use Helm templates.
 # *Warning* if you change any parameter remember to change it in both the deploy and the deploy-using-azure-db targets
 # if they apply to both
-deploy-using-azure-db: configure-tmp-provision-shard deploy-namespace-template deploy-istio-configurations-template deploy-secrets-template
-	oc process --local -f deploy/openshift-templates/arohcp-db-template.yml \
-	-p DATABASE_USER=clusters-service \
-	-p DATABASE_NAME=clusters-service \
-	-p DATABASE_PASSWORD="" \
-	-p DATABASE_SERVICE=$(shell az postgres flexible-server list --resource-group ${RESOURCEGROUP} --query "[?starts_with(name, 'cs-pg-')].fullyQualifiedDomainName" -o tsv) | oc apply -f -
+deploy-using-azure-db: configure-tmp-provision-shard deploy-namespace-template deploy-istio-configurations-template deploy-secrets-template-using-azure-db
 	AZURE_CS_MI_CLIENT_ID=$(shell az identity show \
 			-g ${RESOURCEGROUP} \
 			-n clusters-service \
@@ -90,6 +85,14 @@ deploy-secrets-template: configure-tmp-provision-shard
 	oc process --local -f deploy/openshift-templates/arohcp-secrets-template.yml \
 		-p PROVISION_SHARDS_CONFIG="$$( base64 -i deploy/tmp-provisioning-shard.yml)" | oc apply -f -
 
+deploy-secrets-template-using-azure-db: configure-tmp-provision-shard
+	oc process --local -f deploy/openshift-templates/arohcp-secrets-template.yml \
+		-p DATABASE_USER=clusters-service \
+		-p DATABASE_NAME=clusters-service \
+		-p DATABASE_PASSWORD="" \
+		-p DATABASE_HOST=$(shell az postgres flexible-server list --resource-group ${RESOURCEGROUP} --query "[?starts_with(name, 'cs-pg-')].fullyQualifiedDomainName" -o tsv) \
+		-p PROVISION_SHARDS_CONFIG="$$( base64 -i deploy/tmp-provisioning-shard.yml)" | oc apply -f -
+
 configure-tmp-provision-shard:
 	ZONE_RESOURCE_ID=$(shell az network dns zone list -g ${REGIONAL_RESOURCEGROUP} --query "[?zoneType=='Public'].id" -o tsv) && \
 	sed -e "s#ZONE_RESOURCE_ID#$${ZONE_RESOURCE_ID}#g" -e "s/REGION/${REGION}/g" -e "s/CONSUMER_NAME/${CONSUMER_NAME}/g" deploy/mvp-provisioning-shards.yml > deploy/tmp-provisioning-shard.yml
@@ -99,4 +102,4 @@ provision-shard:
 	@ZONE_RESOURCE_ID=$(shell az network dns zone list -g ${REGIONAL_RESOURCEGROUP} --query "[?zoneType=='Public'].id" -o tsv) && \
 	sed -e "s#ZONE_RESOURCE_ID#$${ZONE_RESOURCE_ID}#g" -e "s/REGION/${REGION}/g" -e "s/CONSUMER_NAME/${CONSUMER_NAME}/g" deploy/dev-provisioning-shards.yml
 
-.PHONY: deploy deploy-using-azure-db deploy-integ provision-shard configure-tmp-provision-shard deploy-secrets-template deploy-istio-configurations-template deploy-namespace-template
+.PHONY: deploy deploy-using-azure-db deploy-integ provision-shard configure-tmp-provision-shard deploy-secrets-template deploy-secrets-template-using-azure-db deploy-istio-configurations-template deploy-namespace-template

--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -8,17 +8,12 @@ CONSUMER_NAME ?= $(shell az aks list --query "[?tags.clusterType == 'mgmt-cluste
 KEYVAULT_NAME ?= $(shell az keyvault list --query "[?tags.aroHCPPurpose=='service'].name" -g  ${SVC_KV_RESOURCEGROUP} --output tsv)
 FPA_CERT_NAME ?= firstPartyCert
 AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID ?= "57e54810-3138-4f38-bd3b-29cb33f4c358"
+CLUSTERS_SERVICE_IMAGE_TAG ?= "4f12dd5"
 
-deploy:
-	ZONE_RESOURCE_ID=$(shell az network dns zone list -g ${REGIONAL_RESOURCEGROUP} --query "[?zoneType=='Public'].id" -o tsv) && \
-	sed -e "s#ZONE_RESOURCE_ID#$${ZONE_RESOURCE_ID}#g" -e "s/REGION/${REGION}/g" -e "s/CONSUMER_NAME/${CONSUMER_NAME}/g" deploy/mvp-provisioning-shards.yml > deploy/tmp-provisioning-shard.yml
-	ISTO_VERSION=$(shell az aks list --query "[?tags.clusterType == 'svc-cluster' && starts_with(resourceGroup, '${RESOURCEGROUP}')].serviceMeshProfile.istio.revisions[-1]" -o tsv)  && \
-	oc process --local -f deploy/openshift-templates/arohcp-namespace-template.yml \
-	  -p ISTIO_VERSION=$${ISTO_VERSION} | oc apply -f -
-	kubectl apply -f deploy/istio.yml
+# *Warning* if you change any parameter remember to change it in both the deploy and the deploy-using-azure-db targets
+# if they apply to both
+deploy: configure-tmp-provision-shard deploy-namespace-template deploy-istio-configurations-template deploy-secrets-template
 	oc process --local -f deploy/openshift-templates/arohcp-db-template.yml | oc apply -f -
-	oc process --local -f deploy/openshift-templates/arohcp-secrets-template.yml \
-	  -p PROVISION_SHARDS_CONFIG="$$( base64 -i deploy/tmp-provisioning-shard.yml)" | oc apply -f -
 	AZURE_CS_MI_CLIENT_ID=$(shell az identity show \
 			-g ${RESOURCEGROUP} \
 			-n clusters-service \
@@ -29,28 +24,79 @@ deploy:
 	OIDC_BLOB_SERVICE_ENDPOINT=$(shell az storage account list --query "[?starts_with(name, 'arohcpoidc')].primaryEndpoints.blob" -g ${REGIONAL_RESOURCEGROUP} -o tsv) && \
 	OIDC_WEB_ENDPOINT=$(shell az storage account list --query "[?starts_with(name, 'arohcpoidc')].primaryEndpoints.web" -g ${REGIONAL_RESOURCEGROUP} -o tsv) && \
 	oc process --local -f deploy/openshift-templates/arohcp-service-template.yml \
-	  -p AZURE_CS_MI_CLIENT_ID=$${AZURE_CS_MI_CLIENT_ID} \
-	  -p TENANT_ID=$${TENANT_ID} \
-	  -p REGION=${REGION} \
-	  -p SERVICE_KEYVAULT_NAME=${KEYVAULT_NAME} \
-	  -p CS_SERVICE_PRINCIPAL_CREDS_BASE64=$${CS_SERVICE_PRINCIPAL_CREDS_BASE64} \
-	  -p IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}.azurecr.io \
-	  -p IMAGE_REPOSITORY=app-sre/uhc-clusters-service \
-	  -p AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID=$${AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID} \
-	  -p FPA_CERT_NAME=${FPA_CERT_NAME} \
-	  -p IMAGE_TAG=cf23767 | oc apply -f -
+		-p AZURE_CS_MI_CLIENT_ID=$${AZURE_CS_MI_CLIENT_ID} \
+		-p TENANT_ID=$${TENANT_ID} \
+		-p REGION=${REGION} \
+		-p SERVICE_KEYVAULT_NAME=${KEYVAULT_NAME} \
+		-p CS_SERVICE_PRINCIPAL_CREDS_BASE64=$${CS_SERVICE_PRINCIPAL_CREDS_BASE64} \
+		-p IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}.azurecr.io \
+		-p IMAGE_REPOSITORY=app-sre/uhc-clusters-service \
+		-p AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID=$${AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID} \
+		-p FPA_CERT_NAME=${FPA_CERT_NAME} \
+		-p IMAGE_TAG=${CLUSTERS_SERVICE_IMAGE_TAG} \
+		-p DATABASE_DISABLE_TLS=true \
+		-p DATABASE_AUTH_METHOD="postgres" | oc apply -f -
 
-deploy-integ:
+# We temporarily create another target to deploy CS using the Azure Database for PostgreSQL database. This will
+# be redesigned when we move to use Helm templates.
+# *Warning* if you change any parameter remember to change it in both the deploy and the deploy-using-azure-db targets
+# if they apply to both
+deploy-using-azure-db: configure-tmp-provision-shard deploy-namespace-template deploy-istio-configurations-template deploy-secrets-template
+	oc process --local -f deploy/openshift-templates/arohcp-db-template.yml \
+	-p DATABASE_USER=clusters-service \
+	-p DATABASE_NAME=clusters-service \
+	-p DATABASE_PASSWORD="" \
+	-p DATABASE_SERVICE=$(shell az postgres flexible-server list --resource-group ${RESOURCEGROUP} --query "[?starts_with(name, 'cs-pg-')].fullyQualifiedDomainName" -o tsv) | oc apply -f -
 	AZURE_CS_MI_CLIENT_ID=$(shell az identity show \
 			-g ${RESOURCEGROUP} \
 			-n clusters-service \
 			--query clientId) && \
-	oc process --local -f deploy/integration/cluster-service-namespace.yaml \
-	-p CLIENT_ID=$${AZURE_CS_MI_CLIENT_ID} | oc apply -f -
+	AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID=${AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID} && \
+	CS_SERVICE_PRINCIPAL_CREDS_BASE64='$(shell az keyvault secret show --vault-name "service-kv-aro-hcp-dev" --name "aro-hcp-dev-sp-cs" | jq .value -r | base64 | tr -d '\n')' && \
+	TENANT_ID=$(shell az account show --query tenantId --output tsv) && \
+	OIDC_BLOB_SERVICE_ENDPOINT=$(shell az storage account list --query "[?starts_with(name, 'arohcpoidc')].primaryEndpoints.blob" -g ${REGIONAL_RESOURCEGROUP} -o tsv) && \
+	OIDC_WEB_ENDPOINT=$(shell az storage account list --query "[?starts_with(name, 'arohcpoidc')].primaryEndpoints.web" -g ${REGIONAL_RESOURCEGROUP} -o tsv) && \
+	oc process --local -f deploy/openshift-templates/arohcp-service-template.yml \
+		-p AZURE_CS_MI_CLIENT_ID=$${AZURE_CS_MI_CLIENT_ID} \
+		-p TENANT_ID=$${TENANT_ID} \
+		-p REGION=${REGION} \
+		-p SERVICE_KEYVAULT_NAME=${KEYVAULT_NAME} \
+		-p CS_SERVICE_PRINCIPAL_CREDS_BASE64=$${CS_SERVICE_PRINCIPAL_CREDS_BASE64} \
+		-p IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}.azurecr.io \
+		-p IMAGE_REPOSITORY=app-sre/uhc-clusters-service \
+		-p AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID=$${AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID} \
+		-p FPA_CERT_NAME=${FPA_CERT_NAME} \
+		-p IMAGE_TAG=${CLUSTERS_SERVICE_IMAGE_TAG} \
+		-p DATABASE_DISABLE_TLS=false \
+		-p DATABASE_AUTH_METHOD="az-entra" | oc apply -f -
+
+deploy-integ:
+	AZURE_CS_MI_CLIENT_ID=$(shell az identity show \
+		-g ${RESOURCEGROUP} \
+		-n clusters-service \
+		--query clientId) && \
+		oc process --local -f deploy/integration/cluster-service-namespace.yaml \
+			-p CLIENT_ID=$${AZURE_CS_MI_CLIENT_ID} | oc apply -f -
+
+deploy-namespace-template:
+	ISTO_VERSION=$(shell az aks list --query "[?tags.clusterType == 'svc-cluster' && starts_with(resourceGroup, '${RESOURCEGROUP}')].serviceMeshProfile.istio.revisions[-1]" -o tsv)  && \
+	oc process --local -f deploy/openshift-templates/arohcp-namespace-template.yml \
+		-p ISTIO_VERSION=$${ISTO_VERSION} | oc apply -f -
+
+deploy-istio-configurations-template:
+	kubectl apply -f deploy/istio.yml
+
+deploy-secrets-template: configure-tmp-provision-shard
+	oc process --local -f deploy/openshift-templates/arohcp-secrets-template.yml \
+		-p PROVISION_SHARDS_CONFIG="$$( base64 -i deploy/tmp-provisioning-shard.yml)" | oc apply -f -
+
+configure-tmp-provision-shard:
+	ZONE_RESOURCE_ID=$(shell az network dns zone list -g ${REGIONAL_RESOURCEGROUP} --query "[?zoneType=='Public'].id" -o tsv) && \
+	sed -e "s#ZONE_RESOURCE_ID#$${ZONE_RESOURCE_ID}#g" -e "s/REGION/${REGION}/g" -e "s/CONSUMER_NAME/${CONSUMER_NAME}/g" deploy/mvp-provisioning-shards.yml > deploy/tmp-provisioning-shard.yml
 
 # for local development
 provision-shard:
 	@ZONE_RESOURCE_ID=$(shell az network dns zone list -g ${REGIONAL_RESOURCEGROUP} --query "[?zoneType=='Public'].id" -o tsv) && \
 	sed -e "s#ZONE_RESOURCE_ID#$${ZONE_RESOURCE_ID}#g" -e "s/REGION/${REGION}/g" -e "s/CONSUMER_NAME/${CONSUMER_NAME}/g" deploy/dev-provisioning-shards.yml
 
-.PHONY: deploy deploy-integ provision-shard
+.PHONY: deploy deploy-using-azure-db deploy-integ provision-shard configure-tmp-provision-shard deploy-secrets-template deploy-istio-configurations-template deploy-namespace-template

--- a/cluster-service/deploy/openshift-templates/arohcp-db-template.yml
+++ b/cluster-service/deploy/openshift-templates/arohcp-db-template.yml
@@ -16,21 +16,8 @@ parameters:
     required: true
     value: ocm-cs-db
 
-  - name: DATABASE_USER
-    description: Username for PostgreSQL user that will be used for accessing the database.
-    displayName: PostgreSQLUsername
-    required: true
-    value: ocm
-
-  - name: DATABASE_PASSWORD
-    description: Password for the PostgreSQL connection user.
-    displayName: PostgreSQL Password
-    required: true
-    value: TheBlurstOfTimes
-
-  - name: DATABASE_NAME
-    description: Name of the PostgreSQL database accessed.
-    displayName: PostgreSQL Database Name
+  - name: DATABASE_K8S_SECRET_NAME
+    description: The name of the K8s secret where CS DB connection information is placed
     required: true
     value: ocm-cs-db
 
@@ -112,17 +99,17 @@ objects:
                   valueFrom:
                     secretKeyRef:
                       key: db.user
-                      name: ${DATABASE_SERVICE_NAME}
+                      name: ${DATABASE_K8S_SECRET_NAME}
                 - name: POSTGRES_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       key: db.password
-                      name: ${DATABASE_SERVICE_NAME}
+                      name: ${DATABASE_K8S_SECRET_NAME}
                 - name: POSTGRES_DB
                   valueFrom:
                     secretKeyRef:
                       key: db.name
-                      name: ${DATABASE_SERVICE_NAME}
+                      name: ${DATABASE_K8S_SECRET_NAME}
                 - name: PGDATA
                   value: /var/lib/pgsql/data/pgdata
               image: docker.io/library/postgres:16.2
@@ -158,15 +145,3 @@ objects:
               persistentVolumeClaim:
                 claimName: ${DATABASE_SERVICE_NAME}
     status: {}
-
-  - apiVersion: v1
-    kind: Secret
-    metadata:
-      name: ${DATABASE_SERVICE_NAME}
-      namespace: ${NAMESPACE}
-    stringData:
-      db.host: ${DATABASE_SERVICE_NAME}
-      db.name: ${DATABASE_NAME}
-      db.password: ${DATABASE_PASSWORD}
-      db.user: ${DATABASE_USER}
-      db.port: "5432"

--- a/cluster-service/deploy/openshift-templates/arohcp-secrets-template.yml
+++ b/cluster-service/deploy/openshift-templates/arohcp-secrets-template.yml
@@ -34,6 +34,41 @@ parameters:
     required: true
     value: cluster-service
 
+  - name: DATABASE_K8S_SECRET_NAME
+    description: The name of the K8s secret where CS DB connection information is placed
+    required: true
+    value: ocm-cs-db
+
+  - name: DATABASE_HOST
+    description: The hostname of the postgres server/service. It can be a K8s service name
+    displayName: Database Service Name
+    required: true
+    value: ocm-cs-db
+
+  - name: DATABASE_USER
+    description: Username for PostgreSQL user that will be used for accessing the database.
+    displayName: PostgreSQLUsername
+    required: true
+    value: ocm
+
+  - name: DATABASE_PASSWORD
+    description: Password for the PostgreSQL connection user.
+    displayName: PostgreSQL Password
+    required: false
+    value: "TheBlurstOfTimes"
+
+  - name: DATABASE_NAME
+    description: Name of the PostgreSQL database accessed.
+    displayName: PostgreSQL Database Name
+    required: true
+    value: ocm-cs-db
+
+  - name: DATABASE_PORT
+    description: Host port
+    displayName: PostgreSQL Database Host Port
+    required: true
+    value: "5432"
+
 objects:
 
   - apiVersion: v1
@@ -52,3 +87,15 @@ objects:
     stringData:
       client.id: ${CLIENT_ID}
       client.secret: ${CLIENT_SECRET}
+
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ${DATABASE_K8S_SECRET_NAME}
+      namespace: ${NAMESPACE}
+    stringData:
+      db.host: ${DATABASE_HOST}
+      db.name: ${DATABASE_NAME}
+      db.password: ${DATABASE_PASSWORD}
+      db.user: ${DATABASE_USER}
+      db.port: ${DATABASE_PORT}

--- a/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
+++ b/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
@@ -233,6 +233,12 @@ parameters:
   value: ""
 - name: FPA_CERT_NAME
   description: The name of the secret that contains the first party application certificate bundle.
+- name: DATABASE_DISABLE_TLS
+  description: "If set to true the connection to the database is performed without TLS"
+  value: "false"
+- name: DATABASE_AUTH_METHOD
+  description: "Authentication method to use when connecting to the database. Accepted values are 'az-entra', 'postgres'"
+  value: "az-entra"
 
 objects:
 
@@ -454,7 +460,8 @@ objects:
           - --db-name=@/secrets/rds/db.name
           - --db-user=@/secrets/rds/db.user
           - --db-password=@/secrets/rds/db.password
-          - --db-disable-tls=true
+          - --db-disable-tls=${DATABASE_DISABLE_TLS}
+          - --db-auth-method=${DATABASE_AUTH_METHOD}
           - --force-migration=${FORCE_MIGRATION}
           - --batch-processes-dry-run=${BATCH_PROCESSES_DRY_RUN}
           - --batch-processes=${BATCH_PROCESSES}
@@ -514,7 +521,8 @@ objects:
           - --db-name=@/secrets/rds/db.name
           - --db-user=@/secrets/rds/db.user
           - --db-password=@/secrets/rds/db.password
-          - --db-disable-tls=true
+          - --db-disable-tls=${DATABASE_DISABLE_TLS}
+          - --db-auth-method=${DATABASE_AUTH_METHOD}
           - --gateway-url=${GATEWAY_URL}
           - --client-id=@/secrets/service/client.id
           - --client-secret=@/secrets/service/client.secret

--- a/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
+++ b/dev-infrastructure/configurations/mvp-svc-cluster.bicepparam
@@ -20,7 +20,7 @@ param maestroPostgresServerStorageSizeGB = 32
 param deployMaestroPostgres = false
 param maestroPostgresPrivate = false
 
-param deployCsInfra = false
+param deployCsInfra = true
 param csPostgresServerName = 'cs-pg-aro-hcp-dev'
 param clusterServicePostgresPrivate = false
 


### PR DESCRIPTION
### What this PR does

This PR enables the usage of Azure Workload Identity for the CS deployment and also enables the usage of Azure Database for PostgreSQL using Microsoft Entra authentication.

It also changes the P1 environment to use both functionalities.

The changes specifically:
Update the CS image which enables the use
of Azure Workload Identity for the CS deployment itself.
    
We also create an additional Makefile target for CS that
allows deploying CS pointing to an Azure Database for PostgreSQL
Flexible Server. This approach is a workaround/temporary solution
to allow us using this in the P1 environment until we move to
Helm charts where it will be designed in a good way.
    
The changes also refactor the Makefile to avoid duplicating part of
the code.

Finally, the P1 configuration and pipelines are changed to use the new functionalities in the P1 environment.



Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
