### PR TITLE
add missing IP whitelisting for public postgres DBs

### DIFF
--- a/dev-infrastructure/modules/postgres/postgres.bicep
+++ b/dev-infrastructure/modules/postgres/postgres.bicep
@@ -110,6 +110,15 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview'
   }
 }
 
+resource postgres_allow_public_access 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2023-12-01-preview' = if (!private) {
+  name: 'AllowPublicAccess'
+  parent: postgres
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '255.255.255.255'
+  }
+}
+
 resource postgres_allow_azure_firewall 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2023-12-01-preview' = {
   name: 'AllowAllAzureServicesAndResourcesWithinAzureIps'
   parent: postgres
@@ -117,6 +126,7 @@ resource postgres_allow_azure_firewall 'Microsoft.DBforPostgreSQL/flexibleServer
     startIpAddress: '0.0.0.0'
     endIpAddress: '0.0.0.0'
   }
+  dependsOn: [postgres_allow_public_access]
 }
 
 @batchSize(1)


### PR DESCRIPTION
### What this PR does

a public postgres DB still needs a firewall setting to allow traffic from IP ranges. these settings are added by this update.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
