### PR TITLE
create public IP before AKS cluster

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -459,6 +459,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-04-02-previ
   dependsOn: [
     aksNetworkContributorRoleAssignment
     aks_keyvault_crypto_user
+    aksClusterOutboundIPAddress
   ]
 }
 

--- a/dev-infrastructure/templates/feature-registration.bicep
+++ b/dev-infrastructure/templates/feature-registration.bicep
@@ -9,6 +9,7 @@ param features array = [
   'Microsoft.ContainerService/DisableSSHPreview'
   'Microsoft.ContainerService/IstioNativeSidecarModePreview'
   'Microsoft.Compute/EncryptionAtHost'
+  'Microsoft.Network/AllowBringYourOwnPublicIpAddress'
 ]
 
 resource featureReg 'Microsoft.Features/featureProviders/subscriptionFeatureRegistrations@2021-07-01' = [


### PR DESCRIPTION
### What this PR does

create implicit dependency between public egress IP address and AKS cluster. this way bicep will only start the AKS creation/modification once the public IP is created and ready.

additionally persist the registration of the `Microsoft.Network/AllowBringYourOwnPublicIpAddress` AFEC flag, which is required to bring our own egress IP for the AKS cluter.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
