### PR TITLE
add jfchevrette to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,10 @@
 * @bennerv @jharrington22 @SudoBrendan @ulrichschlueter @zgalor
-/dev-infrastructure/ @bennerv @geoberle @janboll @jmelis @jonathan34c @SudoBrendan @ulrichschlueter @weinong @whober0521 @tony-schndr
+/dev-infrastructure/ @bennerv @geoberle @janboll @jmelis @jonathan34c @SudoBrendan @ulrichschlueter @weinong @whober0521 @tony-schndr @jfchevrette
 /image-sync/ @bennerv @geoberle @janboll @jmelis @jonathan34c @SudoBrendan @ulrichschlueter @weinong @whober0521
 /api/ @bennerv @mbarnes @SudoBrendan @mociarain @venkateshsredhat @nanyte25
 /frontend/ @bennerv @mbarnes @SudoBrendan @mociarain @venkateshsredhat @nanyte25 @kostola
 /backend/ @bennerv @mbarnes @SudoBrendan @mociarain @venkateshsredhat @nanyte25 @kostola
 /internal/ @bennerv @mbarnes @SudoBrendan @mociarain @venkateshsredhat @nanyte25 @kostola
-/tooling/ @bennerv @geoberle @janboll @weinong @whober0521 @tony-schndr
-/config/ @bennerv @geoberle @janboll @weinong @whober0521 @tony-schndr
+/tooling/ @bennerv @geoberle @janboll @weinong @whober0521 @tony-schndr @jfchevrette
+/config/ @bennerv @geoberle @janboll @weinong @whober0521 @tony-schndr @jfchevrette
+/metrics/ @bennerv @geoberle @janboll @weinong @whober0521 @tony-schndr @jfchevrette


### PR DESCRIPTION
As a Service Lifecycle team member I am adding myself (@jfchevrette) as a code owner for Service Lifecycle related components

Also adds `/metrics/` with same permissions as other Service Lifecycle components
