### PR TITLE
feat: update cluster service image tag to 'a23276d'

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -103,7 +103,7 @@ clouds:
       maestroImageBase: quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
       maestroImageTag: ea066c250a002f0cc458711945165591bc9f6d3f
       # Cluster Service
-      clusterServiceImageTag: 4f12dd5
+      clusterServiceImageTag: a23276d
       clusterServiceImageRepo: app-sre/uhc-clusters-service
       # Hypershift Operator
       hypershiftOperatorImageTag: 99a256f

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -6,7 +6,7 @@
   "baseDnsZoneRG": "global",
   "clusterServiceAcrRG": "global",
   "clusterServiceImageRepo": "app-sre/uhc-clusters-service",
-  "clusterServiceImageTag": "4f12dd5",
+  "clusterServiceImageTag": "a23276d",
   "clusterServicePostgresDeploy": true,
   "clusterServicePostgresName": "cs-9c782",
   "clusterServicePostgresPrivate": false,

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -6,7 +6,7 @@
   "baseDnsZoneRG": "global",
   "clusterServiceAcrRG": "global",
   "clusterServiceImageRepo": "app-sre/uhc-clusters-service",
-  "clusterServiceImageTag": "4f12dd5",
+  "clusterServiceImageTag": "a23276d",
   "clusterServicePostgresDeploy": true,
   "clusterServicePostgresName": "cs-157ff",
   "clusterServicePostgresPrivate": false,

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -6,7 +6,7 @@
   "baseDnsZoneRG": "global",
   "clusterServiceAcrRG": "global",
   "clusterServiceImageRepo": "app-sre/uhc-clusters-service",
-  "clusterServiceImageTag": "4f12dd5",
+  "clusterServiceImageTag": "a23276d",
   "clusterServicePostgresDeploy": false,
   "clusterServicePostgresName": "cs-76fc6",
   "clusterServicePostgresPrivate": false,


### PR DESCRIPTION
### What this PR does
Updates the Cluster Service Image tag to `a23276d`

Changes included are listed here: [4f12dd5...a23276d](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/compare/4f12dd5fe962d689d5171b1256eb9521445de063...a23276dc62d9fd2f0080d5f43c56e4152af4907b)

Includes changes for the related JIRA issues:
* [ARO-9946](https://issues.redhat.com/browse/ARO-9946): Support configurable ACR and ImageContentSources
* [ARO-7653](https://issues.redhat.com/browse/ARO-7653): Support configurable TenantID
* [ARO-11071](https://issues.redhat.com/browse/ARO-11071): Support cluster operator managed identity configuration
* [ARO-11074](https://issues.redhat.com/browse/ARO-11074): Support Identities requirements configuration in the CS PR check environment
* [ARO-10272](https://issues.redhat.com/browse/ARO-10272): Improve artificats names in Sandbox PR checks
* [ARO-7452](https://issues.redhat.com/browse/ARO-7452): Implement Role Assignments for ARM Helper Identity

Link to demo recording: N/A

### Special notes for your reviewer
N/A
