### PR TITLE
aks-cluster: remove 3 per-az user agent pools & let azure scale nodes across AZs in a single pool

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -211,11 +211,10 @@ clouds:
                 vmSize: 'Standard_D2s_v3'
                 osDiskSizeGB: 32
               userAgentPool:
-                minCount: 1
+                minCount: 3
                 maxCount: 3
                 vmSize: 'Standard_D2s_v3'
                 osDiskSizeGB: 32
-                azCount: 3
               clusterOutboundIPAddressIPTags: "FirstPartyUsage:/NonProd"
             istio:
               ingressGatewayIPAddressIPTags: "FirstPartyUsage:/NonProd"
@@ -229,11 +228,10 @@ clouds:
                 vmSize: 'Standard_E8s_v3'
                 osDiskSizeGB: 128
               userAgentPool:
-                minCount: 1
+                minCount: 3
                 maxCount: 12
                 vmSize: 'Standard_D16s_v3'
                 osDiskSizeGB: 128
-                azCount: 3
               clusterOutboundIPAddressIPTags: "FirstPartyUsage:/NonProd"
           # DNS
           dns:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -29,9 +29,6 @@
           },
           "vmSize": {
             "type": "string"
-          },
-          "azCount": {
-            "type": "number"
           }
         },
         "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -230,31 +230,28 @@ clouds:
           etcd:
             kvSoftDelete: false
           systemAgentPool:
-            minCount: 1
+            minCount: 3
             maxCount: 3
             vmSize: 'Standard_D2s_v3'
             osDiskSizeGB: 32
           userAgentPool:
-            minCount: 1
+            minCount: 3
             maxCount: 3
             vmSize: 'Standard_D2s_v3'
             osDiskSizeGB: 32
-            azCount: 3
-
       mgmt:
         aks:
           # MGMTM AKS nodepools - big enough for 2 HCPs
           systemAgentPool:
-            minCount: 1
-            maxCount: 4
+            minCount: 3
+            maxCount: 3
             vmSize: 'Standard_D2s_v3'
             osDiskSizeGB: 32
           userAgentPool:
-            minCount: 1
-            maxCount: 6
+            minCount: 3
+            maxCount: 3
             vmSize: 'Standard_D4s_v3'
             osDiskSizeGB: 100
-            azCount: 3
           etcd:
             kvSoftDelete: false
         subscription: ARO Hosted Control Planes (EA Subscription 1)
@@ -282,14 +279,14 @@ clouds:
           mgmt:
             aks:
               systemAgentPool:
-                minCount: 1
-                maxCount: 4
+                minCount: 3
+                maxCount: 3
                 vmSize: 'Standard_E8s_v3'
                 osDiskSizeGB: 128
               # MC AKS nodepools
               # big enough for multiple HCPs
               userAgentPool:
-                minCount: 1
+                minCount: 3
                 maxCount: 3
                 vmSize: 'Standard_D16s_v3'
                 osDiskSizeGB: 128
@@ -312,20 +309,20 @@ clouds:
               # MC AKS nodepools
               # big enough for multiple CS instances during PR checks
               userAgentPool:
-                minCount: 2
+                minCount: 3
                 maxCount: 12
           mgmt:
             aks:
               systemAgentPool:
-                minCount: 1
-                maxCount: 4
+                minCount: 3
+                maxCount: 3
                 vmSize: 'Standard_E8s_v3'
                 osDiskSizeGB: 128
               # MC AKS nodepools
               # big enough for multiple HCPs
               userAgentPool:
-                minCount: 1
-                maxCount: 3
+                minCount: 3
+                maxCount: 9
                 vmSize: 'Standard_D16s_v3'
                 osDiskSizeGB: 128
           # DNS

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -158,15 +158,14 @@
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {
-        "maxCount": 4,
-        "minCount": 1,
+        "maxCount": 3,
+        "minCount": 3,
         "osDiskSizeGB": 128,
         "vmSize": "Standard_E8s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
-        "maxCount": 3,
-        "minCount": 1,
+        "maxCount": 9,
+        "minCount": 3,
         "osDiskSizeGB": 128,
         "vmSize": "Standard_D16s_v3"
       },
@@ -221,14 +220,13 @@
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {
         "maxCount": 3,
-        "minCount": 1,
+        "minCount": 3,
         "osDiskSizeGB": 32,
         "vmSize": "Standard_D2s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 12,
-        "minCount": 2,
+        "minCount": 3,
         "osDiskSizeGB": 32,
         "vmSize": "Standard_D2s_v3"
       },

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -158,15 +158,14 @@
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {
-        "maxCount": 4,
-        "minCount": 1,
+        "maxCount": 3,
+        "minCount": 3,
         "osDiskSizeGB": 128,
         "vmSize": "Standard_E8s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 3,
-        "minCount": 1,
+        "minCount": 3,
         "osDiskSizeGB": 128,
         "vmSize": "Standard_D16s_v3"
       },
@@ -221,14 +220,13 @@
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {
         "maxCount": 3,
-        "minCount": 1,
+        "minCount": 3,
         "osDiskSizeGB": 32,
         "vmSize": "Standard_D2s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 3,
-        "minCount": 1,
+        "minCount": 3,
         "osDiskSizeGB": 32,
         "vmSize": "Standard_D2s_v3"
       },

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -164,9 +164,8 @@
         "vmSize": "Standard_E8s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 12,
-        "minCount": 1,
+        "minCount": 3,
         "osDiskSizeGB": 128,
         "vmSize": "Standard_D16s_v3"
       },
@@ -221,9 +220,8 @@
         "vmSize": "Standard_D2s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 3,
-        "minCount": 1,
+        "minCount": 3,
         "osDiskSizeGB": 32,
         "vmSize": "Standard_D2s_v3"
       },

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -158,15 +158,14 @@
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {
-        "maxCount": 4,
-        "minCount": 1,
+        "maxCount": 3,
+        "minCount": 3,
         "osDiskSizeGB": 32,
         "vmSize": "Standard_D2s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
-        "maxCount": 6,
-        "minCount": 1,
+        "maxCount": 3,
+        "minCount": 3,
         "osDiskSizeGB": 100,
         "vmSize": "Standard_D4s_v3"
       },
@@ -221,14 +220,13 @@
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {
         "maxCount": 3,
-        "minCount": 1,
+        "minCount": 3,
         "osDiskSizeGB": 32,
         "vmSize": "Standard_D2s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 3,
-        "minCount": 1,
+        "minCount": 3,
         "osDiskSizeGB": 32,
         "vmSize": "Standard_D2s_v3"
       },

--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -15,7 +15,6 @@ param aksSystemOsDiskSizeGB = {{ .mgmt.aks.systemAgentPool.osDiskSizeGB }}
 param userAgentMinCount = {{ .mgmt.aks.userAgentPool.minCount }}
 param userAgentMaxCount = {{ .mgmt.aks.userAgentPool.maxCount }}
 param userAgentVMSize = '{{ .mgmt.aks.userAgentPool.vmSize }}'
-param userAgentPoolAZCount = {{ .mgmt.aks.userAgentPool.azCount }}
 param aksUserOsDiskSizeGB = {{ .mgmt.aks.userAgentPool.osDiskSizeGB }}
 param aksClusterOutboundIPAddressIPTags = '{{ .mgmt.aks.clusterOutboundIPAddressIPTags }}'
 

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -19,7 +19,6 @@ param aksSystemOsDiskSizeGB = {{ .svc.aks.systemAgentPool.osDiskSizeGB }}
 param userAgentMinCount = {{ .svc.aks.userAgentPool.minCount }}
 param userAgentMaxCount = {{ .svc.aks.userAgentPool.maxCount }}
 param userAgentVMSize = '{{ .svc.aks.userAgentPool.vmSize }}'
-param userAgentPoolAZCount = {{ .svc.aks.userAgentPool.azCount }}
 param aksUserOsDiskSizeGB = {{ .svc.aks.userAgentPool.osDiskSizeGB }}
 param aksClusterOutboundIPAddressIPTags = '{{ .svc.aks.clusterOutboundIPAddressIPTags }}'
 

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -34,9 +34,6 @@ param userAgentMaxCount int = 3
 @description('VM instance type for the worker nodes')
 param userAgentVMSize string = 'Standard_D2s_v3'
 
-@description('Availability Zone count for worker nodes')
-param userAgentPoolAZCount int = 3
-
 @description('Min replicas for the system nodes')
 param systemAgentMinCount int = 2
 
@@ -120,7 +117,6 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     aksKeyVaultName: aksKeyVaultName
     pullAcrResourceIds: [ocpAcrResourceId, svcAcrResourceId]
     userAgentMinCount: userAgentMinCount
-    userAgentPoolAZCount: userAgentPoolAZCount
     userAgentMaxCount: userAgentMaxCount
     userAgentVMSize: userAgentVMSize
     systemAgentMinCount: systemAgentMinCount

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -31,9 +31,6 @@ param userAgentMaxCount int
 @description('VM instance type for the worker nodes')
 param userAgentVMSize string
 
-@description('Number of availability zones to use for the AKS clusters user agent pool')
-param userAgentPoolAZCount int
-
 @description('The resource ID of the OCP ACR')
 param ocpAcrResourceId string
 
@@ -211,7 +208,6 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     userAgentMinCount: userAgentMinCount
     userAgentMaxCount: userAgentMaxCount
     userAgentVMSize: userAgentVMSize
-    userAgentPoolAZCount: userAgentPoolAZCount
     systemAgentMinCount: systemAgentMinCount
     systemAgentMaxCount: systemAgentMaxCount
     systemAgentVMSize: systemAgentVMSize


### PR DESCRIPTION
### What this PR does

As $SUBJECT:
* Remove the creation of 3 user node pools, each set up on a specific AZ
* Add a single user node pool, configured to span 3 AZs
* Remove `azCount` from configs. All AZ-enabled regions have 3 AZs (1, 2, 3)
* Adjust configs to provision a minimum of 3 nodes for each of system and user node pools in environments where we need the availability. Previously the node count was per node pool (1x3 AZs so 3 total)
* Let Azure handle scaling and distribution across AZs. Azure should keep this balanced as much as possible

Reasons for having multiple node pools are not requirements for us:
* Different workloads on the cluster may require different node SKUs and sizes
* Workloads sensitive to AZ locality
* Complex network configurations

This change will also pave a simpler way to handle deploying to regions that do not support AZs

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
