### PR TITLE
Ensure maestro namespace exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ services_mgmt_pipelines = hypershiftoperator
 	$(eval export dirname=$(subst .,/,$(basename $@)))
 	./templatize.sh $(DEPLOY_ENV) -p ./$(dirname)/pipeline.yaml -s deploy -P run -c public -d
 
-svc.deployall:  $(addsuffix .deploy, $(services_svc)) $(addsuffix .deploy_pipeline, $(services_svc_pipelines))
+svc.deployall: $(addsuffix .deploy_pipeline, $(services_svc_pipelines)) $(addsuffix .deploy, $(services_svc))
 mgmt.deployall: $(addsuffix .deploy, $(services_mgmt)) $(addsuffix .deploy_pipeline, $(services_mgmt_pipelines))
 deployall: svc.deployall mgmt.deployall
 


### PR DESCRIPTION
### What this PR does
Change order of maestro steps. Previously registration was run after server and thus the namespace always existed. Restore server before registration order.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
