### PR TITLE
chore: add Miguel, Zohar, Jameel and Manyanda as owners of cluster-service code directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,3 +9,4 @@ go.work* @bennerv @mbarnes @SudoBrendan @mociarain @venkateshsredhat @nanyte25 @
 /tooling/ @bennerv @geoberle @janboll @weinong @whober0521 @tony-schndr @jfchevrette
 /config/ @bennerv @geoberle @janboll @weinong @whober0521 @tony-schndr @jfchevrette
 /metrics/ @bennerv @geoberle @janboll @weinong @whober0521 @tony-schndr @jfchevrette
+/cluster-service/ @machi1990 @zgalor @miguelsorianod @JameelB


### PR DESCRIPTION

### What this PR does

add Miguel, Zohar, Jameel and Manyanda as owners of cluster-service code directory

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
