### PR TITLE
`deploymentLevel` mandatory in pipeline files

### DIFF
--- a/tooling/templatize/internal/end2end/e2e_test.go
+++ b/tooling/templatize/internal/end2end/e2e_test.go
@@ -82,7 +82,7 @@ func TestE2EArmDeploy(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	e2eImpl := newE2E(tmpDir)
-	e2eImpl.AddStep(pipeline.NewARMStep("test", "test.bicep", "test.bicepparm"), 0)
+	e2eImpl.AddStep(pipeline.NewARMStep("test", "test.bicep", "test.bicepparm", "ResourceGroup"), 0)
 	cleanup := e2eImpl.UseRandomRG()
 	defer func() {
 		err := cleanup()
@@ -149,7 +149,7 @@ func TestE2EArmDeployWithOutput(t *testing.T) {
 
 	e2eImpl := newE2E(tmpDir)
 
-	e2eImpl.AddStep(pipeline.NewARMStep("createZone", "test.bicep", "test.bicepparm"), 0)
+	e2eImpl.AddStep(pipeline.NewARMStep("createZone", "test.bicep", "test.bicepparm", "ResourceGroup"), 0)
 
 	e2eImpl.AddStep(pipeline.NewShellStep(
 		"readInput", "echo ${zoneName} > env.txt",
@@ -192,8 +192,8 @@ func TestE2EArmDeployWithOutputToArm(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	e2eImpl := newE2E(tmpDir)
-	e2eImpl.AddStep(pipeline.NewARMStep("parameterA", "testa.bicep", "testa.bicepparm"), 0)
-	e2eImpl.AddStep(pipeline.NewARMStep("parameterB", "testb.bicep", "testb.bicepparm").WithVariables(pipeline.Variable{
+	e2eImpl.AddStep(pipeline.NewARMStep("parameterA", "testa.bicep", "testa.bicepparm", "ResourceGroup"), 0)
+	e2eImpl.AddStep(pipeline.NewARMStep("parameterB", "testb.bicep", "testb.bicepparm", "ResourceGroup").WithVariables(pipeline.Variable{
 		Name: "parameterB",
 		Input: &pipeline.Input{
 			Name: "parameterA",
@@ -253,7 +253,7 @@ func TestE2EArmDeployWithOutputRGOverlap(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	e2eImpl := newE2E(tmpDir)
-	e2eImpl.AddStep(pipeline.NewARMStep("parameterA", "testa.bicep", "testa.bicepparm"), 0)
+	e2eImpl.AddStep(pipeline.NewARMStep("parameterA", "testa.bicep", "testa.bicepparm", "ResourceGroup"), 0)
 
 	e2eImpl.AddResourceGroup()
 
@@ -296,7 +296,7 @@ func TestE2EArmDeploySubscriptionScope(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	e2eImpl := newE2E(tmpDir)
-	e2eImpl.AddStep(pipeline.NewARMStep("parameterA", "testa.bicep", "testa.bicepparm").WithDeploymentLevel("Subscription"), 0)
+	e2eImpl.AddStep(pipeline.NewARMStep("parameterA", "testa.bicep", "testa.bicepparm", "Subscription"), 0)
 	rgName := GenerateRandomRGName()
 	e2eImpl.AddBicepTemplate(fmt.Sprintf(`
 targetScope='subscription'

--- a/tooling/templatize/pkg/pipeline/inspect_test.go
+++ b/tooling/templatize/pkg/pipeline/inspect_test.go
@@ -49,7 +49,7 @@ func TestInspectVars(t *testing.T) {
 		},
 		{
 			name:     "failed action",
-			caseStep: NewARMStep("step", "test.bicep", "test.bicepparam"),
+			caseStep: NewARMStep("step", "test.bicep", "test.bicepparam", "ResourceGroup"),
 			err:      "inspecting step variables not implemented for action type ARM",
 		},
 		{

--- a/tooling/templatize/pkg/pipeline/pipeline.schema.v1.json
+++ b/tooling/templatize/pkg/pipeline/pipeline.schema.v1.json
@@ -209,7 +209,8 @@
                                     },
                                     "required": [
                                         "template",
-                                        "parameters"
+                                        "parameters",
+                                        "deploymentLevel"
                                     ]
                                 },
                                 {

--- a/tooling/templatize/pkg/pipeline/types.go
+++ b/tooling/templatize/pkg/pipeline/types.go
@@ -169,8 +169,8 @@ func NewARMStep(name string, template string, parameters string, deploymentLevel
 			Name:   name,
 			Action: "ARM",
 		},
-		Template:   template,
-		Parameters: parameters,
+		Template:        template,
+		Parameters:      parameters,
 		DeploymentLevel: deploymentLevel,
 	}
 }

--- a/tooling/templatize/pkg/pipeline/types.go
+++ b/tooling/templatize/pkg/pipeline/types.go
@@ -163,7 +163,7 @@ func (s *ShellStep) WithOutputFunc(outputFunc outPutHandler) *ShellStep {
 	return s
 }
 
-func NewARMStep(name string, template string, parameters string) *ARMStep {
+func NewARMStep(name string, template string, parameters string, deploymentLevel string) *ARMStep {
 	return &ARMStep{
 		StepMeta: StepMeta{
 			Name:   name,
@@ -171,6 +171,7 @@ func NewARMStep(name string, template string, parameters string) *ARMStep {
 		},
 		Template:   template,
 		Parameters: parameters,
+		DeploymentLevel: deploymentLevel,
 	}
 }
 
@@ -181,11 +182,6 @@ func (s *ARMStep) WithDependsOn(dependsOn ...string) *ARMStep {
 
 func (s *ARMStep) WithVariables(variables ...Variable) *ARMStep {
 	s.Variables = variables
-	return s
-}
-
-func (s *ARMStep) WithDeploymentLevel(deploymentLevel string) *ARMStep {
-	s.DeploymentLevel = deploymentLevel
 	return s
 }
 

--- a/tooling/templatize/testdata/pipeline.yaml
+++ b/tooling/templatize/testdata/pipeline.yaml
@@ -23,6 +23,7 @@ resourceGroups:
     action: ARM
     template: templates/svc-cluster.bicep
     parameters: test.bicepparam
+    deploymentLevel: ResourceGroup
   - name: DelegateChildZoneBase
     action: DelegateChildZoneExtension
     parentZoneName:

--- a/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2pipeline.yaml
+++ b/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2pipeline.yaml
@@ -22,6 +22,7 @@ resourceGroups:
           action: ARM
           template: templates/svc-cluster.bicep
           parameters: ev2-precompiled-test.bicepparam
+          deploymentLevel: ResourceGroup
         - name: DelegateChildZoneBase
           action: DelegateChildZoneExtension
           dependsOn:

--- a/tooling/templatize/testdata/zz_fixture_TestRawOptions.yaml
+++ b/tooling/templatize/testdata/zz_fixture_TestRawOptions.yaml
@@ -23,6 +23,7 @@ resourceGroups:
     action: ARM
     template: templates/svc-cluster.bicep
     parameters: test.bicepparam
+    deploymentLevel: ResourceGroup
   - name: DelegateChildZoneBase
     action: DelegateChildZoneExtension
     parentZoneName:


### PR DESCRIPTION
### What this PR does

adapt the pipeline schema to demand a `deploymentLevel` for ARM steps. followup for https://github.com/Azure/ARO-HCP/pull/1035

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
