### PR TITLE
fix: ensure kubeconfigfile cmds only return the file path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ infra.svc:
 .PHONY: infra.svc
 
 infra.svc.aks.kubeconfigfile:
-	@cd dev-infrastructure && DEPLOY_ENV=$(DEPLOY_ENV) make svc.aks.kubeconfigfile
+	@cd dev-infrastructure && DEPLOY_ENV=$(DEPLOY_ENV) make -s svc.aks.kubeconfigfile
 .PHONY: infra.svc.aks.kubeconfigfile
 
 infra.mgmt:
@@ -50,7 +50,7 @@ infra.mgmt:
 .PHONY: infra.mgmt
 
 infra.mgmt.aks.kubeconfigfile:
-	@cd dev-infrastructure && DEPLOY_ENV=$(DEPLOY_ENV) make mgmt.aks.kubeconfigfile
+	@cd dev-infrastructure && DEPLOY_ENV=$(DEPLOY_ENV) make -s mgmt.aks.kubeconfigfile
 .PHONY: infra.mgmt.aks.kubeconfigfile
 
 infra.imagesync:


### PR DESCRIPTION
### What this PR does

Fixes the following make targets to ensure it only returns the file path of the kubeconfig:
* `infra.svc.aks.kubeconfigfile`
* `infra.mgmt.aks.kubeconfigfile`

Adds a -s, silent flag, which ensures the Entering Directory or Leaving Directory is not included in the output. For example, without this flag, the output is:
```
make[1]: Entering directory '/path'
/path
make[1]: Leaving directory '/path'
```

With this change, the output of the cmd is as follows:
```
/path
```


Jira: N/A
Link to demo recording: N/A

### Special notes for your reviewer
In our documentation, the cmds above are used for accessing the aks clusters like so:
```
export KUBECONFIG=$(make infra.svc.aks.kubeconfigfile)
export KUBECONFIG=$(make infra.mgmt.aks.kubeconfigfile)
```

See https://github.com/Azure/ARO-HCP/blob/main/dev-infrastructure/docs/development-setup.md#create-infrastructure-the-easy-way
