### PR TITLE
fix ACM operator mirror

### DIFF
--- a/dev-infrastructure/templates/image-sync.bicep
+++ b/dev-infrastructure/templates/image-sync.bicep
@@ -335,7 +335,7 @@ var acmMirrorConfig = {
   mirror: {
     operators: [
       {
-        catalog: 'registry.redhat.io/redhat/redhat-operator-index:v4.17'
+        catalog: 'registry.redhat.io/redhat/redhat-operator-index:v4.16'
         packages: [
           {
             name: 'multicluster-engine'


### PR DESCRIPTION
### What this PR does

the ACM operator version we need are listed in the registry.redhat.io/redhat/redhat-operator-index:v4.16 catalog image, not the 4.17 one

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
