### PR TITLE
feat: add Standard_D8ps_v6 as supported instance type in CS

### DIFF
--- a/cluster-service/deploy/helm/templates/cloud-resource-constraints-config.configmap.yaml
+++ b/cluster-service/deploy/helm/templates/cloud-resource-constraints-config.configmap.yaml
@@ -10,6 +10,9 @@ data:
       - id: Standard_D8s_v3
         ccs_only: true
         enabled: true
+      - id: Standard_D8ps_v6
+        ccs_only: true
+        enabled: true
   cloud-region-constraints.yaml: |
     cloud_regions:
       - id: {{ .Values.region }}

--- a/cluster-service/deploy/helm/templates/cloud-resources-config.configmap.yaml
+++ b/cluster-service/deploy/helm/templates/cloud-resources-config.configmap.yaml
@@ -15,6 +15,15 @@ data:
         category: general_purpose
         size: d8s_v3
         generic_name: standard-d8s_v3
+      - id: Standard_D8ps_v6
+        name: D8ps_v6 - General purpose
+        cloud_provider_id: azure
+        cpu_cores: 8
+        memory: 34359738368
+        category: general_purpose
+        size: d8ps_v6
+        generic_name: standard-d8ps_v6
+        architecture: arm64
   cloud-regions.yaml: |
     cloud_regions:
       - id: {{ .Values.region }}


### PR DESCRIPTION

### What this PR does

To have an allowed instance type that is based on arm64.

This is needed so we can deploy and test ARM64 based Node Pools.


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
