### PR TITLE
mirror catalog images for 4.16

### DIFF
--- a/dev-infrastructure/templates/image-sync.bicep
+++ b/dev-infrastructure/templates/image-sync.bicep
@@ -249,6 +249,10 @@ var ocpMirrorConfig = {
       graph: true
     }
     additionalImages: [
+      { name: 'registry.redhat.io/redhat/redhat-operator-index:v4.16' }
+      { name: 'registry.redhat.io/redhat/certified-operator-index:v4.16' }
+      { name: 'registry.redhat.io/redhat/community-operator-index:v4.16' }
+      { name: 'registry.redhat.io/redhat/redhat-marketplace-index:v4.16' }
       { name: 'registry.redhat.io/redhat/redhat-operator-index:v4.17' }
       { name: 'registry.redhat.io/redhat/certified-operator-index:v4.17' }
       { name: 'registry.redhat.io/redhat/community-operator-index:v4.17' }


### PR DESCRIPTION
### What this PR does

the 4.17 CPO references the 4.16 catalog images so they need to remain synced

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
