### PR TITLE
service deployment makefile cleanup

### DIFF
--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -239,14 +239,14 @@ There are more fine grained cleanup tasks available as well
 To followup sections describe how to deploy the components individually. But if you are looking for a quick and easy way to install or update ALL components on both clusters with one command, then run this:
 
   ```bash
-  make deploy.svc.all
-  make deploy.mgmt.all
+  make svc.deployall
+  make mgmt.deployall
   ```
 
 Or even simpler with
 
   ```bash
-  make deploy.all
+  make deployall
   ```
 
 ## Deploy Services to the service cluster
@@ -273,7 +273,7 @@ To access the HTTP and GRPC endpoints of maestro, run
 > This might not work with `oc` 4.17.0, please use oc 4.16.x until this is fixed in 4.17
 
    ```bash
-   make cs.deploy
+   make cluster-service.deploy
    ```
 
 To validate, have a look at the `cluster-service` namespace or the service cluster.
@@ -283,8 +283,8 @@ To validate, have a look at the `cluster-service` namespace or the service clust
 The ARO-HCP resource provider consists of independent frontend and backend components.
 
   ```bash
-  make rp.frontend.deploy
-  make rp.backend.deploy
+  make frontend.deploy
+  make backend.deploy
   ```
 
 To validate, have a look at the `aro-hcp` namespace on the service cluster.
@@ -300,7 +300,7 @@ To validate, have a look at the `aro-hcp` namespace on the service cluster.
 ### Hypershift Operator and External DNS
 
   ```bash
-  make hypershift.deploy
+  make hypershiftoperator.deploy
   ```
 
 ### Maestro Agent

--- a/svc-deploy.sh
+++ b/svc-deploy.sh
@@ -1,23 +1,29 @@
 #!/bin/bash
 
+# bash will report what is happening and stop in case of non zero return code
+set -xe
+
 # deploy a service to a cluster
 # ./svc-deploy <deploy-env> <dir> <cluster> [target]
 # this script expects the <dir> to contain a Makefile that takes care
 # of processing any config.mk template on its own
 
-cd $(dirname "$(realpath "${BASH_SOURCE[0]}")") || exit
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 export DEPLOY_ENV=$1
 export DIR=$2
 export CLUSTER=$3
 export TARGET=${4:-deploy}
 
-if [[ "$CLUSTER" != "svc" && "$CLUSTER" != "mgmt" ]]; then
-    echo "Error: CLUSTER must be either 'svc' or 'mgmt'."
+if [[ "${CLUSTER}" != "svc" && "${CLUSTER}" != "mgmt" ]]; then
+    echo "Error: CLUSTER must be either 'svc' or 'mgmt'." >&2
     exit 1
 fi
 
-export KUBECONFIG=$(cd dev-infrastructure || exit ; make --no-print-directory $CLUSTER.aks.kubeconfigfile)
+cd dev-infrastructure
+KUBECONFIG=$(make --no-print-directory "${CLUSTER}.aks.kubeconfigfile")
+export KUBECONFIG
+cd -
 
-cd ${DIR} || exit
-make $TARGET
+cd "${DIR}"
+make "${TARGET}"


### PR DESCRIPTION
### What this PR does

Lower a cognitive load when trying to understand what components we have and how are they deployed via the makefile:

- Removing code duplication for service deployment via general makefile target.
- Simplifying the definition of service placement: instead of two places, now there is a single place to define where a service should be deployed (eg. pko was defined, but not deployed - which is easy to miss).
- Removing aliases for services (eg. `cs` for `cluster-service`, `hypershift` for `hypershiftoperator`) - I don't want to remember multiple different names for a component. To keep things straightforward, I would like to insist on a single name of a component to be used everywhere.
- Removing aliases for multiple components, eg. `maestro` covering agent, server and registration  - we need to handle a single component as a standalone unit in all contexts from the beginning, it will make the deps more visible.
- Establishing a convention about deploying services, makefile targets should always end with .deploy to keep them separate from other actions.

Making the svc deploy script more robust and easy to debug in case of problems (there were few explicit checks, but few others were not handled, and in case of a failure, it would not be clear what went wrong).

Ideally, we have some README which explains how we define and deploy components, which could be started in this PR if needed.

Jira: related to https://issues.redhat.com/browse/ARO-12810

### Special notes for your reviewer

<!-- optional -->
