### PR TITLE
ensure AKS managed RG has perist:true tag

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -29,9 +29,6 @@ param location string
 param locationAvailabilityZones array
 var locationHasAvailabilityZones = length(locationAvailabilityZones) > 0
 
-@description('Set to true to prevent resources from being pruned after 48 hours')
-param persist bool = false
-
 param kubernetesVersion string
 param deployIstio bool
 param istioVersions array = []
@@ -288,7 +285,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-04-02-previ
     tier: 'Standard'
   }
   tags: {
-    persist: toLower(string(persist))
+    persist: 'true'
     clusterType: clusterType
   }
   identity: {

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -6,9 +6,6 @@ param location string = resourceGroup().location
 @description('List of Availability Zones to use for the AKS cluster')
 param locationAvailabilityZones array = getLocationAvailabilityZones(location)
 
-@description('Set to true to prevent resources from being pruned after 48 hours')
-param persist bool = false
-
 @description('AKS cluster name')
 param aksClusterName string = 'aro-hcp-aks'
 
@@ -106,7 +103,6 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
   params: {
     location: location
     locationAvailabilityZones: locationAvailabilityZones
-    persist: persist
     aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName
     aksEtcdKVEnableSoftDelete: aksEtcdKVEnableSoftDelete

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -7,9 +7,6 @@ param location string = resourceGroup().location
 param locationAvailabilityZones array = getLocationAvailabilityZones(location)
 var locationHasAvailabilityZones = length(locationAvailabilityZones) > 0
 
-@description('Set to true to prevent resources from being pruned after 48 hours')
-param persist bool = false
-
 @description('AKS cluster name')
 param aksClusterName string
 
@@ -199,7 +196,6 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
   params: {
     location: location
     locationAvailabilityZones: locationAvailabilityZones
-    persist: persist
     aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName
     aksEtcdKVEnableSoftDelete: aksEtcdKVEnableSoftDelete


### PR DESCRIPTION
### What this PR does

an AKS clusters RG inherits the tags of the AKS resource itself. but even if an ARO HCP environment is set up with `persist: false`, the managed RG of the AKS clusters should not be touched by our RG cleanup job as they are lifecycled together with their AKS cluster anyways.

therefore we will set `persist:true` on all AKS clusters we create, regardless of the nature of the environment.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
