### PR TITLE
frontend: Better handle listing node pools on missing cluster

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -264,7 +264,11 @@ func (f *Frontend) ArmResourceList(writer http.ResponseWriter, request *http.Req
 		resourceDoc, err = f.dbClient.GetResourceDoc(ctx, prefix)
 		if err != nil {
 			logger.Error(err.Error())
-			arm.WriteInternalServerError(writer)
+			if errors.Is(err, database.ErrNotFound) {
+				arm.WriteResourceNotFoundError(writer, prefix)
+			} else {
+				arm.WriteInternalServerError(writer)
+			}
 			return
 		}
 


### PR DESCRIPTION
### What this PR does

When attempting to list node pools for a nonexistent cluster,
```
$ curl --silent --referer http://localhost:8443 --request GET \
"localhost:8443/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/dev-test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/no-such-cluster/nodePools?api-version=2024-06-10-preview"
```
the RP used to respond with:
```json
{
    "error": {
        "code": "InternalServerError",
        "message": "Internal server error."
    }
}
```
it now responds with
```json
{
    "error": {
        "code": "ResourceNotFound",
        "message": "The resource 'hcpOpenShiftClusters/no-such-cluster' under resource group 'dev-test-rg' was not found.",
        "target": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/dev-test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/no-such-cluster"
    }
}
```

Jira: fixes a test case in QE bug https://issues.redhat.com/browse/ARO-9860

### Special notes for your reviewer
