### PR TITLE
[API] Move ClusterSpec.IssuerURL to PlatformProfile.IssuerURL

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -84,12 +84,6 @@ model HcpOpenShiftClusterProperties {
   /** Azure platform configuration */
   @visibility("create", "read")
   platform?: PlatformProfile;
-
-  /** URL for the OIDC provider to be used for authentication
-   * to authenticate against user Azure cloud account
-   */
-  @visibility("read")
-  issuerUrl: url;
 }
 
 /** HCP patchable cluster properties */
@@ -267,6 +261,12 @@ model PlatformProfile {
 
   /** The configuration that the operators of the cluster have to authenticate to Azure */
   operatorsAuthentication: OperatorsAuthenticationProfile;
+
+  /** URL for the OIDC provider to be used for authentication
+   * to authenticate against user Azure cloud account
+   */
+  @visibility("read")
+  issuerUrl: url;
 }
 
 scalar SubnetResourceId

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1235,19 +1235,12 @@
             "read",
             "create"
           ]
-        },
-        "issuerUrl": {
-          "type": "string",
-          "format": "uri",
-          "description": "URL for the OIDC provider to be used for authentication\nto authenticate against user Azure cloud account",
-          "readOnly": true
         }
       },
       "required": [
         "version",
         "console",
-        "api",
-        "issuerUrl"
+        "api"
       ]
     },
     "HcpOpenShiftClusterResource": {
@@ -1728,11 +1721,18 @@
         "operatorsAuthentication": {
           "$ref": "#/definitions/OperatorsAuthenticationProfile",
           "description": "The configuration that the operators of the cluster have to authenticate to Azure"
+        },
+        "issuerUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL for the OIDC provider to be used for authentication\nto authenticate against user Azure cloud account",
+          "readOnly": true
         }
       },
       "required": [
         "subnetId",
-        "operatorsAuthentication"
+        "operatorsAuthentication",
+        "issuerUrl"
       ]
     },
     "ProvisioningState": {

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -108,8 +108,8 @@ func ConvertCStoHCPOpenShiftCluster(resourceID *azcorearm.ResourceID, cluster *a
 				SubnetID:               cluster.Azure().SubnetResourceID(),
 				OutboundType:           convertOutboundTypeCSToRP(cluster.Azure().NodesOutboundConnectivity().OutboundType()),
 				NetworkSecurityGroupID: cluster.Azure().NetworkSecurityGroupResourceID(),
+				IssuerURL:              "",
 			},
-			IssuerURL: "",
 		},
 	}
 

--- a/frontend/utils/create.go
+++ b/frontend/utils/create.go
@@ -68,8 +68,8 @@ func CreateJSONFile() error {
 				NetworkSecurityGroupID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dev-test-rg/providers/Microsoft.Network/networkSecurityGroups/xyz",
 				SubnetID:               "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dev-test-rg/providers/Microsoft.Network/virtualNetworks/xyz/subnets/xyz",
 				OutboundType:           api.OutboundType("loadBalancer"),
+				IssuerURL:              "",
 			},
-			IssuerURL: "",
 		},
 	}
 

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -24,7 +24,6 @@ type HCPOpenShiftClusterProperties struct {
 	API                           APIProfile            `json:"api,omitempty"                           visibility:"read create"`
 	DisableUserWorkloadMonitoring bool                  `json:"disableUserWorkloadMonitoring,omitempty" visibility:"read create update"`
 	Platform                      PlatformProfile       `json:"platform,omitempty"                      visibility:"read create"`
-	IssuerURL                     string                `json:"issuerUrl,omitempty"                     visibility:"read"`
 }
 
 // VersionProfile represents the cluster control plane version.
@@ -70,6 +69,7 @@ type PlatformProfile struct {
 	OutboundType            OutboundType                   `json:"outboundType,omitempty"         validate:"omitempty,enum_outboundtype"`
 	NetworkSecurityGroupID  string                         `json:"networkSecurityGroupId,omitempty"`
 	OperatorsAuthentication OperatorsAuthenticationProfile `json:"operatorsAuthentication,omitempty"`
+	IssuerURL               string                         `json:"issuerUrl,omitempty"                     visibility:"read"`
 }
 
 // OperatorsAuthenticationProfile represents authentication configuration for

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -184,9 +184,6 @@ type HcpOpenShiftClusterProperties struct {
 	// READ-ONLY; Shows the cluster web console information
 	Console *ConsoleProfile
 
-	// READ-ONLY; URL for the OIDC provider to be used for authentication to authenticate against user Azure cloud account
-	IssuerURL *string
-
 	// READ-ONLY; The status of the last operation.
 	ProvisioningState *ProvisioningState
 }
@@ -489,6 +486,9 @@ type PlatformProfile struct {
 
 	// The core outgoing configuration
 	OutboundType *OutboundType
+
+	// READ-ONLY; URL for the OIDC provider to be used for authentication to authenticate against user Azure cloud account
+	IssuerURL *string
 }
 
 // ProxyResource - The resource model definition for a Azure Resource Manager proxy resource. It will not have tags and a

--- a/internal/api/v20240610preview/generated/models_serde.go
+++ b/internal/api/v20240610preview/generated/models_serde.go
@@ -515,7 +515,6 @@ func (h HcpOpenShiftClusterProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "console", h.Console)
 	populate(objectMap, "dns", h.DNS)
 	populate(objectMap, "disableUserWorkloadMonitoring", h.DisableUserWorkloadMonitoring)
-	populate(objectMap, "issuerUrl", h.IssuerURL)
 	populate(objectMap, "network", h.Network)
 	populate(objectMap, "platform", h.Platform)
 	populate(objectMap, "provisioningState", h.ProvisioningState)
@@ -543,9 +542,6 @@ func (h *HcpOpenShiftClusterProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "disableUserWorkloadMonitoring":
 				err = unpopulate(val, "DisableUserWorkloadMonitoring", &h.DisableUserWorkloadMonitoring)
-			delete(rawMsg, key)
-		case "issuerUrl":
-				err = unpopulate(val, "IssuerURL", &h.IssuerURL)
 			delete(rawMsg, key)
 		case "network":
 				err = unpopulate(val, "Network", &h.Network)
@@ -1273,6 +1269,7 @@ func (o *OperatorsAuthenticationProfile) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type PlatformProfile.
 func (p PlatformProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "issuerUrl", p.IssuerURL)
 	populate(objectMap, "managedResourceGroup", p.ManagedResourceGroup)
 	populate(objectMap, "networkSecurityGroupId", p.NetworkSecurityGroupID)
 	populate(objectMap, "operatorsAuthentication", p.OperatorsAuthentication)
@@ -1290,6 +1287,9 @@ func (p *PlatformProfile) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "issuerUrl":
+				err = unpopulate(val, "IssuerURL", &p.IssuerURL)
+			delete(rawMsg, key)
 		case "managedResourceGroup":
 				err = unpopulate(val, "ManagedResourceGroup", &p.ManagedResourceGroup)
 			delete(rawMsg, key)

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -61,6 +61,7 @@ func newPlatformProfile(from *api.PlatformProfile) *generated.PlatformProfile {
 		OutboundType:            api.Ptr(generated.OutboundType(from.OutboundType)),
 		NetworkSecurityGroupID:  api.Ptr(from.NetworkSecurityGroupID),
 		OperatorsAuthentication: newOperatorsAuthenticationProfile(&from.OperatorsAuthentication),
+		IssuerURL:               api.Ptr(from.IssuerURL),
 	}
 }
 
@@ -106,7 +107,6 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 				API:                           newAPIProfile(&from.Properties.API),
 				DisableUserWorkloadMonitoring: api.Ptr(from.Properties.DisableUserWorkloadMonitoring),
 				Platform:                      newPlatformProfile(&from.Properties.Platform),
-				IssuerURL:                     api.Ptr(from.Properties.IssuerURL),
 			},
 		},
 	}
@@ -202,9 +202,6 @@ func (c *HcpOpenShiftClusterResource) Normalize(out *api.HCPOpenShiftCluster) {
 			}
 			if c.Properties.Platform != nil {
 				normalizePlatform(c.Properties.Platform, &out.Properties.Platform)
-			}
-			if c.Properties.IssuerURL != nil {
-				out.Properties.IssuerURL = *c.Properties.IssuerURL
 			}
 		}
 	}
@@ -398,6 +395,9 @@ func normalizePlatform(p *generated.PlatformProfile, out *api.PlatformProfile) {
 	}
 	if p.OperatorsAuthentication != nil {
 		normalizeOperatorsAuthentication(p.OperatorsAuthentication, &out.OperatorsAuthentication)
+	}
+	if p.IssuerURL != nil {
+		out.IssuerURL = *p.IssuerURL
 	}
 }
 


### PR DESCRIPTION
<!-- Link to Jira issue -->

https://issues.redhat.com/browse/ARO-15338

<!-- Briefly describe what this PR does -->

### Why

Per API review [doc](https://docs.google.com/document/d/1k6sqn7uFe46pnweQU_BPu07ux6U_gAiZPVYdGKKCKww/edit?tab=t.0), move the ClusterSpec.IssuerURL to PlatformProfile.IssuerURL (next to Operator Identities).

### Special notes for your reviewer

<!-- optional -->
