### PR TITLE
database: Fix regression in GetResourceDoc

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -149,7 +149,7 @@ func (d *cosmosDBClient) GetLockClient() *LockClient {
 func (d *cosmosDBClient) GetResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) (*ResourceDocument, error) {
 	pk := NewPartitionKey(resourceID.SubscriptionID)
 
-	query := "SELECT * FROM c WHERE STRINGEQUALS(c.resourceId, @resourceId, true)"
+	query := "SELECT * FROM c WHERE STRINGEQUALS(c.key, @resourceId, true)"
 	opt := azcosmos.QueryOptions{
 		PageSizeHint:    1,
 		QueryParameters: []azcosmos.QueryParameter{{Name: "@resourceId", Value: resourceID.String()}},


### PR DESCRIPTION
### What this PR does

I changed the query expression prematurely.

The JSON field for `ResourceDocument.ResourceID` is still `"key"`. It will change to `"resourceId"` in [PR #1215](https://github.com/Azure/ARO-HCP/pull/1215), along with many other breaking Cosmos DB changes.

Jira: regression from [ARO-14170 - Merge Cosmos DB containers](https://issues.redhat.com/browse/ARO-14170)

### Special notes for your reviewer

<!-- optional -->
