### PR TITLE
frontend: Fix panic during unit tests in EmitCounter

### DIFF
--- a/frontend/pkg/frontend/metrics.go
+++ b/frontend/pkg/frontend/metrics.go
@@ -51,7 +51,7 @@ func (pe *PrometheusEmitter) EmitCounter(name string, value float64, labels map[
 	if !exists {
 		labelKeys := maps.Keys(labels)
 		vec = prometheus.NewCounterVec(prometheus.CounterOpts{Name: name}, labelKeys)
-		prometheus.MustRegister(vec)
+		pe.registry.MustRegister(vec)
 		pe.counters[name] = vec
 	}
 	vec.With(labels).Add(value)


### PR DESCRIPTION
### What this PR does

Fixes #723 

`EmitCounter` was registering its collector to the default registerer instead of the `PrometheusEmitter` registry, so unit tests that used `PrometheusEmitter` would panic on the second test case for trying to register a duplicate collector.

The panic was being caught and obfuscated, however, by `MiddlewarePanic`, and would often manifest in unit test output as
```
    http: superfluous response.WriteHeader call from ...
```
when `MiddlewarePanic` attempted to call `WriteInternalServerError`.

### Special notes for your reviewer

<!-- optional -->
