### PR TITLE
Add Wait for Deployment

### DIFF
--- a/tooling/templatize/cmd/pipeline/run/options.go
+++ b/tooling/templatize/cmd/pipeline/run/options.go
@@ -24,13 +24,15 @@ func BindOptions(opts *RawRunOptions, cmd *cobra.Command) error {
 	}
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", opts.DryRun, "validate the pipeline without executing it")
 	cmd.Flags().BoolVar(&opts.NoPersist, "no-persist-tag", opts.NoPersist, "toggle if persist tag should not be set")
+	cmd.Flags().IntVar(&opts.DeploymentTimeoutSeconds, "deployment-timeout-seconds", pipeline.DefaultDeploymentTimeoutSeconds, "Timeout in Seconds to wait for previous deployments of the pipeline to finish")
 	return nil
 }
 
 type RawRunOptions struct {
-	PipelineOptions *options.RawPipelineOptions
-	DryRun          bool
-	NoPersist       bool
+	PipelineOptions          *options.RawPipelineOptions
+	DryRun                   bool
+	NoPersist                bool
+	DeploymentTimeoutSeconds int
 }
 
 // validatedRunOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
@@ -46,9 +48,10 @@ type ValidatedRunOptions struct {
 
 // completedRunOptions is a private wrapper that enforces a call of Complete() before config generation can be invoked.
 type completedRunOptions struct {
-	PipelineOptions *options.PipelineOptions
-	DryRun          bool
-	NoPersist       bool
+	PipelineOptions          *options.PipelineOptions
+	DryRun                   bool
+	NoPersist                bool
+	DeploymentTimeoutSeconds int
 }
 
 type RunOptions struct {
@@ -78,9 +81,10 @@ func (o *ValidatedRunOptions) Complete() (*RunOptions, error) {
 
 	return &RunOptions{
 		completedRunOptions: &completedRunOptions{
-			PipelineOptions: completed,
-			DryRun:          o.DryRun,
-			NoPersist:       o.NoPersist,
+			PipelineOptions:          completed,
+			DryRun:                   o.DryRun,
+			NoPersist:                o.NoPersist,
+			DeploymentTimeoutSeconds: o.DeploymentTimeoutSeconds,
 		},
 	}, nil
 }
@@ -101,11 +105,12 @@ func (o *RunOptions) RunPipeline(ctx context.Context) error {
 		return err
 	}
 	return pipeline.RunPipeline(o.PipelineOptions.Pipeline, ctx, &pipeline.PipelineRunOptions{
-		DryRun:                o.DryRun,
-		Vars:                  variables,
-		Region:                rolloutOptions.Region,
-		Step:                  o.PipelineOptions.Step,
-		SubsciptionLookupFunc: pipeline.LookupSubscriptionID,
-		NoPersist:             o.NoPersist,
+		DryRun:                   o.DryRun,
+		Vars:                     variables,
+		Region:                   rolloutOptions.Region,
+		Step:                     o.PipelineOptions.Step,
+		SubsciptionLookupFunc:    pipeline.LookupSubscriptionID,
+		NoPersist:                o.NoPersist,
+		DeploymentTimeoutSeconds: o.DeploymentTimeoutSeconds,
 	})
 }

--- a/tooling/templatize/pkg/pipeline/arm_test.go
+++ b/tooling/templatize/pkg/pipeline/arm_test.go
@@ -27,11 +27,13 @@ func TestWaitForExistingDeployment(t *testing.T) {
 			deploymentState: []armresources.ProvisioningState{"Running", "Running"},
 			expectedError:   to.Ptr("Timeout exeeded waiting for deployment test in rg rg"),
 			expecetCallCnt:  1,
+			timeout:         1,
 		},
 		{
 			name:           "Missing Deployment",
 			missing:        true,
 			expecetCallCnt: 1,
+			timeout:        1,
 		},
 		{
 			name:            "Retrying",
@@ -45,6 +47,7 @@ func TestWaitForExistingDeployment(t *testing.T) {
 			expecetCallCnt: 1,
 			returnError:    to.Ptr(fmt.Errorf("Test error")),
 			expectedError:  to.Ptr("Error getting deployment Test error"),
+			timeout:        1,
 		},
 	}
 

--- a/tooling/templatize/pkg/pipeline/arm_test.go
+++ b/tooling/templatize/pkg/pipeline/arm_test.go
@@ -1,0 +1,72 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"gotest.tools/v3/assert"
+)
+
+func TestWaitForExistingDeployment(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name            string
+		deploymentState []armresources.ProvisioningState
+		missing         bool
+		expectedError   *string
+		expecetCallCnt  int
+		timeout         int
+	}{
+		{
+			name:            "Timeout",
+			deploymentState: []armresources.ProvisioningState{"Running", "Running"},
+			expectedError:   to.Ptr("Timeout exeeded waiting for deployment test in rg rg"),
+			expecetCallCnt:  1,
+		},
+		{
+			name:           "Missing Deployment",
+			missing:        true,
+			expecetCallCnt: 1,
+		},
+		{
+			name:            "Retrying",
+			deploymentState: []armresources.ProvisioningState{"Running", "Running", "Succeeded"},
+			expecetCallCnt:  2,
+			timeout:         60,
+		},
+	}
+
+	for _, c := range cases {
+		rg := "rg"
+		depl := "test"
+		callCnt := 0
+		t.Run(c.name, func(t *testing.T) {
+			a := armClient{
+				deploymentRetryWaitTime: 1,
+				GetDeployment: func(_ context.Context, rgName, deploymentName string) (armresources.DeploymentsClientGetResponse, error) {
+					assert.Equal(t, rgName, rg)
+					assert.Equal(t, deploymentName, depl)
+					callCnt++
+					returnObj := armresources.DeploymentsClientGetResponse{
+						DeploymentExtended: armresources.DeploymentExtended{},
+					}
+					if !c.missing {
+						returnObj.DeploymentExtended.Properties = &armresources.DeploymentPropertiesExtended{
+							ProvisioningState: &c.deploymentState[callCnt],
+						}
+					}
+					return returnObj, nil
+				},
+			}
+
+			err := a.waitForExistingDeployment(ctx, c.timeout, rg, depl)
+			if c.expectedError != nil {
+				assert.Equal(t, err.Error(), *c.expectedError)
+			}
+			assert.Equal(t, callCnt, c.expecetCallCnt)
+		})
+	}
+}

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -11,6 +11,8 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/config"
 )
 
+var DefaultDeploymentTimeoutSeconds = 30 * 60
+
 func NewPipelineFromFile(pipelineFilePath string, vars config.Variables) (*Pipeline, error) {
 	bytes, err := config.PreprocessFile(pipelineFilePath, vars)
 	if err != nil {
@@ -39,12 +41,13 @@ func NewPipelineFromFile(pipelineFilePath string, vars config.Variables) (*Pipel
 }
 
 type PipelineRunOptions struct {
-	DryRun                bool
-	Step                  string
-	Region                string
-	Vars                  config.Variables
-	SubsciptionLookupFunc subsciptionLookup
-	NoPersist             bool
+	DryRun                   bool
+	Step                     string
+	Region                   string
+	Vars                     config.Variables
+	SubsciptionLookupFunc    subsciptionLookup
+	NoPersist                bool
+	DeploymentTimeoutSeconds int
 }
 
 type armOutput map[string]any


### PR DESCRIPTION
### What this PR does
This PR changes the behavior of ARM deployments. The current behavior is to run the deployment, this will cause errors. With this PR the runner will block if a previous deployment is already running. 

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
