### PR TITLE
ARO-14927: add custom roles for cpo, kms and capz

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -27,6 +27,7 @@ deploy:
 	OP_FILE_CSI_DRIVER_ROLE_ID=$(shell az role definition list --name "${OP_FILE_CSI_DRIVER_ROLE_NAME}" --query "[].name" -o tsv) && \
 	OP_IMAGE_REGISTRY_DRIVER_ROLE_ID=$(shell az role definition list --name "${OP_IMAGE_REGISTRY_DRIVER_ROLE_NAME}" --query "[].name" -o tsv) && \
 	OP_CLOUD_NETWORK_CONFIG_ROLE_ID=$(shell az role definition list --name "${OP_CLOUD_NETWORK_CONFIG_ROLE_NAME}" --query "[].name" -o tsv) && \
+	OP_KMS_ROLE_ID=$(shell az role definition list --name "${OP_KMS_ROLE_NAME}" --query "[].name" -o tsv) && \
 	ZONE_RESOURCE_ID=$(shell az network dns zone show -n ${ZONE_NAME} -g ${REGIONAL_RESOURCEGROUP} --query id -o tsv) && \
 	CX_SECRETS_KV_URL=$(shell az keyvault show -n ${CX_SECRETS_KV_NAME} -g ${MGMT_RESOURCEGROUP} --query properties.vaultUri -o tsv) && \
 	CX_MI_KV_URL=$(shell az keyvault show -n ${CX_MI_KV_NAME} -g ${MGMT_RESOURCEGROUP} --query properties.vaultUri -o tsv) && \
@@ -80,7 +81,9 @@ deploy:
 	  --set pullBinding.workloadIdentityClientId="$${IMAGE_PULLER_MI_CLIENT_ID}" \
 	  --set pullBinding.workloadIdentityTenantId="$${IMAGE_PULLER_MI_TENANT_ID}" \
 	  --set pullBinding.registry=${ACR_NAME}.azurecr.io \
-	  --set pullBinding.scope=repository:${IMAGE_REPO}:pull
+	  --set pullBinding.scope=repository:${IMAGE_REPO}:pull \
+	  --set azureOperatorsMI.kms.roleName="${OP_KMS_ROLE_NAME}" \
+      --set azureOperatorsMI.kms.roleId="$${OP_KMS_ROLE_ID}"
 
 deploy-pr-env-deps:
 	AZURE_CS_MI_CLIENT_ID=$(shell az identity show -g ${RESOURCEGROUP} -n clusters-service --query clientId -o tsv) && \
@@ -121,6 +124,7 @@ local-azure-operators-managed-identities-config:
 	OP_CONTROL_PLANE_ROLE_ID=$(shell az role definition list --name "${OP_CONTROL_PLANE_ROLE_NAME}" --query "[].name" -o tsv) && \
 	OP_IMAGE_REGISTRY_DRIVER_ROLE_ID=$(shell az role definition list --name "${OP_IMAGE_REGISTRY_DRIVER_ROLE_NAME}" --query "[].name" -o tsv) && \
 	OP_CLOUD_NETWORK_CONFIG_ROLE_ID=$(shell az role definition list --name "${OP_CLOUD_NETWORK_CONFIG_ROLE_NAME}" --query "[].name" -o tsv) && \
+	OP_KMS_ROLE_ID=$(shell az role definition list --name "${OP_KMS_ROLE_NAME}" --query "[].name" -o tsv) && \
 	helm template deploy/helm -s templates/azure-operators-managed-identities-config.configmap.yaml \
 	  --set azureOperatorsMI.cloudControllerManager.roleName="${OP_CLOUD_CONTROLLER_MANAGER_ROLE_NAME}" \
 	  --set azureOperatorsMI.cloudControllerManager.roleId="$${OP_CLOUD_CONTROLLER_MANAGER_ROLE_ID}" \
@@ -138,6 +142,8 @@ local-azure-operators-managed-identities-config:
 	  --set azureOperatorsMI.imageRegistry.roleId="$${OP_IMAGE_REGISTRY_DRIVER_ROLE_ID}" \
 	  --set azureOperatorsMI.cloudNetworkConfig.roleName="${OP_CLOUD_NETWORK_CONFIG_ROLE_NAME}" \
 	  --set azureOperatorsMI.cloudNetworkConfig.roleId="$${OP_CLOUD_NETWORK_CONFIG_ROLE_ID}" \
+	  --set azureOperatorsMI.kms.roleName="${OP_KMS_ROLE_NAME}" \
+	  --set azureOperatorsMI.kms.roleId="$${OP_KMS_ROLE_ID}" \
 	  | yq '.data."azure-operators-managed-identities-config.yaml"' > ./azure-operators-managed-identities-config.yaml
 .PHONY: local-azure-operators-managed-identities-config
 

--- a/cluster-service/deploy/helm/templates/azure-operators-managed-identities-config.configmap.yaml
+++ b/cluster-service/deploy/helm/templates/azure-operators-managed-identities-config.configmap.yaml
@@ -47,6 +47,11 @@ data:
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.cloudNetworkConfig.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.cloudNetworkConfig.roleName }}'
         optional: false
+      kms:
+        minOpenShiftVersion: 4.17
+        azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.kms.roleId }}'
+        azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.kms.roleName }}'
+        optional: false
     dataPlaneOperatorsIdentities:
       disk-csi-driver:
         minOpenShiftVersion: 4.17

--- a/cluster-service/deploy/helm/values.yaml
+++ b/cluster-service/deploy/helm/values.yaml
@@ -297,6 +297,9 @@ azureOperatorsMI:
   cloudNetworkConfig:
     roleName: ''
     roleId: ''
+  kms:
+    roleName: ''
+    roleId: ''
 
 # Pull binding configuration for ACR Pull Operator
 pullBinding:

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -72,6 +72,8 @@ resourceGroups:
       configRef: clusterService.azureOperatorsManagedIdentities.imageRegistry.roleName
     - name: OP_CLOUD_NETWORK_CONFIG_ROLE_NAME
       configRef: clusterService.azureOperatorsManagedIdentities.cloudNetworkConfig.roleName
+    - name: OP_KMS_ROLE_NAME
+      configRef: clusterService.azureOperatorsManagedIdentities.kms.roleName
     - name: ISTO_TAG
       configRef: svc.istio.tag
     - name: MI_NAME

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -171,10 +171,6 @@ clouds:
         imageTag: dca2a71
         imageRepo: app-sre/uhc-clusters-service
         azureOperatorsManagedIdentities:
-          clusterApiAzure:
-            roleName: Contributor
-          controlPlane:
-            roleName: Contributor
           cloudControllerManager:
             roleName: Azure Red Hat OpenShift Cloud Controller Manager Role
           ingress:
@@ -187,6 +183,13 @@ clouds:
             roleName: Azure Red Hat OpenShift Image Registry Operator Role
           cloudNetworkConfig:
             roleName: Azure Red Hat OpenShift Network Operator Role
+          kms:
+            roleName: Key Vault Crypto User
+          # below two are supposed to be replaced with ARO-specific builtin roles
+          clusterApiAzure:
+            roleName: Contributor
+          controlPlane:
+            roleName: Contributor
       hypershiftOperator:
         imageTag: 9aca808
       imageSync:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -240,16 +240,22 @@
               },
               "cloudNetworkConfig": {
                 "$ref": "#/definitions/operatorConfig"
+              },
+              "kms": {
+                "$ref": "#/definitions/operatorConfig"
               }
             },
             "additionalProperties": false,
             "required": [
+              "clusterApiAzure",
+              "controlPlane",
               "cloudControllerManager",
               "ingress",
               "diskCsiDriver",
               "fileCsiDriver",
               "imageRegistry",
-              "cloudNetworkConfig"
+              "cloudNetworkConfig",
+              "kms"
             ]
           }
         },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -187,9 +187,9 @@ clouds:
         imageRepo: app-sre/uhc-clusters-service
         azureOperatorsManagedIdentities:
           clusterApiAzure:
-            roleName: Contributor
+            roleName: Azure Red Hat OpenShift Control Plane Operator Role - Dev
           controlPlane:
-            roleName: Contributor
+            roleName: Azure Red Hat OpenShift Cluster API Role - Dev
           cloudControllerManager:
             roleName: Azure Red Hat OpenShift Cloud Controller Manager - Dev
           ingress:
@@ -202,6 +202,8 @@ clouds:
             roleName: Azure Red Hat OpenShift Image Registry Operator - Dev
           cloudNetworkConfig:
             roleName: Azure Red Hat OpenShift Network Operator - Dev
+          kms:
+            roleName: Azure Red Hat OpenShift KMS Plugin - Dev
       # Hypershift Operator
       hypershiftOperator:
         imageTag: 9aca808

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -16,10 +16,10 @@
         "roleName": "Azure Red Hat OpenShift Network Operator - Dev"
       },
       "clusterApiAzure": {
-        "roleName": "Contributor"
+        "roleName": "Azure Red Hat OpenShift Control Plane Operator Role - Dev"
       },
       "controlPlane": {
-        "roleName": "Contributor"
+        "roleName": "Azure Red Hat OpenShift Cluster API Role - Dev"
       },
       "diskCsiDriver": {
         "roleName": "Azure Red Hat OpenShift Disk Storage Operator - Dev"
@@ -32,6 +32,9 @@
       },
       "ingress": {
         "roleName": "Azure Red Hat OpenShift Cluster Ingress Operator - Dev"
+      },
+      "kms": {
+        "roleName": "Azure Red Hat OpenShift KMS Plugin - Dev"
       }
     },
     "imageRepo": "app-sre/uhc-clusters-service",

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -16,10 +16,10 @@
         "roleName": "Azure Red Hat OpenShift Network Operator - Dev"
       },
       "clusterApiAzure": {
-        "roleName": "Contributor"
+        "roleName": "Azure Red Hat OpenShift Control Plane Operator Role - Dev"
       },
       "controlPlane": {
-        "roleName": "Contributor"
+        "roleName": "Azure Red Hat OpenShift Cluster API Role - Dev"
       },
       "diskCsiDriver": {
         "roleName": "Azure Red Hat OpenShift Disk Storage Operator - Dev"
@@ -32,6 +32,9 @@
       },
       "ingress": {
         "roleName": "Azure Red Hat OpenShift Cluster Ingress Operator - Dev"
+      },
+      "kms": {
+        "roleName": "Azure Red Hat OpenShift KMS Plugin - Dev"
       }
     },
     "imageRepo": "app-sre/uhc-clusters-service",

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -32,6 +32,9 @@
       },
       "ingress": {
         "roleName": "Azure Red Hat OpenShift Cluster Ingress Operator Role"
+      },
+      "kms": {
+        "roleName": "Key Vault Crypto User"
       }
     },
     "imageRepo": "app-sre/uhc-clusters-service",

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -16,10 +16,10 @@
         "roleName": "Azure Red Hat OpenShift Network Operator - Dev"
       },
       "clusterApiAzure": {
-        "roleName": "Contributor"
+        "roleName": "Azure Red Hat OpenShift Control Plane Operator Role - Dev"
       },
       "controlPlane": {
-        "roleName": "Contributor"
+        "roleName": "Azure Red Hat OpenShift Cluster API Role - Dev"
       },
       "diskCsiDriver": {
         "roleName": "Azure Red Hat OpenShift Disk Storage Operator - Dev"
@@ -32,6 +32,9 @@
       },
       "ingress": {
         "roleName": "Azure Red Hat OpenShift Cluster Ingress Operator - Dev"
+      },
+      "kms": {
+        "roleName": "Azure Red Hat OpenShift KMS Plugin - Dev"
       }
     },
     "imageRepo": "app-sre/uhc-clusters-service",

--- a/demo/03-create-cluster.sh
+++ b/demo/03-create-cluster.sh
@@ -164,6 +164,7 @@ main() {
     "file-csi-driver"
     "image-registry"
     "cloud-network-config"
+    "kms"
   )
 
   # data plane operator names required for OCP 4.17.

--- a/dev-infrastructure/configurations/dev-operator-roles.bicepparam
+++ b/dev-infrastructure/configurations/dev-operator-roles.bicepparam
@@ -135,4 +135,59 @@ param roles = [
     ]
     notDataActions: []
   }
+  {
+    roleName: 'Azure Red Hat OpenShift Cluster API Role - Dev'
+    roleDescription: 'Enables permissions to allow cluster API to manage nodes, networks and disks for OpenShift cluster.'
+    actions: [
+      'Microsoft.Authorization/policies/auditIfNotExists/action'
+      'Microsoft.Compute/availabilitySets/delete'
+      'Microsoft.Compute/availabilitySets/read'
+      'Microsoft.Compute/availabilitySets/write'
+      'Microsoft.Compute/disks/delete'
+      'Microsoft.Compute/disks/read'
+      'Microsoft.Compute/disks/write'
+      'Microsoft.Compute/virtualMachines/delete'
+      'Microsoft.Compute/virtualMachines/read'
+      'Microsoft.Compute/virtualMachines/write'
+      'Microsoft.Network/loadBalancers/backendAddressPools/join/action'
+      'Microsoft.Network/networkInterfaces/delete'
+      'Microsoft.Network/networkInterfaces/join/action'
+      'Microsoft.Network/networkInterfaces/read'
+      'Microsoft.Network/networkInterfaces/write'
+      'Microsoft.Network/virtualNetworks/subnets/join/action'
+    ]
+    notActions: []
+    dataActions: []
+    notDataActions: []
+  }
+  {
+    roleName: 'Azure Red Hat OpenShift Control Plane Operator Role - Dev'
+    roleDescription: 'Enables the control plane operator to read resources necessary for OpenShift cluster.'
+    actions: [
+      'Microsoft.Resources/subscriptions/resourceGroups/read'
+      'Microsoft.Network/virtualNetworks/read'
+      'Microsoft.Network/networkSecurityGroups/read'
+    ]
+    notActions: []
+    dataActions: []
+    notDataActions: []
+  }
+  {
+    roleName: 'Azure Red Hat OpenShift KMS Plugin - Dev'
+    roleDescription: 'Enables permissions for the apiserver encryption plugin to access the Azure KeyVault instance from the OpenShift cluster.'
+    actions: []
+    notActions: []
+    dataActions: [
+      'Microsoft.KeyVault/vaults/keys/read'
+      'Microsoft.KeyVault/vaults/keys/update/action'
+      'Microsoft.KeyVault/vaults/keys/backup/action'
+      'Microsoft.KeyVault/vaults/keys/encrypt/action'
+      'Microsoft.KeyVault/vaults/keys/decrypt/action'
+      'Microsoft.KeyVault/vaults/keys/wrap/action'
+      'Microsoft.KeyVault/vaults/keys/unwrap/action'
+      'Microsoft.KeyVault/vaults/keys/sign/action'
+      'Microsoft.KeyVault/vaults/keys/verify/action'
+    ]
+    notDataActions: []
+  }
 ]

--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -382,6 +382,7 @@ Then register it with the Maestro Server
     az identity create -n ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX} -g <resource-group>
     az identity create -n ${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX} -g <resource-group>
     az identity create -n ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX} -g <resource-group>
+    az identity create -n ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX} -g <resource-group>
 
     # And then we create variables containing their Azure resource IDs and export them to be used later
     export CP_CONTROL_PLANE_UAMI=$(az identity show -n ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX} -g <resource-group> | jq -r '.id')
@@ -392,6 +393,7 @@ Then register it with the Maestro Server
     export CP_FILE_CSI_DRIVER_UAMI=$(az identity show -n ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX} -g <resource-group> | jq -r '.id')
     export CP_IMAGE_REGISTRY_UAMI=$(az identity show -n ${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX} -g <resource-group> | jq -r '.id')
     export CP_CNC_UAMI=$(az identity show -n ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX} -g <resource-group> | jq -r '.id')
+    export CP_KMS_UAMI=$(az identity show -n ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX} -g <resource-group> | jq -r '.id')
     ```
 
   - Create the User-Assigned Managed Identities for the Data Plane operators. This assumes OCP 4.17 clusters will be created.
@@ -487,6 +489,9 @@ Then register it with the Maestro Server
               },
               "cloud-network-config": {
                 "resource_id": "$CP_CNC_UAMI"
+              },
+              "kms": {
+                "resource_id": "$CP_KMS_UAMI"
               }
             },
             "data_plane_operators_managed_identities": {
@@ -565,6 +570,7 @@ ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/node_pools/$UID
    az identity delete --ids "${CP_FILE_CSI_DRIVER_UAMI}"
    az identity delete --ids "${CP_IMAGE_REGISTRY_UAMI}"
    az identity delete --ids "${CP_CNC_UAMI}"
+   az identity delete --ids "${CP_KMS_UAMI}"
    az identity delete --ids "${DP_DISK_CSI_DRIVER_UAMI}"
    az identity delete --ids "${DP_IMAGE_REGISTRY_UAMI}"
    az identity delete --ids "${DP_FILE_CSI_DRIVER_UAMI}"


### PR DESCRIPTION
This adds custom roles for control plane operator, KMS and capz. KMS is unused by Hypershift for now, but pre-created to enable the hypershift changes later.

Those custom roles will be replaced by builtin roles for INT after we're done with the onboarding and approval process.

### What this PR does

Jira: ARO-14927
