### PR TITLE
oc-mirror amd64 images

### DIFF
--- a/dev-infrastructure/templates/image-sync.bicep
+++ b/dev-infrastructure/templates/image-sync.bicep
@@ -238,7 +238,7 @@ var ocMirrorConfig = {
   }
   mirror: {
     platform: {
-      architectures: ['multi']
+      architectures: ['multi', 'amd64']
       channels: [
         {
           name: 'stable-4.17'


### PR DESCRIPTION
### What this PR does

mirroring with the `multi` option alone is leaving gaps in the sync result. this PR reintroduces the `amd64` architecture to be synced

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
