### PR TITLE
Remove auditIfNotExists permission from CAPZ

### DIFF
--- a/dev-infrastructure/configurations/dev-operator-roles.bicepparam
+++ b/dev-infrastructure/configurations/dev-operator-roles.bicepparam
@@ -143,7 +143,6 @@ param roles = [
     roleName: 'Azure Red Hat OpenShift Cluster API Role - Dev'
     roleDescription: 'Enables permissions to allow cluster API to manage nodes, networks and disks for OpenShift cluster.'
     actions: [
-      'Microsoft.Authorization/policies/auditIfNotExists/action'
       'Microsoft.Compute/availabilitySets/delete'
       'Microsoft.Compute/availabilitySets/read'
       'Microsoft.Compute/availabilitySets/write'


### PR DESCRIPTION
This permission isn't used anywhere in the CAPZ repo and seems to be a left-over from the OpenShift installer with no references to an actual policy being executed.

### What this PR does


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
