### PR TITLE
frontend: suppress warnings when running tests

### DIFF
--- a/frontend/pkg/frontend/helpers_test.go
+++ b/frontend/pkg/frontend/helpers_test.go
@@ -151,7 +151,7 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 		for directState, directConflict := range tt.directConflicts {
 			name = fmt.Sprintf("%s (directState=%s)", tt.name, directState)
 			t.Run(name, func(t *testing.T) {
-				ctx := context.Background()
+				ctx := ContextWithLogger(context.Background(), testLogger)
 				ctrl := gomock.NewController(t)
 				mockDBClient := mocks.NewMockDBClient(ctrl)
 
@@ -189,7 +189,7 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 		for parentState, parentConflict := range tt.parentConflicts {
 			name = fmt.Sprintf("%s (parentState=%s)", tt.name, parentState)
 			t.Run(name, func(t *testing.T) {
-				ctx := context.Background()
+				ctx := ContextWithLogger(context.Background(), testLogger)
 				ctrl := gomock.NewController(t)
 				mockDBClient := mocks.NewMockDBClient(ctrl)
 


### PR DESCRIPTION
### What this PR does

This change adds a default logger to
`TestCheckForProvisioningStateConflict()` otherwise the test output gets cluttered with warnings with the `-v` option.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
