### PR TITLE
add maestro agent metrics

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -88,6 +88,9 @@ defaults:
     restrictIstioIngress: true
     consumerName: hcp-underlay-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}
     imageBase: quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
+    agentSideCar:
+      imageBase: mcr.microsoft.com/azurelinux/base/nginx
+      imageTag: '1.25'
 
   # Cluster Service
   clusterService:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -632,6 +632,17 @@
               "databaseName"
             ]
           },
+          "agentSideCar":{
+            "type:": "object",
+            "properties": {
+              "imageBase":{
+                "type": "string"
+              },
+              "imageTag":{
+                "type": "string"
+              }
+            }
+          },
           "restrictIstioIngress": {
             "type": "boolean"
           }
@@ -645,7 +656,8 @@
           "imageBase",
           "imageTag",
           "postgres",
-          "restrictIstioIngress"
+          "restrictIstioIngress",
+          "agentSideCar"
         ]
       },
       "mce": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -89,6 +89,9 @@ defaults:
     restrictIstioIngress: true
     consumerName: hcp-underlay-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}
     imageBase: quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
+    agentSideCar:
+      imageBase: mcr.microsoft.com/azurelinux/base/nginx
+      imageTag: '1.25'
 
   pko:
     image: arohcpsvcdev.azurecr.io/package-operator/package-operator-package

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -114,6 +114,10 @@
   },
   "kvCertOfficerPrincipalId": "c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb",
   "maestro": {
+    "agentSideCar": {
+      "imageBase": "mcr.microsoft.com/azurelinux/base/nginx",
+      "imageTag": "1.25"
+    },
     "certDomain": "selfsigned.maestro.keyvault.azure.com",
     "consumerName": "hcp-underlay-cspr-mgmt-1",
     "eventGrid": {

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -114,6 +114,10 @@
   },
   "kvCertOfficerPrincipalId": "c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb",
   "maestro": {
+    "agentSideCar": {
+      "imageBase": "mcr.microsoft.com/azurelinux/base/nginx",
+      "imageTag": "1.25"
+    },
     "certDomain": "selfsigned.maestro.keyvault.azure.com",
     "consumerName": "hcp-underlay-dev-mgmt-1",
     "eventGrid": {

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -114,6 +114,10 @@
   },
   "kvCertOfficerPrincipalId": "32af88de-a61c-4f71-b709-50538598c4f2",
   "maestro": {
+    "agentSideCar": {
+      "imageBase": "mcr.microsoft.com/azurelinux/base/nginx",
+      "imageTag": "1.25"
+    },
     "certDomain": "selfsigned.maestro.keyvault.azure.com",
     "consumerName": "hcp-underlay-int-mgmt-1",
     "eventGrid": {

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -114,6 +114,10 @@
   },
   "kvCertOfficerPrincipalId": "c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb",
   "maestro": {
+    "agentSideCar": {
+      "imageBase": "mcr.microsoft.com/azurelinux/base/nginx",
+      "imageTag": "1.25"
+    },
     "certDomain": "selfsigned.maestro.keyvault.azure.com",
     "consumerName": "hcp-underlay-usw3tst-mgmt-1",
     "eventGrid": {

--- a/maestro/agent/Makefile
+++ b/maestro/agent/Makefile
@@ -16,5 +16,7 @@ deploy:
 		--set azure.clientId=$${MAESTRO_MI_CLIENT_ID} \
 		--set azure.tenantId=$${TENANT_ID} \
 		--set image.base=${IMAGE_BASE} \
-		--set image.tag=${IMAGE_TAG}
+		--set image.tag=${IMAGE_TAG} \
+		--set sideCar.imageBase=${SIDECAR_IMAGE_BASE} \
+		--set sideCar.imageTag=${SIDECAR_IMAGE_TAG}
 .PHONY: deploy

--- a/maestro/agent/helm/templates/maestro-agent.deployment.yaml
+++ b/maestro/agent/helm/templates/maestro-agent.deployment.yaml
@@ -17,7 +17,37 @@ spec:
         checksum/credsstore: {{ include (print $.Template.BasePath "/maestro.secretproviderclass.yaml") . | sha256sum }}
         checksum/config: {{ include (print $.Template.BasePath "/maestro.secret.yaml") . | sha256sum }}
     spec:
+      initContainers:
+      - name: init
+        image: "{{ .Values.sideCar.imageBase }}:{{ .Values.sideCar.imageTag }}"
+        env:
+          - name: TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: metrics-access-token
+                key: token
+        volumeMounts:
+        - name: nginx-config
+          mountPath: /etc/nginx/
+        - name: nginx-config-tmp
+          mountPath: /tmp/nginx/nginx.conf
+          subPath: nginx.conf
+        command:
+          - sh
+          - -c
+          - cp /tmp/nginx/nginx.conf /etc/nginx/nginx.conf && sed -i "s/TOKEN/$TOKEN/g" /etc/nginx/nginx.conf
       containers:
+      - name: metrics-proxy
+        image: "{{ .Values.sideCar.imageBase }}:{{ .Values.sideCar.imageTag }}"
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        volumeMounts:
+        - name: nginx-config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+        command: ["/bin/sh", "-c", "nginx -g 'daemon off;'"]
       - command:
         - /usr/local/bin/maestro
         - agent
@@ -36,6 +66,11 @@ spec:
           readOnly: true
       serviceAccountName: maestro
       volumes:
+      - name: nginx-config-tmp
+        configMap:
+          name: nginx-config
+      - name: nginx-config
+        emptyDir: {}
       - name: maestro
         secret:
           secretName: maestro

--- a/maestro/agent/helm/templates/maestro-agent.podmonitor.yaml
+++ b/maestro/agent/helm/templates/maestro-agent.podmonitor.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: maestro-agent-metrics
+  namespace: maestro
+spec:
+  selector:
+    matchLabels:
+      app: maestro-agent
+  namespaceSelector:
+    matchNames:
+      - maestro
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics
+      scheme: http

--- a/maestro/agent/helm/templates/metrics-access-token.secret.yaml
+++ b/maestro/agent/helm/templates/metrics-access-token.secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metrics-access-token
+  namespace: maestro
+  annotations:
+    kubernetes.io/service-account.name: metrics-proxy-sa
+type: kubernetes.io/service-account-token

--- a/maestro/agent/helm/templates/metrics-proxy.clusterrole.yaml
+++ b/maestro/agent/helm/templates/metrics-proxy.clusterrole.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-proxy-access
+rules:
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get

--- a/maestro/agent/helm/templates/metrics-proxy.clusterrolebinding.yaml
+++ b/maestro/agent/helm/templates/metrics-proxy.clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-proxy-access-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics-proxy-access
+subjects:
+  - kind: ServiceAccount
+    name: metrics-proxy-sa
+    namespace: maestro

--- a/maestro/agent/helm/templates/metrics-proxy.configmap.yaml
+++ b/maestro/agent/helm/templates/metrics-proxy.configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+data:
+  nginx.conf: |
+    worker_processes auto;
+    pid /run/nginx.pid;
+
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+        access_log  /dev/null;
+        error_log  /dev/null;
+
+        server {
+            listen 8080;
+
+            location / {
+                proxy_ssl_verify off;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+                proxy_set_header Authorization "Bearer TOKEN";
+                proxy_pass https://localhost:8443;
+            }
+        }
+    }

--- a/maestro/agent/helm/templates/metrics-proxy.serviceaccount.yaml
+++ b/maestro/agent/helm/templates/metrics-proxy.serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-proxy-sa
+  namespace: maestro
+automountServiceAccountToken: true

--- a/maestro/agent/helm/values.yaml
+++ b/maestro/agent/helm/values.yaml
@@ -12,3 +12,6 @@ credsKeyVault:
   secret: ""
 consumerName: ""
 installAppliedManifestWorkCRD: false
+sideCar:
+  imageBase: ""
+  imageTag: ""

--- a/maestro/agent/pipeline.yaml
+++ b/maestro/agent/pipeline.yaml
@@ -28,3 +28,7 @@ resourceGroups:
       configRef: maestro.imageBase
     - name: IMAGE_TAG
       configRef: maestro.imageTag
+    - name: SIDECAR_IMAGE_BASE
+      configRef: maestro.agentSideCar.imageBase
+    - name: SIDECAR_IMAGE_TAG
+      configRef: maestro.agentSideCar.imageTag


### PR DESCRIPTION
### What this PR does
Adds ability to scrape maestro agent metrics using nginx container source from MCR.
The init pod reads the service account token and copies it into nginx.conf that is then picked up by the metrics-proxy sidecar container.

Why is this needed?  Because Azure Managed Prometheus agent cannot scrape metrics using a token since it incorrectly masks the value AND maestro agent is built on ACM and removing authentication is not an option at this time.

Jira:: https://issues.redhat.com/browse/ARO-10274
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
