### PR TITLE
refactor templatize ev2 package

### DIFF
--- a/tooling/templatize/pkg/config/config.go
+++ b/tooling/templatize/pkg/config/config.go
@@ -258,7 +258,7 @@ func PreprocessFile(templateFilePath string, vars map[string]any) ([]byte, error
 	return processedContent, nil
 }
 
-// PreprocessFile processes a gotemplate from memory
+// PreprocessContent processes a gotemplate from memory
 func PreprocessContent(content []byte, vars map[string]any) ([]byte, error) {
 	tmpl := template.New("file")
 	tmpl, err := tmpl.Parse(string(content))

--- a/tooling/templatize/pkg/config/config.go
+++ b/tooling/templatize/pkg/config/config.go
@@ -247,20 +247,28 @@ func (cp *configProviderImpl) loadConfig(configReplacements *ConfigReplacements)
 // PreprocessFile reads and processes a gotemplate
 // The path will be read as is. It parses the file as a template, and executes it with the provided variables.
 func PreprocessFile(templateFilePath string, vars map[string]any) ([]byte, error) {
-	tmpl := template.New("file")
 	content, err := os.ReadFile(templateFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %s: %w", templateFilePath, err)
 	}
-
-	tmpl, err = tmpl.Parse(string(content))
+	processedContent, err := PreprocessContent(content, vars)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse template %s: %w", templateFilePath, err)
+		return nil, fmt.Errorf("failed to preprocess file %s: %w", templateFilePath, err)
+	}
+	return processedContent, nil
+}
+
+// PreprocessFile processes a gotemplate from memory
+func PreprocessContent(content []byte, vars map[string]any) ([]byte, error) {
+	tmpl := template.New("file")
+	tmpl, err := tmpl.Parse(string(content))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
 	}
 
 	var tmplBytes bytes.Buffer
 	if err := tmpl.Option("missingkey=error").Execute(&tmplBytes, vars); err != nil {
-		return nil, fmt.Errorf("failed to execute template %s: %w", templateFilePath, err)
+		return nil, fmt.Errorf("failed to execute template: %w", err)
 	}
 	return tmplBytes.Bytes(), nil
 }

--- a/tooling/templatize/pkg/ev2/pipeline.go
+++ b/tooling/templatize/pkg/ev2/pipeline.go
@@ -1,6 +1,7 @@
 package ev2
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -10,73 +11,109 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/pipeline"
 )
 
-func PrecompilePipelineForEV2(pipelineFilePath string, vars config.Variables) (string, error) {
-	// switch to the pipeline file dir so all relative paths are resolved correctly
-	originalDir, err := os.Getwd()
-	if err != nil {
-		return "", nil
-	}
-	pipelineDir := filepath.Dir(pipelineFilePath)
-	err = os.Chdir(pipelineDir)
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		_ = os.Chdir(originalDir)
-	}()
+const precompiledPrefix = "ev2-precompiled-"
 
-	// precompile the pipeline file
-	pipelineFileName := filepath.Base(pipelineFilePath)
-	p, err := pipeline.NewPipelineFromFile(pipelineFileName, vars)
-	if err != nil {
-		return "", err
-	}
-	err = processPipelineForEV2(p, vars)
+func PrecompilePipelineFileForEV2(pipelineFilePath string, vars config.Variables) (string, error) {
+	precompiledPipeline, err := PrecompilePipelineForEV2(pipelineFilePath, vars)
 	if err != nil {
 		return "", err
 	}
 
 	// store as new file
-	pipelineBytes, err := yaml.Marshal(p)
+	pipelineBytes, err := yaml.Marshal(precompiledPipeline)
 	if err != nil {
 		return "", err
 	}
-	newPipelineFileName := "ev2-precompiled-" + pipelineFileName
-	err = os.WriteFile(newPipelineFileName, pipelineBytes, 0644)
+	err = os.WriteFile(precompiledPipeline.PipelineFilePath(), pipelineBytes, 0644)
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(pipelineDir, newPipelineFileName), nil
+	return precompiledPipeline.PipelineFilePath(), nil
 }
 
-func processPipelineForEV2(p *pipeline.Pipeline, vars config.Variables) error {
-	_, scopeBoundVars := EV2Mapping(vars, []string{})
+func PrecompilePipelineForEV2(pipelineFilePath string, vars config.Variables) (*pipeline.Pipeline, error) {
+	// load the pipeline and referenced files
+	originalPipeline, err := pipeline.NewPipelineFromFile(pipelineFilePath, vars)
+	if err != nil {
+		return nil, err
+	}
+	referencedFiles, err := readReferencedPipelineFiles(originalPipeline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read referenced files of pipeline %s: %w", originalPipeline.PipelineFilePath(), err)
+	}
+
+	// precompile the pipeline and referenced files
+	processedPipeline, processedFiles, err := processPipelineForEV2(originalPipeline, referencedFiles, vars)
+	if err != nil {
+		return nil, err
+	}
+
+	// store the processed files to disk relative to the pipeline directory
+	_, restoreDir, err := processedPipeline.EnterPipelineDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to enter pipeline directory: %w", err)
+	}
+	defer restoreDir()
+	for filePath, content := range processedFiles {
+		err := os.WriteFile(filePath, content, 0644)
+		if err != nil {
+			return nil, fmt.Errorf("failed to write precompiled file %q: %w", filePath, err)
+		}
+	}
+
+	return processedPipeline, nil
+}
+
+func readReferencedPipelineFiles(p *pipeline.Pipeline) (map[string][]byte, error) {
+	// switch to pipeline directory to ensure relative paths are resolvable
+	_, restoreDir, err := p.EnterPipelineDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to enter pipeline directory: %w", err)
+	}
+	defer restoreDir()
+
+	referencedFiles := make(map[string][]byte)
 	for _, rg := range p.ResourceGroups {
 		for _, step := range rg.Steps {
 			if step.Parameters != "" {
-				newParameterFilePath, err := precompileFileAndStore(step.Parameters, scopeBoundVars)
+				paramFileContent, err := os.ReadFile(step.Parameters)
 				if err != nil {
-					return err
+					return nil, fmt.Errorf("failed to read parameter file %q: %w", step.Parameters, err)
 				}
+				referencedFiles[step.Parameters] = paramFileContent
+			}
+		}
+	}
+	return referencedFiles, nil
+}
+
+func processPipelineForEV2(p *pipeline.Pipeline, referencedFiles map[string][]byte, vars config.Variables) (*pipeline.Pipeline, map[string][]byte, error) {
+	processingPipeline, err := p.DeepCopy(buildPrefixedFilePath(p.PipelineFilePath(), precompiledPrefix))
+	if err != nil {
+		return nil, nil, err
+	}
+	processedFiles := make(map[string][]byte)
+	_, scopeBoundVars := EV2Mapping(vars, []string{})
+	for _, rg := range processingPipeline.ResourceGroups {
+		for _, step := range rg.Steps {
+			// preprocess the parameters file with scopebinding variables
+			if step.Parameters != "" {
+				paramFileContent, ok := referencedFiles[step.Parameters]
+				if !ok {
+					return nil, nil, fmt.Errorf("parameter file %q not found", step.Parameters)
+				}
+				preprocessedBytes, err := config.PreprocessContent(paramFileContent, scopeBoundVars)
+				if err != nil {
+					return nil, nil, err
+				}
+				newParameterFilePath := buildPrefixedFilePath(step.Parameters, precompiledPrefix)
+				processedFiles[newParameterFilePath] = preprocessedBytes
 				step.Parameters = newParameterFilePath
 			}
 		}
 	}
-	return nil
-}
-
-func precompileFileAndStore(filePath string, vars map[string]interface{}) (string, error) {
-	preprocessedBytes, err := config.PreprocessFile(filePath, vars)
-	if err != nil {
-		return "", err
-	}
-	newFilePath := buildPrefixedFilePath(filePath, "ev2-precompiled-")
-	err = os.WriteFile(newFilePath, preprocessedBytes, 0644)
-	if err != nil {
-		return "", err
-	}
-	return newFilePath, nil
+	return processingPipeline, processedFiles, nil
 }
 
 func buildPrefixedFilePath(path, prefix string) string {

--- a/tooling/templatize/pkg/ev2/utils.go
+++ b/tooling/templatize/pkg/ev2/utils.go
@@ -10,7 +10,7 @@ import (
 // This package contains helper functions to extract EV2 conformant data from a config.yaml file.
 //
 
-func newEv2ConfigReplacements() *config.ConfigReplacements {
+func NewEv2ConfigReplacements() *config.ConfigReplacements {
 	return config.NewConfigReplacements(
 		"$location()",
 		"$(regionShortName)",
@@ -23,7 +23,7 @@ func newEv2ConfigReplacements() *config.ConfigReplacements {
 // The variable values are formatted to contain EV2 $location(), $stamp() and $(serviceConfigVar) variables.
 // This function is useful to get the variables to fill the `Settings` section of an EV2 `ServiceConfig.json“
 func GetNonRegionalServiceConfigVariables(configProvider config.ConfigProvider, cloud, deployEnv string) (config.Variables, error) {
-	return configProvider.GetVariables(cloud, deployEnv, "", newEv2ConfigReplacements())
+	return configProvider.GetVariables(cloud, deployEnv, "", NewEv2ConfigReplacements())
 }
 
 // GetRegionalServiceConfigVariableOverrides returns the regional overrides of a config.yaml file.
@@ -36,7 +36,7 @@ func GetRegionalServiceConfigVariableOverrides(configProvider config.ConfigProvi
 	}
 	overrides := make(map[string]config.Variables)
 	for _, region := range regions {
-		regionOverrides, err := configProvider.GetRegionOverrides(cloud, deployEnv, region, newEv2ConfigReplacements())
+		regionOverrides, err := configProvider.GetRegionOverrides(cloud, deployEnv, region, NewEv2ConfigReplacements())
 		if err != nil {
 			return nil, err
 		}
@@ -49,7 +49,7 @@ func GetRegionalServiceConfigVariableOverrides(configProvider config.ConfigProvi
 // It uses the provided configProvider to fetch the variables, flattens them into a __VAR__ = $config(var) formatted map.
 // This function is useful to get the find/replace pairs for an EV2 `ScopeBinding.json`
 func ScopeBindingVariables(configProvider config.ConfigProvider, cloud, deployEnv string) (map[string]string, error) {
-	vars, err := configProvider.GetVariables(cloud, deployEnv, "", newEv2ConfigReplacements())
+	vars, err := configProvider.GetVariables(cloud, deployEnv, "", NewEv2ConfigReplacements())
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func ScopeBindingVariables(configProvider config.ConfigProvider, cloud, deployEn
 // while maintaining EV2 conformant system variables.
 // This function is useful to process a pipeline.yaml file so that it contains EV2 system variables.
 func PreprocessFileForEV2SystemVars(configProvider config.ConfigProvider, cloud, deployEnv string, templateFile string) ([]byte, error) {
-	vars, err := configProvider.GetVariables(cloud, deployEnv, "", newEv2ConfigReplacements())
+	vars, err := configProvider.GetVariables(cloud, deployEnv, "", NewEv2ConfigReplacements())
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func PreprocessFileForEV2SystemVars(configProvider config.ConfigProvider, cloud,
 // This function is useful to process bicepparam files so that they can be used within EV2 together
 // with scopebinding.
 func PreprocessFileForEV2ScopeBinding(configProvider config.ConfigProvider, cloud, deployEnv string, templateFile string) ([]byte, error) {
-	vars, err := configProvider.GetVariables(cloud, deployEnv, "", newEv2ConfigReplacements())
+	vars, err := configProvider.GetVariables(cloud, deployEnv, "", NewEv2ConfigReplacements())
 	if err != nil {
 		return nil, err
 	}

--- a/tooling/templatize/pkg/pipeline/arm.go
+++ b/tooling/templatize/pkg/pipeline/arm.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-logr/logr"
 )
 
-func (s *step) runArmStep(ctx context.Context, executionTarget *ExecutionTarget, options *PipelineRunOptions) error {
+func (s *Step) runArmStep(ctx context.Context, executionTarget *ExecutionTarget, options *PipelineRunOptions) error {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	// Transform Bicep to ARM
@@ -59,7 +59,7 @@ func (s *step) runArmStep(ctx context.Context, executionTarget *ExecutionTarget,
 	return nil
 }
 
-func (s *step) ensureResourceGroupExists(ctx context.Context, executionTarget *ExecutionTarget) error {
+func (s *Step) ensureResourceGroupExists(ctx context.Context, executionTarget *ExecutionTarget) error {
 	// Create a new Azure identity client
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {

--- a/tooling/templatize/pkg/pipeline/common.go
+++ b/tooling/templatize/pkg/pipeline/common.go
@@ -2,7 +2,6 @@ package pipeline
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"gopkg.in/yaml.v3"
@@ -26,22 +25,6 @@ func (p *Pipeline) PipelineFilePath() string {
 	return p.pipelineFilePath
 }
 
-func (p *Pipeline) EnterPipelineDir() (string, func(), error) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return "", nil, err
-	}
-
-	pipelineDir, err := filepath.Abs(filepath.Dir(p.pipelineFilePath))
-	if err != nil {
-		return "", nil, err
-	}
-	err = os.Chdir(pipelineDir)
-	if err != nil {
-		return "", nil, err
-	}
-
-	return pipelineDir, func() {
-		_ = os.Chdir(currentDir)
-	}, nil
+func (p *Pipeline) AbsoluteFilePath(filePath string) (string, error) {
+	return filepath.Abs(filepath.Join(filepath.Dir(p.pipelineFilePath), filePath))
 }

--- a/tooling/templatize/pkg/pipeline/common.go
+++ b/tooling/templatize/pkg/pipeline/common.go
@@ -1,0 +1,47 @@
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+func (p *Pipeline) DeepCopy(newPipelineFilePath string) (*Pipeline, error) {
+	copy := new(Pipeline)
+	data, err := yaml.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal pipeline: %v", err)
+	}
+	err = yaml.Unmarshal(data, copy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal pipeline: %v", err)
+	}
+	copy.pipelineFilePath = newPipelineFilePath
+	return copy, nil
+}
+
+func (p *Pipeline) PipelineFilePath() string {
+	return p.pipelineFilePath
+}
+
+func (p *Pipeline) EnterPipelineDir() (string, func(), error) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", nil, err
+	}
+
+	pipelineDir, err := filepath.Abs(filepath.Dir(p.pipelineFilePath))
+	if err != nil {
+		return "", nil, err
+	}
+	err = os.Chdir(pipelineDir)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return pipelineDir, func() {
+		_ = os.Chdir(currentDir)
+	}, nil
+}

--- a/tooling/templatize/pkg/pipeline/common_test.go
+++ b/tooling/templatize/pkg/pipeline/common_test.go
@@ -1,0 +1,68 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"gotest.tools/v3/assert"
+
+	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/config"
+)
+
+func TestDeepCopy(t *testing.T) {
+	configProvider := config.NewConfigProvider("../../testdata/config.yaml")
+	vars, err := configProvider.GetVariables("public", "int", "", config.NewConfigReplacements("r", "sr", "s"))
+	if err != nil {
+		t.Errorf("failed to get variables: %v", err)
+	}
+	pipeline, err := NewPipelineFromFile("../../testdata/pipeline.yaml", vars)
+	if err != nil {
+		t.Errorf("failed to read new pipeline: %v", err)
+	}
+
+	newPipelinePath := "new-pipeline.yaml"
+	pipelineCopy, err := pipeline.DeepCopy(newPipelinePath)
+	if err != nil {
+		t.Errorf("failed to copy pipeline: %v", err)
+	}
+
+	assert.Assert(t, pipeline != pipelineCopy, "expected pipeline and copy to be different")
+	assert.Equal(t, pipelineCopy.PipelineFilePath(), newPipelinePath, "expected pipeline copy to have new path")
+
+	if diff := cmp.Diff(pipeline, pipelineCopy, cmpopts.IgnoreUnexported(Pipeline{}, Step{})); diff != "" {
+		t.Errorf("got diffs after pipeline deep copy: %v", diff)
+	}
+}
+
+func TestEnterPipelineDir(t *testing.T) {
+	configProvider := config.NewConfigProvider("../../testdata/config.yaml")
+	vars, err := configProvider.GetVariables("public", "int", "", config.NewConfigReplacements("r", "sr", "s"))
+	if err != nil {
+		t.Errorf("failed to get variables: %v", err)
+	}
+	pipeline, err := NewPipelineFromFile("../../testdata/pipeline.yaml", vars)
+	if err != nil {
+		t.Errorf("failed to read new pipeline: %v", err)
+	}
+
+	originalDir, _ := os.Getwd()
+
+	pipelineDir, cleanup, err := pipeline.EnterPipelineDir()
+	if err != nil {
+		t.Errorf("failed to enter pipeline dir: %v", err)
+	}
+	defer cleanup()
+
+	currentDir, _ := os.Getwd()
+	pipelineAbsDir, _ := filepath.Abs(pipelineDir)
+	assert.Equal(t, pipelineDir, pipelineAbsDir, "expected absolute pipeline dir to be announced")
+	assert.Equal(t, currentDir, pipelineAbsDir, "expected to be in pipeline dir")
+
+	cleanup()
+	restoredDir, _ := os.Getwd()
+	assert.Equal(t, restoredDir, originalDir, "expected to return to original dir")
+
+}

--- a/tooling/templatize/pkg/pipeline/inspect.go
+++ b/tooling/templatize/pkg/pipeline/inspect.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/config"
 )
 
-type StepInspectScope func(*step, *InspectOptions, io.Writer) error
+type StepInspectScope func(*Step, *InspectOptions, io.Writer) error
 
 func NewStepInspectScopes() map[string]StepInspectScope {
 	return map[string]StepInspectScope{
@@ -57,7 +57,7 @@ func (p *Pipeline) Inspect(ctx context.Context, options *InspectOptions, writer 
 	return fmt.Errorf("step %q not found", options.Step)
 }
 
-func inspectVars(s *step, options *InspectOptions, writer io.Writer) error {
+func inspectVars(s *Step, options *InspectOptions, writer io.Writer) error {
 	var envVars map[string]string
 	var err error
 	switch s.Action {

--- a/tooling/templatize/pkg/pipeline/inspect_test.go
+++ b/tooling/templatize/pkg/pipeline/inspect_test.go
@@ -14,14 +14,14 @@ import (
 func TestInspectVars(t *testing.T) {
 	testCases := []struct {
 		name     string
-		caseStep *step
+		caseStep *Step
 		options  *InspectOptions
 		expected string
 		err      string
 	}{
 		{
 			name: "basic",
-			caseStep: &step{
+			caseStep: &Step{
 				Action: "Shell",
 				Env: []EnvVar{
 					{
@@ -40,7 +40,7 @@ func TestInspectVars(t *testing.T) {
 		},
 		{
 			name: "makefile",
-			caseStep: &step{
+			caseStep: &Step{
 				Action: "Shell",
 				Env: []EnvVar{
 					{
@@ -59,12 +59,12 @@ func TestInspectVars(t *testing.T) {
 		},
 		{
 			name:     "failed action",
-			caseStep: &step{Action: "Unknown"},
+			caseStep: &Step{Action: "Unknown"},
 			err:      "inspecting step variables not implemented for action type Unknown",
 		},
 		{
 			name:     "failed format",
-			caseStep: &step{Action: "Shell"},
+			caseStep: &Step{Action: "Shell"},
 			options:  &InspectOptions{Format: "unknown"},
 			err:      "unknown output format \"unknown\"",
 		},
@@ -86,8 +86,8 @@ func TestInspectVars(t *testing.T) {
 
 func TestInspect(t *testing.T) {
 	p := Pipeline{
-		ResourceGroups: []*resourceGroup{{
-			Steps: []*step{
+		ResourceGroups: []*ResourceGroup{{
+			Steps: []*Step{
 				{
 					Name: "step1",
 				},
@@ -98,7 +98,7 @@ func TestInspect(t *testing.T) {
 	opts := NewInspectOptions(config.Variables{}, "", "step1", "scope", "format")
 
 	opts.ScopeFunctions = map[string]StepInspectScope{
-		"scope": func(s *step, o *InspectOptions, w io.Writer) error {
+		"scope": func(s *Step, o *InspectOptions, w io.Writer) error {
 			assert.Equal(t, s.Name, "step1")
 			return nil
 		},
@@ -110,8 +110,8 @@ func TestInspect(t *testing.T) {
 
 func TestInspectWrongScope(t *testing.T) {
 	p := Pipeline{
-		ResourceGroups: []*resourceGroup{{
-			Steps: []*step{
+		ResourceGroups: []*ResourceGroup{{
+			Steps: []*Step{
 				{
 					Name: "step1",
 				},

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -78,7 +78,7 @@ func (p *Pipeline) Run(ctx context.Context, options *PipelineRunOptions) error {
 	return nil
 }
 
-func (rg *resourceGroup) run(ctx context.Context, options *PipelineRunOptions) error {
+func (rg *ResourceGroup) run(ctx context.Context, options *PipelineRunOptions) error {
 	// prepare execution context
 	subscriptionID, err := lookupSubscriptionID(ctx, rg.Subscription)
 	if err != nil {
@@ -132,7 +132,7 @@ func (rg *resourceGroup) run(ctx context.Context, options *PipelineRunOptions) e
 	return nil
 }
 
-func (s *step) run(ctx context.Context, kubeconfigFile string, executionTarget *ExecutionTarget, options *PipelineRunOptions) error {
+func (s *Step) run(ctx context.Context, kubeconfigFile string, executionTarget *ExecutionTarget, options *PipelineRunOptions) error {
 	fmt.Println("\n---------------------")
 	if options.DryRun {
 		fmt.Println("This is a dry run!")
@@ -169,7 +169,7 @@ func prepareKubeConfig(ctx context.Context, executionTarget *ExecutionTarget) (s
 	return kubeconfigFile, nil
 }
 
-func (s *step) description() string {
+func (s *Step) description() string {
 	var details []string
 	switch s.Action {
 	case "Shell":
@@ -191,7 +191,7 @@ func (p *Pipeline) Validate() error {
 	return nil
 }
 
-func (rg *resourceGroup) Validate() error {
+func (rg *ResourceGroup) Validate() error {
 	if rg.Name == "" {
 		return fmt.Errorf("resource group name is required")
 	}

--- a/tooling/templatize/pkg/pipeline/shell.go
+++ b/tooling/templatize/pkg/pipeline/shell.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/utils"
 )
 
-func (s *step) createCommand(ctx context.Context, dryRun bool, envVars map[string]string) (*exec.Cmd, bool) {
+func (s *Step) createCommand(ctx context.Context, dryRun bool, envVars map[string]string) (*exec.Cmd, bool) {
 	var cmd *exec.Cmd
 	if dryRun {
 		if s.DryRun.Command == nil && s.DryRun.EnvVars == nil {
@@ -33,7 +33,7 @@ func (s *step) createCommand(ctx context.Context, dryRun bool, envVars map[strin
 	return cmd, false
 }
 
-func (s *step) runShellStep(ctx context.Context, kubeconfigFile string, options *PipelineRunOptions) error {
+func (s *Step) runShellStep(ctx context.Context, kubeconfigFile string, options *PipelineRunOptions) error {
 	if s.outputFunc == nil {
 		s.outputFunc = func(output string) {
 			fmt.Println(output)
@@ -73,7 +73,7 @@ func (s *step) runShellStep(ctx context.Context, kubeconfigFile string, options 
 	return nil
 }
 
-func (s *step) mapStepVariables(vars config.Variables) (map[string]string, error) {
+func (s *Step) mapStepVariables(vars config.Variables) (map[string]string, error) {
 	envVars := make(map[string]string)
 	for _, e := range s.Env {
 		value, found := vars.GetByPath(e.ConfigRef)

--- a/tooling/templatize/pkg/pipeline/shell_test.go
+++ b/tooling/templatize/pkg/pipeline/shell_test.go
@@ -13,7 +13,7 @@ func TestCreateCommand(t *testing.T) {
 	ctx := context.Background()
 	testCases := []struct {
 		name            string
-		step            *step
+		step            *Step
 		dryRun          bool
 		envVars         map[string]string
 		expectedCommand string
@@ -23,7 +23,7 @@ func TestCreateCommand(t *testing.T) {
 	}{
 		{
 			name: "basic",
-			step: &step{
+			step: &Step{
 				Command: []string{"/usr/bin/echo", "hello"},
 			},
 			expectedCommand: "/usr/bin/echo",
@@ -31,9 +31,9 @@ func TestCreateCommand(t *testing.T) {
 		},
 		{
 			name: "dry-run",
-			step: &step{
+			step: &Step{
 				Command: []string{"/usr/bin/echo", "hello"},
-				DryRun: dryRun{
+				DryRun: DryRun{
 					Command: []string{"/usr/bin/echo", "dry-run"},
 				},
 			},
@@ -43,9 +43,9 @@ func TestCreateCommand(t *testing.T) {
 		},
 		{
 			name: "dry-run-env",
-			step: &step{
+			step: &Step{
 				Command: []string{"/usr/bin/echo"},
-				DryRun: dryRun{
+				DryRun: DryRun{
 					EnvVars: []EnvVar{
 						{
 							Name:  "DRY_RUN",
@@ -61,7 +61,7 @@ func TestCreateCommand(t *testing.T) {
 		},
 		{
 			name: "dry-run fail",
-			step: &step{
+			step: &Step{
 				Command: []string{"/usr/bin/echo"},
 			},
 			dryRun:      true,
@@ -90,7 +90,7 @@ func TestMapStepVariables(t *testing.T) {
 	testCases := []struct {
 		name     string
 		vars     config.Variables
-		step     step
+		step     Step
 		expected map[string]string
 		err      string
 	}{
@@ -99,7 +99,7 @@ func TestMapStepVariables(t *testing.T) {
 			vars: config.Variables{
 				"FOO": "bar",
 			},
-			step: step{
+			step: Step{
 				Env: []EnvVar{
 					{
 						Name:      "BAZ",
@@ -114,7 +114,7 @@ func TestMapStepVariables(t *testing.T) {
 		{
 			name: "missing",
 			vars: config.Variables{},
-			step: step{
+			step: Step{
 				Env: []EnvVar{
 					{
 						ConfigRef: "FOO",
@@ -128,7 +128,7 @@ func TestMapStepVariables(t *testing.T) {
 			vars: config.Variables{
 				"FOO": 42,
 			},
-			step: step{
+			step: Step{
 				Env: []EnvVar{
 					{
 						Name:      "BAZ",
@@ -157,7 +157,7 @@ func TestMapStepVariables(t *testing.T) {
 
 func TestRunShellStep(t *testing.T) {
 	expectedOutput := "hello\n"
-	s := &step{
+	s := &Step{
 		Command: []string{"echo", "hello"},
 		outputFunc: func(output string) {
 			assert.Equal(t, output, expectedOutput)

--- a/tooling/templatize/pkg/pipeline/types.go
+++ b/tooling/templatize/pkg/pipeline/types.go
@@ -4,37 +4,37 @@ type Pipeline struct {
 	pipelineFilePath string
 	ServiceGroup     string           `yaml:"serviceGroup"`
 	RolloutName      string           `yaml:"rolloutName"`
-	ResourceGroups   []*resourceGroup `yaml:"resourceGroups"`
+	ResourceGroups   []*ResourceGroup `yaml:"resourceGroups"`
 }
 
-type resourceGroup struct {
+type ResourceGroup struct {
 	Name         string  `yaml:"name"`
 	Subscription string  `yaml:"subscription"`
-	AKSCluster   string  `yaml:"aksCluster"`
-	Steps        []*step `yaml:"steps"`
+	AKSCluster   string  `yaml:"aksCluster,omitempty"`
+	Steps        []*Step `yaml:"steps"`
 }
 
 type outPutHandler func(string)
 
-type step struct {
+type Step struct {
 	Name       string   `yaml:"name"`
 	Action     string   `yaml:"action"`
-	Command    []string `yaml:"command"`
-	Env        []EnvVar `yaml:"env"`
-	Template   string   `yaml:"template"`
-	Parameters string   `yaml:"parameters"`
-	DependsOn  []string `yaml:"dependsOn"`
-	DryRun     dryRun   `yaml:"dryRun"`
+	Command    []string `yaml:"command,omitempty"`
+	Env        []EnvVar `yaml:"env,omitempty"`
+	Template   string   `yaml:"template,omitempty"`
+	Parameters string   `yaml:"parameters,omitempty"`
+	DependsOn  []string `yaml:"dependsOn,omitempty"`
+	DryRun     DryRun   `yaml:"dryRun,omitempty"`
 	outputFunc outPutHandler
 }
 
-type dryRun struct {
-	EnvVars []EnvVar `yaml:"envVars"`
-	Command []string `yaml:"command"`
+type DryRun struct {
+	EnvVars []EnvVar `yaml:"envVars,omitempty"`
+	Command []string `yaml:"command,omitempty"`
 }
 
 type EnvVar struct {
 	Name      string `yaml:"name"`
-	ConfigRef string `yaml:"configRef"`
-	Value     string `yaml:"value"`
+	ConfigRef string `yaml:"configRef,omitempty"`
+	Value     string `yaml:"value,omitempty"`
 }

--- a/tooling/templatize/testdata/zz_fixture_TestPreprocessContent.bicepparam
+++ b/tooling/templatize/testdata/zz_fixture_TestPreprocessContent.bicepparam
@@ -1,0 +1,10 @@
+// copy from dev-infrastructure/configurations/region.bicepparam
+using '../templates/region.bicep'
+
+// dns
+param baseDNSZoneName = 'hcp.osadev.cloud'
+param baseDNSZoneResourceGroup = 'global'
+
+// CS
+param csImage = 'cs-image'
+param regionRG = 'bahamas'

--- a/tooling/templatize/testdata/zz_fixture_TestPreprocessFilebicepparam
+++ b/tooling/templatize/testdata/zz_fixture_TestPreprocessFilebicepparam
@@ -1,0 +1,10 @@
+// copy from dev-infrastructure/configurations/region.bicepparam
+using '../templates/region.bicep'
+
+// dns
+param baseDNSZoneName = 'hcp.osadev.cloud'
+param baseDNSZoneResourceGroup = 'global'
+
+// CS
+param csImage = 'cs-image'
+param regionRG = 'bahamas'

--- a/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2ev2-precompiled-test.bicepparam
+++ b/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2ev2-precompiled-test.bicepparam
@@ -1,0 +1,1 @@
+param regionRG = '__REGIONRG__'

--- a/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2pipeline.yaml
+++ b/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2pipeline.yaml
@@ -1,0 +1,28 @@
+serviceGroup: Microsoft.Azure.ARO.Test
+rolloutName: Test Rollout
+resourceGroups:
+    - name: hcp-underlay-$(regionShortName)
+      subscription: hcp-$location()
+      aksCluster: aro-hcp-aks
+      steps:
+        - name: deploy
+          action: Shell
+          command:
+            - make
+            - deploy
+          env:
+            - name: MAESTRO_IMAGE
+              configRef: maestro_image
+        - name: dry-run
+          action: Shell
+          command:
+            - make
+            - deploy
+          dryRun:
+            envVars:
+                - name: DRY_RUN
+                  value: A very dry one
+        - name: svc
+          action: ARM
+          template: templates/svc-cluster.bicep
+          parameters: ev2-precompiled-test.bicepparam


### PR DESCRIPTION
### What this PR does

* `PrecompilePipelineForEV2` renamed to `PrecompilePipelineFileForEV2`
* `PrecompilePipelineForEV2` reintroduced but returns a parsed `pipeline.Pipeline` struct
* export all `config.Pipeline` sub-structs
* export `NewEv2ConfigReplacements`
* refactor tests to use fixtures

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
