### PR TITLE
.github: fix az login check workflow and re-introduce fork check

### DIFF
--- a/.github/workflows/aro-hcp-cd.yml
+++ b/.github/workflows/aro-hcp-cd.yml
@@ -41,6 +41,15 @@
     cancel-in-progress: false
 
   jobs:
+    is_running_on_fork:
+      name: 'Ensure PR is submitted from Azure/ARO-HCP'
+      if: github.event_name != 'workflow_dispatch'
+      runs-on: ubuntu-latest
+      steps:
+        - name: Fail if PR submitted from fork
+          if: ${{ github.event.pull_request.head.repo.full_name != 'Azure/ARO-HCP' }}
+          run: core.setFailed('Expected source repository to be Azure/ARO-HCP, not ${{ github.event.pull_request.head.repo.full_name }}, re-create PR as a branch of Azure/ARO-HCP')
+
     deploy_global_rg:
       name: 'Deploy global resources'
       if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/aro-hcp-login-check.yml
+++ b/.github/workflows/aro-hcp-login-check.yml
@@ -33,20 +33,18 @@
         - closed
 
   jobs:
-    is_running_on_fork:
-      name: 'Ensure PR is submitted from Azure/ARO-HCP'
+    azure_login:
+      name: 'Azure login'
       if: github.event_name != 'workflow_dispatch'
       runs-on: ubuntu-latest
       permissions:
         id-token: 'write'
         contents: 'read'
       steps:
-        - name: 'Az CLI login - will fail if PR is submitted from a fork of the repo'
-          uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+        - uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
           with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}
             subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        - name: Fail if PR submitted from fork
-          if: failure()
-          run: core.setFailed('Expected source repository to be Azure/ARO-HCP, not ${{ github.event.pull_request.head.repo.full_name }}, re-create PR as a branch of Azure/ARO-HCP')
+        - if: failure()
+          run: core.setFailed('Failed to login to Azure')


### PR DESCRIPTION
### What this PR does

The jobs/steps names for workflow `Azure Login Check` which were added in #882 are misleading. One example can be seen in https://github.com/Azure/ARO-HCP/actions/runs/12396846632/job/34606970167?pr=992

This also re-introduces the job that checks if PRs are opened from a different repo, which I believe may have been erroneously removed in #882 

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
