### PR TITLE
frontend: fix correlation headers in the HTTP response

### DIFF
--- a/frontend/pkg/frontend/middleware_correlation.go
+++ b/frontend/pkg/frontend/middleware_correlation.go
@@ -31,14 +31,13 @@ func MiddlewareCorrelationData(w http.ResponseWriter, r *http.Request, next http
 		logger = logger.With("correlation_request_id", correlationData.CorrelationRequestID)
 	}
 	ctx = ContextWithLogger(ctx, logger)
-
 	r = r.WithContext(ctx)
-
-	next(w, r)
 
 	w.Header().Set(arm.HeaderNameRequestID, correlationData.RequestID.String())
 	returnClientRequestID := r.Header.Get(arm.HeaderNameReturnClientRequestID)
 	if strings.EqualFold(returnClientRequestID, "true") {
 		w.Header().Set(arm.HeaderNameClientRequestID, correlationData.ClientRequestID)
 	}
+
+	next(w, r)
 }

--- a/frontend/pkg/frontend/middleware_tracing_test.go
+++ b/frontend/pkg/frontend/middleware_tracing_test.go
@@ -33,14 +33,6 @@ func TestMiddlewareTracing(t *testing.T) {
 		expectedAttrs   map[string]string
 		expectedBaggage map[string]string
 	}{
-		//{
-		//	// Verify that the function doesn't panic if there's no span in the
-		//	// context.
-		//	name:               "no span context",
-		//	data:               &arm.CorrelationData{},
-		//	withoutSpanContext: true,
-		//},
-
 		{
 			name: "empty correlation data",
 			data: &arm.CorrelationData{},


### PR DESCRIPTION
### What this PR does

50dd65dc introduces a regression: the RP frontend stopped returning correlation headers in the HTTP response. The reason was that changing the Header map after calling `ResponseWriter.WriteHeader()` has no effect. The existing tests didn't catch the issue because they were accessing `httptest.ResponseRecorder` directly instead of testing the `*http.Response` value returned by `writer.Result()`.


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

I notice that other middleware tests have the same flaw (e.g. working directly on the ResponseRecorder instead of calling `*ResponseRecorder.Result()`). I'll post a follow-up PR to clean them up too.