### PR TITLE
fix setupenv.mk cache invalidation

### DIFF
--- a/setup-env.mk
+++ b/setup-env.mk
@@ -8,7 +8,7 @@ PROJECT_ROOT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 DEPLOY_ENV ?= personal-dev
 PIPELINE ?= pipeline.yaml
 PIPELINE_STEP ?= deploy
-HASH = $(shell echo -n "$(DEPLOY_ENV)$(PIPELINE)$(PIPELINE_STEP)" | sha256sum | cut -d " " -f 1)
+HASH = $(shell echo -n "$(DEPLOY_ENV)$(PIPELINE)$(PIPELINE_STEP)$(PWD)" | sha256sum | cut -d " " -f 1)
 ENV_VARS_FILE ?= /tmp/deploy.${HASH}.cfg
 
 # Target to generate the environment variables file


### PR DESCRIPTION
### What this PR does

the generated cached env file was not per Makefile, so running multiple make deploy targets in a row failed


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
