### PR TITLE
adapt child zone delegation step schema for pipeline files

### DIFF
--- a/tooling/templatize/pkg/pipeline/pipeline.schema.v1.json
+++ b/tooling/templatize/pkg/pipeline/pipeline.schema.v1.json
@@ -130,7 +130,7 @@
                                 },
                                 "action": {
                                     "type": "string",
-                                    "enum": ["ARM", "Shell", "DelegateChildZoneExtension", "SetCertificateIssuer"]
+                                    "enum": ["ARM", "Shell", "DelegateChildZone", "SetCertificateIssuer"]
                                 },
                                 "template": {
                                     "type": "string"
@@ -166,10 +166,10 @@
                                 "provider": {
                                     "$ref": "#/definitions/variableRef"
                                 },
-                                "parentZoneName": {
+                                "parentZone": {
                                     "$ref": "#/definitions/variableRef"
                                 },
-                                "childZoneName": {
+                                "childZone": {
                                     "$ref": "#/definitions/variableRef"
                                 }
                             },
@@ -266,12 +266,12 @@
                                         },
                                         "action": {
                                             "type": "string",
-                                            "enum": ["DelegateChildZoneExtension"]
+                                            "enum": ["DelegateChildZone"]
                                         },
-                                        "parentZoneName": {
+                                        "parentZone": {
                                             "$ref": "#/definitions/variableRef"
                                         },
-                                        "childZoneName": {
+                                        "childZone": {
                                             "$ref": "#/definitions/variableRef"
                                         },
                                         "dependsOn": {
@@ -282,8 +282,8 @@
                                         }
                                     },
                                     "required": [
-                                        "parentZoneName",
-                                        "childZoneName"
+                                        "parentZone",
+                                        "childZone"
                                     ]
                                 },
                                 {

--- a/tooling/templatize/pkg/pipeline/types.go
+++ b/tooling/templatize/pkg/pipeline/types.go
@@ -65,7 +65,7 @@ func NewPlainPipelineFromBytes(filepath string, bytes []byte) (*Pipeline, error)
 				rg.Steps[i] = &ShellStep{}
 			case "ARM":
 				rg.Steps[i] = &ARMStep{}
-			case "DelegateChildZoneExtension":
+			case "DelegateChildZone":
 				rg.Steps[i] = &DelegateChildZoneStep{}
 			case "SetCertificateIssuer":
 				rg.Steps[i] = &SetCertificateIssuerStep{}

--- a/tooling/templatize/testdata/pipeline.yaml
+++ b/tooling/templatize/testdata/pipeline.yaml
@@ -24,12 +24,12 @@ resourceGroups:
     template: templates/svc-cluster.bicep
     parameters: test.bicepparam
     deploymentLevel: ResourceGroup
-  - name: DelegateChildZoneBase
-    action: DelegateChildZoneExtension
-    parentZoneName:
+  - name: cxChildZone
+    action: DelegateChildZone
+    parentZone:
       configRef: parentZone
-    childZoneName:
-      value: childZone
+    childZone:
+      configRef: childZone
     dependsOn:
     - deploy
   - name: issuerTest

--- a/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2pipeline.yaml
+++ b/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2pipeline.yaml
@@ -23,14 +23,12 @@ resourceGroups:
           template: templates/svc-cluster.bicep
           parameters: ev2-precompiled-test.bicepparam
           deploymentLevel: ResourceGroup
-        - name: DelegateChildZoneBase
-          action: DelegateChildZoneExtension
+        - name: cxChildZone
+          action: DelegateChildZone
           dependsOn:
             - deploy
-          parentZoneName:
-            configRef: parentZone
-          childZoneName:
-            value: childZone
+          parentZoneName: {}
+          childZoneName: {}
         - name: issuerTest
           action: SetCertificateIssuer
           dependsOn:

--- a/tooling/templatize/testdata/zz_fixture_TestRawOptions.yaml
+++ b/tooling/templatize/testdata/zz_fixture_TestRawOptions.yaml
@@ -24,12 +24,12 @@ resourceGroups:
     template: templates/svc-cluster.bicep
     parameters: test.bicepparam
     deploymentLevel: ResourceGroup
-  - name: DelegateChildZoneBase
-    action: DelegateChildZoneExtension
-    parentZoneName:
+  - name: cxChildZone
+    action: DelegateChildZone
+    parentZone:
       configRef: parentZone
-    childZoneName:
-      value: childZone
+    childZone:
+      configRef: childZone
     dependsOn:
     - deploy
   - name: issuerTest


### PR DESCRIPTION
### What this PR does

shorter names are better. also MSFT started to use the shorter names in the pipeline definitions.

- rename `DelegateChildZoneExtension` to `DelegateChildZone`
- rename `parentZoneName` to `parentZone`
- rename `childZoneName` to `childZone`

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
