### PR TITLE
Fix azure cli version parsing

### DIFF
--- a/tooling/templatize/cmd/pipeline/run/cmd.go
+++ b/tooling/templatize/cmd/pipeline/run/cmd.go
@@ -21,7 +21,7 @@ type Version struct {
 var versionConstraints = []Version{
 	{
 		Name:       "Azure CLI",
-		Cmd:        "az  --version 2>/dev/null | grep azure-cli |awk '{print $2}'",
+		Cmd:        `az version --query '"azure-cli"' -otsv`,
 		Constraint: ">=2.68.0",
 	},
 	{
@@ -49,7 +49,7 @@ func NewCommand() (*cobra.Command, error) {
 
 func ensureDependencies(ctx context.Context) error {
 	for _, c := range versionConstraints {
-		fmt.Println("Checking verion of", c.Name)
+		fmt.Println("Checking version of", c.Name)
 		cmd := exec.CommandContext(ctx, "/bin/bash", "-c", c.Cmd)
 		output, err := cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
### What this PR does
```
az --version 2>/dev/null | grep azure-cli |awk '{print $2}'
```
the above command which is used to retrieve the azure cli version also returns the keyword location in addition to the expected version, because the `az --version` also contains the keyword `azure-cli` in the path of the returned Python location.
Below is the output of the above command.
```
2.68.0
location
```

Output of the `az --version` command:
```
azure-cli                         2.68.0 *

core                              2.68.0 *
telemetry                          1.1.0

Dependencies:
msal                              1.31.1
azure-mgmt-resource               23.1.1

Python location '/opt/homebrew/Cellar/azure-cli/2.68.0/libexec/bin/python'
```

This change parses the version correctly

version returned affter this change:
```
> az version --query '"azure-cli"' -otsv
2.68.0
```

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
