### PR TITLE
Improve Availability Zone selection when provisioning AKS and zone-redundant resources

### DIFF
--- a/dev-infrastructure/scripts/list-az-regions.sh
+++ b/dev-infrastructure/scripts/list-az-regions.sh
@@ -7,12 +7,12 @@ az rest \
   --method get \
   --uri "/subscriptions/$(az account show --query id --output tsv)/locations?api-version=2024-11-01" \
   | jq -r '
-    # First, print items with availabilityZoneMappings set
-    "Regions with Availability Zones:",
-    (.value[] | select(.availabilityZoneMappings) | .name),
-    "",
-    # Then, print items without availabilityZoneMappings
-    "Regions without Availability Zones:",
-    (.value[] | select(.availabilityZoneMappings | not) | .name)
-  '
-
+    reduce .value[] as $item ({}; .[$item.name] = {
+      availabilityZones: (
+        if $item.availabilityZoneMappings then
+          $item.availabilityZoneMappings | map(.logicalZone)
+        else
+          []
+        end
+      )
+    }) | to_entries | sort_by(.key) | from_entries'

--- a/dev-infrastructure/templates/common.bicep
+++ b/dev-infrastructure/templates/common.bicep
@@ -1,101 +1,414 @@
 // https://learn.microsoft.com/en-us/azure/reliability/availability-zones-region-support
 // See helper script in dev-infrastructure/scripts/list-az-locations.sh
-var _zoneRedundantLocations = [
-  'australiaeast'
-  'brazilsouth'
-  'canadacentral'
-  'centralindia'
-  'centralus'
-  'centraluseuap'
-  'eastasia'
-  'eastus'
-  'eastus2'
-  'eastus2euap'
-  'francecentral'
-  'germanywestcentral'
-  'israelcentral'
-  'italynorth'
-  'japaneast'
-  'koreacentral'
-  'mexicocentral'
-  'newzealandnorth'
-  'northeurope'
-  'norwayeast'
-  'polandcentral'
-  'qatarcentral'
-  'southafricanorth'
-  'southcentralus'
-  'southeastasia'
-  'spaincentral'
-  'swedencentral'
-  'switzerlandnorth'
-  'uaenorth'
-  'uksouth'
-  'westeurope'
-  'westus2'
-  'westus3'
-
-  // The following regions do not support availability zones
-  // asia
-  // asiapacific
-  // australia
-  // australiacentral
-  // australiacentral2
-  // australiasoutheast
-  // brazil
-  // brazilsoutheast
-  // brazilus
-  // canada
-  // canadaeast
-  // centralusstage
-  // eastasiastage
-  // eastus2stage
-  // eastusstage
-  // eastusstg
-  // europe
-  // france
-  // francesouth
-  // germany
-  // germanynorth
-  // global
-  // india
-  // israel
-  // italy
-  // japan
-  // japanwest
-  // jioindiacentral
-  // jioindiawest
-  // korea
-  // koreasouth
-  // newzealand
-  // northcentralus
-  // northcentralusstage
-  // norway
-  // norwaywest
-  // poland
-  // qatar
-  // singapore
-  // southafrica
-  // southafricawest
-  // southcentralusstage
-  // southcentralusstg
-  // southeastasiastage
-  // southindia
-  // sweden
-  // switzerland
-  // switzerlandwest
-  // uae
-  // uaecentral
-  // uk
-  // ukwest
-  // unitedstates
-  // unitedstateseuap
-  // westcentralus
-  // westindia
-  // westus
-  // westus2stage
-  // westusstage
-]
+var _locationAvailabilityZones = {
+  asia: {
+    availabilityZones: []
+  }
+  asiapacific: {
+    availabilityZones: []
+  }
+  australia: {
+    availabilityZones: []
+  }
+  australiacentral: {
+    availabilityZones: []
+  }
+  australiacentral2: {
+    availabilityZones: []
+  }
+  australiaeast: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  australiasoutheast: {
+    availabilityZones: []
+  }
+  brazil: {
+    availabilityZones: []
+  }
+  brazilsouth: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  brazilsoutheast: {
+    availabilityZones: []
+  }
+  brazilus: {
+    availabilityZones: []
+  }
+  canada: {
+    availabilityZones: []
+  }
+  canadacentral: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  canadaeast: {
+    availabilityZones: []
+  }
+  centralindia: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  centralus: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  centraluseuap: {
+    availabilityZones: [
+      '1'
+      '2'
+    ]
+  }
+  centralusstage: {
+    availabilityZones: []
+  }
+  eastasia: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  eastasiastage: {
+    availabilityZones: []
+  }
+  eastus: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  eastus2: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  eastus2euap: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  eastus2stage: {
+    availabilityZones: []
+  }
+  eastusstage: {
+    availabilityZones: []
+  }
+  eastusstg: {
+    availabilityZones: []
+  }
+  europe: {
+    availabilityZones: []
+  }
+  france: {
+    availabilityZones: []
+  }
+  francecentral: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  francesouth: {
+    availabilityZones: []
+  }
+  germany: {
+    availabilityZones: []
+  }
+  germanynorth: {
+    availabilityZones: []
+  }
+  germanywestcentral: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  global: {
+    availabilityZones: []
+  }
+  india: {
+    availabilityZones: []
+  }
+  israel: {
+    availabilityZones: []
+  }
+  israelcentral: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  italy: {
+    availabilityZones: []
+  }
+  italynorth: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  japan: {
+    availabilityZones: []
+  }
+  japaneast: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  japanwest: {
+    availabilityZones: []
+  }
+  jioindiacentral: {
+    availabilityZones: []
+  }
+  jioindiawest: {
+    availabilityZones: []
+  }
+  korea: {
+    availabilityZones: []
+  }
+  koreacentral: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  koreasouth: {
+    availabilityZones: []
+  }
+  mexicocentral: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  newzealand: {
+    availabilityZones: []
+  }
+  newzealandnorth: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  northcentralus: {
+    availabilityZones: []
+  }
+  northcentralusstage: {
+    availabilityZones: []
+  }
+  northeurope: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  norway: {
+    availabilityZones: []
+  }
+  norwayeast: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  norwaywest: {
+    availabilityZones: []
+  }
+  poland: {
+    availabilityZones: []
+  }
+  polandcentral: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  qatar: {
+    availabilityZones: []
+  }
+  qatarcentral: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  singapore: {
+    availabilityZones: []
+  }
+  southafrica: {
+    availabilityZones: []
+  }
+  southafricanorth: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  southafricawest: {
+    availabilityZones: []
+  }
+  southcentralus: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  southcentralusstage: {
+    availabilityZones: []
+  }
+  southcentralusstg: {
+    availabilityZones: []
+  }
+  southeastasia: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  southeastasiastage: {
+    availabilityZones: []
+  }
+  southindia: {
+    availabilityZones: []
+  }
+  spaincentral: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  sweden: {
+    availabilityZones: []
+  }
+  swedencentral: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  switzerland: {
+    availabilityZones: []
+  }
+  switzerlandnorth: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  switzerlandwest: {
+    availabilityZones: []
+  }
+  uae: {
+    availabilityZones: []
+  }
+  uaecentral: {
+    availabilityZones: []
+  }
+  uaenorth: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  uk: {
+    availabilityZones: []
+  }
+  uksouth: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  ukwest: {
+    availabilityZones: []
+  }
+  unitedstates: {
+    availabilityZones: []
+  }
+  unitedstateseuap: {
+    availabilityZones: []
+  }
+  westcentralus: {
+    availabilityZones: []
+  }
+  westeurope: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  westindia: {
+    availabilityZones: []
+  }
+  westus: {
+    availabilityZones: []
+  }
+  westus2: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  westus2stage: {
+    availabilityZones: []
+  }
+  westus3: {
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  westusstage: {
+    availabilityZones: []
+  }
+}
 
 @export()
-func locationIsZoneRedundant(region string) bool => contains(_zoneRedundantLocations, region)
+func getLocationAvailabilityZones(region string) array => _locationAvailabilityZones[region].availabilityZones

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -1,5 +1,10 @@
+import { getLocationAvailabilityZones } from 'common.bicep'
+
 @description('Azure Region Location')
 param location string = resourceGroup().location
+
+@description('List of Availability Zones to use for the AKS cluster')
+param locationAvailabilityZones array = getLocationAvailabilityZones(location)
 
 @description('Set to true to prevent resources from being pruned after 48 hours')
 param persist bool = false
@@ -94,6 +99,7 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
   scope: resourceGroup()
   params: {
     location: location
+    locationAvailabilityZones: locationAvailabilityZones
     persist: persist
     aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -1,7 +1,11 @@
-import { locationIsZoneRedundant } from '../templates/common.bicep'
+import { getLocationAvailabilityZones } from 'common.bicep'
 
 @description('Azure Region Location')
 param location string = resourceGroup().location
+
+@description('List of Availability Zones to use for the AKS cluster')
+param locationAvailabilityZones array = getLocationAvailabilityZones(location)
+var locationHasAvailabilityZones = length(locationAvailabilityZones) > 0
 
 @description('Set to true to prevent resources from being pruned after 48 hours')
 param persist bool = false
@@ -191,6 +195,7 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
   scope: resourceGroup()
   params: {
     location: location
+    locationAvailabilityZones: locationAvailabilityZones
     persist: persist
     aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName
@@ -376,7 +381,7 @@ module oidc '../modules/oidc/main.bicep' = {
     location: location
     storageAccountName: oidcStorageAccountName
     rpMsiName: csMIName
-    skuName: locationIsZoneRedundant(location) ? 'Standard_ZRS' : 'Standard_LRS'
+    skuName: locationHasAvailabilityZones ? 'Standard_ZRS' : 'Standard_LRS'
     msiId: aroDevopsMsiId
     deploymentScriptLocation: location
   }


### PR DESCRIPTION
### What this PR does

* Refactor helper script to get regions and AZs in a better format to put in the `common.bicep` file
* Updated common.bicep with AZ availability for each region, add func to get list of AZs for a region
* Update aks-cluster, svc-cluster, mgmt-cluster templates to use the AZs provided by the updated data
  * Regions are not provisioned appropriately based on AZ availability 

Jira: https://issues.redhat.com/browse/XCMSTRAT-1067

Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
