### PR TITLE
fix: register frontend metrics to global registry

### DIFF
--- a/frontend/cmd/cmd.go
+++ b/frontend/cmd/cmd.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 
 	"github.com/Azure/ARO-HCP/frontend/pkg/config"
@@ -85,7 +86,7 @@ func (opts *FrontendOpts) Run() error {
 	logger.Info(fmt.Sprintf("%s (%s) started", frontend.ProgramName, version()))
 
 	// Init prometheus emitter
-	prometheusEmitter := frontend.NewPrometheusEmitter()
+	prometheusEmitter := frontend.NewPrometheusEmitter(prometheus.DefaultRegisterer)
 
 	// Configure database configuration and client
 	dbClient := database.NewCache()

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
@@ -40,7 +42,7 @@ func TestReadiness(t *testing.T) {
 			f := &Frontend{
 				dbClient: database.NewCache(),
 				logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
-				metrics:  NewPrometheusEmitter(),
+				metrics:  NewPrometheusEmitter(prometheus.NewRegistry()),
 			}
 			f.ready.Store(test.ready)
 			ts := httptest.NewServer(f.routes())
@@ -92,7 +94,7 @@ func TestSubscriptionsGET(t *testing.T) {
 			f := &Frontend{
 				dbClient: database.NewCache(),
 				logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
-				metrics:  NewPrometheusEmitter(),
+				metrics:  NewPrometheusEmitter(prometheus.NewRegistry()),
 			}
 
 			if test.subDoc != nil {
@@ -210,7 +212,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 			f := &Frontend{
 				dbClient: database.NewCache(),
 				logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
-				metrics:  NewPrometheusEmitter(),
+				metrics:  NewPrometheusEmitter(prometheus.NewRegistry()),
 			}
 
 			body, err := json.Marshal(&test.subscription)

--- a/frontend/pkg/frontend/metrics.go
+++ b/frontend/pkg/frontend/metrics.go
@@ -29,11 +29,11 @@ type PrometheusEmitter struct {
 	registry prometheus.Registerer
 }
 
-func NewPrometheusEmitter() *PrometheusEmitter {
+func NewPrometheusEmitter(r prometheus.Registerer) *PrometheusEmitter {
 	return &PrometheusEmitter{
 		gauges:   make(map[string]*prometheus.GaugeVec),
 		counters: make(map[string]*prometheus.CounterVec),
-		registry: prometheus.NewRegistry(),
+		registry: r,
 	}
 }
 

--- a/frontend/pkg/frontend/node_pool_test.go
+++ b/frontend/pkg/frontend/node_pool_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	_ "github.com/Azure/ARO-HCP/internal/api/v20240610preview"
@@ -89,7 +91,7 @@ func TestCreateNodePool(t *testing.T) {
 			f := &Frontend{
 				dbClient:             database.NewCache(),
 				logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
-				metrics:              NewPrometheusEmitter(),
+				metrics:              NewPrometheusEmitter(prometheus.NewRegistry()),
 				clusterServiceClient: &mockCSClient,
 			}
 			hcpCluster := api.NewDefaultHCPOpenShiftCluster()


### PR DESCRIPTION
### What this PR does

This change registers the frontend metrics to the global registry instead of creating a new registry which isn't exposed to the /metrics endpoint.

### Special notes for your reviewer

<!-- optional -->
