### PR TITLE
frontend: refactor subscription metrics

### DIFF
--- a/frontend/pkg/metrics/metrics.go
+++ b/frontend/pkg/metrics/metrics.go
@@ -1,0 +1,190 @@
+package metrics
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/Azure/ARO-HCP/internal/database"
+)
+
+type subscription struct {
+	id         string
+	state      string
+	updated_at int64
+}
+
+type SubscriptionCollector struct {
+	dbClient database.DBClient
+	location string
+
+	errCounter               prometheus.Counter
+	refreshCounter           prometheus.Counter
+	lastSyncDuration         prometheus.Gauge
+	lastSyncResult           prometheus.Gauge
+	lastSuccessSyncTimestamp prometheus.Gauge
+
+	mtx           sync.RWMutex
+	subscriptions []subscription
+}
+
+const (
+	errCounterName               = "frontend_subscription_collector_failed_syncs_total"
+	refreshCounterName           = "frontend_subscription_collector_syncs_total"
+	lastSyncDurationName         = "frontend_subscription_collector_last_sync_duration_seconds"
+	lastSyncResultName           = "frontend_subscription_collector_last_sync"
+	lastSuccessSyncTimestampName = "frontend_subscription_collector_last_success_timestamp_seconds"
+	subscriptionStateName        = "frontend_lifecycle_state"
+	subscriptionLastUpdatedName  = "frontend_lifecycle_last_update_timestamp_seconds"
+)
+
+func NewSubscriptionCollector(r prometheus.Registerer, dbClient database.DBClient, location string) *SubscriptionCollector {
+	sc := &SubscriptionCollector{
+		dbClient: dbClient,
+		location: location,
+
+		errCounter: promauto.With(r).NewCounter(
+			prometheus.CounterOpts{
+				Name: errCounterName,
+				Help: "Total number of failed syncs for the Subscription collector.",
+			},
+		),
+		refreshCounter: promauto.With(r).NewCounter(
+			prometheus.CounterOpts{
+				Name: refreshCounterName,
+				Help: "Total number of syncs for the Subscription collector.",
+			},
+		),
+		lastSyncDuration: promauto.With(r).NewGauge(
+			prometheus.GaugeOpts{
+				Name: lastSyncDurationName,
+				Help: "Last sync operation's duration.",
+			},
+		),
+		lastSyncResult: promauto.With(r).NewGauge(
+			prometheus.GaugeOpts{
+				Name: lastSyncResultName,
+				Help: "Last sync operation's result (1: success, 0: failed).",
+			},
+		),
+		lastSuccessSyncTimestamp: promauto.With(r).NewGauge(
+			prometheus.GaugeOpts{
+				Name: lastSuccessSyncTimestampName,
+				Help: "Last successful operation's timestamp.",
+			},
+		),
+	}
+	// Register the collector itself.
+	r.MustRegister(sc)
+
+	return sc
+}
+
+// Run starts the loop which reads the subscriptions from the database at
+// periodic intervals (30s) to populate the subscription metrics.
+func (sc *SubscriptionCollector) Run(logger *slog.Logger, stop <-chan struct{}) {
+	// Populate the internal cache.
+	sc.refresh(logger)
+
+	t := time.NewTicker(30 * time.Second)
+	for {
+		select {
+		case <-stop:
+			return
+		case <-t.C:
+			sc.refresh(logger)
+		}
+	}
+}
+
+func (sc *SubscriptionCollector) refresh(logger *slog.Logger) {
+	now := time.Now()
+	defer func() {
+		sc.lastSyncDuration.Set(time.Since(now).Seconds())
+	}()
+
+	sc.refreshCounter.Inc()
+	if err := sc.updateCache(); err != nil {
+		logger.Warn("failed to update subscription collector cache", "err", err)
+		sc.lastSyncResult.Set(0)
+		sc.errCounter.Inc()
+		return
+	}
+
+	sc.lastSyncResult.Set(1)
+	sc.lastSuccessSyncTimestamp.SetToCurrentTime()
+}
+
+func (sc *SubscriptionCollector) updateCache() error {
+	var subscriptions []subscription
+
+	iter := sc.dbClient.ListAllSubscriptionDocs()
+	for sub := range iter.Items(context.Background()) {
+		subscriptions = append(subscriptions, subscription{
+			id:         sub.ID,
+			state:      string(sub.Subscription.State),
+			updated_at: int64(sub.CosmosTimestamp),
+		})
+	}
+	if err := iter.GetError(); err != nil {
+		return err
+	}
+
+	sc.mtx.Lock()
+	sc.subscriptions = subscriptions
+	sc.mtx.Unlock()
+
+	return nil
+}
+
+var (
+	subscriptionStateDesc = prometheus.NewDesc(
+		subscriptionStateName,
+		"Reports the current state of the subscription.",
+		[]string{"location", "subscription_id", "state"},
+		nil,
+	)
+	subscriptionLastUpdatedDesc = prometheus.NewDesc(
+		subscriptionLastUpdatedName,
+		"Reports the timestamp when the subscription has been updated for the last time.",
+		[]string{"location", "subscription_id"},
+		nil,
+	)
+)
+
+// Describe implements the prometheus.Collector interface.
+func (sc *SubscriptionCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- subscriptionStateDesc
+	ch <- subscriptionLastUpdatedDesc
+}
+
+// Collect implements the prometheus.Collector interface.
+func (sc *SubscriptionCollector) Collect(ch chan<- prometheus.Metric) {
+	sc.mtx.RLock()
+	defer sc.mtx.RUnlock()
+
+	for _, sub := range sc.subscriptions {
+		ch <- prometheus.MustNewConstMetric(
+			subscriptionStateDesc,
+			prometheus.GaugeValue,
+			1.0,
+			sc.location,
+			sub.id,
+			string(sub.state),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			subscriptionLastUpdatedDesc,
+			prometheus.GaugeValue,
+			float64(sub.updated_at),
+			sc.location,
+			sub.id,
+		)
+	}
+}

--- a/frontend/pkg/metrics/metrics_test.go
+++ b/frontend/pkg/metrics/metrics_test.go
@@ -1,0 +1,158 @@
+package metrics
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/mocks"
+)
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+func TestSubscriptionCollector(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	nosubs := slices.Values([]*database.SubscriptionDocument{})
+	subs := slices.Values([]*database.SubscriptionDocument{
+		database.NewSubscriptionDocument(
+			"00000000-0000-0000-0000-000000000000",
+			&arm.Subscription{
+				State:            arm.SubscriptionStateRegistered,
+				RegistrationDate: api.Ptr(time.Now().String()),
+			}),
+	})
+	ctrl := gomock.NewController(t)
+
+	mockDBClient := mocks.NewMockDBClient(ctrl)
+
+	r := prometheus.NewPedanticRegistry()
+	collector := NewSubscriptionCollector(r, mockDBClient, "test")
+
+	t.Run("no subscription", func(t *testing.T) {
+		mockIter := mocks.NewMockDBClientIterator[database.SubscriptionDocument](ctrl)
+		mockIter.EXPECT().
+			Items(gomock.Any()).
+			Return(database.DBClientIteratorItem[database.SubscriptionDocument](nosubs))
+		mockIter.EXPECT().
+			GetError().
+			Return(nil)
+
+		mockDBClient.EXPECT().
+			ListAllSubscriptionDocs().
+			Return(mockIter).
+			Times(1)
+		collector.refresh(logger)
+
+		assertMetrics(t, r, 5, `# HELP frontend_subscription_collector_failed_syncs_total Total number of failed syncs for the Subscription collector.
+# TYPE frontend_subscription_collector_failed_syncs_total counter
+frontend_subscription_collector_failed_syncs_total 0
+# HELP frontend_subscription_collector_syncs_total Total number of syncs for the Subscription collector.
+# TYPE frontend_subscription_collector_syncs_total counter
+frontend_subscription_collector_syncs_total 1
+# HELP frontend_subscription_collector_last_sync Last sync operation's result (1: success, 0: failed).
+# TYPE frontend_subscription_collector_last_sync gauge
+frontend_subscription_collector_last_sync 1
+`)
+	})
+
+	t.Run("db error", func(t *testing.T) {
+		mockIter := mocks.NewMockDBClientIterator[database.SubscriptionDocument](ctrl)
+		mockIter.EXPECT().
+			Items(gomock.Any()).
+			Return(database.DBClientIteratorItem[database.SubscriptionDocument](nosubs))
+		mockIter.EXPECT().
+			GetError().
+			Return(errors.New("db error"))
+		mockDBClient.EXPECT().
+			ListAllSubscriptionDocs().
+			Return(mockIter).
+			Times(1)
+
+		collector.refresh(logger)
+
+		assertMetrics(t, r, 5, `# HELP frontend_subscription_collector_failed_syncs_total Total number of failed syncs for the Subscription collector.
+# TYPE frontend_subscription_collector_failed_syncs_total counter
+frontend_subscription_collector_failed_syncs_total 1
+# HELP frontend_subscription_collector_syncs_total Total number of syncs for the Subscription collector.
+# TYPE frontend_subscription_collector_syncs_total counter
+frontend_subscription_collector_syncs_total 2
+# HELP frontend_subscription_collector_last_sync Last sync operation's result (1: success, 0: failed).
+# TYPE frontend_subscription_collector_last_sync gauge
+frontend_subscription_collector_last_sync 0
+`)
+	})
+
+	t.Run("refresh with 1 subscription", func(t *testing.T) {
+		mockIter := mocks.NewMockDBClientIterator[database.SubscriptionDocument](ctrl)
+		mockIter.EXPECT().
+			Items(gomock.Any()).
+			Return(database.DBClientIteratorItem[database.SubscriptionDocument](subs))
+		mockIter.EXPECT().
+			GetError().
+			Return(nil)
+		mockDBClient.EXPECT().
+			ListAllSubscriptionDocs().
+			Return(mockIter).
+			Times(1)
+
+		collector.refresh(logger)
+
+		assertMetrics(t, r, 7, `
+# HELP frontend_lifecycle_last_update_timestamp_seconds Reports the timestamp when the subscription has been updated for the last time.
+# TYPE frontend_lifecycle_last_update_timestamp_seconds gauge
+frontend_lifecycle_last_update_timestamp_seconds{location="test",subscription_id="00000000-0000-0000-0000-000000000000"} 0
+# HELP frontend_lifecycle_state Reports the current state of the subscription.
+# TYPE frontend_lifecycle_state gauge
+frontend_lifecycle_state{location="test",state="Registered",subscription_id="00000000-0000-0000-0000-000000000000"} 1
+# HELP frontend_subscription_collector_failed_syncs_total Total number of failed syncs for the Subscription collector.
+# TYPE frontend_subscription_collector_failed_syncs_total counter
+frontend_subscription_collector_failed_syncs_total 1
+# HELP frontend_subscription_collector_syncs_total Total number of syncs for the Subscription collector.
+# TYPE frontend_subscription_collector_syncs_total counter
+frontend_subscription_collector_syncs_total 3
+# HELP frontend_subscription_collector_last_sync Last sync operation's result (1: success, 0: failed).
+# TYPE frontend_subscription_collector_last_sync gauge
+frontend_subscription_collector_last_sync 1
+`)
+	})
+}
+
+func assertMetrics(t *testing.T, r prometheus.Gatherer, metrics int, expectedOutput string) {
+	t.Helper()
+
+	n, err := testutil.GatherAndCount(r)
+	assert.NoError(t, err)
+	assert.Equal(t, metrics, n)
+
+	// We can't check the timestamp-based metrics.
+	err = testutil.GatherAndCompare(
+		r,
+		bytes.NewBufferString(expectedOutput),
+		errCounterName,
+		refreshCounterName,
+		lastSyncResultName,
+		subscriptionStateName,
+		subscriptionLastUpdatedName,
+	)
+	assert.NoError(t, err)
+
+	problems, err := testutil.GatherAndLint(r)
+	assert.NoError(t, err)
+
+	for _, p := range problems {
+		t.Errorf("metric %q: %s", p.Metric, p.Text)
+	}
+}


### PR DESCRIPTION
### What this PR does

This change implements a custom collector for the subscription lifecycle metrics. In practice, the collector maintains a local cache of subscriptions which is refreshed periodically from the database.

The benefits are:
* The metrics are persisted upon restart of the process (previously a subscription would only exist as a metric if it was accessed by some HTTP operation).
* All frontend replicas report the same metrics.
* Only the latest state of a subscription is reported (in the previous implementation, the old state would still be reported after an update).

The cache is refreshed every 30 seconds which should be good enough assuming that the metrics are scraped at a similar (or greater) interval.


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
