### PR TITLE
frontend: Make PrometheusEmitter concurrency-safe

### DIFF
--- a/frontend/pkg/frontend/metrics.go
+++ b/frontend/pkg/frontend/metrics.go
@@ -6,6 +6,7 @@ package frontend
 import (
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -22,6 +23,7 @@ type Emitter interface {
 }
 
 type PrometheusEmitter struct {
+	mutex    sync.Mutex
 	gauges   map[string]*prometheus.GaugeVec
 	counters map[string]*prometheus.CounterVec
 	registry prometheus.Registerer
@@ -36,6 +38,8 @@ func NewPrometheusEmitter() *PrometheusEmitter {
 }
 
 func (pe *PrometheusEmitter) EmitGauge(name string, value float64, labels map[string]string) {
+	pe.mutex.Lock()
+	defer pe.mutex.Unlock()
 	vec, exists := pe.gauges[name]
 	if !exists {
 		labelKeys := maps.Keys(labels)
@@ -47,11 +51,13 @@ func (pe *PrometheusEmitter) EmitGauge(name string, value float64, labels map[st
 }
 
 func (pe *PrometheusEmitter) EmitCounter(name string, value float64, labels map[string]string) {
+	pe.mutex.Lock()
+	defer pe.mutex.Unlock()
 	vec, exists := pe.counters[name]
 	if !exists {
 		labelKeys := maps.Keys(labels)
 		vec = prometheus.NewCounterVec(prometheus.CounterOpts{Name: name}, labelKeys)
-		prometheus.MustRegister(vec)
+		pe.registry.MustRegister(vec)
 		pe.counters[name] = vec
 	}
 	vec.With(labels).Add(value)


### PR DESCRIPTION
### What this PR does

[http.Server.Serve](https://pkg.go.dev/net/http#Server.Serve) creates a new goroutine for each incoming connection so `PrometheusEmitter` needs to be concurrency-safe when registering new collectors.