### PR TITLE
api: Set OutboundType default in NewDefaultHCPOpenShiftCluster

### DIFF
--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -125,6 +125,9 @@ func NewDefaultHCPOpenShiftCluster() *HCPOpenShiftCluster {
 					NetworkType: NetworkTypeOVNKubernetes,
 					HostPrefix:  23,
 				},
+				Platform: PlatformProfile{
+					OutboundType: OutboundTypeLoadBalancer,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
### What this PR does

Followup to [#1171 - frontend: Plumb the OutboundType API value through to CS](https://github.com/Azure/ARO-HCP/pull/1171)

`platform.outboundType` is supposed to have a default value but I forgot to set it in `NewDefaultHCPOpenShiftCluster`.

Jira: [ARO-12228 - Frontend Implements API Field for outboundtype](https://issues.redhat.com/browse/ARO-12228)

### Special notes for your reviewer

<!-- optional -->
