### PR TITLE
arm: Drop azcorearm.ResourceID wrapper

### DIFF
--- a/backend/operations_scanner_test.go
+++ b/backend/operations_scanner_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"go.uber.org/mock/gomock"
 
@@ -64,7 +65,7 @@ func TestDeleteOperationCompleted(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockDBClient := mocks.NewMockDBClient(ctrl)
 
-			resourceID, err := arm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/testCluster")
+			resourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/testCluster")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -89,7 +90,7 @@ func TestDeleteOperationCompleted(t *testing.T) {
 
 			mockDBClient.EXPECT().
 				DeleteResourceDoc(gomock.Any(), resourceID).
-				Do(func(ctx context.Context, resourceID *arm.ResourceID) {
+				Do(func(ctx context.Context, resourceID *azcorearm.ResourceID) {
 					resourceDocDeleted = tt.resourceDocPresent
 				})
 			mockDBClient.EXPECT().
@@ -212,7 +213,7 @@ func TestUpdateOperationStatus(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockDBClient := mocks.NewMockDBClient(ctrl)
 
-			resourceID, err := arm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/testCluster")
+			resourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/testCluster")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -252,7 +253,7 @@ func TestUpdateOperationStatus(t *testing.T) {
 				})
 			mockDBClient.EXPECT().
 				UpdateResourceDoc(gomock.Any(), resourceID, gomock.Any()).
-				DoAndReturn(func(ctx context.Context, resourceID *arm.ResourceID, callback func(*database.ResourceDocument) bool) (bool, error) {
+				DoAndReturn(func(ctx context.Context, resourceID *azcorearm.ResourceID, callback func(*database.ResourceDocument) bool) (bool, error) {
 					if resourceDoc != nil {
 						return callback(resourceDoc), nil
 					} else {

--- a/frontend/pkg/frontend/context.go
+++ b/frontend/pkg/frontend/context.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
 	"github.com/Azure/ARO-HCP/frontend/pkg/config"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -114,12 +116,12 @@ func DBClientFromContext(ctx context.Context) (database.DBClient, error) {
 	return dbClient, nil
 }
 
-func ContextWithResourceID(ctx context.Context, resourceID *arm.ResourceID) context.Context {
+func ContextWithResourceID(ctx context.Context, resourceID *azcorearm.ResourceID) context.Context {
 	return context.WithValue(ctx, contextKeyResourceID, resourceID)
 }
 
-func ResourceIDFromContext(ctx context.Context) (*arm.ResourceID, error) {
-	resourceID, ok := ctx.Value(contextKeyResourceID).(*arm.ResourceID)
+func ResourceIDFromContext(ctx context.Context) (*azcorearm.ResourceID, error) {
+	resourceID, ok := ctx.Value(contextKeyResourceID).(*azcorearm.ResourceID)
 	if !ok {
 		err := &ContextError{
 			got: resourceID,

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"golang.org/x/sync/errgroup"
 
@@ -197,7 +198,7 @@ func (f *Frontend) ArmResourceList(writer http.ResponseWriter, request *http.Req
 		prefixString += "/providers/" + api.ProviderNamespace
 		prefixString += "/" + api.ClusterResourceTypeName + "/" + resourceName
 	}
-	prefix, err := arm.ParseResourceID(prefixString)
+	prefix, err := azcorearm.ParseResourceID(prefixString)
 	if err != nil {
 		logger.Error(err.Error())
 		arm.WriteInternalServerError(writer)

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"go.uber.org/mock/gomock"
@@ -35,8 +36,8 @@ func getMockDBDoc[T any](t *T) (*T, error) {
 	}
 }
 
-func equalResourceID(expectResourceID *arm.ResourceID) gomock.Matcher {
-	return gomock.Cond(func(actualResourceID *arm.ResourceID) bool {
+func equalResourceID(expectResourceID *azcorearm.ResourceID) gomock.Matcher {
+	return gomock.Cond(func(actualResourceID *azcorearm.ResourceID) bool {
 		return strings.EqualFold(actualResourceID.String(), expectResourceID.String())
 	})
 }

--- a/frontend/pkg/frontend/helpers.go
+++ b/frontend/pkg/frontend/helpers.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
@@ -47,7 +48,7 @@ func (f *Frontend) CheckForProvisioningStateConflict(ctx context.Context, operat
 		}
 	}
 
-	parent := doc.ResourceId.GetParent()
+	parent := doc.ResourceId.Parent
 
 	// ResourceType casing is preserved for parents in the same namespace.
 	for parent.ResourceType.Namespace == doc.ResourceId.ResourceType.Namespace {
@@ -66,7 +67,7 @@ func (f *Frontend) CheckForProvisioningStateConflict(ctx context.Context, operat
 				strings.ToLower(string(operationRequest)))
 		}
 
-		parent = parent.GetParent()
+		parent = parent.Parent
 	}
 
 	return nil
@@ -75,7 +76,7 @@ func (f *Frontend) CheckForProvisioningStateConflict(ctx context.Context, operat
 func (f *Frontend) DeleteAllResources(ctx context.Context, subscriptionID string) *arm.CloudError {
 	logger := LoggerFromContext(ctx)
 
-	prefix, err := arm.ParseResourceID("/subscriptions/" + subscriptionID)
+	prefix, err := azcorearm.ParseResourceID("/subscriptions/" + subscriptionID)
 	if err != nil {
 		logger.Error(err.Error())
 		return arm.NewInternalServerError()
@@ -229,7 +230,7 @@ func (f *Frontend) DeleteResource(ctx context.Context, resourceDoc *database.Res
 	return operationDoc.ID, nil
 }
 
-func (f *Frontend) MarshalResource(ctx context.Context, resourceID *arm.ResourceID, versionedInterface api.Version) ([]byte, *arm.CloudError) {
+func (f *Frontend) MarshalResource(ctx context.Context, resourceID *azcorearm.ResourceID, versionedInterface api.Version) ([]byte, *arm.CloudError) {
 	var responseBody []byte
 
 	logger := LoggerFromContext(ctx)

--- a/frontend/pkg/frontend/helpers_test.go
+++ b/frontend/pkg/frontend/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"testing"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -143,7 +144,7 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 	for _, tt := range tests {
 		var name string
 
-		resourceID, err := arm.ParseResourceID(tt.resourceID)
+		resourceID, err := azcorearm.ParseResourceID(tt.resourceID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -162,7 +163,7 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 				doc := database.NewResourceDocument(resourceID)
 				doc.ProvisioningState = directState
 
-				parentResourceID := resourceID.GetParent()
+				parentResourceID := resourceID.Parent
 				parentDoc := database.NewResourceDocument(parentResourceID)
 				// Hold the provisioning state to something benign.
 				parentDoc.ProvisioningState = arm.ProvisioningStateSucceeded
@@ -201,7 +202,7 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 				// Hold the provisioning state to something benign.
 				doc.ProvisioningState = arm.ProvisioningStateSucceeded
 
-				parentResourceID := resourceID.GetParent()
+				parentResourceID := resourceID.Parent
 				if parentResourceID.ResourceType.Namespace == resourceID.ResourceType.Namespace {
 					parentDoc := database.NewResourceDocument(parentResourceID)
 					parentDoc.ProvisioningState = parentState

--- a/frontend/pkg/frontend/middleware_resourceid.go
+++ b/frontend/pkg/frontend/middleware_resourceid.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Azure/ARO-HCP/internal/api/arm"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 )
 
 // This middleware only applies to endpoints whose path form a valid Azure
@@ -24,7 +24,7 @@ func MiddlewareResourceID(w http.ResponseWriter, r *http.Request, next http.Hand
 		originalPath = r.URL.Path
 	}
 
-	resourceID, err := arm.ParseResourceID(originalPath)
+	resourceID, err := azcorearm.ParseResourceID(originalPath)
 	if err == nil {
 		ctx = ContextWithResourceID(ctx, resourceID)
 		r = r.WithContext(ctx)

--- a/frontend/pkg/frontend/middleware_resourceid_test.go
+++ b/frontend/pkg/frontend/middleware_resourceid_test.go
@@ -120,7 +120,7 @@ func TestMiddlewareResourceID(t *testing.T) {
 			resourceTypes := []string{}
 			for resourceID != nil {
 				resourceTypes = append(resourceTypes, resourceID.ResourceType.String())
-				resourceID = resourceID.GetParent()
+				resourceID = resourceID.Parent
 			}
 
 			if !reflect.DeepEqual(resourceTypes, tt.resourceTypes) {

--- a/frontend/pkg/frontend/middleware_validatestatic.go
+++ b/frontend/pkg/frontend/middleware_validatestatic.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/google/uuid"
 
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -24,7 +25,7 @@ func MiddlewareValidateStatic(w http.ResponseWriter, r *http.Request, next http.
 	// in response messages.
 	//TODO: Inspect the error instead of ignoring it
 	originalPath, _ := OriginalPathFromContext(r.Context())
-	resource, _ := arm.ParseResourceID(originalPath)
+	resource, _ := azcorearm.ParseResourceID(originalPath)
 
 	if resource != nil {
 		if resource.SubscriptionID != "" {

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -170,7 +170,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		}
 	} else {
 		logger.Info(fmt.Sprintf("creating resource %s", resourceID))
-		clusterDoc, err := f.dbClient.GetResourceDoc(ctx, resourceID.GetParent())
+		clusterDoc, err := f.dbClient.GetResourceDoc(ctx, resourceID.Parent)
 		if err != nil {
 			logger.Error(err.Error())
 			arm.WriteInternalServerError(writer)

--- a/frontend/pkg/frontend/node_pool_test.go
+++ b/frontend/pkg/frontend/node_pool_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/mock/gomock"
 
@@ -43,11 +44,11 @@ var dummyChannelGroup = "dummyChannelGroup"
 var dummyVersionID = "dummy"
 
 func TestCreateNodePool(t *testing.T) {
-	clusterResourceID, _ := arm.ParseResourceID(dummyClusterID)
+	clusterResourceID, _ := azcorearm.ParseResourceID(dummyClusterID)
 	clusterDoc := database.NewResourceDocument(clusterResourceID)
 	clusterDoc.InternalID, _ = ocm.NewInternalID(dummyClusterHREF)
 
-	nodePoolResourceID, _ := arm.ParseResourceID(dummyNodePoolID)
+	nodePoolResourceID, _ := azcorearm.ParseResourceID(dummyNodePoolID)
 	nodePoolDoc := database.NewResourceDocument(nodePoolResourceID)
 	nodePoolDoc.InternalID, _ = ocm.NewInternalID(dummyNodePoolHREF)
 

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"net/http"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/google/uuid"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	configv1 "github.com/openshift/api/config/v1"
-
-	"github.com/google/uuid"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -44,7 +44,7 @@ func convertVisibilityToListening(visibility api.Visibility) (listening cmv1.Lis
 }
 
 // ConvertCStoHCPOpenShiftCluster converts a CS Cluster object into HCPOpenShiftCluster object
-func ConvertCStoHCPOpenShiftCluster(resourceID *arm.ResourceID, cluster *cmv1.Cluster) *api.HCPOpenShiftCluster {
+func ConvertCStoHCPOpenShiftCluster(resourceID *azcorearm.ResourceID, cluster *cmv1.Cluster) *api.HCPOpenShiftCluster {
 	// A word about ProvisioningState:
 	// ProvisioningState is stored in Cosmos and is applied to the
 	// HCPOpenShiftCluster struct along with the ARM metadata that
@@ -162,7 +162,7 @@ func ensureManagedResourceGroupName(hcpCluster *api.HCPOpenShiftCluster) string 
 }
 
 // BuildCSCluster creates a CS Cluster object from an HCPOpenShiftCluster object
-func (f *Frontend) BuildCSCluster(resourceID *arm.ResourceID, requestHeader http.Header, hcpCluster *api.HCPOpenShiftCluster, updating bool) (*cmv1.Cluster, error) {
+func (f *Frontend) BuildCSCluster(resourceID *azcorearm.ResourceID, requestHeader http.Header, hcpCluster *api.HCPOpenShiftCluster, updating bool) (*cmv1.Cluster, error) {
 
 	// Ensure required headers are present.
 	if requestHeader.Get(arm.HeaderNameHomeTenantID) == "" {
@@ -283,7 +283,7 @@ func (f *Frontend) BuildCSCluster(resourceID *arm.ResourceID, requestHeader http
 }
 
 // ConvertCStoNodePool converts a CS Node Pool object into HCPOpenShiftClusterNodePool object
-func ConvertCStoNodePool(resourceID *arm.ResourceID, np *cmv1.NodePool) *api.HCPOpenShiftClusterNodePool {
+func ConvertCStoNodePool(resourceID *azcorearm.ResourceID, np *cmv1.NodePool) *api.HCPOpenShiftClusterNodePool {
 	nodePool := &api.HCPOpenShiftClusterNodePool{
 		TrackedResource: arm.TrackedResource{
 			Resource: arm.Resource{

--- a/frontend/pkg/frontend/operations.go
+++ b/frontend/pkg/frontend/operations.go
@@ -12,6 +12,8 @@ import (
 	"path"
 	"strings"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
@@ -91,7 +93,7 @@ func (f *Frontend) ExposeOperation(writer http.ResponseWriter, request *http.Req
 	_, err := f.dbClient.UpdateOperationDoc(ctx, operationID, func(updateDoc *database.OperationDocument) bool {
 		// There is no way to propagate a parse error here but it should
 		// never fail since we are building a trusted resource ID string.
-		operationID, err := arm.ParseResourceID(path.Join("/",
+		operationID, err := azcorearm.ParseResourceID(path.Join("/",
 			"subscriptions", updateDoc.ExternalID.SubscriptionID,
 			"providers", api.ProviderNamespace,
 			"locations", f.location,

--- a/internal/api/arm/error.go
+++ b/internal/api/arm/error.go
@@ -123,7 +123,7 @@ func WriteInternalServerError(w http.ResponseWriter) {
 }
 
 // NewResourceNotFoundError creates a CloudError for a nonexistent resource error
-func NewResourceNotFoundError(resourceID *ResourceID) *CloudError {
+func NewResourceNotFoundError(resourceID *azcorearm.ResourceID) *CloudError {
 	var code string
 	var message string
 
@@ -149,7 +149,7 @@ func NewResourceNotFoundError(resourceID *ResourceID) *CloudError {
 }
 
 // WriteResourceNotFoundError writes a nonexistent resource error to the given ResponseWriter
-func WriteResourceNotFoundError(w http.ResponseWriter, resourceID *ResourceID) {
+func WriteResourceNotFoundError(w http.ResponseWriter, resourceID *azcorearm.ResourceID) {
 	WriteCloudError(w, NewResourceNotFoundError(resourceID))
 }
 

--- a/internal/api/arm/operation.go
+++ b/internal/api/arm/operation.go
@@ -6,17 +6,19 @@ package arm
 import (
 	"encoding/json"
 	"time"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 )
 
 // Operation is an ARM-defined resource returned by operation status endpoints.
 type Operation struct {
-	ID              *ResourceID       `json:"id,omitempty"`
-	Name            string            `json:"name,omitempty"`
-	Status          ProvisioningState `json:"status"`
-	StartTime       *time.Time        `json:"startTime,omitempty"`
-	EndTime         *time.Time        `json:"endTime,omitempty"`
-	PercentComplete float64           `json:"percentComplete,omitempty"`
-	Properties      json.RawMessage   `json:"peroperties,omitempty"`
-	Error           *CloudErrorBody   `json:"error,omitempty"`
-	Operations      []Operation       `json:"operations,omitempty"`
+	ID              *azcorearm.ResourceID `json:"id,omitempty"`
+	Name            string                `json:"name,omitempty"`
+	Status          ProvisioningState     `json:"status"`
+	StartTime       *time.Time            `json:"startTime,omitempty"`
+	EndTime         *time.Time            `json:"endTime,omitempty"`
+	PercentComplete float64               `json:"percentComplete,omitempty"`
+	Properties      json.RawMessage       `json:"peroperties,omitempty"`
+	Error           *CloudErrorBody       `json:"error,omitempty"`
+	Operations      []Operation           `json:"operations,omitempty"`
 }

--- a/internal/api/arm/resource.go
+++ b/internal/api/arm/resource.go
@@ -6,48 +6,7 @@ package arm
 import (
 	"maps"
 	"time"
-
-	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 )
-
-// ResourceID is a wrappered ResourceID from azcore with text marshaling and unmarshaling methods.
-type ResourceID struct {
-	azcorearm.ResourceID
-}
-
-// ParseResourceID parses a string to an instance of ResourceID.
-func ParseResourceID(id string) (*ResourceID, error) {
-	newId, err := azcorearm.ParseResourceID(id)
-	if err != nil {
-		return nil, err
-	}
-	return &ResourceID{ResourceID: *newId}, nil
-}
-
-// GetParent returns the parent resource ID, if any. Handles the
-// type-casting necessary to access the parent as a wrapper type.
-func (id *ResourceID) GetParent() *ResourceID {
-	var parent *ResourceID
-	if id.Parent != nil {
-		parent = &ResourceID{ResourceID: *id.Parent}
-	}
-	return parent
-}
-
-// MarshalText returns a textual representation of the ResourceID.
-func (id *ResourceID) MarshalText() ([]byte, error) {
-	return []byte(id.String()), nil
-}
-
-// UnmarshalText decodes the textual representation of a ResourceID.
-func (id *ResourceID) UnmarshalText(text []byte) error {
-	newId, err := azcorearm.ParseResourceID(string(text))
-	if err != nil {
-		return err
-	}
-	id.ResourceID = *newId
-	return nil
-}
 
 // Resource represents a basic ARM resource
 type Resource struct {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -13,10 +13,9 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
-
-	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
 
 const (
@@ -66,13 +65,13 @@ type DBClient interface {
 
 	// GetResourceDoc retrieves a ResourceDocument from the database given its resourceID.
 	// ErrNotFound is returned if an associated ResourceDocument cannot be found.
-	GetResourceDoc(ctx context.Context, resourceID *arm.ResourceID) (*ResourceDocument, error)
+	GetResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) (*ResourceDocument, error)
 	CreateResourceDoc(ctx context.Context, doc *ResourceDocument) error
-	UpdateResourceDoc(ctx context.Context, resourceID *arm.ResourceID, callback func(*ResourceDocument) bool) (bool, error)
+	UpdateResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID, callback func(*ResourceDocument) bool) (bool, error)
 	// DeleteResourceDoc deletes a ResourceDocument from the database given the resourceID
 	// of a Microsoft.RedHatOpenShift/HcpOpenShiftClusters resource or NodePools child resource.
-	DeleteResourceDoc(ctx context.Context, resourceID *arm.ResourceID) error
-	ListResourceDocs(ctx context.Context, prefix *arm.ResourceID, maxItems int32, continuationToken *string) DBClientIterator
+	DeleteResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) error
+	ListResourceDocs(ctx context.Context, prefix *azcorearm.ResourceID, maxItems int32, continuationToken *string) DBClientIterator
 
 	GetOperationDoc(ctx context.Context, operationID string) (*OperationDocument, error)
 	CreateOperationDoc(ctx context.Context, doc *OperationDocument) error
@@ -136,7 +135,7 @@ func (d *CosmosDBClient) GetLockClient() *LockClient {
 }
 
 // GetResourceDoc retrieves a resource document from the "resources" DB using resource ID
-func (d *CosmosDBClient) GetResourceDoc(ctx context.Context, resourceID *arm.ResourceID) (*ResourceDocument, error) {
+func (d *CosmosDBClient) GetResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) (*ResourceDocument, error) {
 	// Make sure partition key is lowercase.
 	pk := azcosmos.NewPartitionKeyString(strings.ToLower(resourceID.SubscriptionID))
 
@@ -209,7 +208,7 @@ func (d *CosmosDBClient) CreateResourceDoc(ctx context.Context, doc *ResourceDoc
 // The callback function should return true if modifications were applied, signaling to proceed
 // with the document replacement. The boolean return value reflects this: returning true if the
 // document was sucessfully replaced, or false with or without an error to indicate no change.
-func (d *CosmosDBClient) UpdateResourceDoc(ctx context.Context, resourceID *arm.ResourceID, callback func(*ResourceDocument) bool) (bool, error) {
+func (d *CosmosDBClient) UpdateResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID, callback func(*ResourceDocument) bool) (bool, error) {
 	var err error
 
 	// Make sure partition key is lowercase.
@@ -252,7 +251,7 @@ func (d *CosmosDBClient) UpdateResourceDoc(ctx context.Context, resourceID *arm.
 }
 
 // DeleteResourceDoc removes a resource document from the "resources" DB using resource ID
-func (d *CosmosDBClient) DeleteResourceDoc(ctx context.Context, resourceID *arm.ResourceID) error {
+func (d *CosmosDBClient) DeleteResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) error {
 	// Make sure partition key is lowercase.
 	pk := azcosmos.NewPartitionKeyString(strings.ToLower(resourceID.SubscriptionID))
 
@@ -275,7 +274,7 @@ func (d *CosmosDBClient) DeleteResourceDoc(ctx context.Context, resourceID *arm.
 // maxItems can limit the number of items returned at once. A negative value will cause the
 // returned iterator to yield all matching items. A positive value will cause the returned
 // iterator to include a continuation token if additional items are available.
-func (d *CosmosDBClient) ListResourceDocs(ctx context.Context, prefix *arm.ResourceID, maxItems int32, continuationToken *string) DBClientIterator {
+func (d *CosmosDBClient) ListResourceDocs(ctx context.Context, prefix *azcorearm.ResourceID, maxItems int32, continuationToken *string) DBClientIterator {
 	// Make sure partition key is lowercase.
 	pk := azcosmos.NewPartitionKeyString(strings.ToLower(prefix.SubscriptionID))
 

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/google/uuid"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -38,7 +39,7 @@ type ResourceDocument struct {
 	BaseDocument
 
 	// FIXME: Change the JSON field name when we're ready to break backward-compat.
-	ResourceId        *arm.ResourceID       `json:"key,omitempty"`
+	ResourceId        *azcorearm.ResourceID `json:"key,omitempty"`
 	PartitionKey      string                `json:"partitionKey,omitempty"`
 	InternalID        ocm.InternalID        `json:"internalId,omitempty"`
 	ActiveOperationID string                `json:"activeOperationId,omitempty"`
@@ -47,7 +48,7 @@ type ResourceDocument struct {
 	Tags              map[string]string     `json:"tags,omitempty"`
 }
 
-func NewResourceDocument(resourceID *arm.ResourceID) *ResourceDocument {
+func NewResourceDocument(resourceID *azcorearm.ResourceID) *ResourceDocument {
 	return &ResourceDocument{
 		BaseDocument: newBaseDocument(),
 		ResourceId:   resourceID,
@@ -75,12 +76,12 @@ type OperationDocument struct {
 	// Request is the type of asynchronous operation requested
 	Request OperationRequest `json:"request,omitempty"`
 	// ExternalID is the Azure resource ID of the cluster or node pool
-	ExternalID *arm.ResourceID `json:"externalId,omitempty"`
+	ExternalID *azcorearm.ResourceID `json:"externalId,omitempty"`
 	// InternalID is the Cluster Service resource identifier in the form of a URL path
 	InternalID ocm.InternalID `json:"internalId,omitempty"`
 	// OperationID is the Azure resource ID of the operation status (may be nil if the
 	// operation was implicit, such as deleting a child resource along with the parent)
-	OperationID *arm.ResourceID `json:"operationId,omitempty"`
+	OperationID *azcorearm.ResourceID `json:"operationId,omitempty"`
 	// NotificationURI is provided by the Azure-AsyncNotificationUri header if the
 	// Async Operation Callbacks ARM feature is enabled
 	NotificationURI string `json:"notificationUri,omitempty"`
@@ -96,7 +97,7 @@ type OperationDocument struct {
 	Error *arm.CloudErrorBody `json:"error,omitempty"`
 }
 
-func NewOperationDocument(request OperationRequest, externalID *arm.ResourceID, internalID ocm.InternalID) *OperationDocument {
+func NewOperationDocument(request OperationRequest, externalID *azcorearm.ResourceID, internalID ocm.InternalID) *OperationDocument {
 	now := time.Now().UTC()
 
 	doc := &OperationDocument{

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -14,8 +14,8 @@ import (
 	iter "iter"
 	reflect "reflect"
 
-	arm "github.com/Azure/ARO-HCP/internal/api/arm"
 	database "github.com/Azure/ARO-HCP/internal/database"
+	arm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	gomock "go.uber.org/mock/gomock"
 )
 


### PR DESCRIPTION
### What this PR does

The `azcorearm.ResourceID` text marshalling feature I [submitted upstream](https://github.com/Azure/azure-sdk-for-go/pull/23381), and was the reason for the wrapper, got released in [azcore 1.17.0](https://github.com/Azure/azure-sdk-for-go/releases/tag/sdk/azcore/v1.17.0).

Jira: no Jira; code cleanup