### PR TITLE
Add capability to merge maps

### DIFF
--- a/tooling/templatize/internal/config/config_test.go
+++ b/tooling/templatize/internal/config/config_test.go
@@ -30,3 +30,95 @@ func TestConfigProvider(t *testing.T) {
 	// key is in the config file, default, varaible value
 	assert.Equal(t, fmt.Sprintf("hcp-underlay-%s-%s", region, regionStamp), variables["region_resourcegroup"])
 }
+
+func TestInterfaceToVariable(t *testing.T) {
+	testCases := []struct {
+		name               string
+		i                  interface{}
+		ok                 bool
+		expecetedVariables Variables
+	}{
+		{
+			name:               "empty interface",
+			ok:                 false,
+			expecetedVariables: Variables{},
+		},
+		{
+			name:               "empty map",
+			i:                  map[string]interface{}{},
+			ok:                 true,
+			expecetedVariables: Variables{},
+		},
+		{
+			name: "map",
+			i: map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			ok: true,
+			expecetedVariables: Variables{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			vars, ok := interfaceToVariables(tc.i)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.expecetedVariables, vars)
+		})
+	}
+}
+
+func TestMergeVariable(t *testing.T) {
+	testCases := []struct {
+		name     string
+		base     Variables
+		override Variables
+		expected Variables
+	}{
+		{
+			name:     "nil base",
+			expected: nil,
+		},
+		{
+			name:     "empty base and override",
+			base:     Variables{},
+			expected: Variables{},
+		},
+		{
+			name:     "merge into empty base",
+			base:     Variables{},
+			override: Variables{"key1": "value1"},
+			expected: Variables{"key1": "value1"},
+		},
+		{
+			name:     "merge into base",
+			base:     Variables{"key1": "value1"},
+			override: Variables{"key2": "value2"},
+			expected: Variables{"key1": "value1", "key2": "value2"},
+		},
+		{
+			name:     "override base, change schema",
+			base:     Variables{"key1": Variables{"key2": "value2"}},
+			override: Variables{"key1": "value1"},
+			expected: Variables{"key1": "value1"},
+		},
+		{
+			name:     "merge into sub map",
+			base:     Variables{"key1": Variables{"key2": "value2"}},
+			override: Variables{"key1": Variables{"key3": "value3"}},
+			expected: Variables{"key1": Variables{"key2": "value2", "key3": "value3"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := mergeVariables(tc.base, tc.override)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+
+}


### PR DESCRIPTION
This makes it possible to use maps in the configuration file. The idea behind this change is to make it easier to copy and paste configuration, cause the keys in the configuration will be way shorter and thus easier to read. It's also closer to being idomatic yaml.

### What this PR does


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
