### PR TITLE
ARO-14927: add managed identity role for dev

### DIFF
--- a/dev-infrastructure/templates/mock-identities.bicep
+++ b/dev-infrastructure/templates/mock-identities.bicep
@@ -96,6 +96,15 @@ resource msiCustomRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
     permissions: [
       {
         actions: [
+          'Microsoft.Network/virtualNetworks/read'
+          'Microsoft.Network/virtualNetworks/subnets/read'
+          'Microsoft.Network/virtualNetworks/subnets/write'
+          'Microsoft.Network/routeTables/read'
+          'Microsoft.Network/routeTables/join/action'
+          'Microsoft.Network/natGateways/join/action'
+          'Microsoft.Network/natGateways/read'
+          'Microsoft.Network/networkSecurityGroups/read'
+          'Microsoft.Network/networkSecurityGroups/join/action'
           'Microsoft.ManagedIdentity/userAssignedIdentities/read'
           'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/read'
           'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write'


### PR DESCRIPTION
What this PR does
This adds the permissions for the managed identity role for the dev provisioning process

Jira: [ARO-14927](https://issues.redhat.com/browse/ARO-14927)