### PR TITLE
Sudobrendan/add helm namespaces to 1p

### DIFF
--- a/backend/deploy/helm/backend/templates/allow-metrics.authorizationpolicy.yaml
+++ b/backend/deploy/helm/backend/templates/allow-metrics.authorizationpolicy.yaml
@@ -2,6 +2,7 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: allow-metrics-backend
+  namespace: {{ .Release.Namespace }}
 spec:
   action: "ALLOW"
   rules:

--- a/backend/deploy/helm/backend/templates/backend.configmap.yaml
+++ b/backend/deploy/helm/backend/templates/backend.configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: backend-config
+  namespace: {{ .Release.Namespace }}
 data:
   DB_NAME: '{{ .Values.configMap.databaseName }}'
   DB_URL: '{{ .Values.configMap.databaseUrl }}'

--- a/backend/deploy/helm/backend/templates/backend.deployment.yaml
+++ b/backend/deploy/helm/backend/templates/backend.deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: aro-hcp-backend
   name: aro-hcp-backend
+  namespace: {{ .Release.Namespace }}
 spec:
   progressDeadlineSeconds: 600
   replicas: 2

--- a/backend/deploy/helm/backend/templates/metrics.service.yaml
+++ b/backend/deploy/helm/backend/templates/metrics.service.yaml
@@ -5,6 +5,7 @@ metadata:
     app: aro-hcp-backend
     port: metrics
   name: aro-hcp-backend-metrics
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - port: 8081

--- a/backend/deploy/helm/backend/templates/serviceaccount.yaml
+++ b/backend/deploy/helm/backend/templates/serviceaccount.yaml
@@ -4,3 +4,4 @@ metadata:
   annotations:
     azure.workload.identity/client-id: '{{ .Values.serviceAccount.workloadIdentityClientId }}'
   name: backend
+  namespace: {{ .Release.Namespace }}

--- a/backend/deploy/helm/backend/templates/servicemonitor.yaml
+++ b/backend/deploy/helm/backend/templates/servicemonitor.yaml
@@ -2,6 +2,7 @@ apiVersion: azmonitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: aro-hcp-backend-service-monitor
+  namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
   - interval: 30s
@@ -10,7 +11,7 @@ spec:
     scheme: http
   namespaceSelector:
     matchNames:
-    - aro-hcp
+    - {{ .Release.Namespace }}
   selector:
     matchLabels:
       app: aro-hcp-backend

--- a/backend/deploy/helm/backend/values.yaml
+++ b/backend/deploy/helm/backend/values.yaml
@@ -1,10 +1,15 @@
+# the configuration of the backend service
 configMap:
   location: ""
   currentVersion: ""
   backendMiClientId: ""
   databaseUrl: ""
   databaseName: ""
+
+# values used by the backend deployment resource
 deployment:
   imageName: ""
+
+# the ServiceAccount of the backend service
 serviceAccount:
   workloadIdentityClientId: ""

--- a/frontend/deploy/helm/frontend/templates/acrpullbinding.yaml
+++ b/frontend/deploy/helm/frontend/templates/acrpullbinding.yaml
@@ -2,6 +2,7 @@ apiVersion: acrpull.microsoft.com/v1beta2
 kind: AcrPullBinding
 metadata:
   name: pull-binding
+  namespace: {{ .Release.Namespace }}
 spec:
   acr:
     environment: PublicCloud

--- a/frontend/deploy/helm/frontend/templates/allow-ingress.authorizationpolicy.yaml
+++ b/frontend/deploy/helm/frontend/templates/allow-ingress.authorizationpolicy.yaml
@@ -2,13 +2,13 @@ apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: allow-istio-ingress
-  namespace: aro-hcp
+  namespace: {{ .Release.Namespace }}
 spec:
   action: ALLOW
   rules:
   - from:
     - source:
-        namespaces: ["aks-istio-ingress"]
+        namespaces: ["{{ .Values.ingress.namespace }}"]
     to:
     - operation:
         methods: ["GET"]

--- a/frontend/deploy/helm/frontend/templates/allow-metrics.authorizationpolicy.yaml
+++ b/frontend/deploy/helm/frontend/templates/allow-metrics.authorizationpolicy.yaml
@@ -2,6 +2,7 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: allow-metrics-frontend
+  namespace: {{ .Release.Namespace }}
 spec:
   action: "ALLOW"
   rules:

--- a/frontend/deploy/helm/frontend/templates/authorizationpolicy.yaml
+++ b/frontend/deploy/helm/frontend/templates/authorizationpolicy.yaml
@@ -2,4 +2,5 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: allow-nothing
+  namespace: {{ .Release.Namespace }}
 spec: {}

--- a/frontend/deploy/helm/frontend/templates/frontend.configmap.yaml
+++ b/frontend/deploy/helm/frontend/templates/frontend.configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: frontend-config
+  namespace: {{ .Release.Namespace }}
 data:
   DB_NAME: '{{ .Values.configMap.databaseName }}'
   DB_URL: '{{ .Values.configMap.databaseUrl }}'

--- a/frontend/deploy/helm/frontend/templates/frontend.deployment.yaml
+++ b/frontend/deploy/helm/frontend/templates/frontend.deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: aro-hcp-frontend
   name: aro-hcp-frontend
+  namespace: {{ .Release.Namespace }}
 spec:
   progressDeadlineSeconds: 600
   replicas: 2
@@ -27,7 +28,7 @@ spec:
         - name: aro-hcp-frontend
           image: '{{ .Values.deployment.imageName }}'
           imagePullPolicy: Always
-          args: ["--clusters-service-url", "http://clusters-service.{{ .Values.clusterService.namespace }}.svc.cluster.local:8000"]
+          args: ["--clusters-service-url", "http://{{ .Values.clusterService.service.name }}.{{ .Values.clusterService.namespace }}.svc.cluster.local:{{ .Values.clusterService.service.port }}"]
           env:
           - name: DB_NAME
             valueFrom:

--- a/frontend/deploy/helm/frontend/templates/frontend.gateway.yaml
+++ b/frontend/deploy/helm/frontend/templates/frontend.gateway.yaml
@@ -2,10 +2,12 @@ apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: aro-hcp-gateway-external
-  namespace: aks-istio-ingress
+  namespace: {{ .Values.ingress.namespace }}
 spec:
   selector:
-    istio: aks-istio-ingressgateway-external
+    {{- with .Values.ingress.istioSelector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   servers:
   - port:
       number: 443

--- a/frontend/deploy/helm/frontend/templates/frontend.poddisruptionbudget.yaml
+++ b/frontend/deploy/helm/frontend/templates/frontend.poddisruptionbudget.yaml
@@ -2,6 +2,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: aro-hcp-frontend
+  namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: 1
   selector:

--- a/frontend/deploy/helm/frontend/templates/frontend.secret-refresher.yaml
+++ b/frontend/deploy/helm/frontend/templates/frontend.secret-refresher.yaml
@@ -11,7 +11,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend-certificate-refresher
-  namespace: aks-istio-ingress
+  namespace: {{ .Values.ingress.namespace }}
 spec:
   replicas: 1
   selector:

--- a/frontend/deploy/helm/frontend/templates/frontend.secretproviderclass.yaml
+++ b/frontend/deploy/helm/frontend/templates/frontend.secretproviderclass.yaml
@@ -9,7 +9,7 @@ apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: frontend-scp
-  namespace: aks-istio-ingress
+  namespace: {{ .Values.ingress.namespace }}
 spec:
   parameters:
     usePodIdentity: "false"

--- a/frontend/deploy/helm/frontend/templates/frontend.service.yaml
+++ b/frontend/deploy/helm/frontend/templates/frontend.service.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: aro-hcp-frontend
   name: aro-hcp-frontend
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - port: 8443

--- a/frontend/deploy/helm/frontend/templates/frontend.virtualservice.yaml
+++ b/frontend/deploy/helm/frontend/templates/frontend.virtualservice.yaml
@@ -7,7 +7,7 @@ spec:
   hosts:
     - "*"
   gateways:
-    - aks-istio-ingress/aro-hcp-gateway-external
+    - {{ .Values.ingress.namespace }}/{{ .Values.ingress.gatewayName }}
   http:
     - match:
         - uri:

--- a/frontend/deploy/helm/frontend/templates/metrics.service.yaml
+++ b/frontend/deploy/helm/frontend/templates/metrics.service.yaml
@@ -5,6 +5,7 @@ metadata:
     app: aro-hcp-frontend
     port: metrics
   name: aro-hcp-frontend-metrics
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - port: 8081

--- a/frontend/deploy/helm/frontend/templates/serviceaccount.yaml
+++ b/frontend/deploy/helm/frontend/templates/serviceaccount.yaml
@@ -5,3 +5,4 @@ metadata:
     azure.workload.identity/client-id: '{{ .Values.serviceAccount.workloadIdentityClientId }}'
     azure.workload.identity/tenant-id: '{{ .Values.serviceAccount.workloadIdentityTenantId }}'
   name: frontend
+  namespace: {{ .Release.Namespace }}

--- a/frontend/deploy/helm/frontend/templates/servicemonitor.yaml
+++ b/frontend/deploy/helm/frontend/templates/servicemonitor.yaml
@@ -2,6 +2,7 @@ apiVersion: azmonitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: aro-hcp-frontend-service-monitor
+  namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
   - interval: 30s

--- a/frontend/deploy/helm/frontend/values.yaml
+++ b/frontend/deploy/helm/frontend/values.yaml
@@ -23,3 +23,11 @@ pullBinding:
 clusterService:
   namespace: cluster-service
   serviceAccount: clusters-service
+  service:
+    name: clusters-service
+    port: 8000
+ingress:
+  namespace: aks-istio-ingress
+  gatewayName: aro-hcp-gateway-external
+  istioSelector:
+    istio: aks-istio-ingressgateway-external


### PR DESCRIPTION
### What this PR does

While performing a security audit of 1P components, I found it difficult to understand what namespaces objects were landing in. This PR makes it clear what is landing where, and includes a bit of parameterization for some components and dependencies.


Jira: Related to https://issues.redhat.com/browse/ARO-11682
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

I tested the changes with

```
git checkout main
helm template ./path/to/chart --namespace aro-hcp > main.yml
git checkout <this branch>
helm template ./path/to/chart --namespace aro-hcp > changes.yml
colordiff main.yml changes.yml
```

Which only included changes for reflecting the namespace name `aro-hcp` in a few resources - which is what happens in our releases today.
