### PR TITLE
backend: Rewrite Cosmos DB scanning

### DIFF
--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -10,6 +10,9 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"slices"
+	"strconv"
+	"sync"
 	"time"
 
 	ocmsdk "github.com/openshift-online/ocm-sdk-go"
@@ -23,17 +26,26 @@ import (
 )
 
 const (
-	defaultCosmosOperationsPollInterval = 30 * time.Second
-	defaultClusterServicePollInterval   = 10 * time.Second
+	defaultSubscriptionConcurrency   = 10
+	defaultPollIntervalSubscriptions = 10 * time.Minute
+	defaultPollIntervalOperations    = 10 * time.Second
 )
 
+type operation struct {
+	id     string
+	doc    *database.OperationDocument
+	logger *slog.Logger
+}
+
 type OperationsScanner struct {
-	dbClient           database.DBClient
-	lockClient         *database.LockClient
-	clusterService     ocm.ClusterServiceClient
-	activeOperations   []*database.OperationDocument
-	notificationClient *http.Client
-	done               chan struct{}
+	dbClient            database.DBClient
+	lockClient          *database.LockClient
+	clusterService      ocm.ClusterServiceClient
+	notificationClient  *http.Client
+	subscriptions       []string
+	subscriptionsLock   sync.Mutex
+	subscriptionChannel chan string
+	subscriptionWorkers sync.WaitGroup
 }
 
 func NewOperationsScanner(dbClient database.DBClient, ocmConnection *ocmsdk.Connection) *OperationsScanner {
@@ -41,47 +53,88 @@ func NewOperationsScanner(dbClient database.DBClient, ocmConnection *ocmsdk.Conn
 		dbClient:           dbClient,
 		lockClient:         dbClient.GetLockClient(),
 		clusterService:     ocm.ClusterServiceClient{Conn: ocmConnection},
-		activeOperations:   make([]*database.OperationDocument, 0),
 		notificationClient: http.DefaultClient,
-		done:               make(chan struct{}),
+		subscriptions:      make([]string, 0),
 	}
 }
 
+// getInterval parses an environment variable into a time.Duration value.
+// If the environment variable is not defined or its value is invalid,
+// getInternal returns defaultVal.
 func getInterval(envName string, defaultVal time.Duration, logger *slog.Logger) time.Duration {
 	if intervalString, ok := os.LookupEnv(envName); ok {
 		interval, err := time.ParseDuration(intervalString)
 		if err == nil {
 			return interval
 		} else {
-			logger.Warn(fmt.Sprintf("Cannot use %s: %s", envName, err.Error()))
+			logger.Warn(fmt.Sprintf("Cannot use %s: %v", envName, err.Error()))
 		}
 	}
 	return defaultVal
 }
 
-func (s *OperationsScanner) Run(ctx context.Context, logger *slog.Logger) {
-	defer close(s.done)
+// getPositiveInt parses an environment variable into a positive integer.
+// If the environment variable is not defined or its value is invalid,
+// getPositiveInt returns defaultVal.
+func getPositiveInt(envName string, defaultVal int, logger *slog.Logger) int {
+	if intString, ok := os.LookupEnv(envName); ok {
+		positiveInt, err := strconv.Atoi(intString)
+		if err == nil && positiveInt <= 0 {
+			err = errors.New("value must be positive")
+		}
+		if err == nil {
+			return positiveInt
+		} else {
+			logger.Warn(fmt.Sprintf("Cannot use %s: %v", envName, err.Error()))
+		}
+	}
+	return defaultVal
+}
 
+// Run executes the main loop of the OperationsScanner.
+func (s *OperationsScanner) Run(ctx context.Context, logger *slog.Logger) {
 	var interval time.Duration
 
-	interval = getInterval("COSMOS_OPERATIONS_POLL_INTERVAL", defaultCosmosOperationsPollInterval, logger)
-	logger.Info("Polling Cosmos Operations items every " + interval.String())
-	pollDBOperationsTicker := time.NewTicker(interval)
+	interval = getInterval("BACKEND_POLL_INTERVAL_SUBSCRIPTIONS", defaultPollIntervalSubscriptions, logger)
+	logger.Info("Polling subscriptions in Cosmos DB every " + interval.String())
+	collectSubscriptionsTicker := time.NewTicker(interval)
 
-	interval = getInterval("CLUSTER_SERVICE_POLL_INTERVAL", defaultClusterServicePollInterval, logger)
-	logger.Info("Polling Cluster Service every " + interval.String())
-	pollCSOperationsTicker := time.NewTicker(interval)
+	interval = getInterval("BACKEND_POLL_INTERVAL_OPERATIONS", defaultPollIntervalOperations, logger)
+	logger.Info("Polling operations in Cosmos DB every " + interval.String())
+	processSubscriptionsTicker := time.NewTicker(interval)
 
-	// Poll database immediately on startup.
-	s.pollDBOperations(ctx, logger)
+	numWorkers := getPositiveInt("BACKEND_SUBSCRIPTION_CONCURRENCY", defaultSubscriptionConcurrency, logger)
+	logger.Info(fmt.Sprintf("Processing %d subscriptions at a time", numWorkers))
+
+	// Create a buffered channel using worker pool size as a heuristic.
+	s.subscriptionChannel = make(chan string, numWorkers)
+	defer close(s.subscriptionChannel)
+
+	// In this worker pool, each worker processes all operations within
+	// a single Azure subscription / Cosmos DB partition.
+	for i := 0; i < numWorkers; i++ {
+		go func() {
+			defer s.subscriptionWorkers.Done()
+			for subscriptionID := range s.subscriptionChannel {
+				subscriptionLogger := logger.With("subscription_id", subscriptionID)
+				s.withSubscriptionLock(ctx, subscriptionLogger, subscriptionID, func(ctx context.Context) {
+					s.processOperations(ctx, subscriptionID, subscriptionLogger)
+				})
+			}
+		}()
+	}
+	s.subscriptionWorkers.Add(numWorkers)
+
+	// Collect subscriptions immediately on startup.
+	s.collectSubscriptions(ctx, logger)
 
 loop:
 	for {
 		select {
-		case <-pollDBOperationsTicker.C:
-			s.pollDBOperations(ctx, logger)
-		case <-pollCSOperationsTicker.C:
-			s.pollCSOperations(logger)
+		case <-collectSubscriptionsTicker.C:
+			s.collectSubscriptions(ctx, logger)
+		case <-processSubscriptionsTicker.C:
+			s.processSubscriptions(logger)
 		case <-ctx.Done():
 			// break alone just breaks out of select.
 			// Use a label to break out of the loop.
@@ -90,119 +143,145 @@ loop:
 	}
 }
 
+// Join waits for the OperationsScanner to gracefully shut down.
 func (s *OperationsScanner) Join() {
-	<-s.done
+	s.subscriptionWorkers.Wait()
 }
 
-func (s *OperationsScanner) pollDBOperations(ctx context.Context, logger *slog.Logger) {
-	var activeOperations []*database.OperationDocument
+// collectSubscriptions builds an internal list of Azure subscription IDs by
+// querying Cosmos DB.
+func (s *OperationsScanner) collectSubscriptions(ctx context.Context, logger *slog.Logger) {
+	var subscriptions []string
 
-	iterator := s.dbClient.ListAllOperationDocs()
+	iterator := s.dbClient.ListAllSubscriptionDocs()
 
-	for doc := range iterator.Items(ctx) {
-		if !doc.Status.IsTerminal() {
-			activeOperations = append(activeOperations, doc)
+	for subscriptionDoc := range iterator.Items(ctx) {
+		// Unregistered subscriptions should have no active operations,
+		// not even deletes.
+		if subscriptionDoc.Subscription.State != arm.SubscriptionStateUnregistered {
+			subscriptions = append(subscriptions, subscriptionDoc.ID)
 		}
 	}
 
 	err := iterator.GetError()
-	if err == nil {
-		s.activeOperations = activeOperations
-		if len(s.activeOperations) > 0 {
-			logger.Info(fmt.Sprintf("Tracking %d active operations", len(s.activeOperations)))
-		}
-	} else {
-		logger.Error(fmt.Sprintf("Error while paging through Cosmos query results: %s", err.Error()))
-	}
-}
-
-func (s *OperationsScanner) pollCSOperations(logger *slog.Logger) {
-	var activeOperations []*database.OperationDocument
-
-	// We use a separate context here so that if the process receives a
-	// terminate signal, the backend can finish processing an operation
-	// before terminating.
-	//
-	// This is necessary in the absence of database transactions, though
-	// still not foolproof, to try to ensure consistency between resource
-	// and operation documents in Cosmos DB.
-	//
-	// Database transactions would be the preferred solution and we're
-	// working toward that.
-	ctx := context.Background()
-
-	for _, doc := range s.activeOperations {
-		var requeue bool
-		var err error
-
-		opLogger := logger.With(
-			"operation", doc.Request,
-			"operation_id", doc.ID,
-			"resource_id", doc.ExternalID.String(),
-			"internal_id", doc.InternalID.String())
-
-		switch doc.InternalID.Kind() {
-		case cmv1.ClusterKind:
-			requeue, err = s.pollClusterOperation(ctx, opLogger, doc)
-		case cmv1.NodePoolKind:
-			requeue, err = s.pollNodePoolOperation(ctx, opLogger, doc)
-		}
-		if requeue {
-			activeOperations = append(activeOperations, doc)
-		}
-		if err != nil {
-			opLogger.Error(fmt.Sprintf("Error while polling operation '%s': %s", doc.ID, err.Error()))
-		}
-	}
-
-	s.activeOperations = activeOperations
-}
-
-func (s *OperationsScanner) pollClusterOperation(ctx context.Context, logger *slog.Logger, doc *database.OperationDocument) (bool, error) {
-	var requeue bool = true
-
-	clusterStatus, err := s.clusterService.GetCSClusterStatus(ctx, doc.InternalID)
 	if err != nil {
-		var ocmError *ocmerrors.Error
-		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound && doc.Request == database.OperationRequestDelete {
-			err = s.withSubscriptionLock(ctx, logger, doc.ExternalID.SubscriptionID, func(ctx context.Context) error {
-				return s.deleteOperationCompleted(ctx, logger, doc)
-			})
-			if err == nil {
-				requeue = false
+		logger.Error(fmt.Sprintf("Error while paging through Cosmos query results: %v", err.Error()))
+		return
+	}
+
+	s.subscriptionsLock.Lock()
+	defer s.subscriptionsLock.Unlock()
+
+	if len(subscriptions) != len(s.subscriptions) {
+		logger.Info(fmt.Sprintf("Tracking %d active subscriptions", len(subscriptions)))
+	}
+
+	s.subscriptions = subscriptions
+}
+
+// processSubscriptions feeds the internal list of Azure subscription IDs
+// to the worker pool for processing. processSubscriptions may block if the
+// worker pool gets overloaded. The log will indicate if this occurs.
+func (s *OperationsScanner) processSubscriptions(logger *slog.Logger) {
+	// This method may block while feeding subscription IDs to the
+	// worker pool, so take a clone of the subscriptions slice to
+	// iterate over.
+	s.subscriptionsLock.Lock()
+	subscriptions := slices.Clone(s.subscriptions)
+	s.subscriptionsLock.Unlock()
+
+	for _, subscriptionID := range subscriptions {
+		select {
+		case s.subscriptionChannel <- subscriptionID:
+		default:
+			// The channel is full. Push the subscription anyway
+			// but log how long we block for. This will indicate
+			// when the worker pool size needs increased.
+			start := time.Now()
+			s.subscriptionChannel <- subscriptionID
+			logger.Warn(fmt.Sprintf("Subscription processing blocked for %s", time.Since(start)))
+		}
+	}
+}
+
+// processOperations processes all operations in a single Azure subscription.
+func (s *OperationsScanner) processOperations(ctx context.Context, subscriptionID string, logger *slog.Logger) {
+	var numProcessed int
+
+	iterator := s.dbClient.ListOperationDocs(subscriptionID)
+
+	for operationDoc := range iterator.Items(ctx) {
+		if !operationDoc.Status.IsTerminal() {
+			operationLogger := logger.With(
+				"operation", operationDoc.Request,
+				"operation_id", operationDoc.ID,
+				"resource_id", operationDoc.ExternalID.String(),
+				"internal_id", operationDoc.InternalID.String())
+			op := operation{operationDoc.ID, operationDoc, operationLogger}
+
+			switch operationDoc.InternalID.Kind() {
+			case cmv1.ClusterKind:
+				s.pollClusterOperation(ctx, op)
+				numProcessed++
+			case cmv1.NodePoolKind:
+				s.pollNodePoolOperation(ctx, op)
+				numProcessed++
 			}
 		}
-		return requeue, err
 	}
 
-	opStatus, opError, err := convertClusterStatus(clusterStatus, doc.Status)
+	err := iterator.GetError()
 	if err != nil {
-		logger.Warn(err.Error())
-		err = nil
-	} else {
-		err = s.withSubscriptionLock(ctx, logger, doc.ExternalID.SubscriptionID, func(ctx context.Context) error {
-			return s.updateOperationStatus(ctx, logger, doc, opStatus, opError)
-		})
+		logger.Error(fmt.Sprintf("Error while paging through Cosmos query results: %v", err.Error()))
+	}
+}
+
+// pollClusterOperation updates the status of a cluster operation.
+func (s *OperationsScanner) pollClusterOperation(ctx context.Context, op operation) {
+	clusterStatus, err := s.clusterService.GetCSClusterStatus(ctx, op.doc.InternalID)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound && op.doc.Request == database.OperationRequestDelete {
+			err = s.setDeleteOperationAsCompleted(ctx, op)
+			if err != nil {
+				op.logger.Error(fmt.Sprintf("Failed to handle a completed deletion: %v", err))
+			}
+		} else {
+			op.logger.Error(fmt.Sprintf("Failed to get cluster status: %v", err))
+		}
+		return
 	}
 
-	return requeue, err
+	opStatus, opError, err := convertClusterStatus(clusterStatus, op.doc.Status)
+	if err != nil {
+		op.logger.Warn(err.Error())
+		return
+	}
+
+	err = s.updateOperationStatus(ctx, op, opStatus, opError)
+	if err != nil {
+		op.logger.Error(fmt.Sprintf("Failed to update operation status: %v", err))
+	}
 }
 
-func (s *OperationsScanner) pollNodePoolOperation(ctx context.Context, logger *slog.Logger, doc *database.OperationDocument) (bool, error) {
-	var requeue bool = true
+// pollNodePoolOperation updates the status of a node pool operation.
+func (s *OperationsScanner) pollNodePoolOperation(ctx context.Context, op operation) {
 	// FIXME Implement when new OCM API is available.
-	return requeue, nil
 }
 
-func (s *OperationsScanner) withSubscriptionLock(ctx context.Context, logger *slog.Logger, subscriptionID string, fn func(ctx context.Context) error) error {
+// withSubscriptionLock holds a subscription lock while executing the given function.
+// In the event the subscription lock is lost, the context passed to the function will
+// be canceled.
+func (s *OperationsScanner) withSubscriptionLock(ctx context.Context, logger *slog.Logger, subscriptionID string, fn func(ctx context.Context)) {
 	timeout := s.lockClient.GetDefaultTimeToLive()
 	lock, err := s.lockClient.AcquireLock(ctx, subscriptionID, &timeout)
 	if err != nil {
-		return fmt.Errorf("Failed to acquire lock for subscription '%s': %w", subscriptionID, err)
+		logger.Error(fmt.Sprintf("Failed to acquire lock: %v", err))
+		return
 	}
 
 	lockedCtx, stop := s.lockClient.HoldLock(ctx, lock)
-	err = fn(lockedCtx)
+	fn(lockedCtx)
 	lock = stop()
 
 	if lock != nil {
@@ -210,51 +289,51 @@ func (s *OperationsScanner) withSubscriptionLock(ctx context.Context, logger *sl
 		if nonFatalErr != nil {
 			// Failure here is non-fatal but still log the error.
 			// The lock's TTL ensures it will be released eventually.
-			logger.Error(fmt.Sprintf("Failed to release lock for subscription '%s': %v", subscriptionID, nonFatalErr))
+			logger.Warn(fmt.Sprintf("Failed to release lock: %v", nonFatalErr))
 		}
 	}
-
-	return err
 }
 
-func (s *OperationsScanner) deleteOperationCompleted(ctx context.Context, logger *slog.Logger, doc *database.OperationDocument) error {
-	err := s.dbClient.DeleteResourceDoc(ctx, doc.ExternalID)
+// setDeleteOperationAsCompleted updates Cosmos DB to reflect a completed resource deletion.
+func (s *OperationsScanner) setDeleteOperationAsCompleted(ctx context.Context, op operation) error {
+	err := s.dbClient.DeleteResourceDoc(ctx, op.doc.ExternalID)
 	if err != nil {
 		return err
 	}
 
 	// Save a final "succeeded" operation status until TTL expires.
 	const opStatus arm.ProvisioningState = arm.ProvisioningStateSucceeded
-	updated, err := s.dbClient.UpdateOperationDoc(ctx, doc.ID, func(updateDoc *database.OperationDocument) bool {
+	updated, err := s.dbClient.UpdateOperationDoc(ctx, op.id, func(updateDoc *database.OperationDocument) bool {
 		return updateDoc.UpdateStatus(opStatus, nil)
 	})
 	if err != nil {
 		return err
 	}
 	if updated {
-		logger.Info(fmt.Sprintf("Updated Operations container item for '%s' with status '%s'", doc.ID, opStatus))
-		s.maybePostAsyncNotification(ctx, logger, doc)
+		op.logger.Info("Deletion completed")
+		s.maybePostAsyncNotification(ctx, op)
 	}
 
 	return nil
 }
 
-func (s *OperationsScanner) updateOperationStatus(ctx context.Context, logger *slog.Logger, doc *database.OperationDocument, opStatus arm.ProvisioningState, opError *arm.CloudErrorBody) error {
-	updated, err := s.dbClient.UpdateOperationDoc(ctx, doc.ID, func(updateDoc *database.OperationDocument) bool {
+// updateOperationStatus updates Cosmos DB to reflect an updated resource status.
+func (s *OperationsScanner) updateOperationStatus(ctx context.Context, op operation, opStatus arm.ProvisioningState, opError *arm.CloudErrorBody) error {
+	updated, err := s.dbClient.UpdateOperationDoc(ctx, op.id, func(updateDoc *database.OperationDocument) bool {
 		return updateDoc.UpdateStatus(opStatus, opError)
 	})
 	if err != nil {
 		return err
 	}
 	if updated {
-		logger.Info(fmt.Sprintf("Updated Operations container item for '%s' with status '%s'", doc.ID, opStatus))
-		s.maybePostAsyncNotification(ctx, logger, doc)
+		op.logger.Info(fmt.Sprintf("Updated status to '%s'", opStatus))
+		s.maybePostAsyncNotification(ctx, op)
 	}
 
-	updated, err = s.dbClient.UpdateResourceDoc(ctx, doc.ExternalID, func(updateDoc *database.ResourceDocument) bool {
+	_, err = s.dbClient.UpdateResourceDoc(ctx, op.doc.ExternalID, func(updateDoc *database.ResourceDocument) bool {
 		var updated bool
 
-		if doc.ID == updateDoc.ActiveOperationID {
+		if op.id == updateDoc.ActiveOperationID {
 			if opStatus != updateDoc.ProvisioningState {
 				updateDoc.ProvisioningState = opStatus
 				updated = true
@@ -270,24 +349,24 @@ func (s *OperationsScanner) updateOperationStatus(ctx context.Context, logger *s
 	if err != nil {
 		return err
 	}
-	if updated {
-		logger.Info(fmt.Sprintf("Updated Resources container item for '%s' with provisioning state '%s'", doc.ExternalID, opStatus))
-	}
 
 	return nil
 }
 
-func (s *OperationsScanner) maybePostAsyncNotification(ctx context.Context, logger *slog.Logger, doc *database.OperationDocument) {
-	if len(doc.NotificationURI) > 0 {
-		err := s.postAsyncNotification(ctx, doc.NotificationURI)
+// maybePostAsyncNotification attempts to notify ARM of a completed asynchronous
+// operation if the initial request included an "Azure-AsyncNotificationUri" header.
+func (s *OperationsScanner) maybePostAsyncNotification(ctx context.Context, op operation) {
+	if len(op.doc.NotificationURI) > 0 {
+		err := s.postAsyncNotification(ctx, op.doc.NotificationURI)
 		if err == nil {
-			logger.Info(fmt.Sprintf("Posted async notification for operation '%s'", doc.ID))
+			op.logger.Info("Posted async notification")
 		} else {
-			logger.Error(fmt.Sprintf("Failed to post async notification for operation '%s': %s", doc.ID, err.Error()))
+			op.logger.Error(fmt.Sprintf("Failed to post async notification: %v", err.Error()))
 		}
 	}
 }
 
+// postAsyncNotification submits an empty POST request to the given URL.
 func (s *OperationsScanner) postAsyncNotification(ctx context.Context, url string) error {
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	if err != nil {
@@ -307,6 +386,9 @@ func (s *OperationsScanner) postAsyncNotification(ctx context.Context, url strin
 	return nil
 }
 
+// convertClusterStatus attempts to translate a ClusterStatus object from
+// Cluster Service into an ARM provisioning state and, if necessary, a
+// structured OData error.
 func convertClusterStatus(clusterStatus *arohcpv1alpha1.ClusterStatus, current arm.ProvisioningState) (arm.ProvisioningState, *arm.CloudErrorBody, error) {
 	var opStatus arm.ProvisioningState = current
 	var opError *arm.CloudErrorBody

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -79,7 +79,6 @@ type DBClient interface {
 	GetOperationDoc(ctx context.Context, operationID string) (*OperationDocument, error)
 	CreateOperationDoc(ctx context.Context, doc *OperationDocument) error
 	UpdateOperationDoc(ctx context.Context, operationID string, callback func(*OperationDocument) bool) (bool, error)
-	DeleteOperationDoc(ctx context.Context, operationID string) error
 	ListOperationDocs(subscriptionID string) DBClientIterator[OperationDocument]
 	ListAllOperationDocs() DBClientIterator[OperationDocument]
 
@@ -403,22 +402,6 @@ func (d *CosmosDBClient) UpdateOperationDoc(ctx context.Context, operationID str
 	}
 
 	return false, err
-}
-
-// DeleteOperationDoc deletes the asynchronous operation document for the given
-// operation ID from the "operations" container
-func (d *CosmosDBClient) DeleteOperationDoc(ctx context.Context, operationID string) error {
-	// Make sure lookup keys are lowercase.
-	operationID = strings.ToLower(operationID)
-
-	pk := azcosmos.NewPartitionKeyString(operationsPartitionKey)
-
-	_, err := d.operations.DeleteItem(ctx, pk, operationID, nil)
-	if err != nil && !isResponseError(err, http.StatusNotFound) {
-		return fmt.Errorf("failed to delete Operations container item for '%s': %w", operationID, err)
-	}
-
-	return nil
 }
 
 func (d *CosmosDBClient) ListOperationDocs(subscriptionID string) DBClientIterator[OperationDocument] {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -80,7 +80,6 @@ type DBClient interface {
 	CreateOperationDoc(ctx context.Context, doc *OperationDocument) error
 	UpdateOperationDoc(ctx context.Context, operationID string, callback func(*OperationDocument) bool) (bool, error)
 	ListOperationDocs(subscriptionID string) DBClientIterator[OperationDocument]
-	ListAllOperationDocs() DBClientIterator[OperationDocument]
 
 	// GetSubscriptionDoc retrieves a SubscriptionDocument from the database given the subscriptionID.
 	// ErrNotFound is returned if an associated SubscriptionDocument cannot be found.
@@ -420,11 +419,6 @@ func (d *CosmosDBClient) ListOperationDocs(subscriptionID string) DBClientIterat
 	pager := d.operations.NewQueryItemsPager(query, pk, &opt)
 
 	return newQueryItemsIterator[OperationDocument](pager)
-}
-
-func (d *CosmosDBClient) ListAllOperationDocs() DBClientIterator[OperationDocument] {
-	pk := azcosmos.NewPartitionKeyString(operationsPartitionKey)
-	return newQueryItemsIterator[OperationDocument](d.operations.NewQueryItemsPager("SELECT * FROM c", pk, nil))
 }
 
 // GetSubscriptionDoc retreives a subscription document from async DB using the subscription ID

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -237,20 +237,6 @@ func (mr *MockDBClientMockRecorder) GetSubscriptionDoc(ctx, subscriptionID any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubscriptionDoc", reflect.TypeOf((*MockDBClient)(nil).GetSubscriptionDoc), ctx, subscriptionID)
 }
 
-// ListAllOperationDocs mocks base method.
-func (m *MockDBClient) ListAllOperationDocs() database.DBClientIterator[database.OperationDocument] {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAllOperationDocs")
-	ret0, _ := ret[0].(database.DBClientIterator[database.OperationDocument])
-	return ret0
-}
-
-// ListAllOperationDocs indicates an expected call of ListAllOperationDocs.
-func (mr *MockDBClientMockRecorder) ListAllOperationDocs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllOperationDocs", reflect.TypeOf((*MockDBClient)(nil).ListAllOperationDocs))
-}
-
 // ListAllSubscriptionDocs mocks base method.
 func (m *MockDBClient) ListAllSubscriptionDocs() database.DBClientIterator[database.SubscriptionDocument] {
 	m.ctrl.T.Helper()

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -164,20 +164,6 @@ func (mr *MockDBClientMockRecorder) DBConnectionTest(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DBConnectionTest", reflect.TypeOf((*MockDBClient)(nil).DBConnectionTest), ctx)
 }
 
-// DeleteOperationDoc mocks base method.
-func (m *MockDBClient) DeleteOperationDoc(ctx context.Context, operationID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteOperationDoc", ctx, operationID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteOperationDoc indicates an expected call of DeleteOperationDoc.
-func (mr *MockDBClientMockRecorder) DeleteOperationDoc(ctx, operationID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOperationDoc", reflect.TypeOf((*MockDBClient)(nil).DeleteOperationDoc), ctx, operationID)
-}
-
 // DeleteResourceDoc mocks base method.
 func (m *MockDBClient) DeleteResourceDoc(ctx context.Context, resourceID *arm.ResourceID) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### What this PR does

In anticipation of the Cosmos DB containers being merged and partitioned by Azure subscription ID, this PR fully rewrites how the backend finds and processes operation documents in Cosmos DB.

Instead of querying for all operation documents across all Azure subscriptions and processing them serially, the backend now uses a goroutine-based "worker pool" where each worker is responsible for processing operation documents within a single Azure subscription / (soon-to-be) Cosmos DB partition.

Specifically, the backend periodically (every 10 minutes) reads all the items in the [newly-added PartitionKeys container](https://github.com/Azure/ARO-HCP/pull/1189) and builds an internal list of Azure subscription IDs.  Then, on a more frequent cycle (every 10 seconds), it deals this list of subscription IDs out to the pool of worker goroutines through a channel.

Each worker goroutine then [locks the Azure subscription ID its been given](https://github.com/Azure/ARO-HCP/pull/680), queries Cosmos DB for any operation items within that Azure subscription, calls Cluster Service for a cluster or (eventually) node pool status update on each operation, updates or deletes Cosmos DB items as necessary, unlocks the Azure subscription ID, and finally listens to the channel again for the next subscription ID to process.

This dramatically increases the parallelism within the backend without significantly changing the Cluster Service interaction logic.

The polling intervals and worker pool size within the backend may require further tuning.  I've exposed these "tuning knobs" as environment variables (though haven't yet mapped them to a configmap).  Also if the worker pool channel — whose buffer grows with the worker pool size — gets full and starts blocking, we'll get log messages stating so as an indication to re-tune. (We'll probably want metrics for this as well.)

Jira: [ARO-14170 - Merge Cosmos DB containers](https://issues.redhat.com/browse/ARO-14170)

### Special notes for your reviewer

<!-- optional -->
