### PR TITLE
frontend: inject the correlation ID into CosmosDB requests

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -16,6 +16,9 @@ import (
 	ocmsdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/spf13/cobra"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+
 	"github.com/Azure/ARO-HCP/internal/database"
 )
 
@@ -73,7 +76,14 @@ func Run(cmd *cobra.Command, args []string) error {
 	logger := slog.New(handler)
 
 	// Create the database client.
-	cosmosDatabaseClient, err := database.NewCosmosDatabaseClient(argCosmosURL, argCosmosName)
+	cosmosDatabaseClient, err := database.NewCosmosDatabaseClient(
+		argCosmosURL,
+		argCosmosName,
+		azcore.ClientOptions{
+			// FIXME Cloud should be determined by other means.
+			Cloud: cloud.AzurePublic,
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create the CosmosDB client: %w", err)
 	}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 
@@ -515,15 +514,10 @@ func (d *CosmosDBClient) UpdateSubscriptionDoc(ctx context.Context, subscription
 }
 
 // NewCosmosDatabaseClient instantiates a generic Cosmos database client.
-func NewCosmosDatabaseClient(url string, dbName string) (*azcosmos.DatabaseClient, error) {
-	azcoreClientOptions := azcore.ClientOptions{
-		// FIXME Cloud should be determined by other means.
-		Cloud: cloud.AzurePublic,
-	}
-
+func NewCosmosDatabaseClient(url string, dbName string, clientOptions azcore.ClientOptions) (*azcosmos.DatabaseClient, error) {
 	credential, err := azidentity.NewDefaultAzureCredential(
 		&azidentity.DefaultAzureCredentialOptions{
-			ClientOptions: azcoreClientOptions,
+			ClientOptions: clientOptions,
 		})
 	if err != nil {
 		return nil, err
@@ -533,7 +527,7 @@ func NewCosmosDatabaseClient(url string, dbName string) (*azcosmos.DatabaseClien
 		url,
 		credential,
 		&azcosmos.ClientOptions{
-			ClientOptions: azcoreClientOptions,
+			ClientOptions: clientOptions,
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What this PR does

This change adds a new policy to the frontend CosmosDB client which reads the correlation request ID from the request's context and injects the header into the request being sent to the CosmosDB API. It enables better traceability of incoming requests.

Jira: https://issues.redhat.com/browse/ARO-14434
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

I couldn't find a practical way to test the functionality without a "real" CosmosDB client.