### PR TITLE
database: Add PartitionKeys container

### DIFF
--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -24,6 +24,9 @@ var containers = [
     name: 'Resources'
   }
   {
+    name: 'PartitionKeys'
+  }
+  {
     name: 'Billing'
   }
   {

--- a/internal/database/partitionkeys.go
+++ b/internal/database/partitionkeys.go
@@ -1,0 +1,114 @@
+package database
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+// XXX The Azure SDK for Go does not support cross-partition Cosmos DB
+//     queries which means the partition keys of a Cosmos DB container
+//     cannot be discovered through the Go SDK.
+//
+//     The Azure SDK for other languages like .NET, Java, and Python
+//     already support cross-partition queries, so there is reason to
+//     hope the Go SDK may some day catch up.
+//
+//     In the meantime, this container serves as a workaround. This is
+//     a single-partition container that simply collects the partition
+//     keys of the Resources container, like an index.
+//
+//     Once [1] is fixed we could simply drop this container and begin
+//     using cross-partition queries on the Resources container.
+//
+//     [1] https://github.com/Azure/azure-sdk-for-go/issues/18578
+
+const (
+	// partitionKeysPartitionKey is a constant (and somewhat pointed)
+	// partition key value for all items in the PartitionKeys container.
+	partitionKeysPartitionKey = "azure-sdk-for-go-issue-18578"
+)
+
+// partitionKeyDocument holds a partition key for another container as
+// the document ID. The PartitionKey for this document is held constant.
+type partitionKeyDocument struct {
+	BaseDocument
+	PartitionKey string `json:"partitionKey,omitempty"`
+}
+
+// partitionKeyIterator implements DBClientIterator for subscriptions.
+type partitionKeyIterator struct {
+	client DBClient
+	pager  *runtime.Pager[azcosmos.QueryItemsResponse]
+	err    error
+}
+
+func upsertPartitionKey(ctx context.Context, containerClient *azcosmos.ContainerClient, id string) error {
+	pk := azcosmos.NewPartitionKeyString(partitionKeysPartitionKey)
+
+	data, err := json.Marshal(&partitionKeyDocument{
+		BaseDocument: BaseDocument{ID: id},
+		PartitionKey: partitionKeysPartitionKey,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = containerClient.UpsertItem(ctx, pk, data, nil)
+
+	return err
+}
+
+func listPartitionKeys(containerClient *azcosmos.ContainerClient, client DBClient) DBClientIterator[SubscriptionDocument] {
+	pk := azcosmos.NewPartitionKeyString(partitionKeysPartitionKey)
+
+	pager := containerClient.NewQueryItemsPager("SELECT c.id FROM c", pk, nil)
+
+	return &partitionKeyIterator{client: client, pager: pager}
+}
+
+func (iter *partitionKeyIterator) Items(ctx context.Context) DBClientIteratorItem[SubscriptionDocument] {
+	return func(yield func(*SubscriptionDocument) bool) {
+		for iter.pager.More() {
+			response, err := iter.pager.NextPage(ctx)
+			if err != nil {
+				iter.err = err
+				return
+			}
+			for _, item := range response.Items {
+				var doc BaseDocument
+
+				// Since the query just selects the "id" field,
+				// BaseDocument is sufficient for unmarshalling.
+				err = json.Unmarshal(item, &doc)
+				if err != nil {
+					iter.err = err
+					return
+				}
+
+				subscription, err := iter.client.GetSubscriptionDoc(ctx, doc.ID)
+				if err != nil {
+					iter.err = err
+					return
+				}
+
+				if !yield(subscription) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (iter *partitionKeyIterator) GetContinuationToken() string {
+	return ""
+}
+
+func (iter *partitionKeyIterator) GetError() error {
+	return iter.err
+}

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -279,6 +279,20 @@ func (mr *MockDBClientMockRecorder) ListAllSubscriptionDocs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllSubscriptionDocs", reflect.TypeOf((*MockDBClient)(nil).ListAllSubscriptionDocs))
 }
 
+// ListOperationDocs mocks base method.
+func (m *MockDBClient) ListOperationDocs(subscriptionID string) database.DBClientIterator[database.OperationDocument] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListOperationDocs", subscriptionID)
+	ret0, _ := ret[0].(database.DBClientIterator[database.OperationDocument])
+	return ret0
+}
+
+// ListOperationDocs indicates an expected call of ListOperationDocs.
+func (mr *MockDBClientMockRecorder) ListOperationDocs(subscriptionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOperationDocs", reflect.TypeOf((*MockDBClient)(nil).ListOperationDocs), subscriptionID)
+}
+
 // ListResourceDocs mocks base method.
 func (m *MockDBClient) ListResourceDocs(prefix *arm.ResourceID, maxItems int32, continuationToken *string) database.DBClientIterator[database.ResourceDocument] {
 	m.ctrl.T.Helper()

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -265,6 +265,20 @@ func (mr *MockDBClientMockRecorder) ListAllOperationDocs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllOperationDocs", reflect.TypeOf((*MockDBClient)(nil).ListAllOperationDocs))
 }
 
+// ListAllSubscriptionDocs mocks base method.
+func (m *MockDBClient) ListAllSubscriptionDocs() database.DBClientIterator[database.SubscriptionDocument] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllSubscriptionDocs")
+	ret0, _ := ret[0].(database.DBClientIterator[database.SubscriptionDocument])
+	return ret0
+}
+
+// ListAllSubscriptionDocs indicates an expected call of ListAllSubscriptionDocs.
+func (mr *MockDBClientMockRecorder) ListAllSubscriptionDocs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllSubscriptionDocs", reflect.TypeOf((*MockDBClient)(nil).ListAllSubscriptionDocs))
+}
+
 // ListResourceDocs mocks base method.
 func (m *MockDBClient) ListResourceDocs(prefix *arm.ResourceID, maxItems int32, continuationToken *string) database.DBClientIterator[database.ResourceDocument] {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### What this PR does

In anticipation of merging the "Resources", "Operations" and "Subscriptions" Cosmos DB containers, this PR adds a new container named "PartitionKeys" and two new `DBClient` methods: `ListOperationDocs` and `ListAllSubscriptionDocs`.

The PartitionKeys container is essentially the same hack [we're currently using for the Operations container](https://github.com/Azure/ARO-HCP/blob/760f2f748ca7c94cbc4bf74e7f4a04752b91d71b/internal/database/database.go#L28-L41), but the Operations container will soon be merged into the Resources container.  After the merge, Operation documents will be partitioned by Azure subscription ID.

The PartitionKeys container is an index of partition keys (Azure subscription IDs) for the Resources container.  This is necessary because the [Azure SDK for Go does not support cross-partition Cosmos DB queries](https://github.com/Azure/azure-sdk-for-go/issues/18578), and so the partition keys of a container are otherwise undiscoverable.

We overcome this same problem in the PartitionKeys container itself by keeping all items in a single partition (and a known partition key) so they can be found with a single-partition query.

If Azure's Go SDK ever catches up to their SDK for other languages, we can simply drop this container and start using cross-partition queries on the Resources container. **No data migration needed.**

As for the new `DBClient` methods:

- `ListOperationDocs` is a variation of `ListAllOperationDocs` that limits the query to operations within a single Azure subscription.  After the Cosmos DB containers are merged, this method will be reimplemented as a single-partition query and `DBClient.ListAllOperationDocs` will be removed.

- `ListAllSubscriptionDocs` should be self-explanatory.

Jira: [ARO-14170 - Merge Cosmos DB containers](https://issues.redhat.com/browse/ARO-14170)

### Special notes for your reviewer

The new `DBClient` methods are not used in this pull request.  They will be used in the [_next_ pull request for this Jira](https://github.com/Azure/ARO-HCP/pull/1200).  I thought it made more sense to introduce them here since they both leverage the PartitionKeys container.