### PR TITLE
hardcode 'managedIdentitiesDataPlaneAudienceResource' field of the azure runtime config to a dummy value.

### DIFF
--- a/cluster-service/deploy/azure-runtime-config.tmpl.yaml
+++ b/cluster-service/deploy/azure-runtime-config.tmpl.yaml
@@ -1,6 +1,7 @@
 {
   "cloudEnvironment": "AzurePublicCloud",
   "tenantId": "{{ .extraVars.tenantId }}",
+  "managedIdentitiesDataPlaneAudienceResource": "https://dummy.org",
   "ocpImagesAcr": {
     "resourceId": "{{ .extraVars.ocpAcrResourceId }}",
     "url": "{{ .extraVars.ocpAcrResourceUrl }}",

--- a/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
+++ b/cluster-service/deploy/openshift-templates/arohcp-service-template.yml
@@ -357,6 +357,8 @@ objects:
             version_constraints:
               min_version: 4.11.0
 
+# TODO: parameterize managedIdentitiesDataPlaneAudienceResource after templatize refactor and helm chart conversion
+# so that the value can be configured in higher envs.
 - apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -367,6 +369,7 @@ objects:
       {
         "cloudEnvironment": "AzurePublicCloud",
         "tenantId": "${TENANT_ID}",
+        "managedIdentitiesDataPlaneAudienceResource": "https://dummy.org",
         "ocpImagesAcr": {
           "resourceId": "${OCP_ACR_RESOURCE_ID}",
           "url": "${OCP_ACR_URL}",


### PR DESCRIPTION
Hardcode 'managedIdentitiesDataPlaneAudienceResource' field of the azure runtime config to a dummy value.
This is good enough for dev or int env.
Once templatize refactor and helm chart conversion is in place, the value will need to be parameterized.

### What this PR does


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
