### PR TITLE
Add scripts to encrypt/decrypt using Keyvault stored certificates

### DIFF
--- a/tooling/secret-sync/decrypt.sh
+++ b/tooling/secret-sync/decrypt.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [[ $# -ne 3 ]];
+then
+    echo "usage"
+    echo "decrypt.sh file key-vault privateKeySecret"
+    echo ""
+    echo "Use - as file parameter for stdin"
+    echo "cat secret.out | decrypt.sh - key-vault privateKeySecret"
+    exit 1
+fi
+
+filename=${1}
+keyvault=${2}
+privateKeySecret=${3}
+
+secretFile=$(mktemp)
+
+az keyvault secret show --vault-name "${keyvault}" --name "${privateKeySecret}" |jq '.value' -r |base64 -d > ${secretFile}
+
+openssl pkeyutl -decrypt -inkey ${secretFile} -in ${filename}

--- a/tooling/secret-sync/encrypt.sh
+++ b/tooling/secret-sync/encrypt.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ $# -ne 2 ]];
+then
+    echo "usage"
+    echo "echo content | catencrypt.sh certificate.pfx outputFile"
+fi
+
+certificate=${1}
+outputFile=${2}
+
+cat < /dev/stdin | openssl pkeyutl -encrypt -certin -inkey ${certificate} -in - -out ${outputFile}


### PR DESCRIPTION
### What this PR does
Adds scripts that can be used to encrypt data using Ceritificates from Key Vault. 

It's missing the pipeline to write data back from the repo into the key vault. This would be done for each use case.


Jira: https://issues.redhat.com/browse/ARO-15318