### PR TITLE
remove oc dep from PKO install

### DIFF
--- a/pko/Makefile
+++ b/pko/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash
 
 deploy:
-	oc apply -f https://github.com/package-operator/package-operator/releases/download/v1.11.0/self-bootstrap-job.yaml
+	kubectl apply -f https://github.com/package-operator/package-operator/releases/download/v1.11.0/self-bootstrap-job.yaml
 
 .PHONY: deploy


### PR DESCRIPTION
### What this PR does

use kubectl apply for PKO instead of oc apply
this way we don't need to oc dep for MC rollouts

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
