### PR TITLE
Centralize writing HTTP response bodies

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -249,14 +249,7 @@ func (f *Frontend) ArmResourceList(writer http.ResponseWriter, request *http.Req
 		}
 	}
 
-	resp, err := json.Marshal(pagedResponse)
-	if err != nil {
-		f.logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
-	}
-
-	_, err = writer.Write(resp)
+	_, err = arm.WriteJSONResponse(writer, http.StatusOK, pagedResponse)
 	if err != nil {
 		f.logger.Error(err.Error())
 	}
@@ -290,7 +283,7 @@ func (f *Frontend) ArmResourceRead(writer http.ResponseWriter, request *http.Req
 		return
 	}
 
-	_, err = writer.Write(responseBody)
+	_, err = arm.WriteJSONResponse(writer, http.StatusOK, responseBody)
 	if err != nil {
 		f.logger.Error(err.Error())
 	}
@@ -529,9 +522,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 		return
 	}
 
-	writer.WriteHeader(successStatusCode)
-
-	_, err = writer.Write(responseBody)
+	_, err = arm.WriteJSONResponse(writer, successStatusCode, responseBody)
 	if err != nil {
 		f.logger.Error(err.Error())
 	}
@@ -665,14 +656,7 @@ func (f *Frontend) ArmSubscriptionGet(writer http.ResponseWriter, request *http.
 		return
 	}
 
-	resp, err := json.Marshal(&doc.Subscription)
-	if err != nil {
-		f.logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
-	}
-
-	_, err = writer.Write(resp)
+	_, err = arm.WriteJSONResponse(writer, http.StatusOK, &doc.Subscription)
 	if err != nil {
 		f.logger.Error(err.Error())
 	}
@@ -746,15 +730,7 @@ func (f *Frontend) ArmSubscriptionPut(writer http.ResponseWriter, request *http.
 		"state":          string(subscription.State),
 	})
 
-	resp, err := json.Marshal(subscription)
-	if err != nil {
-		f.logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
-	}
-
-	writer.WriteHeader(http.StatusCreated)
-	_, err = writer.Write(resp)
+	_, err = arm.WriteJSONResponse(writer, http.StatusCreated, subscription)
 	if err != nil {
 		f.logger.Error(err.Error())
 	}
@@ -909,14 +885,7 @@ func (f *Frontend) OperationStatus(writer http.ResponseWriter, request *http.Req
 		return
 	}
 
-	responseBody, err := json.Marshal(doc.ToStatus())
-	if err != nil {
-		f.logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
-	}
-
-	_, err = writer.Write(responseBody)
+	_, err = arm.WriteJSONResponse(writer, http.StatusOK, doc.ToStatus())
 	if err != nil {
 		f.logger.Error(err.Error())
 	}
@@ -930,7 +899,7 @@ func marshalCSCluster(csCluster *cmv1.Cluster, doc *database.ResourceDocument, v
 	hcpCluster.TrackedResource.Tags = maps.Clone(doc.Tags)
 	hcpCluster.Properties.ProvisioningState = doc.ProvisioningState
 
-	return json.Marshal(versionedInterface.NewHCPOpenShiftCluster(hcpCluster))
+	return arm.Marshal(versionedInterface.NewHCPOpenShiftCluster(hcpCluster))
 }
 
 func getSubscriptionDifferences(oldSub, newSub *arm.Subscription) []string {
@@ -1039,9 +1008,7 @@ func (f *Frontend) OperationResult(writer http.ResponseWriter, request *http.Req
 		return
 	}
 
-	writer.WriteHeader(successStatusCode)
-
-	_, err = writer.Write(responseBody)
+	_, err = arm.WriteJSONResponse(writer, successStatusCode, responseBody)
 	if err != nil {
 		f.logger.Error(err.Error())
 	}

--- a/frontend/pkg/frontend/middleware_logging.go
+++ b/frontend/pkg/frontend/middleware_logging.go
@@ -34,8 +34,6 @@ type LoggingResponseWriter struct {
 }
 
 func (w *LoggingResponseWriter) Write(b []byte) (int, error) {
-	// All response body content is application/json.
-	w.Header().Set("Content-Type", "application/json")
 	n, err := w.ResponseWriter.Write(b)
 	w.bytesWritten += n
 	return n, err

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -251,9 +251,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		return
 	}
 
-	writer.WriteHeader(successStatusCode)
-
-	_, err = writer.Write(responseBody)
+	_, err = arm.WriteJSONResponse(writer, successStatusCode, responseBody)
 	if err != nil {
 		f.logger.Error(err.Error())
 	}
@@ -266,5 +264,5 @@ func marshalCSNodePool(csNodePool *cmv1.NodePool, doc *database.ResourceDocument
 	hcpNodePool.TrackedResource.Tags = maps.Clone(doc.Tags)
 	hcpNodePool.Properties.ProvisioningState = doc.ProvisioningState
 
-	return json.Marshal(versionedInterface.NewHCPOpenShiftClusterNodePool(hcpNodePool))
+	return arm.Marshal(versionedInterface.NewHCPOpenShiftClusterNodePool(hcpNodePool))
 }

--- a/internal/api/arm/error.go
+++ b/internal/api/arm/error.go
@@ -105,12 +105,8 @@ func WriteError(w http.ResponseWriter, statusCode int, code, target, format stri
 
 // WriteCloudError writes a CloudError to the given ResponseWriter
 func WriteCloudError(w http.ResponseWriter, err *CloudError) {
-	w.Header()["Content-Type"] = []string{"application/json"}
 	w.Header()[HeaderNameErrorCode] = []string{err.Code}
-	w.WriteHeader(err.StatusCode)
-	encoder := json.NewEncoder(w)
-	encoder.SetIndent("", "    ")
-	_ = encoder.Encode(err)
+	_, _ = WriteJSONResponse(w, err.StatusCode, err)
 }
 
 // NewInternalServerError creates a CloudError for an internal server error

--- a/internal/api/arm/preflight.go
+++ b/internal/api/arm/preflight.go
@@ -89,9 +89,5 @@ func WriteDeploymentPreflightResponse(w http.ResponseWriter, preflightErrors []C
 		}
 	}
 
-	w.Header()["Content-Type"] = []string{"application/json"}
-	w.WriteHeader(http.StatusOK)
-	encoder := json.NewEncoder(w)
-	encoder.SetIndent("", "    ")
-	_ = encoder.Encode(response)
+	_, _ = WriteJSONResponse(w, http.StatusOK, response)
 }

--- a/internal/api/arm/resource.go
+++ b/internal/api/arm/resource.go
@@ -4,9 +4,7 @@ package arm
 // Licensed under the Apache License 2.0.
 
 import (
-	"encoding/json"
 	"maps"
-	"net/url"
 	"time"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -155,35 +153,4 @@ func (s ProvisioningState) IsTerminal() bool {
 	default:
 		return false
 	}
-}
-
-// PagedResponse is the response format for resource collection requests.
-type PagedResponse struct {
-	Value    []json.RawMessage `json:"value"`
-	NextLink string            `json:"nextLink,omitempty"`
-}
-
-// AddValue adds a JSON encoded value to a PagedResponse.
-func (r *PagedResponse) AddValue(value json.RawMessage) {
-	r.Value = append(r.Value, value)
-}
-
-// SetNextLink sets NextLink to a URL with a $skipToken parameter.
-// If skipToken is empty, the function does nothing and returns nil.
-func (r *PagedResponse) SetNextLink(baseURL, skipToken string) error {
-	if skipToken == "" {
-		return nil
-	}
-
-	u, err := url.ParseRequestURI(baseURL)
-	if err != nil {
-		return err
-	}
-
-	values := u.Query()
-	values.Set("$skipToken", skipToken)
-	u.RawQuery = values.Encode()
-
-	r.NextLink = u.String()
-	return nil
 }

--- a/internal/api/arm/response.go
+++ b/internal/api/arm/response.go
@@ -1,0 +1,40 @@
+package arm
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// PagedResponse is the response format for resource collection requests.
+type PagedResponse struct {
+	Value    []json.RawMessage `json:"value"`
+	NextLink string            `json:"nextLink,omitempty"`
+}
+
+// AddValue adds a JSON encoded value to a PagedResponse.
+func (r *PagedResponse) AddValue(value json.RawMessage) {
+	r.Value = append(r.Value, value)
+}
+
+// SetNextLink sets NextLink to a URL with a $skipToken parameter.
+// If skipToken is empty, the function does nothing and returns nil.
+func (r *PagedResponse) SetNextLink(baseURL, skipToken string) error {
+	if skipToken == "" {
+		return nil
+	}
+
+	u, err := url.ParseRequestURI(baseURL)
+	if err != nil {
+		return err
+	}
+
+	values := u.Query()
+	values.Set("$skipToken", skipToken)
+	u.RawQuery = values.Encode()
+
+	r.NextLink = u.String()
+	return nil
+}

--- a/internal/api/arm/response_test.go
+++ b/internal/api/arm/response_test.go
@@ -1,0 +1,87 @@
+package arm
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestWriteJSONResponse(t *testing.T) {
+	resourceStruct := &TrackedResource{
+		Resource: Resource{
+			ID:   "00000000-0000-0000-0000-000000000000",
+			Name: "testCluster",
+			Type: "Microsoft.RedHatOpenShift/hcpOpenShiftClusters",
+		},
+		Location: "eastus1",
+		Tags: map[string]string{
+			"nameA": "valueA",
+			"nameB": "valueB",
+		},
+	}
+
+	resourceBytes, err := Marshal(resourceStruct)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       any
+	}{
+		{
+			name:       "Write structured data",
+			statusCode: http.StatusAccepted,
+			body:       resourceStruct,
+		},
+		{
+			name:       "Write byte slice",
+			statusCode: http.StatusCreated,
+			body:       resourceBytes,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+
+			_, err := WriteJSONResponse(recorder, tt.statusCode, tt.body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result := recorder.Result()
+
+			if result.StatusCode != tt.statusCode {
+				t.Errorf("Got status code %d, expected %d", result.StatusCode, tt.statusCode)
+			}
+
+			contentType := result.Header.Get("Content-Type")
+			if contentType == "" {
+				t.Errorf("Response is missing a Content-Type header")
+			} else if contentType != "application/json" {
+				t.Errorf("Got Content-Type %s, expected application/json", contentType)
+			}
+
+			expectBody, err := Marshal(resourceStruct)
+			if err != nil {
+				t.Fatal(err)
+			}
+			actualBody, err := io.ReadAll(result.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(actualBody) != string(expectBody) {
+				t.Error("Response body had unexpected variations:\n" + cmp.Diff(string(expectBody), string(actualBody)))
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
### What this PR does

Adds functions to the `/internal/api/arm` package to correctly write HTTP response bodies with consistent JSON formatting:

```
// Marshal returns the JSON encoding of v.
//
// Call this function instead of the marshal functions in "encoding/json" for
// HTTP responses to ensure the formatting is consistent.
func Marshal(v any) ([]byte, error)

// WriteJSONResponse writes a JSON response body to the http.ResponseWriter in
// the proper sequence: first setting Content-Type to "application/json", then
// setting the HTTP status code, and finally writing a JSON encoding of body.
//
// The function accepts anything for the body argument that can be marshalled
// to JSON. One special case, however, is a byte slice. A byte slice will be
// written verbatim with the expectation that it was produced by Marshal.
func WriteJSONResponse(writer http.ResponseWriter, statusCode int, body any) (int, error)
```

Having these in the `arm` package allows them to be called from anywhere.

In the past I tried to centralize adding `Content-Type: application/json` headers to response bodies ([#677](https://github.com/Azure/ARO-HCP/pull/677)) but it didn't work because I misunderstood `http.ResponseWriter` semantics (and apparently didn't test it very well).  This PR reverts that attempted solution.

Jira: No Jira, just refactoring.
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
