### PR TITLE
docs: minor updates to dev setup guide

### DIFF
--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -208,9 +208,9 @@ Please not that these kubeconfig files require an active Azure CLI session (`az 
 If you loose these files, you can recreate them by running
 
   ```bash
-  make -f dev-infrastructure/Makefile svc.aks.admin-access svc.aks.kubeconfig
+  make --directory=dev-infrastructure svc.aks.admin-access svc.aks.kubeconfig
   or
-  make -f dev-infrastructure/Makefile mgmt.aks.admin-access mgmt.aks.kubeconfig
+  make --directory=dev-infrastructure mgmt.aks.admin-access mgmt.aks.kubeconfig
   ```
 
 > Freshly granted cluster admin permissions might not be effective immediately. If you get permission denied errors on your `kubectl` commands, consider waiting a couple of minutes for the permissions to be propagated

--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -12,6 +12,7 @@ The idea of this repo is to provide means to create a development environment th
 * `az login` with your Red Hat email
 * Register the needed [AFEC](https://aka.ms/afec) feature flags using `cd dev-infrastructure && make feature-registration
 * __NOTE:__ This will take awhile, you will have to wait until they're in a registered state.
+* Your Red Hat account has been added to the ARO HCP Engineering App Developer group in Azure portal. This will give your account access to resources on Azure for development purposes. Please reach out to your manager or team lead to add you to this group.
 
 ## Infrastructure
 
@@ -96,16 +97,6 @@ Every developer creates their own set of service/management clusters, including 
 * `testing` - can be removed????
   what: foo-bar
   purpose: unkown
-
-### Grant yourself Key Vault access
-
-In order to access shared Service Principle credentials you need access to the Key Vault. To grant yourself access, run
-
-```bash
-az role assignment create --role "Key Vault Secrets User" --assignee $(az ad signed-in-user show --query id -o tsv) --scope $(az keyvault show --name aro-hcp-dev-svc-kv --query id -o tsv)
-```
-
-Note: you only need to run this once. Re-running it wont hurt, but it will not change anything.
 
 ### Customizing infra deployment
 


### PR DESCRIPTION
### What this PR does
* Removes the section on granting access for the svc Key Vault as anyone in the ARO HCP Engineering group should inherit the correct permissions to access it.
    * Getting added to this group is noted as a pre-requisite instead.
* Update cmd to switch directories when running the svc and mgmt admin-access make targets

Jira: N/A
Link to demo recording: N/A

### Special notes for your reviewer
N/A
