### PR TITLE
disable grafana registration for now

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -492,7 +492,7 @@ metrics-infra: regional.rg
 		--template-file modules/metrics/metrics.bicep \
 		$(PROMPT_TO_CONFIRM) \
 		--parameters configurations/metrics.bicepparam;
-	@scripts/add-grafana-datasource.sh $(GRAFANA_NAME) $(GLOBAL_RESOURCEGROUP) $(MONITOR_NAME) $(REGIONAL_RESOURCEGROUP)
+#	@scripts/add-grafana-datasource.sh $(GRAFANA_NAME) $(GLOBAL_RESOURCEGROUP) $(MONITOR_NAME) $(REGIONAL_RESOURCEGROUP)
 .PHONY: metrics-infra
 
 metrics-infra.what-if: regional.rg


### PR DESCRIPTION
### What this PR does

grafana registration yields an error dín the GH action pipelines. disabling this for now allows us to run pipelines for the time being until we figure out the details

```
ERROR: 401 Client Error: Unauthorized for url: https://arohcp-dev-c9g7a4fjanb0c4gc.eus.grafana.azure.com/api/datasources
```

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
