### PR TITLE
remove templatize build caching

### DIFF
--- a/templatize.sh
+++ b/templatize.sh
@@ -96,10 +96,7 @@ else
     REGION_STAMP="${CLEAN_DEPLOY_ENV}"
 fi
 
-TEMPLATIZE=${PROJECT_ROOT_DIR}/tooling/templatize/templatize
-if [ ! -f "${TEMPLATIZE}" ] || [ -n "${REBUILD_TEMPLATIZE}" ]; then
-    go build -o "$TEMPLATIZE" ${PROJECT_ROOT_DIR}/tooling/templatize
-fi
+TEMPLATIZE="go run ${PROJECT_ROOT_DIR}/tooling/templatize"
 
 CONFIG_FILE=${PROJECT_ROOT_DIR}/config/config.yaml
 if [ -n "$INPUT" ] && [ -n "$OUTPUT" ]; then


### PR DESCRIPTION
### What this PR does

we don't have good cache invalidation for the templatize build cache. so people end up with potential stale binaries and get errors :(

this PR removes the build cache until we have a good solution

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
