### PR TITLE
restructure AKS config schema in config.yaml

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -12,11 +12,9 @@ defaults:
     globalMSIName: "global-ev2-identity"
 
   # General AKS config
-  kubernetesVersion: 1.30.6
-  vnetAddressPrefix: "10.128.0.0/14"
-  subnetPrefix: "10.128.8.0/21"
-  podSubnetPrefix: "10.128.64.0/18"
   aksName: aro-hcp-aks
+
+  # ACR Pull
   acrPullImageDigest: sha256:1d18e828564dcd509a8551185808549bd8bfddec1fcc4a2783914dc2103bc2ca #v0.1.7
 
   # Hypershift
@@ -27,9 +25,14 @@ defaults:
   svc:
     subscription: hcp-{{ .ctx.region }}
     rg: hcp-underlay-{{ .ctx.region }}-svc
-    etcd:
-      kvName: arohcp-etcd-{{ .ctx.regionShort }}
-      kvSoftDelete: true
+    aks:
+      vnetAddressPrefix: "10.128.0.0/14"
+      subnetPrefix: "10.128.8.0/21"
+      podSubnetPrefix: "10.128.64.0/18"
+      kubernetesVersion: 1.30.6
+      etcd:
+        kvName: arohcp-etcd-{{ .ctx.regionShort }}
+        kvSoftDelete: true
     istio:
       istioctlVersion: "1.24.1"
       tag: "prod-stable"
@@ -41,9 +44,14 @@ defaults:
     clusterServiceResourceId: 'todo'
     subscription: hcp-{{ .ctx.region }}
     rg: hcp-underlay-{{ .ctx.region }}-mgmt-{{ .ctx.stamp }}
-    etcd:
-      kvName: arohcp-etcd-{{ .ctx.regionShort }}-{{ .ctx.stamp }}
-      kvSoftDelete: true
+    aks:
+      vnetAddressPrefix: "10.128.0.0/14"
+      subnetPrefix: "10.128.8.0/21"
+      podSubnetPrefix: "10.128.64.0/18"
+      kubernetesVersion: 1.30.6
+      etcd:
+        kvName: arohcp-etcd-{{ .ctx.regionShort }}-{{ .ctx.stamp }}
+        kvSoftDelete: true
 
   # Frontend
   frontend:
@@ -186,26 +194,33 @@ clouds:
           oidcStorageAccountName: arohcpoidcint{{ .ctx.regionShort }}
           # SVC
           svc:
-            userAgentPool:
-              minCount: 1
-              maxCount: 3
-              vmSize: 'Standard_D2s_v3'
-              osDiskSizeGB: 32
-              azCount: 3
+            aks:
+              systemAgentPool:
+                minCount: 1
+                maxCount: 3
+                vmSize: 'Standard_D2s_v3'
+                osDiskSizeGB: 32
+              userAgentPool:
+                minCount: 1
+                maxCount: 3
+                vmSize: 'Standard_D2s_v3'
+                osDiskSizeGB: 32
+                azCount: 3
           # MC
           mgmt:
-            # MGMTM AKS nodepools - big enough for 2 HCPs
-            systemAgentPool:
-              minCount: 1
-              maxCount: 4
-              vmSize: 'Standard_E8s_v3'
-              osDiskSizeGB: 128
-            userAgentPool:
-              minCount: 1
-              maxCount: 12
-              vmSize: 'Standard_D16s_v3'
-              osDiskSizeGB: 128
-              azCount: 3
+            aks:
+              # MGMTM AKS nodepools - big enough for 2 HCPs
+              systemAgentPool:
+                minCount: 1
+                maxCount: 4
+                vmSize: 'Standard_E8s_v3'
+                osDiskSizeGB: 128
+              userAgentPool:
+                minCount: 1
+                maxCount: 12
+                vmSize: 'Standard_D16s_v3'
+                osDiskSizeGB: 128
+                azCount: 3
 
           # DNS
           dns:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -14,6 +14,81 @@
         "required": [
           "roleName"
         ]
+      },
+      "aksAgentPool": {
+        "type": "object",
+        "properties": {
+          "maxCount": {
+            "type": "number"
+          },
+          "minCount": {
+            "type": "number"
+          },
+          "osDiskSizeGB": {
+            "type": "number"
+          },
+          "vmSize": {
+            "type": "string"
+          },
+          "azCount": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "maxCount",
+          "minCount",
+          "osDiskSizeGB",
+          "vmSize"
+        ]
+      },
+      "aksConfig": {
+        "type": "object",
+        "properties": {
+          "vnetAddressPrefix": {
+            "type": "string"
+          },
+          "subnetPrefix": {
+            "type": "string"
+          },
+          "podSubnetPrefix": {
+            "type": "string"
+          },
+          "kubernetesVersion": {
+            "type": "string"
+          },
+          "etcd": {
+            "type": "object",
+            "properties": {
+              "kvName": {
+                "type": "string"
+              },
+              "kvSoftDelete": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "kvName",
+              "kvSoftDelete"
+            ]
+          },
+          "userAgentPool": {
+            "$ref": "#/definitions/aksAgentPool"
+          },
+          "systemAgentPool": {
+            "$ref": "#/definitions/aksAgentPool"
+          }
+        },
+        "required": [
+          "vnetAddressPrefix",
+          "subnetPrefix",
+          "podSubnetPrefix",
+          "kubernetesVersion",
+          "etcd",
+          "userAgentPool",
+          "systemAgentPool"
+        ]
       }
     },
     "properties": {
@@ -403,9 +478,6 @@
           "rg"
         ]
       },
-      "kubernetesVersion": {
-        "type": "string"
-      },
       "acrPullImageDigest": {
         "type": "string"
       },
@@ -546,21 +618,8 @@
       "mgmt": {
         "type": "object",
         "properties": {
-          "etcd": {
-            "type": "object",
-            "properties": {
-              "kvName": {
-                "type": "string"
-              },
-              "kvSoftDelete": {
-                "type": "boolean"
-              }
-            },
-            "additionalProperties": false,
-            "required": [
-              "kvName",
-              "kvSoftDelete"
-            ]
+          "aks": {
+            "$ref": "#/definitions/aksConfig"
           },
           "rg": {
             "type": "string"
@@ -570,68 +629,14 @@
           },
           "clusterServiceResourceId": {
             "type": "string"
-          },
-          "systemAgentPool": {
-            "type": "object",
-            "properties": {
-              "maxCount": {
-                "type": "number"
-              },
-              "minCount": {
-                "type": "number"
-              },
-              "osDiskSizeGB": {
-                "type": "number"
-              },
-              "vmSize": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false,
-            "required": [
-              "maxCount",
-              "minCount",
-              "osDiskSizeGB",
-              "vmSize"
-            ]
-          },
-          "userAgentPool": {
-            "type": "object",
-            "properties": {
-              "azCount": {
-                "type": "number"
-              },
-              "maxCount": {
-                "type": "number"
-              },
-              "minCount": {
-                "type": "number"
-              },
-              "osDiskSizeGB": {
-                "type": "number"
-              },
-              "vmSize": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false,
-            "required": [
-              "azCount",
-              "maxCount",
-              "minCount",
-              "osDiskSizeGB",
-              "vmSize"
-            ]
           }
         },
         "additionalProperties": false,
         "required": [
+          "aks",
           "clusterServiceResourceId",
-          "etcd",
           "rg",
-          "systemAgentPool",
-          "subscription",
-          "userAgentPool"
+          "subscription"
         ]
       },
       "mgmtKeyVault": {
@@ -704,9 +709,6 @@
       "oidcStorageAccountName": {
         "type": "string"
       },
-      "podSubnetPrefix": {
-        "type": "string"
-      },
       "region": {
         "type": "string"
       },
@@ -741,55 +743,11 @@
           "softDelete"
         ]
       },
-      "subnetPrefix": {
-        "type": "string"
-      },
       "svc": {
         "type": "object",
         "properties": {
-          "etcd": {
-            "type": "object",
-            "properties": {
-              "kvName": {
-                "type": "string"
-              },
-              "kvSoftDelete": {
-                "type": "boolean"
-              }
-            },
-            "additionalProperties": false,
-            "required": [
-              "kvName",
-              "kvSoftDelete"
-            ]
-          },
-          "userAgentPool": {
-            "type": "object",
-            "properties": {
-              "azCount": {
-                "type": "number"
-              },
-              "maxCount": {
-                "type": "number"
-              },
-              "minCount": {
-                "type": "number"
-              },
-              "osDiskSizeGB": {
-                "type": "number"
-              },
-              "vmSize": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false,
-            "required": [
-              "azCount",
-              "maxCount",
-              "minCount",
-              "osDiskSizeGB",
-              "vmSize"
-            ]
+          "aks": {
+            "$ref": "#/definitions/aksConfig"
           },
           "rg": {
             "type": "string"
@@ -823,16 +781,13 @@
         },
         "additionalProperties": false,
         "required": [
-          "etcd",
           "rg",
           "subscription",
-          "userAgentPool"
+          "aks",
+          "istio"
         ]
       },
       "svcAcrName": {
-        "type": "string"
-      },
-      "vnetAddressPrefix": {
         "type": "string"
       }
     },
@@ -848,7 +803,6 @@
       "hypershift",
       "hypershiftOperator",
       "imageSync",
-      "kubernetesVersion",
       "acrPullImageDigest",
       "maestro",
       "mgmt",
@@ -857,13 +811,10 @@
       "msiKeyVault",
       "ocpAcrName",
       "oidcStorageAccountName",
-      "podSubnetPrefix",
       "region",
       "regionRG",
       "serviceKeyVault",
-      "subnetPrefix",
       "svc",
-      "svcAcrName",
-      "vnetAddressPrefix"
+      "svcAcrName"
     ]
   }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,11 +10,9 @@ defaults:
     globalMSIName: "global-rollout-identity"
 
   # General AKS config
-  kubernetesVersion: 1.31.2
-  vnetAddressPrefix: "10.128.0.0/14"
-  subnetPrefix: "10.128.8.0/21"
-  podSubnetPrefix: "10.128.64.0/18"
   aksName: aro-hcp-aks
+
+  # ACR Pull
   acrPullImageDigest: sha256:1d18e828564dcd509a8551185808549bd8bfddec1fcc4a2783914dc2103bc2ca #v0.1.7
 
   # Hypershift
@@ -25,23 +23,33 @@ defaults:
   svc:
     subscription: ARO Hosted Control Planes (EA Subscription 1)
     rg: hcp-underlay-{{ .ctx.regionShort }}-svc
-    etcd:
-      kvName: arohcp-etcd-{{ .ctx.regionShort }}
-      kvSoftDelete: true
     istio:
       istioctlVersion: "1.23.1"
       tag: "prod-stable"
       targetVersion: "asm-1-23"
       versions: "asm-1-23"
+    aks:
+      vnetAddressPrefix: "10.128.0.0/14"
+      subnetPrefix: "10.128.8.0/21"
+      podSubnetPrefix: "10.128.64.0/18"
+      kubernetesVersion: 1.31.2
+      etcd:
+        kvName: arohcp-etcd-{{ .ctx.regionShort }}
+        kvSoftDelete: true
 
   # MGMT cluster specifics
   mgmt:
     clusterServiceResourceId: /subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourcegroups/hcp-underlay-{{ .ctx.regionShort }}-svc/providers/Microsoft.ManagedIdentity/userAssignedIdentities/clusters-service
     subscription: ARO Hosted Control Planes (EA Subscription 1)
     rg: hcp-underlay-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}
-    etcd:
-      kvName: arohcp-etcd-{{ .ctx.regionShort }}-{{ .ctx.stamp }}
-      kvSoftDelete: true
+    aks:
+      vnetAddressPrefix: "10.128.0.0/14"
+      subnetPrefix: "10.128.8.0/21"
+      podSubnetPrefix: "10.128.64.0/18"
+      kubernetesVersion: 1.31.2
+      etcd:
+        kvName: arohcp-etcd-{{ .ctx.regionShort }}-{{ .ctx.stamp }}
+        kvSoftDelete: true
 
   # Frontend
   frontend:
@@ -205,29 +213,37 @@ clouds:
       # disable soft delete on etcd KVs in DEV
       svc:
         subscription: ARO Hosted Control Planes (EA Subscription 1)
-        etcd:
-          kvSoftDelete: false
-        userAgentPool:
-          minCount: 1
-          maxCount: 3
-          vmSize: 'Standard_D2s_v3'
-          osDiskSizeGB: 32
-          azCount: 3
+        aks:
+          etcd:
+            kvSoftDelete: false
+          systemAgentPool:
+            minCount: 1
+            maxCount: 3
+            vmSize: 'Standard_D2s_v3'
+            osDiskSizeGB: 32
+          userAgentPool:
+            minCount: 1
+            maxCount: 3
+            vmSize: 'Standard_D2s_v3'
+            osDiskSizeGB: 32
+            azCount: 3
+
       mgmt:
-        # MGMTM AKS nodepools - big enough for 2 HCPs
-        systemAgentPool:
-          minCount: 1
-          maxCount: 4
-          vmSize: 'Standard_D2s_v3'
-          osDiskSizeGB: 32
-        userAgentPool:
-          minCount: 1
-          maxCount: 6
-          vmSize: 'Standard_D4s_v3'
-          osDiskSizeGB: 100
-          azCount: 3
-        etcd:
-          kvSoftDelete: false
+        aks:
+          # MGMTM AKS nodepools - big enough for 2 HCPs
+          systemAgentPool:
+            minCount: 1
+            maxCount: 4
+            vmSize: 'Standard_D2s_v3'
+            osDiskSizeGB: 32
+          userAgentPool:
+            minCount: 1
+            maxCount: 6
+            vmSize: 'Standard_D4s_v3'
+            osDiskSizeGB: 100
+            azCount: 3
+          etcd:
+            kvSoftDelete: false
         subscription: ARO Hosted Control Planes (EA Subscription 1)
       # Shared ACRs
       svcAcrName: arohcpsvcdev
@@ -249,11 +265,12 @@ clouds:
       dev:
         # this is the integrated DEV environment
         defaults:
-          # MGMTM AKS nodepools - big enough for multiple HCPs
           mgmt:
-            userAgentPool:
-              minCount: 2
-              maxCount: 12
+            aks:
+              # MGMTM AKS nodepools - big enough for multiple HCPs
+              userAgentPool:
+                minCount: 2
+                maxCount: 12
           # DNS
           dns:
             regionalSubdomain: '{{ .ctx.region }}'
@@ -269,16 +286,19 @@ clouds:
         # this is the cluster service PR check and full cycle test environment
         defaults:
           svc:
-            # MC AKS nodepools
-            # big enough for multiple CS instances during PR checks
-            userAgentPool:
-              minCount: 2
-              maxCount: 12
+            aks:
+              # MC AKS nodepools
+              # big enough for multiple CS instances during PR checks
+              userAgentPool:
+                minCount: 2
+                maxCount: 12
           mgmt:
-            # MC AKS nodepools - big enough for multiple HCPs
-            userAgentPool:
-              minCount: 2
-              maxCount: 12
+            aks:
+              # MC AKS nodepools
+              # big enough for multiple HCPs
+              userAgentPool:
+                minCount: 2
+                maxCount: 12
           # DNS
           dns:
             regionalSubdomain: '{{ .ctx.region }}-cs'

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -105,7 +105,6 @@
     },
     "rg": "hcp-underlay-westus3-imagesync-dev"
   },
-  "kubernetesVersion": "1.31.2",
   "maestro": {
     "certDomain": "selfsigned.maestro.keyvault.azure.com",
     "consumerName": "hcp-underlay-cspr-mgmt-1",
@@ -141,26 +140,32 @@
     }
   },
   "mgmt": {
+    "aks": {
+      "etcd": {
+        "kvName": "arohcp-etcd-cspr-1",
+        "kvSoftDelete": false
+      },
+      "kubernetesVersion": "1.31.2",
+      "podSubnetPrefix": "10.128.64.0/18",
+      "subnetPrefix": "10.128.8.0/21",
+      "systemAgentPool": {
+        "maxCount": 4,
+        "minCount": 1,
+        "osDiskSizeGB": 32,
+        "vmSize": "Standard_D2s_v3"
+      },
+      "userAgentPool": {
+        "azCount": 3,
+        "maxCount": 12,
+        "minCount": 2,
+        "osDiskSizeGB": 100,
+        "vmSize": "Standard_D4s_v3"
+      },
+      "vnetAddressPrefix": "10.128.0.0/14"
+    },
     "clusterServiceResourceId": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourcegroups/hcp-underlay-cspr-svc/providers/Microsoft.ManagedIdentity/userAssignedIdentities/clusters-service",
-    "etcd": {
-      "kvName": "arohcp-etcd-cspr-1",
-      "kvSoftDelete": false
-    },
     "rg": "hcp-underlay-cspr-mgmt-1",
-    "subscription": "ARO Hosted Control Planes (EA Subscription 1)",
-    "systemAgentPool": {
-      "maxCount": 4,
-      "minCount": 1,
-      "osDiskSizeGB": 32,
-      "vmSize": "Standard_D2s_v3"
-    },
-    "userAgentPool": {
-      "azCount": 3,
-      "maxCount": 12,
-      "minCount": 2,
-      "osDiskSizeGB": 100,
-      "vmSize": "Standard_D4s_v3"
-    }
+    "subscription": "ARO Hosted Control Planes (EA Subscription 1)"
   },
   "mgmtKeyVault": {
     "name": "arohcp-mgmt-cspr-1",
@@ -182,7 +187,6 @@
   },
   "ocpAcrName": "arohcpocpdev",
   "oidcStorageAccountName": "arohcpoidccspr",
-  "podSubnetPrefix": "10.128.64.0/18",
   "region": "westus3",
   "regionRG": "hcp-underlay-cspr",
   "serviceKeyVault": {
@@ -192,11 +196,29 @@
     "rg": "global",
     "softDelete": true
   },
-  "subnetPrefix": "10.128.8.0/21",
   "svc": {
-    "etcd": {
-      "kvName": "arohcp-etcd-cspr",
-      "kvSoftDelete": false
+    "aks": {
+      "etcd": {
+        "kvName": "arohcp-etcd-cspr",
+        "kvSoftDelete": false
+      },
+      "kubernetesVersion": "1.31.2",
+      "podSubnetPrefix": "10.128.64.0/18",
+      "subnetPrefix": "10.128.8.0/21",
+      "systemAgentPool": {
+        "maxCount": 3,
+        "minCount": 1,
+        "osDiskSizeGB": 32,
+        "vmSize": "Standard_D2s_v3"
+      },
+      "userAgentPool": {
+        "azCount": 3,
+        "maxCount": 12,
+        "minCount": 2,
+        "osDiskSizeGB": 32,
+        "vmSize": "Standard_D2s_v3"
+      },
+      "vnetAddressPrefix": "10.128.0.0/14"
     },
     "istio": {
       "istioctlVersion": "1.23.1",
@@ -205,15 +227,7 @@
       "versions": "asm-1-23"
     },
     "rg": "hcp-underlay-cspr-svc",
-    "subscription": "ARO Hosted Control Planes (EA Subscription 1)",
-    "userAgentPool": {
-      "azCount": 3,
-      "maxCount": 12,
-      "minCount": 2,
-      "osDiskSizeGB": 32,
-      "vmSize": "Standard_D2s_v3"
-    }
+    "subscription": "ARO Hosted Control Planes (EA Subscription 1)"
   },
-  "svcAcrName": "arohcpsvcdev",
-  "vnetAddressPrefix": "10.128.0.0/14"
+  "svcAcrName": "arohcpsvcdev"
 }

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -105,7 +105,6 @@
     },
     "rg": "hcp-underlay-westus3-imagesync-dev"
   },
-  "kubernetesVersion": "1.31.2",
   "maestro": {
     "certDomain": "selfsigned.maestro.keyvault.azure.com",
     "consumerName": "hcp-underlay-dev-mgmt-1",
@@ -141,26 +140,32 @@
     }
   },
   "mgmt": {
+    "aks": {
+      "etcd": {
+        "kvName": "arohcp-etcd-dev-1",
+        "kvSoftDelete": false
+      },
+      "kubernetesVersion": "1.31.2",
+      "podSubnetPrefix": "10.128.64.0/18",
+      "subnetPrefix": "10.128.8.0/21",
+      "systemAgentPool": {
+        "maxCount": 4,
+        "minCount": 1,
+        "osDiskSizeGB": 32,
+        "vmSize": "Standard_D2s_v3"
+      },
+      "userAgentPool": {
+        "azCount": 3,
+        "maxCount": 12,
+        "minCount": 2,
+        "osDiskSizeGB": 100,
+        "vmSize": "Standard_D4s_v3"
+      },
+      "vnetAddressPrefix": "10.128.0.0/14"
+    },
     "clusterServiceResourceId": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourcegroups/hcp-underlay-dev-svc/providers/Microsoft.ManagedIdentity/userAssignedIdentities/clusters-service",
-    "etcd": {
-      "kvName": "arohcp-etcd-dev-1",
-      "kvSoftDelete": false
-    },
     "rg": "hcp-underlay-dev-mgmt-1",
-    "subscription": "ARO Hosted Control Planes (EA Subscription 1)",
-    "systemAgentPool": {
-      "maxCount": 4,
-      "minCount": 1,
-      "osDiskSizeGB": 32,
-      "vmSize": "Standard_D2s_v3"
-    },
-    "userAgentPool": {
-      "azCount": 3,
-      "maxCount": 12,
-      "minCount": 2,
-      "osDiskSizeGB": 100,
-      "vmSize": "Standard_D4s_v3"
-    }
+    "subscription": "ARO Hosted Control Planes (EA Subscription 1)"
   },
   "mgmtKeyVault": {
     "name": "arohcp-mgmt-dev-1",
@@ -182,7 +187,6 @@
   },
   "ocpAcrName": "arohcpocpdev",
   "oidcStorageAccountName": "arohcpoidcdev",
-  "podSubnetPrefix": "10.128.64.0/18",
   "region": "westus3",
   "regionRG": "hcp-underlay-dev",
   "serviceKeyVault": {
@@ -192,11 +196,29 @@
     "rg": "global",
     "softDelete": true
   },
-  "subnetPrefix": "10.128.8.0/21",
   "svc": {
-    "etcd": {
-      "kvName": "arohcp-etcd-dev",
-      "kvSoftDelete": false
+    "aks": {
+      "etcd": {
+        "kvName": "arohcp-etcd-dev",
+        "kvSoftDelete": false
+      },
+      "kubernetesVersion": "1.31.2",
+      "podSubnetPrefix": "10.128.64.0/18",
+      "subnetPrefix": "10.128.8.0/21",
+      "systemAgentPool": {
+        "maxCount": 3,
+        "minCount": 1,
+        "osDiskSizeGB": 32,
+        "vmSize": "Standard_D2s_v3"
+      },
+      "userAgentPool": {
+        "azCount": 3,
+        "maxCount": 3,
+        "minCount": 1,
+        "osDiskSizeGB": 32,
+        "vmSize": "Standard_D2s_v3"
+      },
+      "vnetAddressPrefix": "10.128.0.0/14"
     },
     "istio": {
       "istioctlVersion": "1.23.1",
@@ -205,15 +227,7 @@
       "versions": "asm-1-23"
     },
     "rg": "hcp-underlay-dev-svc",
-    "subscription": "ARO Hosted Control Planes (EA Subscription 1)",
-    "userAgentPool": {
-      "azCount": 3,
-      "maxCount": 3,
-      "minCount": 1,
-      "osDiskSizeGB": 32,
-      "vmSize": "Standard_D2s_v3"
-    }
+    "subscription": "ARO Hosted Control Planes (EA Subscription 1)"
   },
-  "svcAcrName": "arohcpsvcdev",
-  "vnetAddressPrefix": "10.128.0.0/14"
+  "svcAcrName": "arohcpsvcdev"
 }

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -105,7 +105,6 @@
     },
     "rg": "hcp-underlay-imagesync"
   },
-  "kubernetesVersion": "1.30.6",
   "maestro": {
     "certDomain": "selfsigned.maestro.keyvault.azure.com",
     "consumerName": "hcp-underlay-int-mgmt-1",
@@ -136,26 +135,32 @@
     }
   },
   "mgmt": {
+    "aks": {
+      "etcd": {
+        "kvName": "arohcp-etcd-int-1",
+        "kvSoftDelete": true
+      },
+      "kubernetesVersion": "1.30.6",
+      "podSubnetPrefix": "10.128.64.0/18",
+      "subnetPrefix": "10.128.8.0/21",
+      "systemAgentPool": {
+        "maxCount": 4,
+        "minCount": 1,
+        "osDiskSizeGB": 128,
+        "vmSize": "Standard_E8s_v3"
+      },
+      "userAgentPool": {
+        "azCount": 3,
+        "maxCount": 12,
+        "minCount": 1,
+        "osDiskSizeGB": 128,
+        "vmSize": "Standard_D16s_v3"
+      },
+      "vnetAddressPrefix": "10.128.0.0/14"
+    },
     "clusterServiceResourceId": "todo",
-    "etcd": {
-      "kvName": "arohcp-etcd-int-1",
-      "kvSoftDelete": true
-    },
     "rg": "hcp-underlay-westus3-mgmt-1",
-    "subscription": "hcp-westus3",
-    "systemAgentPool": {
-      "maxCount": 4,
-      "minCount": 1,
-      "osDiskSizeGB": 128,
-      "vmSize": "Standard_E8s_v3"
-    },
-    "userAgentPool": {
-      "azCount": 3,
-      "maxCount": 12,
-      "minCount": 1,
-      "osDiskSizeGB": 128,
-      "vmSize": "Standard_D16s_v3"
-    }
+    "subscription": "hcp-westus3"
   },
   "mgmtKeyVault": {
     "name": "arohcp-mgmt-int-1",
@@ -177,7 +182,6 @@
   },
   "ocpAcrName": "arohcpocpint",
   "oidcStorageAccountName": "arohcpoidcintint",
-  "podSubnetPrefix": "10.128.64.0/18",
   "region": "westus3",
   "regionRG": "westus3-shared-resources",
   "serviceKeyVault": {
@@ -187,11 +191,29 @@
     "rg": "hcp-underlay-westus3-svc",
     "softDelete": false
   },
-  "subnetPrefix": "10.128.8.0/21",
   "svc": {
-    "etcd": {
-      "kvName": "arohcp-etcd-int",
-      "kvSoftDelete": true
+    "aks": {
+      "etcd": {
+        "kvName": "arohcp-etcd-int",
+        "kvSoftDelete": true
+      },
+      "kubernetesVersion": "1.30.6",
+      "podSubnetPrefix": "10.128.64.0/18",
+      "subnetPrefix": "10.128.8.0/21",
+      "systemAgentPool": {
+        "maxCount": 3,
+        "minCount": 1,
+        "osDiskSizeGB": 32,
+        "vmSize": "Standard_D2s_v3"
+      },
+      "userAgentPool": {
+        "azCount": 3,
+        "maxCount": 3,
+        "minCount": 1,
+        "osDiskSizeGB": 32,
+        "vmSize": "Standard_D2s_v3"
+      },
+      "vnetAddressPrefix": "10.128.0.0/14"
     },
     "istio": {
       "istioctlVersion": "1.24.1",
@@ -200,15 +222,7 @@
       "versions": "asm-1-22,asm-1-23"
     },
     "rg": "hcp-underlay-westus3-svc",
-    "subscription": "hcp-westus3",
-    "userAgentPool": {
-      "azCount": 3,
-      "maxCount": 3,
-      "minCount": 1,
-      "osDiskSizeGB": 32,
-      "vmSize": "Standard_D2s_v3"
-    }
+    "subscription": "hcp-westus3"
   },
-  "svcAcrName": "arohcpsvcint",
-  "vnetAddressPrefix": "10.128.0.0/14"
+  "svcAcrName": "arohcpsvcint"
 }

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -105,7 +105,6 @@
     },
     "rg": "hcp-underlay-westus3-imagesync-dev"
   },
-  "kubernetesVersion": "1.31.2",
   "maestro": {
     "certDomain": "selfsigned.maestro.keyvault.azure.com",
     "consumerName": "hcp-underlay-usw3tst-mgmt-1",
@@ -141,26 +140,32 @@
     }
   },
   "mgmt": {
+    "aks": {
+      "etcd": {
+        "kvName": "arohcp-etcd-usw3tst-1",
+        "kvSoftDelete": false
+      },
+      "kubernetesVersion": "1.31.2",
+      "podSubnetPrefix": "10.128.64.0/18",
+      "subnetPrefix": "10.128.8.0/21",
+      "systemAgentPool": {
+        "maxCount": 4,
+        "minCount": 1,
+        "osDiskSizeGB": 32,
+        "vmSize": "Standard_D2s_v3"
+      },
+      "userAgentPool": {
+        "azCount": 3,
+        "maxCount": 6,
+        "minCount": 1,
+        "osDiskSizeGB": 100,
+        "vmSize": "Standard_D4s_v3"
+      },
+      "vnetAddressPrefix": "10.128.0.0/14"
+    },
     "clusterServiceResourceId": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourcegroups/hcp-underlay-usw3tst-svc/providers/Microsoft.ManagedIdentity/userAssignedIdentities/clusters-service",
-    "etcd": {
-      "kvName": "arohcp-etcd-usw3tst-1",
-      "kvSoftDelete": false
-    },
     "rg": "hcp-underlay-usw3tst-mgmt-1",
-    "subscription": "ARO Hosted Control Planes (EA Subscription 1)",
-    "systemAgentPool": {
-      "maxCount": 4,
-      "minCount": 1,
-      "osDiskSizeGB": 32,
-      "vmSize": "Standard_D2s_v3"
-    },
-    "userAgentPool": {
-      "azCount": 3,
-      "maxCount": 6,
-      "minCount": 1,
-      "osDiskSizeGB": 100,
-      "vmSize": "Standard_D4s_v3"
-    }
+    "subscription": "ARO Hosted Control Planes (EA Subscription 1)"
   },
   "mgmtKeyVault": {
     "name": "arohcp-mgmt-usw3tst-1",
@@ -182,7 +187,6 @@
   },
   "ocpAcrName": "arohcpocpdev",
   "oidcStorageAccountName": "arohcpoidcusw3tst",
-  "podSubnetPrefix": "10.128.64.0/18",
   "region": "westus3",
   "regionRG": "hcp-underlay-usw3tst",
   "serviceKeyVault": {
@@ -192,11 +196,29 @@
     "rg": "global",
     "softDelete": true
   },
-  "subnetPrefix": "10.128.8.0/21",
   "svc": {
-    "etcd": {
-      "kvName": "arohcp-etcd-usw3tst",
-      "kvSoftDelete": false
+    "aks": {
+      "etcd": {
+        "kvName": "arohcp-etcd-usw3tst",
+        "kvSoftDelete": false
+      },
+      "kubernetesVersion": "1.31.2",
+      "podSubnetPrefix": "10.128.64.0/18",
+      "subnetPrefix": "10.128.8.0/21",
+      "systemAgentPool": {
+        "maxCount": 3,
+        "minCount": 1,
+        "osDiskSizeGB": 32,
+        "vmSize": "Standard_D2s_v3"
+      },
+      "userAgentPool": {
+        "azCount": 3,
+        "maxCount": 3,
+        "minCount": 1,
+        "osDiskSizeGB": 32,
+        "vmSize": "Standard_D2s_v3"
+      },
+      "vnetAddressPrefix": "10.128.0.0/14"
     },
     "istio": {
       "istioctlVersion": "1.23.1",
@@ -205,15 +227,7 @@
       "versions": "asm-1-23"
     },
     "rg": "hcp-underlay-usw3tst-svc",
-    "subscription": "ARO Hosted Control Planes (EA Subscription 1)",
-    "userAgentPool": {
-      "azCount": 3,
-      "maxCount": 3,
-      "minCount": 1,
-      "osDiskSizeGB": 32,
-      "vmSize": "Standard_D2s_v3"
-    }
+    "subscription": "ARO Hosted Control Planes (EA Subscription 1)"
   },
-  "svcAcrName": "arohcpsvcdev",
-  "vnetAddressPrefix": "10.128.0.0/14"
+  "svcAcrName": "arohcpsvcdev"
 }

--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -1,22 +1,22 @@
 using '../templates/mgmt-cluster.bicep'
 
 // AKS
-param kubernetesVersion = '{{ .kubernetesVersion}}'
-param vnetAddressPrefix = '{{ .vnetAddressPrefix }}'
-param subnetPrefix = '{{ .subnetPrefix }}'
-param podSubnetPrefix = '{{ .podSubnetPrefix }}'
+param kubernetesVersion = '{{ .mgmt.aks.kubernetesVersion }}'
+param vnetAddressPrefix = '{{ .mgmt.aks.vnetAddressPrefix }}'
+param subnetPrefix = '{{ .mgmt.aks.subnetPrefix }}'
+param podSubnetPrefix = '{{ .mgmt.aks.podSubnetPrefix }}'
 param aksClusterName = '{{ .aksName }}'
-param aksKeyVaultName = '{{ .mgmt.etcd.kvName }}'
-param aksEtcdKVEnableSoftDelete = {{ .mgmt.etcd.kvSoftDelete }}
-param systemAgentMinCount = {{ .mgmt.systemAgentPool.minCount}}
-param systemAgentMaxCount = {{ .mgmt.systemAgentPool.maxCount }}
-param systemAgentVMSize = '{{ .mgmt.systemAgentPool.vmSize }}'
-param aksSystemOsDiskSizeGB = {{ .mgmt.systemAgentPool.osDiskSizeGB }}
-param userAgentMinCount = {{ .mgmt.userAgentPool.minCount }}
-param userAgentMaxCount = {{ .mgmt.userAgentPool.maxCount }}
-param userAgentVMSize = '{{ .mgmt.userAgentPool.vmSize }}'
-param aksUserOsDiskSizeGB = {{ .mgmt.userAgentPool.osDiskSizeGB }}
-param userAgentPoolAZCount = {{ .mgmt.userAgentPool.azCount }}
+param aksKeyVaultName = '{{ .mgmt.aks.etcd.kvName }}'
+param aksEtcdKVEnableSoftDelete = {{ .mgmt.aks.etcd.kvSoftDelete }}
+param systemAgentMinCount = {{ .mgmt.aks.systemAgentPool.minCount}}
+param systemAgentMaxCount = {{ .mgmt.aks.systemAgentPool.maxCount }}
+param systemAgentVMSize = '{{ .mgmt.aks.systemAgentPool.vmSize }}'
+param aksSystemOsDiskSizeGB = {{ .mgmt.aks.systemAgentPool.osDiskSizeGB }}
+param userAgentMinCount = {{ .mgmt.aks.userAgentPool.minCount }}
+param userAgentMaxCount = {{ .mgmt.aks.userAgentPool.maxCount }}
+param userAgentVMSize = '{{ .mgmt.aks.userAgentPool.vmSize }}'
+param userAgentPoolAZCount = {{ .mgmt.aks.userAgentPool.azCount }}
+param aksUserOsDiskSizeGB = {{ .mgmt.aks.userAgentPool.osDiskSizeGB }}
 
 // Maestro
 param maestroConsumerName = '{{ .maestro.consumerName }}'

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -1,19 +1,24 @@
 using '../templates/svc-cluster.bicep'
 
-param kubernetesVersion = '{{ .kubernetesVersion }}'
 param istioVersions = '{{ .svc.istio.versions }}'
-param vnetAddressPrefix = '{{ .vnetAddressPrefix }}'
-param subnetPrefix = '{{ .subnetPrefix }}'
-param podSubnetPrefix = '{{ .podSubnetPrefix }}'
-param aksClusterName = '{{ .aksName }}'
-param aksKeyVaultName = '{{ .svc.etcd.kvName }}'
-param aksEtcdKVEnableSoftDelete = {{ .svc.etcd.kvSoftDelete }}
 
-param userAgentMinCount = {{ .svc.userAgentPool.minCount }}
-param userAgentMaxCount = {{ .svc.userAgentPool.maxCount }}
-param userAgentVMSize = '{{ .svc.userAgentPool.vmSize }}'
-param aksUserOsDiskSizeGB = {{ .svc.userAgentPool.osDiskSizeGB }}
-param userAgentPoolAZCount = {{ .svc.userAgentPool.azCount }}
+// AKS
+param kubernetesVersion = '{{ .svc.aks.kubernetesVersion }}'
+param vnetAddressPrefix = '{{ .svc.aks.vnetAddressPrefix }}'
+param subnetPrefix = '{{ .svc.aks.subnetPrefix }}'
+param podSubnetPrefix = '{{ .svc.aks.podSubnetPrefix }}'
+param aksClusterName = '{{ .aksName }}'
+param aksKeyVaultName = '{{ .svc.aks.etcd.kvName }}'
+param aksEtcdKVEnableSoftDelete = {{ .svc.aks.etcd.kvSoftDelete }}
+param systemAgentMinCount = {{ .svc.aks.systemAgentPool.minCount}}
+param systemAgentMaxCount = {{ .svc.aks.systemAgentPool.maxCount }}
+param systemAgentVMSize = '{{ .svc.aks.systemAgentPool.vmSize }}'
+param aksSystemOsDiskSizeGB = {{ .svc.aks.systemAgentPool.osDiskSizeGB }}
+param userAgentMinCount = {{ .svc.aks.userAgentPool.minCount }}
+param userAgentMaxCount = {{ .svc.aks.userAgentPool.maxCount }}
+param userAgentVMSize = '{{ .svc.aks.userAgentPool.vmSize }}'
+param userAgentPoolAZCount = {{ .svc.aks.userAgentPool.azCount }}
+param aksUserOsDiskSizeGB = {{ .svc.aks.userAgentPool.osDiskSizeGB }}
 
 param disableLocalAuth = {{ .frontend.cosmosDB.disableLocalAuth }}
 param deployFrontendCosmos = {{ .frontend.cosmosDB.deploy }}

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -7,23 +7,32 @@ param persist bool = false
 @description('AKS cluster name')
 param aksClusterName string
 
+@description('Minimum node count for system agent pool')
+param systemAgentMinCount int
+
+@description('Maximum node count for system agent pool')
+param systemAgentMaxCount int
+
+@description('VM instance type for the system nodes')
+param systemAgentVMSize string
+
 @description('Disk size for the AKS system nodes')
-param aksSystemOsDiskSizeGB int = 32
+param aksSystemOsDiskSizeGB int
 
 @description('Disk size for the AKS user nodes')
-param aksUserOsDiskSizeGB int = 32
+param aksUserOsDiskSizeGB int
 
 @description('Min replicas for the worker nodes')
-param userAgentMinCount int = 1
+param userAgentMinCount int
 
 @description('Max replicas for the worker nodes')
-param userAgentMaxCount int = 3
+param userAgentMaxCount int
 
 @description('VM instance type for the worker nodes')
-param userAgentVMSize string = 'Standard_D2s_v3'
+param userAgentVMSize string
 
-@description('Availability Zone count for worker nodes')
-param userAgentPoolAZCount int = 3
+@description('Number of availability zones to use for the AKS clusters user agent pool')
+param userAgentPoolAZCount int
 
 @description('Names of additional resource group contains ACRs the AKS cluster will get pull permissions on')
 param acrPullResourceGroups array = []
@@ -182,9 +191,12 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     systemOsDiskSizeGB: aksSystemOsDiskSizeGB
     userOsDiskSizeGB: aksUserOsDiskSizeGB
     userAgentMinCount: userAgentMinCount
-    userAgentPoolAZCount: userAgentPoolAZCount
     userAgentMaxCount: userAgentMaxCount
     userAgentVMSize: userAgentVMSize
+    userAgentPoolAZCount: userAgentPoolAZCount
+    systemAgentMinCount: systemAgentMinCount
+    systemAgentMaxCount: systemAgentMaxCount
+    systemAgentVMSize: systemAgentVMSize
     workloadIdentities: items({
       frontend_wi: {
         uamiName: 'frontend'


### PR DESCRIPTION
### What this PR does

introduce a reusable schema for AKS clusters and their nodepools and use it under `svc.aks` and `mgmt.aks`

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
