### PR TITLE
move persist tag management to *-infra.bicep

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -200,7 +200,9 @@ svc: svc.rg
 		--template-file templates/svc-infra.bicep \
 		$(PROMPT_TO_CONFIRM) \
 		--parameters \
-			configurations/svc-infra.bicepparam
+			configurations/svc-infra.bicepparam \
+		--parameters \
+			persist=${PERSIST}
 	@./ensure-no-running-deployment.sh $(SVC_RESOURCEGROUP) $(SVC_RG_DEPLOYMENT_NAME)
 	az deployment group create \
 		--name $(SVC_RG_DEPLOYMENT_NAME) \
@@ -322,7 +324,9 @@ mgmt: mgmt.wait mgmt.rg
 		--template-file templates/mgmt-infra.bicep \
 		$(PROMPT_TO_CONFIRM) \
 		--parameters \
-			configurations/mgmt-infra.bicepparam
+			configurations/mgmt-infra.bicepparam \
+		--parameters \
+			persist=${PERSIST}
 	@scripts/cleanup-orphaned-rolebindings.sh $(MGMT_RESOURCEGROUP)
 	az deployment group create \
 		--name $(MGMG_RG_DEPLOYMENT_NAME) \

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -147,17 +147,6 @@ resource serviceKeyVault 'Microsoft.KeyVault/vaults@2024-04-01-preview' existing
   scope: resourceGroup(serviceKeyVaultResourceGroup)
 }
 
-// Tags the resource group
-resource subscriptionTags 'Microsoft.Resources/tags@2024-03-01' = {
-  name: 'default'
-  scope: resourceGroup()
-  properties: {
-    tags: {
-      persist: toLower(string(persist))
-    }
-  }
-}
-
 module svcCluster '../modules/aks-cluster-base.bicep' = {
   name: 'cluster'
   scope: resourceGroup()

--- a/dev-infrastructure/templates/svc-infra.bicep
+++ b/dev-infrastructure/templates/svc-infra.bicep
@@ -22,6 +22,20 @@ param certName string
 @description('This is a regional DNS zone')
 param regionalDNSZoneName string
 
+@description('Set to true to prevent resources from being pruned after 48 hours')
+param persist bool = false
+
+// Tags the resource group
+resource resourcegroupTags 'Microsoft.Resources/tags@2024-03-01' = {
+  name: 'default'
+  scope: resourceGroup()
+  properties: {
+    tags: {
+      persist: toLower(string(persist))
+    }
+  }
+}
+
 //
 //   K E Y V A U L T S
 //


### PR DESCRIPTION
### What this PR does

RG tag management will move from the `*-cluster.bicep` to the `*-infra.bicep` modules.

background: we want to be able to ramp infra without clusters for various testing purposes, hence only the infra templates might run and RG tagging needs to run as part of that

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
