### PR TITLE
feat: update CS image in deployment environments to include new changes

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -217,7 +217,7 @@ clouds:
           digest: sha256:fe8dbccbadf3de107d362bf11f98b4fe89d474b3aa287276c1d48d582e863bf7
       clusterService:
         image:
-          digest: sha256:2d8d8819267b01e34e8303a6904aa9e283c79a0a82d5b73f3c8c3afdb787e141
+          digest: sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b
       hypershiftOperator:
         image:
           repository: acm-d/rhtap-hypershift-operator

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -205,7 +205,7 @@ clouds:
       # Cluster Service
       clusterService:
         image:
-          digest: sha256:2d8d8819267b01e34e8303a6904aa9e283c79a0a82d5b73f3c8c3afdb787e141
+          digest: sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b
         azureOperatorsManagedIdentities:
           clusterApiAzure:
             roleName: Azure Red Hat OpenShift Control Plane Operator Role - Dev

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -48,7 +48,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:2d8d8819267b01e34e8303a6904aa9e283c79a0a82d5b73f3c8c3afdb787e141",
+      "digest": "sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b",
       "repository": "app-sre/uhc-clusters-service"
     },
     "k8s": {

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -48,7 +48,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:2d8d8819267b01e34e8303a6904aa9e283c79a0a82d5b73f3c8c3afdb787e141",
+      "digest": "sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b",
       "repository": "app-sre/uhc-clusters-service"
     },
     "k8s": {

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -48,7 +48,7 @@
     },
     "environment": "arohcpint",
     "image": {
-      "digest": "sha256:2d8d8819267b01e34e8303a6904aa9e283c79a0a82d5b73f3c8c3afdb787e141",
+      "digest": "sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b",
       "repository": "app-sre/uhc-clusters-service"
     },
     "k8s": {

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -48,7 +48,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:2d8d8819267b01e34e8303a6904aa9e283c79a0a82d5b73f3c8c3afdb787e141",
+      "digest": "sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b",
       "repository": "app-sre/uhc-clusters-service"
     },
     "k8s": {


### PR DESCRIPTION
### What this PR does

Updates the CS image, corresponding to tag 2a03722.

A non exhaustive list of new changes are:
- Fix ARO-HCP Node Pools reconciling when using OCM Commercial
  endpoints
- Limit and validate CS environment attribute length at
  CS startup time
- Validate the Managed Resource Group of a given ARO-HCP
  cluster being created is unique within an Azure Subscription
- Validate that the Managed Resource Group of a given ARO-HCP
  cluster being created does not have the same name as
  the Resource Group of that same cluster

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
