### PR TITLE
don't uppercase scope binding replacement vars

### DIFF
--- a/tooling/templatize/pkg/ev2/mapping.go
+++ b/tooling/templatize/pkg/ev2/mapping.go
@@ -21,7 +21,7 @@ func EV2Mapping(input config.Variables, prefix []string) (map[string]string, map
 			}
 			replaced[key] = replacement
 		} else {
-			placeholder := fmt.Sprintf("__%s__", strings.ToUpper(strings.Join(nestedKey, "_")))
+			placeholder := fmt.Sprintf("__%s__", strings.Join(nestedKey, "_"))
 			output[placeholder] = strings.Join(nestedKey, ".")
 			replaced[key] = placeholder
 		}

--- a/tooling/templatize/pkg/ev2/mapping_test.go
+++ b/tooling/templatize/pkg/ev2/mapping_test.go
@@ -21,19 +21,19 @@ func TestMapping(t *testing.T) {
 		},
 	}
 	expectedFlattened := map[string]string{
-		"__KEY1__":                  "key1",
-		"__KEY2__":                  "key2",
-		"__KEY3__":                  "key3",
-		"__PARENT_NESTED__":         "parent.nested",
-		"__PARENT_DEEPER_DEEPEST__": "parent.deeper.deepest",
+		"__key1__":                  "key1",
+		"__key2__":                  "key2",
+		"__key3__":                  "key3",
+		"__parent_nested__":         "parent.nested",
+		"__parent_deeper_deepest__": "parent.deeper.deepest",
 	}
 	expectedReplace := map[string]interface{}{
-		"key1": "__KEY1__",
-		"key2": "__KEY2__",
-		"key3": "__KEY3__",
+		"key1": "__key1__",
+		"key2": "__key2__",
+		"key3": "__key3__",
 		"parent": map[string]interface{}{
-			"nested": "__PARENT_NESTED__",
-			"deeper": map[string]interface{}{"deepest": "__PARENT_DEEPER_DEEPEST__"},
+			"nested": "__parent_nested__",
+			"deeper": map[string]interface{}{"deepest": "__parent_deeper_deepest__"},
 		},
 	}
 	flattened, replace := EV2Mapping(testData, []string{})

--- a/tooling/templatize/pkg/ev2/utils_test.go
+++ b/tooling/templatize/pkg/ev2/utils_test.go
@@ -16,18 +16,18 @@ func TestScopeBindingVariables(t *testing.T) {
 		t.Fatalf("ScopeBindingVariables failed: %v", err)
 	}
 	expectedVars := map[string]string{
-		"__AKSNAME__":                       "$config(aksName)",
-		"__GLOBALRG__":                      "$config(globalRG)",
-		"__IMAGESYNCRG__":                   "$config(imageSyncRG)",
-		"__MAESTRO_HELM_CHART__":            "$config(maestro_helm_chart)",
-		"__MAESTRO_IMAGE__":                 "$config(maestro_image)",
-		"__MANAGEMENTCLUSTERRG__":           "$config(managementClusterRG)",
-		"__MANAGEMENTCLUSTERSUBSCRIPTION__": "$config(managementClusterSubscription)",
-		"__REGION__":                        "$config(region)",
-		"__REGIONRG__":                      "$config(regionRG)",
-		"__SERVICECLUSTERRG__":              "$config(serviceClusterRG)",
-		"__SERVICECLUSTERSUBSCRIPTION__":    "$config(serviceClusterSubscription)",
-		"__CLUSTERSERVICE_IMAGETAG__":       "$config(clusterService.imageTag)",
+		"__aksName__":                       "$config(aksName)",
+		"__globalRG__":                      "$config(globalRG)",
+		"__imageSyncRG__":                   "$config(imageSyncRG)",
+		"__maestro_helm_chart__":            "$config(maestro_helm_chart)",
+		"__maestro_image__":                 "$config(maestro_image)",
+		"__managementClusterRG__":           "$config(managementClusterRG)",
+		"__managementClusterSubscription__": "$config(managementClusterSubscription)",
+		"__region__":                        "$config(region)",
+		"__regionRG__":                      "$config(regionRG)",
+		"__serviceClusterRG__":              "$config(serviceClusterRG)",
+		"__serviceClusterSubscription__":    "$config(serviceClusterSubscription)",
+		"__clusterService_imageTag__":       "$config(clusterService.imageTag)",
 	}
 
 	if diff := cmp.Diff(expectedVars, vars); diff != "" {

--- a/tooling/templatize/testdata/zz_fixture_TestPreprocessFileForEV2ScopeBinding.bicepparam
+++ b/tooling/templatize/testdata/zz_fixture_TestPreprocessFileForEV2ScopeBinding.bicepparam
@@ -6,5 +6,5 @@ param baseDNSZoneName = 'hcp.osadev.cloud'
 param baseDNSZoneResourceGroup = 'global'
 
 // CS
-param csImage = '__CLUSTERSERVICE_IMAGETAG__'
-param regionRG = '__REGIONRG__'
+param csImage = '__clusterService_imageTag__'
+param regionRG = '__regionRG__'

--- a/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2ev2-precompiled-test.bicepparam
+++ b/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2ev2-precompiled-test.bicepparam
@@ -1,1 +1,1 @@
-param regionRG = '__REGIONRG__'
+param regionRG = '__regionRG__'


### PR DESCRIPTION
### What this PR does

don't uppercase variables in scope binding. it's not required and we avoid checking that names in the schema are unique even after `upper`

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
