### PR TITLE
frontend: add PeerAuthentication resource for metrics

### DIFF
--- a/frontend/deploy/helm/frontend/templates/peerauthentication.yaml
+++ b/frontend/deploy/helm/frontend/templates/peerauthentication.yaml
@@ -1,0 +1,11 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: aro-hcp-frontend-metrics
+spec:
+  selector:
+    matchLabels:
+      app: aro-hcp-frontend
+  portLevelMtls:
+    8081:
+      mode: PERMISSIVE


### PR DESCRIPTION
### What this PR does

This change disables mTLS for the metrics port otherwise the collection fails because Envoy rejects the scrape request. It is similar to what exists for the Maestro server.

After applying the manifest, metrics are ingested in managed Prometheus.

![image](https://github.com/user-attachments/assets/d9910f83-6474-4974-8205-24b7cda17eaf)

Jira: <!-- optional: link to Jira issue -->
Link to demo recording: <!-- optional: link to a demo recording -->

### Special notes for your reviewer

<!-- optional -->
