### PR TITLE
Github Actions helm-lint workflow update

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -3,7 +3,17 @@
 # More info at https://github.com/helm/chart-testing-action
 name: Lint Helm Charts
 
-on: pull_request
+on:
+  create:
+  push:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      debug:
+        required: false
+        default: "false"
 
 jobs:
   lint-test:
@@ -53,3 +63,4 @@ jobs:
             --all \
             --validate-maintainers=false \
             --target-branch ${{ github.event.repository.default_branch }}
+            --debug=${{ inputs.debug }}


### PR DESCRIPTION
[Modify Helm lint to run on **branch creation, pushes to branch, on pull request only to main branch and allow manual triggering** with debug flag.]

This is a PoC for an improvement on testing using the Github CICD environment. 