### PR TITLE
frontend: set default otel resource attributes

### DIFF
--- a/frontend/cmd/cmd.go
+++ b/frontend/cmd/cmd.go
@@ -18,9 +18,8 @@ import (
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
-	"github.com/Azure/ARO-HCP/frontend/pkg/config"
 	"github.com/Azure/ARO-HCP/frontend/pkg/frontend"
-	"github.com/Azure/ARO-HCP/frontend/pkg/info"
+	"github.com/Azure/ARO-HCP/frontend/pkg/util"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
@@ -46,7 +45,7 @@ func NewRootCmd() *cobra.Command {
 	opts := &FrontendOpts{}
 	rootCmd := &cobra.Command{
 		Use:     "aro-hcp-frontend",
-		Version: info.Version(),
+		Version: util.Version(),
 		Args:    cobra.NoArgs,
 		Short:   "Serve the ARO HCP Frontend",
 		Long: `Serve the ARO HCP Frontend
@@ -102,8 +101,8 @@ func correlationIDPolicy(req *policy.Request) (*http.Response, error) {
 }
 
 func (opts *FrontendOpts) Run() error {
-	logger := config.DefaultLogger()
-	logger.Info(fmt.Sprintf("%s (%s) started", frontend.ProgramName, info.Version()))
+	logger := util.DefaultLogger()
+	logger.Info(fmt.Sprintf("%s (%s) started", frontend.ProgramName, util.Version()))
 
 	// Init the Prometheus emitter.
 	prometheusEmitter := frontend.NewPrometheusEmitter(prometheus.DefaultRegisterer)
@@ -177,7 +176,7 @@ func (opts *FrontendOpts) Run() error {
 	close(stop)
 
 	f.Join()
-	logger.Info(fmt.Sprintf("%s (%s) stopped", frontend.ProgramName, info.Version()))
+	logger.Info(fmt.Sprintf("%s (%s) stopped", frontend.ProgramName, util.Version()))
 
 	return nil
 }

--- a/frontend/cmd/cmd.go
+++ b/frontend/cmd/cmd.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"runtime/debug"
 	"syscall"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -21,6 +20,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/frontend/pkg/config"
 	"github.com/Azure/ARO-HCP/frontend/pkg/frontend"
+	"github.com/Azure/ARO-HCP/frontend/pkg/info"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
@@ -46,7 +46,7 @@ func NewRootCmd() *cobra.Command {
 	opts := &FrontendOpts{}
 	rootCmd := &cobra.Command{
 		Use:     "aro-hcp-frontend",
-		Version: version(),
+		Version: info.Version(),
 		Args:    cobra.NoArgs,
 		Short:   "Serve the ARO HCP Frontend",
 		Long: `Serve the ARO HCP Frontend
@@ -103,7 +103,7 @@ func correlationIDPolicy(req *policy.Request) (*http.Response, error) {
 
 func (opts *FrontendOpts) Run() error {
 	logger := config.DefaultLogger()
-	logger.Info(fmt.Sprintf("%s (%s) started", frontend.ProgramName, version()))
+	logger.Info(fmt.Sprintf("%s (%s) started", frontend.ProgramName, info.Version()))
 
 	// Init the Prometheus emitter.
 	prometheusEmitter := frontend.NewPrometheusEmitter(prometheus.DefaultRegisterer)
@@ -177,21 +177,7 @@ func (opts *FrontendOpts) Run() error {
 	close(stop)
 
 	f.Join()
-	logger.Info(fmt.Sprintf("%s (%s) stopped", frontend.ProgramName, version()))
+	logger.Info(fmt.Sprintf("%s (%s) stopped", frontend.ProgramName, info.Version()))
 
 	return nil
-}
-
-func version() string {
-	version := "unknown"
-	if info, ok := debug.ReadBuildInfo(); ok {
-		for _, setting := range info.Settings {
-			if setting.Key == "vcs.revision" {
-				version = setting.Value
-				break
-			}
-		}
-	}
-
-	return version
 }

--- a/frontend/pkg/frontend/context.go
+++ b/frontend/pkg/frontend/context.go
@@ -7,7 +7,7 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
-	"github.com/Azure/ARO-HCP/frontend/pkg/config"
+	"github.com/Azure/ARO-HCP/frontend/pkg/util"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
@@ -80,7 +80,7 @@ func LoggerFromContext(ctx context.Context) *slog.Logger {
 		}
 		// Return the default logger as a fail-safe, but log
 		// the failure to obtain the logger from the context.
-		logger = config.DefaultLogger()
+		logger = util.DefaultLogger()
 		logger.Error(err.Error())
 	}
 	return logger

--- a/frontend/pkg/frontend/middleware_logging_test.go
+++ b/frontend/pkg/frontend/middleware_logging_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/Azure/ARO-HCP/frontend/pkg/config"
+	"github.com/Azure/ARO-HCP/frontend/pkg/util"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
@@ -45,7 +45,7 @@ func TestMiddlewareLoggingPostMux(t *testing.T) {
 		request.Header = tt.header
 
 		// we assume the request carries a logger, we set it explicitly to not fail
-		ctx := ContextWithLogger(request.Context(), config.DefaultLogger())
+		ctx := ContextWithLogger(request.Context(), util.DefaultLogger())
 		request = request.WithContext(ctx)
 
 		next := func(w http.ResponseWriter, r *http.Request) {

--- a/frontend/pkg/frontend/otel_sdk.go
+++ b/frontend/pkg/frontend/otel_sdk.go
@@ -17,7 +17,7 @@ import (
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 
-	"github.com/Azure/ARO-HCP/frontend/pkg/info"
+	"github.com/Azure/ARO-HCP/frontend/pkg/util"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -44,7 +44,7 @@ func InstallOpenTelemetryTracer(ctx context.Context, logger *slog.Logger, resour
 	}
 	opts = append(opts, resource.WithAttributes(
 		semconv.ServiceNameKey.String(ProgramName),
-		semconv.ServiceVersionKey.String(info.Version()),
+		semconv.ServiceVersionKey.String(util.Version()),
 	))
 	resources, err := resource.New(ctx, opts...)
 	if err != nil {

--- a/frontend/pkg/frontend/otel_sdk.go
+++ b/frontend/pkg/frontend/otel_sdk.go
@@ -15,6 +15,9 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/trace"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+
+	"github.com/Azure/ARO-HCP/frontend/pkg/info"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -39,6 +42,10 @@ func InstallOpenTelemetryTracer(ctx context.Context, logger *slog.Logger, resour
 	if len(resourceAttrs) > 0 {
 		opts = append(opts, resource.WithAttributes(resourceAttrs...))
 	}
+	opts = append(opts, resource.WithAttributes(
+		semconv.ServiceNameKey.String(ProgramName),
+		semconv.ServiceVersionKey.String(info.Version()),
+	))
 	resources, err := resource.New(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialise trace resources: %w", err)

--- a/frontend/pkg/info/version.go
+++ b/frontend/pkg/info/version.go
@@ -1,0 +1,20 @@
+package info
+
+import "runtime/debug"
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+func Version() string {
+	version := "unknown"
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				version = setting.Value
+				break
+			}
+		}
+	}
+
+	return version
+}

--- a/frontend/pkg/util/logger.go
+++ b/frontend/pkg/util/logger.go
@@ -1,4 +1,7 @@
-package config
+package util
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
 
 import (
 	"log/slog"

--- a/frontend/pkg/util/version.go
+++ b/frontend/pkg/util/version.go
@@ -1,9 +1,9 @@
-package info
-
-import "runtime/debug"
+package util
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
+
+import "runtime/debug"
 
 func Version() string {
 	version := "unknown"


### PR DESCRIPTION
### What this PR does


Jira: https://issues.redhat.com/browse/ARO-14935
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

This change will add a default service name and version key similar like on OCM Cluster Service.

e.g. previous default:
![image](https://github.com/user-attachments/assets/f0d572b9-0c20-44e7-96e3-a7b0d735cdf6)

---

cc @dinhxuanvu