### PR TITLE
setup DEV KV permissions during infra provisioning

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -263,7 +263,10 @@ svc.kv.permission:
 	@scripts/kv-permissions.sh $(PRINCIPAL_ID) $(SVC_KV_RESOURCEGROUP) $(SVC_KV_NAME)
 .PHONY: svc.kv.permission
 
-svc.init: region metrics-infra svc svc.aks.admin-access svc.aks.kubeconfig svc.istio svc.oidc.storage.permissions
+svc.dev.permissions: svc.oidc.storage.permissions svc.kv.permission
+.PHONY: svc.dev.permissions
+
+svc.init: region metrics-infra svc svc.aks.admin-access svc.aks.kubeconfig svc.istio svc.dev.permissions
 .PHONY: svc.init
 
 svc.what-if: svc.rg
@@ -353,7 +356,7 @@ mgmt.aks.kubeconfigfile:
 	@echo ${MGMT_KUBECONFIG_FILE}
 .PHONY: mgmt.aks.kubeconfigfile
 
-mgmt.init: region metrics-infra mgmt mgmt.aks.admin-access mgmt.aks.kubeconfig 
+mgmt.init: region metrics-infra mgmt mgmt.aks.admin-access mgmt.aks.kubeconfig mgmt.dev.permissions
 .PHONY: mgmt.init
 
 mgmt.what-if: mgmt.rg
@@ -385,6 +388,9 @@ mgmt.kv.permission:
 	@scripts/kv-permissions.sh $(PRINCIPAL_ID) $(MGMT_RESOURCEGROUP) $(MSI_KV_NAME)
 	@scripts/kv-permissions.sh $(PRINCIPAL_ID) $(MGMT_RESOURCEGROUP) $(MGMT_KV_NAME)
 .PHONY: mgmt.kv.permission
+
+mgmt.dev.permissions: mgmt.kv.permission
+.PHONY: mgmt.dev.permissions
 
 # ACR
 
@@ -570,5 +576,5 @@ clean: svc.clean mgmt.clean region.clean
 # Local CS Development
 #
 
-local-cs-permissions: svc.oidc.storage.permissions svc.kv.permission mgmt.kv.permission
+local-cs-permissions: svc.dev.permissions mgmt.dev.permissions
 .PHONY: local-cs-permissions

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -251,12 +251,15 @@ svc.aks.kubeconfigfile:
 .PHONY: svc.aks.kubeconfigfile
 
 svc.oidc.storage.permissions:
-	@STORAGEACCOUNTID=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${SVC_RESOURCEGROUP} --query id -o tsv) && \
-	az role assignment create \
-	--role "Storage Blob Data Contributor" \
-	--assignee ${PRINCIPAL_ID} \
-	--scope "$${STORAGEACCOUNTID}" \
-	--only-show-errors
+	@USER_TYPE=$(shell az account show -o json | jq -r '.user.type') && \
+	if [ "$${USER_TYPE}" = "user" ]; then \
+		STORAGEACCOUNTID=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${SVC_RESOURCEGROUP} --query id -o tsv) && \
+		az role assignment create \
+		--role "Storage Blob Data Contributor" \
+		--assignee ${PRINCIPAL_ID} \
+		--scope "$${STORAGEACCOUNTID}" \
+		--only-show-errors; \
+	fi
 .PHONY: svc.oidc.storage.permissions
 
 svc.kv.permission:

--- a/dev-infrastructure/scripts/kv-permissions.sh
+++ b/dev-infrastructure/scripts/kv-permissions.sh
@@ -6,6 +6,10 @@ KV_NAME=$3
 
 KV_RESOURCE_ID=$(az keyvault show --name ${KV_NAME} --resource-group ${RG_NAME} --query id -o tsv 2>/dev/null)
 
+if [ "$(az account show -o json | jq -r '.user.type')" != "user" ]; then
+    # service principals can't assign themselves permissions
+    exit 0
+fi
 if [ -z "${KV_RESOURCE_ID}" ]; then
     echo "Error: Key Vault resource ID for ${KV_NAME} in ${RG_NAME} could not be retrieved."
     exit 0


### PR DESCRIPTION
### What this PR does

up until now, CS developers needed to manually run the `local-cs-permissions` make target if they wanted to have permissions to the shared OIDC storage, the SVC KV and the MC KVs.

with this patch, such permissions are set up automatically during personal dev environment creation

integrated DEV, CSPR and higher envs are unaffected by this change

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
