### PR TITLE
allow the installation of an MC without SC dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ infra.mgmt:
 	@cd dev-infrastructure && DEPLOY_ENV=$(DEPLOY_ENV) make mgmt.init
 .PHONY: infra.mgmt
 
+infra.mgmt.solo:
+	@cd dev-infrastructure && DEPLOY_ENV=$(DEPLOY_ENV) make mgmt.solo.init
+.PHONY: infra.mgmt.solo
+
 infra.mgmt.aks.kubeconfigfile:
 	@cd dev-infrastructure && DEPLOY_ENV=$(DEPLOY_ENV) make -s mgmt.aks.kubeconfigfile
 .PHONY: infra.mgmt.aks.kubeconfigfile

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -368,3 +368,19 @@ clouds:
           frontend:
             cosmosDB:
               private: false
+      personal-perfscale:
+        defaults:
+          dns:
+            regionalSubdomain: '{{ .ctx.regionShort }}'
+          mgmt:
+            aks:
+              systemAgentPool:
+                minCount: 1
+                maxCount: 4
+                vmSize: 'Standard_E8s_v3'
+                osDiskSizeGB: 128
+              userAgentPool:
+                minCount: 1
+                maxCount: 3
+                vmSize: 'Standard_D16s_v3'
+                osDiskSizeGB: 128

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -243,6 +243,12 @@ mgmt.kv.permission:
 mgmt.dev.permissions: mgmt.kv.permission
 .PHONY: mgmt.dev.permissions
 
+mgmt.solo.init: region mgmt.solo mgmt.aks.admin-access mgmt.aks.kubeconfig mgmt.dev.permissions
+
+mgmt.solo:
+	../templatize.sh $(DEPLOY_ENV) -p mgmt-solo-pipeline.yaml -P run -c public
+.PHONY: mgmt.solo
+
 # ACR DEV customizations
 
 acr: acr-svc-cfg acr-ocp-cfg

--- a/dev-infrastructure/mgmt-solo-pipeline.yaml
+++ b/dev-infrastructure/mgmt-solo-pipeline.yaml
@@ -1,0 +1,78 @@
+$schema: "pipeline.schema.v1"
+serviceGroup: Microsoft.Azure.ARO.HCP.Management.Infra.Solo
+rolloutName: Management Cluster Rollout
+resourceGroups:
+- name: {{ .global.rg }}
+  subscription: {{ .global.subscription }}
+  steps:
+  - name: global-output
+    action: ARM
+    template: templates/output-global.bicep
+    parameters: configurations/output-global.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
+- name: {{ .regionRG }}
+  subscription: {{ .svc.subscription }}
+  steps:
+  - name: region-output
+    action: ARM
+    template: templates/output-region.bicep
+    parameters: configurations/output-region.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
+- name: {{ .mgmt.rg }}
+  subscription: {{ .mgmt.subscription }}
+  steps:
+  - name: mgmt-infra
+    action: ARM
+    template: templates/mgmt-infra.bicep
+    parameters: configurations/mgmt-infra.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    variables:
+    - name: clusterServiceMIResourceId
+      # we don't need to grant KV permissions to CS as there is no CS in the MC solo deployment
+      value: ""
+  # Build the MC
+  - name: mgmt-cluster
+    action: ARM
+    template: templates/mgmt-cluster.bicep
+    parameters: configurations/mgmt-cluster.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    variables:
+    - name: ocpAcrResourceId
+      input:
+        step: global-output
+        name: ocpAcrResourceId
+    - name: svcAcrResourceId
+      input:
+        step: global-output
+        name: svcAcrResourceId
+    - name: azureMonitoringWorkspaceId
+      input:
+        step: region-output
+        name: azureMonitoringWorkspaceId
+    - name: maestroEventGridNamespaceId
+      input:
+        step: region-output
+        name: maestroEventGridNamespaceId
+    dependsOn:
+    - mgmt-infra
+    - region-output
+    - global-output
+- name: {{ .mgmt.rg }}
+  subscription: {{ .mgmt.subscription }}
+  aksCluster: {{ .aksName }}
+  steps:
+  # Install ACRpull
+  - name: acrpull
+    action: Shell
+    command: make -C ../acrpull deploy
+    dryRun:
+      variables:
+        - name: DRY_RUN
+          value: "true"
+    variables:
+      - name: ACRPULL_DIGEST
+        configRef: acrPullImageDigest
+    dependsOn:
+    - mgmt-cluster

--- a/dev-infrastructure/modules/cluster-service-mc-kv-access.bicep
+++ b/dev-infrastructure/modules/cluster-service-mc-kv-access.bicep
@@ -1,0 +1,50 @@
+@description('Cluster user assigned identity resource id, used to grant KeyVault access')
+param clusterServiceMIResourceId string
+
+@description('The name of the CX KeyVault')
+param cxKeyVaultName string
+
+@description('The name of the MSI KeyVault')
+param msiKeyVaultName string
+
+//
+//   C L U S T E R   S E R V I C E   K V   A C C E S S
+//
+
+import * as res from 'resource.bicep'
+var clusterServiceMIRef = res.msiRefFromId(clusterServiceMIResourceId)
+
+resource clusterServiceMI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  scope: resourceGroup(clusterServiceMIRef.resourceGroup.subscriptionId, clusterServiceMIRef.resourceGroup.name)
+  name: clusterServiceMIRef.name
+}
+
+module cxClusterServiceKeyVaultAccess '../modules/keyvault/keyvault-secret-access.bicep' = [
+  for role in [
+    'Key Vault Secrets Officer'
+    'Key Vault Certificate User'
+    'Key Vault Certificates Officer'
+  ]: {
+    name: guid(cxKeyVaultName, clusterServiceMIResourceId, role)
+    params: {
+      keyVaultName: cxKeyVaultName
+      roleName: role
+      managedIdentityPrincipalId: clusterServiceMI.properties.principalId
+    }
+  }
+]
+
+module msiClusterServiceKeyVaultAccess '../modules/keyvault/keyvault-secret-access.bicep' = [
+  for role in [
+    'Key Vault Secrets Officer'
+    'Key Vault Certificate User'
+    'Key Vault Certificates Officer'
+  ]: {
+    name: guid(msiKeyVaultName, clusterServiceMIResourceId, role)
+    params: {
+      keyVaultName: msiKeyVaultName
+      roleName: role
+      managedIdentityPrincipalId: clusterServiceMI.properties.principalId
+    }
+  }
+]

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -190,7 +190,7 @@ resource mgmtKeyVault 'Microsoft.KeyVault/vaults@2024-04-01-preview' existing = 
 //   M A E S T R O
 //
 
-module maestroConsumer '../modules/maestro/maestro-consumer.bicep' = {
+module maestroConsumer '../modules/maestro/maestro-consumer.bicep' = if (maestroEventGridNamespaceId != '') {
   name: 'maestro-consumer'
   params: {
     maestroAgentManagedIdentityPrincipalId: filter(
@@ -212,7 +212,7 @@ module maestroConsumer '../modules/maestro/maestro-consumer.bicep' = {
 //  E V E N T   G R I D   P R I V A T E   E N D P O I N T   C O N N E C T I O N
 //
 
-module eventGrindPrivateEndpoint '../modules/private-endpoint.bicep' = {
+module eventGrindPrivateEndpoint '../modules/private-endpoint.bicep' = if (maestroEventGridNamespaceId != '') {
   name: 'eventGridPrivateEndpoint'
   params: {
     location: location

--- a/templatize.sh
+++ b/templatize.sh
@@ -119,6 +119,8 @@ esac
 
 if [ "$DEPLOY_ENV" == "personal-dev" ]; then
     REGION_STAMP="${REGION_SHORT}${USER:0:4}"
+elif [ "$DEPLOY_ENV" == "personal-perfscale" ]; then
+    REGION_STAMP="${REGION_SHORT}p${USER:0:4}"
 else
     CLEAN_DEPLOY_ENV=$(echo "${DEPLOY_ENV}" | tr -cd '[:alnum:]')
     REGION_STAMP="${CLEAN_DEPLOY_ENV}"


### PR DESCRIPTION
### What this PR does

this is targeted mostly for perfscale usecases where only an MC is required along with the respective MC services.

creating a perfscale MC can be done via

```sh
DEPLOY_ENV=personal-perfscale make infra.mgmt.solo
```

this leverages the new `personal-perfscale` profile, which is the same as `personal-dev` except for prod-ready AKS nodepools

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
