### PR TITLE
Struct tag validation enhancements for managed identity

### DIFF
--- a/internal/api/arm/identity.go
+++ b/internal/api/arm/identity.go
@@ -4,7 +4,7 @@ package arm
 // Licensed under the Apache License 2.0.
 
 // Represents to support the ManagedServiceIdentity ARM resource.
-type Identity struct {
+type ManagedServiceIdentity struct {
 	PrincipalID            string                           `json:"principalId,omitempty"`
 	TenantID               string                           `json:"tenantId,omitempty"`
 	Type                   ManagedServiceIdentityType       `json:"type"`

--- a/internal/api/arm/identity.go
+++ b/internal/api/arm/identity.go
@@ -5,16 +5,16 @@ package arm
 
 // Represents to support the ManagedServiceIdentity ARM resource.
 type ManagedServiceIdentity struct {
-	PrincipalID            string                           `json:"principalId,omitempty"`
-	TenantID               string                           `json:"tenantId,omitempty"`
-	Type                   ManagedServiceIdentityType       `json:"type"`
-	UserAssignedIdentities map[string]*UserAssignedIdentity `json:"userAssignedIdentities,omitempty"`
+	PrincipalID            string                           `json:"principalId,omitempty"            visibility:"read"`
+	TenantID               string                           `json:"tenantId,omitempty"               visibility:"read"`
+	Type                   ManagedServiceIdentityType       `json:"type"                                               validate:"omitempty,enum_managedserviceidentitytype"`
+	UserAssignedIdentities map[string]*UserAssignedIdentity `json:"userAssignedIdentities,omitempty"                   validate:"dive,keys,resource_id=Microsoft.ManagedIdentity/userAssignedIdentities,endkeys"`
 }
 
 // UserAssignedIdentity - User assigned identity properties https://azure.github.io/typespec-azure/docs/libraries/azure-resource-manager/reference/data-types/#Azure.ResourceManager.CommonTypes.UserAssignedIdentity
 type UserAssignedIdentity struct {
-	ClientID    *string
-	PrincipalID *string
+	ClientID    *string `json:"clientId,omitempty"    visibility:"read"`
+	PrincipalID *string `json:"principalId,omitempty" visibility:"read"`
 }
 
 type ManagedServiceIdentityType string

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -102,9 +102,9 @@ type OperatorsAuthenticationProfile struct {
 // UserAssignedIdentitiesProfile represents authentication configuration for
 // OpenShift operators using user-assigned managed identities.
 type UserAssignedIdentitiesProfile struct {
-	ControlPlaneOperators  map[string]string `json:"controlPlaneOperators,omitempty"`
-	DataPlaneOperators     map[string]string `json:"dataPlaneOperators,omitempty"`
-	ServiceManagedIdentity string            `json:"serviceManagedIdentity,omitempty"`
+	ControlPlaneOperators  map[string]string `json:"controlPlaneOperators,omitempty"  validate:"dive,resource_id=Microsoft.ManagedIdentity/userAssignedIdentities"`
+	DataPlaneOperators     map[string]string `json:"dataPlaneOperators,omitempty"     validate:"dive,resource_id=Microsoft.ManagedIdentity/userAssignedIdentities"`
+	ServiceManagedIdentity string            `json:"serviceManagedIdentity,omitempty" validate:"omitempty,resource_id=Microsoft.ManagedIdentity/userAssignedIdentities"`
 }
 
 // ExternalAuthConfigProfile represents the external authentication configuration.

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -13,7 +13,7 @@ import (
 type HCPOpenShiftCluster struct {
 	arm.TrackedResource
 	Properties HCPOpenShiftClusterProperties `json:"properties,omitempty" validate:"required_for_put"`
-	Identity   arm.Identity                  `json:"identity,omitempty"`
+	Identity   arm.ManagedServiceIdentity    `json:"identity,omitempty"`
 }
 
 // HCPOpenShiftClusterProperties represents the property bag of a HCPOpenShiftCluster resource.

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -116,6 +116,9 @@ type ExternalAuthConfigProfile struct {
 // Creates an HCPOpenShiftCluster with any non-zero default values.
 func NewDefaultHCPOpenShiftCluster() *HCPOpenShiftCluster {
 	return &HCPOpenShiftCluster{
+		Identity: arm.ManagedServiceIdentity{
+			Type: arm.ManagedServiceIdentityTypeNone,
+		},
 		Properties: HCPOpenShiftClusterProperties{
 			Spec: ClusterSpec{
 				Network: NetworkProfile{

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -312,6 +312,17 @@ func (c *HcpOpenShiftClusterResource) Normalize(out *api.HCPOpenShiftCluster) {
 	}
 }
 
+// validateStaticComplex performs more complex, multi-field validations than
+// are possible with struct tag validation. The returned CloudErrorBody slice
+// contains structured but user-friendly details for all discovered errors.
+func validateStaticComplex(normalized *api.HCPOpenShiftCluster, updating bool) []arm.CloudErrorBody {
+	var errorDetails []arm.CloudErrorBody
+
+	// FIXME Perform user-assigned managed identity validation checks.
+
+	return errorDetails
+}
+
 func (c *HcpOpenShiftClusterResource) ValidateStatic(current api.VersionedHCPOpenShiftCluster, updating bool, method string) *arm.CloudError {
 	var normalized api.HCPOpenShiftCluster
 	var errorDetails []arm.CloudErrorBody
@@ -337,6 +348,17 @@ func (c *HcpOpenShiftClusterResource) ValidateStatic(current api.VersionedHCPOpe
 	errorDetails = api.ValidateRequest(validate, method, &normalized)
 	if errorDetails != nil {
 		cloudError.Details = append(cloudError.Details, errorDetails...)
+	}
+
+	// Proceed with complex, multi-field validation only if single-field
+	// validation has passed. This avoids running further checks on data
+	// we already know to be invalid and prevents the response body from
+	// becoming overwhelming.
+	if len(cloudError.Details) == 0 {
+		errorDetails = validateStaticComplex(&normalized, updating)
+		if errorDetails != nil {
+			cloudError.Details = append(cloudError.Details, errorDetails...)
+		}
 	}
 
 	switch len(cloudError.Details) {

--- a/internal/api/validate.go
+++ b/internal/api/validate.go
@@ -35,6 +35,10 @@ func EnumValidateTag[S ~string](values ...S) string {
 	s := make([]string, len(values))
 	for i, e := range values {
 		s[i] = string(e)
+		// Replace special characters with the UTF-8 hex representation.
+		// https://pkg.go.dev/github.com/go-playground/validator/v10#hdr-Using_Validator_Tags
+		s[i] = strings.ReplaceAll(s[i], ",", "0x2C")
+		s[i] = strings.ReplaceAll(s[i], "|", "0x7C")
 	}
 	return fmt.Sprintf("oneof=%s", strings.Join(s, " "))
 }
@@ -51,6 +55,11 @@ func NewValidator() *validator.Validate {
 	})
 
 	// Register ARM-mandated enumeration types.
+	validate.RegisterAlias("enum_managedserviceidentitytype", EnumValidateTag(
+		arm.ManagedServiceIdentityTypeNone,
+		arm.ManagedServiceIdentityTypeSystemAssigned,
+		arm.ManagedServiceIdentityTypeSystemAssignedUserAssigned,
+		arm.ManagedServiceIdentityTypeUserAssigned))
 	validate.RegisterAlias("enum_subscriptionstate", EnumValidateTag(
 		arm.SubscriptionStateRegistered,
 		arm.SubscriptionStateUnregistered,

--- a/internal/api/visibility.go
+++ b/internal/api/visibility.go
@@ -99,7 +99,7 @@ type StructTagMap map[string]reflect.StructTag
 
 func buildStructTagMap(structTagMap StructTagMap, t reflect.Type, path string) {
 	switch t.Kind() {
-	case reflect.Pointer, reflect.Slice:
+	case reflect.Map, reflect.Pointer, reflect.Slice:
 		buildStructTagMap(structTagMap, t.Elem(), path)
 
 	case reflect.Struct:

--- a/internal/api/visibility_test.go
+++ b/internal/api/visibility_test.go
@@ -101,8 +101,11 @@ type TestModelType struct {
 	// Slice of struct type inherits visibility but can override.
 	D []*TestModelSubtype `visibility:"update nocase"`
 
+	// Map of struct type inherits visibility but can override.
+	E map[string]*TestModelSubtype `visibility:"update nocase"`
+
 	// For equality checks of various reflect types.
-	E any `visibility:"read"`
+	F any `visibility:"read"`
 }
 
 type TestModelSubtype struct {
@@ -135,7 +138,12 @@ func TestStructTagMap(t *testing.T) {
 		"D.ReadNoCase":       reflect.StructTag("visibility:\"read nocase\""),
 		"D.ReadCreate":       reflect.StructTag("visibility:\"read create\""),
 		"D.ReadCreateUpdate": reflect.StructTag("visibility:\"read create update\""),
-		"E":                  reflect.StructTag("visibility:\"read\""),
+		"E":                  reflect.StructTag("visibility:\"update nocase\""),
+		"E.Read":             reflect.StructTag("visibility:\"read\""),
+		"E.ReadNoCase":       reflect.StructTag("visibility:\"read nocase\""),
+		"E.ReadCreate":       reflect.StructTag("visibility:\"read create\""),
+		"E.ReadCreateUpdate": reflect.StructTag("visibility:\"read create update\""),
+		"F":                  reflect.StructTag("visibility:\"read\""),
 	}
 
 	// The test cases are encoded into the type itself.
@@ -437,10 +445,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for bool type fields",
 			v: TestModelType{
-				E: Ptr(bool(true)),
+				F: Ptr(bool(true)),
 			},
 			w: TestModelType{
-				E: Ptr(bool(true)),
+				F: Ptr(bool(true)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -449,10 +457,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for bool type fields",
 			v: TestModelType{
-				E: Ptr(bool(true)),
+				F: Ptr(bool(true)),
 			},
 			w: TestModelType{
-				E: Ptr(bool(false)),
+				F: Ptr(bool(false)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -461,10 +469,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for int type fields",
 			v: TestModelType{
-				E: Ptr(int(1)),
+				F: Ptr(int(1)),
 			},
 			w: TestModelType{
-				E: Ptr(int(1)),
+				F: Ptr(int(1)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -473,10 +481,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for int type fields",
 			v: TestModelType{
-				E: Ptr(int(1)),
+				F: Ptr(int(1)),
 			},
 			w: TestModelType{
-				E: Ptr(int(0)),
+				F: Ptr(int(0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -485,10 +493,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for int8 type fields",
 			v: TestModelType{
-				E: Ptr(int8(1)),
+				F: Ptr(int8(1)),
 			},
 			w: TestModelType{
-				E: Ptr(int8(1)),
+				F: Ptr(int8(1)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -497,10 +505,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for int8 type fields",
 			v: TestModelType{
-				E: Ptr(int8(1)),
+				F: Ptr(int8(1)),
 			},
 			w: TestModelType{
-				E: Ptr(int8(0)),
+				F: Ptr(int8(0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -509,10 +517,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for int16 type fields",
 			v: TestModelType{
-				E: Ptr(int16(1)),
+				F: Ptr(int16(1)),
 			},
 			w: TestModelType{
-				E: Ptr(int16(1)),
+				F: Ptr(int16(1)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -521,10 +529,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for int16 type fields",
 			v: TestModelType{
-				E: Ptr(int16(1)),
+				F: Ptr(int16(1)),
 			},
 			w: TestModelType{
-				E: Ptr(int16(0)),
+				F: Ptr(int16(0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -533,10 +541,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for int32 type fields",
 			v: TestModelType{
-				E: Ptr(int32(1)),
+				F: Ptr(int32(1)),
 			},
 			w: TestModelType{
-				E: Ptr(int32(1)),
+				F: Ptr(int32(1)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -545,10 +553,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for int32 type fields",
 			v: TestModelType{
-				E: Ptr(int32(1)),
+				F: Ptr(int32(1)),
 			},
 			w: TestModelType{
-				E: Ptr(int32(0)),
+				F: Ptr(int32(0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -557,10 +565,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for int64 type fields",
 			v: TestModelType{
-				E: Ptr(int64(1)),
+				F: Ptr(int64(1)),
 			},
 			w: TestModelType{
-				E: Ptr(int64(1)),
+				F: Ptr(int64(1)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -569,10 +577,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for int64 type fields",
 			v: TestModelType{
-				E: Ptr(int64(1)),
+				F: Ptr(int64(1)),
 			},
 			w: TestModelType{
-				E: Ptr(int64(0)),
+				F: Ptr(int64(0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -581,10 +589,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for uint type fields",
 			v: TestModelType{
-				E: Ptr(uint(1)),
+				F: Ptr(uint(1)),
 			},
 			w: TestModelType{
-				E: Ptr(uint(1)),
+				F: Ptr(uint(1)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -593,10 +601,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for uint type fields",
 			v: TestModelType{
-				E: Ptr(uint(1)),
+				F: Ptr(uint(1)),
 			},
 			w: TestModelType{
-				E: Ptr(uint(0)),
+				F: Ptr(uint(0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -605,10 +613,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for uintptr type fields",
 			v: TestModelType{
-				E: Ptr(uintptr(1)),
+				F: Ptr(uintptr(1)),
 			},
 			w: TestModelType{
-				E: Ptr(uintptr(1)),
+				F: Ptr(uintptr(1)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -617,10 +625,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for uintptr type fields",
 			v: TestModelType{
-				E: Ptr(uintptr(1)),
+				F: Ptr(uintptr(1)),
 			},
 			w: TestModelType{
-				E: Ptr(uintptr(0)),
+				F: Ptr(uintptr(0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -629,10 +637,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for uint8 type fields",
 			v: TestModelType{
-				E: Ptr(uint8(1)),
+				F: Ptr(uint8(1)),
 			},
 			w: TestModelType{
-				E: Ptr(uint8(1)),
+				F: Ptr(uint8(1)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -641,10 +649,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for uint8 type fields",
 			v: TestModelType{
-				E: Ptr(uint8(1)),
+				F: Ptr(uint8(1)),
 			},
 			w: TestModelType{
-				E: Ptr(uint8(0)),
+				F: Ptr(uint8(0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -653,10 +661,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for uint16 type fields",
 			v: TestModelType{
-				E: Ptr(uint16(1)),
+				F: Ptr(uint16(1)),
 			},
 			w: TestModelType{
-				E: Ptr(uint16(1)),
+				F: Ptr(uint16(1)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -665,10 +673,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for uint16 type fields",
 			v: TestModelType{
-				E: Ptr(uint16(1)),
+				F: Ptr(uint16(1)),
 			},
 			w: TestModelType{
-				E: Ptr(uint16(0)),
+				F: Ptr(uint16(0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -677,10 +685,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for uint32 type fields",
 			v: TestModelType{
-				E: Ptr(uint32(1)),
+				F: Ptr(uint32(1)),
 			},
 			w: TestModelType{
-				E: Ptr(uint32(1)),
+				F: Ptr(uint32(1)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -689,10 +697,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for uint32 type fields",
 			v: TestModelType{
-				E: Ptr(uint32(1)),
+				F: Ptr(uint32(1)),
 			},
 			w: TestModelType{
-				E: Ptr(uint32(0)),
+				F: Ptr(uint32(0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -701,10 +709,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for uint64 type fields",
 			v: TestModelType{
-				E: Ptr(uint64(1)),
+				F: Ptr(uint64(1)),
 			},
 			w: TestModelType{
-				E: Ptr(uint64(1)),
+				F: Ptr(uint64(1)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -713,10 +721,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for uint64 type fields",
 			v: TestModelType{
-				E: Ptr(uint64(1)),
+				F: Ptr(uint64(1)),
 			},
 			w: TestModelType{
-				E: Ptr(uint64(0)),
+				F: Ptr(uint64(0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -725,10 +733,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for float32 type fields",
 			v: TestModelType{
-				E: Ptr(float32(1.0)),
+				F: Ptr(float32(1.0)),
 			},
 			w: TestModelType{
-				E: Ptr(float32(1.0)),
+				F: Ptr(float32(1.0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -737,10 +745,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for float32 type fields",
 			v: TestModelType{
-				E: Ptr(float32(1.0)),
+				F: Ptr(float32(1.0)),
 			},
 			w: TestModelType{
-				E: Ptr(float32(0.0)),
+				F: Ptr(float32(0.0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -749,10 +757,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for float64 type fields",
 			v: TestModelType{
-				E: Ptr(float64(1.0)),
+				F: Ptr(float64(1.0)),
 			},
 			w: TestModelType{
-				E: Ptr(float64(1.0)),
+				F: Ptr(float64(1.0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -761,10 +769,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for float64 type fields",
 			v: TestModelType{
-				E: Ptr(float64(1.0)),
+				F: Ptr(float64(1.0)),
 			},
 			w: TestModelType{
-				E: Ptr(float64(0.0)),
+				F: Ptr(float64(0.0)),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -773,10 +781,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for complex64 type fields",
 			v: TestModelType{
-				E: Ptr(complex(float32(1.0), float32(-1.0))),
+				F: Ptr(complex(float32(1.0), float32(-1.0))),
 			},
 			w: TestModelType{
-				E: Ptr(complex(float32(1.0), float32(-1.0))),
+				F: Ptr(complex(float32(1.0), float32(-1.0))),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -785,10 +793,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for complex64 type fields",
 			v: TestModelType{
-				E: Ptr(complex(float32(1.0), float32(-1.0))),
+				F: Ptr(complex(float32(1.0), float32(-1.0))),
 			},
 			w: TestModelType{
-				E: Ptr(complex(float32(0.0), float32(1.0))),
+				F: Ptr(complex(float32(0.0), float32(1.0))),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -797,10 +805,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for complex128 type fields",
 			v: TestModelType{
-				E: Ptr(complex(float64(1.0), float64(-1.0))),
+				F: Ptr(complex(float64(1.0), float64(-1.0))),
 			},
 			w: TestModelType{
-				E: Ptr(complex(float64(1.0), float64(-1.0))),
+				F: Ptr(complex(float64(1.0), float64(-1.0))),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -809,10 +817,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality for complex128 type fields",
 			v: TestModelType{
-				E: Ptr(complex(float64(1.0), float64(-1.0))),
+				F: Ptr(complex(float64(1.0), float64(-1.0))),
 			},
 			w: TestModelType{
-				E: Ptr(complex(float64(0.0), float64(1.0))),
+				F: Ptr(complex(float64(0.0), float64(1.0))),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -821,10 +829,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for slice fields",
 			v: TestModelType{
-				E: []int{1, 2, 3},
+				F: []int{1, 2, 3},
 			},
 			w: TestModelType{
-				E: []int{1, 2, 3},
+				F: []int{1, 2, 3},
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -833,10 +841,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality due to nil pointer for slice fields",
 			v: TestModelType{
-				E: []int{1, 2, 3},
+				F: []int{1, 2, 3},
 			},
 			w: TestModelType{
-				E: []int(nil),
+				F: []int(nil),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -845,10 +853,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality due to length for slice fields",
 			v: TestModelType{
-				E: []int{1, 2, 3},
+				F: []int{1, 2, 3},
 			},
 			w: TestModelType{
-				E: []int{1},
+				F: []int{1},
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -857,10 +865,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality due to content for slice fields",
 			v: TestModelType{
-				E: []int{3, 2, 1},
+				F: []int{3, 2, 1},
 			},
 			w: TestModelType{
-				E: []int{1, 2, 3},
+				F: []int{1, 2, 3},
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -869,10 +877,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for array fields",
 			v: TestModelType{
-				E: [3]int{1, 2, 3},
+				F: [3]int{1, 2, 3},
 			},
 			w: TestModelType{
-				E: [3]int{1, 2, 3},
+				F: [3]int{1, 2, 3},
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -881,10 +889,10 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality due for array fields",
 			v: TestModelType{
-				E: [3]int{3, 2, 1},
+				F: [3]int{3, 2, 1},
 			},
 			w: TestModelType{
-				E: [3]int{1, 2, 3},
+				F: [3]int{1, 2, 3},
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -893,7 +901,7 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test equality for map fields",
 			v: TestModelType{
-				E: map[string]string{
+				F: map[string]string{
 					"Blinky": "Shadow",
 					"Pinky":  "Speedy",
 					"Inky":   "Bashful",
@@ -901,7 +909,7 @@ func TestValidateVisibility(t *testing.T) {
 				},
 			},
 			w: TestModelType{
-				E: map[string]string{
+				F: map[string]string{
 					"Blinky": "Shadow",
 					"Pinky":  "Speedy",
 					"Inky":   "Bashful",
@@ -915,7 +923,7 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality due to nil pointer for map fields",
 			v: TestModelType{
-				E: map[string]string{
+				F: map[string]string{
 					"Blinky": "Shadow",
 					"Pinky":  "Speedy",
 					"Inky":   "Bashful",
@@ -923,7 +931,7 @@ func TestValidateVisibility(t *testing.T) {
 				},
 			},
 			w: TestModelType{
-				E: map[string]string(nil),
+				F: map[string]string(nil),
 			},
 			m:              TestModelTypeStructTagMap,
 			updating:       false,
@@ -932,7 +940,7 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality due to length for map fields",
 			v: TestModelType{
-				E: map[string]string{
+				F: map[string]string{
 					"Blinky": "Shadow",
 					"Pinky":  "Speedy",
 					"Inky":   "Bashful",
@@ -940,7 +948,7 @@ func TestValidateVisibility(t *testing.T) {
 				},
 			},
 			w: TestModelType{
-				E: map[string]string{
+				F: map[string]string{
 					"Blinky": "Shadow",
 				},
 			},
@@ -951,7 +959,7 @@ func TestValidateVisibility(t *testing.T) {
 		{
 			name: "Test inequality due to content for map fields",
 			v: TestModelType{
-				E: map[string]string{
+				F: map[string]string{
 					"Akabei": "Oikake",
 					"Pinky":  "Machibuse",
 					"Aosuke": "Kimagure",
@@ -959,7 +967,7 @@ func TestValidateVisibility(t *testing.T) {
 				},
 			},
 			w: TestModelType{
-				E: map[string]string{
+				F: map[string]string{
 					"Blinky": "Shadow",
 					"Pinky":  "Speedy",
 					"Inky":   "Bashful",


### PR DESCRIPTION
### What this PR does

Adds struct tag validation enhancements to support managed identity fields:

- Define `enum_managedserviceidentitytype` validation tag for the `ManagedServiceIdentityType` field.
- Define `resource_id[=<resource-type>]` validation tag for resource ID fields.
- Add validation tags to `ManagedServiceIdentity` type and its descendants.
- Add validation tags to `UserAssignedIdentitiesProfile` type.
- Fix some bugs around `visibility` tag validation for maps.  (This was tricky; added unit test cases to prove it out.)

The final commit stubs in a place for more complex, multi-field validation checks needed to complete the Jira story.

Jira: Partially completes [ARO-14453 - Add frontend validation for user-assigned identity fields](https://issues.redhat.com/browse/ARO-14453)

### Special notes for your reviewer

As usual, I suggest reviewing commit by commit.  Some commit messages have additional context.
