### PR TITLE
provide a shared OIDC storage account for CS development

### DIFF
--- a/cluster-service/.gitignore
+++ b/cluster-service/.gitignore
@@ -1,4 +1,5 @@
 deploy/tmp-provisioning-shard.yml
 deploy/provisioning-shards.yml
 deploy/dev-provisioning-shards.yml
+deploy/azure-runtime-config.yaml
 config.mk

--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -64,4 +64,53 @@ provision-shard:
 	../templatize.sh $(DEPLOY_ENV) deploy/provisioning-shards.tmpl.yml deploy/provisioning-shards.yml -e zoneResourceId=$${ZONE_RESOURCE_ID}
 	@cat deploy/provisioning-shards.yml
 
-.PHONY: deploy deploy-using-azure-db deploy-integ provision-shard configure-tmp-provision-shard deploy-secrets-template deploy-secrets-template-using-azure-db deploy-istio-configurations-template deploy-namespace-template
+personal-runtime-config:
+	@TENANT_ID=$(shell az account show --query tenantId --output tsv) && \
+	OIDC_BLOB_SERVICE_ENDPOINT=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${RESOURCEGROUP} --query primaryEndpoints.blob -o tsv) && \
+	OIDC_ISSUER_BASE_ENDPOINT=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${RESOURCEGROUP} --query primaryEndpoints.web -o tsv) && \
+	OCP_ACR_URL=$(shell az acr show -n ${OCP_ACR_NAME} --query loginServer -o tsv) && \
+	OCP_ACR_RESOURCE_ID=$(shell az acr show -n ${OCP_ACR_NAME} --query id -o tsv) && \
+	../templatize.sh $(DEPLOY_ENV) deploy/azure-runtime-config.tmpl.yaml deploy/azure-runtime-config.yaml \
+		-e tenantId=$${TENANT_ID},ocpAcrResourceId=$${OCP_ACR_RESOURCE_ID},ocpAcrResourceUrl=$${OCP_ACR_URL},oidc_container='$$web',oidc_issuer_base_url=$${OIDC_ISSUER_BASE_ENDPOINT},oidc_service_url=$${OIDC_BLOB_SERVICE_ENDPOINT}
+	@cat deploy/azure-runtime-config.yaml
+.PHONY: personal-runtime-config
+
+#
+# Shared OIDC Storage
+#
+
+SHARED_OIDC_RG_NAME ?= "cs-shared-oidc-storage"
+SHARED_OIDC_STORAGE_ACCOUNT_NAME ?= "arohcpdevoidcshared"
+
+shared-oidc-storage:
+	@if [ "$$(az group exists --name $(SHARED_OIDC_RG_NAME))" = "false" ]; then \
+		az group create \
+			--name $(SHARED_OIDC_RG_NAME)  \
+			--location westus3 \
+			--output none; \
+	fi
+	az deployment group create \
+		--name oidc \
+		--resource-group $(SHARED_OIDC_RG_NAME) \
+		--template-file ../dev-infrastructure/modules/oidc/storage.bicep \
+		$(PROMPT_TO_CONFIRM) \
+		--parameters \
+			location=westus3 \
+			accountName=${SHARED_OIDC_STORAGE_ACCOUNT_NAME} \
+			publicBlobAccess=true \
+			aroDevopsMsiId=${DEVOPS_MSI_ID} \
+			deploymentScriptLocation=westus3
+.PHONY: shared-oidc-storage
+
+shared-storage-runtime-config:
+	@TENANT_ID=$(shell az account show --query tenantId --output tsv) && \
+	OIDC_BLOB_SERVICE_ENDPOINT=$(shell az storage account show -n ${SHARED_OIDC_STORAGE_ACCOUNT_NAME} -g ${SHARED_OIDC_RG_NAME} --query primaryEndpoints.blob -o tsv) && \
+	OIDC_ISSUER_BASE_ENDPOINT=$(shell az storage account show -n ${SHARED_OIDC_STORAGE_ACCOUNT_NAME} -g ${SHARED_OIDC_RG_NAME} --query primaryEndpoints.web -o tsv) && \
+	OCP_ACR_URL=$(shell az acr show -n ${OCP_ACR_NAME} --query loginServer -o tsv) && \
+	OCP_ACR_RESOURCE_ID=$(shell az acr show -n ${OCP_ACR_NAME} --query id -o tsv) && \
+	../templatize.sh $(DEPLOY_ENV) deploy/azure-runtime-config.tmpl.yaml deploy/azure-runtime-config.yaml \
+		-e tenantId=$${TENANT_ID},ocpAcrResourceId=$${OCP_ACR_RESOURCE_ID},ocpAcrResourceUrl=$${OCP_ACR_URL},oidc_container='$$web',oidc_issuer_base_url=$${OIDC_ISSUER_BASE_ENDPOINT},oidc_service_url=$${OIDC_BLOB_SERVICE_ENDPOINT}
+	@cat deploy/azure-runtime-config.yaml
+.PHONY: shared-storage-runtime-config
+
+.PHONY: deploy deploy-using-azure-db deploy-integ provision-shard configure-tmp-provision-shard deploy-secrets-template deploy-secrets-template-using-azure-db deploy-istio-configurations-template deploy-namespace-template runtime-config

--- a/cluster-service/config.tmpl.mk
+++ b/cluster-service/config.tmpl.mk
@@ -17,3 +17,5 @@ DATABASE_DISABLE_TLS ?= {{ not .clusterServicePostgresDeploy }}
 DATABASE_AUTH_METHOD ?= {{ ternary "az-entra" "postgres" .clusterServicePostgresDeploy }}
 DATABASE_SERVER_NAME ?= {{ .clusterServicePostgresName }}
 DB_SECRET_TARGET = {{ ternary "deploy-azure-db-secret" "deploy-local-db-secret" .clusterServicePostgresDeploy }}
+
+DEVOPS_MSI_ID ?= {{ .aroDevopsMsiId }}

--- a/cluster-service/deploy/azure-runtime-config.tmpl.yaml
+++ b/cluster-service/deploy/azure-runtime-config.tmpl.yaml
@@ -1,0 +1,14 @@
+{
+  "cloudEnvironment": "AzurePublicCloud",
+  "tenantId": "{{ .extraVars.tenantId }}",
+  "ocpImagesAcr": {
+    "resourceId": "{{ .extraVars.ocpAcrResourceId }}",
+    "url": "{{ .extraVars.ocpAcrResourceUrl }}",
+    "scopeMapName": "_repositories_pull"
+  },
+  "dataplane_identities_oidc_configuration": {
+    "storage_account_blob_container_name": "{{ .extraVars.oidc_container }}",
+    "storage_account_blob_service_url": "{{ .extraVars.oidc_service_url }}",
+    "oidc_issuer_base_url": "{{ .extraVars.oidc_issuer_base_url }}"
+  }
+}

--- a/dev-infrastructure/modules/oidc/storage.bicep
+++ b/dev-infrastructure/modules/oidc/storage.bicep
@@ -20,7 +20,7 @@ param skuName string = 'Standard_ZRS'
 param publicBlobAccess bool
 
 @description('The service principal ID to be added to Azure Storage account.')
-param principalId string
+param principalId string = ''
 
 @description('Id of the MSI that will be used to run the deploymentScript')
 param aroDevopsMsiId string
@@ -52,7 +52,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
 }
 
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (principalId != '') {
   name: guid(storageAccount.id, principalId, roleDefinitionId)
   scope: storageAccount
   properties: {


### PR DESCRIPTION
in certain DEV scenarios, CS developers don't require a full infra stack to work on features. in such a scenario a shared OIDC storage account is sufficient. the way objects are stored in an OIDC storage account makes it reusable accross all developers without the risk of conflicts.

this PR introduces such a storage account `arohcpdevoidcshared` in the resourcegroup `cs-shared-oidc-storage`.

this storage account can be created and updated by running `make shared-oidc-storage`.

in addition, the CS makefile offers two new targets to improve developer UX

`make shared-storage-runtime-config` provides a CS azure runtime config that leverages the shared OIDC storage

`make personal-runtime-config` provides a CS azure runtime config that leverages the OIDC storage account of a personal developer environment (if it has been created)

### What this PR does


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
