### PR TITLE
fix azureOperatorsManagedIdentities

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -17,7 +17,8 @@ deploy:
 	OCP_ACR_RESOURCE_ID=$(shell az acr show -n ${OCP_ACR_NAME} --query id -o tsv) && \
 	DB_HOST=$$(if [ "${USE_AZURE_DB}" = "true" ]; then az postgres flexible-server show -g ${RESOURCEGROUP} -n ${DATABASE_SERVER_NAME} --query fullyQualifiedDomainName -o tsv; else echo "ocm-cs-db"; fi) && \
 	OVERRIDES=$$(if [ "${USE_AZURE_DB}" = "true" ]; then echo "azuredb.values.yaml"; else echo "containerdb.values.yaml"; fi) && \
-	OP_CONTROL_PLANE_OPERATOR_ROLE_ID=$(shell az role definition list --name "${OP_CONTROL_PLANE_OPERATOR_ROLE_NAME}" --query "[].name" -o tsv) && \
+	OP_CLUSTER_API_AZURE_ROLE_ID=$(shell az role definition list --name "${OP_CLUSTER_API_AZURE_ROLE_NAME}" --query "[].name" -o tsv) && \
+	OP_CONTROL_PLANE_ROLE_ID=$(shell az role definition list --name "${OP_CONTROL_PLANE_ROLE_NAME}" --query "[].name" -o tsv) && \
 	OP_CLOUD_CONTROLLER_MANAGER_ROLE_ID=$(shell az role definition list --name "${OP_CLOUD_CONTROLLER_MANAGER_ROLE_NAME}" --query "[].name" -o tsv) && \
 	OP_INGRESS_ROLE_ID=$(shell az role definition list --name "${OP_INGRESS_ROLE_NAME}" --query "[].name" -o tsv) && \
 	OP_DISK_CSI_DRIVER_ROLE_ID=$(shell az role definition list --name "${OP_DISK_CSI_DRIVER_ROLE_NAME}" --query "[].name" -o tsv) && \
@@ -58,8 +59,10 @@ deploy:
 	  --set azureArmHelperIdentityCertName=${ARM_HELPER_CERT_NAME} \
 	  --set azureArmHelperIdentityClientId=${AZURE_ARM_HELPER_IDENTITY_CLIENT_ID} \
 	  --set azureArmHelperMockFpaPrincipalId=${AZURE_ARM_HELPER_MOCK_FPA_PRINCIPAL_ID} \
-	  --set azureOperatorsMI.controlPlaneOperator.roleName="${OP_CONTROL_PLANE_OPERATOR_ROLE_NAME}" \
-	  --set azureOperatorsMI.controlPlaneOperator.roleId="$${OP_CONTROL_PLANE_OPERATOR_ROLE_ID}" \
+	  --set azureOperatorsMI.clusterApiAzure.roleName="${OP_CLUSTER_API_AZURE_ROLE_NAME}" \
+	  --set azureOperatorsMI.clusterApiAzure.roleId="$${OP_CLUSTER_API_AZURE_ROLE_ID}" \
+	  --set azureOperatorsMI.controlPlane.roleName="${OP_CONTROL_PLANE_ROLE_NAME}" \
+	  --set azureOperatorsMI.controlPlane.roleId="$${OP_CONTROL_PLANE_ROLE_ID}" \
 	  --set azureOperatorsMI.cloudControllerManager.roleName="${OP_CLOUD_CONTROLLER_MANAGER_ROLE_NAME}" \
 	  --set azureOperatorsMI.cloudControllerManager.roleId="$${OP_CLOUD_CONTROLLER_MANAGER_ROLE_ID}" \
 	  --set azureOperatorsMI.ingress.roleName="${OP_INGRESS_ROLE_NAME}" \

--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -17,6 +17,7 @@ deploy:
 	OCP_ACR_RESOURCE_ID=$(shell az acr show -n ${OCP_ACR_NAME} --query id -o tsv) && \
 	DB_HOST=$$(if [ "${USE_AZURE_DB}" = "true" ]; then az postgres flexible-server show -g ${RESOURCEGROUP} -n ${DATABASE_SERVER_NAME} --query fullyQualifiedDomainName -o tsv; else echo "ocm-cs-db"; fi) && \
 	OVERRIDES=$$(if [ "${USE_AZURE_DB}" = "true" ]; then echo "azuredb.values.yaml"; else echo "containerdb.values.yaml"; fi) && \
+	OP_CONTROL_PLANE_OPERATOR_ROLE_ID=$(shell az role definition list --name "${OP_CONTROL_PLANE_OPERATOR_ROLE_NAME}" --query "[].name" -o tsv) && \
 	OP_CLOUD_CONTROLLER_MANAGER_ROLE_ID=$(shell az role definition list --name "${OP_CLOUD_CONTROLLER_MANAGER_ROLE_NAME}" --query "[].name" -o tsv) && \
 	OP_INGRESS_ROLE_ID=$(shell az role definition list --name "${OP_INGRESS_ROLE_NAME}" --query "[].name" -o tsv) && \
 	OP_DISK_CSI_DRIVER_ROLE_ID=$(shell az role definition list --name "${OP_DISK_CSI_DRIVER_ROLE_NAME}" --query "[].name" -o tsv) && \
@@ -57,6 +58,8 @@ deploy:
 	  --set azureArmHelperIdentityCertName=${ARM_HELPER_CERT_NAME} \
 	  --set azureArmHelperIdentityClientId=${AZURE_ARM_HELPER_IDENTITY_CLIENT_ID} \
 	  --set azureArmHelperMockFpaPrincipalId=${AZURE_ARM_HELPER_MOCK_FPA_PRINCIPAL_ID} \
+	  --set azureOperatorsMI.controlPlaneOperator.roleName="${OP_CONTROL_PLANE_OPERATOR_ROLE_NAME}" \
+	  --set azureOperatorsMI.controlPlaneOperator.roleId="$${OP_CONTROL_PLANE_OPERATOR_ROLE_ID}" \
 	  --set azureOperatorsMI.cloudControllerManager.roleName="${OP_CLOUD_CONTROLLER_MANAGER_ROLE_NAME}" \
 	  --set azureOperatorsMI.cloudControllerManager.roleId="$${OP_CLOUD_CONTROLLER_MANAGER_ROLE_ID}" \
 	  --set azureOperatorsMI.ingress.roleName="${OP_INGRESS_ROLE_NAME}" \

--- a/cluster-service/deploy/helm/templates/azure-operators-managed-identities-config.configmap.yaml
+++ b/cluster-service/deploy/helm/templates/azure-operators-managed-identities-config.configmap.yaml
@@ -7,10 +7,15 @@ metadata:
 data:
   azure-operators-managed-identities-config.yaml: |
     controlPlaneOperatorsIdentities:
-      control-plane-operator:
+      cluster-api-azure:
         minOpenShiftVersion: 4.17
-        azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.controlPlaneOperator.roleId }}'
-        azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.controlPlaneOperator.roleName }}'
+        azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.clusterApiAzure.roleId }}'
+        azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.clusterApiAzure.roleName }}'
+        optional: false
+      control-plane:
+        minOpenShiftVersion: 4.17
+        azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.controlPlane.roleId }}'
+        azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.controlPlane.roleName }}'
         optional: false
       cloud-controller-manager:
         minOpenShiftVersion: 4.17

--- a/cluster-service/deploy/helm/templates/azure-operators-managed-identities-config.configmap.yaml
+++ b/cluster-service/deploy/helm/templates/azure-operators-managed-identities-config.configmap.yaml
@@ -7,6 +7,11 @@ metadata:
 data:
   azure-operators-managed-identities-config.yaml: |
     controlPlaneOperatorsIdentities:
+      control-plane-operator:
+        minOpenShiftVersion: 4.17
+        azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.controlPlaneOperator.roleId }}'
+        azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.controlPlaneOperator.roleName }}'
+        optional: false
       cloud-controller-manager:
         minOpenShiftVersion: 4.17
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.cloudControllerManager.roleId }}'
@@ -69,20 +74,4 @@ data:
             namespace: 'openshift-cluster-csi-drivers'
           - name: 'azure-file-csi-driver-node-sa'
             namespace: 'openshift-cluster-csi-drivers'
-        optional: false
-      ingress:
-        minOpenShiftVersion: 4.17
-        azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.ingress.roleId }}'
-        azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.ingress.roleName }}'
-        k8sServiceAccounts:
-          - name: 'ingress-operator'
-            namespace: 'openshift-ingress-operator'
-        optional: false
-      cloud-network-config:
-        minOpenShiftVersion: 4.17
-        azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.cloudNetworkConfig.roleId }}'
-        azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.cloudNetworkConfig.roleName }}'
-        k8sServiceAccounts:
-          - name: 'cloud-network-config-controller'
-            namespace: 'openshift-cloud-network-config-controller'
         optional: false

--- a/cluster-service/deploy/helm/values.yaml
+++ b/cluster-service/deploy/helm/values.yaml
@@ -273,7 +273,10 @@ managedIdentitiesDataPlaneAudienceResource: "https://dummy.org"
 
 # The Azure Operator Managed Identities.
 azureOperatorsMI:
-  controlPlaneOperator:
+  clusterApiAzure:
+    roleName: ''
+    roleId: ''
+  controlPlane:
     roleName: ''
     roleId: ''
   cloudControllerManager:

--- a/cluster-service/deploy/helm/values.yaml
+++ b/cluster-service/deploy/helm/values.yaml
@@ -273,6 +273,9 @@ managedIdentitiesDataPlaneAudienceResource: "https://dummy.org"
 
 # The Azure Operator Managed Identities.
 azureOperatorsMI:
+  controlPlaneOperator:
+    roleName: ''
+    roleId: ''
   cloudControllerManager:
     roleName: ''
     roleId: ''

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -58,6 +58,8 @@ resourceGroups:
       configRef: clusterService.postgres.name
     - name: DEVOPS_MSI_ID
       configRef: aroDevopsMsiId
+    - name: OP_CONTROL_PLANE_OPERATOR_ROLE_NAME
+      configRef: clusterService.azureOperatorsManagedIdentities.controlPlaneOperator.roleName
     - name: OP_CLOUD_CONTROLLER_MANAGER_ROLE_NAME
       configRef: clusterService.azureOperatorsManagedIdentities.cloudControllerManager.roleName
     - name: OP_INGRESS_ROLE_NAME

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -58,8 +58,10 @@ resourceGroups:
       configRef: clusterService.postgres.name
     - name: DEVOPS_MSI_ID
       configRef: aroDevopsMsiId
-    - name: OP_CONTROL_PLANE_OPERATOR_ROLE_NAME
-      configRef: clusterService.azureOperatorsManagedIdentities.controlPlaneOperator.roleName
+    - name: OP_CLUSTER_API_AZURE_ROLE_NAME
+      configRef: clusterService.azureOperatorsManagedIdentities.clusterApiAzure.roleName
+    - name: OP_CONTROL_PLANE_ROLE_NAME
+      configRef: clusterService.azureOperatorsManagedIdentities.controlPlane.roleName
     - name: OP_CLOUD_CONTROLLER_MANAGER_ROLE_NAME
       configRef: clusterService.azureOperatorsManagedIdentities.cloudControllerManager.roleName
     - name: OP_INGRESS_ROLE_NAME

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -166,7 +166,9 @@ clouds:
         imageTag: ecd15ad
         imageRepo: app-sre/uhc-clusters-service
         azureOperatorsManagedIdentities:
-          controlPlaneOperator:
+          clusterApiAzure:
+            roleName: Contributor
+          controlPlane:
             roleName: Contributor
           cloudControllerManager:
             roleName: Azure Red Hat OpenShift Cloud Controller Manager Role

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -166,6 +166,8 @@ clouds:
         imageTag: ecd15ad
         imageRepo: app-sre/uhc-clusters-service
         azureOperatorsManagedIdentities:
+          controlPlaneOperator:
+            roleName: Contributor
           cloudControllerManager:
             roleName: Azure Red Hat OpenShift Cloud Controller Manager Role
           ingress:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -216,7 +216,10 @@
           "azureOperatorsManagedIdentities": {
             "type": "object",
             "properties": {
-              "controlPlaneOperator": {
+              "clusterApiAzure": {
+                "$ref": "#/definitions/operatorConfig"
+              },
+              "controlPlane": {
                 "$ref": "#/definitions/operatorConfig"
               },
               "cloudControllerManager": {

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -216,6 +216,9 @@
           "azureOperatorsManagedIdentities": {
             "type": "object",
             "properties": {
+              "controlPlaneOperator": {
+                "$ref": "#/definitions/operatorConfig"
+              },
               "cloudControllerManager": {
                 "$ref": "#/definitions/operatorConfig"
               },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -182,7 +182,9 @@ clouds:
         imageTag: a51079c
         imageRepo: app-sre/uhc-clusters-service
         azureOperatorsManagedIdentities:
-          controlPlaneOperator:
+          clusterApiAzure:
+            roleName: Contributor
+          controlPlane:
             roleName: Contributor
           cloudControllerManager:
             roleName: Azure Red Hat OpenShift Cloud Controller Manager - Dev

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -182,6 +182,8 @@ clouds:
         imageTag: a51079c
         imageRepo: app-sre/uhc-clusters-service
         azureOperatorsManagedIdentities:
+          controlPlaneOperator:
+            roleName: Contributor
           cloudControllerManager:
             roleName: Azure Red Hat OpenShift Cloud Controller Manager - Dev
           ingress:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -16,7 +16,10 @@
       "cloudNetworkConfig": {
         "roleName": "Azure Red Hat OpenShift Network Operator - Dev"
       },
-      "controlPlaneOperator": {
+      "clusterApiAzure": {
+        "roleName": "Contributor"
+      },
+      "controlPlane": {
         "roleName": "Contributor"
       },
       "diskCsiDriver": {

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -16,6 +16,9 @@
       "cloudNetworkConfig": {
         "roleName": "Azure Red Hat OpenShift Network Operator - Dev"
       },
+      "controlPlaneOperator": {
+        "roleName": "Contributor"
+      },
       "diskCsiDriver": {
         "roleName": "Azure Red Hat OpenShift Disk Storage Operator - Dev"
       },

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -16,7 +16,10 @@
       "cloudNetworkConfig": {
         "roleName": "Azure Red Hat OpenShift Network Operator - Dev"
       },
-      "controlPlaneOperator": {
+      "clusterApiAzure": {
+        "roleName": "Contributor"
+      },
+      "controlPlane": {
         "roleName": "Contributor"
       },
       "diskCsiDriver": {

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -16,6 +16,9 @@
       "cloudNetworkConfig": {
         "roleName": "Azure Red Hat OpenShift Network Operator - Dev"
       },
+      "controlPlaneOperator": {
+        "roleName": "Contributor"
+      },
       "diskCsiDriver": {
         "roleName": "Azure Red Hat OpenShift Disk Storage Operator - Dev"
       },

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -16,6 +16,9 @@
       "cloudNetworkConfig": {
         "roleName": "Azure Red Hat OpenShift Network Operator Role"
       },
+      "controlPlaneOperator": {
+        "roleName": "Contributor"
+      },
       "diskCsiDriver": {
         "roleName": "Azure Red Hat OpenShift Disk Storage Operator Role"
       },

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -16,7 +16,10 @@
       "cloudNetworkConfig": {
         "roleName": "Azure Red Hat OpenShift Network Operator Role"
       },
-      "controlPlaneOperator": {
+      "clusterApiAzure": {
+        "roleName": "Contributor"
+      },
+      "controlPlane": {
         "roleName": "Contributor"
       },
       "diskCsiDriver": {

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -16,7 +16,10 @@
       "cloudNetworkConfig": {
         "roleName": "Azure Red Hat OpenShift Network Operator - Dev"
       },
-      "controlPlaneOperator": {
+      "clusterApiAzure": {
+        "roleName": "Contributor"
+      },
+      "controlPlane": {
         "roleName": "Contributor"
       },
       "diskCsiDriver": {

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -16,6 +16,9 @@
       "cloudNetworkConfig": {
         "roleName": "Azure Red Hat OpenShift Network Operator - Dev"
       },
+      "controlPlaneOperator": {
+        "roleName": "Contributor"
+      },
       "diskCsiDriver": {
         "roleName": "Azure Red Hat OpenShift Disk Storage Operator - Dev"
       },

--- a/demo/03-create-cluster.sh
+++ b/demo/03-create-cluster.sh
@@ -149,6 +149,8 @@ main() {
   # identities for a given OCP version will be provided
   # via API.
   CONTROL_PLANE_OPERATORS_NAMES=(
+    "cluster-azure-api"
+    "control-plane"
     "cloud-controller-manager"
     "ingress"
     "disk-csi-driver"
@@ -162,11 +164,9 @@ main() {
   # identities for a given OCP version will be provided
   # via API.
   DATA_PLANE_OPERATORS_NAMES=(
-    "ingress"
     "disk-csi-driver"
     "file-csi-driver"
     "image-registry"
-    "cloud-network-config"
   )
 
   # We declare and initialize the control plane


### PR DESCRIPTION
### What this PR does
Removes network/ingress identities from data plane identities
Adds a new identity for the control plane operator with Contributor Role.
Adds a new identity for cluster-azure-api with Contributor Role.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
