### PR TITLE
frontend: refactor tracing and logging middlewares

### DIFF
--- a/frontend/pkg/frontend/middleware_correlation.go
+++ b/frontend/pkg/frontend/middleware_correlation.go
@@ -1,0 +1,44 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+// MiddlewareCorrelationData reads the correlation data from the incoming
+// request, extends the contextual logger with correlation attributes and adds
+// the necessary X-ms-* headers to the HTTP response.
+func MiddlewareCorrelationData(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	var (
+		ctx    = r.Context()
+		logger = LoggerFromContext(ctx)
+	)
+
+	correlationData := arm.NewCorrelationData(r)
+	ctx = ContextWithCorrelationData(ctx, correlationData)
+
+	logger = logger.With("request_id", correlationData.RequestID.String())
+	if correlationData.ClientRequestID != "" {
+		logger = logger.With("client_request_id", correlationData.ClientRequestID)
+	}
+
+	if correlationData.CorrelationRequestID != "" {
+		logger = logger.With("correlation_request_id", correlationData.CorrelationRequestID)
+	}
+	ctx = ContextWithLogger(ctx, logger)
+
+	r = r.WithContext(ctx)
+
+	next(w, r)
+
+	w.Header().Set(arm.HeaderNameRequestID, correlationData.RequestID.String())
+	returnClientRequestID := r.Header.Get(arm.HeaderNameReturnClientRequestID)
+	if strings.EqualFold(returnClientRequestID, "true") {
+		w.Header().Set(arm.HeaderNameClientRequestID, correlationData.ClientRequestID)
+	}
+}

--- a/frontend/pkg/frontend/middleware_correlation_test.go
+++ b/frontend/pkg/frontend/middleware_correlation_test.go
@@ -1,0 +1,183 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+func TestMiddlewareCorrelation(t *testing.T) {
+	const (
+		testClientRequestID      = "22222222-2222-2222-2222-222222222222"
+		testCorrelationRequestID = "33333333-3333-3333-3333-333333333333"
+	)
+
+	type headerTest func(*testing.T, http.Header)
+
+	headerValueEqual := func(k, expected string) headerTest {
+		return func(t *testing.T, h http.Header) {
+			t.Helper()
+			if got := h.Get(k); expected != got {
+				t.Fatalf("expected header %q to be %q, got %q", k, expected, got)
+			}
+		}
+	}
+	headerPresent := func(k string) headerTest {
+		return func(t *testing.T, h http.Header) {
+			t.Helper()
+			if got := h.Get(k); got == "" {
+				t.Fatalf("expected header %q to be present, got none", k)
+			}
+		}
+	}
+	headerAbsent := func(k string) headerTest {
+		return func(t *testing.T, h http.Header) {
+			t.Helper()
+			if got := h.Get(k); got != "" {
+				t.Fatalf("expected header %q to be absent, got %q", k, got)
+			}
+		}
+	}
+
+	type testCase struct {
+		name string
+		r    http.Request
+
+		expectedHeaders         []headerTest
+		expectedCorrelationID   string
+		expectedClientRequestID string
+	}
+
+	tests := []testCase{
+		{
+			name: "should set the request ID header",
+			r:    http.Request{},
+			expectedHeaders: []headerTest{
+				headerPresent(arm.HeaderNameRequestID),
+				headerAbsent(arm.HeaderNameClientRequestID),
+			},
+		},
+		{
+			name: "should set the clientRequestId header when the 'should return client request id' header is true",
+			r: http.Request{
+				Header: http.Header{
+					arm.HeaderNameClientRequestID:       []string{testClientRequestID},
+					arm.HeaderNameCorrelationRequestID:  []string{testCorrelationRequestID},
+					arm.HeaderNameReturnClientRequestID: []string{"true"},
+				},
+			},
+			expectedHeaders: []headerTest{
+				headerPresent(arm.HeaderNameRequestID),
+				headerValueEqual(arm.HeaderNameClientRequestID, testClientRequestID),
+			},
+			expectedCorrelationID:   testCorrelationRequestID,
+			expectedClientRequestID: testClientRequestID,
+		},
+		{
+			name: "should not set the clientRequestId header when the 'should return client request id' header is false",
+			r: http.Request{
+				Header: http.Header{
+					arm.HeaderNameClientRequestID:       []string{testClientRequestID},
+					arm.HeaderNameCorrelationRequestID:  []string{testCorrelationRequestID},
+					arm.HeaderNameReturnClientRequestID: []string{"false"},
+				},
+			},
+			expectedHeaders: []headerTest{
+				headerPresent(arm.HeaderNameRequestID),
+				headerAbsent(arm.HeaderNameClientRequestID),
+			},
+			expectedCorrelationID:   testCorrelationRequestID,
+			expectedClientRequestID: testClientRequestID,
+		},
+		{
+			name: "should not set the clientRequestId header when the 'should return client request id' header is missing",
+			r: http.Request{
+				Header: http.Header{
+					arm.HeaderNameClientRequestID:      []string{testClientRequestID},
+					arm.HeaderNameCorrelationRequestID: []string{testCorrelationRequestID},
+				},
+			},
+			expectedHeaders: []headerTest{
+				headerPresent(arm.HeaderNameRequestID),
+				headerAbsent(arm.HeaderNameClientRequestID),
+			},
+			expectedCorrelationID:   testCorrelationRequestID,
+			expectedClientRequestID: testClientRequestID,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				writer = httptest.NewRecorder()
+				req    = &tt.r
+				buf    bytes.Buffer
+				logger = slog.New(slog.NewTextHandler(&buf, nil))
+				data   *arm.CorrelationData
+			)
+			req = req.WithContext(ContextWithLogger(req.Context(), logger))
+
+			next := func(w http.ResponseWriter, r *http.Request) {
+				var err error
+				// Capture the correlation data from the context.
+				if data, err = CorrelationDataFromContext(r.Context()); err != nil {
+					t.Logf("err: %s", err)
+				}
+
+				logger := LoggerFromContext(r.Context())
+				// Emit a log message to check that it includes the correlation attributes.
+				logger.Info("test")
+				w.WriteHeader(http.StatusOK)
+			}
+
+			MiddlewareCorrelationData(writer, req, next)
+
+			// Check that the expected headers are sent.
+			for _, headerTest := range tt.expectedHeaders {
+				headerTest(t, writer.Header())
+			}
+
+			// Check that the correlation data was found in the next handler.
+			assert.NotNil(t, data)
+			if data.RequestID.String() == "" {
+				t.Fatalf("got empty request ID in the context")
+			}
+
+			if data.CorrelationRequestID != tt.expectedCorrelationID {
+				t.Fatalf("expected correlation ID %q, got %q", tt.expectedCorrelationID, data.CorrelationRequestID)
+			}
+
+			if data.ClientRequestID != tt.expectedClientRequestID {
+				t.Fatalf("expected client request ID %q, got %q", tt.expectedClientRequestID, data.ClientRequestID)
+			}
+
+			// Check that the contextual logger had the expected attributes.
+			lines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
+			assert.Equal(t, 1, len(lines))
+
+			line := string(lines[0])
+			assert.Contains(t, line, " request_id=")
+
+			if tt.expectedCorrelationID != "" {
+				assert.Contains(t, line, tt.expectedCorrelationID)
+			} else {
+				assert.NotContains(t, line, " correlation_request_id=")
+			}
+
+			if tt.expectedClientRequestID != "" {
+				assert.Contains(t, line, tt.expectedClientRequestID)
+			} else {
+				assert.NotContains(t, line, " client_request_id=")
+			}
+		})
+	}
+}

--- a/frontend/pkg/frontend/middleware_logging_test.go
+++ b/frontend/pkg/frontend/middleware_logging_test.go
@@ -1,74 +1,19 @@
 package frontend
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
+	"strings"
 	"testing"
-	"time"
 
-	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 
-	"github.com/Azure/ARO-HCP/frontend/pkg/util"
 	"github.com/Azure/ARO-HCP/internal/api"
-	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
-
-const (
-	client_request_id             = "random_client_request_id"
-	correlation_request_id string = "random_correlation_request_id"
-)
-
-func TestMiddlewareLoggingPostMux(t *testing.T) {
-	type testCase struct {
-		name   string
-		header http.Header
-	}
-
-	tt := testCase{
-		name: "is able to process and forward the values from request's header to context",
-		header: http.Header{
-			arm.HeaderNameClientRequestID:      []string{client_request_id},
-			arm.HeaderNameCorrelationRequestID: []string{correlation_request_id},
-			arm.HeaderNameRequestID:            []string{uuid.NewString()},
-		},
-	}
-
-	t.Run(tt.name, func(t *testing.T) {
-		request, err := http.NewRequest(http.MethodGet, "", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		request.Header = tt.header
-
-		// we assume the request carries a logger, we set it explicitly to not fail
-		ctx := ContextWithLogger(request.Context(), util.DefaultLogger())
-		request = request.WithContext(ctx)
-
-		next := func(w http.ResponseWriter, r *http.Request) {
-			request = r // capture modified request
-			w.WriteHeader(http.StatusOK)
-		}
-
-		writer := httptest.NewRecorder()
-		MiddlewareLoggingPostMux(writer, request, next)
-
-		result, err := CorrelationDataFromContext(request.Context())
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if result.ClientRequestID != client_request_id {
-			t.Fatalf("ClientRequestID from header was not propperly propagated to requestcontext, expected %v, but got %v",
-				client_request_id,
-				result.ClientRequestID)
-		}
-	})
-
-}
 
 // ReqPathModifier is an alias to a function that receives a request
 // and it should modify its Path value as needed, for testing purposes.
@@ -79,30 +24,13 @@ func noModifyReqfunc(req *http.Request) {
 	// empty on purpose
 }
 
-func Test_getLogAttrs(t *testing.T) {
-	var expectedRequestID = uuid.New()
-
+func TestMiddlewareLoggingPostMux(t *testing.T) {
 	fakeSubscriptionId := "the_subscription_id"
 	fakeResourceGroupName := "the_resource_group_name"
 	fakeResourceName := "the_resource_name"
 
-	sampleCorrelationData := &arm.CorrelationData{
-		RequestID:            expectedRequestID,
-		ClientRequestID:      client_request_id,
-		CorrelationRequestID: correlation_request_id,
-		RequestTime:          time.Now(),
-	}
-
-	commonAttrs := []slog.Attr{
-		slog.String("request_id", expectedRequestID.String()),
-		slog.String("client_request_id", client_request_id),
-		slog.String("correlation_request_id", correlation_request_id),
-	}
-
 	type testCase struct {
 		name            string
-		correlationData *arm.CorrelationData
-		req             *http.Request
 		want            []slog.Attr
 		setReqPathValue ReqPathModifier
 	}
@@ -110,44 +38,33 @@ func Test_getLogAttrs(t *testing.T) {
 	tests := []testCase{
 		{
 			name:            "handles the common logging attributes",
-			correlationData: sampleCorrelationData,
-			req:             &http.Request{},
-			want:            commonAttrs,
+			want:            []slog.Attr{},
 			setReqPathValue: noModifyReqfunc,
 		},
 		{
-			name:            "handles the common attributes and the attributes for the subscription_id segment path",
-			correlationData: sampleCorrelationData,
-			req:             &http.Request{},
-			want:            append(commonAttrs, slog.String("subscription_id", fakeSubscriptionId)),
+			name: "handles the common attributes and the attributes for the subscription_id segment path",
+			want: []slog.Attr{slog.String("subscription_id", fakeSubscriptionId)},
 			setReqPathValue: func(req *http.Request) {
 				req.SetPathValue(PathSegmentSubscriptionID, fakeSubscriptionId)
 			},
 		},
 		{
-			name:            "handles the common attributes and the attributes for the resourcegroupname path",
-			correlationData: sampleCorrelationData,
-			req:             &http.Request{},
-			want:            append(commonAttrs, slog.String("resource_group", fakeResourceGroupName)),
+			name: "handles the common attributes and the attributes for the resourcegroupname path",
+			want: []slog.Attr{slog.String("resource_group", fakeResourceGroupName)},
 			setReqPathValue: func(req *http.Request) {
 				req.SetPathValue(PathSegmentResourceGroupName, fakeResourceGroupName)
 			},
 		},
 		{
-			name:            "handles the common attributes and the attributes for the resourcegroupname path",
-			correlationData: sampleCorrelationData,
-			req:             &http.Request{},
-			want:            append(commonAttrs, slog.String("resource_group", fakeResourceGroupName)),
+			name: "handles the common attributes and the attributes for the resourcegroupname path",
+			want: []slog.Attr{slog.String("resource_group", fakeResourceGroupName)},
 			setReqPathValue: func(req *http.Request) {
 				req.SetPathValue(PathSegmentResourceGroupName, fakeResourceGroupName)
 			},
 		},
 		{
-			name:            "handles the common attributes and the attributes for the resourcename path, and produces the correct resourceID attribute",
-			correlationData: sampleCorrelationData,
-			req:             &http.Request{},
-			want: append(
-				commonAttrs,
+			name: "handles the common attributes and the attributes for the resourcename path, and produces the correct resourceID attribute",
+			want: []slog.Attr{
 				slog.String("subscription_id", fakeSubscriptionId),
 				slog.String("resource_group", fakeResourceGroupName),
 				slog.String("resource_name", fakeResourceName),
@@ -159,7 +76,7 @@ func Test_getLogAttrs(t *testing.T) {
 						fakeResourceGroupName,
 						api.ClusterResourceType,
 						fakeResourceName)),
-			),
+			},
 			setReqPathValue: func(req *http.Request) {
 				// assuming the PathSegmentResourceName is present in the Path
 				req.SetPathValue(PathSegmentResourceName, fakeResourceName)
@@ -175,101 +92,34 @@ func Test_getLogAttrs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.setReqPathValue(tt.req)
-			got := getLogAttrs(tt.correlationData, tt.req)
-			if !reflect.DeepEqual(tt.want, got) {
-				t.Errorf("want %v, but got %v", tt.want, got)
+			var (
+				writer = httptest.NewRecorder()
+				buf    bytes.Buffer
+				logger = slog.New(slog.NewTextHandler(&buf, nil))
+			)
+
+			ctx := ContextWithLogger(context.Background(), logger)
+			req, err := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+			assert.NoError(t, err)
+			tt.setReqPathValue(req)
+
+			next := func(w http.ResponseWriter, r *http.Request) {
+				logger := LoggerFromContext(r.Context())
+				// Emit a log message to check that it includes the expected attributes.
+				logger.Info("test")
+				w.WriteHeader(http.StatusOK)
+			}
+
+			MiddlewareLoggingPostMux(writer, req, next)
+
+			// Check that the contextual logger has the expected attributes.
+			lines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
+			assert.Equal(t, 1, len(lines))
+
+			line := string(lines[0])
+			for _, attr := range tt.want {
+				assert.Contains(t, line, attr.String())
 			}
 		})
-	}
-}
-
-func Test_setHeaders(t *testing.T) {
-	var expectedRequestId = uuid.New()
-	const expectedClientRequestId = "the_client_request_id"
-
-	type testCase struct {
-		name            string
-		w               http.ResponseWriter
-		r               *http.Request
-		correlationData *arm.CorrelationData
-		expectedHeaders http.Header
-	}
-
-	tests := []testCase{
-		{
-			name:            "should set the requestId header to the value of correlation data",
-			w:               &httptest.ResponseRecorder{},
-			r:               &http.Request{},
-			correlationData: &arm.CorrelationData{RequestID: expectedRequestId},
-			expectedHeaders: http.Header{
-				arm.HeaderNameRequestID: []string{expectedRequestId.String()},
-			},
-		},
-		{
-			name: "should set the clientRequestId header to the value of correlation data when the 'should return client request id' header is true",
-			w:    &httptest.ResponseRecorder{},
-			r: &http.Request{
-				Header: http.Header{
-					arm.HeaderNameReturnClientRequestID: []string{"true"},
-				},
-			},
-			correlationData: &arm.CorrelationData{
-				RequestID:       expectedRequestId,
-				ClientRequestID: expectedClientRequestId,
-			},
-			expectedHeaders: http.Header{
-				arm.HeaderNameRequestID:       []string{expectedRequestId.String()},
-				arm.HeaderNameClientRequestID: []string{expectedClientRequestId},
-			},
-		},
-		{
-			name: "should not set the clientRequestId header to the value of correlation data when the 'should return client request id' header is false",
-			w:    &httptest.ResponseRecorder{},
-			r: &http.Request{
-				Header: http.Header{
-					arm.HeaderNameReturnClientRequestID: []string{"false"},
-				},
-			},
-			correlationData: &arm.CorrelationData{
-				RequestID:       expectedRequestId,
-				ClientRequestID: expectedClientRequestId,
-			},
-			expectedHeaders: http.Header{
-				arm.HeaderNameRequestID: []string{expectedRequestId.String()},
-			},
-		},
-		{
-			name: "should not set the clientRequestId header to the value from correlation data when header is empty",
-			w:    &httptest.ResponseRecorder{},
-			r:    &http.Request{},
-			correlationData: &arm.CorrelationData{
-				RequestID:       expectedRequestId,
-				ClientRequestID: expectedClientRequestId,
-			},
-			expectedHeaders: http.Header{
-				arm.HeaderNameRequestID: []string{expectedRequestId.String()},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			setHeaders(tt.w, tt.r, tt.correlationData)
-			assertAllHeadersAreWritten(t, tt.expectedHeaders, tt.w)
-		})
-	}
-}
-
-// assertAllHeadersAreWritten asserts that all the headers h are written in w
-func assertAllHeadersAreWritten(t *testing.T, h http.Header, w http.ResponseWriter) {
-	for expectedKey, expectedValues := range h {
-		valueInHeader := w.Header().Get(expectedKey)
-		if valueInHeader == "" {
-			t.Fatalf("header with key %v is not present in response writer\n", expectedKey)
-		}
-
-		if valueInHeader != expectedValues[0] {
-			t.Fatalf("header with key %v and value %v is different than expected value %v in response writer\n", expectedKey, valueInHeader, expectedValues[0])
-		}
 	}
 }

--- a/frontend/pkg/frontend/middleware_tracing.go
+++ b/frontend/pkg/frontend/middleware_tracing.go
@@ -16,24 +16,47 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
 
-// MiddlewareTracing starts a span wrapping all incoming HTTP requests.
-// Other middlwares or actual request handlers can extend its metadata or create
-// their own associated spans.
+// MiddlewareTracing starts an OpenTelemetry span wrapping all incoming HTTP
+// requests. Other middlewares or actual request handlers can extend its
+// metadata or create their own associated spans.
+// The middleware expects that the trace provider is initialized and configured
+// in advance.
 func MiddlewareTracing(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	otelhttp.NewHandler(http.Handler(next), fmt.Sprintf("HTTP %s", r.Method)).ServeHTTP(w, r)
+	otelhttp.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var (
+			ctx    = r.Context()
+			logger = LoggerFromContext(ctx)
+		)
+
+		data, err := CorrelationDataFromContext(ctx)
+		if err != nil {
+			span := trace.SpanFromContext(ctx)
+			span.RecordError(err)
+			logger.ErrorContext(ctx, "failed to find correlation data in context", "error", err)
+			next(w, r)
+			return
+		}
+
+		r = r.WithContext(
+			addCorrelationDataToSpanContext(ctx, data),
+		)
+
+		next(w, r)
+	}), fmt.Sprintf("HTTP %s", r.Method)).ServeHTTP(w, r)
 }
 
-// ContextWithTraceCorrelationData adds correlationData as attributes to a propagated span.
-// It also registers a baggage with correlation data to the context.
-// If the context does not maintain a span, it has no effect.
-func ContextWithTraceCorrelationData(ctx context.Context, data *arm.CorrelationData) context.Context {
-	logger := LoggerFromContext(ctx)
-	// NOTE: Here the middleware span is extended by further attributes.
-	// If the tracingMiddleware is not registered, this lines will have no effect.
-	span := trace.SpanFromContext(ctx)
+// addCorrelationDataToSpanContext adds the correlation data as attributes to
+// the propagated span. It also adds correlation data to the span's baggage
+// which is propagated to the downstream services (e.g. Clusters Service). If
+// the context does not maintain a span, the function has no effect.
+func addCorrelationDataToSpanContext(ctx context.Context, data *arm.CorrelationData) context.Context {
+	var (
+		logger = LoggerFromContext(ctx)
+		span   = trace.SpanFromContext(ctx)
+	)
+
 	// Calling New() without any member never returns an error.
 	bag, _ := baggage.New()
-
 	for _, e := range []struct {
 		name  string
 		value string
@@ -51,16 +74,22 @@ func ContextWithTraceCorrelationData(ctx context.Context, data *arm.CorrelationD
 			value: data.RequestID.String(),
 		},
 	} {
+		if e.value == "" {
+			continue
+		}
+
 		span.SetAttributes(attribute.String(e.name, e.value))
 
 		m, err := baggage.NewMemberRaw(e.name, e.value)
 		if err != nil {
-			fmtStr := "unable to create baggage member %q"
-			span.RecordError(fmt.Errorf(fmtStr+": %w", e.name, err))
-			logger.ErrorContext(ctx, fmt.Sprintf(fmtStr, e.name), "error", err)
+			msg := fmt.Sprintf("unable to create baggage member %q", e.name)
+			span.RecordError(fmt.Errorf("%s: %w", msg, err))
+			logger.ErrorContext(ctx, msg, "error", err)
+
 			continue
 		}
 
+		// SetMember will only return an error if m is uninitialized.
 		bag, _ = bag.SetMember(m)
 	}
 

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -45,6 +45,7 @@ func (f *Frontend) routes() *MiddlewareMux {
 
 	mux := NewMiddlewareMux(
 		MiddlewarePanic,
+		MiddlewareCorrelationData,
 		MiddlewareTracing,
 		MiddlewareLogging,
 		// NOTE: register panic middlware twice.

--- a/internal/api/arm/correlation.go
+++ b/internal/api/arm/correlation.go
@@ -27,7 +27,7 @@ type CorrelationData struct {
 }
 
 // NewCorrelationData allocates and initializes a new CorrelationData from
-// HTTP request headers
+// HTTP request headers.
 func NewCorrelationData(r *http.Request) *CorrelationData {
 	return &CorrelationData{
 		RequestID:            uuid.New(),


### PR DESCRIPTION
### What this PR does

This change adds a new middleware (MiddlewareCorrelation) which is responsible for populating the correlation data into the incoming request's context. The rationale is that both logging and tracing middlewares rely on the correlation data and it's easier to have a single middleware responsible for it.

The commit also refactors the existing unit tests to exercise the middlewares rather than the inner functions.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
