### PR TITLE
update min ocp version in MIs requirements config to 4.18

### DIFF
--- a/cluster-service/deploy/helm/templates/azure-operators-managed-identities-config.configmap.yaml
+++ b/cluster-service/deploy/helm/templates/azure-operators-managed-identities-config.configmap.yaml
@@ -8,53 +8,53 @@ data:
   azure-operators-managed-identities-config.yaml: |
     controlPlaneOperatorsIdentities:
       cluster-api-azure:
-        minOpenShiftVersion: 4.17
+        minOpenShiftVersion: 4.18
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.clusterApiAzure.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.clusterApiAzure.roleName }}'
         optional: false
       control-plane:
-        minOpenShiftVersion: 4.17
+        minOpenShiftVersion: 4.18
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.controlPlane.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.controlPlane.roleName }}'
         optional: false
       cloud-controller-manager:
-        minOpenShiftVersion: 4.17
+        minOpenShiftVersion: 4.18
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.cloudControllerManager.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.cloudControllerManager.roleName }}'
         optional: false
       ingress:
-        minOpenShiftVersion: 4.17
+        minOpenShiftVersion: 4.18
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.ingress.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.ingress.roleName }}'
         optional: false
       disk-csi-driver:
-        minOpenShiftVersion: 4.17
+        minOpenShiftVersion: 4.18
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.diskCsiDriver.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.diskCsiDriver.roleName }}'
         optional: false
       file-csi-driver:
-        minOpenShiftVersion: 4.17
+        minOpenShiftVersion: 4.18
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.fileCsiDriver.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.fileCsiDriver.roleName }}'
         optional: false
       image-registry:
-        minOpenShiftVersion: 4.17
+        minOpenShiftVersion: 4.18
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.imageRegistry.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.imageRegistry.roleName }}'
         optional: false
       cloud-network-config:
-        minOpenShiftVersion: 4.17
+        minOpenShiftVersion: 4.18
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.cloudNetworkConfig.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.cloudNetworkConfig.roleName }}'
         optional: false
       kms:
-        minOpenShiftVersion: 4.17
+        minOpenShiftVersion: 4.18
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.kms.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.kms.roleName }}'
         optional: true
     dataPlaneOperatorsIdentities:
       disk-csi-driver:
-        minOpenShiftVersion: 4.17
+        minOpenShiftVersion: 4.18
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.diskCsiDriver.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.diskCsiDriver.roleName }}'
         k8sServiceAccounts:
@@ -64,7 +64,7 @@ data:
             namespace: 'openshift-cluster-csi-drivers'
         optional: false
       image-registry:
-        minOpenShiftVersion: 4.17
+        minOpenShiftVersion: 4.18
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.imageRegistry.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.imageRegistry.roleName }}'
         k8sServiceAccounts:
@@ -74,7 +74,7 @@ data:
             namespace: 'openshift-image-registry'
         optional: false
       file-csi-driver:
-        minOpenShiftVersion: 4.17
+        minOpenShiftVersion: 4.18
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.fileCsiDriver.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.fileCsiDriver.roleName }}'
         k8sServiceAccounts:


### PR DESCRIPTION
### What this PR does
The minimum OCP version we will support for the ARO-HCP offering will now be 4.18 so we update the Managed Identities requirements config file to specify 4.18 as the minimum OCP version for all the operators defined.


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
