### PR TITLE
Add leader election to the backend

### DIFF
--- a/backend/deploy/helm/backend/templates/backend.deployment.yaml
+++ b/backend/deploy/helm/backend/templates/backend.deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: aro-hcp-backend
 spec:
   progressDeadlineSeconds: 600
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/backend/deploy/helm/backend/templates/backend.deployment.yaml
+++ b/backend/deploy/helm/backend/templates/backend.deployment.yaml
@@ -44,6 +44,10 @@ spec:
               configMapKeyRef:
                 name: backend-config
                 key: LOCATION
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           ports:
             - containerPort: 8081
               protocol: TCP

--- a/backend/deploy/helm/backend/templates/leader-election.role.yaml
+++ b/backend/deploy/helm/backend/templates/leader-election.role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+  - patch

--- a/backend/deploy/helm/backend/templates/leader-election.rolebinding.yaml
+++ b/backend/deploy/helm/backend/templates/leader-election.rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backend-leader-election
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election
+subjects:
+- kind: ServiceAccount
+  name: backend
+  namespace: {{ .Release.Namespace }}

--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -59,7 +59,7 @@ func getInterval(envName string, defaultVal time.Duration, logger *slog.Logger) 
 	return defaultVal
 }
 
-func (s *OperationsScanner) Run(logger *slog.Logger, stop <-chan struct{}) {
+func (s *OperationsScanner) Run(ctx context.Context, logger *slog.Logger) {
 	defer close(s.done)
 
 	var interval time.Duration
@@ -72,19 +72,20 @@ func (s *OperationsScanner) Run(logger *slog.Logger, stop <-chan struct{}) {
 	logger.Info("Polling Cluster Service every " + interval.String())
 	pollCSOperationsTicker := time.NewTicker(interval)
 
-	ctx := context.Background()
-
 	// Poll database immediately on startup.
 	s.pollDBOperations(ctx, logger)
 
+loop:
 	for {
 		select {
 		case <-pollDBOperationsTicker.C:
 			s.pollDBOperations(ctx, logger)
 		case <-pollCSOperationsTicker.C:
-			s.pollCSOperations(ctx, logger, stop)
-		case <-stop:
-			break
+			s.pollCSOperations(logger)
+		case <-ctx.Done():
+			// break alone just breaks out of select.
+			// Use a label to break out of the loop.
+			break loop
 		}
 	}
 }
@@ -123,35 +124,42 @@ func (s *OperationsScanner) pollDBOperations(ctx context.Context, logger *slog.L
 	}
 }
 
-func (s *OperationsScanner) pollCSOperations(ctx context.Context, logger *slog.Logger, stop <-chan struct{}) {
+func (s *OperationsScanner) pollCSOperations(logger *slog.Logger) {
 	var activeOperations []*database.OperationDocument
 
+	// We use a separate context here so that if the process receives a
+	// terminate signal, the backend can finish processing an operation
+	// before terminating.
+	//
+	// This is necessary in the absence of database transactions, though
+	// still not foolproof, to try to ensure consistency between resource
+	// and operation documents in Cosmos DB.
+	//
+	// Database transactions would be the preferred solution and we're
+	// working toward that.
+	ctx := context.Background()
+
 	for _, doc := range s.activeOperations {
-		select {
-		case <-stop:
-			break
-		default:
-			var requeue bool
-			var err error
+		var requeue bool
+		var err error
 
-			opLogger := logger.With(
-				"operation", doc.Request,
-				"operation_id", doc.ID,
-				"resource_id", doc.ExternalID.String(),
-				"internal_id", doc.InternalID.String())
+		opLogger := logger.With(
+			"operation", doc.Request,
+			"operation_id", doc.ID,
+			"resource_id", doc.ExternalID.String(),
+			"internal_id", doc.InternalID.String())
 
-			switch doc.InternalID.Kind() {
-			case cmv1.ClusterKind:
-				requeue, err = s.pollClusterOperation(ctx, opLogger, doc)
-			case cmv1.NodePoolKind:
-				requeue, err = s.pollNodePoolOperation(ctx, opLogger, doc)
-			}
-			if requeue {
-				activeOperations = append(activeOperations, doc)
-			}
-			if err != nil {
-				opLogger.Error(fmt.Sprintf("Error while polling operation '%s': %s", doc.ID, err.Error()))
-			}
+		switch doc.InternalID.Kind() {
+		case cmv1.ClusterKind:
+			requeue, err = s.pollClusterOperation(ctx, opLogger, doc)
+		case cmv1.NodePoolKind:
+			requeue, err = s.pollNodePoolOperation(ctx, opLogger, doc)
+		}
+		if requeue {
+			activeOperations = append(activeOperations, doc)
+		}
+		if err != nil {
+			opLogger.Error(fmt.Sprintf("Error while polling operation '%s': %s", doc.ID, err.Error()))
 		}
 	}
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -792,6 +792,7 @@ github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfE
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
@@ -1876,6 +1877,7 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220906165534-d0df966e6959/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
### What this PR does

Adds leader election to the backend deployment using the [k8s.io/client-go/tools/leaderelection](https://pkg.go.dev/k8s.io/client-go/tools/leaderelection) module so it can be horizontally scaled but still restrict active polling to one pod at a time.

Jira: No Jira, added by request
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

- The leader election module emits unstructured log messages through [klog](https://pkg.go.dev/k8s.io/klog/v2), so I had to catch these messages and try to adapt them to the standard library [structured logger](https://pkg.go.dev/log/slog), which required some futzing.  Please enlighten me if there's a better way to do this.

- I went ahead and bumped the backend replica count to 2 just to prove it works in dev environments.

- We should add a `/healthz` endpoint to the backend at some point.  The leader election module offers healthz integration for when it fails to renew the leader lease, but that's a pull request for another day.
