### PR TITLE
CODEOWNERS: Give RP maintainers ownership over go.work[.sum]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 * @bennerv @jharrington22 @SudoBrendan @ulrichschlueter @zgalor
+go.work* @bennerv @mbarnes @SudoBrendan @mociarain @venkateshsredhat @nanyte25 @kostola
 /dev-infrastructure/ @bennerv @geoberle @janboll @jmelis @jonathan34c @SudoBrendan @ulrichschlueter @weinong @whober0521 @tony-schndr @jfchevrette
 /image-sync/ @bennerv @geoberle @janboll @jmelis @jonathan34c @SudoBrendan @ulrichschlueter @weinong @whober0521
 /api/ @bennerv @mbarnes @SudoBrendan @mociarain @venkateshsredhat @nanyte25


### PR DESCRIPTION
Every time there's a `go.work.sum` change in a pull request I'm locked out of merging it, even if the rest of the changes are strictly RP focused.