### PR TITLE
update CS supported OCP version to 4.18 RC8

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -186,7 +186,7 @@ clouds:
         imageTag: c9a36e110a32c0c25aa5025cfe6d51af797e6d4b
       # Cluster Service
       clusterService:
-        imageTag: 978cc66
+        imageTag: d62fa9d
         imageRepo: app-sre/uhc-clusters-service
         azureOperatorsManagedIdentities:
           clusterApiAzure:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -39,7 +39,7 @@
       }
     },
     "imageRepo": "app-sre/uhc-clusters-service",
-    "imageTag": "978cc66",
+    "imageTag": "d62fa9d",
     "k8s": {
       "namespace": "cluster-service",
       "serviceAccountName": "clusters-service"

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -39,7 +39,7 @@
       }
     },
     "imageRepo": "app-sre/uhc-clusters-service",
-    "imageTag": "978cc66",
+    "imageTag": "d62fa9d",
     "k8s": {
       "namespace": "cluster-service",
       "serviceAccountName": "clusters-service"

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -39,7 +39,7 @@
       }
     },
     "imageRepo": "app-sre/uhc-clusters-service",
-    "imageTag": "978cc66",
+    "imageTag": "d62fa9d",
     "k8s": {
       "namespace": "cluster-service",
       "serviceAccountName": "clusters-service"

--- a/demo/cluster.tmpl.json
+++ b/demo/cluster.tmpl.json
@@ -2,7 +2,7 @@
   "properties": {
     "spec": {
       "version": {
-        "id": "openshift-v4.18.0-rc.6-candidate",
+        "id": "openshift-v4.18.0-rc.8-candidate",
         "channelGroup": "candidate"
       },
       "dns": {},

--- a/demo/node_pool.tmpl.json
+++ b/demo/node_pool.tmpl.json
@@ -2,7 +2,7 @@
   "properties": {
     "spec": {
       "version": {
-        "id": "openshift-v4.18.0-rc.6-candidate",
+        "id": "openshift-v4.18.0-rc.8-candidate",
         "channelGroup": "candidate"
       },
       "platform": {

--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -366,7 +366,7 @@ Then register it with the Maestro Server
     ```
     export CS_CLUSTER_NAME="<desired-cluster-name>"
     ```
-  - Create the User-Assigned Managed Identities for the Control Plane operators. This assumes OCP 4.17 based will be created.
+  - Create the User-Assigned Managed Identities for the Control Plane operators. This assumes OCP 4.18 based will be created.
     > NOTE: Managed Identities cannot be reused between operators nor between clusters. This is, each operator must use
             a different managed identity, and different clusters must use different managed identities, even for the same
             operators.
@@ -396,7 +396,7 @@ Then register it with the Maestro Server
     export CP_KMS_UAMI=$(az identity show -n ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX} -g <resource-group> | jq -r '.id')
     ```
 
-  - Create the User-Assigned Managed Identities for the Data Plane operators. This assumes OCP 4.17 clusters will be created.
+  - Create the User-Assigned Managed Identities for the Data Plane operators. This assumes OCP 4.18 clusters will be created.
     > NOTE: Managed Identities cannot be reused between operators nor between clusters. This is, each operator must use
             a different managed identity, and different clusters must use different managed identities, even for the same
             operators.
@@ -425,7 +425,7 @@ Then register it with the Maestro Server
     export SERVICE_MANAGED_IDENTITY_UAMI=$(az identity show -n ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX} -g <resource-group> | jq -r '.id')
     ```
 
-3) Create the cluster. This assumes OCP 4.17 clusters will be created.
+3) Create the cluster. This assumes OCP 4.18 clusters will be created.
     > **NOTE** See the [Cluster Service API](https://api.openshift.com/#/default/post_api_clusters_mgmt_v1_clusters) documentation
     > for further information on the properties within the payload below
 
@@ -511,9 +511,6 @@ Then register it with the Maestro Server
           }
         }
       },
-      "version": {
-        "id": "openshift-v4.17.0"
-      }
     }
     EOF
 


### PR DESCRIPTION
### What this PR does

We update the supported OCP version in CS to 4.18 RC8, which is the latest 4.18 RC released at the moment of writing this.

This release contains the fixes to the control plane operator (CPO) that allow setting the encoding of the CSI secrets related to MIs.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
