### PR TITLE
ARO-12097 | feat: Use snake case for azure runtime config

### DIFF
--- a/cluster-service/deploy/azure-runtime-config.tmpl.yaml
+++ b/cluster-service/deploy/azure-runtime-config.tmpl.yaml
@@ -1,11 +1,11 @@
 {
-  "cloudEnvironment": "AzurePublicCloud",
-  "tenantId": "{{ .extraVars.tenantId }}",
-  "managedIdentitiesDataPlaneAudienceResource": "https://dummy.org",
-  "ocpImagesAcr": {
-    "resourceId": "{{ .extraVars.ocpAcrResourceId }}",
+  "cloud_environment": "AzurePublicCloud",
+  "tenant_id": "{{ .extraVars.tenantId }}",
+  "managed_identities_data_plane_audience_resource": "https://dummy.org",
+  "ocp_images_acr": {
+    "resource_id": "{{ .extraVars.ocpAcrResourceId }}",
     "url": "{{ .extraVars.ocpAcrResourceUrl }}",
-    "scopeMapName": "_repositories_pull"
+    "scope_map_name": "_repositories_pull"
   },
   "dataplane_identities_oidc_configuration": {
     "storage_account_blob_container_name": "{{ .extraVars.oidc_container }}",

--- a/cluster-service/deploy/helm/templates/azure-runtime-config.configmap.yaml
+++ b/cluster-service/deploy/helm/templates/azure-runtime-config.configmap.yaml
@@ -15,6 +15,14 @@ data:
         "url": "{{ .Values.ocpAcrUrl }}",
         "scopeMapName": "_repositories_pull"
       },
+      "cloud_environment": "AzurePublicCloud",
+      "managed_identities_data_plane_audience_resource": "{{ .Values.managedIdentitiesDataPlaneAudienceResource }}",
+      "tenant_id": "{{ .Values.tenantId }}",
+      "ocp_images_acr": {
+        "resource_id": "{{ .Values.ocpAcrResourceId }}",
+        "url": "{{ .Values.ocpAcrUrl }}",
+        "scope_map_name": "_repositories_pull"
+      },
       "dataplane_identities_oidc_configuration": {
         "storage_account_blob_container_name": "$web",
         "storage_account_blob_service_url": "{{ .Values.oidcIssuerBlobServiceUrl }}",


### PR DESCRIPTION
### What this PR does
Change the keys in the Azure runtime config to snake case. The helm config temporarily has both camel and snake case files to prevent breaking CS deployments during transition.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
