### PR TITLE
Migrate the status client to use the new /arohcp/v1alpha1 endpoints

### DIFF
--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	ocmsdk "github.com/openshift-online/ocm-sdk-go"
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
@@ -306,7 +307,7 @@ func (s *OperationsScanner) postAsyncNotification(ctx context.Context, url strin
 	return nil
 }
 
-func convertClusterStatus(clusterStatus *cmv1.ClusterStatus, current arm.ProvisioningState) (arm.ProvisioningState, *arm.CloudErrorBody, error) {
+func convertClusterStatus(clusterStatus *arohcpv1alpha1.ClusterStatus, current arm.ProvisioningState) (arm.ProvisioningState, *arm.CloudErrorBody, error) {
 	var opStatus arm.ProvisioningState = current
 	var opError *arm.CloudErrorBody
 	var err error
@@ -316,7 +317,7 @@ func convertClusterStatus(clusterStatus *cmv1.ClusterStatus, current arm.Provisi
 	//       ClusterStatus from the "/api/clusters_mgmt/v1" API.
 
 	switch state := clusterStatus.State(); state {
-	case cmv1.ClusterStateError:
+	case arohcpv1alpha1.ClusterStateError:
 		opStatus = arm.ProvisioningStateFailed
 		// FIXME This is guesswork. Need clarity from Cluster Service
 		//       on what provision error codes are possible so we can
@@ -330,13 +331,13 @@ func convertClusterStatus(clusterStatus *cmv1.ClusterStatus, current arm.Provisi
 			message = clusterStatus.Description()
 		}
 		opError = &arm.CloudErrorBody{Code: code, Message: message}
-	case cmv1.ClusterStateInstalling:
+	case arohcpv1alpha1.ClusterStateInstalling:
 		opStatus = arm.ProvisioningStateProvisioning
-	case cmv1.ClusterStateReady:
+	case arohcpv1alpha1.ClusterStateReady:
 		opStatus = arm.ProvisioningStateSucceeded
-	case cmv1.ClusterStateUninstalling:
+	case arohcpv1alpha1.ClusterStateUninstalling:
 		opStatus = arm.ProvisioningStateDeleting
-	case cmv1.ClusterStatePending, cmv1.ClusterStateValidating:
+	case arohcpv1alpha1.ClusterStatePending, arohcpv1alpha1.ClusterStateValidating:
 		// These are valid cluster states for ARO-HCP but there are
 		// no unique ProvisioningState values for them. They should
 		// only occur when ProvisioningState is Accepted.

--- a/backend/operations_scanner_test.go
+++ b/backend/operations_scanner_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -311,7 +311,7 @@ func TestConvertClusterStatus(t *testing.T) {
 
 	tests := []struct {
 		name                     string
-		clusterState             cmv1.ClusterState
+		clusterState             arohcpv1alpha1.ClusterState
 		currentProvisioningState arm.ProvisioningState
 		updatedProvisioningState arm.ProvisioningState
 		expectCloudError         bool
@@ -319,7 +319,7 @@ func TestConvertClusterStatus(t *testing.T) {
 	}{
 		{
 			name:                     "Convert ClusterStateError",
-			clusterState:             cmv1.ClusterStateError,
+			clusterState:             arohcpv1alpha1.ClusterStateError,
 			currentProvisioningState: arm.ProvisioningStateAccepted,
 			updatedProvisioningState: arm.ProvisioningStateFailed,
 			expectCloudError:         true,
@@ -327,7 +327,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		},
 		{
 			name:                     "Convert ClusterStateHibernating",
-			clusterState:             cmv1.ClusterStateHibernating,
+			clusterState:             arohcpv1alpha1.ClusterStateHibernating,
 			currentProvisioningState: arm.ProvisioningStateAccepted,
 			updatedProvisioningState: arm.ProvisioningStateAccepted,
 			expectCloudError:         false,
@@ -335,7 +335,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		},
 		{
 			name:                     "Convert ClusterStateInstalling",
-			clusterState:             cmv1.ClusterStateInstalling,
+			clusterState:             arohcpv1alpha1.ClusterStateInstalling,
 			currentProvisioningState: arm.ProvisioningStateAccepted,
 			updatedProvisioningState: arm.ProvisioningStateProvisioning,
 			expectCloudError:         false,
@@ -343,7 +343,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		},
 		{
 			name:                     "Convert ClusterStatePending (while accepted)",
-			clusterState:             cmv1.ClusterStatePending,
+			clusterState:             arohcpv1alpha1.ClusterStatePending,
 			currentProvisioningState: arm.ProvisioningStateAccepted,
 			updatedProvisioningState: arm.ProvisioningStateAccepted,
 			expectCloudError:         false,
@@ -351,7 +351,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		},
 		{
 			name:                     "Convert ClusterStatePending (while not accepted)",
-			clusterState:             cmv1.ClusterStatePending,
+			clusterState:             arohcpv1alpha1.ClusterStatePending,
 			currentProvisioningState: arm.ProvisioningStateFailed,
 			updatedProvisioningState: arm.ProvisioningStateFailed,
 			expectCloudError:         false,
@@ -359,7 +359,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		},
 		{
 			name:                     "Convert ClusterStatePoweringDown",
-			clusterState:             cmv1.ClusterStatePoweringDown,
+			clusterState:             arohcpv1alpha1.ClusterStatePoweringDown,
 			currentProvisioningState: arm.ProvisioningStateAccepted,
 			updatedProvisioningState: arm.ProvisioningStateAccepted,
 			expectCloudError:         false,
@@ -367,7 +367,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		},
 		{
 			name:                     "Convert ClusterStateReady",
-			clusterState:             cmv1.ClusterStateReady,
+			clusterState:             arohcpv1alpha1.ClusterStateReady,
 			currentProvisioningState: arm.ProvisioningStateAccepted,
 			updatedProvisioningState: arm.ProvisioningStateSucceeded,
 			expectCloudError:         false,
@@ -375,7 +375,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		},
 		{
 			name:                     "Convert ClusterStateResuming",
-			clusterState:             cmv1.ClusterStateResuming,
+			clusterState:             arohcpv1alpha1.ClusterStateResuming,
 			currentProvisioningState: arm.ProvisioningStateAccepted,
 			updatedProvisioningState: arm.ProvisioningStateAccepted,
 			expectCloudError:         false,
@@ -383,7 +383,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		},
 		{
 			name:                     "Convert ClusterStateUninstalling",
-			clusterState:             cmv1.ClusterStateUninstalling,
+			clusterState:             arohcpv1alpha1.ClusterStateUninstalling,
 			currentProvisioningState: arm.ProvisioningStateAccepted,
 			updatedProvisioningState: arm.ProvisioningStateDeleting,
 			expectCloudError:         false,
@@ -391,7 +391,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		},
 		{
 			name:                     "Convert ClusterStateUnknown",
-			clusterState:             cmv1.ClusterStateUnknown,
+			clusterState:             arohcpv1alpha1.ClusterStateUnknown,
 			currentProvisioningState: arm.ProvisioningStateAccepted,
 			updatedProvisioningState: arm.ProvisioningStateAccepted,
 			expectCloudError:         false,
@@ -399,7 +399,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		},
 		{
 			name:                     "Convert ClusterStateValidating (while accepted)",
-			clusterState:             cmv1.ClusterStateValidating,
+			clusterState:             arohcpv1alpha1.ClusterStateValidating,
 			currentProvisioningState: arm.ProvisioningStateAccepted,
 			updatedProvisioningState: arm.ProvisioningStateAccepted,
 			expectCloudError:         false,
@@ -407,7 +407,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		},
 		{
 			name:                     "Convert ClusterStateValidating (while not accepted)",
-			clusterState:             cmv1.ClusterStateValidating,
+			clusterState:             arohcpv1alpha1.ClusterStateValidating,
 			currentProvisioningState: arm.ProvisioningStateFailed,
 			updatedProvisioningState: arm.ProvisioningStateFailed,
 			expectCloudError:         false,
@@ -415,7 +415,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		},
 		{
 			name:                     "Convert ClusterStateWaiting",
-			clusterState:             cmv1.ClusterStateWaiting,
+			clusterState:             arohcpv1alpha1.ClusterStateWaiting,
 			currentProvisioningState: arm.ProvisioningStateAccepted,
 			updatedProvisioningState: arm.ProvisioningStateAccepted,
 			expectCloudError:         false,
@@ -423,7 +423,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		},
 		{
 			name:                     "Convert unexpected cluster state",
-			clusterState:             cmv1.ClusterState("unexpected cluster state"),
+			clusterState:             arohcpv1alpha1.ClusterState("unexpected cluster state"),
 			currentProvisioningState: arm.ProvisioningStateAccepted,
 			updatedProvisioningState: arm.ProvisioningStateAccepted,
 			expectCloudError:         false,
@@ -433,7 +433,7 @@ func TestConvertClusterStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			clusterStatus, err := cmv1.NewClusterStatus().
+			clusterStatus, err := arohcpv1alpha1.NewClusterStatus().
 				State(tt.clusterState).
 				Build()
 			if err != nil {

--- a/go.work.sum
+++ b/go.work.sum
@@ -801,6 +801,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
 github.com/golang/glog v1.2.1/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+github.com/golang/glog v1.2.2/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -1814,7 +1815,6 @@ golang.org/x/oauth2 v0.18.0/go.mod h1:Wf7knwG0MPoWIMMBgFlEaSUDaKskp0dCfrlJRJXbBi
 golang.org/x/oauth2 v0.20.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
 golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
-golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -79,8 +79,8 @@ func (csc *ClusterServiceClient) GetCSCluster(ctx context.Context, internalID In
 }
 
 // GetCSClusterStatus creates and sends a GET request to fetch a cluster's status from Clusters Service
-func (csc *ClusterServiceClient) GetCSClusterStatus(ctx context.Context, internalID InternalID) (*cmv1.ClusterStatus, error) {
-	client, ok := internalID.GetClusterClient(csc.Conn)
+func (csc *ClusterServiceClient) GetCSClusterStatus(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.ClusterStatus, error) {
+	client, ok := internalID.GetAroHCPClusterClient(csc.Conn)
 	if !ok {
 		return nil, fmt.Errorf("OCM path is not a cluster: %s", internalID)
 	}


### PR DESCRIPTION
### What this PR does
Migrates the status endpoint to use the new `arohcp` endpoints dedicated for ARO-HCP.

Jira: https://issues.redhat.com/browse/ARO-14449
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
