### PR TITLE
Refactor frontend/backend make deploy to use most recent image tags if COMMIT is not provided

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,10 +1,15 @@
 -include ../setup-env.mk
 
-ifndef COMMIT
-COMMIT := $(shell git rev-parse --short=7 HEAD)
+ARO_HCP_REGISTRY ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
+ARO_HCP_REPOSITORY := arohcpbackend
+ARO_HCP_BACKEND_IMAGE ?= $(ARO_HCP_REGISTRY)/$(ARO_HCP_REPOSITORY)
+
+ifeq ($(strip $(COMMIT)),)
+COMMIT := $(shell az acr repository show-tags --name ${ARO_HCP_IMAGE_ACR} --repository ${ARO_HCP_REPOSITORY} --orderby time_desc --top 1 --output tsv)
 endif
-ARO_HCP_BASE_IMAGE ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
-ARO_HCP_BACKEND_IMAGE ?= $(ARO_HCP_BASE_IMAGE)/arohcpbackend:$(COMMIT)
+
+BUILD_TAG := $(ARO_HCP_BACKEND_IMAGE):$(shell git rev-parse --short=7 HEAD)
+DEPLOY_TAG := $(ARO_HCP_BACKEND_IMAGE):$(COMMIT)
 
 .DEFAULT_GOAL := backend
 
@@ -23,13 +28,13 @@ clean:
 
 image:
 	pushd .. && git archive --output backend/archive.tar.gz HEAD && popd
-	docker build -f "./Dockerfile" -t ${ARO_HCP_BACKEND_IMAGE} .
+	docker build -f "./Dockerfile" -t ${ARO_HCP_BACKEND_IMAGE}:${BUILD_TAG} .
 	rm -f archive.tar.gz
 .PHONY: image
 
 push: image
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
-	docker push ${ARO_HCP_BACKEND_IMAGE}
+	docker push ${ARO_HCP_BACKEND_IMAGE}:${BUILD_TAG}
 .PHONY: push
 
 deploy:
@@ -47,9 +52,9 @@ deploy:
 		--set configMap.databaseUrl="$${DB_URL}" \
 		--set configMap.backendMiClientId="$${BACKEND_MI_CLIENT_ID}" \
 		--set serviceAccount.workloadIdentityClientId="$${BACKEND_MI_CLIENT_ID}" \
-		--set configMap.currentVersion=${ARO_HCP_BACKEND_IMAGE} \
+		--set configMap.currentVersion=${ARO_HCP_BACKEND_IMAGE}:${DEPLOY_IMAGE} \
 		--set configMap.location=${LOCATION} \
-		--set deployment.imageName=${ARO_HCP_BACKEND_IMAGE} \
+		--set deployment.imageName=${ARO_HCP_BACKEND_IMAGE}:${DEPLOY_IMAGE} \
 		--namespace aro-hcp
 .PHONY: deploy
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -235,10 +235,10 @@ clouds:
         imageTag: 9aca808
       # Frontend
       frontend:
-        imageTag: '' # if empty uses commit sha of repo
+        imageTag: '' # if empty will use the most recent tag
       # Backend
       backend:
-        imageTag: '' # if empty uses commit sha of repo
+        imageTag: '' # if empty will use the most recent tag
       # Shared SVC KV
       serviceKeyVault:
         name: 'aro-hcp-dev-svc-kv'

--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -287,6 +287,15 @@ The ARO-HCP resource provider consists of independent frontend and backend compo
   make backend.deploy
   ```
 
+This will deploy the most recent image tags of the frontend and backend components.
+
+Optionally, a commit hash can be provided to the `frontend.deploy` and `backend.deploy` targets to deploy a specific version of the components. This is useful for testing changes in the frontend or backend components.
+
+  ```bash
+  make frontend.deploy COMMIT=<short-sha>
+  make backend.deploy  COMMIT=<short-sha>
+  ```
+
 To validate, have a look at the `aro-hcp` namespace on the service cluster.
 
 ## Deploy Services to the management cluster

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -13,6 +13,12 @@ DEPLOY_TAG := $(ARO_HCP_FRONTEND_IMAGE):$(COMMIT)
 
 .DEFAULT_GOAL := frontend
 
+testjfc:
+	@echo "BUILD_TAG: $(BUILD_TAG)"
+	@echo "DEPLOY_TAG: $(DEPLOY_TAG)"
+	@echo "ARO_HCP_FRONTEND_IMAGE: $(ARO_HCP_FRONTEND_IMAGE)"
+
+
 frontend:
 	go build -o aro-hcp-frontend .
 

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,10 +1,15 @@
 -include ../setup-env.mk
 
-ifndef COMMIT
-COMMIT := $(shell git rev-parse --short=7 HEAD)
+ARO_HCP_REGISTRY ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
+ARO_HCP_REPOSITORY := arohcpfrontend
+ARO_HCP_FRONTEND_IMAGE ?= $(ARO_HCP_REGISTRY)/$(ARO_HCP_REPOSITORY)
+
+ifeq ($(strip $(COMMIT)),)
+COMMIT := $(shell az acr repository show-tags --name ${ARO_HCP_IMAGE_ACR} --repository ${ARO_HCP_REPOSITORY} --orderby time_desc --top 1 --output tsv)
 endif
-ARO_HCP_BASE_IMAGE ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
-ARO_HCP_FRONTEND_IMAGE ?= $(ARO_HCP_BASE_IMAGE)/arohcpfrontend:$(COMMIT)
+
+BUILD_TAG := $(ARO_HCP_FRONTEND_IMAGE):$(shell git rev-parse --short=7 HEAD)
+DEPLOY_TAG := $(ARO_HCP_FRONTEND_IMAGE):$(COMMIT)
 
 .DEFAULT_GOAL := frontend
 
@@ -30,13 +35,13 @@ build-push: image push
 
 image:
 	pushd .. && git archive --output frontend/archive.tar.gz HEAD && popd
-	docker build -f "./Dockerfile" -t ${ARO_HCP_FRONTEND_IMAGE} .
+	docker build -f "./Dockerfile" -t ${ARO_HCP_FRONTEND_IMAGE}:${BUILD_TAG} .
 	rm -f archive.tar.gz
 .PHONY: image
 
 push: image
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
-	docker push ${ARO_HCP_FRONTEND_IMAGE}
+	docker push ${ARO_HCP_FRONTEND_IMAGE}:${BUILD_TAG}
 
 deploy:
 	FRONTEND_MI_CLIENT_ID=$$(az identity show \
@@ -62,9 +67,9 @@ deploy:
 		--set credsKeyVault.name=${SERVICE_KEY_VAULT} \
 		--set credsKeyVault.secret=${CERTIFICATE_NAME} \
 		--set serviceAccount.workloadIdentityClientId="$${FRONTEND_MI_CLIENT_ID}" \
-		--set configMap.currentVersion=${ARO_HCP_FRONTEND_IMAGE} \
+		--set configMap.currentVersion=${ARO_HCP_FRONTEND_IMAGE}:${DEPLOY_TAG} \
 		--set configMap.location=${LOCATION}  \
-		--set deployment.imageName=${ARO_HCP_FRONTEND_IMAGE} \
+		--set deployment.imageName=${ARO_HCP_FRONTEND_IMAGE}:${DEPLOY_TAG} \
 		--namespace aro-hcp
 .PHONY: deploy
 


### PR DESCRIPTION
### What this PR does

Small refactor of frontend & backend Makefiles with the following functional changes:
* If COMMIT is provided, no change (same behavior as before)
* If COMMIT is not provided, lookup the most recent tag in the registry and use that
* Adjust documentation to that effect

Jira: https://issues.redhat.com/browse/ARO-13263
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
