### PR TITLE
HCP Cluster Resource Deletion Cascading Subscription Delete

### DIFF
--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -165,7 +165,7 @@ func (s *OperationsScanner) pollClusterOperation(ctx context.Context, logger *sl
 	if err != nil {
 		var ocmError *ocmerrors.Error
 		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound && doc.Request == database.OperationRequestDelete {
-			err = s.withSubscriptionLock(ctx, logger, doc.OperationID.SubscriptionID, func(ctx context.Context) error {
+			err = s.withSubscriptionLock(ctx, logger, doc.ExternalID.SubscriptionID, func(ctx context.Context) error {
 				return s.deleteOperationCompleted(ctx, logger, doc)
 			})
 			if err == nil {
@@ -180,7 +180,7 @@ func (s *OperationsScanner) pollClusterOperation(ctx context.Context, logger *sl
 		logger.Warn(err.Error())
 		err = nil
 	} else {
-		err = s.withSubscriptionLock(ctx, logger, doc.OperationID.SubscriptionID, func(ctx context.Context) error {
+		err = s.withSubscriptionLock(ctx, logger, doc.ExternalID.SubscriptionID, func(ctx context.Context) error {
 			return s.updateOperationStatus(ctx, logger, doc, opStatus, opError)
 		})
 	}

--- a/backend/operations_scanner_test.go
+++ b/backend/operations_scanner_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
 )
 
 func TestDeleteOperationCompleted(t *testing.T) {
@@ -48,6 +49,12 @@ func TestDeleteOperationCompleted(t *testing.T) {
 		},
 	}
 
+	// Placeholder InternalID for NewOperationDocument
+	internalID, err := ocm.NewInternalID("/api/clusters_mgmt/v1/clusters/placeholder")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var request *http.Request
@@ -71,8 +78,7 @@ func TestDeleteOperationCompleted(t *testing.T) {
 				notificationClient: server.Client(),
 			}
 
-			operationDoc := database.NewOperationDocument(database.OperationRequestDelete)
-			operationDoc.ExternalID = resourceID
+			operationDoc := database.NewOperationDocument(database.OperationRequestDelete, resourceID, internalID)
 			operationDoc.NotificationURI = server.URL
 			operationDoc.Status = tt.operationStatus
 
@@ -190,6 +196,12 @@ func TestUpdateOperationStatus(t *testing.T) {
 		},
 	}
 
+	// Placeholder InternalID for NewOperationDocument
+	internalID, err := ocm.NewInternalID("/api/clusters_mgmt/v1/clusters/placeholder")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var request *http.Request
@@ -213,8 +225,7 @@ func TestUpdateOperationStatus(t *testing.T) {
 				notificationClient: server.Client(),
 			}
 
-			operationDoc := database.NewOperationDocument(database.OperationRequestCreate)
-			operationDoc.ExternalID = resourceID
+			operationDoc := database.NewOperationDocument(database.OperationRequestCreate, resourceID, internalID)
 			operationDoc.NotificationURI = server.URL
 			operationDoc.Status = tt.currentOperationStatus
 

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -507,9 +507,18 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 		}
 	}
 
-	operationDoc, err := f.StartOperation(writer, request, doc, operationRequest)
+	operationDoc := database.NewOperationDocument(operationRequest, doc.Key, doc.InternalID)
+
+	err = f.dbClient.CreateOperationDoc(ctx, operationDoc)
 	if err != nil {
-		f.logger.Error(fmt.Sprintf("failed to write operation document: %v", err))
+		f.logger.Error(err.Error())
+		arm.WriteInternalServerError(writer)
+		return
+	}
+
+	err = f.ExposeOperation(writer, request, operationDoc.ID)
+	if err != nil {
+		f.logger.Error(err.Error())
 		arm.WriteInternalServerError(writer)
 		return
 	}
@@ -638,9 +647,18 @@ func (f *Frontend) ArmResourceDelete(writer http.ResponseWriter, request *http.R
 		}
 	}
 
-	operationDoc, err := f.StartOperation(writer, request, resourceDoc, operationRequest)
+	operationDoc := database.NewOperationDocument(operationRequest, resourceDoc.Key, resourceDoc.InternalID)
+
+	err = f.dbClient.CreateOperationDoc(ctx, operationDoc)
 	if err != nil {
-		f.logger.Error(fmt.Sprintf("failed to write operation document: %v", err))
+		f.logger.Error(err.Error())
+		arm.WriteInternalServerError(writer)
+		return
+	}
+
+	err = f.ExposeOperation(writer, request, operationDoc.ID)
+	if err != nil {
+		f.logger.Error(err.Error())
 		arm.WriteInternalServerError(writer)
 		return
 	}

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -759,7 +759,7 @@ func (f *Frontend) ArmSubscriptionPut(writer http.ResponseWriter, request *http.
 		"state":          string(subscription.State),
 	})
 
-	_, err = arm.WriteJSONResponse(writer, http.StatusCreated, subscription)
+	_, err = arm.WriteJSONResponse(writer, http.StatusOK, subscription)
 	if err != nil {
 		f.logger.Error(err.Error())
 	}

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -759,6 +759,15 @@ func (f *Frontend) ArmSubscriptionPut(writer http.ResponseWriter, request *http.
 		"state":          string(subscription.State),
 	})
 
+	// Clean up resources if subscription is deleted.
+	if subscription.State == arm.SubscriptionStateDeleted {
+		cloudError := f.DeleteAllResources(ctx, subscriptionID)
+		if cloudError != nil {
+			arm.WriteCloudError(writer, cloudError)
+			return
+		}
+	}
+
 	_, err = arm.WriteJSONResponse(writer, http.StatusOK, subscription)
 	if err != nil {
 		f.logger.Error(err.Error())

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -141,7 +141,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 				Properties:       nil,
 			},
 			subDoc:             nil,
-			expectedStatusCode: http.StatusCreated,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
 			name:    "PUT Subscription - Doc Exists",
@@ -161,7 +161,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 					Properties:       nil,
 				},
 			},
-			expectedStatusCode: http.StatusCreated,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
 			name:    "PUT Subscription - Invalid Subscription",

--- a/frontend/pkg/frontend/helpers.go
+++ b/frontend/pkg/frontend/helpers.go
@@ -5,6 +5,7 @@ package frontend
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -69,39 +70,120 @@ func (f *Frontend) CheckForProvisioningStateConflict(ctx context.Context, operat
 	return nil
 }
 
-func (f *Frontend) DeleteResource(ctx context.Context, resourceID *arm.ResourceID) (*database.ResourceDocument, *arm.CloudError) {
-	doc, err := f.dbClient.GetResourceDoc(ctx, resourceID)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			return nil, arm.NewResourceNotFoundError(resourceID)
-		} else {
-			f.logger.Error(err.Error())
-			return nil, arm.NewInternalServerError()
-		}
-	}
+func (f *Frontend) DeleteResource(ctx context.Context, resourceDoc *database.ResourceDocument) (string, *arm.CloudError) {
+	const operationRequest = database.OperationRequestDelete
+	var err error
 
-	switch doc.InternalID.Kind() {
+	switch resourceDoc.InternalID.Kind() {
 	case cmv1.ClusterKind:
-		err = f.clusterServiceClient.DeleteCSCluster(ctx, doc.InternalID)
+		err = f.clusterServiceClient.DeleteCSCluster(ctx, resourceDoc.InternalID)
 
 	case cmv1.NodePoolKind:
-		err = f.clusterServiceClient.DeleteCSNodePool(ctx, doc.InternalID)
+		err = f.clusterServiceClient.DeleteCSNodePool(ctx, resourceDoc.InternalID)
 
 	default:
-		f.logger.Error(fmt.Sprintf("unsupported Cluster Service path: %s", doc.InternalID))
-		return nil, arm.NewInternalServerError()
+		f.logger.Error(fmt.Sprintf("unsupported Cluster Service path: %s", resourceDoc.InternalID))
+		return "", arm.NewInternalServerError()
 	}
 
 	if err != nil {
 		var ocmError *ocmerrors.Error
 		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound {
-			return nil, arm.NewResourceNotFoundError(resourceID)
+			return "", arm.NewResourceNotFoundError(resourceDoc.Key)
 		}
 		f.logger.Error(err.Error())
-		return nil, arm.NewInternalServerError()
+		return "", arm.NewInternalServerError()
 	}
 
-	return doc, nil
+	// Cluster Service will take care of canceling any ongoing operations
+	// on the resource or child resources, but we need to do some database
+	// bookkeeping to reflect that.
+
+	// FIXME This would be a good place to use Cosmos DB's transactional batch
+	//       operations to ensure all these write operations succeed together
+	//       or roll back. We would need two parallel transactions: one for
+	//       the Operations container and another for the Resources container.
+	//       But we're stymied currently by the DBClient interface, and I have
+	//       no desire to implement this in the in-memory cache. DBClient has
+	//       served us well up to this point, but I think it's time to bid it
+	//       farewell and switch to gomock in unit tests.
+
+	err = f.CancelActiveOperation(ctx, resourceDoc)
+	if err != nil {
+		f.logger.Error(err.Error())
+		return "", arm.NewInternalServerError()
+	}
+
+	operationDoc := database.NewOperationDocument(operationRequest, resourceDoc.Key, resourceDoc.InternalID)
+
+	err = f.dbClient.CreateOperationDoc(ctx, operationDoc)
+	if err != nil {
+		f.logger.Error(err.Error())
+		return "", arm.NewInternalServerError()
+	}
+
+	_, err = f.dbClient.UpdateResourceDoc(ctx, resourceDoc.Key, func(updateDoc *database.ResourceDocument) bool {
+		updateDoc.ActiveOperationID = operationDoc.ID
+		updateDoc.ProvisioningState = operationDoc.Status
+		return true
+	})
+	if err != nil {
+		f.logger.Error(err.Error())
+		return "", arm.NewInternalServerError()
+	}
+
+	iterator := f.dbClient.ListResourceDocs(ctx, resourceDoc.Key, -1, nil)
+
+	for item := range iterator.Items(ctx) {
+		// Anonymous function avoids repetitive error handling.
+		err = func() error {
+			var child database.ResourceDocument
+
+			err = json.Unmarshal(item, &child)
+			if err != nil {
+				return err
+			}
+
+			err = f.CancelActiveOperation(ctx, &child)
+			if err != nil {
+				return err
+			}
+
+			// This operation is not accessible through any REST endpoint.
+			// Its purpose is to cause the backend to delete the resource
+			// document once resource deletion completes.
+
+			childOperationDoc := database.NewOperationDocument(operationRequest, child.Key, child.InternalID)
+
+			err = f.dbClient.CreateOperationDoc(ctx, childOperationDoc)
+			if err != nil {
+				return err
+			}
+
+			_, err = f.dbClient.UpdateResourceDoc(ctx, child.Key, func(updateDoc *database.ResourceDocument) bool {
+				updateDoc.ActiveOperationID = childOperationDoc.ID
+				updateDoc.ProvisioningState = childOperationDoc.Status
+				return true
+			})
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}()
+		if err != nil {
+			f.logger.Error(err.Error())
+			return "", arm.NewInternalServerError()
+		}
+	}
+
+	err = iterator.GetError()
+	if err != nil {
+		f.logger.Error(err.Error())
+		return "", arm.NewInternalServerError()
+	}
+
+	return operationDoc.ID, nil
 }
 
 func (f *Frontend) MarshalResource(ctx context.Context, resourceID *arm.ResourceID, versionedInterface api.Version) ([]byte, *arm.CloudError) {

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -193,9 +193,18 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		}
 	}
 
-	operationDoc, err := f.StartOperation(writer, request, doc, operationRequest)
+	operationDoc := database.NewOperationDocument(operationRequest, doc.Key, doc.InternalID)
+
+	err = f.dbClient.CreateOperationDoc(ctx, operationDoc)
 	if err != nil {
-		f.logger.Error(fmt.Sprintf("failed to write operation document: %v", err))
+		f.logger.Error(err.Error())
+		arm.WriteInternalServerError(writer)
+		return
+	}
+
+	err = f.ExposeOperation(writer, request, operationDoc.ID)
+	if err != nil {
+		f.logger.Error(err.Error())
 		arm.WriteInternalServerError(writer)
 		return
 	}

--- a/frontend/pkg/frontend/operations.go
+++ b/frontend/pkg/frontend/operations.go
@@ -80,7 +80,7 @@ func (f *Frontend) AddLocationHeader(writer http.ResponseWriter, request *http.R
 func (f *Frontend) StartOperation(writer http.ResponseWriter, request *http.Request, resourceDoc *database.ResourceDocument, operationRequest database.OperationRequest) (*database.OperationDocument, error) {
 	ctx := request.Context()
 
-	operationDoc := database.NewOperationDocument(operationRequest)
+	operationDoc := database.NewOperationDocument(operationRequest, resourceDoc.Key, resourceDoc.InternalID)
 
 	operationID, err := arm.ParseResourceID(path.Join("/",
 		"subscriptions", resourceDoc.Key.SubscriptionID,
@@ -93,8 +93,6 @@ func (f *Frontend) StartOperation(writer http.ResponseWriter, request *http.Requ
 
 	operationDoc.TenantID = request.Header.Get(arm.HeaderNameHomeTenantID)
 	operationDoc.ClientID = request.Header.Get(arm.HeaderNameClientObjectID)
-	operationDoc.ExternalID = resourceDoc.Key
-	operationDoc.InternalID = resourceDoc.InternalID
 	operationDoc.OperationID = operationID
 	operationDoc.NotificationURI = request.Header.Get(arm.HeaderNameAsyncNotificationURI)
 

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -94,13 +94,15 @@ type OperationDocument struct {
 	Error *arm.CloudErrorBody `json:"error,omitempty"`
 }
 
-func NewOperationDocument(request OperationRequest) *OperationDocument {
+func NewOperationDocument(request OperationRequest, externalID *arm.ResourceID, internalID ocm.InternalID) *OperationDocument {
 	now := time.Now().UTC()
 
 	doc := &OperationDocument{
 		BaseDocument:       newBaseDocument(),
 		PartitionKey:       operationsPartitionKey,
 		Request:            request,
+		ExternalID:         externalID,
+		InternalID:         internalID,
 		StartTime:          now,
 		LastTransitionTime: now,
 		Status:             arm.ProvisioningStateAccepted,

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -77,7 +77,8 @@ type OperationDocument struct {
 	ExternalID *arm.ResourceID `json:"externalId,omitempty"`
 	// InternalID is the Cluster Service resource identifier in the form of a URL path
 	InternalID ocm.InternalID `json:"internalId,omitempty"`
-	// OperationID is the Azure resource ID of the operation's status
+	// OperationID is the Azure resource ID of the operation status (may be nil if the
+	// operation was implicit, such as deleting a child resource along with the parent)
 	OperationID *arm.ResourceID `json:"operationId,omitempty"`
 	// NotificationURI is provided by the Azure-AsyncNotificationUri header if the
 	// Async Operation Callbacks ARM feature is enabled


### PR DESCRIPTION
### What this PR does

When a subscription state changes to "**Deleted**", the RP now triggers a deletion of all HCP clusters under the subscription as per the [Resource Provider Contract](https://github.com/cloud-and-ai-microsoft/resource-provider-contract/blob/master/v1.0/subscription-lifecycle-api-reference.md#subscription-states).

Behind the scenes, this introduces the concept of "implicit" and "explicit" async operations:

-  An "implicit" async operation has an "Operation" item in Cosmos DB, but no status endpoint for ARM to poll.
-  An "explicit" async operation starts as an "implicit" operation.  The `Frontend.ExposeOperation` method enriches the "Operation" item with information necessary to make the status endpoint accessible to ARM, and adds appropriate async headers to an `http.ResponseWriter`.

Importantly, the backend pod does not distinguish between implicit and explicit async operations.  The sole purpose of an "implicit" async operation at the moment, which is only used for deletions, is for the backend to delete the "Resource" item in Cosmos DB after the actual resource is deleted.

Jira: [ARO-13321 - Implement Cascading Subscription Deletion](https://issues.redhat.com/browse/ARO-13321)

### Special notes for your reviewer

- This duplicates a few database iterator commits from [#883](https://github.com/Azure/ARO-HCP/pull/883), which is still outstanding.
- I'll add unit tests for this in a follow-up PR _after_ I convert our existing unit tests to use [gomock](https://github.com/uber-go/mock) for Cosmos DB operations.  To add unit tests now would just create extra work for myself in the conversion effort.
- I still need to document asynchronous operation mechanics in general and this "implicit" vs "explicit" concept will be part of it.  I've been holding off on writing documentation until I can make some (imo) necessary changes to our database design.  This is just to say I haven't forgotten about it.
