### PR TITLE
move CS permission setup into CS module

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -69,7 +69,7 @@ defaults:
   # Cluster Service
   clusterService:
     #acrRG: '{{ .ctx.region }}-shared-resources'
-    acrRg: ''
+    acrRG: ''
     postgres:
       name: arohcp-cs-{{ .ctx.regionShort }}
       deploy: true

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -68,7 +68,8 @@ defaults:
 
   # Cluster Service
   clusterService:
-    acrRG: '{{ .ctx.region }}-shared-resources'
+    #acrRG: '{{ .ctx.region }}-shared-resources'
+    acrRg: ''
     postgres:
       name: arohcp-cs-{{ .ctx.regionShort }}
       deploy: true

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -5,7 +5,7 @@
   "baseDnsZoneName": "aro-hcp.azure-test.net'",
   "baseDnsZoneRG": "westus3-shared-resources",
   "clusterService": {
-    "acrRG": "westus3-shared-resources",
+    "acrRG": "",
     "imageRepo": "app-sre/uhc-clusters-service",
     "imageTag": "aac7623",
     "postgres": {

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -30,7 +30,7 @@ param maestroPostgresServerStorageSizeGB = {{ .maestro.postgres.serverStorageSiz
 param deployMaestroPostgres = {{ .maestro.postgres.deploy }}
 param maestroPostgresPrivate = {{ .maestro.postgres.private }}
 
-param deployCsInfra = {{ .clusterService.postgres.deploy }}
+param csPostgresDeploy = {{ .clusterService.postgres.deploy }}
 param csPostgresServerName = '{{ .clusterService.postgres.name }}'
 param csPostgresServerMinTLSVersion = '{{ .clusterService.postgres.minTLSVersion }}'
 param clusterServicePostgresPrivate = {{ .clusterService.postgres.private }}

--- a/dev-infrastructure/modules/cluster-service.bicep
+++ b/dev-infrastructure/modules/cluster-service.bicep
@@ -7,6 +7,9 @@ param clusterServiceManagedIdentityName string
 @description('The managed identity CS uses to interact with Azure resources')
 param clusterServiceManagedIdentityPrincipalId string
 
+@description('Defines if the Postgres server should be deployed')
+param deployPostgres bool
+
 @description('The name of the database to create for CS')
 param csDatabaseName string = 'clusters-service'
 
@@ -16,18 +19,40 @@ param postgresServerName string
 @description('The minimum TLS version for the Postgres server')
 param postgresServerMinTLSVersion string
 
+@description('Defines if the Postgres server is private')
 param postgresServerPrivate bool
 
+@description('The subnet ID for the private endpoint of the Postgres server')
 param privateEndpointSubnetId string = ''
 
+@description('The VNET ID for the private endpoint of the Postgres server')
 param privateEndpointVnetId string = ''
+
+@description('The name of the service keyvault')
+param serviceKeyVaultName string
+
+@description('The resource group of the service keyvault')
+param serviceKeyVaultResourceGroup string
+
+@description('The name of the regional DNS zone')
+param regionalDNSZoneName string
+
+@description('The regional resourece group')
+param regionalResourceGroup string
+
+@description('The names of the ACR resource groups / will be refactored soon into dedicated ACR Resource IDs')
+param acrResourceGroupNames array = []
+
+//
+//   P O S T G R E S
+//
 
 resource postgresAdminManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: '${postgresServerName}-db-admin-msi'
   location: location
 }
 
-module postgres 'postgres/postgres.bicep' = {
+module postgres 'postgres/postgres.bicep' = if (deployPostgres) {
   name: '${deployment().name}-postgres'
   params: {
     name: postgresServerName
@@ -79,7 +104,7 @@ module postgres 'postgres/postgres.bicep' = {
 // Create DB user for the clusters-service managed identity and enable entra authentication
 //
 
-module csManagedIdentityDatabaseAccess 'postgres/postgres-access.bicep' = {
+module csManagedIdentityDatabaseAccess 'postgres/postgres-access.bicep' = if (deployPostgres) {
   name: '${deployment().name}-cs-db-access'
   params: {
     postgresServerName: postgresServerName
@@ -94,9 +119,53 @@ module csManagedIdentityDatabaseAccess 'postgres/postgres-access.bicep' = {
 }
 
 //
-// output
+//   K E Y V A U L T   A C C E S S
 //
 
-output postgresHostname string = postgres.outputs.hostname
-output csDatabaseName string = csDatabaseName
-output csDatabaseUsername string = clusterServiceManagedIdentityName
+module csServiceKeyVaultAccess '../modules/keyvault/keyvault-secret-access.bicep' = {
+  name: guid(serviceKeyVaultName, 'cs', 'read')
+  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  params: {
+    keyVaultName: serviceKeyVaultName
+    roleName: 'Key Vault Secrets User'
+    managedIdentityPrincipalId: clusterServiceManagedIdentityPrincipalId
+  }
+}
+
+//
+//   D N S
+//
+
+module csDnsZoneContributor '../modules/dns/zone-contributor.bicep' = {
+  name: guid(regionalDNSZoneName, clusterServiceManagedIdentityPrincipalId)
+  scope: resourceGroup(regionalResourceGroup)
+  params: {
+    zoneName: regionalDNSZoneName
+    zoneContributerManagedIdentityPrincipalId: clusterServiceManagedIdentityPrincipalId
+  }
+}
+
+//
+//   O C P   A C R   P E R M I S S I O N S
+//
+
+resource clustersServiceAcrResourceGroups 'Microsoft.Resources/resourceGroups@2023-07-01' existing = [
+  for rg in acrResourceGroupNames: if (rg != '') {
+    // temp hack for MSFT pipelines
+    name: rg
+    scope: subscription()
+  }
+]
+
+module acrManageTokenRole '../modules/acr-permissions.bicep' = [
+  for (_, i) in acrResourceGroupNames: if (acrResourceGroupNames[i] != '') {
+    // temp hack for MSFT pipelines
+    name: guid(clustersServiceAcrResourceGroups[i].id, resourceGroup().name, 'clusters-service', 'manage-tokens')
+    scope: clustersServiceAcrResourceGroups[i]
+    params: {
+      principalId: clusterServiceManagedIdentityPrincipalId
+      grantManageTokenAccess: true
+      acrResourceGroupid: clustersServiceAcrResourceGroups[i].id
+    }
+  }
+]


### PR DESCRIPTION
### What this PR does

move the CS permission setup into the `cluster-service.bicep` module
make acr permission management optional for the time being if no or only and empty string RG is provided
the empty string RG check represents a hack for MSFT pipelines until we have a proper solution

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
