### PR TITLE
Fix azure cli version parsing

### DIFF
--- a/tooling/templatize/cmd/pipeline/run/cmd.go
+++ b/tooling/templatize/cmd/pipeline/run/cmd.go
@@ -21,7 +21,7 @@ type Version struct {
 var versionConstraints = []Version{
 	{
 		Name:       "Azure CLI",
-		Cmd:        "az --version | grep azure-cli |awk '{print $NF}'",
+		Cmd:        "az --version | grep azure-cli |awk '{print $NF}' | grep -o '^[0-9.]*'",
 		Constraint: ">=2.68.0",
 	},
 	{
@@ -49,7 +49,7 @@ func NewCommand() (*cobra.Command, error) {
 
 func ensureDependencies(ctx context.Context) error {
 	for _, c := range versionConstraints {
-		fmt.Println("Checking verion of", c.Name)
+		fmt.Println("Checking version of", c.Name)
 		cmd := exec.CommandContext(ctx, "/bin/bash", "-c", c.Cmd)
 		output, err := cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
### What this PR does

```
az --version | grep azure-cli |awk '{print $NF}'
```
command also returns the Python location which contains `azure-cli` in the path. 
Below is the output of the above command.
```
2.68.0
'/opt/homebrew/Cellar/azure-cli/2.68.0/libexec/bin/python'
```
This change parses the version correctly

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
