### PR TITLE
Bump maestro's image tag to bc2f131579c6ffc664c15f48c50a9936f1b4a7ce

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -130,7 +130,7 @@ clouds:
     # the following vars need approprivate overrides:
     defaults:
       maestro:
-        imageTag: ea066c250a002f0cc458711945165591bc9f6d3f
+        imageTag: bc2f131579c6ffc664c15f48c50a9936f1b4a7ce
       clusterService:
         imageTag: ecd15ad
         imageRepo: app-sre/uhc-clusters-service

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -137,7 +137,7 @@ clouds:
       maestro:
         postgres:
           deploy: false
-        imageTag: ea066c250a002f0cc458711945165591bc9f6d3f
+        imageTag: bc2f131579c6ffc664c15f48c50a9936f1b4a7ce
       # Cluster Service
       clusterService:
         imageTag: 6157c57

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -83,7 +83,7 @@
       "private": false
     },
     "imageBase": "quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro",
-    "imageTag": "ea066c250a002f0cc458711945165591bc9f6d3f",
+    "imageTag": "bc2f131579c6ffc664c15f48c50a9936f1b4a7ce",
     "postgres": {
       "deploy": false,
       "minTLSVersion": "TLSV1.2",

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -83,7 +83,7 @@
       "private": false
     },
     "imageBase": "quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro",
-    "imageTag": "ea066c250a002f0cc458711945165591bc9f6d3f",
+    "imageTag": "bc2f131579c6ffc664c15f48c50a9936f1b4a7ce",
     "postgres": {
       "deploy": false,
       "minTLSVersion": "TLSV1.2",

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -83,7 +83,7 @@
       "private": false
     },
     "imageBase": "quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro",
-    "imageTag": "ea066c250a002f0cc458711945165591bc9f6d3f",
+    "imageTag": "bc2f131579c6ffc664c15f48c50a9936f1b4a7ce",
     "postgres": {
       "deploy": false,
       "minTLSVersion": "TLSV1.2",

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -83,7 +83,7 @@
       "private": false
     },
     "imageBase": "quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro",
-    "imageTag": "ea066c250a002f0cc458711945165591bc9f6d3f",
+    "imageTag": "bc2f131579c6ffc664c15f48c50a9936f1b4a7ce",
     "postgres": {
       "deploy": false,
       "minTLSVersion": "TLSV1.2",


### PR DESCRIPTION
### What this PR does

Bump maestro's image tag to bc2f131579c6ffc664c15f48c50a9936f1b4a7ce

The following changes are included in the bump;

- ensure spec is returned in the status change event when a maestro bundle is being deleted (https://github.com/openshift-online/maestro/pull/225)
- support entra auth for postgres (https://github.com/openshift-online/maestro/pull/221)
- fix maestro agent resync unstable (https://github.com/openshift-online/maestro/pull/220)
- register cloud events metrics(https://github.com/openshift-online/maestro/pull/217)
- avoid nil point in go-sdk (https://github.com/openshift-online/maestro/pull/212)
- update mqtt lib to resolve mqtt pinger problem (https://github.com/openshift-online/maestro/pull/200)
- support print date in log (https://github.com/openshift-online/maestro/pull/195)
- avoid race conditions on maestro-agent (https://github.com/openshift-online/maestro/pull/196)
- use  orphan delete option as default option for read only update strategy (https://github.com/openshift-online/maestro/pull/189)

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->

Re `support entra auth for postgres (https://github.com/openshift-online/maestro/pull/221)` the default is still native PG password authentication.