### PR TITLE
tell the user what is going to happen

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -164,6 +164,7 @@ region: region.wait regional.rg
 
 region.clean:
 	@if [ "$$(az group exists --name $(REGIONAL_RESOURCEGROUP))" = "true" ]; then \
+		echo "Will delete Azure resource group $(REGIONAL_RESOURCEGROUP)"; \
 		az group delete -g $(REGIONAL_RESOURCEGROUP); \
 	fi
 .PHONY: region.clean
@@ -291,6 +292,7 @@ svc.dev-role-assignments:
 
 svc.clean:
 	@if [ "$$(az group exists --name $(SVC_RESOURCEGROUP))" = "true" ]; then \
+		echo "Will delete Azure resource group $(SVC_RESOURCEGROUP)"; \
 		az group delete -g $(SVC_RESOURCEGROUP); \
 	fi
 .PHONY: svc.clean
@@ -378,6 +380,7 @@ mgmt.what-if: mgmt.rg
 
 mgmt.clean:
 	@if [ "$$(az group exists --name $(MGMT_RESOURCEGROUP))" = "true" ]; then \
+		echo "Will delete Azure resource group $(MGMT_RESOURCEGROUP)"; \
 		az group delete -g $(MGMT_RESOURCEGROUP); \
 	fi
 .PHONY: mgmt.clean


### PR DESCRIPTION
### What this PR does

Small change which adds a message before running `az ... delete` actions for `.clean` make targets

As a new user I found it unsettling to see the following when running `make clean` and having to blindly answer `yes`

```
# make clean
Are you sure you want to perform this operation? (y/n): y
Are you sure you want to perform this operation? (y/n): y
Are you sure you want to perform this operation? (y/n): y
```

With this simple change, the user knows what operation they are agreeing to

An alternate option was to remove the `@` and let make output the commands, but this also outputs the if conditions and is unnecessarily verbose

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
