### PR TITLE
change pipeline step schema for SetCertificateIssuer

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -53,8 +53,7 @@ resourceGroups:
       input:
         name: cxKeyVaultUrl
         step: mgmt-infra
-    provider:
-      name: provider
+    issuer:
       value: OneCertV2-PublicCA
   - name: mgmt-oncert-private-kv-issuer
     action: SetCertificateIssuer
@@ -64,8 +63,7 @@ resourceGroups:
       input:
         name: mgmtKeyVaultUrl
         step: mgmt-infra
-    provider:
-      name: provider
+    issuer:
       value: OneCertV2-PrivateCA
   - name: mgmt-oncert-public-kv-issuer
     action: SetCertificateIssuer
@@ -75,8 +73,7 @@ resourceGroups:
       input:
         name: mgmtKeyVaultUrl
         step: mgmt-infra
-    provider:
-      name: provider
+    issuer:
       value: OneCertV2-PublicCA
   # Build the MC
   - name: mgmt-cluster

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -50,8 +50,7 @@ resourceGroups:
       input:
         name: svcKeyVaultUrl
         step: svc-infra
-    provider:
-      name: provider
+    issuer:
       value: OneCertV2-PrivateCA
   - name: svc-oncert-public-kv-issuer
     action: SetCertificateIssuer
@@ -61,8 +60,7 @@ resourceGroups:
       input:
         name: svcKeyVaultUrl
         step: svc-infra
-    provider:
-      name: provider
+    issuer:
       value: OneCertV2-PublicCA
   # Create SVC cluster
   - name: svc

--- a/tooling/templatize/pkg/pipeline/pipeline.schema.v1.json
+++ b/tooling/templatize/pkg/pipeline/pipeline.schema.v1.json
@@ -163,7 +163,7 @@
                                 "vaultBaseUrl": {
                                     "$ref": "#/definitions/variableRef"
                                 },
-                                "provider": {
+                                "issuer": {
                                     "$ref": "#/definitions/variableRef"
                                 },
                                 "parentZone": {
@@ -305,7 +305,7 @@
                                         "vaultBaseUrl": {
                                             "$ref": "#/definitions/variableRef"
                                         },
-                                        "provider": {
+                                        "issuer": {
                                             "$ref": "#/definitions/variableRef"
                                         },
                                         "dependsOn": {
@@ -317,7 +317,7 @@
                                     },
                                     "required": [
                                         "vaultBaseUrl",
-                                        "provider"
+                                        "issuer"
                                     ]
                                 }
                             ],

--- a/tooling/templatize/pkg/pipeline/types.go
+++ b/tooling/templatize/pkg/pipeline/types.go
@@ -220,7 +220,7 @@ func (s *DelegateChildZoneStep) Description() string {
 type SetCertificateIssuerStep struct {
 	StepMeta     `yaml:",inline"`
 	VaultBaseUrl VariableRef `yaml:"vaultBaseUrl"`
-	Provider     VariableRef `yaml:"provider"`
+	Issuer       VariableRef `yaml:"issuer"`
 }
 
 func (s *SetCertificateIssuerStep) Description() string {

--- a/tooling/templatize/testdata/pipeline.yaml
+++ b/tooling/templatize/testdata/pipeline.yaml
@@ -36,7 +36,7 @@ resourceGroups:
     action: SetCertificateIssuer
     vaultBaseUrl:
       configRef: vaultBaseUrl
-    provider:
+    issuer:
       configRef: provider
     dependsOn:
     - deploy

--- a/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2pipeline.yaml
+++ b/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2pipeline.yaml
@@ -37,5 +37,5 @@ resourceGroups:
             - deploy
           vaultBaseUrl:
             configRef: vaultBaseUrl
-          provider:
+          issuer:
             configRef: provider

--- a/tooling/templatize/testdata/zz_fixture_TestRawOptions.yaml
+++ b/tooling/templatize/testdata/zz_fixture_TestRawOptions.yaml
@@ -36,7 +36,7 @@ resourceGroups:
     action: SetCertificateIssuer
     vaultBaseUrl:
       configRef: vaultBaseUrl
-    provider:
+    issuer:
       configRef: provider
     dependsOn:
     - deploy


### PR DESCRIPTION
### What this PR does

the EV2 generator changes the `provider` field to `issuer` in the `SetCertificateIssuer` step.
we don't have an implementation for this step in thr RH pipeline runner, but need to comply with the schema

ADO PR: https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/ARO-Pipelines/pullrequest/11696136
Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
