### PR TITLE
pipeline preprocess steps on load

### DIFF
--- a/tooling/templatize/Makefile
+++ b/tooling/templatize/Makefile
@@ -5,7 +5,7 @@ SHELL = /bin/bash
 BINARY = templatize
 
 # Define the source files
-SOURCES = $(shell find . -name '*.go')
+SOURCES = $(shell find . -name '*.go' -o -name '*.json')
 
 # Build the binary
 $(BINARY): $(SOURCES) $(MAKEFILE_LIST)

--- a/tooling/templatize/pkg/pipeline/pipeline.schema.v1.json
+++ b/tooling/templatize/pkg/pipeline/pipeline.schema.v1.json
@@ -18,7 +18,11 @@
         },
         "variableRef": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
+                "name": {
+                    "type": "string"
+                },
                 "input": {
                     "type": "object",
                     "additionalProperties": false,
@@ -62,6 +66,7 @@
         },
         "variable": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "name": {
                     "type": "string"

--- a/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2pipeline.yaml
+++ b/tooling/templatize/testdata/zz_fixture_TestProcessPipelineForEV2pipeline.yaml
@@ -29,41 +29,53 @@ resourceGroups:
             - deploy
           childZone:
             configRef: childZone
+            name: childZone
           parentZone:
             configRef: parentZone
+            name: parentZone
         - name: issuerTest
           action: SetCertificateIssuer
           dependsOn:
             - deploy
           issuer:
             configRef: provider
+            name: issuer
           vaultBaseUrl:
             configRef: vaultBaseUrl
+            name: vaultBaseUrl
         - name: issuerTestOutputChaining
           action: SetCertificateIssuer
           dependsOn:
             - deploy
           issuer:
+            name: issuer
             value: provider
           vaultBaseUrl:
             input:
                 name: kvUrl
                 step: deploy
+            name: vaultBaseUrl
         - name: cert
           action: CreateCertificate
           certificateName:
+            name: certificateName
             value: hcp-mdsd
           contentType:
+            name: contentType
             value: x-pem-file
           issuer:
+            name: issuer
             value: OneCertV2-PrivateCA
           san:
+            name: san
             value: hcp-mdsd.geneva.keyvault.aro-int.azure.com
           vaultBaseUrl:
+            name: vaultBaseUrl
             value: https://arohcp-svc-ln.vault.azure.net
         - name: rpRegistration
           action: ResourceProviderRegistration
           resourceProviderNamespaces:
+            name: resourceProviderNamespaces
             value:
                 - Microsoft.Storage
                 - Microsoft.EventHub
@@ -71,11 +83,15 @@ resourceGroups:
         - name: clusterAccount
           action: LogsAccount
           certdescription:
+            name: certdescription
             value: HCP Management Cluster
           certsan:
+            name: certsan
             value: MGMT.GENEVA.KEYVAULT.ARO-HCP-INT.AZURE.COM
           namespace:
+            name: namespace
             value: HCPManagementLogs
           subscriptionId:
+            name: subscriptionId
             value:
                 - abc


### PR DESCRIPTION
### What

we use the `pipeline.Variable` struct for both jsonschema `variable` and `variableRef` types. the only difference between them is `name` being required by `variable` while it's optional by `variableRef`. to simplify codepaths on the EV2 generator, we will keep the optional nature in `variableRef` but fill the name with a default during pipeline loading and preprocessing.

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
