### PR TITLE
Default az version to latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   version:
     description: 'Azure CLI Version to install'
     required: false
-    default: "2.63.0" # pin to 2.63.0 because of https://github.com/Azure/azure-cli/issues/29828
+    default: "latest"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
### What this PR does
Default az version to latest instead of pinning to a specific version because https://github.com/Azure/cli/issues/165 has been resolved

### Special notes for your reviewer
This is on a fork, but if it's valuable feel free to recreate