### PR TITLE
frontend: lint Prometheus metrics

### DIFF
--- a/frontend/pkg/frontend/node_pool_test.go
+++ b/frontend/pkg/frontend/node_pool_test.go
@@ -90,10 +90,11 @@ func TestCreateNodePool(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockDBClient := mocks.NewMockDBClient(ctrl)
+			reg := prometheus.NewRegistry()
 
 			f := &Frontend{
 				dbClient:             mockDBClient,
-				metrics:              NewPrometheusEmitter(prometheus.NewRegistry()),
+				metrics:              NewPrometheusEmitter(reg),
 				clusterServiceClient: &mockCSClient,
 			}
 			hcpCluster := api.NewDefaultHCPOpenShiftCluster()
@@ -166,6 +167,8 @@ func TestCreateNodePool(t *testing.T) {
 			if rs.StatusCode != test.expectedStatusCode {
 				t.Errorf("expected status code %d, got %d", test.expectedStatusCode, rs.StatusCode)
 			}
+
+			lintMetrics(t, reg)
 		})
 	}
 }


### PR DESCRIPTION
### What this PR does

This change renames the `frontend_count` metric to `frontend_requests_total` to comply with the Prometheus guidelines.

It also bounds the cardinality of the `route` label by using the matched pattern instead of the actual path.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

Before this PR

````
# TYPE frontend_count counter
frontend_count{api_version="",code="200",route="/healthz",state="Unknown",verb="GET"} 2
frontend_count{api_version="",code="404",route="/notfound",state="Unknown",verb="GET"} 1
frontend_count{api_version="",code="404",route="/notfound2",state="Unknown",verb="GET"} 1
frontend_count{api_version="",code="404",route="/notfound3",state="Unknown",verb="GET"} 1
frontend_count{api_version="2.0",code="201",route="/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b",state="Registered",verb="PUT"} 1
frontend_count{api_version="2024-06-10-preview",code="200",route="/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourcegroups/simon-net-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters",state="Registered",verb="GET"} 2
frontend_count{api_version="2024-06-10-preview",code="404",route="/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourcegroups/simon-net-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/simon",state="Registered",verb="GET"} 2
# HELP frontend_duration 
# TYPE frontend_duration gauge
frontend_duration{api_version="",code="200",route="/healthz",verb="GET"} 0
frontend_duration{api_version="",code="404",route="/notfound",verb="GET"} 0
frontend_duration{api_version="",code="404",route="/notfound2",verb="GET"} 0
frontend_duration{api_version="",code="404",route="/notfound3",verb="GET"} 0
frontend_duration{api_version="2.0",code="201",route="/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b",verb="PUT"} 1
frontend_duration{api_version="2024-06-10-preview",code="200",route="/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourcegroups/simon-net-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters",verb="GET"} 431
frontend_duration{api_version="2024-06-10-preview",code="404",route="/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourcegroups/simon-net-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/simon",verb="GET"} 0
# HELP frontend_health 
# TYPE frontend_health gauge
frontend_health{endpoint="/healthz"} 1
````

After this PR (note how all the 404 paths are folded into the `/` route):

````
# HELP frontend_duration 
# TYPE frontend_duration gauge
frontend_duration{api_version="",code="200",route="/healthz",verb="GET"} 5.8412e-05
frontend_duration{api_version="",code="404",route="/",verb="GET"} 2.7196e-05
frontend_duration{api_version="2.0",code="201",route="/subscriptions/{subscriptionid}",verb="PUT"} 0.000267956
frontend_duration{api_version="2024-06-10-preview",code="200",route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters",verb="GET"} 0.829475008
frontend_duration{api_version="2024-06-10-preview",code="400",route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}",verb="GET"} 0.000129962
frontend_duration{api_version="2024-06-10-preview",code="404",route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}",verb="GET"} 0.000103378
# HELP frontend_health 
# TYPE frontend_health gauge
frontend_health{endpoint="/healthz"} 1
# HELP frontend_requests_total 
# TYPE frontend_requests_total counter
frontend_requests_total{api_version="",code="200",route="/healthz",state="Unknown",verb="GET"} 1
frontend_requests_total{api_version="",code="404",route="/",state="Unknown",verb="GET"} 1
frontend_requests_total{api_version="2.0",code="201",route="/subscriptions/{subscriptionid}",state="Registered",verb="PUT"} 1
frontend_requests_total{api_version="2024-06-10-preview",code="200",route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters",state="Registered",verb="GET"} 1
frontend_requests_total{api_version="2024-06-10-preview",code="400",route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}",state="Unknown",verb="GET"} 1
frontend_requests_total{api_version="2024-06-10-preview",code="404",route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}",state="Registered",verb="GET"} 2
...
````

### Special notes for your reviewer

<!-- optional -->
