### PR TITLE
Set the default AZ version back to the latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   version:
     description: 'Azure CLI Version to install'
     required: false
-    default: "2.63.0" # pin to 2.63.0 because of https://github.com/Azure/azure-cli/issues/29828
+    default: "latest"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
The reason for pinning the version is resolved. See here for more details: https://github.com/Azure/ARO-HCP/pull/974

Note: When this is merged [this](https://github.com/Azure/ARO-HCP/pull/974) PR can be closed
