### PR TITLE
AKS creation timing issue with KV rolebinding

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -361,6 +361,10 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-04-02-previ
     }
     supportPlan: 'KubernetesOfficial'
   }
+  dependsOn: [
+    aksNetworkContributorRoleAssignment
+    aks_keyvault_crypto_user
+  ]
 }
 
 resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2024-04-02-preview' = [


### PR DESCRIPTION
### What this PR does

sometimes the AKS cluster creation fails because the AKS MI does not have permissions on the etcd KV yet. this PR introduces an explicit dependency from the AKS resource to the KV roleassignment (and the VNET role assignment as well).

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
