### PR TITLE
Add geo-replications to svc and ocp ACRs

### DIFF
--- a/dev-infrastructure/configurations/region.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/region.tmpl.bicepparam
@@ -1,5 +1,14 @@
 using '../templates/region.bicep'
 
+// general
+param globalRegion = '{{ .global.region }}'
+param globalResourceGroup = '{{ .global.rg }}'
+param regionalRegion = '{{ .region }}'
+
+// acr
+param ocpAcrName = '{{ .ocpAcrName }}'
+param svcAcrName = '{{ .svcAcrName }}'
+
 // dns
 param baseDNSZoneName = '{{ .baseDnsZoneName }}'
 param baseDNSZoneResourceGroup = '{{ .baseDnsZoneRG }}'

--- a/dev-infrastructure/modules/acr/acr-replication.bicep
+++ b/dev-infrastructure/modules/acr/acr-replication.bicep
@@ -1,0 +1,23 @@
+@description('ACR replication resource location')
+param acrReplicationLocation string
+
+@description('Parent ACR resource name')
+param acrReplicationParentAcrName string
+
+@minLength(5)
+@maxLength(40)
+@description('ACR replication name (must be globally unique)')
+param acrReplicationReplicaName string
+
+resource parentAcr 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' existing = {
+  name: acrReplicationParentAcrName
+}
+
+resource acrReplication 'Microsoft.ContainerRegistry/registries/replications@2023-11-01-preview' = {
+  parent: parentAcr
+  name: acrReplicationReplicaName
+  location: acrReplicationLocation
+  properties: {
+    regionEndpointEnabled: true
+  }
+}


### PR DESCRIPTION
### What this PR does

* Add an `acr-replication` bicep module used to set up a replication
* Use the `acr-replication` module in `region.bicep` to deploy ACR replications for both the svc and ocp ACRs
* An ACR replication cannot exist in the same region as the parent ACR and the module usage definitions checks for that

Jira: https://issues.redhat.com/browse/ARO-13411
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer