### PR TITLE
pipeline chaining example

### DIFF
--- a/dev-infrastructure/configurations/outputs/region.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/outputs/region.tmpl.bicepparam
@@ -1,0 +1,2 @@
+using '../../templates/outputs/region.bicep'
+

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -1,6 +1,13 @@
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Management Cluster Rollout
 resourceGroups:
+- name: {{ .svc.rg }}
+  subscription: {{ .svc.subscription }}
+  steps:
+  - name: regionOutput
+    action: ARM
+    template: templates/outputs/region.bicep
+    parameters: configuration/outputs/region.tmpl.bicepparam
 - name: {{ .mgmt.rg }}
   subscription: {{ .mgmt.subscription }}
   aksCluster: {{ .aksName }}
@@ -9,6 +16,10 @@ resourceGroups:
     action: ARM
     template: templates/mgmt-cluster.bicep
     parameters: configurations/mgmt-cluster.tmpl.bicepparam
+    inputs:
+    - name: clusterServiceMIResourceId
+      step: regionOutput
+      output: cs.msi.resourceID
   - name: enable-metrics
     action: Shell
     command: ["scripts/enable-aks-metrics.sh"]

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -7,7 +7,7 @@ resourceGroups:
   - name: regionOutput
     action: ARM
     template: templates/outputs/region.bicep
-    parameters: configuration/outputs/region.tmpl.bicepparam
+    parameters: configurations/outputs/region.tmpl.bicepparam
 - name: {{ .mgmt.rg }}
   subscription: {{ .mgmt.subscription }}
   aksCluster: {{ .aksName }}

--- a/dev-infrastructure/templates/outputs/region.bicep
+++ b/dev-infrastructure/templates/outputs/region.bicep
@@ -1,4 +1,3 @@
-
 resource csMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: 'clusters-service'
   location: resourceGroup().location

--- a/dev-infrastructure/templates/outputs/region.bicep
+++ b/dev-infrastructure/templates/outputs/region.bicep
@@ -1,0 +1,11 @@
+
+resource csMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'clusters-service'
+  location: resourceGroup().location
+}
+
+output cs object = {
+  msi: {
+    resourceID: csMSI.id
+  }
+}

--- a/tooling/templatize/pkg/pipeline/types.go
+++ b/tooling/templatize/pkg/pipeline/types.go
@@ -29,6 +29,7 @@ type Step struct {
 	Parameters string   `yaml:"parameters,omitempty"`
 	DependsOn  []string `yaml:"dependsOn,omitempty"`
 	DryRun     DryRun   `yaml:"dryRun,omitempty"`
+	Inputs     []Input  `yaml:"inputs,omitempty"`
 	outputFunc outPutHandler
 }
 
@@ -41,4 +42,10 @@ type EnvVar struct {
 	Name      string `yaml:"name"`
 	ConfigRef string `yaml:"configRef,omitempty"`
 	Value     string `yaml:"value,omitempty"`
+}
+
+type Input struct {
+	Name   string `yaml:"name"`
+	Step   string `yaml:"step"`
+	Output string `yaml:"output"`
 }


### PR DESCRIPTION
### What this PR does

propose a format for pipeline chaining to be used in both EV2 and local runner.

* introduce the concept for output bicep templates that provide relevant metadata for a certain scope (e.g. region, global, mgmt), to be consumed by other scopes
* provide a format to declare output consumption for an ARM step in pipeline.yaml

this PR also contains an example how the CS MSI ID is provided to the mgmt-cluster.bicep template to setup KV access for CS.

Jira: https://issues.redhat.com/browse/ARO-13157
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
