### PR TITLE
remove aks metrics enablement from GH action

### DIFF
--- a/.github/workflows/environment-infra-cd.yml
+++ b/.github/workflows/environment-infra-cd.yml
@@ -150,4 +150,4 @@
         - name: 'Deploy rest'
           run: |
             cd dev-infrastructure/
-            PRINCIPAL_ID=${{ secrets.GHA_PRINCIPAL_ID }} make mgmt.aks.admin-access mgmt.enable-aks-metrics
+            PRINCIPAL_ID=${{ secrets.GHA_PRINCIPAL_ID }} make mgmt.aks.admin-access


### PR DESCRIPTION
### What this PR does

as of https://github.com/Azure/ARO-HCP/pull/1078 AKS metrics enablement is not managed via bicep

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
