### PR TITLE
fix typo in the storage container name

### DIFF
--- a/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
+++ b/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
@@ -373,7 +373,7 @@ objects:
           "scopeMapName": "_repositories_pull"
         },
         "dataplane_identities_oidc_configuration": {
-          "storage_account_blob_container_name": "$$web",
+          "storage_account_blob_container_name": "$web",
           "storage_account_blob_service_url": "${OIDC_ISSUER_BLOB_SERVICE_URL}",
           "oidc_issuer_base_url": "${OIDC_ISSUER_BASE_URL}"
           }


### PR DESCRIPTION
### What this PR does

There was a typo in container name from the https://github.com/Azure/ARO-HCP/pull/860 PR . It should've been `$web` and not `$$web`. Notice the extra `$`


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
