### PR TITLE
Propagate managed identity API fields to Cluster Service

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -327,13 +327,6 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 		return
 	}
 
-	tenantID := request.Header.Get(arm.HeaderNameHomeTenantID)
-	if tenantID == "" {
-		f.logger.Error("Missing " + arm.HeaderNameHomeTenantID + " header")
-		arm.WriteInternalServerError(writer)
-		return
-	}
-
 	f.logger.Info(fmt.Sprintf("%s: ArmResourceCreateOrUpdate", versionedInterface))
 
 	doc, err := f.dbClient.GetResourceDoc(ctx, resourceID)
@@ -432,7 +425,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 	versionedRequestCluster.Normalize(hcpCluster)
 
 	hcpCluster.Name = request.PathValue(PathSegmentResourceName)
-	csCluster, err := f.BuildCSCluster(resourceID, tenantID, hcpCluster, updating)
+	csCluster, err := f.BuildCSCluster(resourceID, request.Header, hcpCluster, updating)
 	if err != nil {
 		f.logger.Error(err.Error())
 		arm.WriteInternalServerError(writer)

--- a/frontend/pkg/frontend/node_pool_test.go
+++ b/frontend/pkg/frontend/node_pool_test.go
@@ -94,8 +94,11 @@ func TestCreateNodePool(t *testing.T) {
 			}
 			hcpCluster := api.NewDefaultHCPOpenShiftCluster()
 
+			requestHeader := make(http.Header)
+			requestHeader.Add(arm.HeaderNameHomeTenantID, dummyTenantId)
+
 			hcpCluster.Name = dummyClusterName
-			csCluster, _ := f.BuildCSCluster(clusterResouceID, dummyTenantId, hcpCluster, false)
+			csCluster, _ := f.BuildCSCluster(clusterResouceID, requestHeader, hcpCluster, false)
 
 			if test.subDoc != nil {
 				err := f.dbClient.CreateSubscriptionDoc(context.TODO(), test.subDoc)

--- a/internal/api/arm/headers.go
+++ b/internal/api/arm/headers.go
@@ -18,4 +18,5 @@ const (
 	HeaderNameCorrelationRequestID  = "X-Ms-Correlation-Request-Id"
 	HeaderNameReturnClientRequestID = "X-Ms-Return-Client-Request-Id"
 	HeaderNameARMResourceSystemData = "X-Ms-Arm-Resource-System-Data"
+	HeaderNameIdentityURL           = "X-Ms-Identity-Url"
 )

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -84,11 +84,26 @@ type ProxyProfile struct {
 // PlatformProfile represents the Azure platform configuration.
 // Visibility for the entire struct is "read create".
 type PlatformProfile struct {
-	ManagedResourceGroup   string       `json:"managedResourceGroup,omitempty"`
-	SubnetID               string       `json:"subnetId,omitempty"             validate:"required_for_put"`
-	OutboundType           OutboundType `json:"outboundType,omitempty"         validate:"omitempty,enum_outboundtype"`
-	NetworkSecurityGroupID string       `json:"networkSecurityGroupId,omitempty"`
-	EtcdEncryptionSetID    string       `json:"etcdEncryptionSetId,omitempty"`
+	ManagedResourceGroup    string                         `json:"managedResourceGroup,omitempty"`
+	SubnetID                string                         `json:"subnetId,omitempty"             validate:"required_for_put"`
+	OutboundType            OutboundType                   `json:"outboundType,omitempty"         validate:"omitempty,enum_outboundtype"`
+	NetworkSecurityGroupID  string                         `json:"networkSecurityGroupId,omitempty"`
+	EtcdEncryptionSetID     string                         `json:"etcdEncryptionSetId,omitempty"`
+	OperatorsAuthentication OperatorsAuthenticationProfile `json:"operatorsAuthentication,omitempty"`
+}
+
+// OperatorsAuthenticationProfile represents authentication configuration for
+// OpenShift operators.
+type OperatorsAuthenticationProfile struct {
+	UserAssignedIdentities UserAssignedIdentitiesProfile `json:"userAssignedIdentities,omitempty"`
+}
+
+// UserAssignedIdentitiesProfile represents authentication configuration for
+// OpenShift operators using user-assigned managed identities.
+type UserAssignedIdentitiesProfile struct {
+	ControlPlaneOperators  map[string]string `json:"controlPlaneOperators,omitempty"`
+	DataPlaneOperators     map[string]string `json:"dataPlaneOperators,omitempty"`
+	ServiceManagedIdentity string            `json:"serviceManagedIdentity,omitempty"`
 }
 
 // ExternalAuthConfigProfile represents the external authentication configuration.

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -63,3 +63,23 @@ func StringPtrMapToStringMap(m map[string]*string) map[string]string {
 	}
 	return out
 }
+
+// MergeStringPtrMap merges a map of string pointers into a map of strings
+// following the rules of JSON merge-patch (RFC 7396). In particular, if a
+// key in src has a nil value, that entry is deleted from dst. The function
+// takes a pointer to the dst map in case the dst map is nil and needs to be
+// initialized.
+func MergeStringPtrMap(src map[string]*string, dst *map[string]string) {
+	if src != nil && dst != nil {
+		for key, val := range src {
+			if val == nil {
+				delete(*dst, key)
+			} else {
+				if *dst == nil {
+					*dst = make(map[string]string)
+				}
+				(*dst)[key] = *val
+			}
+		}
+	}
+}

--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -1,0 +1,129 @@
+package api
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMergeStringPtrMap(t *testing.T) {
+	tests := []struct {
+		name   string
+		src    map[string]*string
+		dst    map[string]string
+		expect map[string]string
+	}{
+		{
+			name:   "No source map and no destination map",
+			src:    nil,
+			dst:    nil,
+			expect: nil,
+		},
+		{
+			name: "No source map but existing destination map",
+			src:  nil,
+			dst: map[string]string{
+				"Blinky": "Shadow",
+			},
+			expect: map[string]string{
+				"Blinky": "Shadow",
+			},
+		},
+		{
+			name: "Add entry to a new map",
+			src: map[string]*string{
+				"Blinky": Ptr("Shadow"),
+			},
+			dst: nil,
+			expect: map[string]string{
+				"Blinky": "Shadow",
+			},
+		},
+		{
+			name: "Add entry to an existing map",
+			src: map[string]*string{
+				"Blinky": Ptr("Shadow"),
+			},
+			dst: map[string]string{
+				"Pinky": "Speedy",
+				"Inky":  "Bashful",
+				"Clyde": "Pokey",
+			},
+			expect: map[string]string{
+				"Blinky": "Shadow",
+				"Pinky":  "Speedy",
+				"Inky":   "Bashful",
+				"Clyde":  "Pokey",
+			},
+		},
+		{
+			name: "Delete entry from a non-existent map",
+			src: map[string]*string{
+				"Blinky": nil,
+			},
+			dst:    nil,
+			expect: nil,
+		},
+		{
+			name: "Delete entry from an existing map",
+			src: map[string]*string{
+				"Blinky": nil,
+			},
+			dst: map[string]string{
+				"Blinky": "Shadow",
+				"Pinky":  "Speedy",
+				"Inky":   "Bashful",
+				"Clyde":  "Pokey",
+			},
+			expect: map[string]string{
+				"Pinky": "Speedy",
+				"Inky":  "Bashful",
+				"Clyde": "Pokey",
+			},
+		},
+		{
+			name: "Both add and delete entries from an existing map",
+			src: map[string]*string{
+				"Blinky": nil,
+				"Pinky":  nil,
+				"Inky":   Ptr("Bashful"),
+				"Clyde":  Ptr("Pokey"),
+			},
+			dst: map[string]string{
+				"Blinky": "Shadow",
+				"Inky":   "Bashful",
+			},
+			expect: map[string]string{
+				"Inky":  "Bashful",
+				"Clyde": "Pokey",
+			},
+		},
+		{
+			name: "Modify an entry in an existing map",
+			src: map[string]*string{
+				"Blinky": Ptr("Oikake"),
+			},
+			dst: map[string]string{
+				"Blinky": "Shadow",
+				"Inky":   "Bashful",
+			},
+			expect: map[string]string{
+				"Blinky": "Oikake",
+				"Inky":   "Bashful",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			MergeStringPtrMap(tt.src, &tt.dst)
+			if !reflect.DeepEqual(tt.expect, tt.dst) {
+				t.Error(cmp.Diff(tt.expect, tt.dst))
+			}
+		})
+	}
+}

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -66,11 +66,26 @@ func newProxyProfile(from *api.ProxyProfile) *generated.ProxyProfile {
 
 func newPlatformProfile(from *api.PlatformProfile) *generated.PlatformProfile {
 	return &generated.PlatformProfile{
-		ManagedResourceGroup:   api.Ptr(from.ManagedResourceGroup),
-		SubnetID:               api.Ptr(from.SubnetID),
-		OutboundType:           api.Ptr(generated.OutboundType(from.OutboundType)),
-		NetworkSecurityGroupID: api.Ptr(from.NetworkSecurityGroupID),
-		EtcdEncryptionSetID:    api.Ptr(from.EtcdEncryptionSetID),
+		ManagedResourceGroup:    api.Ptr(from.ManagedResourceGroup),
+		SubnetID:                api.Ptr(from.SubnetID),
+		OutboundType:            api.Ptr(generated.OutboundType(from.OutboundType)),
+		NetworkSecurityGroupID:  api.Ptr(from.NetworkSecurityGroupID),
+		EtcdEncryptionSetID:     api.Ptr(from.EtcdEncryptionSetID),
+		OperatorsAuthentication: newOperatorsAuthenticationProfile(&from.OperatorsAuthentication),
+	}
+}
+
+func newOperatorsAuthenticationProfile(from *api.OperatorsAuthenticationProfile) *generated.OperatorsAuthenticationProfile {
+	return &generated.OperatorsAuthenticationProfile{
+		UserAssignedIdentities: newUserAssignedIdentitiesProfile(&from.UserAssignedIdentities),
+	}
+}
+
+func newUserAssignedIdentitiesProfile(from *api.UserAssignedIdentitiesProfile) *generated.UserAssignedIdentitiesProfile {
+	return &generated.UserAssignedIdentitiesProfile{
+		ControlPlaneOperators:  api.StringMapToStringPtrMap(from.ControlPlaneOperators),
+		DataPlaneOperators:     api.StringMapToStringPtrMap(from.DataPlaneOperators),
+		ServiceManagedIdentity: api.Ptr(from.ServiceManagedIdentity),
 	}
 }
 
@@ -398,6 +413,23 @@ func normalizePlatform(p *generated.PlatformProfile, out *api.PlatformProfile) {
 	}
 	if p.EtcdEncryptionSetID != nil {
 		out.EtcdEncryptionSetID = *p.EtcdEncryptionSetID
+	}
+	if p.OperatorsAuthentication != nil {
+		normalizeOperatorsAuthentication(p.OperatorsAuthentication, &out.OperatorsAuthentication)
+	}
+}
+
+func normalizeOperatorsAuthentication(p *generated.OperatorsAuthenticationProfile, out *api.OperatorsAuthenticationProfile) {
+	if p.UserAssignedIdentities != nil {
+		normalizeUserAssignedIdentities(p.UserAssignedIdentities, &out.UserAssignedIdentities)
+	}
+}
+
+func normalizeUserAssignedIdentities(p *generated.UserAssignedIdentitiesProfile, out *api.UserAssignedIdentitiesProfile) {
+	api.MergeStringPtrMap(p.ControlPlaneOperators, &out.ControlPlaneOperators)
+	api.MergeStringPtrMap(p.DataPlaneOperators, &out.DataPlaneOperators)
+	if p.ServiceManagedIdentity != nil {
+		out.ServiceManagedIdentity = *p.ServiceManagedIdentity
 	}
 }
 

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -17,38 +17,6 @@ type HcpOpenShiftClusterResource struct {
 	generated.HcpOpenShiftClusterResource
 }
 
-type VersionProfile struct {
-	generated.VersionProfile
-}
-
-type DNSProfile struct {
-	generated.DNSProfile
-}
-
-type NetworkProfile struct {
-	generated.NetworkProfile
-}
-
-type ConsoleProfile struct {
-	generated.ConsoleProfile
-}
-
-type APIProfile struct {
-	generated.APIProfile
-}
-
-type ProxyProfile struct {
-	generated.ProxyProfile
-}
-
-type PlatformProfile struct {
-	generated.PlatformProfile
-}
-
-type ExternalAuthConfigProfile struct {
-	generated.ExternalAuthConfigProfile
-}
-
 func newVersionProfile(from *api.VersionProfile) *generated.VersionProfile {
 	return &generated.VersionProfile{
 		ID:                api.Ptr(from.ID),
@@ -342,10 +310,6 @@ func (c *HcpOpenShiftClusterResource) ValidateStatic(current api.VersionedHCPOpe
 	return cloudError
 }
 
-func (p *VersionProfile) Normalize(out *api.VersionProfile) {
-	normalizeVersion(&p.VersionProfile, out)
-}
-
 func normalizeVersion(p *generated.VersionProfile, out *api.VersionProfile) {
 	if p.ID != nil {
 		out.ID = *p.ID
@@ -356,10 +320,6 @@ func normalizeVersion(p *generated.VersionProfile, out *api.VersionProfile) {
 	out.AvailableUpgrades = api.StringPtrSliceToStringSlice(p.AvailableUpgrades)
 }
 
-func (p *DNSProfile) Normalize(out *api.DNSProfile) {
-	normailzeDNS(&p.DNSProfile, out)
-}
-
 func normailzeDNS(p *generated.DNSProfile, out *api.DNSProfile) {
 	if p.BaseDomain != nil {
 		out.BaseDomain = *p.BaseDomain
@@ -367,10 +327,6 @@ func normailzeDNS(p *generated.DNSProfile, out *api.DNSProfile) {
 	if p.BaseDomainPrefix != nil {
 		out.BaseDomainPrefix = *p.BaseDomainPrefix
 	}
-}
-
-func (p *NetworkProfile) Normalize(out *api.NetworkProfile) {
-	normalizeNetwork(&p.NetworkProfile, out)
 }
 
 func normalizeNetwork(p *generated.NetworkProfile, out *api.NetworkProfile) {
@@ -391,18 +347,10 @@ func normalizeNetwork(p *generated.NetworkProfile, out *api.NetworkProfile) {
 	}
 }
 
-func (p *ConsoleProfile) Normalize(out *api.ConsoleProfile) {
-	normalizeConsole(&p.ConsoleProfile, out)
-}
-
 func normalizeConsole(p *generated.ConsoleProfile, out *api.ConsoleProfile) {
 	if p.URL != nil {
 		out.URL = *p.URL
 	}
-}
-
-func (p *APIProfile) Normalize(out *api.APIProfile) {
-	normalizeAPI(&p.APIProfile, out)
 }
 
 func normalizeAPI(p *generated.APIProfile, out *api.APIProfile) {
@@ -412,10 +360,6 @@ func normalizeAPI(p *generated.APIProfile, out *api.APIProfile) {
 	if p.Visibility != nil {
 		out.Visibility = api.Visibility(*p.Visibility)
 	}
-}
-
-func (p *ProxyProfile) Normalize(out *api.ProxyProfile) {
-	normalizeProxy(&p.ProxyProfile, out)
 }
 
 func normalizeProxy(p *generated.ProxyProfile, out *api.ProxyProfile) {
@@ -431,10 +375,6 @@ func normalizeProxy(p *generated.ProxyProfile, out *api.ProxyProfile) {
 	if p.TrustedCa != nil {
 		out.TrustedCA = *p.TrustedCa
 	}
-}
-
-func (p *PlatformProfile) Normalize(out *api.PlatformProfile) {
-	normalizePlatform(&p.PlatformProfile, out)
 }
 
 func normalizePlatform(p *generated.PlatformProfile, out *api.PlatformProfile) {
@@ -453,10 +393,6 @@ func normalizePlatform(p *generated.PlatformProfile, out *api.PlatformProfile) {
 	if p.EtcdEncryptionSetID != nil {
 		out.EtcdEncryptionSetID = *p.EtcdEncryptionSetID
 	}
-}
-
-func (p *ExternalAuthConfigProfile) Normalize(out *api.ExternalAuthConfigProfile) {
-	normalizeExternalAuthConfig(&p.ExternalAuthConfigProfile, out)
 }
 
 func normalizeExternalAuthConfig(p *generated.ExternalAuthConfigProfile, out *api.ExternalAuthConfigProfile) {

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -226,6 +226,12 @@ func (c *HcpOpenShiftClusterResource) Normalize(out *api.HCPOpenShiftCluster) {
 	if c.Location != nil {
 		out.TrackedResource.Location = *c.Location
 	}
+	// Per RPC-Patch-V1-04, the Tags field does NOT follow
+	// JSON merge-patch (RFC 7396) semantics:
+	//
+	//   When Tags are patched, the tags from the request
+	//   replace all existing tags for the resource
+	//
 	out.Tags = api.StringPtrMapToStringMap(c.Tags)
 	if c.Properties != nil {
 		if c.Properties.ProvisioningState != nil {

--- a/internal/api/v20240610preview/nodepools_methods.go
+++ b/internal/api/v20240610preview/nodepools_methods.go
@@ -43,6 +43,12 @@ func (h *HcpOpenShiftClusterNodePoolResource) Normalize(out *api.HCPOpenShiftClu
 	if h.Location != nil {
 		out.TrackedResource.Location = *h.Location
 	}
+	// Per RPC-Patch-V1-04, the Tags field does NOT follow
+	// JSON merge-patch (RFC 7396) semantics:
+	//
+	//   When Tags are patched, the tags from the request
+	//   replace all existing tags for the resource
+	//
 	out.Tags = api.StringPtrMapToStringMap(h.Tags)
 	if h.Properties != nil {
 		if h.Properties.ProvisioningState != nil {


### PR DESCRIPTION
### What this PR does

There's no validation on this data at the moment.

Also note for dev-environment testing, the cluster PUT request has to include an "**X-Ms-Identity-Url**" header for this to work.  (This is the "**ManagedIdentitiesDataPlaneIdentityUrl**" field in CS.)  If the header isn't present the entire managed identities section is skipped.

Jira: [ARO-10911 - API: HCP supports managed identities](https://issues.redhat.com/browse/ARO-10911)
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
