### PR TITLE
fix DNS zone delegation for

### DIFF
--- a/dev-infrastructure/templates/region.bicep
+++ b/dev-infrastructure/templates/region.bicep
@@ -81,7 +81,7 @@ module regionalSvcZoneDelegation '../modules/dns/zone-delegation.bicep' = {
   params: {
     childZoneName: regionalDNSSubdomain
     childZoneNameservers: regionalSvcZone.properties.nameServers
-    parentZoneName: cxBaseDNSZoneName
+    parentZoneName: svcBaseDNSZoneName
   }
 }
 


### PR DESCRIPTION
### What this PR does

this PR fixes a bug where the regional svc zone delegation was overriding the regional CX zone delegation.

as a result, the regional CX zone was not part reachable anymore from a DNS delegation perspective.

this bug was introduced in https://github.com/Azure/ARO-HCP/pull/1077

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
