### PR TITLE
unique deploy name for frontend-cert in differnt envs

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -190,12 +190,9 @@ svc.rg:
 	fi
 .PHONY: svc.rg
 
-svc.wait:
-	@./ensure-no-running-deployment.sh $(SVC_RESOURCEGROUP) $(SVC_RG_DEPLOYMENT_NAME)
-.PHONY: svc.wait
-
-svc: svc.wait svc.rg
+svc: svc.rg
 	@scripts/cleanup-orphaned-rolebindings.sh $(SVC_RESOURCEGROUP)
+	@./ensure-no-running-deployment.sh $(SVC_RESOURCEGROUP) $(SVC_RG_DEPLOYMENT_NAME)-infra
 	az deployment group create \
 		--name $(SVC_RG_DEPLOYMENT_NAME)-infra \
 		--resource-group $(SVC_RESOURCEGROUP) \
@@ -203,6 +200,7 @@ svc: svc.wait svc.rg
 		$(PROMPT_TO_CONFIRM) \
 		--parameters \
 			configurations/svc-infra.bicepparam
+	@./ensure-no-running-deployment.sh $(SVC_RESOURCEGROUP) $(SVC_RG_DEPLOYMENT_NAME)
 	az deployment group create \
 		--name $(SVC_RG_DEPLOYMENT_NAME) \
 		--resource-group $(SVC_RESOURCEGROUP) \

--- a/dev-infrastructure/templates/svc-infra.bicep
+++ b/dev-infrastructure/templates/svc-infra.bicep
@@ -46,7 +46,7 @@ output svcKeyVaultName string = serviceKeyVault.outputs.kvName
 var clientAuthenticationName = 'frontend.${regionalDNSZoneName}'
 
 module clientCertificate '../modules/keyvault/key-vault-cert.bicep' = {
-  name: 'frontend-cert'
+  name: 'frontend-cert-${uniqueString(certName)}'
   scope: resourceGroup(serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVault.outputs.kvName


### PR DESCRIPTION
### What this PR does

* set a unique deployment name for the frontent-cert deployment - this way deployments of different people won't block each other
* also make sure there is only one service-infra deployment running concurrently as it touches the shared svc KV

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
