### PR TITLE
provision shard generation with cx keyvaults

### DIFF
--- a/cluster-service/deploy/provisioning-shards.tmpl.yml
+++ b/cluster-service/deploy/provisioning-shards.tmpl.yml
@@ -11,8 +11,11 @@ provision_shards:
       "consumer_name": "{{ .maestroConsumerName }}"
     }
   status: active
-  azure_base_domain: "{{ .extraVars.zoneResourceId }}"
   management_cluster_id: local-cluster
   region: {{ .region }}
   cloud_provider: azure
   topology: dedicated
+  azure_shard:
+    public_dns_zone_resource_id: "{{ .extraVars.zoneResourceId }}"
+    cx_secrets_key_vault_url: "{{ .extraVars.cxSecretsKeyVaultUrl }}"
+    cx_managed_identities_key_vault_url: "{{ .extraVars.cxMiKeyVaultUrl }}"


### PR DESCRIPTION
### What this PR does

adapts the provision shard configuration to the new format with the dedicated azure section, referencing the the DNS zone, and MGMT cluster KVs to use (CX secrets + CX MSI).

⚠️ only merge together with a CS promotion that implements the new provision shard structure

Jira: ARO-10856
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
