### PR TITLE
config controlled cosmos db zone redundancy

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -63,6 +63,7 @@ defaults:
       disableLocalAuth: true
       name: arohcp-rp-{{ .ctx.regionShort }}
       private: true
+      zoneRedundantMode: 'Auto'
 
   # Maestro
   maestro:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -365,6 +365,10 @@
               },
               "private": {
                 "type": "boolean"
+              },
+              "zoneRedundantMode": {
+                "type": "string",
+                "enum": ["Disabled", "Enabled", "Auto"]
               }
             },
             "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -61,6 +61,7 @@ defaults:
       disableLocalAuth: true
       name: arohcp-rp-{{ .ctx.regionShort }}
       private: true
+      zoneRedundantMode: 'Auto'
     cert:
       name: frontend-cert-{{ .ctx.regionShort }}
       issuer: Self
@@ -321,6 +322,7 @@ clouds:
           frontend:
             cosmosDB:
               private: false
+              zoneRedundantMode: 'Disabled'
       cs-pr:
         # this is the cluster service PR check and full cycle test environment
         defaults:
@@ -357,6 +359,7 @@ clouds:
           frontend:
             cosmosDB:
               private: false
+              zoneRedundantMode: 'Disabled'
       personal-dev:
         # this is the personal DEV environment
         defaults:
@@ -377,6 +380,7 @@ clouds:
           frontend:
             cosmosDB:
               private: false
+              zoneRedundantMode: 'Disabled'
       personal-perfscale:
         defaults:
           dns:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -76,7 +76,8 @@
       "deploy": true,
       "disableLocalAuth": true,
       "name": "arohcp-rp-cspr",
-      "private": false
+      "private": false,
+      "zoneRedundantMode": "Disabled"
     },
     "imageTag": ""
   },

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -76,7 +76,8 @@
       "deploy": true,
       "disableLocalAuth": true,
       "name": "arohcp-rp-dev",
-      "private": false
+      "private": false,
+      "zoneRedundantMode": "Disabled"
     },
     "imageTag": ""
   },

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -76,7 +76,8 @@
       "deploy": true,
       "disableLocalAuth": true,
       "name": "arohcp-rp-int",
-      "private": false
+      "private": false,
+      "zoneRedundantMode": "Auto"
     },
     "imageTag": "be13820"
   },

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -76,7 +76,8 @@
       "deploy": true,
       "disableLocalAuth": true,
       "name": "arohcp-rp-usw3tst",
-      "private": false
+      "private": false,
+      "zoneRedundantMode": "Disabled"
     },
     "imageTag": ""
   },

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -27,6 +27,7 @@ param disableLocalAuth = {{ .frontend.cosmosDB.disableLocalAuth }}
 param deployFrontendCosmos = {{ .frontend.cosmosDB.deploy }}
 param rpCosmosDbName = '{{ .frontend.cosmosDB.name }}'
 param rpCosmosDbPrivate = {{ .frontend.cosmosDB.private }}
+param rpCosmosZoneRedundantMode = '{{ .frontend.cosmosDB.zoneRedundantMode }}'
 
 param maestroMIName = '{{ .maestro.server.managedIdentityName }}'
 param maestroNamespace = '{{ .maestro.server.k8s.namespace }}'

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -90,6 +90,10 @@ param rpCosmosDbName string
 @description('If true, make the Cosmos DB instance private')
 param rpCosmosDbPrivate bool
 
+@description('If true, make the Cosmos DB instance zone redundant')
+@allowed(['Enabled', 'Disabled', 'Auto'])
+param rpCosmosZoneRedundantMode string
+
 @description('The resourcegroup for regional infrastructure')
 param regionalResourceGroup string
 
@@ -291,7 +295,7 @@ module rpCosmosDb '../modules/rp-cosmos.bicep' = if (deployFrontendCosmos) {
   params: {
     name: rpCosmosDbName
     location: location
-    locationIsZoneRedundant: locationHasAvailabilityZones
+    locationIsZoneRedundant: rpCosmosZoneRedundantMode == 'Auto' ? locationHasAvailabilityZones : rpCosmosZoneRedundantMode == 'Enabled'
     aksNodeSubnetId: svcCluster.outputs.aksNodeSubnetId
     vnetId: svcCluster.outputs.aksVnetId
     disableLocalAuth: disableLocalAuth


### PR DESCRIPTION
### What this PR does

there are situations where we want to control zone redundancy settings for cosmos db, e.g. a region that has generally zone redundancy support is not offering it right now. crucial for dev envs

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
