### PR TITLE
demo scripts: add set options to enhance script safety and improve curl error handling

### DIFF
--- a/demo/01-register-sub.sh
+++ b/demo/01-register-sub.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 source "$(dirname "$0")"/common.sh
 
-correlation_headers | curl -si -H @- -X PUT "localhost:8443/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b?api-version=2.0" --json '{"state":"Registered", "registrationDate": "now", "properties": { "tenantId": "64dc69e4-d083-49fc-9569-ebece1dd1408"}}'
+correlation_headers | curl -sSi -H @- -X PUT "localhost:8443/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b?api-version=2.0" --json '{"state":"Registered", "registrationDate": "now", "properties": { "tenantId": "64dc69e4-d083-49fc-9569-ebece1dd1408"}}'

--- a/demo/02-customer-infra.sh
+++ b/demo/02-customer-infra.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 source env_vars
 
 az group create --name "${CUSTOMER_RG_NAME}" --location ${LOCATION}

--- a/demo/03-create-cluster.sh
+++ b/demo/03-create-cluster.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 source env_vars
 source "$(dirname "$0")"/common.sh
@@ -209,7 +211,7 @@ main() {
       .identity.userAssignedIdentities = $identity_uamis_json_map
     ' "${CLUSTER_TMPL_FILE}" > ${CLUSTER_FILE}
 
-  (arm_system_data_header; correlation_headers; arm_x_ms_identity_url_header) | curl -si -X PUT "localhost:8443/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CUSTOMER_RG_NAME}/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/${CLUSTER_NAME}?api-version=2024-06-10-preview" \
+  (arm_system_data_header; correlation_headers; arm_x_ms_identity_url_header) | curl -sSi -X PUT "localhost:8443/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CUSTOMER_RG_NAME}/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/${CLUSTER_NAME}?api-version=2024-06-10-preview" \
     --header @- \
     --json @${CLUSTER_FILE}
 }

--- a/demo/04-create-nodepool.sh
+++ b/demo/04-create-nodepool.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 source env_vars
 source "$(dirname "$0")"/common.sh
 
@@ -13,6 +17,6 @@ jq \
   --arg subnet_id "$SUBNET_ID" \
   '.properties.spec.platform.subnetId = $subnet_id' "${NODEPOOL_TMPL_FILE}" > ${NODEPOOL_FILE}
 
-(arm_system_data_header; correlation_headers) | curl -si -X PUT "localhost:8443/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CUSTOMER_RG_NAME}/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/${CLUSTER_NAME}/nodePools/${NP_NAME}?api-version=2024-06-10-preview" \
+(arm_system_data_header; correlation_headers) | curl -sSi -X PUT "localhost:8443/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CUSTOMER_RG_NAME}/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/${CLUSTER_NAME}/nodePools/${NP_NAME}?api-version=2024-06-10-preview" \
   --header @- \
   --json @${NODEPOOL_FILE}

--- a/demo/05-delete-cluster.sh
+++ b/demo/05-delete-cluster.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 source env_vars
 source "$(dirname "$0")"/common.sh
 
 get_existing_cluster_payload() {
-  EXISTING_CLUSTER_PAYLOAD=$(curl -s "${FRONTEND_HOST}:${FRONTEND_PORT}${CLUSTER_RESOURCE_ID}?${FRONTEND_API_VERSION_QUERY_PARAM}")
+  EXISTING_CLUSTER_PAYLOAD=$(curl -sS "${FRONTEND_HOST}:${FRONTEND_PORT}${CLUSTER_RESOURCE_ID}?${FRONTEND_API_VERSION_QUERY_PARAM}")
 }
 
 delete_managed_identities_from_cluster() {
@@ -38,7 +40,7 @@ delete_managed_identities_from_cluster() {
 
 delete_cluster() {
   echo "deleting cluster ${CLUSTER_RESOURCE_ID}"
-  correlation_headers | curl -si -H @- -X DELETE "${FRONTEND_HOST}:${FRONTEND_PORT}${CLUSTER_RESOURCE_ID}?${FRONTEND_API_VERSION_QUERY_PARAM}"
+  correlation_headers | curl -sSi -H @- -X DELETE "${FRONTEND_HOST}:${FRONTEND_PORT}${CLUSTER_RESOURCE_ID}?${FRONTEND_API_VERSION_QUERY_PARAM}"
   if [ "${WAIT_FOR_CLUSTER_DELETION}" -eq "0" ]; then
     echo "wait for cluster deletion disabled. Continuing"
     return
@@ -47,7 +49,7 @@ delete_cluster() {
   echo "waiting for cluster to be fully deleted ..."
   SLEEP_DURATION_SECONDS=10
   while true ; do
-    CLUSTER_GET_RESP=$(curl -s "${FRONTEND_HOST}:${FRONTEND_PORT}${CLUSTER_RESOURCE_ID}?${FRONTEND_API_VERSION_QUERY_PARAM}")
+    CLUSTER_GET_RESP=$(curl -sS "${FRONTEND_HOST}:${FRONTEND_PORT}${CLUSTER_RESOURCE_ID}?${FRONTEND_API_VERSION_QUERY_PARAM}")
     CLUSTER_GET_RESP_PAYLOAD=$(echo ${CLUSTER_GET_RESP} | jq -r .)
     if [ "$?" -ne "0" ]; then
       echo "HTTP GET ${CLUSTER_RESOURCE_ID} returned invalid json:"

--- a/demo/env_vars
+++ b/demo/env_vars
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 
-if [ -z "$CUSTOMER_RG_NAME" ]; then
+if [ -z "${CUSTOMER_RG_NAME:-}" ]; then
     export CUSTOMER_RG_NAME="$USER-net-rg"
 fi
 export CUSTOMER_VNET_NAME="customer-vnet"
 export CUSTOMER_VNET_SUBNET1="customer-subnet-1"
 export CUSTOMER_NSG="customer-nsg"
 export LOCATION="westus3"
-if [ -z "$CLUSTER_NAME" ]; then
+if [ -z "${CLUSTER_NAME:-}" ]; then
     export CLUSTER_NAME="$USER"
 fi
 MANAGED_RESOURCE_GROUP="$CLUSTER_NAME-rg"
 
-if [ -z "$NP_NAME" ]; then
+if [ -z "${NP_NAME:-}" ]; then
     export NP_NAME="np-1"
 fi


### PR DESCRIPTION
### What this PR does

This PR adds some set options to the demo bash scripts, ensuring they exit on errors, undefined variables, or pipeline failures.

In addition, it updates curl commands to include `-S` with `-s`, ensuring error messages are displayed while suppressing non-essential output. For example:

```
❯ ./01-register-sub.sh
curl: (7) Failed to connect to localhost port 8443 after 0 ms: Couldn't connect to server
```
