### PR TITLE
configure istio after cluster installation

### DIFF
--- a/.github/workflows/services-cd.yml
+++ b/.github/workflows/services-cd.yml
@@ -81,10 +81,6 @@
             cd dev-infrastructure/
             make svc.aks.kubeconfig
 
-        - name: 'Deploy Istio Configuration'
-          run: |
-            make istio.deploy_pipeline
-
         - name: 'Deploy ACR Pull Configuration'
           run: |
             make acrpull.deploy_pipeline

--- a/.github/workflows/services-pr-check.yml
+++ b/.github/workflows/services-pr-check.yml
@@ -88,10 +88,6 @@
           run: |
             make maestro.server.dry_run
 
-        - name: 'Dry Run Istio'
-          run: |
-            make istio.dry_run
-
         - name: 'Dry Run ACR Pull'
           run: |
             make acrpull.dry_run

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -111,6 +111,14 @@ resourceGroups:
       configRef: svc.rg
     dependsOn:
     - svc
+  # configure istio
+  - name: deploy
+    action: Shell
+    command: make -C ../istio deploy
+    dryRun:
+      variables:
+        - name: DRY_RUN
+          value: "true"
   # Install ACRpull
   - name: acrpull
     action: Shell


### PR DESCRIPTION
### What this PR does

adding the istio step as a cluster provisioning post step makes sure istio is ready to be used before service rollouts happen

follows up on https://github.com/Azure/ARO-HCP/pull/1261

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
