### PR TITLE
doc: document ARO-HCP Clusters creation in CS with Managed Identities

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -77,11 +77,16 @@ curl -X GET "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/r
 ```
 
 Create or Update a HcpOpenShiftClusterResource
+
 ```bash
 curl -X PUT "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dev-test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/dev-test-cluster?api-version=2024-06-10-preview" \
   -H "X-Ms-Arm-Resource-System-Data: {\"createdBy\": \"aro-hcp-local-testing\", \"createdByType\": \"User\", \"createdAt\": \"2024-06-06T19:26:56+00:00\"}" \
+  -H "X-Ms-Identity-Url": https://dummyhost.identity.azure.net" \
   --json @cluster.json
 ```
+
+You will notice that the request contains a `X-Ms-Identity-Url` with the value `https://dummyhost.identity.azure.net`. Setting the `X-Ms-Identity-Url` HTTP header when interacting directly
+with the Frontend is required. However, for the environments where a real managed identities data plane does not exist the value can be any arbitrary/dummy HTTPS URL that ends in `identity.azure.net`.
 
 Delete a HcpOpenShiftClusterResource
 ```bash


### PR DESCRIPTION
### What this PR does

We document how to create the N needed Managed Identities when creating ARO-HCP Clusters directly against CS.

As an important remark, this assumes 4.17.x clusters creation. The set of required managed identities can differ between OCP versions. For now assuming 4.17.x is good enough but in the future we might want to improve on this.

As an important note, similar documentation / scripts should be created for the frontend side.
### Special notes for your reviewer

<!-- optional -->
