### PR TITLE
support static variable values in ARM steps

### DIFF
--- a/tooling/templatize/pkg/pipeline/arm.go
+++ b/tooling/templatize/pkg/pipeline/arm.go
@@ -60,7 +60,7 @@ func (a *armClient) waitForExistingDeployment(ctx context.Context, timeOutInSeco
 	for timeOutInSeconds > 0 {
 		resp, err := a.getExistingDeployment(ctx, rgName, deploymentName)
 		if err != nil {
-			return fmt.Errorf("Error getting deployment %w", err)
+			return fmt.Errorf("error getting deployment %w", err)
 		}
 		if resp.Properties == nil {
 			return nil
@@ -71,7 +71,7 @@ func (a *armClient) waitForExistingDeployment(ctx context.Context, timeOutInSeco
 		time.Sleep(time.Duration(a.deploymentRetryWaitTime) * time.Second)
 		timeOutInSeconds -= a.deploymentRetryWaitTime
 	}
-	return fmt.Errorf("Timeout exeeded waiting for deployment %s in rg %s", deploymentName, rgName)
+	return fmt.Errorf("timeout exeeded waiting for deployment %s in rg %s", deploymentName, rgName)
 }
 
 func (a *armClient) runArmStep(ctx context.Context, options *PipelineRunOptions, rgName string, step *ARMStep, input map[string]output) (output, error) {
@@ -84,7 +84,7 @@ func (a *armClient) runArmStep(ctx context.Context, options *PipelineRunOptions,
 	// Run deployment
 
 	if err := a.waitForExistingDeployment(ctx, options.DeploymentTimeoutSeconds, rgName, step.Name); err != nil {
-		return nil, fmt.Errorf("Error waiting for deploymenty %w", err)
+		return nil, fmt.Errorf("error waiting for deploymenty %w", err)
 	}
 
 	if !options.DryRun || (options.DryRun && step.OutputOnly) {
@@ -151,7 +151,7 @@ func pollAndPrint[T any](ctx context.Context, p *runtime.Poller[T]) error {
 	case armresources.DeploymentsClientWhatIfAtSubscriptionScopeResponse:
 		printChangeReport(m.Properties.Changes)
 	default:
-		return fmt.Errorf("Unknown type %T", m)
+		return fmt.Errorf("unknown type %T", m)
 	}
 	return nil
 }
@@ -159,7 +159,7 @@ func pollAndPrint[T any](ctx context.Context, p *runtime.Poller[T]) error {
 func doDryRun(ctx context.Context, client *armresources.DeploymentsClient, rgName string, step *ARMStep, vars config.Variables, input map[string]output) (output, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
-	inputValues, err := getInputValues(step.Variables, input)
+	inputValues, err := getInputValues(step.Variables, vars, input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get input values: %w", err)
 	}
@@ -215,7 +215,7 @@ func pollAndGetOutput[T any](ctx context.Context, p *runtime.Poller[T]) (armOutp
 	case armresources.DeploymentsClientCreateOrUpdateAtSubscriptionScopeResponse:
 		outputs = resp.Properties.Outputs
 	default:
-		return nil, fmt.Errorf("Unknown type %T", resp)
+		return nil, fmt.Errorf("unknown type %T", resp)
 	}
 
 	if outputs != nil {
@@ -233,7 +233,7 @@ func pollAndGetOutput[T any](ctx context.Context, p *runtime.Poller[T]) (armOutp
 func doWaitForDeployment(ctx context.Context, client *armresources.DeploymentsClient, rgName string, step *ARMStep, vars config.Variables, input map[string]output) (output, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
-	inputValues, err := getInputValues(step.Variables, input)
+	inputValues, err := getInputValues(step.Variables, vars, input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get input values: %w", err)
 	}
@@ -244,7 +244,7 @@ func doWaitForDeployment(ctx context.Context, client *armresources.DeploymentsCl
 	}
 
 	if hasTemplateResources(deploymentProperties.Template) && step.OutputOnly {
-		return nil, fmt.Errorf("Deployment step %s is outputOnly, but contains resources", step.Name)
+		return nil, fmt.Errorf("deployment step %s is outputOnly, but contains resources", step.Name)
 	}
 
 	// Create the deployment

--- a/tooling/templatize/pkg/pipeline/arm_test.go
+++ b/tooling/templatize/pkg/pipeline/arm_test.go
@@ -25,7 +25,7 @@ func TestWaitForExistingDeployment(t *testing.T) {
 		{
 			name:            "Timeout",
 			deploymentState: []armresources.ProvisioningState{"Running", "Running"},
-			expectedError:   to.Ptr("Timeout exeeded waiting for deployment test in rg rg"),
+			expectedError:   to.Ptr("timeout exeeded waiting for deployment test in rg rg"),
 			expecetCallCnt:  1,
 			timeout:         1,
 		},
@@ -45,8 +45,8 @@ func TestWaitForExistingDeployment(t *testing.T) {
 			name:           "Handle Error",
 			missing:        true,
 			expecetCallCnt: 1,
-			returnError:    to.Ptr(fmt.Errorf("Test error")),
-			expectedError:  to.Ptr("Error getting deployment Test error"),
+			returnError:    to.Ptr(fmt.Errorf("test error")),
+			expectedError:  to.Ptr("error getting deployment test error"),
 			timeout:        1,
 		},
 	}

--- a/tooling/templatize/pkg/pipeline/inspect.go
+++ b/tooling/templatize/pkg/pipeline/inspect.go
@@ -62,7 +62,7 @@ func inspectVars(s Step, options *InspectOptions, writer io.Writer) error {
 	var err error
 	switch step := s.(type) {
 	case *ShellStep:
-		envVars, err = step.mapStepVariables(options.Vars)
+		envVars, err = step.mapStepVariables(options.Vars, map[string]output{})
 	default:
 		return fmt.Errorf("inspecting step variables not implemented for action type %s", s.ActionType())
 	}

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -194,7 +194,7 @@ func RunStep(s Step, ctx context.Context, kubeconfigFile string, executionTarget
 	}
 }
 
-func getInputValues(configuredVariables []Variable, inputs map[string]output) (map[string]any, error) {
+func getInputValues(configuredVariables []Variable, cfg config.Variables, inputs map[string]output) (map[string]any, error) {
 	values := make(map[string]any)
 	for _, i := range configuredVariables {
 		if i.Input != nil {
@@ -207,6 +207,14 @@ func getInputValues(configuredVariables []Variable, inputs map[string]output) (m
 			} else {
 				return nil, fmt.Errorf("step %s not found in provided outputs", i.Input.Step)
 			}
+		} else if i.ConfigRef != "" {
+			value, found := cfg.GetByPath(i.ConfigRef)
+			if !found {
+				return nil, fmt.Errorf("failed to lookup config reference %s for %s", i.ConfigRef, i.Name)
+			}
+			values[i.Name] = value
+		} else {
+			values[i.Name] = i.Value
 		}
 	}
 	return values, nil


### PR DESCRIPTION
### What this PR does

the variables section of an ARM step will now also support `value` variables, specifying a static value. this is supported in the EV2 generator and this PR introduces parity.

(i've also lowercased the first char of several `fmt.Errorf` since vscode complained about that)

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
