### PR TITLE
Added a cronjob to delete orphaned jenkins job namespaces

### DIFF
--- a/cluster-service/deploy/integration/cluster-service-namespace.yaml
+++ b/cluster-service/deploy/integration/cluster-service-namespace.yaml
@@ -4,13 +4,19 @@ kind: Template
 metadata:
   name: cluster-service-admin
 parameters:
-- name: NAMESPACE
-  description: The namespace to create
-  required: true
-  value: cluster-service-admin
-- name: CLIENT_ID
-  description: The Azure Client ID used for federation
-  required: true
+  - name: NAMESPACE
+    description: The namespace to create
+    required: true
+    value: cluster-service-admin
+  - name: CLIENT_ID
+    description: The Azure Client ID used for federation
+    required: true
+  - name: ORPHANED_NAMESPACE_CLEANER
+    description: The namespace to create to have a cronjob which will delete the orphaned namespace which are not deleted due to any issues with the jenkins job.
+    value: orphaned-namespace-cleaner
+  - name: KUBECTL_IMAGE
+    description: An image which have the `kubectl` binary in it.
+    value: quay.io/rhn_support_ansverma/ubi8-minimal-kubectl:latest
 
 objects:
   - apiVersion: v1
@@ -27,12 +33,12 @@ objects:
     metadata:
       name: namespace-admin
     rules:
-    - apiGroups:
-      - ""
-      resources:
-      - namespaces
-      verbs:
-      - "*"
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+        verbs:
+          - "*"
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -42,9 +48,9 @@ objects:
       kind: ClusterRole
       name: admin
     subjects:
-    - kind: ServiceAccount
-      name: cluster-service-mgmt
-      namespace: cluster-service-admin
+      - kind: ServiceAccount
+        name: cluster-service-mgmt
+        namespace: cluster-service-admin
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -54,9 +60,9 @@ objects:
       kind: ClusterRole
       name: namespace-admin
     subjects:
-    - kind: ServiceAccount
-      name: cluster-service-mgmt
-      namespace: cluster-service-admin
+      - kind: ServiceAccount
+        name: cluster-service-mgmt
+        namespace: cluster-service-admin
   - apiVersion: v1
     kind: Secret
     metadata:
@@ -72,3 +78,45 @@ objects:
       namespace: ${NAMESPACE}
     data:
       cs-client-id: ${CLIENT_ID}
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: orphaned-namespace-cleaner-cronjob
+      namespace: ${ORPHANED_NAMESPACE_CLEANER}
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: orphaned-namespace-cleaner-cronjob
+    subjects:
+      - kind: ServiceAccount
+        name: orphaned-namespace-cleaner-cronjob
+        namespace: ${ORPHANED_NAMESPACE_CLEANER}
+    roleRef:
+      kind: ClusterRole
+      name: namespace-admin
+      apiGroup: rbac.authorization.k8s.io
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: orphaned-namespace-cleaner
+      namespace: ${ORPHANED_NAMESPACE_CLEANER}
+    spec:
+      schedule: "0 0 * * *"
+      successfulJobsHistoryLimit: 3
+      failedJobsHistoryLimit: 1
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              serviceAccountName: orphaned-namespace-cleaner-cronjob
+              containers:
+                - name: kubectl-container
+                  image: ${KUBECTL_IMAGE}
+                  command: ["/bin/sh", "-c"]
+                  args:
+                    - |
+                      echo "Starting to clear orphaned namespaces"
+                      echo "deleting the orphaned namespaces"
+                      kubectl get namespaces -o json | jq -r '.items[] | select(.metadata.labels."sandbox-jenkins-type"=="aro-hcp") | select((now - (.metadata.creationTimestamp | fromdate)) / 60 > 60) | .metadata.name' | xargs kubectl delete namespace
+                      echo "Script execution completed."
+              restartPolicy: Never


### PR DESCRIPTION
### What this PR does
This PR added few more resource including a cronjob to the integration environment in the svc cluster. The cronjob is run once a day to clear the orphaned namespaces which are created by the pr_check jenkins job. Sometime, the namespaces does not get deleted due to some jenkins issue like a crashed jenkins job before executing the namespace delete logic. The cronjob targets such namespaces and delete them.

The logic is delete the namespaces which has the label `sandbox-jenkins-type: aro-hcp` and is >60 mins old.

Jira: [ARO-10434](https://issues.redhat.com/browse/ARO-10434)
