### PR TITLE
configurable loglevel for maestro agent

### DIFF
--- a/cluster-service/deploy/provisioning-shards.tmpl.yml
+++ b/cluster-service/deploy/provisioning-shards.tmpl.yml
@@ -8,7 +8,7 @@ provision_shards:
       "grpc_api_config": {
         "url": "{{ .extraVars.maestroGrpUrl }}"
       },
-      "consumer_name": "{{ .maestro.consumerName }}"
+      "consumer_name": "{{ .maestro.agent.consumerName }}"
     }
   status: active
   management_cluster_id: local-cluster

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -89,7 +89,7 @@ resourceGroups:
     # this is maestro consumer registration stuff
     # this goes away when we have a real registration process
     - name: CONSUMER_NAME
-      configRef: maestro.consumerName
+      configRef: maestro.agent.consumerName
     - name: REGIONAL_RESOURCEGROUP
       configRef: regionRG
     - name: MGMT_RESOURCEGROUP

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -73,11 +73,17 @@ defaults:
   maestro:
     server:
       mqttClientName: maestro-server
-      loglevel: "4"
+      loglevel: 4
       managedIdentityName: maestro-server
       k8s:
         namespace: maestro
         serviceAccountName: maestro
+    agent:
+      consumerName: hcp-underlay-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}
+      loglevel: 4
+      sidecar:
+        imageBase: mcr.microsoft.com/azurelinux/base/nginx
+        imageTag: '1.25'
     eventGrid:
       name: arohcp-maestro-{{ .ctx.regionShort }}
       maxClientSessionsPerAuthName: 4
@@ -93,11 +99,7 @@ defaults:
       minTLSVersion: 'TLSV1.2'
       databaseName: maestro
     restrictIstioIngress: true
-    consumerName: hcp-underlay-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}
     imageRepo: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
-    agentSideCar:
-      imageBase: mcr.microsoft.com/azurelinux/base/nginx
-      imageTag: '1.25'
 
   # Cluster Service
   clusterService:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -577,9 +577,6 @@
           "certIssuer": {
             "$ref": "#/definitions/certificateIssuer"
           },
-          "consumerName": {
-            "type": "string"
-          },
           "server": {
             "type": "object",
             "properties": {
@@ -590,7 +587,7 @@
                 "type": "string"
               },
               "loglevel": {
-                "type": "string"
+                "type": "integer"
               },
               "k8s": {
                 "type": "object",
@@ -615,6 +612,34 @@
               "managedIdentityName",
               "loglevel",
               "k8s"
+            ]
+          },
+          "agent": {
+            "type": "object",
+            "properties": {
+              "consumerName": {
+                "type": "string"
+              },
+              "loglevel": {
+                "type": "integer"
+              },
+              "sidecar":{
+                "type:": "object",
+                "properties": {
+                  "imageBase":{
+                    "type": "string"
+                  },
+                  "imageTag":{
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "consumerName",
+              "loglevel",
+              "sidecar"
             ]
           },
           "eventGrid": {
@@ -680,17 +705,6 @@
               "databaseName"
             ]
           },
-          "agentSideCar":{
-            "type:": "object",
-            "properties": {
-              "imageBase":{
-                "type": "string"
-              },
-              "imageTag":{
-                "type": "string"
-              }
-            }
-          },
           "restrictIstioIngress": {
             "type": "boolean"
           }
@@ -698,14 +712,13 @@
         "additionalProperties": false,
         "required": [
           "certIssuer",
-          "consumerName",
+          "agent",
           "server",
           "eventGrid",
           "imageRepo",
           "imageTag",
           "postgres",
-          "restrictIstioIngress",
-          "agentSideCar"
+          "restrictIstioIngress"
         ]
       },
       "mce": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -71,11 +71,17 @@ defaults:
   maestro:
     server:
       mqttClientName: maestro-server
-      loglevel: "4"
+      loglevel: 4
       managedIdentityName: maestro-server
       k8s:
         namespace: maestro
         serviceAccountName: maestro
+    agent:
+      consumerName: hcp-underlay-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}
+      loglevel: 4
+      sidecar:
+        imageBase: mcr.microsoft.com/azurelinux/base/nginx
+        imageTag: '1.25'
     eventGrid:
       name: arohcp-maestro-{{ .ctx.regionShort }}
       maxClientSessionsPerAuthName: 6
@@ -91,11 +97,7 @@ defaults:
       minTLSVersion: 'TLSV1.2'
       databaseName: maestro
     restrictIstioIngress: true
-    consumerName: hcp-underlay-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}
     imageRepo: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
-    agentSideCar:
-      imageBase: mcr.microsoft.com/azurelinux/base/nginx
-      imageTag: '1.25'
 
   pko:
     image: arohcpsvcdev.azurecr.io/package-operator/package-operator-package

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -126,13 +126,16 @@
     "serviceAccountName": "genevabit-aggregator"
   },
   "maestro": {
-    "agentSideCar": {
-      "imageBase": "mcr.microsoft.com/azurelinux/base/nginx",
-      "imageTag": "1.25"
+    "agent": {
+      "consumerName": "hcp-underlay-cspr-mgmt-1",
+      "loglevel": 4,
+      "sidecar": {
+        "imageBase": "mcr.microsoft.com/azurelinux/base/nginx",
+        "imageTag": "1.25"
+      }
     },
     "certDomain": "selfsigned.maestro.keyvault.azure.com",
     "certIssuer": "Self",
-    "consumerName": "hcp-underlay-cspr-mgmt-1",
     "eventGrid": {
       "maxClientSessionsPerAuthName": 6,
       "name": "arohcp-maestro-cspr",
@@ -155,7 +158,7 @@
         "namespace": "maestro",
         "serviceAccountName": "maestro"
       },
-      "loglevel": "4",
+      "loglevel": 4,
       "managedIdentityName": "maestro-server",
       "mqttClientName": "maestro-server-cspr-cs"
     }

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -126,13 +126,16 @@
     "serviceAccountName": "genevabit-aggregator"
   },
   "maestro": {
-    "agentSideCar": {
-      "imageBase": "mcr.microsoft.com/azurelinux/base/nginx",
-      "imageTag": "1.25"
+    "agent": {
+      "consumerName": "hcp-underlay-dev-mgmt-1",
+      "loglevel": 4,
+      "sidecar": {
+        "imageBase": "mcr.microsoft.com/azurelinux/base/nginx",
+        "imageTag": "1.25"
+      }
     },
     "certDomain": "selfsigned.maestro.keyvault.azure.com",
     "certIssuer": "Self",
-    "consumerName": "hcp-underlay-dev-mgmt-1",
     "eventGrid": {
       "maxClientSessionsPerAuthName": 6,
       "name": "arohcp-maestro-dev",
@@ -155,7 +158,7 @@
         "namespace": "maestro",
         "serviceAccountName": "maestro"
       },
-      "loglevel": "4",
+      "loglevel": 4,
       "managedIdentityName": "maestro-server",
       "mqttClientName": "maestro-server-dev-dev"
     }

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -126,13 +126,16 @@
     "serviceAccountName": "genevabit-aggregator"
   },
   "maestro": {
-    "agentSideCar": {
-      "imageBase": "mcr.microsoft.com/azurelinux/base/nginx",
-      "imageTag": "1.25"
+    "agent": {
+      "consumerName": "hcp-underlay-int-mgmt-1",
+      "loglevel": 4,
+      "sidecar": {
+        "imageBase": "mcr.microsoft.com/azurelinux/base/nginx",
+        "imageTag": "1.25"
+      }
     },
     "certDomain": "",
     "certIssuer": "OneCertV2-PrivateCA",
-    "consumerName": "hcp-underlay-int-mgmt-1",
     "eventGrid": {
       "maxClientSessionsPerAuthName": 4,
       "name": "arohcp-maestro-int",
@@ -155,7 +158,7 @@
         "namespace": "maestro",
         "serviceAccountName": "maestro"
       },
-      "loglevel": "4",
+      "loglevel": 4,
       "managedIdentityName": "maestro-server",
       "mqttClientName": "maestro-server"
     }

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -126,13 +126,16 @@
     "serviceAccountName": "genevabit-aggregator"
   },
   "maestro": {
-    "agentSideCar": {
-      "imageBase": "mcr.microsoft.com/azurelinux/base/nginx",
-      "imageTag": "1.25"
+    "agent": {
+      "consumerName": "hcp-underlay-usw3tst-mgmt-1",
+      "loglevel": 4,
+      "sidecar": {
+        "imageBase": "mcr.microsoft.com/azurelinux/base/nginx",
+        "imageTag": "1.25"
+      }
     },
     "certDomain": "selfsigned.maestro.keyvault.azure.com",
     "certIssuer": "Self",
-    "consumerName": "hcp-underlay-usw3tst-mgmt-1",
     "eventGrid": {
       "maxClientSessionsPerAuthName": 6,
       "name": "arohcp-maestro-usw3tst",
@@ -155,7 +158,7 @@
         "namespace": "maestro",
         "serviceAccountName": "maestro"
       },
-      "loglevel": "4",
+      "loglevel": 4,
       "managedIdentityName": "maestro-server",
       "mqttClientName": "maestro-server-usw3tst"
     }

--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -20,7 +20,7 @@ param aksUserOsDiskSizeGB = {{ .mgmt.aks.userAgentPool.osDiskSizeGB }}
 param aksClusterOutboundIPAddressIPTags = '{{ .mgmt.aks.clusterOutboundIPAddressIPTags }}'
 
 // Maestro
-param maestroConsumerName = '{{ .maestro.consumerName }}'
+param maestroConsumerName = '{{ .maestro.agent.consumerName }}'
 param maestroEventGridNamespaceId = '__maestroEventGridNamespaceId__'
 param maestroCertDomain = '{{ .maestro.certDomain }}'
 param maestroCertIssuer = '{{ .maestro.certIssuer }}'

--- a/maestro/agent/Makefile
+++ b/maestro/agent/Makefile
@@ -9,6 +9,7 @@ deploy:
 	${HELM_CMD} maestro-agent ./helm \
 		--namespace maestro \
 		--set consumerName=${CONSUMER_NAME} \
+		--set glog_v=${MAESTRO_LOG_LEVEL} \
 		--set broker.host=$${EVENTGRID_HOSTNAME} \
 		--set credsKeyVault.name=${KEYVAULT_NAME} \
 		--set credsKeyVault.secret=${CONSUMER_NAME} \

--- a/maestro/agent/helm/templates/maestro-agent.deployment.yaml
+++ b/maestro/agent/helm/templates/maestro-agent.deployment.yaml
@@ -55,6 +55,7 @@ spec:
         - --workload-source-driver=mqtt
         - --workload-source-config=/secrets/maestro/config.yaml
         - --cloudevents-client-id={{ .Values.consumerName }}-work-agent
+        - -v={{ .Values.glog_v }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         name: maestro-agent

--- a/maestro/agent/helm/values.yaml
+++ b/maestro/agent/helm/values.yaml
@@ -12,6 +12,7 @@ credsKeyVault:
   name: ""
   secret: ""
 consumerName: ""
+glog_v: "4"
 installAppliedManifestWorkCRD: false
 sideCar:
   imageBase: ""

--- a/maestro/agent/pipeline.yaml
+++ b/maestro/agent/pipeline.yaml
@@ -21,7 +21,9 @@ resourceGroups:
     - name: MGMT_RG
       configRef: mgmt.rg
     - name: CONSUMER_NAME
-      configRef: maestro.consumerName
+      configRef: maestro.agent.consumerName
+    - name: MAESTRO_LOG_LEVEL
+      configRef: maestro.agent.loglevel
     - name: KEYVAULT_NAME
       configRef: mgmtKeyVault.name
     - name: IMAGE_REPO
@@ -29,9 +31,9 @@ resourceGroups:
     - name: IMAGE_TAG
       configRef: maestro.imageTag
     - name: SIDECAR_IMAGE_BASE
-      configRef: maestro.agentSideCar.imageBase
+      configRef: maestro.agent.sidecar.imageBase
     - name: SIDECAR_IMAGE_TAG
-      configRef: maestro.agentSideCar.imageTag
+      configRef: maestro.agent.sidecar.imageTag
     - name: ACR_NAME
       configRef: svcAcrName
 - name: {{ .svc.rg }}
@@ -47,7 +49,7 @@ resourceGroups:
         value: "true"
     variables:
     - name: CONSUMER_NAME
-      configRef: maestro.consumerName
+      configRef: maestro.agent.consumerName
     - name: NAMESPACE
       configRef: maestro.server.k8s.namespace
     dependsOn:


### PR DESCRIPTION
### What this PR does

this PR introduce configurable loglevel for the maestro agent via the `maestro.agent.loglevel` config option.

this PR also moves maestro agent config options from `maestro.xxx` to `maestro.agent.xxx`


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
