### PR TITLE
local_CS_script_fix to properly create provision shard config file in CS directory

### DIFF
--- a/dev-infrastructure/local_CS.sh
+++ b/dev-infrastructure/local_CS.sh
@@ -17,7 +17,7 @@ cp ./configs/development.yml .
 yq -i '(.aws-access-key-id, .aws-secret-access-key, .route53-access-key-id, .route53-secret-access-key, .oidc-access-key-id, .oidc-secret-access-key, .network-verifier-access-key-id, .network-verifier-secret-access-key, .client-id, .client-secret) = "none"' development.yml
 
 # Generate a provision_shards.config for port-forwarded maestro ...
-make -C ../ARO-HCP/cluster-service provision-shard > provision_shards.config
+make -C ../ARO-HCP/cluster-service local-deploy-provision-shard > provision_shards.config
 
 # Enable the westus3 region in cloud region config
 
@@ -28,7 +28,7 @@ cat <<EOF>> ./configs/cloud-resources/cloud-regions.yaml
     supports_multi_az: true
 EOF
 
-cat <<EOF>> ./configs/cloud-resources/cloud-regions-constraints.yaml
+cat <<EOF>> ./configs/cloud-resource-constraints/cloud-region-constraints.yaml
   - id: westus3
     enabled: true
     govcloud: false


### PR DESCRIPTION
### What this PR does
This PR makes changes so that it generates the provision shard config file in CS directory properly by pointing to the correct makefile target/command; when running CS locally.
Fixing the issue where the target/command "provision-shard" does not exist under /ARO-HCP/cluster-service/Makefile.

Changes ->
From: "provision-shard"
To: "local-deploy-provision-shard"

In addition, updating the cloud-region-constraints yaml file name to the correct name and to the correct directory:
From: "./configs/cloud-resources/cloud-regions-constraints.yaml"
To: "./configs/cloud-resource-constraints/cloud-region-constraints.yaml"
(conforming with check via 
"https://github.com/Azure/ARO-HCP/blob/main/dev-infrastructure/local_CS.sh#L39")



After the infrastructure was deployed with command:
"SKIP_CONFIRM=1 make infra.all deployall"
The above changes were required to successfully connect with the provision shard as well as setting the cloud_regions "westus3" to be enabled in the local instance/run of clusters service.

Jira: N/A
Link to demo recording: N/A

### Special notes for your reviewer
N/A