### PR TITLE
chore: change default demo nodepool size from 30 to 64 GiB

### DIFF
--- a/demo/node_pool.tmpl.json
+++ b/demo/node_pool.tmpl.json
@@ -7,7 +7,7 @@
     "platform": {
       "subnetId": "/subscriptions/$sub/resourceGroups/$customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet/subnets/customer-subnet-1",
       "vmSize": "Standard_D8s_v3",
-      "diskSizeGiB": 30,
+      "diskSizeGiB": 64,
       "diskStorageAccountType": "StandardSSD_LRS"
     },
     "replicas": 2


### PR DESCRIPTION

### What this PR does

The reason is that we found out that for some instance types 30 GiB is not enough.


Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
