### PR TITLE
frontend: add aro prefix to custom span attributes

### DIFF
--- a/frontend/pkg/frontend/middleware_tracing.go
+++ b/frontend/pkg/frontend/middleware_tracing.go
@@ -62,15 +62,15 @@ func addCorrelationDataToSpanContext(ctx context.Context, data *arm.CorrelationD
 		value string
 	}{
 		{
-			name:  "correlation.id",
+			name:  "aro.correlation.id",
 			value: data.CorrelationRequestID,
 		},
 		{
-			name:  "client.request.id",
+			name:  "aro.client.request.id",
 			value: data.ClientRequestID,
 		},
 		{
-			name:  "request.id",
+			name:  "aro.request.id",
 			value: data.RequestID.String(),
 		},
 	} {

--- a/frontend/pkg/frontend/middleware_tracing_test.go
+++ b/frontend/pkg/frontend/middleware_tracing_test.go
@@ -59,14 +59,14 @@ func TestMiddlewareTracing(t *testing.T) {
 				CorrelationRequestID: testCorrelationRequestID,
 			},
 			expectedAttrs: map[string]string{
-				"request.id":        testRequestID.String(),
-				"client.request.id": testClientRequestID,
-				"correlation.id":    testCorrelationRequestID,
+				"aro.request.id":        testRequestID.String(),
+				"aro.client.request.id": testClientRequestID,
+				"aro.correlation.id":    testCorrelationRequestID,
 			},
 			expectedBaggage: map[string]string{
-				"request.id":        testRequestID.String(),
-				"client.request.id": testClientRequestID,
-				"correlation.id":    testCorrelationRequestID,
+				"aro.request.id":        testRequestID.String(),
+				"aro.client.request.id": testClientRequestID,
+				"aro.correlation.id":    testCorrelationRequestID,
 			},
 		},
 	} {

--- a/frontend/pkg/frontend/middleware_tracing_test.go
+++ b/frontend/pkg/frontend/middleware_tracing_test.go
@@ -45,10 +45,10 @@ func TestMiddlewareTracing(t *testing.T) {
 			name: "empty correlation data",
 			data: &arm.CorrelationData{},
 			expectedAttrs: map[string]string{
-				"request.id": "00000000-0000-0000-0000-000000000000",
+				"aro.request.id": "00000000-0000-0000-0000-000000000000",
 			},
 			expectedBaggage: map[string]string{
-				"request.id": "00000000-0000-0000-0000-000000000000",
+				"aro.request.id": "00000000-0000-0000-0000-000000000000",
 			},
 		},
 		{


### PR DESCRIPTION
### What this PR does

Since e.g. aws uses similar IDs for tracking and this could lead to conflicts in cs, we have decided to introduce a prefix. As of today, correlation id, request id and client request id are not listed in the [azure semantic-conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/azure.md). 

This PR proposes `aro` as custom prefix.




Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->

cc @simonpasquier @dinhxuanvu 