### PR TITLE
Explicitly declare default goals in Makefiles

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -4,6 +4,8 @@ COMMIT ?= $(shell git rev-parse --short=7 HEAD)
 ARO_HCP_BASE_IMAGE ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
 ARO_HCP_BACKEND_IMAGE ?= $(ARO_HCP_BASE_IMAGE)/arohcpbackend:$(COMMIT)
 
+.DEFAULT_GOAL := backend
+
 backend:
 	go build -o aro-hcp-backend .
 .PHONY: backend

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -4,6 +4,8 @@ COMMIT ?= $(shell git rev-parse --short=7 HEAD)
 ARO_HCP_BASE_IMAGE ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
 ARO_HCP_FRONTEND_IMAGE ?= $(ARO_HCP_BASE_IMAGE)/arohcpfrontend:$(COMMIT)
 
+.DEFAULT_GOAL := frontend
+
 frontend:
 	go build -o aro-hcp-frontend .
 


### PR DESCRIPTION
### What this PR does

`setup-env.mk` is now included before the "frontend" or "backend" goal is defined in `frontend/Makefile` and `backend/Makefile` respectively, and because we were not explicitly naming those as the default goal, the 1st goal in `setup-env.mk` became the implicit default goal.