### PR TITLE
remove svc.enable-aks-metrics from GH action

### DIFF
--- a/.github/workflows/environment-infra-cd.yml
+++ b/.github/workflows/environment-infra-cd.yml
@@ -105,7 +105,7 @@
         - name: 'Deploy rest'
           run: |
             cd dev-infrastructure/
-            PRINCIPAL_ID=${{ secrets.GHA_PRINCIPAL_ID }} make svc.aks.admin-access svc.istio svc.enable-aks-metrics
+            PRINCIPAL_ID=${{ secrets.GHA_PRINCIPAL_ID }} make svc.aks.admin-access svc.istio
 
         - name: 'CS PR check MSI'
           if: inputs.deploy_cs_pr_check_deps


### PR DESCRIPTION
### What this PR does

the `svc.enable-aks-metrics` target has been removed just recently and does not need to be called

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
