### PR TITLE
set storage account zonal settings to Auto

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -283,7 +283,7 @@ clouds:
 
       # OIDC
       oidcStorageAccountName: arohcpoidc{{ .ctx.regionShort }}
-      oidcZoneRedundantMode: Disabled
+      oidcZoneRedundantMode: Auto
 
       # Metrics
       monitoring:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -215,7 +215,7 @@
   "ocpAcrName": "arohcpocpdev",
   "ocpAcrZoneRedundantMode": "Disabled",
   "oidcStorageAccountName": "arohcpoidccspr",
-  "oidcZoneRedundantMode": "Disabled",
+  "oidcZoneRedundantMode": "Auto",
   "pko": {
     "image": "arohcpsvcdev.azurecr.io/package-operator/package-operator-package",
     "imageManager": "arohcpsvcdev.azurecr.io/package-operator/package-operator-manager",

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -215,7 +215,7 @@
   "ocpAcrName": "arohcpocpdev",
   "ocpAcrZoneRedundantMode": "Disabled",
   "oidcStorageAccountName": "arohcpoidcdev",
-  "oidcZoneRedundantMode": "Disabled",
+  "oidcZoneRedundantMode": "Auto",
   "pko": {
     "image": "arohcpsvcdev.azurecr.io/package-operator/package-operator-package",
     "imageManager": "arohcpsvcdev.azurecr.io/package-operator/package-operator-manager",

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -215,7 +215,7 @@
   "ocpAcrName": "arohcpocpdev",
   "ocpAcrZoneRedundantMode": "Disabled",
   "oidcStorageAccountName": "arohcpoidcusw3tst",
-  "oidcZoneRedundantMode": "Disabled",
+  "oidcZoneRedundantMode": "Auto",
   "pko": {
     "image": "arohcpsvcdev.azurecr.io/package-operator/package-operator-package",
     "imageManager": "arohcpsvcdev.azurecr.io/package-operator/package-operator-manager",


### PR DESCRIPTION
### What this PR does

the CS-PR env and integrated dev storage has been created multizonal so the settings need to reflect that as well. otherwise bicep complaints

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
