### PR TITLE
unique deployment name for dns zone delegation

### DIFF
--- a/dev-infrastructure/templates/region.bicep
+++ b/dev-infrastructure/templates/region.bicep
@@ -48,7 +48,7 @@ resource regionalZone 'Microsoft.Network/dnsZones@2018-05-01' = {
 }
 
 module regionalZoneDelegation '../modules/dns/zone-delegation.bicep' = {
-  name: '${deployment().name}-zone-deleg'
+  name: '${regionalDNSSubdomain}-zone-deleg'
   scope: resourceGroup(baseDNSZoneResourceGroup)
   params: {
     childZoneName: regionalDNSSubdomain


### PR DESCRIPTION
### What this PR does

two pipelines creating different zone delegations in the global RG were interferring with each other over the name of the deployment, which was not zone specific

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
