### PR TITLE
add cs platform identities config map

### DIFF
--- a/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
+++ b/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
@@ -368,6 +368,107 @@ objects:
         }
       }
 
+# TODO: parameterize data.platform-identities.yaml after templatize refactor and helm chart conversion
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: azure-operators-managed-identities-config
+    namespace: ${NAMESPACE}
+  data:
+    azure-operators-managed-identities-config.yaml: |
+      controlPlaneOperatorsIdentities:
+
+        cloud-controller-manager:
+          minOpenShiftVersion: 4.17
+          azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/ebe170ec-1247-536a-86d9-74c829dd9844'
+          azureRoleDefinitionName: 'Azure Red Hat OpenShift Cloud Controller Manager - Dev'
+          optional: false
+
+        ingress:
+          minOpenShiftVersion: 4.17
+          azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/589ca160-4fac-501e-ad6c-006a19583727'
+          azureRoleDefinitionName: 'Azure Red Hat OpenShift Cluster Ingress Operator - Dev'
+          optional: false
+
+        disk-csi-driver:
+          minOpenShiftVersion: 4.17
+          azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/4367fe74-0b43-5033-b629-15d9f28415ac'
+          azureRoleDefinitionName: 'Azure Red Hat OpenShift Disk Storage Operator - Dev'
+          optional: false
+
+        file-csi-driver:
+          minOpenShiftVersion: 4.17
+          azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/fdc0aaaa-1c3e-548e-ad27-0321e5fab18b'
+          azureRoleDefinitionName: 'Azure Red Hat OpenShift File Storage Operator - Dev'
+          optional: false
+
+        image-registry:
+          minOpenShiftVersion: 4.17
+          azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/357b9263-656f-5d45-9d7a-ccb825f0683f'
+          azureRoleDefinitionName: 'Azure Red Hat OpenShift Image Registry Operator - Dev'
+          optional: false
+
+        cloud-network-config:
+          minOpenShiftVersion: 4.17
+          azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/4e4f23fe-3fab-568b-a001-10b233b0f840'
+          azureRoleDefinitionName: 'Azure Red Hat OpenShift Network Operator - Dev'
+          optional: false
+
+      dataPlaneOperatorsIdentities:
+
+        disk-csi-driver:
+          minOpenShiftVersion: 4.17
+          azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/4367fe74-0b43-5033-b629-15d9f28415ac'
+          azureRoleDefinitionName: 'Azure Red Hat OpenShift Disk Storage Operator - Dev'
+          k8sServiceAccounts:
+            - name:  'azure-disk-csi-driver-operator'
+              namespace: 'openshift-cluster-csi-drivers'
+            - name: 'azure-disk-csi-driver-controller-sa'
+              namespace: 'openshift-cluster-csi-drivers'
+          optional: false
+
+        image-registry:
+          minOpenShiftVersion: 4.17
+          azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/357b9263-656f-5d45-9d7a-ccb825f0683f'
+          azureRoleDefinitionName: 'Azure Red Hat OpenShift Image Registry Operator - Dev'
+          k8sServiceAccounts:
+            - name: 'cluster-image-registry-operator'
+              namespace: 'openshift-image-registry'
+            - name: 'registry'
+              namespace:  'openshift-image-registry'
+          optional: false
+
+        file-csi-driver:
+          minOpenShiftVersion: 4.17
+          azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/fdc0aaaa-1c3e-548e-ad27-0321e5fab18b'
+          azureRoleDefinitionName: 'Azure Red Hat OpenShift File Storage Operator - Dev'
+          k8sServiceAccounts:
+            - name: ':azure-file-csi-driver-operator'
+              namespace:  'openshift-cluster-csi-drivers'
+            - name: 'azure-file-csi-driver-controller-sa'
+              namespace:  'openshift-cluster-csi-drivers'
+            - name: 'azure-file-csi-driver-node-sa'
+              namespace:  'openshift-cluster-csi-drivers'
+          optional: false
+
+        ingress:
+          minOpenShiftVersion: 4.17
+          azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/589ca160-4fac-501e-ad6c-006a19583727'
+          azureRoleDefinitionName: 'Azure Red Hat OpenShift Cluster Ingress Operator - Dev'
+          k8sServiceAccounts:
+            - name: 'ingress-operator'
+              namespace:  'openshift-ingress-operator'
+          optional: false
+
+        cloud-network-config:
+          minOpenShiftVersion: 4.17
+          azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/4e4f23fe-3fab-568b-a001-10b233b0f840'
+          azureRoleDefinitionName: 'Azure Red Hat OpenShift Network Operator - Dev'
+          k8sServiceAccounts:
+            - name: 'cloud-network-config-controller'
+              namespace:  'openshift-cloud-network-config-controller'
+          optional: false
+
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
@@ -444,6 +545,9 @@ objects:
         - name: azure-runtime-config
           configMap:
             name: azure-runtime-config
+        - name: azure-operators-managed-identities-config
+          configMap:
+            name: azure-operators-managed-identities-config
         - name: mixin-pull-secret
           secret:
             secretName: hive-ci-global-pull-secret
@@ -517,6 +621,9 @@ objects:
             readOnly: true
           - name: azure-runtime-config
             mountPath: /configs/azure-runtime-config
+          - name: azure-operators-managed-identities-config
+            mountPath: /configs/azure-operators-managed-identities-config.yaml
+            subPath: azure-operators-managed-identities-config.yaml
           env:
           - name: NAMESPACE
             valueFrom:
@@ -568,6 +675,7 @@ objects:
           - --azure-first-party-application-client-id=${AZURE_FIRST_PARTY_APPLICATION_CLIENT_ID}
           - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
           - --azure-runtime-config-path=/configs/azure-runtime-config/config.json
+          - --azure-operators-managed-identities-config-path=/configs/azure-operators-managed-identities-config.yaml
           livenessProbe:
             httpGet:
               path: /api/clusters_mgmt/v1


### PR DESCRIPTION
### What this PR does

Adds a config map containing platform identity role mappings required for CS.  Mapping is derived from production [RP-Config](https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/RP-Config?path=/deploy/prod-config.yaml&version=GBmaster&line=2946&lineEnd=2947&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents). 

Jira: https://issues.redhat.com/browse/ARO-9598
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer
The config map currently contains role identities from public prod environment.  This will be parameterized per environment once templatize refactor is complete and cluster service is deployable via helm to reduce rework.
<!-- optional -->
