### PR TITLE
add nodes outbound type and enable some of the provision steps by default in CS

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -140,7 +140,7 @@ clouds:
         imageTag: bc2f131579c6ffc664c15f48c50a9936f1b4a7ce
       # Cluster Service
       clusterService:
-        imageTag: 6157c57
+        imageTag: 9f7fef3
         imageRepo: app-sre/uhc-clusters-service
       # Hypershift Operator
       hypershiftOperator:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -11,7 +11,7 @@
   "clusterService": {
     "acrRG": "global",
     "imageRepo": "app-sre/uhc-clusters-service",
-    "imageTag": "6157c57",
+    "imageTag": "9f7fef3",
     "postgres": {
       "deploy": true,
       "minTLSVersion": "TLSV1.2",

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -11,7 +11,7 @@
   "clusterService": {
     "acrRG": "global",
     "imageRepo": "app-sre/uhc-clusters-service",
-    "imageTag": "6157c57",
+    "imageTag": "9f7fef3",
     "postgres": {
       "deploy": true,
       "minTLSVersion": "TLSV1.2",

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -11,7 +11,7 @@
   "clusterService": {
     "acrRG": "global",
     "imageRepo": "app-sre/uhc-clusters-service",
-    "imageTag": "6157c57",
+    "imageTag": "9f7fef3",
     "postgres": {
       "deploy": false,
       "minTLSVersion": "TLSV1.2",

--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -393,12 +393,6 @@ Then register it with the Maestro Server
         "subnet_resource_id": "$SUBNETRESOURCEID",
         "network_security_group_resource_id":"$NSG"
       },
-      "properties": {
-        "provisioner_hostedcluster_step_enabled": "true",
-        "provisioner_managedcluster_step_enabled": "true",
-        "np_provisioner_provision_enabled": "true",
-        "np_provisioner_deprovision_enabled": "true"
-      },
       "version": {
         "id": "openshift-v4.17.0"
       }

--- a/internal/ocm/mock.go
+++ b/internal/ocm/mock.go
@@ -42,7 +42,7 @@ func NewMockClusterServiceClient() MockClusterServiceClient {
 func (mcsc *MockClusterServiceClient) GetConn() *sdk.Connection { panic("GetConn not implemented") }
 
 func (csc *MockClusterServiceClient) AddProperties(builder *cmv1.ClusterBuilder) *cmv1.ClusterBuilder {
-	additionalProperties := getDefaultAdditionalProperities()
+	additionalProperties := map[string]string{}
 	return builder.Properties(additionalProperties)
 }
 

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -24,27 +24,6 @@ type ClusterServiceClientSpec interface {
 	DeleteCSNodePool(ctx context.Context, internalID InternalID) error
 }
 
-// Get the default set of properties for the Cluster Service
-func getDefaultAdditionalProperities() map[string]string {
-	// additionalProperties should be empty in production, it is configurable for development to pin to specific
-	// provision shards or instruct CS to skip the full provisioning/deprovisioning flow.
-	additionalProperties := map[string]string{
-		// Enable the ARO HCP provisioner during development. For now, if not set a cluster will not progress past the
-		// installing state in CS.
-		"provisioner_hostedcluster_step_enabled": "true",
-		// Enable the provisioning of ACM's ManagedCluster CR associated to the ARO-HCP
-		// cluster during ARO-HCP Cluster provisioning. For now, if not set a cluster will not progress past the
-		// installing state in CS.
-		"provisioner_managedcluster_step_enabled": "true",
-
-		// Enable the provisioning and deprovisioning of ARO-HCP Node Pools. For now, if not set the provisioning
-		// and deprovisioning of day 2 ARO-HCP Node Pools will not be performed on the Management Cluster.
-		"np_provisioner_provision_enabled":   "true",
-		"np_provisioner_deprovision_enabled": "true",
-	}
-	return additionalProperties
-}
-
 type ClusterServiceClient struct {
 	// Conn is an ocm-sdk-go connection to Cluster Service
 	Conn *sdk.Connection
@@ -66,7 +45,7 @@ func (csc *ClusterServiceClient) GetConn() *sdk.Connection { return csc.Conn }
 
 // AddProperties injects the some addtional properties into the CSCluster Object.
 func (csc *ClusterServiceClient) AddProperties(builder *cmv1.ClusterBuilder) *cmv1.ClusterBuilder {
-	additionalProperties := getDefaultAdditionalProperities()
+	additionalProperties := map[string]string{}
 	if csc.ProvisionShardID != nil {
 		additionalProperties["provision_shard_id"] = *csc.ProvisionShardID
 	}


### PR DESCRIPTION
### What this PR does
* feat: remove explicit properties enabling specific cs provisioner steps
    Now the steps are enabled by default, and the properties that enable/disable some of them have been renamed
* update cluster service image to 9f7fef3



Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
