### PR TITLE
Support & enable audit logging for Key Vault and AKS for dev & cspr environments (regionalized)

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -203,6 +203,7 @@ defaults:
 
   # Logs
   logs:
+    enableLogAnalytics: false
     namespace: logs
     msiName: logs-mdsd
     serviceAccountName: genevabit-aggregator

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -820,6 +820,9 @@
     "logs": {
       "type": "object",
       "properties": {
+        "enableLogAnalytics": {
+          "type": "boolean"
+        },
         "namespace": {
           "type": "string"
         },
@@ -832,6 +835,7 @@
       },
       "additionalProperties": false,
       "required": [
+        "enableLogAnalytics",
         "namespace",
         "msiName",
         "serviceAccountName"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -22,6 +22,9 @@ defaults:
     namespace: hypershift
     additionalInstallArg: '--tech-preview-no-upgrade'
 
+  logs:
+    enableLogAnalytics: false
+
   # SVC cluster specifics
   svc:
     subscription: ARO Hosted Control Planes (EA Subscription 1)
@@ -324,6 +327,8 @@ clouds:
       dev:
         # this is the integrated DEV environment
         defaults:
+          logs:
+            enableLogAnalytics: true
           mgmt:
             aks:
               systemAgentPool:
@@ -353,6 +358,8 @@ clouds:
       cs-pr:
         # this is the cluster service PR check and full cycle test environment
         defaults:
+          logs:
+            enableLogAnalytics: true
           svc:
             aks:
               # MC AKS nodepools

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -142,6 +142,7 @@
   },
   "kvCertOfficerPrincipalId": "c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb",
   "logs": {
+    "enableLogAnalytics": true,
     "msiName": "logs-mdsd",
     "namespace": "logs",
     "serviceAccountName": "genevabit-aggregator"

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -142,6 +142,7 @@
   },
   "kvCertOfficerPrincipalId": "c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb",
   "logs": {
+    "enableLogAnalytics": true,
     "msiName": "logs-mdsd",
     "namespace": "logs",
     "serviceAccountName": "genevabit-aggregator"

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -142,6 +142,7 @@
   },
   "kvCertOfficerPrincipalId": "32af88de-a61c-4f71-b709-50538598c4f2",
   "logs": {
+    "enableLogAnalytics": false,
     "msiName": "logs-mdsd",
     "namespace": "logs",
     "serviceAccountName": "genevabit-aggregator"

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -142,6 +142,7 @@
   },
   "kvCertOfficerPrincipalId": "c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb",
   "logs": {
+    "enableLogAnalytics": false,
     "msiName": "logs-mdsd",
     "namespace": "logs",
     "serviceAccountName": "genevabit-aggregator"

--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -51,3 +51,6 @@ param azureMonitoringWorkspaceId = '__azureMonitoringWorkspaceId__'
 param logsNamespace = '{{ .logs.namespace }}'
 param logsMSI = '{{ .logs.msiName }}'
 param logsServiceAccount = '{{ .logs.serviceAccountName }}'
+
+// Log Analytics Workspace ID will be passed from region pipeline if enabled in config
+param logAnalyticsWorkspaceId = '__logAnalyticsWorkspaceId__'

--- a/dev-infrastructure/configurations/mgmt-infra.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-infra.tmpl.bicepparam
@@ -24,3 +24,6 @@ param aroDevopsMsiId = '{{ .aroDevopsMsiId }}'
 // Cluster Service identity
 // used for Key Vault access
 param clusterServiceMIResourceId = '__clusterServiceMIResourceId__'
+
+// Log Analytics Workspace ID will be passed from region pipeline if enabled in config
+param logAnalyticsWorkspaceId = '__logAnalyticsWorkspaceId__'

--- a/dev-infrastructure/configurations/output-region.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/output-region.tmpl.bicepparam
@@ -2,3 +2,4 @@ using '../templates/output-region.bicep'
 
 param azureMonitorWorkspaceName = '{{ .monitoring.workspaceName }}'
 param maestroEventGridNamespacesName = '{{ .maestro.eventGrid.name }}'
+param enableLogAnalytics = {{ .logs.enableLogAnalytics }}

--- a/dev-infrastructure/configurations/region.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/region.tmpl.bicepparam
@@ -21,3 +21,6 @@ param maestroCertificateIssuer = '{{ .maestro.certIssuer }}'
 
 // MI for resource access during pipeline runs
 param aroDevopsMsiId = '{{ .aroDevopsMsiId }}'
+
+// Log Analytics
+param enableLogAnalytics = {{ .logs.enableLogAnalytics }}

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -81,3 +81,6 @@ param azureMonitoringWorkspaceId = '__azureMonitoringWorkspaceId__'
 param logsNamespace = '{{ .logs.namespace }}'
 param logsMSI = '{{ .logs.msiName }}'
 param logsServiceAccount = '{{ .logs.serviceAccountName }}'
+
+// Log Analytics Workspace ID will be passed from region pipeline if enabled in config
+param logAnalyticsWorkspaceId = '__logAnalyticsWorkspaceId__'

--- a/dev-infrastructure/configurations/svc-infra.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-infra.tmpl.bicepparam
@@ -11,3 +11,6 @@ param aroDevopsMsiId = '{{ .aroDevopsMsiId }}'
 
 // SP for KV certificate issuer registration
 param kvCertOfficerPrincipalId = '{{ .kvCertOfficerPrincipalId }}'
+
+// Log Analytics Workspace ID will be passed from region pipeline if enabled in config
+param logAnalyticsWorkspaceId = '__logAnalyticsWorkspaceId__'

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -42,7 +42,12 @@ resourceGroups:
       input:
         step: svc-output
         name: cs
+    - name: logAnalyticsWorkspaceId
+      input:
+        step: region-output
+        name: logAnalyticsWorkspaceId
     dependsOn:
+    - region-output
     - svc-output
   # Configure certificate issuers for the MC KVs
   - name: cx-oncert-public-kv-issuer

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -103,6 +103,10 @@ resourceGroups:
       input:
         step: region-output
         name: maestroEventGridNamespaceId
+    - name: logAnalyticsWorkspaceId
+      input:
+        step: region-output
+        name: logAnalyticsWorkspaceId
     dependsOn:
     - cx-oncert-public-kv-issuer
     - mgmt-oncert-private-kv-issuer

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -62,6 +62,8 @@ var istioIngressGatewayIPAddressIPTagsArray = [
 @maxLength(24)
 param aksKeyVaultName string
 
+param logAnalyticsWorkspaceId string = ''
+
 // Local Params
 @description('Optional DNS prefix to use with hosted Kubernetes API server FQDN.')
 param dnsPrefix string = aksClusterName
@@ -459,6 +461,25 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-04-02-previ
     aksClusterOutboundIPAddress
   ]
 }
+
+resource aksDiagnosticSettings 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = if (logAnalyticsWorkspaceId != '') {
+  scope: aksCluster
+  name: aksClusterName
+  properties: {
+    logs: [
+      {
+        category: 'kube-audit'
+        enabled: true
+      }
+      {
+        category: 'kube-audit-admin'
+        enabled: true
+      }
+    ]
+    workspaceId: logAnalyticsWorkspaceId
+  }
+}
+
 
 resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2024-04-02-preview' = [
   for i in range(0, userAgentPoolAZCount): {

--- a/dev-infrastructure/modules/keyvault/keyvault.bicep
+++ b/dev-infrastructure/modules/keyvault/keyvault.bicep
@@ -13,6 +13,9 @@ param private bool
 @description('Purpose of the keyvault.')
 param purpose string
 
+@description('Log Analytics Workspace ID if logging to Log Analytics')
+param logAnalyticsWorkspaceId string = ''
+
 resource keyVault 'Microsoft.KeyVault/vaults@2024-04-01-preview' = {
   location: location
   name: keyVaultName
@@ -32,6 +35,24 @@ resource keyVault 'Microsoft.KeyVault/vaults@2024-04-01-preview' = {
       family: 'A'
     }
     tenantId: subscription().tenantId
+  }
+}
+
+resource keyVaultDiagnosticSettings 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = if (logAnalyticsWorkspaceId != '') {
+  scope: keyVault
+  name: keyVaultName
+  properties: {
+    logs: [
+      {
+        category: 'AuditEvent'
+        enabled: true
+      }
+      {
+        category: 'AzurePolicyEvaluationDetails'
+        enabled: true
+      }
+    ]
+    workspaceId: logAnalyticsWorkspaceId
   }
 }
 

--- a/dev-infrastructure/modules/maestro/maestro-infra.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-infra.bicep
@@ -24,6 +24,9 @@ param maxClientSessionsPerAuthName int
 ])
 param publicNetworkAccess string
 
+@description('Log Analytics Workspace ID if logging to Log Analytics')
+param logAnalyticsWorkspaceId string = ''
+
 param certificateIssuer string
 
 //
@@ -50,6 +53,44 @@ resource eventGridNamespace 'Microsoft.EventGrid/namespaces@2024-12-15-preview' 
         ]
       }
     }
+  }
+}
+
+resource eventGridNamespaceDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (logAnalyticsWorkspaceId != '') {
+  scope: eventGridNamespace
+  name: eventGridNamespaceName
+  properties: {
+    logs: [
+      {
+        category: 'SuccessfulMqttConnections'
+        enabled: true
+      }
+      {
+        category: 'FailedMqttConnections'
+        enabled: true
+      }
+      {
+        category: 'MqttDisconnections'
+        enabled: true
+      }
+      {
+        category: 'FailedMqttPublishedMessages'
+        enabled: true
+      }
+      {
+        category: 'FailedMqttSubscriptionOperations'
+        enabled: true
+      }
+      {
+        category: 'SuccessfulHttpDataPlaneOperations'
+        enabled: true
+      }
+      {
+        category: 'FailedHttpDataPlaneOperations'
+        enabled: true
+      }
+    ]
+    workspaceId: logAnalyticsWorkspaceId
   }
 }
 

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -88,6 +88,10 @@ resourceGroups:
       input:
         step: region-output
         name: azureMonitoringWorkspaceId
+    - name: logAnalyticsWorkspaceId
+      input:
+        step: region-output
+        name: logAnalyticsWorkspaceId
     dependsOn:
     - svc-oncert-private-kv-issuer
     - svc-oncert-public-kv-issuer

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -41,6 +41,13 @@ resourceGroups:
     template: templates/svc-infra.bicep
     parameters: configurations/svc-infra.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    variables:
+    - name: logAnalyticsWorkspaceId
+      input:
+        step: region-output
+        name: logAnalyticsWorkspaceId
+    dependsOn:
+    - region-output
   # Configure certificate issuers for the SVC KV
   - name: svc-oncert-private-kv-issuer
     action: SetCertificateIssuer

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -108,6 +108,9 @@ param logsMSI string
 @description('The service account name of the logs managed identity')
 param logsServiceAccount string
 
+// Log Analytics Workspace ID will be passed from region pipeline if enabled in config
+param logAnalyticsWorkspaceId string = ''
+
 module mgmtCluster '../modules/aks-cluster-base.bicep' = {
   name: 'cluster'
   scope: resourceGroup()
@@ -142,6 +145,7 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
       }
     })
     aksKeyVaultName: aksKeyVaultName
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
     pullAcrResourceIds: [ocpAcrResourceId, svcAcrResourceId]
     userAgentMinCount: userAgentMinCount
     userAgentPoolAZCount: userAgentPoolAZCount

--- a/dev-infrastructure/templates/mgmt-infra.bicep
+++ b/dev-infrastructure/templates/mgmt-infra.bicep
@@ -40,6 +40,9 @@ param kvCertOfficerPrincipalId string
 @description('MSI that will be used during pipeline runs')
 param aroDevopsMsiId string
 
+// Log Analytics Workspace ID will be passed from region pipeline if enabled in config
+param logAnalyticsWorkspaceId string = ''
+
 resource resourcegroupTags 'Microsoft.Resources/tags@2024-03-01' = {
   name: 'default'
   scope: resourceGroup()
@@ -80,6 +83,7 @@ module cxKeyVault '../modules/keyvault/keyvault.bicep' = {
     private: cxKeyVaultPrivate
     enableSoftDelete: cxKeyVaultSoftDelete
     purpose: 'cx'
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
   }
 }
 
@@ -110,6 +114,7 @@ module msiKeyVault '../modules/keyvault/keyvault.bicep' = {
     private: msiKeyVaultPrivate
     enableSoftDelete: msiKeyVaultSoftDelete
     purpose: 'msi'
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
   }
 }
 
@@ -123,6 +128,7 @@ module mgmtKeyVault '../modules/keyvault/keyvault.bicep' = {
     private: mgmtKeyVaultPrivate
     enableSoftDelete: mgmtKeyVaultSoftDelete
     purpose: 'mgmt'
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
   }
 }
 

--- a/dev-infrastructure/templates/output-region.bicep
+++ b/dev-infrastructure/templates/output-region.bicep
@@ -4,6 +4,9 @@ param azureMonitorWorkspaceName string
 @description('The name of the eventgrid namespace for Maestro.')
 param maestroEventGridNamespacesName string
 
+@description('Enable Log Analytics')
+param enableLogAnalytics bool
+
 resource monitor 'microsoft.monitor/accounts@2021-06-03-preview' existing = {
   name: azureMonitorWorkspaceName
 }
@@ -15,3 +18,13 @@ resource maestroEventGridNamespace 'Microsoft.EventGrid/namespaces@2024-06-01-pr
 output azureMonitoringWorkspaceId string = monitor.id
 output monitorPrometheusQueryEndpoint string = monitor.properties.metrics.prometheusQueryEndpoint
 output maestroEventGridNamespaceId string = maestroEventGridNamespace.id
+
+//
+//   L O G   A N A L Y T I C S
+//
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = if (enableLogAnalytics) {
+  name: 'log-analytics-workspace'
+}
+
+output logAnalyticsWorkspaceId string = enableLogAnalytics ? logAnalyticsWorkspace.id : ''

--- a/dev-infrastructure/templates/region.bicep
+++ b/dev-infrastructure/templates/region.bicep
@@ -42,6 +42,9 @@ param svcAcrResourceId string
 @description('MSI that will be used during pipeline runs')
 param aroDevopsMsiId string
 
+@description('Enable Log Analytics')
+param enableLogAnalytics bool
+
 import * as res from '../modules/resource.bicep'
 
 // Tags the resource group
@@ -155,5 +158,20 @@ module maestroInfra '../modules/maestro/maestro-infra.bicep' = {
     maxClientSessionsPerAuthName: maestroEventGridMaxClientSessionsPerAuthName
     publicNetworkAccess: maestroEventGridPrivate ? 'Disabled' : 'Enabled'
     certificateIssuer: maestroCertificateIssuer
+  }
+}
+
+//
+//   L O G   A N A L Y T I C S
+//
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = if (enableLogAnalytics) {
+  name: 'log-analytics-workspace'
+  location: resourceGroup().location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 90
   }
 }

--- a/dev-infrastructure/templates/region.bicep
+++ b/dev-infrastructure/templates/region.bicep
@@ -158,6 +158,7 @@ module maestroInfra '../modules/maestro/maestro-infra.bicep' = {
     maxClientSessionsPerAuthName: maestroEventGridMaxClientSessionsPerAuthName
     publicNetworkAccess: maestroEventGridPrivate ? 'Disabled' : 'Enabled'
     certificateIssuer: maestroCertificateIssuer
+    logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
   }
 }
 

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -201,6 +201,9 @@ param logsMSI string
 @description('The service account name of the logs managed identity')
 param logsServiceAccount string
 
+// Log Analytics Workspace ID will be passed from region pipeline if enabled in config
+param logAnalyticsWorkspaceId string = ''
+
 resource serviceKeyVault 'Microsoft.KeyVault/vaults@2024-04-01-preview' existing = {
   name: serviceKeyVaultName
   scope: resourceGroup(serviceKeyVaultResourceGroup)
@@ -267,6 +270,7 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
       }
     })
     aksKeyVaultName: aksKeyVaultName
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
     pullAcrResourceIds: [svcAcrResourceId]
     aroDevopsMsiId: aroDevopsMsiId
     dcrId: dataCollection.outputs.dcrId

--- a/dev-infrastructure/templates/svc-infra.bicep
+++ b/dev-infrastructure/templates/svc-infra.bicep
@@ -22,6 +22,9 @@ param aroDevopsMsiId string
 @description('Set to true to prevent resources from being pruned after 48 hours')
 param persist bool = false
 
+// Log Analytics Workspace ID will be passed from region pipeline if enabled in config
+param logAnalyticsWorkspaceId string = ''
+
 // Tags the resource group
 resource resourcegroupTags 'Microsoft.Resources/tags@2024-03-01' = {
   name: 'default'
@@ -70,6 +73,7 @@ module serviceKeyVault '../modules/keyvault/keyvault.bicep' = {
     private: serviceKeyVaultPrivate
     enableSoftDelete: serviceKeyVaultSoftDelete
     purpose: 'service'
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
   }
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-15221
https://issues.redhat.com/browse/ARO-15223
https://issues.redhat.com/browse/ARO-15224

### What

Is a new PR based on #1375 which was reverted due to the requirement for the log analytics workspace and data collection rules to be in the same region (only diff in the PR is that the log analytics workspace is now regional)

* Add a Log Analytics workspace in the region RG
  * New config flag `log.enableLogAnalytics` - defaults to false, true for dev and cspr)  
* Add support for Key Vault audit logging via `Diagnostic Dettings`
* Enable Key Vault audit logging for the following Key Vaults in (dev & cspr only)
  * svc: svc
  * mgmt: cx, mgmt, msi
* Enable AKS audit logging for svc and mgmt clusters (dev & cspr only)
  * kube-audit
  * Container logs

### Why

These logs are being enabled only for dev/cspr environments to help with troubleshooting. Int, stage and production will use a different logging mechanism that is only available in EV2

### Special notes for your reviewer

Suggest reviewing commit by commit
