### PR TITLE
observability: add codeowerns entry

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,3 +11,4 @@ go.work* @bennerv @mbarnes @SudoBrendan @mociarain @venkateshsredhat @nanyte25 @
 /config/ @bennerv @geoberle @janboll @weinong @whober0521 @tony-schndr @jfchevrette
 /metrics/ @bennerv @geoberle @janboll @weinong @whober0521 @tony-schndr @jfchevrette
 /cluster-service/ @machi1990 @zgalor @miguelsorianod @JameelB
+/observability/ @frzifus @simonpasquier @dinhxuanvu @mbarnes


### PR DESCRIPTION
### What this PR does

Set codeowners for newly introduced observability section.

- https://github.com/Azure/ARO-HCP/pull/1319

