### PR TITLE
refactor csv string parameter handling - fix empty string to array split

### DIFF
--- a/dev-infrastructure/modules/common.bicep
+++ b/dev-infrastructure/modules/common.bicep
@@ -411,10 +411,16 @@ var _locationAvailabilityZones = {
 }
 
 @export()
+func csvToArray(inputString string) array => inputString == '' ? [] : split(inputString, ',')
+
+@export()
+func arrayToCSV(inputArray array) string => join(inputArray, ',')
+
+@export()
 func getLocationAvailabilityZones(region string) array => _locationAvailabilityZones[region].availabilityZones
 
 @export()
-func getLocationAvailabilityZonesCSV(region string) string => join(getLocationAvailabilityZones(region), ',')
+func getLocationAvailabilityZonesCSV(region string) string => arrayToCSV(getLocationAvailabilityZones(region))
 
 @export()
 func determineZoneRedundancyForRegion(region string, mode string) bool => determineZoneRedundancy(getLocationAvailabilityZones(region), mode)

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -1,11 +1,11 @@
-import { getLocationAvailabilityZonesCSV } from '../modules/common.bicep'
+import { getLocationAvailabilityZonesCSV, csvToArray } from '../modules/common.bicep'
 
 @description('Azure Region Location')
 param location string = resourceGroup().location
 
-@description('List of Availability Zones to use for the infrastructure, defaults to all the zones of the location')
+@description('Availability Zones to use for the infrastructure, as a CSV string. Defaults to all the zones of the location')
 param locationAvailabilityZones string = getLocationAvailabilityZonesCSV(location)
-var locationAvailabilityZoneList = split(locationAvailabilityZones, ',')
+var locationAvailabilityZoneList = csvToArray(locationAvailabilityZones)
 
 @description('AKS cluster name')
 param aksClusterName string = 'aro-hcp-aks'

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -1,11 +1,11 @@
-import { getLocationAvailabilityZonesCSV, determineZoneRedundancy } from '../modules/common.bicep'
+import { getLocationAvailabilityZonesCSV, determineZoneRedundancy, csvToArray } from '../modules/common.bicep'
 
 @description('Azure Region Location')
 param location string = resourceGroup().location
 
-@description('List of Availability Zones to use for the infrastructure, defaults to all the zones of the location')
+@description('Availability Zones to use for the infrastructure, as a CSV string. Defaults to all the zones of the location')
 param locationAvailabilityZones string = getLocationAvailabilityZonesCSV(location)
-var locationAvailabilityZoneList = split(locationAvailabilityZones, ',')
+var locationAvailabilityZoneList = csvToArray(locationAvailabilityZones)
 
 @description('AKS cluster name')
 param aksClusterName string


### PR DESCRIPTION
### What this PR does

`split` when passed an empty string, will return an array with the empty string as the first element, even if there were no occurrences of the split delimiter. In our use case, we actually want no items in the array if there were no items in the string (empty string should be considered no item)

This current breaks the case when no availability zones are passed (either by the use of an empty array or by passing an empty string)

Example showing what happens
```bicep
var emptyArray = []
var joinEmptyArray = join(emptyArray, ',') // => ""
var splitEmptyString = split(joinEmptyArray, ',') // => [""]
```

The change improves the param description and adds helper functions which help clarify the intent and makes it reusable

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
