### PR TITLE
zone redundancy control via config

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -8,9 +8,12 @@ defaults:
   global:
     rg: global-shared-resources
     subscription: hcp-{{ .ctx.region }}
-    region: uksouth
     globalMSIName: "global-ev2-identity"
     safeDnsIntAppObjectId: "c54b6bce-1cd3-4d37-bebe-aa22f4ce4fbc"
+
+  # ACR
+  svcAcrZoneRedundantMode: Enabled
+  ocpAcrZoneRedundantMode: Enabled
 
   # ACR Pull
   acrPullImageDigest: sha256:1d18e828564dcd509a8551185808549bd8bfddec1fcc4a2783914dc2103bc2ca #v0.1.7
@@ -20,6 +23,7 @@ defaults:
     namespace: hypershift
     additionalInstallArg: '--tech-preview-no-upgrade'
 
+  # SVC cluster specifics
   svc:
     subscription: hcp-{{ .ctx.region }}
     rg: hcp-underlay-{{ .ctx.region }}-svc
@@ -28,7 +32,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.31.2
+      kubernetesVersion: 1.31.3
       etcd:
         kvName: arohcp-etcd-{{ .ctx.regionShort }}
         kvSoftDelete: true
@@ -50,7 +54,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.31.2
+      kubernetesVersion: 1.31.3
       etcd:
         kvName: arohcp-etcd-{{ .ctx.regionShort }}-{{ .ctx.stamp }}
         kvSoftDelete: true
@@ -214,11 +218,19 @@ clouds:
       int:
         # this is the MSFT INT environment
         defaults:
+
+          # Region for global resources in INT is uksouth
+          global:
+            region: uksouth
+
           # Cluster Service
           clusterService:
             environment: "arohcpint"
+
           # OIDC
           oidcStorageAccountName: arohcpoidcint{{ .ctx.regionShort }}
+          oidcZoneRedundantMode: Auto
+
           # SVC
           svc:
             aks:
@@ -252,6 +264,7 @@ clouds:
                 osDiskSizeGB: 128
                 azCount: 3
               clusterOutboundIPAddressIPTags: "FirstPartyUsage:/NonProd"
+
           # DNS
           dns:
             cxParentZoneName: aroapp-hcp.azure-test.net

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -108,6 +108,14 @@
           "OneCertV2-PublicCA",
           "OneCertV2-PrivateCA"
         ]
+      },
+      "zoneRedundantMode": {
+        "type": "string",
+        "enum": [
+          "Enabled",
+          "Disabled",
+          "Auto"
+        ]
       }
     },
     "properties": {
@@ -367,8 +375,7 @@
                 "type": "boolean"
               },
               "zoneRedundantMode": {
-                "type": "string",
-                "enum": ["Disabled", "Enabled", "Auto"]
+                "$ref": "#/definitions/zoneRedundantMode"
               }
             },
             "additionalProperties": false,
@@ -823,11 +830,14 @@
       "ocpAcrName": {
         "type": "string"
       },
-      "ocpAcrZoneRedundancy": {
-        "type": "string"
+      "ocpAcrZoneRedundantMode": {
+        "$ref": "#/definitions/zoneRedundantMode"
       },
       "oidcStorageAccountName": {
         "type": "string"
+      },
+      "oidcZoneRedundantMode": {
+        "$ref": "#/definitions/zoneRedundantMode"
       },
       "region": {
         "type": "string"
@@ -920,8 +930,8 @@
       "svcAcrName": {
         "type": "string"
       },
-      "svcAcrZoneRedundancy": {
-        "type": "string"
+      "svcAcrZoneRedundantMode": {
+        "$ref": "#/definitions/zoneRedundantMode"
       }
     },
     "additionalProperties": false,
@@ -945,11 +955,14 @@
       "monitoring",
       "msiKeyVault",
       "ocpAcrName",
+      "ocpAcrZoneRedundantMode",
       "oidcStorageAccountName",
+      "oidcZoneRedundantMode",
       "region",
       "regionRG",
       "serviceKeyVault",
       "svc",
-      "svcAcrName"
+      "svcAcrName",
+      "svcAcrZoneRedundantMode"
     ]
   }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,6 +18,7 @@ defaults:
     namespace: hypershift
     additionalInstallArg: '--tech-preview-no-upgrade'
 
+  # SVC cluster specifics
   svc:
     subscription: ARO Hosted Control Planes (EA Subscription 1)
     rg: hcp-underlay-{{ .ctx.regionShort }}-svc
@@ -269,16 +270,21 @@ clouds:
           etcd:
             kvSoftDelete: false
         subscription: ARO Hosted Control Planes (EA Subscription 1)
+
       # Shared ACRs
       svcAcrName: arohcpsvcdev
-      svcAcrZoneRedundancy: Disabled
+      svcAcrZoneRedundantMode: Disabled
       ocpAcrName: arohcpocpdev
-      ocpAcrZoneRedundancy: Disabled
+      ocpAcrZoneRedundantMode: Disabled
+
       # Shared Image Sync
       imageSync:
         rg: hcp-underlay-westus3-imagesync-dev
+
       # OIDC
       oidcStorageAccountName: arohcpoidc{{ .ctx.regionShort }}
+      oidcZoneRedundantMode: Disabled
+
       # Metrics
       monitoring:
         workspaceName: 'arohcp-{{ .ctx.regionShort }}'

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -213,8 +213,9 @@
     "softDelete": false
   },
   "ocpAcrName": "arohcpocpdev",
-  "ocpAcrZoneRedundancy": "Disabled",
+  "ocpAcrZoneRedundantMode": "Disabled",
   "oidcStorageAccountName": "arohcpoidccspr",
+  "oidcZoneRedundantMode": "Disabled",
   "pko": {
     "image": "arohcpsvcdev.azurecr.io/package-operator/package-operator-package",
     "imageManager": "arohcpsvcdev.azurecr.io/package-operator/package-operator-manager",
@@ -267,5 +268,5 @@
     "subscription": "ARO Hosted Control Planes (EA Subscription 1)"
   },
   "svcAcrName": "arohcpsvcdev",
-  "svcAcrZoneRedundancy": "Disabled"
+  "svcAcrZoneRedundantMode": "Disabled"
 }

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -213,8 +213,9 @@
     "softDelete": false
   },
   "ocpAcrName": "arohcpocpdev",
-  "ocpAcrZoneRedundancy": "Disabled",
+  "ocpAcrZoneRedundantMode": "Disabled",
   "oidcStorageAccountName": "arohcpoidcdev",
+  "oidcZoneRedundantMode": "Disabled",
   "pko": {
     "image": "arohcpsvcdev.azurecr.io/package-operator/package-operator-package",
     "imageManager": "arohcpsvcdev.azurecr.io/package-operator/package-operator-manager",
@@ -267,5 +268,5 @@
     "subscription": "ARO Hosted Control Planes (EA Subscription 1)"
   },
   "svcAcrName": "arohcpsvcdev",
-  "svcAcrZoneRedundancy": "Disabled"
+  "svcAcrZoneRedundantMode": "Disabled"
 }

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -171,7 +171,7 @@
         "kvName": "arohcp-etcd-int-1",
         "kvSoftDelete": true
       },
-      "kubernetesVersion": "1.31.2",
+      "kubernetesVersion": "1.31.3",
       "name": "int-mgmt-1",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
@@ -213,7 +213,9 @@
     "softDelete": false
   },
   "ocpAcrName": "arohcpocpint",
+  "ocpAcrZoneRedundantMode": "Enabled",
   "oidcStorageAccountName": "arohcpoidcintint",
+  "oidcZoneRedundantMode": "Auto",
   "region": "westus3",
   "regionRG": "westus3-shared-resources",
   "serviceKeyVault": {
@@ -230,7 +232,7 @@
         "kvName": "arohcp-etcd-int",
         "kvSoftDelete": true
       },
-      "kubernetesVersion": "1.31.2",
+      "kubernetesVersion": "1.31.3",
       "name": "int-svc",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
@@ -260,5 +262,6 @@
     "rg": "hcp-underlay-westus3-svc",
     "subscription": "hcp-westus3"
   },
-  "svcAcrName": "arohcpsvcint"
+  "svcAcrName": "arohcpsvcint",
+  "svcAcrZoneRedundantMode": "Enabled"
 }

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -213,8 +213,9 @@
     "softDelete": false
   },
   "ocpAcrName": "arohcpocpdev",
-  "ocpAcrZoneRedundancy": "Disabled",
+  "ocpAcrZoneRedundantMode": "Disabled",
   "oidcStorageAccountName": "arohcpoidcusw3tst",
+  "oidcZoneRedundantMode": "Disabled",
   "pko": {
     "image": "arohcpsvcdev.azurecr.io/package-operator/package-operator-package",
     "imageManager": "arohcpsvcdev.azurecr.io/package-operator/package-operator-manager",
@@ -267,5 +268,5 @@
     "subscription": "ARO Hosted Control Planes (EA Subscription 1)"
   },
   "svcAcrName": "arohcpsvcdev",
-  "svcAcrZoneRedundancy": "Disabled"
+  "svcAcrZoneRedundantMode": "Disabled"
 }

--- a/dev-infrastructure/configurations/global-acr.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-acr.tmpl.bicepparam
@@ -8,5 +8,5 @@ param ocpAcrSku = 'Premium'
 
 param location = '{{ .global.region }}'
 
-param svcAcrZoneRedundancy = '{{ .svcAcrZoneRedundancy }}'
-param ocpAcrZoneRedundancy = '{{ .ocpAcrZoneRedundancy }}'
+param svcAcrZoneRedundantMode = '{{ .svcAcrZoneRedundantMode }}'
+param ocpAcrZoneRedundantMode = '{{ .ocpAcrZoneRedundantMode }}'

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -59,7 +59,10 @@ param serviceKeyVaultResourceGroup = '{{ .serviceKeyVault.rg }}'
 param ocpAcrResourceId = '__ocpAcrResourceId__'
 param svcAcrResourceId = '__svcAcrResourceId__'
 
+// OIDC
 param oidcStorageAccountName = '{{ .oidcStorageAccountName }}'
+param oidcZoneRedundantMode = '{{ .oidcZoneRedundantMode }}'
+
 param aroDevopsMsiId = '{{ .aroDevopsMsiId }}'
 
 param regionalCXDNSZoneName = '{{ .dns.regionalSubdomain }}.{{ .dns.cxParentZoneName }}'

--- a/dev-infrastructure/modules/acr/acr.bicep
+++ b/dev-infrastructure/modules/acr/acr.bicep
@@ -9,9 +9,8 @@ param location string = resourceGroup().location
 @description('Service tier of the Azure Container Registry.')
 param acrSku string
 
-@allowed(['Enabled', 'Disabled'])
-@description('Toggle zone redundancy of ACR, default is enabled.')
-param zoneRedundancy string = 'Enabled'
+@description('Toggle zone redundancy of ACR.')
+param zoneRedundant bool
 
 resource acrResource 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' = {
   name: acrName
@@ -31,7 +30,7 @@ resource acrResource 'Microsoft.ContainerRegistry/registries@2023-11-01-preview'
       // https://learn.microsoft.com/en-us/azure/container-registry/tutorial-enable-customer-managed-keys#show-encryption-status
       status: 'disabled'
     }
-    zoneRedundancy: zoneRedundancy
+    zoneRedundancy: zoneRedundant ? 'Enabled' : 'Disabled'
     policies: {
       azureADAuthenticationAsArmPolicy: {
         status: 'enabled'

--- a/dev-infrastructure/modules/common.bicep
+++ b/dev-infrastructure/modules/common.bicep
@@ -412,3 +412,12 @@ var _locationAvailabilityZones = {
 
 @export()
 func getLocationAvailabilityZones(region string) array => _locationAvailabilityZones[region].availabilityZones
+
+@export()
+func getLocationAvailabilityZonesCSV(region string) string => join(getLocationAvailabilityZones(region), ',')
+
+@export()
+func determineZoneRedundancyForRegion(region string, mode string) bool => determineZoneRedundancy(getLocationAvailabilityZones(region), mode)
+
+@export()
+func determineZoneRedundancy(availabilityZones array, mode string) bool => mode == 'Auto' ? length(availabilityZones) > 0 : mode == 'Enabled' && length(availabilityZones) > 0

--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -5,7 +5,7 @@ param disableLocalAuth bool = true
 
 // Passed Params and Overrides
 param location string
-param locationIsZoneRedundant bool
+param zoneRedundant bool
 param aksNodeSubnetId string
 param vnetId string
 param userAssignedMIs array
@@ -65,7 +65,7 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' = {
     locations: [
       {
         locationName: location
-        isZoneRedundant: locationIsZoneRedundant
+        isZoneRedundant: zoneRedundant
       }
     ]
     publicNetworkAccess: private ? 'Disabled' : 'Enabled'

--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -1,7 +1,7 @@
 /*
 Sets up the global ACRs for SVC and OCP images.
 */
-import { getLocationAvailabilityZones } from 'common.bicep'
+import { determineZoneRedundancyForRegion } from '../modules/common.bicep'
 
 param ocpAcrName string
 param ocpAcrSku string
@@ -11,8 +11,11 @@ param svcAcrSku string
 
 param location string
 
-param svcAcrZoneRedundancy string = length(getLocationAvailabilityZones(location)) > 0 ? 'Enabled' : 'Disabled'
-param ocpAcrZoneRedundancy string = length(getLocationAvailabilityZones(location)) > 0 ? 'Enabled' : 'Disabled'
+@description('The zone redundancy mode for the OCP ACR')
+param ocpAcrZoneRedundantMode string
+
+@description('The zone redundancy mode for the SVC ACR')
+param svcAcrZoneRedundantMode string
 
 module ocpAcr '../modules/acr/acr.bicep' = {
   name: ocpAcrName
@@ -20,7 +23,7 @@ module ocpAcr '../modules/acr/acr.bicep' = {
     acrName: ocpAcrName
     acrSku: ocpAcrSku
     location: location
-    zoneRedundancy: svcAcrZoneRedundancy
+    zoneRedundant: determineZoneRedundancyForRegion(location, ocpAcrZoneRedundantMode)
   }
 }
 
@@ -30,6 +33,6 @@ module svcAcr '../modules/acr/acr.bicep' = {
     acrName: svcAcrName
     acrSku: svcAcrSku
     location: location
-    zoneRedundancy: ocpAcrZoneRedundancy
+    zoneRedundant: determineZoneRedundancyForRegion(location, svcAcrZoneRedundantMode)
   }
 }

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -1,10 +1,11 @@
-import { getLocationAvailabilityZones } from 'common.bicep'
+import { getLocationAvailabilityZonesCSV } from '../modules/common.bicep'
 
 @description('Azure Region Location')
 param location string = resourceGroup().location
 
-@description('List of Availability Zones to use for the AKS cluster')
-param locationAvailabilityZones array = getLocationAvailabilityZones(location)
+@description('List of Availability Zones to use for the infrastructure, defaults to all the zones of the location')
+param locationAvailabilityZones string = getLocationAvailabilityZonesCSV(location)
+var locationAvailabilityZoneList = split(locationAvailabilityZones, ',')
 
 @description('AKS cluster name')
 param aksClusterName string = 'aro-hcp-aks'
@@ -112,7 +113,7 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
   scope: resourceGroup()
   params: {
     location: location
-    locationAvailabilityZones: locationAvailabilityZones
+    locationAvailabilityZones: locationAvailabilityZoneList
     aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName
     aksEtcdKVEnableSoftDelete: aksEtcdKVEnableSoftDelete


### PR DESCRIPTION
### What this PR does

revamp zone redundancy config options. each potential zone redundant infrastructure assets gets a config option in config.yaml

the value of this option can be one of `Enabled`, `Disabled` and `Auto`, where `Auto` implies using zone redundancy if a region has zone support.

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
