### PR TITLE
http proxy for maestro agent to expose metrics without authn/z

### DIFF
--- a/maestro/agent/helm/templates/maestro-agent.deployment.yaml
+++ b/maestro/agent/helm/templates/maestro-agent.deployment.yaml
@@ -16,6 +16,7 @@ spec:
       annotations:
         checksum/credsstore: {{ include (print $.Template.BasePath "/maestro.secretproviderclass.yaml") . | sha256sum }}
         checksum/config: {{ include (print $.Template.BasePath "/maestro.secret.yaml") . | sha256sum }}
+        checksum/envoyconfig: {{ include (print $.Template.BasePath "/metrics-sidecar.configmap.yaml") . | sha256sum }}
     spec:
       containers:
       - command:
@@ -34,6 +35,13 @@ spec:
         - mountPath: /secrets/mqtt-creds
           name: mqtt-creds
           readOnly: true
+      - name: metrics-proxy
+        image: "{{ .Values.metricsProxy.image.base }}:{{ .Values.metricsProxy.image.tag }}"
+        args:
+        - --config-path /etc/envoy/envoy.yaml
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
       serviceAccountName: maestro
       volumes:
       - name: maestro
@@ -45,3 +53,6 @@ spec:
           volumeAttributes:
             secretProviderClass: maestro
         name: mqtt-creds
+      - name: envoy-config
+        configMap:
+          name: envoy-config

--- a/maestro/agent/helm/templates/maestro-agent.deployment.yaml
+++ b/maestro/agent/helm/templates/maestro-agent.deployment.yaml
@@ -37,6 +37,10 @@ spec:
           readOnly: true
       - name: metrics-proxy
         image: "{{ .Values.metricsProxy.image.base }}:{{ .Values.metricsProxy.image.tag }}"
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         args:
         - --config-path /etc/envoy/envoy.yaml
         volumeMounts:

--- a/maestro/agent/helm/templates/maestro-agent.podmonitor.yaml
+++ b/maestro/agent/helm/templates/maestro-agent.podmonitor.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: maestro-agent-metrics
+  namespace: maestro
+spec:
+  selector:
+    matchLabels:
+      app: maestro-agent
+  namespaceSelector:
+    matchNames:
+      - maestro
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics
+      scheme: http

--- a/maestro/agent/helm/templates/metrics-sidecar.configmap.yaml
+++ b/maestro/agent/helm/templates/metrics-sidecar.configmap.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-config
+  namespace: {{ .Release.Namespace }}
+data:
+  envoy.yaml: |
+    static_resources:
+      listeners:
+        - name: listener_0
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: {{ .Values.metricsProxy.port }}
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: ingress_http
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                        - name: local_service
+                          domains: ["*"]
+                          routes:
+                            - match:
+                                prefix: "/metrics"
+                              route:
+                                cluster: local_service
+                    http_filters:
+                      - name: envoy.filters.http.credential_injector
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.credential_injector.v3.CredentialInjector
+                          allow_request_without_credential: false
+                          overwrite: true
+                          credential:
+                            name: envoy.http.injected_credentials.generic
+                            typed_config:
+                              "@type": type.googleapis.com/envoy.extensions.http.injected_credentials.generic.v3.Generic
+                              credential:
+                                name: credential-bearer
+                              header: "Authorization"
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                          upstream_http_filters:
+                          - name: upstream_header
+                            typed_config:
+                              '@type': type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+                              mutations:
+                                request_mutations:
+                                  append:
+                                    append_action: OVERWRITE_IF_EXISTS
+                                    header:
+                                      key: "Authorization"
+                                      value: "Bearer %REQ(Authorization)%"
+                          - name: envoy.filters.http.upstream_codec
+                            typed_config:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
+
+
+      secrets:
+      - name: credential-bearer
+        generic_secret:
+          secret:
+            filename: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+      clusters:
+        - name: local_service
+          connect_timeout: 0.25s
+          type: LOGICAL_DNS
+          lb_policy: ROUND_ROBIN
+          load_assignment:
+            cluster_name: local_service
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: localhost
+                          port_value: 8443
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext

--- a/maestro/agent/helm/values.yaml
+++ b/maestro/agent/helm/values.yaml
@@ -7,6 +7,11 @@ azure:
 image:
   base: ""
   tag: ""
+metricsProxy:
+  image:
+    base: envoyproxy/envoy
+    tag: v1.32.3
+  port: 8080
 credsKeyVault:
   name: ""
   secret: ""


### PR DESCRIPTION
### What this PR does

introduce an envoy sidecar to the maestro agent that uses the maestro service account token when forwarding requests to the agents `/metrics` endpoint. this way we can scrape maestro agent metrics without dealing with authn/z on azure prometheus side

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
