### PR TITLE
maestro consumer registration pipeline

### DIFF
--- a/.github/workflows/services-cd.yml
+++ b/.github/workflows/services-cd.yml
@@ -99,7 +99,7 @@
 
         - name: 'Deploy Maestro'
           run: |
-            make maestro.server.deploy_pipeline maestro.registration.deploy
+            make maestro.server.deploy_pipeline
 
         - name: 'Deploy CS PR check environment dressup'
           if: inputs.deploy_cs_pr_check_deps

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ infra.clean:
 #   separator "/" (used for maestro only).
 
 # Services deployed on "svc" aks cluster
-services_svc = maestro.registration
+services_svc =
 # Services deployed on "mgmt" aks cluster(s)
 services_mgmt =
 # List of all services

--- a/dev-infrastructure/docs/development-setup.md
+++ b/dev-infrastructure/docs/development-setup.md
@@ -315,12 +315,6 @@ First install the agent
   make maestro.agent.deploy_pipeline
   ```
 
-Then register it with the Maestro Server
-
-  ```bash
-  make maestro.registration.deploy
-  ```
-
 ## Creating an ARO HCP Cluster via Cluster Service
 
 ### Creating a cluster

--- a/maestro/agent/Makefile
+++ b/maestro/agent/Makefile
@@ -1,6 +1,5 @@
 -include ../../setup-env.mk
 -include ../../helm-cmd.mk
-HELM_CMD ?= helm upgrade --install
 
 deploy:
 	@kubectl create namespace maestro --dry-run=client -o json | kubectl apply -f -

--- a/maestro/agent/pipeline.yaml
+++ b/maestro/agent/pipeline.yaml
@@ -6,7 +6,7 @@ resourceGroups:
   subscription: {{ .mgmt.subscription }}
   aksCluster: {{ .aksName }}
   steps:
-  - name: deploy
+  - name: deploy-agent
     action: Shell
     command: make deploy
     dryRun:
@@ -32,3 +32,21 @@ resourceGroups:
       configRef: maestro.agentSideCar.imageBase
     - name: SIDECAR_IMAGE_TAG
       configRef: maestro.agentSideCar.imageTag
+- name: {{ .svc.rg }}
+  subscription: {{ .svc.subscription }}
+  aksCluster: {{ .aksName }}
+  steps:
+  - name: register-agent-with-server
+    action: Shell
+    command: make -C ../registration deploy
+    dryRun:
+      variables:
+      - name: DRY_RUN
+        value: "true"
+    variables:
+    - name: CONSUMER_NAME
+      configRef: maestro.consumerName
+    - name: NAMESPACE
+      configRef: maestro.server.k8s.namespace
+    dependsOn:
+    - deploy-agent

--- a/maestro/registration/Makefile
+++ b/maestro/registration/Makefile
@@ -1,4 +1,3 @@
--include ../../setup-env.mk
 -include ../../helm-cmd.mk
 
 deploy:

--- a/maestro/registration/Makefile
+++ b/maestro/registration/Makefile
@@ -1,9 +1,5 @@
-SHELL = /bin/bash
-DEPLOY_ENV ?= personal-dev
-$(shell ../../templatize.sh $(DEPLOY_ENV) config.tmpl.mk config.mk)
-include config.mk
--include ../helm-cmd.mk
-HELM_CMD ?= helm upgrade --install
+-include ../../setup-env.mk
+-include ../../helm-cmd.mk
 
 deploy:
 	@if ! kubectl get service maestro -n ${NAMESPACE} > /dev/null 2>&1; then \

--- a/maestro/registration/config.tmpl.mk
+++ b/maestro/registration/config.tmpl.mk
@@ -1,2 +1,0 @@
-CONSUMER_NAME ?= {{ .maestro.consumerName }}
-NAMESPACE ?= {{ .maestro.server.k8s.namespace }}


### PR DESCRIPTION
### What this PR does

add the maestro agent registration step to the agent installation pipeline. this way a new agent gets registered immediately with the server after installation.

note: this does not imply that CS will immediately use it as a provisioning shard. this is a dedicated topic for P3

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
