### PR TITLE
feat: add tenant id and ocp images acr to the azure runtime config in the cs template

### DIFF
--- a/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
+++ b/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
@@ -345,7 +345,8 @@ objects:
   data:
     config.json: |
       {
-        "cloudEnvironment": "AzurePublicCloud"
+        "cloudEnvironment": "AzurePublicCloud",
+        "tenantId": "64dc69e4-d083-49fc-9569-ebece1dd1408"
       }
 
 - apiVersion: v1

--- a/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
+++ b/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
@@ -346,7 +346,12 @@ objects:
     config.json: |
       {
         "cloudEnvironment": "AzurePublicCloud",
-        "tenantId": "64dc69e4-d083-49fc-9569-ebece1dd1408"
+        "tenantId": "64dc69e4-d083-49fc-9569-ebece1dd1408",
+        "ocpImagesAcr": {
+          "resourceId": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.ContainerRegistry/registries/arohcpdev",
+          "url": "arohcpdev.azurecr.io",
+          "scopeMapName": "_repositories_pull"
+        }
       }
 
 - apiVersion: v1


### PR DESCRIPTION
### What this PR does

Adds the `tenantId` and `ocpImagesAcr` to the azure runtime config in the CS DEV template

Jira: https://issues.redhat.com/browse/ARO-7653, https://issues.redhat.com/browse/ARO-9331
Link to demo recording: N/A

### Special notes for your reviewer
Please see related MRs: 
* https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/8807
* https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/8761
