### PR TITLE
templatize: fix error handling during bicep run

### DIFF
--- a/tooling/templatize/pkg/pipeline/bicep.go
+++ b/tooling/templatize/pkg/pipeline/bicep.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -54,11 +55,15 @@ func transformParameters(ctx context.Context, vars config.Variables, inputs map[
 		return nil, nil, fmt.Errorf("failed to write to target file: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, "az", "bicep", "build-params", "-f", bicepParamFile.Name(), "--stdout")
+	var buildParamsCmd = []string{"az", "bicep", "build-params", "-f", bicepParamFile.Name(), "--stdout"}
+	cmd := exec.CommandContext(ctx, buildParamsCmd[0], buildParamsCmd[1:]...)
+	var errBuff bytes.Buffer
+	cmd.Stderr = &errBuff
 	output, err := cmd.Output()
 	if err != nil {
-		combinedOutput, _ := cmd.CombinedOutput()
-		return nil, nil, fmt.Errorf("failed to get output from command: %w\n%s", err, string(combinedOutput))
+		cmdStr := strings.Join(buildParamsCmd, " ")
+		cmdErr := string(errBuff.Bytes())
+		return nil, nil, fmt.Errorf("failed to get output from command '%s': %w\n%s", cmdStr, err, cmdErr)
 	}
 
 	var result generationResult


### PR DESCRIPTION
### What this PR does

This commit fixes problem with error reporting in templatize tool, which surfaced in case of `az bicep build-params ...` command failure:

- it was not clear that it happened during the az bicep run
- the error from the 'az bicep' run was not captured
- the 'az bicep' command was run 2 times

Original error:

```
[19:38:44.855] ERROR: command failed {
  "err": "failed to run ARM step: failed to transform Bicep to ARM: failed to get output from command: exit status 1\n"
}
```
Fixed error:

TODO

### Special notes for your reviewer

WIP, this likely needs some tests

<!-- optional -->
