### PR TITLE
feat: automate creation and deletion of clusters against ARO-HCP frontend using UAMIs

### DIFF
--- a/demo/03-create-cluster.sh
+++ b/demo/03-create-cluster.sh
@@ -1,21 +1,218 @@
 #!/bin/bash
 
+set -e
+
 source env_vars
 source "$(dirname "$0")"/common.sh
 
-CLUSTER_TMPL_FILE="cluster.tmpl.json"
-CLUSTER_FILE="cluster.json"
+initialize_control_plane_identities_uamis_names() {
+  for operator_name in "${CONTROL_PLANE_OPERATORS_NAMES[@]}"
+  do
+    CONTROL_PLANE_IDENTITIES_UAMIS_NAMES+=("${USER}-${CLUSTER_NAME}-cp-${operator_name}-${OPERATORS_UAMIS_SUFFIX}")
+  done
+}
 
-NSG_ID=$(az network nsg list -g ${CUSTOMER_RG_NAME} --query "[?name=='${CUSTOMER_NSG}'].id" -o tsv)
-SUBNET_ID=$(az network vnet subnet show -g ${CUSTOMER_RG_NAME} --vnet-name ${CUSTOMER_VNET_NAME} --name ${CUSTOMER_VNET_SUBNET1} --query id -o tsv)
-SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+initialize_data_plane_identities_uamis_names() {
+  for operator_name in "${DATA_PLANE_OPERATORS_NAMES[@]}"
+  do
+    DATA_PLANE_IDENTITIES_UAMIS_NAMES+=("${USER}-${CLUSTER_NAME}-dp-${operator_name}-${OPERATORS_UAMIS_SUFFIX}")
+  done
+}
 
-jq \
-  --arg managed_rg "$MANAGED_RESOURCE_GROUP" \
-  --arg subnet_id "$SUBNET_ID" \
-  --arg nsg_id "$NSG_ID" \
-  '.properties.spec.platform.managedResourceGroup = $managed_rg | .properties.spec.platform.subnetId = $subnet_id | .properties.spec.platform.networkSecurityGroupId = $nsg_id' "${CLUSTER_TMPL_FILE}" > ${CLUSTER_FILE}
+initialize_uamis_json_map() {
 
-(arm_system_data_header; correlation_headers) | curl -si -X PUT "localhost:8443/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CUSTOMER_RG_NAME}/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/${CLUSTER_NAME}?api-version=2024-06-10-preview" \
-  --header @- \
-  --json @${CLUSTER_FILE}
+UAMIS_JSON_MAP=$(cat << 'EOF'
+{
+  "controlPlaneOperators": {},
+  "dataPlaneOperators": {},
+  "serviceManagedIdentity": ""
+}
+EOF
+)
+
+service_managed_identity_uami_resource_id="${UAMIS_RESOURCE_IDS_PREFIX}/${service_managed_identity_uami_name}"
+UAMIS_JSON_MAP=$(echo -n "${UAMIS_JSON_MAP}" | jq \
+  --arg service_managed_identity_resource_id "$service_managed_identity_uami_resource_id" \
+  '
+    .serviceManagedIdentity = $service_managed_identity_resource_id
+  '
+)
+
+for i in "${!CONTROL_PLANE_IDENTITIES_UAMIS_NAMES[@]}"; do
+  curr_operator_name="${CONTROL_PLANE_OPERATORS_NAMES[$i]}"
+  curr_uami_name="${CONTROL_PLANE_IDENTITIES_UAMIS_NAMES[$i]}"
+  curr_uami_resource_id="${UAMIS_RESOURCE_IDS_PREFIX}/${curr_uami_name}"
+  UAMIS_JSON_MAP=$(echo -n "${UAMIS_JSON_MAP}" | jq \
+    --arg operator_name $curr_operator_name \
+    --arg uami_resource_id $curr_uami_resource_id \
+    '
+      .controlPlaneOperators[$operator_name] = $uami_resource_id
+    '
+  )
+done
+
+for i in "${!DATA_PLANE_IDENTITIES_UAMIS_NAMES[@]}"; do
+  curr_operator_name="${DATA_PLANE_OPERATORS_NAMES[$i]}"
+  curr_uami_name="${DATA_PLANE_IDENTITIES_UAMIS_NAMES[$i]}"
+  curr_uami_resource_id="${UAMIS_RESOURCE_IDS_PREFIX}/${curr_uami_name}"
+  UAMIS_JSON_MAP=$(echo -n ${UAMIS_JSON_MAP} | jq \
+    --arg operator_name $curr_operator_name \
+    --arg uami_resource_id $curr_uami_resource_id \
+    '
+      .dataPlaneOperators[$operator_name] = $uami_resource_id
+    '
+  )
+done
+
+}
+
+initialize_uamis_identity_json_map() {
+
+IDENTITY_UAMIS_JSON_MAP=$(cat << 'EOF'
+{
+}
+EOF
+)
+
+for i in "${!CONTROL_PLANE_IDENTITIES_UAMIS_NAMES[@]}"; do
+  curr_operator_name="${CONTROL_PLANE_OPERATORS_NAMES[$i]}"
+  curr_uami_name="${CONTROL_PLANE_IDENTITIES_UAMIS_NAMES[$i]}"
+  curr_uami_resource_id="${UAMIS_RESOURCE_IDS_PREFIX}/${curr_uami_name}"
+  IDENTITY_UAMIS_JSON_MAP=$(echo -n "${IDENTITY_UAMIS_JSON_MAP}" | jq \
+    --arg operator_name $curr_operator_name \
+    --arg uami_resource_id $curr_uami_resource_id \
+    '
+      .[$uami_resource_id] = {}
+    '
+  )
+done
+
+}
+
+create_azure_managed_identities_for_cluster() {
+  for uami_name in "${CONTROL_PLANE_IDENTITIES_UAMIS_NAMES[@]}"
+  do
+    echo "creating azure user-assigned identity ${uami_name} in resource group ${CUSTOMER_RG_NAME}"
+    az identity create -n "${uami_name}" -g "${CUSTOMER_RG_NAME}"
+    echo "user-assigned identity ${uami_name} created"
+  done
+
+  for uami_name in "${DATA_PLANE_IDENTITIES_UAMIS_NAMES[@]}"
+  do
+    echo "creating azure user-assigned identity ${uami_name} in resource group ${CUSTOMER_RG_NAME}"
+    az identity create -n "${uami_name}" -g "${CUSTOMER_RG_NAME}"
+    echo "user-assigned identity ${uami_name} created"
+  done
+
+  echo "creating azure user-assigned identity ${service_managed_identity_uami_name} in resource group ${CUSTOMER_RG_NAME}"
+  az identity create -n ${service_managed_identity_uami_name} -g ${CUSTOMER_RG_NAME}
+  echo "user-assigned identity ${uami_name} created"
+}
+
+arm_x_ms_identity_url_header() {
+  # Requests directly against the frontend
+  # need to send a X-Ms-Identity-Url HTTP
+  # header, which simulates what ARM performs.
+  # By default we set a dummy value, which is
+  # enough in the environments where a real
+  # Managed Identities Data Plane does not
+  # exist like in the development or integration
+  # environments. The default can be overwritten
+  # by providing the environment variable
+  # ARM_X_MS_IDENTITY_URL when running the script.
+  : ${ARM_X_MS_IDENTITY_URL:="https://dummyhost.identity.azure.net"}
+  echo "X-Ms-Identity-Url: ${ARM_X_MS_IDENTITY_URL}"
+}
+
+main() {
+  NSG_ID=$(az network nsg list -g ${CUSTOMER_RG_NAME} --query "[?name=='${CUSTOMER_NSG}'].id" -o tsv)
+  SUBNET_ID=$(az network vnet subnet show -g ${CUSTOMER_RG_NAME} --vnet-name ${CUSTOMER_VNET_NAME} --name ${CUSTOMER_VNET_SUBNET1} --query id -o tsv)
+  SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+
+  UAMIS_RESOURCE_IDS_PREFIX="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CUSTOMER_RG_NAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities"
+
+  # A suffix that will be appended to all the
+  # user-assigned managed identities names that
+  # will be created for the cluster.
+  # By default we generate a 6 characters random
+  # suffix for the azure user-assigned managed
+  # identites to be used by the cluster to be created.
+  # The default can be overwritten by providing the
+  # environment variable OPERATORS_UAMIS_SUFFIX
+  # when running the script.
+  : OPERATORS_UAMIS_SUFFIX=${OPERATORS_UAMIS_SUFFIX:=$(openssl rand -hex 3)}
+
+  # control plane operator names required for OCP 4.17.
+  # TODO in the future the information of the required
+  # identities for a given OCP version will be provided
+  # via API.
+  CONTROL_PLANE_OPERATORS_NAMES=(
+    "cloud-controller-manager"
+    "ingress"
+    "disk-csi-driver"
+    "file-csi-driver"
+    "image-registry"
+    "cloud-network-config"
+  )
+
+  # data plane operator names required for OCP 4.17.
+  # TODO in the future the information of the required
+  # identities for a given OCP version will be provided
+  # via API.
+  DATA_PLANE_OPERATORS_NAMES=(
+    "ingress"
+    "disk-csi-driver"
+    "file-csi-driver"
+    "image-registry"
+    "cloud-network-config"
+  )
+
+  # We declare and initialize the control plane
+  # user assigned identities names to the
+  # empty array.
+  CONTROL_PLANE_IDENTITIES_UAMIS_NAMES=()
+  initialize_control_plane_identities_uamis_names
+
+  # We declare and initialize the data plane
+  # user assigned identities names to the
+  # empty array.
+  DATA_PLANE_IDENTITIES_UAMIS_NAMES=()
+  initialize_data_plane_identities_uamis_names
+
+  # We define the service managed identity
+  # user assigned identity.
+  service_managed_identity_uami_name="${USER}-${CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}"
+
+  UAMIS_JSON_MAP=""
+  initialize_uamis_json_map
+  IDENTITY_UAMIS_JSON_MAP=""
+  initialize_uamis_identity_json_map
+
+  CURRENT_DATE=$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")
+
+  CLUSTER_TMPL_FILE="cluster.tmpl.json"
+  CLUSTER_FILE="cluster.json"
+
+  create_azure_managed_identities_for_cluster
+
+  jq \
+    --arg managed_rg "$MANAGED_RESOURCE_GROUP" \
+    --arg subnet_id "$SUBNET_ID" \
+    --arg nsg_id "$NSG_ID" \
+    --argjson uamis_json_map "$UAMIS_JSON_MAP" \
+    --argjson identity_uamis_json_map "$IDENTITY_UAMIS_JSON_MAP" \
+    '
+      .properties.spec.platform.managedResourceGroup = $managed_rg |
+      .properties.spec.platform.subnetId = $subnet_id |
+      .properties.spec.platform.networkSecurityGroupId = $nsg_id |
+      .properties.spec.platform.operatorsAuthentication.userAssignedIdentities = $uamis_json_map |
+      .identity.userAssignedIdentities = $identity_uamis_json_map
+    ' "${CLUSTER_TMPL_FILE}" > ${CLUSTER_FILE}
+
+  (arm_system_data_header; correlation_headers; arm_x_ms_identity_url_header) | curl -si -X PUT "localhost:8443/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CUSTOMER_RG_NAME}/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/${CLUSTER_NAME}?api-version=2024-06-10-preview" \
+    --header @- \
+    --json @${CLUSTER_FILE}
+}
+
+# Call to the `main` function in the script
+main "$@"

--- a/demo/05-delete-cluster.sh
+++ b/demo/05-delete-cluster.sh
@@ -1,8 +1,64 @@
 #!/bin/bash
 
+set -e
+
 source env_vars
 source "$(dirname "$0")"/common.sh
 
-SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+get_existing_cluster_payload() {
+  EXISTING_CLUSTER_PAYLOAD=$(curl -s "${FRONTEND_HOST}:${FRONTEND_PORT}${CLUSTER_RESOURCE_ID}?${FRONTEND_API_VERSION_QUERY_PARAM}")
+}
 
-correlation_headers | curl -si -H @- -X DELETE "localhost:8443/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CUSTOMER_RG_NAME}/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/${CLUSTER_NAME}?api-version=2024-06-10-preview"
+delete_managed_identities_from_cluster() {
+  UAMIS_JSON_MAP=$(echo ${EXISTING_CLUSTER_PAYLOAD} | jq '.properties.spec.platform.operatorsAuthentication.userAssignedIdentities')
+
+  CP_UAMIS_ENTRIES=$(echo ${UAMIS_JSON_MAP}| jq -c '.controlPlaneOperators | to_entries | .[]')
+  echo -n "${CP_UAMIS_ENTRIES}" | while read cp_uami_entry; do
+    cp_operator_name=$(echo -n "${cp_uami_entry}" | jq .key)
+    cp_operator_mi=$(echo -n "${cp_uami_entry}" | jq .value)
+    echo "deleting $cp_operator_name operator's managed identity $cp_operator_mi"
+    az identity delete --ids $cp_operator_mi
+    echo "deleted managed identity $cp_operator_mi"
+  done
+
+  DP_UAMIS_ENTRIES=$(echo ${UAMIS_JSON_MAP} | jq -c '.dataPlaneOperators | to_entries | .[]')
+  echo -n "${DP_UAMIS_ENTRIES}" | while read dp_uami_entry; do
+    dp_operator_name=$(echo -n "${dp_uami_entry}" | jq .key)
+    dp_operator_mi=$(echo -n "${dp_uami_entry}" | jq .value)
+    echo "deleting $dp_operator_name operator's managed identity $dp_operator_mi"
+    az identity delete --ids $dp_operator_mi
+    echo "deleted managed identity $dp_operator_mi"
+  done
+
+  SMI_UAMI_ENTRY=$(echo ${UAMIS_JSON_MAP} | jq .serviceManagedIdentity)
+  echo "deleting service managed identity ${SMI_UAMI_ENTRY}"
+  az identity delete --ids ${SMI_UAMI_ENTRY}
+  echo "deleted service managed identity ${SMI_UAMI_ENTRY}"
+}
+
+delete_cluster() {
+  echo "deleting cluster ${CLUSTER_RESOURCE_ID}"
+  correlation_headers | curl -si -H @- -X DELETE "${FRONTEND_HOST}:${FRONTEND_PORT}${CLUSTER_RESOURCE_ID}?${FRONTEND_API_VERSION_QUERY_PARAM}"
+  echo "deleted cluster ${CLUSTER_RESOURCE_ID}"
+}
+
+main() {
+  SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+
+  CLUSTER_RESOURCE_ID="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CUSTOMER_RG_NAME}/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/${CLUSTER_NAME}"
+  FRONTEND_API_VERSION_QUERY_PARAM="api-version=2024-06-10-preview"
+  FRONTEND_HOST="localhost"
+  FRONTEND_PORT="8443"
+
+  EXISTING_CLUSTER_PAYLOAD=""
+  get_existing_cluster_payload
+  if [ -z "${EXISTING_CLUSTER_PAYLOAD}" ]; then
+    echo "cluster with resource id ${CLUSTER_RESOURCE_ID} not found"
+    exit 0
+  fi
+
+  delete_cluster
+  delete_managed_identities_from_cluster
+}
+
+main "$@"

--- a/demo/05-delete-cluster.sh
+++ b/demo/05-delete-cluster.sh
@@ -15,7 +15,7 @@ delete_managed_identities_from_cluster() {
   CP_UAMIS_ENTRIES=$(echo ${UAMIS_JSON_MAP}| jq -c '.controlPlaneOperators | to_entries | .[]')
   echo -n "${CP_UAMIS_ENTRIES}" | while read cp_uami_entry; do
     cp_operator_name=$(echo -n "${cp_uami_entry}" | jq .key)
-    cp_operator_mi=$(echo -n "${cp_uami_entry}" | jq .value)
+    cp_operator_mi=$(echo -n "${cp_uami_entry}" | jq .value -r)
     echo "deleting $cp_operator_name operator's managed identity $cp_operator_mi"
     az identity delete --ids $cp_operator_mi
     echo "deleted managed identity $cp_operator_mi"
@@ -24,13 +24,13 @@ delete_managed_identities_from_cluster() {
   DP_UAMIS_ENTRIES=$(echo ${UAMIS_JSON_MAP} | jq -c '.dataPlaneOperators | to_entries | .[]')
   echo -n "${DP_UAMIS_ENTRIES}" | while read dp_uami_entry; do
     dp_operator_name=$(echo -n "${dp_uami_entry}" | jq .key)
-    dp_operator_mi=$(echo -n "${dp_uami_entry}" | jq .value)
+    dp_operator_mi=$(echo -n "${dp_uami_entry}" | jq .value -r)
     echo "deleting $dp_operator_name operator's managed identity $dp_operator_mi"
     az identity delete --ids $dp_operator_mi
     echo "deleted managed identity $dp_operator_mi"
   done
 
-  SMI_UAMI_ENTRY=$(echo ${UAMIS_JSON_MAP} | jq .serviceManagedIdentity)
+  SMI_UAMI_ENTRY=$(echo ${UAMIS_JSON_MAP} | jq .serviceManagedIdentity -r)
   echo "deleting service managed identity ${SMI_UAMI_ENTRY}"
   az identity delete --ids ${SMI_UAMI_ENTRY}
   echo "deleted service managed identity ${SMI_UAMI_ENTRY}"

--- a/demo/cluster.tmpl.json
+++ b/demo/cluster.tmpl.json
@@ -22,9 +22,22 @@
         "managedResourceGroup": "$managed-resource-group",
         "subnetId": "/subscriptions/$sub/resourceGroups/$customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet/subnets/customer-subnet-1",
         "outboundType": "loadBalancer",
-        "networkSecurityGroupId": "/subscriptions/$sub/resourceGroups/$customer-rg/providers/Microsoft.Network/networkSecurityGroups/customer-nsg"
+        "networkSecurityGroupId": "/subscriptions/$sub/resourceGroups/$customer-rg/providers/Microsoft.Network/networkSecurityGroups/customer-nsg",
+        "operatorsAuthentication": {
+          "userAssignedIdentities": {
+            "controlPlaneOperators": {"example_operator": "example_resource_id"},
+            "dataPlaneOperators": {"example_operator": "example_resource_id"},
+            "serviceManagedIdentity": "example_resource_id"
+          }
+        }
       },
       "externalAuth": {}
+    }
+  },
+  "identity": {
+    "type": "UserAssigned",
+    "userAssignedIdentities": {
+      "example_resource_id": {}
     }
   }
 }


### PR DESCRIPTION
### What this PR does

Recently introduced changes in the Frontend and in Clusters Service have introduced the requirement of precreating a set of Azure Managed Identities and passing references to them during cluster creation API requests in both the Frontend API and the Clusters Service API side.

This commit updates the scripts in the `demo` directory to automate the precreation of Azure Managed Identities for the cluster being created and also the automated generation of the ARO-HCP Frontend ARO-HCP Cluster creation payload to include the information about the precreated Azure Managed Identities. It also automates the cleanup of the precreated Managed Identities of the cluster when the cluster is deleted.

Although precreation the identities and passing them as part of the part of the ARO-HCP Cluster creation payload is now a requirement, the Managed Identities will not be leveraged. They are API side changes only. In the future we will enable the actual usage of Managed Identities once the corresponding functionality is finalized.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
