### PR TITLE
frontend: add metrics for the CS client

### DIFF
--- a/frontend/cmd/cmd.go
+++ b/frontend/cmd/cmd.go
@@ -144,6 +144,8 @@ func (opts *FrontendOpts) Run() error {
 		}).
 		URL(opts.clustersServiceURL).
 		Insecure(opts.insecure).
+		MetricsSubsystem("frontend_clusters_service_client").
+		MetricsRegisterer(prometheus.DefaultRegisterer).
 		Build()
 	if err != nil {
 		return err

--- a/go.work.sum
+++ b/go.work.sum
@@ -801,6 +801,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
 github.com/golang/glog v1.2.1/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+github.com/golang/glog v1.2.2/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -1814,7 +1815,6 @@ golang.org/x/oauth2 v0.18.0/go.mod h1:Wf7knwG0MPoWIMMBgFlEaSUDaKskp0dCfrlJRJXbBi
 golang.org/x/oauth2 v0.20.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
 golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
-golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
### What this PR does

This PR adds client-side CS metrics by leveraging the built-in support in the OCM client package.

It adds 2 new metrics: `frontend_clusters_service_client_request_count` and `frontend_clusters_service_client_request_duration` (histogram):
````
# HELP frontend_clusters_service_client_request_count Number of requests sent.
# TYPE frontend_clusters_service_client_request_count counter
frontend_clusters_service_client_request_count{apiservice="ocm-v1alpha1",code="200",method="GET",path="/api/aro_hcp/v1alpha1/clusters/-"} 5
# HELP frontend_clusters_service_client_request_duration Request duration in seconds.
# TYPE frontend_clusters_service_client_request_duration histogram
frontend_clusters_service_client_request_duration_bucket{apiservice="ocm-v1alpha1",code="200",method="GET",path="/api/aro_hcp/v1alpha1/clusters/-",le="0.1"} 5
frontend_clusters_service_client_request_duration_bucket{apiservice="ocm-v1alpha1",code="200",method="GET",path="/api/aro_hcp/v1alpha1/clusters/-",le="1"} 5
frontend_clusters_service_client_request_duration_bucket{apiservice="ocm-v1alpha1",code="200",method="GET",path="/api/aro_hcp/v1alpha1/clusters/-",le="10"} 5
frontend_clusters_service_client_request_duration_bucket{apiservice="ocm-v1alpha1",code="200",method="GET",path="/api/aro_hcp/v1alpha1/clusters/-",le="30"} 5
frontend_clusters_service_client_request_duration_bucket{apiservice="ocm-v1alpha1",code="200",method="GET",path="/api/aro_hcp/v1alpha1/clusters/-",le="+Inf"} 5
frontend_clusters_service_client_request_duration_sum{apiservice="ocm-v1alpha1",code="200",method="GET",path="/api/aro_hcp/v1alpha1/clusters/-"} 0.180475056
frontend_clusters_service_client_request_duration_count{apiservice="ocm-v1alpha1",code="200",method="GET",path="/api/aro_hcp/v1alpha1/clusters/-"} 5
````

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
