### PR TITLE
ARO-13402 | Adding Identity field to the HCPOpenShiftCluster

### DIFF
--- a/internal/api/arm/identity.go
+++ b/internal/api/arm/identity.go
@@ -1,0 +1,27 @@
+package arm
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+// Represents to support the ManagedServiceIdentity ARM resource.
+type Identity struct {
+	PrincipalID            string                           `json:"principalId,omitempty"`
+	TenantID               string                           `json:"tenantId,omitempty"`
+	Type                   ManagedServiceIdentityType       `json:"type"`
+	UserAssignedIdentities map[string]*UserAssignedIdentity `json:"userAssignedIdentities,omitempty"`
+}
+
+// UserAssignedIdentity - User assigned identity properties https://azure.github.io/typespec-azure/docs/libraries/azure-resource-manager/reference/data-types/#Azure.ResourceManager.CommonTypes.UserAssignedIdentity
+type UserAssignedIdentity struct {
+	ClientID    *string
+	PrincipalID *string
+}
+
+type ManagedServiceIdentityType string
+
+const (
+	ManagedServiceIdentityTypeNone                       ManagedServiceIdentityType = "None"
+	ManagedServiceIdentityTypeSystemAssigned             ManagedServiceIdentityType = "SystemAssigned"
+	ManagedServiceIdentityTypeSystemAssignedUserAssigned ManagedServiceIdentityType = "SystemAssigned,UserAssigned"
+	ManagedServiceIdentityTypeUserAssigned               ManagedServiceIdentityType = "UserAssigned"
+)

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -13,6 +13,7 @@ import (
 type HCPOpenShiftCluster struct {
 	arm.TrackedResource
 	Properties HCPOpenShiftClusterProperties `json:"properties,omitempty" validate:"required_for_put"`
+	Identity   arm.Identity                  `json:"identity,omitempty"`
 }
 
 // HCPOpenShiftClusterProperties represents the property bag of a HCPOpenShiftCluster resource.


### PR DESCRIPTION
### What this PR does
The frontend needs to parse and validate the top-level ARM-defined "identity" resource field to fully support managed identities.

Jira: https://issues.redhat.com/browse/ARO-13402


Raised again after my permission issue was fixed , for more info please look into https://github.com/Azure/ARO-HCP/pull/1028 .

### Special notes for your reviewer
The ticket says Visibility tags are TBD so have left them blank .
