### PR TITLE
feat: Update CS Image tag to '9fd02a4'

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -204,7 +204,7 @@ clouds:
       maestro:
         imageTag: c9a36e110a32c0c25aa5025cfe6d51af797e6d4b
       clusterService:
-        imageTag: d519094
+        imageTag: 9fd02a4
       hypershiftOperator:
         imageTag: 1bb8b1a
       imageSync:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -192,7 +192,7 @@ clouds:
         imageTag: 8244a76cbc7d020192648b17ac7b7467abf1f2cb
       # Cluster Service
       clusterService:
-        imageTag: d519094
+        imageTag: 9fd02a4
         imageRepo: app-sre/uhc-clusters-service
         azureOperatorsManagedIdentities:
           clusterApiAzure:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -39,7 +39,7 @@
     },
     "environment": "arohcpdev",
     "imageRepo": "app-sre/uhc-clusters-service",
-    "imageTag": "d519094",
+    "imageTag": "9fd02a4",
     "k8s": {
       "namespace": "cluster-service",
       "serviceAccountName": "clusters-service"

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -39,7 +39,7 @@
     },
     "environment": "arohcpdev",
     "imageRepo": "app-sre/uhc-clusters-service",
-    "imageTag": "d519094",
+    "imageTag": "9fd02a4",
     "k8s": {
       "namespace": "cluster-service",
       "serviceAccountName": "clusters-service"

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -39,7 +39,7 @@
     },
     "environment": "arohcpint",
     "imageRepo": "app-sre/uhc-clusters-service",
-    "imageTag": "d519094",
+    "imageTag": "9fd02a4",
     "k8s": {
       "namespace": "cluster-service",
       "serviceAccountName": "clusters-service"

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -39,7 +39,7 @@
     },
     "environment": "arohcpdev",
     "imageRepo": "app-sre/uhc-clusters-service",
-    "imageTag": "d519094",
+    "imageTag": "9fd02a4",
     "k8s": {
       "namespace": "cluster-service",
       "serviceAccountName": "clusters-service"


### PR DESCRIPTION
### What this PR does

We are rolling out new CS changes to include Multi architecture enabled by default for ARO HCP clusters. 
In order to verify it requires re-creating cluster with 4.18.rc-8 version. 

### Special notes for your reviewer

<!-- optional -->
