### PR TITLE
Apply mgmt-fixes to non-personal mgmt clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,12 @@ services_all = $(join services_svc,services_mgmt)
 # This sections is used to reference pipeline runs and should replace
 # the usage of `svc-deploy.sh` script in the future.
 services_svc_pipelines = istio acrpull metrics backend frontend cluster-service maestro.server
-services_mgmt_pipelines = hypershiftoperator maestro.agent acm
+# Don't apply mgmt cluster fixes to personal clusters
+ifeq ($(DEPLOY_ENV), personal-dev)
+	services_mgmt_pipelines = hypershiftoperator maestro.agent acm
+else
+	services_mgmt_pipelines = mgmt-fixes hypershiftoperator maestro.agent acm
+endif
 %.deploy_pipeline:
 	$(eval export dirname=$(subst .,/,$(basename $@)))
 	./templatize.sh $(DEPLOY_ENV) -p ./$(dirname)/pipeline.yaml -s deploy -P run -c public


### PR DESCRIPTION
### What this PR does

Reenable the mgmt-fixes helm chart, but not for personal clusters (which have too small nodes for those fixes to be usable).

Jira: https://issues.redhat.com/browse/ARO-13357
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
