### PR TITLE
AKS cluster use zone redundancy whenever available

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -218,7 +218,6 @@ clouds:
                 maxCount: 3
                 vmSize: 'Standard_D2s_v3'
                 osDiskSizeGB: 32
-                azCount: 3
               clusterOutboundIPAddressIPTags: "FirstPartyUsage:/NonProd"
             istio:
               ingressGatewayIPAddressIPTags: "FirstPartyUsage:/NonProd"
@@ -236,7 +235,6 @@ clouds:
                 maxCount: 12
                 vmSize: 'Standard_D16s_v3'
                 osDiskSizeGB: 128
-                azCount: 3
               clusterOutboundIPAddressIPTags: "FirstPartyUsage:/NonProd"
           # DNS
           dns:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -29,9 +29,6 @@
           },
           "vmSize": {
             "type": "string"
-          },
-          "azCount": {
-            "type": "number"
           }
         },
         "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -243,7 +243,6 @@ clouds:
             maxCount: 3
             vmSize: 'Standard_D2s_v3'
             osDiskSizeGB: 32
-            azCount: 3
 
       mgmt:
         aks:
@@ -258,7 +257,6 @@ clouds:
             maxCount: 6
             vmSize: 'Standard_D4s_v3'
             osDiskSizeGB: 100
-            azCount: 3
           etcd:
             kvSoftDelete: false
         subscription: ARO Hosted Control Planes (EA Subscription 1)

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -169,7 +169,6 @@
         "vmSize": "Standard_E8s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 3,
         "minCount": 1,
         "osDiskSizeGB": 128,
@@ -231,7 +230,6 @@
         "vmSize": "Standard_D2s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 12,
         "minCount": 2,
         "osDiskSizeGB": 32,

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -169,7 +169,6 @@
         "vmSize": "Standard_E8s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 3,
         "minCount": 1,
         "osDiskSizeGB": 128,
@@ -231,7 +230,6 @@
         "vmSize": "Standard_D2s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 3,
         "minCount": 1,
         "osDiskSizeGB": 32,

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -169,7 +169,6 @@
         "vmSize": "Standard_E8s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 12,
         "minCount": 1,
         "osDiskSizeGB": 128,
@@ -226,7 +225,6 @@
         "vmSize": "Standard_D2s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 3,
         "minCount": 1,
         "osDiskSizeGB": 32,

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -169,7 +169,6 @@
         "vmSize": "Standard_D2s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 6,
         "minCount": 1,
         "osDiskSizeGB": 100,
@@ -231,7 +230,6 @@
         "vmSize": "Standard_D2s_v3"
       },
       "userAgentPool": {
-        "azCount": 3,
         "maxCount": 3,
         "minCount": 1,
         "osDiskSizeGB": 32,

--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -15,7 +15,6 @@ param aksSystemOsDiskSizeGB = {{ .mgmt.aks.systemAgentPool.osDiskSizeGB }}
 param userAgentMinCount = {{ .mgmt.aks.userAgentPool.minCount }}
 param userAgentMaxCount = {{ .mgmt.aks.userAgentPool.maxCount }}
 param userAgentVMSize = '{{ .mgmt.aks.userAgentPool.vmSize }}'
-param userAgentPoolAZCount = {{ .mgmt.aks.userAgentPool.azCount }}
 param aksUserOsDiskSizeGB = {{ .mgmt.aks.userAgentPool.osDiskSizeGB }}
 param aksClusterOutboundIPAddressIPTags = '{{ .mgmt.aks.clusterOutboundIPAddressIPTags }}'
 

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -19,7 +19,6 @@ param aksSystemOsDiskSizeGB = {{ .svc.aks.systemAgentPool.osDiskSizeGB }}
 param userAgentMinCount = {{ .svc.aks.userAgentPool.minCount }}
 param userAgentMaxCount = {{ .svc.aks.userAgentPool.maxCount }}
 param userAgentVMSize = '{{ .svc.aks.userAgentPool.vmSize }}'
-param userAgentPoolAZCount = {{ .svc.aks.userAgentPool.azCount }}
 param aksUserOsDiskSizeGB = {{ .svc.aks.userAgentPool.osDiskSizeGB }}
 param aksClusterOutboundIPAddressIPTags = '{{ .svc.aks.clusterOutboundIPAddressIPTags }}'
 

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -1,3 +1,5 @@
+import { locationIsZoneRedundant } from 'common.bicep'
+
 @description('Azure Region Location')
 param location string = resourceGroup().location
 
@@ -33,9 +35,6 @@ param userAgentMaxCount int = 3
 
 @description('VM instance type for the worker nodes')
 param userAgentVMSize string = 'Standard_D2s_v3'
-
-@description('Availability Zone count for worker nodes')
-param userAgentPoolAZCount int = 3
 
 @description('Min replicas for the system nodes')
 param systemAgentMinCount int = 2
@@ -94,6 +93,7 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
   scope: resourceGroup()
   params: {
     location: location
+    locationIsZoneRedundant: locationIsZoneRedundant(location)
     persist: persist
     aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName
@@ -120,7 +120,6 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     aksKeyVaultName: aksKeyVaultName
     pullAcrResourceIds: [ocpAcrResourceId, svcAcrResourceId]
     userAgentMinCount: userAgentMinCount
-    userAgentPoolAZCount: userAgentPoolAZCount
     userAgentMaxCount: userAgentMaxCount
     userAgentVMSize: userAgentVMSize
     systemAgentMinCount: systemAgentMinCount

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -1,3 +1,5 @@
+import { locationIsZoneRedundant } from 'common.bicep'
+
 @description('Azure Region Location')
 param location string = resourceGroup().location
 
@@ -30,9 +32,6 @@ param userAgentMaxCount int
 
 @description('VM instance type for the worker nodes')
 param userAgentVMSize string
-
-@description('Number of availability zones to use for the AKS clusters user agent pool')
-param userAgentPoolAZCount int
 
 @description('The resource ID of the OCP ACR')
 param ocpAcrResourceId string
@@ -192,6 +191,7 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
   scope: resourceGroup()
   params: {
     location: location
+    locationIsZoneRedundant: locationIsZoneRedundant(location)
     persist: persist
     aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName
@@ -211,7 +211,6 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     userAgentMinCount: userAgentMinCount
     userAgentMaxCount: userAgentMaxCount
     userAgentVMSize: userAgentVMSize
-    userAgentPoolAZCount: userAgentPoolAZCount
     systemAgentMinCount: systemAgentMinCount
     systemAgentMaxCount: systemAgentMaxCount
     systemAgentVMSize: systemAgentVMSize


### PR DESCRIPTION
### What this PR does

* Remove `azCount` config parameter
* Set availability zones for the AKS cluster node pools dynamically based on whether the region is zone redundant
* All regions that support zone redundancy all have 3 availability zones named 1, 2 and 3

Jira: https://issues.redhat.com/browse/ARO-14954
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
