### PR TITLE
chore(maestro): bump maestro's image tag to c9a36e110a32c0c25aa5025cfe6d51af797e6d4b

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -139,7 +139,7 @@ clouds:
     # the following vars need approprivate overrides:
     defaults:
       maestro:
-        imageTag: bc2f131579c6ffc664c15f48c50a9936f1b4a7ce
+        imageTag: c9a36e110a32c0c25aa5025cfe6d51af797e6d4b
       clusterService:
         imageTag: ecd15ad
         imageRepo: app-sre/uhc-clusters-service

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -150,7 +150,7 @@ clouds:
       armHelperFPAPrincipalId: bc17c825-6cf8-40d0-8bd6-5536a993115e
       # Maestro
       maestro:
-        imageTag: eddc46d1f49ccc2d3298fed0d4b8ab25c159e357
+        imageTag: c9a36e110a32c0c25aa5025cfe6d51af797e6d4b
       # Cluster Service
       clusterService:
         imageTag: a51079c

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -107,7 +107,7 @@
       "private": false
     },
     "imageBase": "quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro",
-    "imageTag": "eddc46d1f49ccc2d3298fed0d4b8ab25c159e357",
+    "imageTag": "c9a36e110a32c0c25aa5025cfe6d51af797e6d4b",
     "postgres": {
       "deploy": true,
       "minTLSVersion": "TLSV1.2",

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -107,7 +107,7 @@
       "private": false
     },
     "imageBase": "quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro",
-    "imageTag": "eddc46d1f49ccc2d3298fed0d4b8ab25c159e357",
+    "imageTag": "c9a36e110a32c0c25aa5025cfe6d51af797e6d4b",
     "postgres": {
       "deploy": true,
       "minTLSVersion": "TLSV1.2",

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -107,7 +107,7 @@
       "private": false
     },
     "imageBase": "quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro",
-    "imageTag": "bc2f131579c6ffc664c15f48c50a9936f1b4a7ce",
+    "imageTag": "c9a36e110a32c0c25aa5025cfe6d51af797e6d4b",
     "postgres": {
       "deploy": false,
       "minTLSVersion": "TLSV1.2",

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -107,7 +107,7 @@
       "private": false
     },
     "imageBase": "quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro",
-    "imageTag": "eddc46d1f49ccc2d3298fed0d4b8ab25c159e357",
+    "imageTag": "c9a36e110a32c0c25aa5025cfe6d51af797e6d4b",
     "postgres": {
       "deploy": false,
       "minTLSVersion": "TLSV1.2",


### PR DESCRIPTION
### What this PR does

chore(maestro): bump maestro's image tag to c9a36e110a32c0c25aa5025cfe6d51af797e6d4b

This include the following notable changes;
- purge status events (https://github.com/openshift-online/maestro/pull/232)
- update sdk to support using two topics for kafka (https://github.com/openshift-online/maestro/pull/238)
- multiple instances support for grpc broker. (https://github.com/openshift-online/maestro/pull/235)
- Recreate listener if error is occured (https://github.com/openshift-online/maestro/pull/236)
- fix maestro resource status hash getter. (https://github.com/openshift-online/maestro/pull/245)

The last two contain fixes needed by ARO-HCP as well.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
