### PR TITLE
Use the correct APIVersion

### DIFF
--- a/cluster-service/deploy/integration/cluster-service-namespace.yaml
+++ b/cluster-service/deploy/integration/cluster-service-namespace.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: cluster-service-admin


### PR DESCRIPTION
I found this when doing something else but I'm a bit confused by it. 

- I found the error `no kind "Template" is registered for version "v1" in scheme` when deploying `cluster-service` to the service cluster.
- The docs do indeed point to it being `template.openshift.io/v1` not `v1` [ref](https://docs.openshift.com/container-platform/4.17/rest_api/template_apis/template-apis-index.html#template-template-openshift-iov1)

I'm assuming this was working for others and there's something wrong but my setup but maybe not?
