### PR TITLE
add PRINCIPAL_ID to GH action service rollout steps

### DIFF
--- a/.github/workflows/services-cd.yml
+++ b/.github/workflows/services-cd.yml
@@ -33,6 +33,8 @@
   jobs:
 
     deploy_to_service_cluster:
+      env:
+        PRINCIPAL_ID: ${{ secrets.GHA_PRINCIPAL_ID }}
       permissions:
         id-token: 'write'
         contents: 'read'
@@ -106,6 +108,8 @@
             ./svc-deploy.sh ${DEPLOY_ENV} cluster-service svc deploy-pr-env-deps
 
     deploy_to_management_cluster:
+      env:
+        PRINCIPAL_ID: ${{ secrets.GHA_PRINCIPAL_ID }}
       permissions:
         id-token: 'write'
         contents: 'read'


### PR DESCRIPTION
### What this PR does

the principal_id is required in templatize when the current user is not a real user but a service principal. this principal id is granted access to the respective clusters to roll out services.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
