### PR TITLE
add missing KV permissions for issuer registration via EV2

### DIFF
--- a/dev-infrastructure/configurations/mgmt-infra.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-infra.tmpl.bicepparam
@@ -15,6 +15,9 @@ param mgmtKeyVaultName = '{{ .mgmtKeyVault.name }}'
 param mgmtKeyVaultPrivate = {{ .mgmtKeyVault.private }}
 param mgmtKeyVaultSoftDelete = {{ .mgmtKeyVault.softDelete }}
 
+// SP for KV certificate issuer registration
+param kvCertOfficerPrincipalId = '{{ .kvCertOfficerPrincipalId }}'
+
 // Cluster Service identity
 // used for Key Vault access
 param clusterServiceMIResourceId = '__clusterServiceMIResourceId__'

--- a/dev-infrastructure/configurations/svc-infra.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-infra.tmpl.bicepparam
@@ -10,4 +10,4 @@ param serviceKeyVaultPrivate = {{ .serviceKeyVault.private }}
 param aroDevopsMsiId = '{{ .aroDevopsMsiId }}'
 
 // SP for KV certificate issuer registration
-param svcKvCertOfficerPrincipalId = '{{ .kvCertOfficerPrincipalId }}'
+param kvCertOfficerPrincipalId = '{{ .kvCertOfficerPrincipalId }}'

--- a/dev-infrastructure/templates/svc-infra.bicep
+++ b/dev-infrastructure/templates/svc-infra.bicep
@@ -13,8 +13,8 @@ param serviceKeyVaultSoftDelete bool = true
 @description('If true, make the service keyvault private and only accessible by the svc cluster via private link.')
 param serviceKeyVaultPrivate bool = true
 
-@description('SVC KV certificate officer principal ID')
-param svcKvCertOfficerPrincipalId string
+@description('KV certificate officer principal ID')
+param kvCertOfficerPrincipalId string
 
 @description('MSI that will be used during pipeline runs to access KVs')
 param aroDevopsMsiId string
@@ -55,7 +55,7 @@ module serviceKeyVaultCertOfficer '../modules/keyvault/keyvault-secret-access.bi
   params: {
     keyVaultName: serviceKeyVaultName
     roleName: 'Key Vault Certificates Officer'
-    managedIdentityPrincipalId: svcKvCertOfficerPrincipalId
+    managedIdentityPrincipalId: kvCertOfficerPrincipalId
   }
   dependsOn: [
     serviceKeyVault
@@ -68,7 +68,7 @@ module serviceKeyVaultSecretsOfficer '../modules/keyvault/keyvault-secret-access
   params: {
     keyVaultName: serviceKeyVaultName
     roleName: 'Key Vault Secrets Officer'
-    managedIdentityPrincipalId: svcKvCertOfficerPrincipalId
+    managedIdentityPrincipalId: kvCertOfficerPrincipalId
   }
   dependsOn: [
     serviceKeyVault


### PR DESCRIPTION
### What this PR does

the `kvCertOfficerPrincipalId` SP requires certificate officer permissions on the CX and MGMT KV for issuer registration

Jira: part of https://issues.redhat.com/browse/ARO-14852
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
