### PR TITLE
Ensure map exists

### DIFF
--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -124,8 +124,5 @@ func NewDefaultHCPOpenShiftCluster() *HCPOpenShiftCluster {
 				},
 			},
 		},
-		Identity: arm.Identity{
-			UserAssignedIdentities: make(map[string]*arm.UserAssignedIdentity),
-		},
 	}
 }

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -545,6 +545,9 @@ func normalizeExternalAuthConfig(p *generated.ExternalAuthConfigProfile, out *ap
 }
 
 func normalizeIdentityUserAssignedIdentities(p map[string]*generated.UserAssignedIdentity, out *map[string]*arm.UserAssignedIdentity) {
+	if *out == nil {
+		*out = make(map[string]*arm.UserAssignedIdentity)
+	}
 	for key, value := range p {
 		if value != nil {
 			(*out)[key] = &arm.UserAssignedIdentity{


### PR DESCRIPTION
Context: https://redhat-external.slack.com/archives/C075PHEFZKQ/p1736847149670269

This PR ensures a map is present which should solve the immediate issue.

Note for the future: 
For other maps we initialize on the fly (https://github.com/Azure/ARO-HCP/blob/9396f053c1c2319c05e63339f706156e94038690/internal/api/utils.go#L72). I have a weak preference, since we have a default initialization, to initialize all the maps there but I mainly want one or the other. What do people think?