### PR TITLE
update oc-mirror to 4.18 and use v2 configuration schema

### DIFF
--- a/dev-infrastructure/templates/image-sync.bicep
+++ b/dev-infrastructure/templates/image-sync.bicep
@@ -299,13 +299,7 @@ resource componentSyncJob 'Microsoft.App/jobs@2024-03-01' = if (componentSyncEna
 
 var ocpMirrorConfig = {
   kind: 'ImageSetConfiguration'
-  apiVersion: 'mirror.openshift.io/v1alpha2'
-  storageConfig: {
-    registry: {
-      imageURL: '${ocpAcrName}${environment().suffixes.acrLoginServer}/mirror/oc-mirror-metadata'
-      skipTLS: false
-    }
-  }
+  apiVersion: 'mirror.openshift.io/v2alpha1'
   mirror: {
     platform: {
       architectures: ['multi', 'amd64', 'arm64']

--- a/image-sync/oc-mirror/Dockerfile
+++ b/image-sync/oc-mirror/Dockerfile
@@ -6,7 +6,7 @@ RUN set -eux; \
     tdnf -y install unzip wget tar ca-certificates; \
     tdnf clean all
 
-ENV OC_VERSION=4.16.3
+ENV OC_VERSION=4.18.0-rc.7
 ENV YQ_VERSION=v4.2.0
 
 RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz -o oc.tar.gz  && \

--- a/image-sync/oc-mirror/Makefile
+++ b/image-sync/oc-mirror/Makefile
@@ -40,7 +40,7 @@ ocp-dry-run: image
 		-e XDG_RUNTIME_DIR=/ \
 		-v ${AUTH_FILE}:/containers/auth.json:z \
 		-v ${HOME}/.azure:/root/.azure:z \
-		-e IMAGE_SET_CONFIG=$(shell cat ${PWD}/test/acm-image-set-config.yml | base64) \
+		-e IMAGE_SET_CONFIG=$(shell cat ${PWD}/test/ocp-image-set-config.yml | base64) \
 		-e REGISTRY=${ARO_HCP_OCP_IMAGE_ACR} \
 		-e REGISTRY_URL=${ARO_HCP_OCP_IMAGE_ACR_URL} \
 		${OC_MIRROR_IMAGE_TAGGED} --dry-run

--- a/image-sync/oc-mirror/test/ocp-image-set-config.yml
+++ b/image-sync/oc-mirror/test/ocp-image-set-config.yml
@@ -1,22 +1,31 @@
 kind: ImageSetConfiguration
-apiVersion: mirror.openshift.io/v1alpha2
-storageConfig:
-  registry:
-    imageURL: arohcpocpdev.azurecr.io/mirror/oc-mirror-metadata
-    skipTLS: false
+apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   platform:
     architectures:
       - multi
       - amd64
+      - arm64
     channels:
       - name: stable-4.17
         minVersion: 4.17.0
         maxVersion: 4.17.0
         type: ocp
+      - name: candidate-4.18
+        minVersion: 4.18.0-rc.6
+        full: true
+        type: ocp
     graph: true
   additionalImages:
+  - name: registry.redhat.io/redhat/redhat-operator-index:v4.16
+  - name: registry.redhat.io/redhat/certified-operator-index:v4.16
+  - name: registry.redhat.io/redhat/community-operator-index:v4.16
+  - name: registry.redhat.io/redhat/redhat-marketplace-index:v4.16
   - name: registry.redhat.io/redhat/redhat-operator-index:v4.17
   - name: registry.redhat.io/redhat/certified-operator-index:v4.17
   - name: registry.redhat.io/redhat/community-operator-index:v4.17
   - name: registry.redhat.io/redhat/redhat-marketplace-index:v4.17
+  - name: registry.redhat.io/redhat/redhat-operator-index:v4.18
+  - name: registry.redhat.io/redhat/certified-operator-index:v4.18
+  - name: registry.redhat.io/redhat/community-operator-index:v4.18
+  - name: registry.redhat.io/redhat/redhat-marketplace-index:v4.18


### PR DESCRIPTION
### What this PR does

we observed some missing images after mirroring OCP 4.18.0-rc.6 and were advised to start using oc-mirror 4.18 and the v2 configuration schema. dry-run tests verified that the missing images will be mirrored with this change.

breadcrumbs:
* https://redhat-external.slack.com/archives/C075PHEFZKQ/p1738599967476809
* https://redhat-internal.slack.com/archives/C02JW6VCYS1/p1738675714610109

### Special notes for your reviewer

<!-- optional -->
