### PR TITLE
handle ResourceGroup ScopeLocked error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ env
 */archive.tar.gz
 tooling/bin
 tooling/image-sync/config.yml
+**/venv
+**/__pycache__

--- a/tooling/azure-automation/resources-cleanup/requirements.txt
+++ b/tooling/azure-automation/resources-cleanup/requirements.txt
@@ -19,7 +19,7 @@ portalocker==2.8.2
 pycparser==2.21
 PyJWT==2.8.0
 pytest==7.4.4
-requests==2.32.0
+requests==2.32.3
 six==1.16.0
 tomli==2.0.1
 typing_extensions==4.9.0

--- a/tooling/azure-automation/resources-cleanup/src/resources_cleanup.py
+++ b/tooling/azure-automation/resources-cleanup/src/resources_cleanup.py
@@ -120,10 +120,10 @@ def process_resource_group(resource_group: ResourceGroup, resource_client: Resou
         result_poller = resource_client.resource_groups.begin_delete(resource_group_name)
         print(f"result_poller of resource group deletion: {result_poller}")
     except HttpResponseError as err:
-        target_error_code = "DenyAssignmentAuthorizationFailed"
-        if err.error.code == target_error_code:
-            print("skipping deletion of resource group due to deny assignment in the resource group")
-        else: 
+        error_codes = ("DenyAssignmentAuthorizationFailed", "ScopeLocked")
+        if err.error.code in error_codes:
+            print(f"skipping deletion of resource group due to error code {err.error.code}")
+        else:
             raise err
             
     


### PR DESCRIPTION
### What this PR does
Fixes cleanup automation so the script does not fail when a resource group is ScopeLocked and missing persist=true.

Also ignores some python files and bumps requests as it was yanked.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
