### PR TITLE
frontend: Do not handle panics when running "go test"

### DIFF
--- a/frontend/pkg/frontend/middleware_panic.go
+++ b/frontend/pkg/frontend/middleware_panic.go
@@ -7,18 +7,22 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"testing"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
 
 func MiddlewarePanic(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	defer func() {
-		if e := recover(); e != nil {
-			logger := LoggerFromContext(r.Context())
-			logger.Error(fmt.Sprintf("panic: %#v\n%s\n", e, string(debug.Stack())))
-			arm.WriteInternalServerError(w)
-		}
-	}()
+	// Do not catch panics when running "go test".
+	if !testing.Testing() {
+		defer func() {
+			if e := recover(); e != nil {
+				logger := LoggerFromContext(r.Context())
+				logger.Error(fmt.Sprintf("panic: %#v\n%s\n", e, string(debug.Stack())))
+				arm.WriteInternalServerError(w)
+			}
+		}()
+	}
 
 	next(w, r)
 }


### PR DESCRIPTION
### What this PR does

This effectively disables `MiddlewarePanic` when running unit tests.

Catching a panic can sometimes obscure the root cause of a test failure, especially when the panic is intermittent and happens during a CI pipeline run where there's no opportunity to debug.

This has been observed at least once before in [PR #833](https://github.com/Azure/ARO-HCP/pull/833) and may be happening again according to [issue #1163](https://github.com/Azure/ARO-HCP/issues/1163).