### PR TITLE
frontend: Refetch resource document after updating

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -513,6 +513,13 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 		if updated {
 			f.logger.Info(fmt.Sprintf("document updated for %s", resourceID))
 		}
+		// Get the updated resource document for the response.
+		doc, err = f.dbClient.GetResourceDoc(ctx, resourceID)
+		if err != nil {
+			f.logger.Error(err.Error())
+			arm.WriteInternalServerError(writer)
+			return
+		}
 	}
 
 	responseBody, err := marshalCSCluster(csCluster, doc, versionedInterface)

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -242,6 +242,13 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		if updated {
 			f.logger.Info(fmt.Sprintf("document updated for %s", resourceID))
 		}
+		// Get the updated resource document for the response.
+		doc, err = f.dbClient.GetResourceDoc(ctx, resourceID)
+		if err != nil {
+			f.logger.Error(err.Error())
+			arm.WriteInternalServerError(writer)
+			return
+		}
 	}
 
 	responseBody, err := marshalCSNodePool(csNodePool, doc, versionedInterface)


### PR DESCRIPTION
### What this PR does

Noticed while testing Tags field patching that the PATCH response did not contain the updated Tags. I had to GET the resource again to see the correct set of Tags.

Jira: During testing of [ARO-10911 - API: HCP supports managed identities](https://issues.redhat.com/browse/ARO-10911), though not really related
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
