### PR TITLE
prepare output chaining

### DIFF
--- a/dev-infrastructure/.gitignore
+++ b/dev-infrastructure/.gitignore
@@ -10,6 +10,8 @@ configurations/image-sync.bicepparam
 configurations/dev-role-assignments.bicepparam
 configurations/cs-integ-msi.bicepparam
 configurations/output-region.bicepparam
+configurations/output-global.bicepparam
+configurations/output-svc.bicepparam
 configurations/mock-identities.bicepparam
 configurations/global-acr.bicepparam
 configurations/global-infra.bicepparam

--- a/dev-infrastructure/configurations/output-global.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/output-global.tmpl.bicepparam
@@ -1,0 +1,6 @@
+using '../templates/output-global.bicep'
+
+param svcAcrName = '{{ .svcAcrName }}'
+param ocpAcrName = '{{ .ocpAcrName }}'
+param cxParentZoneName = '{{ .dns.cxParentZoneName }}'
+param svcParentZoneName = '{{ .dns.svcParentZoneName }}'

--- a/dev-infrastructure/configurations/output-region.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/output-region.tmpl.bicepparam
@@ -1,3 +1,4 @@
 using '../templates/output-region.bicep'
 
-param csMIName = '{{ .clusterService.managedIdentityName }}'
+param azureMonitorWorkspaceName = '{{ .monitoring.workspaceName }}'
+param maestroEventGridNamespacesName = '{{ .maestro.eventGrid.name }}'

--- a/dev-infrastructure/configurations/output-svc.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/output-svc.tmpl.bicepparam
@@ -1,0 +1,3 @@
+using '../templates/output-svc.bicep'
+
+param csMIName = '{{ .clusterService.managedIdentityName }}'

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -5,13 +5,14 @@ resourceGroups:
 - name: {{ .svc.rg }}
   subscription: {{ .svc.subscription }}
   steps:
-  - name: region-output
+  - name: svc-output
     action: ARM
-    template: templates/output-region.bicep
-    parameters: configurations/output-region.tmpl.bicepparam
+    template: templates/output-svc.bicep
+    parameters: configurations/output-svc.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
 - name: {{ .mgmt.rg }}
   subscription: {{ .mgmt.subscription }}
-  aksCluster: {{ .aksName }}
   steps:
   - name: mgmt-infra
     action: ARM
@@ -19,12 +20,16 @@ resourceGroups:
     parameters: configurations/mgmt-infra.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     variables:
-    - name: mgmt.clusterServiceResourceId
+    - name: clusterServiceMIResourceId
       input:
-        step: region-output
+        step: svc-output
         name: cs
     dependsOn:
-    - region-output
+    - svc-output
+- name: {{ .mgmt.rg }}
+  subscription: {{ .mgmt.subscription }}
+  aksCluster: {{ .aksName }}
+  steps:
   - name: mgmt-cluster
     action: ARM
     template: templates/mgmt-cluster.bicep

--- a/dev-infrastructure/templates/output-global.bicep
+++ b/dev-infrastructure/templates/output-global.bicep
@@ -1,0 +1,43 @@
+@description('The name of the OCP ACR')
+param ocpAcrName string
+
+@description('The name of the SVC ACR')
+param svcAcrName string
+
+@description('The CX parent DNS zone name')
+param cxParentZoneName string
+
+@description('The SVC parent DNS zone name')
+param svcParentZoneName string
+
+//
+//   A C R
+//
+
+resource ocpAcr 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' existing = {
+  name: ocpAcrName
+}
+
+resource svcAcr 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' existing = {
+  name: svcAcrName
+}
+
+output ocpAcrResourceId string = ocpAcr.id
+output svcAcrResourceId string = svcAcr.id
+
+//
+//   D N S
+//
+
+resource cxParentZone 'Microsoft.Network/dnsZones@2018-05-01' existing = {
+  name: cxParentZoneName
+}
+
+resource svcParentZone 'Microsoft.Network/dnsZones@2018-05-01' existing = {
+  name: svcParentZoneName
+}
+
+output cxParentZoneResourceId string = cxParentZone.id
+output svcParentZoneResourceId string = svcParentZone.id
+
+output foo string = svcAcrName

--- a/dev-infrastructure/templates/output-region.bicep
+++ b/dev-infrastructure/templates/output-region.bicep
@@ -1,9 +1,16 @@
-@description('The name of the CS managed identity')
-param csMIName string
+@description('The name of the Azure Monitor Workspace (stores prometheus metrics)')
+param azureMonitorWorkspaceName string
 
-resource csMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
-  name: csMIName
-  location: resourceGroup().location
+@description('The name of the eventgrid namespace for Maestro.')
+param maestroEventGridNamespacesName string
+
+resource monitor 'microsoft.monitor/accounts@2021-06-03-preview' existing = {
+  name: azureMonitorWorkspaceName
 }
 
-output cs string = csMSI.id
+resource maestroEventGridNamespace 'Microsoft.EventGrid/namespaces@2024-06-01-preview' existing = {
+  name: maestroEventGridNamespacesName
+}
+
+output azureMonitoringWorkspaceId string = monitor.id
+output maestroEventGridNamespaceId string = maestroEventGridNamespace.id

--- a/dev-infrastructure/templates/output-svc.bicep
+++ b/dev-infrastructure/templates/output-svc.bicep
@@ -1,0 +1,8 @@
+@description('The name of the CS managed identity')
+param csMIName string
+
+resource csMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: csMIName
+}
+
+output cs string = csMSI.id

--- a/tooling/templatize/internal/end2end/e2e_test.go
+++ b/tooling/templatize/internal/end2end/e2e_test.go
@@ -192,12 +192,12 @@ func TestE2EArmDeployWithOutputToArm(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	e2eImpl := newE2E(tmpDir)
-	e2eImpl.AddStep(pipeline.NewARMStep("parameterA", "testa.bicep", "testa.bicepparm", "ResourceGroup"), 0)
-	e2eImpl.AddStep(pipeline.NewARMStep("parameterB", "testb.bicep", "testb.bicepparm", "ResourceGroup").WithVariables(pipeline.Variable{
+	e2eImpl.AddStep(pipeline.NewARMStep("stepA", "testa.bicep", "testa.bicepparm", "ResourceGroup"), 0)
+	e2eImpl.AddStep(pipeline.NewARMStep("stepB", "testb.bicep", "testb.bicepparm", "ResourceGroup").WithVariables(pipeline.Variable{
 		Name: "parameterB",
 		Input: &pipeline.Input{
 			Name: "parameterA",
-			Step: "parameterA",
+			Step: "stepA",
 		},
 	}), 0)
 
@@ -208,7 +208,7 @@ func TestE2EArmDeployWithOutputToArm(t *testing.T) {
 			Name: "end",
 			Input: &pipeline.Input{
 				Name: "parameterC",
-				Step: "parameterB",
+				Step: "stepB",
 			},
 		},
 	), 0)
@@ -229,7 +229,7 @@ output parameterC string = parameterB
 		"testb.bicep",
 		`
 using 'testb.bicep'
-param parameterB = '{{ .parameterB }}'
+param parameterB = '< provided at runtime >'
 `,
 		"testb.bicepparm")
 

--- a/tooling/templatize/pkg/pipeline/bicep.go
+++ b/tooling/templatize/pkg/pipeline/bicep.go
@@ -39,15 +39,7 @@ func transformBicepToARMDeployment(ctx context.Context, bicepParameterTemplateFi
 }
 
 func transformParameters(ctx context.Context, vars config.Variables, inputs map[string]any, bicepParameterTemplateFile string) (map[string]interface{}, map[string]interface{}, error) {
-	combinedVars := make(map[string]any)
-	for k, v := range vars {
-		combinedVars[k] = v
-	}
-	for k, v := range inputs {
-		combinedVars[k] = v
-	}
-
-	bicepParamContent, err := config.PreprocessFile(bicepParameterTemplateFile, combinedVars)
+	bicepParamContent, err := config.PreprocessFile(bicepParameterTemplateFile, vars)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to preprocess file: %w", err)
 	}
@@ -80,6 +72,11 @@ func transformParameters(ctx context.Context, vars config.Variables, inputs map[
 	params, err := result.Parameters()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get parameters: %w", err)
+	}
+	for k, v := range inputs {
+		params[k] = map[string]interface{}{
+			"value": v,
+		}
 	}
 	return template, params, nil
 }


### PR DESCRIPTION
### What this PR does

this PR does not have any impact on GH actions or lcoal `make` runs

* introduce output bicep templates for global, regional and svc level
* move CS MI ID lookup into svc level output template
* mark svc output step as `outputOnly`
* output chaining input to bicepparam files does not rely on schema fields anymore

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
