### PR TITLE
Add grafana admin and re-enable grafana/amw integration

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -492,7 +492,7 @@ metrics-infra: regional.rg
 		--template-file modules/metrics/metrics.bicep \
 		$(PROMPT_TO_CONFIRM) \
 		--parameters configurations/metrics.bicepparam;
-#	@scripts/add-grafana-datasource.sh $(GRAFANA_NAME) $(GLOBAL_RESOURCEGROUP) $(MONITOR_NAME) $(REGIONAL_RESOURCEGROUP)
+	@scripts/add-grafana-datasource.sh $(GRAFANA_NAME) $(GLOBAL_RESOURCEGROUP) $(MONITOR_NAME) $(REGIONAL_RESOURCEGROUP)
 .PHONY: metrics-infra
 
 metrics-infra.what-if: regional.rg

--- a/tooling/azure-automation/github-actions/hack/create-application.sh
+++ b/tooling/azure-automation/github-actions/hack/create-application.sh
@@ -20,6 +20,7 @@ OBJ_ID=$(az ad sp create --id $APP_ID | jq -r '.id')
 # Create role assignment and federate credentials
 az role assignment create --assignee "${OBJ_ID}" --role Contributor --scope /subscriptions/${SUBSCRIPTION}
 az role assignment create --assignee "${OBJ_ID}" --role "Role Based Access Control Administrator" --scope /subscriptions/${SUBSCRIPTION}
+az role assignment create --assignee "${OBJ_ID}" --role "Grafana Admin" --scope /subscriptions/${SUBSCRIPTION}
 
 az ad app federated-credential create --id "${APP_ID}" --parameters \
 '{


### PR DESCRIPTION
### What this PR does

Add the Grafana Admin role to the `aro-github-actions-identity` app service principal to allow it to manage Grafana Datasources.  Reverts  https://github.com/Azure/ARO-HCP/pull/1181 to re-enable Grafana.

NOTE: I already added the permission to the identity by running the below command, which should give the identity access to manage all Grafana Instances in the subscription.
```
az role assignment create --assignee "${OBJ_ID}" --role "Grafana Admin" --scope /subscriptions/${SUBSCRIPTION}
```

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
