### PR TITLE
ensure no deployments are running in svc kv rg

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -121,7 +121,27 @@ region.what-if:
 
 svc:
 	@scripts/cleanup-orphaned-rolebindings.sh $(SVC_RESOURCEGROUP)
-	../templatize.sh $(DEPLOY_ENV) -p svc-pipeline.yaml -P run -c public
+	@./ensure-no-running-deployment.sh $(SVC_RESOURCEGROUP) $(SVC_RG_DEPLOYMENT_NAME)-infra
+	@./ensure-no-running-deployment.sh $(SVC_KV_RESOURCEGROUP) svc-kv-cert-officer
+	az deployment group create \
+		--name $(SVC_RG_DEPLOYMENT_NAME)-infra \
+		--resource-group $(SVC_RESOURCEGROUP) \
+		--template-file templates/svc-infra.bicep \
+		$(PROMPT_TO_CONFIRM) \
+		--parameters \
+			configurations/svc-infra.bicepparam \
+		--parameters \
+			persist=${PERSIST}
+	@./ensure-no-running-deployment.sh $(SVC_RESOURCEGROUP) $(SVC_RG_DEPLOYMENT_NAME)
+	az deployment group create \
+		--name $(SVC_RG_DEPLOYMENT_NAME) \
+		--resource-group $(SVC_RESOURCEGROUP) \
+		--template-file templates/svc-cluster.bicep \
+		$(PROMPT_TO_CONFIRM) \
+		--parameters \
+			configurations/svc-cluster.bicepparam \
+		--parameters \
+			persist=${PERSIST}
 .PHONY: svc
 
 svc.cs-pr-check-msi:


### PR DESCRIPTION
### What this PR does
This change ensures that no deployments are running in the service keyvault resource group before starting the "svc.infra" deployment.  This should fix the error:

```
{"code": "DeploymentActive", "message": "Unable to edit or replace deployment 'svc-kv-cert-officer': previous deployment from '1/30/2025 9:36:11 PM' is still active (expiration time is '2/6/2025 9:36:10 PM'). Please see https://aka.ms/arm-deploy-resources for usage details."}
```

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
