### PR TITLE
database: Add ManagedServiceIdentity struct to ResourceDocument

### DIFF
--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -42,13 +42,14 @@ type ResourceDocument struct {
 	baseDocument
 
 	// FIXME: Change the JSON field name when we're ready to break backward-compat.
-	ResourceID        *azcorearm.ResourceID `json:"key,omitempty"`
-	PartitionKey      string                `json:"partitionKey,omitempty"`
-	InternalID        ocm.InternalID        `json:"internalId,omitempty"`
-	ActiveOperationID string                `json:"activeOperationId,omitempty"`
-	ProvisioningState arm.ProvisioningState `json:"provisioningState,omitempty"`
-	SystemData        *arm.SystemData       `json:"systemData,omitempty"`
-	Tags              map[string]string     `json:"tags,omitempty"`
+	ResourceID        *azcorearm.ResourceID       `json:"key,omitempty"`
+	PartitionKey      string                      `json:"partitionKey,omitempty"`
+	InternalID        ocm.InternalID              `json:"internalId,omitempty"`
+	ActiveOperationID string                      `json:"activeOperationId,omitempty"`
+	ProvisioningState arm.ProvisioningState       `json:"provisioningState,omitempty"`
+	Identity          *arm.ManagedServiceIdentity `json:"identity,omitempty"`
+	SystemData        *arm.SystemData             `json:"systemData,omitempty"`
+	Tags              map[string]string           `json:"tags,omitempty"`
 }
 
 func NewResourceDocument(resourceID *azcorearm.ResourceID) *ResourceDocument {


### PR DESCRIPTION
### What this PR does

Cluster Service holds the user-assigned identities that are present in the top-level "identity" section of a cluster resource, but the other fields of that section were being lost.

Currently the other "identity" fields should have
```
  "identity": {
    "principalId": "",
    "tenantId": "",
    "type": "UserAssigned"
  }
```
but we should not be assuming this.

The RP is required to include the top-level "identity" section in full when returning a cluster resource in a response body. Therefore we will stash these remaining "identity" fields in Cosmos DB alongside the Azure system metadata and resource tags.

Jira: no Jira; observed during testing