### PR TITLE
fix(demo): attach service managed identities to the "identities.userAssignedIdentities" field

### DIFF
--- a/demo/03-create-cluster.sh
+++ b/demo/03-create-cluster.sh
@@ -89,6 +89,14 @@ for i in "${!CONTROL_PLANE_IDENTITIES_UAMIS_NAMES[@]}"; do
   )
 done
 
+service_managed_identity_resource_id="${UAMIS_RESOURCE_IDS_PREFIX}/${service_managed_identity_uami_name}"
+IDENTITY_UAMIS_JSON_MAP=$(echo -n "${IDENTITY_UAMIS_JSON_MAP}" | jq \
+    --arg uami_resource_id $service_managed_identity_resource_id \
+    '
+      .[$uami_resource_id] = {}
+    '
+  )
+
 }
 
 create_azure_managed_identities_for_cluster() {


### PR DESCRIPTION
### What this PR does

Attach service managed identities to the "identities.userAssignedIdentities" field

This fixes the newly added validation in the RP which returned an error

```
{
    "error": {
        "message": "must be same as count of OperatorsAuthentication Managed Identities",
        "target": "identity.userAssignedIdentities"
    }
}
```

The fix ensures that all control plane identities + the service identity are copied to the identities.userAssignedIdentities map (as map keys)


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
