### PR TITLE
Ensure all JSON timestamps use UTC time

### DIFF
--- a/internal/api/arm/correlation.go
+++ b/internal/api/arm/correlation.go
@@ -5,7 +5,6 @@ package arm
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/google/uuid"
 )
@@ -21,9 +20,6 @@ type CorrelationData struct {
 
 	// CorrelationRequestID contains the value of header "x-ms-correlation-request-id".
 	CorrelationRequestID string `json:"correlationRequestId,omitempty"`
-
-	// RequestTime is the time that the request was received.
-	RequestTime time.Time `json:"requestTime,omitempty"`
 }
 
 // NewCorrelationData allocates and initializes a new CorrelationData from
@@ -33,6 +29,5 @@ func NewCorrelationData(r *http.Request) *CorrelationData {
 		RequestID:            uuid.New(),
 		ClientRequestID:      r.Header.Get(HeaderNameClientRequestID),
 		CorrelationRequestID: r.Header.Get(HeaderNameCorrelationRequestID),
-		RequestTime:          time.Now(),
 	}
 }

--- a/internal/api/arm/correlation_test.go
+++ b/internal/api/arm/correlation_test.go
@@ -43,10 +43,6 @@ func TestNewCorrelationData(t *testing.T) {
 			if correlationData.CorrelationRequestID != correlation_request_id {
 				t.Errorf("got %v, but want %v", correlationData.CorrelationRequestID, correlation_request_id)
 			}
-
-			if correlationData.RequestTime.IsZero() {
-				t.Fatalf("correlationData.RequestTime was not initialized")
-			}
 		})
 	}
 }

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -146,7 +146,7 @@ func (doc *OperationDocument) ToStatus() *arm.Operation {
 // is intended to be used with DBClient.UpdateOperationDoc.
 func (doc *OperationDocument) UpdateStatus(status arm.ProvisioningState, err *arm.CloudErrorBody) bool {
 	if doc.Status != status {
-		doc.LastTransitionTime = time.Now()
+		doc.LastTransitionTime = time.Now().UTC()
 		doc.Status = status
 		doc.Error = err
 		return true


### PR DESCRIPTION
### What this PR does

Did a quick audit of the RP code to make sure all timestamps that appear in JSON data - whether for logging or response bodies - use UTC time.  Found one case to fix and one case to remove.