### PR TITLE
backend: Make Makefile image variables consistent with frontend

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -3,9 +3,9 @@
 HELM_CMD ?= helm upgrade --install
 
 CURRENT_COMMIT := $(shell git rev-parse --short=7 HEAD)
-
-ARO_HCP_BASE_IMAGE ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
-ARO_HCP_BACKEND_IMAGE ?= $(ARO_HCP_BASE_IMAGE)/arohcpbackend
+ARO_HCP_IMAGE_REGISTRY ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
+ARO_HCP_IMAGE_REPOSITORY ?= arohcpbackend
+ARO_HCP_BACKEND_IMAGE ?= $(ARO_HCP_IMAGE_REGISTRY)/$(ARO_HCP_IMAGE_REPOSITORY)
 
 .DEFAULT_GOAL := backend
 


### PR DESCRIPTION
### What this PR does

The image variables in `frontend/Makefile` changed recently in [PR #1011](https://github.com/Azure/ARO-HCP/pull/1011).

This just makes `backend/Makefile` use consistent variable names.