### PR TITLE
Make pull toggable

### DIFF
--- a/dev-infrastructure/modules/acr/acr-permissions.bicep
+++ b/dev-infrastructure/modules/acr/acr-permissions.bicep
@@ -6,6 +6,10 @@ param principalId string
 @description('Whether to grant push access to the ACR')
 param grantPushAccess bool = false
 
+
+@description('Whether to grant pull access from the ACR')
+param grantPullAccess bool = false
+
 @description('Whether to grant manage token access to the ACR')
 param grantManageTokenAccess bool = false
 
@@ -40,7 +44,7 @@ resource acrInstance 'Microsoft.ContainerRegistry/registries@2023-11-01-preview'
   name: acrName
 }
 
-resource acrPullRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!grantPushAccess) {
+resource acrPullRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (grantPullAccess) {
   name: guid(acrName, principalId, acrPullRoleDefinitionId)
   scope: acrInstance
   properties: {

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -525,6 +525,7 @@ module acrPullRole 'acr/acr-permissions.bicep' = [
     params: {
       principalId: aksCluster.properties.identityProfile.kubeletidentity.objectId
       acrName: acrRef.name
+      grantPullAccess: true
     }
   }
 ]
@@ -566,6 +567,7 @@ module acrPullerRoles 'acr/acr-permissions.bicep' = [
     params: {
       principalId: pullerIdentity.properties.principalId
       acrName: acrRef.name
+      grantPullAccess: true
     }
   }
 ]

--- a/dev-infrastructure/templates/image-sync.bicep
+++ b/dev-infrastructure/templates/image-sync.bicep
@@ -145,6 +145,7 @@ module acrPullPermissions '../modules/acr/acr-permissions.bicep' = [
     params: {
       principalId: uami.properties.principalId
       acrName: ocpAcrName
+      grantPullAccess: true
     }
   }
 ]


### PR DESCRIPTION
### What this PR does

This makes image pull role assignment configurable. It also grant this only to the image pull and image syn identities, since other services should rely on acrpull operator.



