### PR TITLE
feat: make KMS Managed Identity optional in the managed identities configmap

### DIFF
--- a/cluster-service/deploy/helm/templates/azure-operators-managed-identities-config.configmap.yaml
+++ b/cluster-service/deploy/helm/templates/azure-operators-managed-identities-config.configmap.yaml
@@ -51,7 +51,7 @@ data:
         minOpenShiftVersion: 4.17
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.kms.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.kms.roleName }}'
-        optional: false
+        optional: true
     dataPlaneOperatorsIdentities:
       disk-csi-driver:
         minOpenShiftVersion: 4.17


### PR DESCRIPTION
### What this PR does

The KMS functionality is optional when creating clusters. Therefore, the Managed Identity associated to it should be considered optional.

This commit changes the `optional` attribute for this identity to `true`.

Even when provided right now, CS still does not support the KMS functionality so the identity will be unused for now.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
