### PR TITLE
unique name for private endpoint service creation

### DIFF
--- a/dev-infrastructure/modules/private-endpoint.bicep
+++ b/dev-infrastructure/modules/private-endpoint.bicep
@@ -53,7 +53,7 @@ resource privateEndpointDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' =
 
 resource privatEndpoint 'Microsoft.Network/privateEndpoints@2023-09-01' = [
   for aksNodeSubnetId in subnetIds: {
-    name: '${serviceType}-${uniqueString(aksNodeSubnetId)}'
+    name: '${serviceType}-${uniqueString(aksNodeSubnetId, privateLinkServiceId)}'
     location: location
     properties: {
       privateLinkServiceConnections: [


### PR DESCRIPTION
### What this PR does

adapt the private endpoint name pattern to include the actual endpoint service id. otherwise only one private endpoint can be created per resourcegroup and service type.

⚠️  before merging this all private endpoints need to be deleted manually from the integrated DEV and CS PR environments

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
