### PR TITLE
arm: Add NewPagedResponse function

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -166,7 +166,6 @@ func (f *Frontend) ArmResourceList(writer http.ResponseWriter, request *http.Req
 
 	var pageSizeHint int32 = 20
 	var continuationToken *string
-	var pagedResponse arm.PagedResponse
 
 	// The Resource Provider Contract implies $top is only honored when
 	// following a "nextLink" after the initial collection GET request.
@@ -247,6 +246,8 @@ func (f *Frontend) ArmResourceList(writer http.ResponseWriter, request *http.Req
 	}
 	query := fmt.Sprintf("id in (%s)", strings.Join(queryIDs, ", "))
 	logger.Info(fmt.Sprintf("Searching Cluster Service for %q", query))
+
+	pagedResponse := arm.NewPagedResponse()
 
 	switch resourceTypeName {
 	case strings.ToLower(api.ClusterResourceTypeName):

--- a/internal/api/arm/response.go
+++ b/internal/api/arm/response.go
@@ -62,6 +62,11 @@ type PagedResponse struct {
 	NextLink string            `json:"nextLink,omitempty"`
 }
 
+// NewPagedResponse returns a new PagedResponse instance.
+func NewPagedResponse() PagedResponse {
+	return PagedResponse{Value: []json.RawMessage{}}
+}
+
 // AddValue adds a JSON encoded value to a PagedResponse.
 func (r *PagedResponse) AddValue(value json.RawMessage) {
 	r.Value = append(r.Value, value)


### PR DESCRIPTION
### What this PR does

An empty response from a "list items" endpoint used to look like:

```
{
    "value": null
}
```

The [Resource Provider Contract](https://github.com/cloud-and-ai-microsoft/resource-provider-contract/tree/master/v1.0) does not _explicitly_ say this is wrong, but since `value` is normally a list of items I think it would be better to return an empty list:

```
{
    "value": []
}
```

Jira: no Jira, just a bug I noticed

### Special notes for your reviewer

<!-- optional -->
