### PR TITLE
Frontend Changes for Providing Cluster Creds to Customers

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -474,3 +474,27 @@ model NodePoolAutoScaling {
  * End NodePool resources
  * =======================================
  */
+
+/*
+ * =======================================
+ *   HCP cluster credentials
+ * =======================================
+ */
+
+/** HCP cluster admin credential */
+model HcpOpenShiftClusterAdminCredential {
+  /** Admin kubeconfig with a temporary client certificate */
+  @visibility(Lifecycle.Read)
+  @secret
+  kubeconfig: string;
+
+  /** Expiration timestamp for the kubeconfig's client certificate */
+  @visibility(Lifecycle.Read)
+  expirationTimestamp: utcDateTime;
+}
+
+/*
+ * =======================================
+ *   End HCP cluster credentials
+ * =======================================
+ */

--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster.tsp
@@ -24,6 +24,21 @@ interface HcpOpenShiftClusters {
   delete is ArmResourceDeleteWithoutOkAsync<HcpOpenShiftCluster>;
   listByResourceGroup is ArmResourceListByParent<HcpOpenShiftCluster>;
   listBySubscription is ArmListBySubscription<HcpOpenShiftCluster>;
+
+  // ------------------------------
+  // The requestAdminCredential and revokeAdminCredentials are
+  // asynchronous POST actions on an HcpOpenShiftClusterResource.
+  /** Request a temporary admin kubeconfig for the cluster */
+  requestAdminCredential is ArmResourceActionAsync<
+    HcpOpenShiftCluster,
+    void,
+    HcpOpenShiftClusterAdminCredential
+  >;
+  /** Revoke all credentials issued by requestAdminCredential */
+  revokeCredentials is ArmResourceActionNoResponseContentAsync<
+    HcpOpenShiftCluster,
+    void
+  >;
 }
 
 /** HCP cluster node pools */

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -754,6 +754,120 @@
         },
         "x-ms-long-running-operation": true
       }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/{hcpOpenShiftClusterName}/requestAdminCredential": {
+      "post": {
+        "operationId": "HcpOpenShiftClusters_RequestAdminCredential",
+        "tags": [
+          "HcpOpenShiftClusters"
+        ],
+        "description": "Request a temporary admin kubeconfig for the cluster",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "hcpOpenShiftClusterName",
+            "in": "path",
+            "description": "The name of the HcpOpenShiftCluster",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HcpOpenShiftClusterAdminCredential"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/{hcpOpenShiftClusterName}/revokeCredentials": {
+      "post": {
+        "operationId": "HcpOpenShiftClusters_RevokeCredentials",
+        "tags": [
+          "HcpOpenShiftClusters"
+        ],
+        "description": "Revoke all credentials issued by requestAdminCredential",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "hcpOpenShiftClusterName",
+            "in": "path",
+            "description": "The name of the HcpOpenShiftCluster",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
     }
   },
   "definitions": {
@@ -942,6 +1056,29 @@
         {
           "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
         }
+      ]
+    },
+    "HcpOpenShiftClusterAdminCredential": {
+      "type": "object",
+      "description": "HCP cluster admin credential",
+      "properties": {
+        "kubeconfig": {
+          "type": "string",
+          "format": "password",
+          "description": "Admin kubeconfig with a temporary client certificate",
+          "readOnly": true,
+          "x-ms-secret": true
+        },
+        "expirationTimestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expiration timestamp for the kubeconfig's client certificate",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "kubeconfig",
+        "expirationTimestamp"
       ]
     },
     "HcpOpenShiftClusterListResult": {

--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -309,7 +309,7 @@ func (s *OperationsScanner) processOperations(ctx context.Context, subscriptionI
 
 	pk := database.NewPartitionKey(subscriptionID)
 
-	iterator := s.dbClient.ListActiveOperationDocs(pk)
+	iterator := s.dbClient.ListActiveOperationDocs(pk, nil)
 
 	for operationID, operationDoc := range iterator.Items(ctx) {
 		operationLogger := logger.With(

--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -600,7 +600,7 @@ func (s *OperationsScanner) postAsyncNotification(ctx context.Context, op operat
 		return err
 	}
 
-	data, err := arm.Marshal(doc.ToStatus())
+	data, err := arm.MarshalJSON(doc.ToStatus())
 	if err != nil {
 		return err
 	}

--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -305,8 +305,6 @@ func (s *OperationsScanner) processSubscriptions(logger *slog.Logger) {
 func (s *OperationsScanner) processOperations(ctx context.Context, subscriptionID string, logger *slog.Logger) {
 	defer s.updateOperationMetrics(processOperationsLabel)()
 
-	var numProcessed int
-
 	pk := database.NewPartitionKey(subscriptionID)
 
 	iterator := s.dbClient.ListActiveOperationDocs(pk, nil)
@@ -322,10 +320,8 @@ func (s *OperationsScanner) processOperations(ctx context.Context, subscriptionI
 		switch operationDoc.InternalID.Kind() {
 		case cmv1.ClusterKind:
 			s.pollClusterOperation(ctx, op)
-			numProcessed++
 		case cmv1.NodePoolKind:
 			s.pollNodePoolOperation(ctx, op)
-			numProcessed++
 		}
 	}
 

--- a/frontend/pkg/frontend/const.go
+++ b/frontend/pkg/frontend/const.go
@@ -9,8 +9,9 @@ const (
 	// APIVersionKey is the request parameter name for the API version.
 	APIVersionKey = "api-version"
 
-	// Wildcard path segment names for request multiplexing, must be lowercase as we lowercase the request URL pattern when registering handlers
-	PathSegmentActionName        = "actionname"
+	// Wildcard path segment names for request multiplexing.
+	// Must be lowercase as we lowercase the request URL pattern
+	// when registering handlers.
 	PathSegmentDeploymentName    = "deploymentname"
 	PathSegmentLocation          = "location"
 	PathSegmentNodePoolName      = "nodepoolname"

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -978,7 +978,7 @@ func marshalCSCluster(csCluster *arohcpv1alpha1.Cluster, doc *database.ResourceD
 		hcpCluster.Identity.Type = doc.Identity.Type
 	}
 
-	return arm.Marshal(versionedInterface.NewHCPOpenShiftCluster(hcpCluster))
+	return arm.MarshalJSON(versionedInterface.NewHCPOpenShiftCluster(hcpCluster))
 }
 
 func getSubscriptionDifferences(oldSub, newSub *arm.Subscription) []string {

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -671,10 +671,6 @@ func (f *Frontend) ArmResourceDelete(writer http.ResponseWriter, request *http.R
 	writer.WriteHeader(http.StatusAccepted)
 }
 
-func (f *Frontend) ArmResourceAction(writer http.ResponseWriter, request *http.Request) {
-	writer.WriteHeader(http.StatusOK)
-}
-
 func (f *Frontend) ArmSubscriptionGet(writer http.ResponseWriter, request *http.Request) {
 	ctx := request.Context()
 	logger := LoggerFromContext(ctx)

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -978,7 +978,7 @@ func marshalCSCluster(csCluster *arohcpv1alpha1.Cluster, doc *database.ResourceD
 		hcpCluster.Identity.Type = doc.Identity.Type
 	}
 
-	return arm.MarshalJSON(versionedInterface.NewHCPOpenShiftCluster(hcpCluster))
+	return versionedInterface.MarshalHCPOpenShiftCluster(hcpCluster)
 }
 
 func getSubscriptionDifferences(oldSub, newSub *arm.Subscription) []string {

--- a/frontend/pkg/frontend/helpers.go
+++ b/frontend/pkg/frontend/helpers.go
@@ -30,18 +30,14 @@ func (f *Frontend) CheckForProvisioningStateConflict(ctx context.Context, operat
 		// Resource must already exist for there to be a conflict.
 	case database.OperationRequestDelete:
 		if doc.ProvisioningState == arm.ProvisioningStateDeleting {
-			return arm.NewCloudError(
-				http.StatusConflict,
-				arm.CloudErrorCodeConflict,
-				doc.ResourceID.String(),
+			return arm.NewConflictError(
+				doc.ResourceID,
 				"Resource is already deleting")
 		}
 	case database.OperationRequestUpdate:
 		if !doc.ProvisioningState.IsTerminal() {
-			return arm.NewCloudError(
-				http.StatusConflict,
-				arm.CloudErrorCodeConflict,
-				doc.ResourceID.String(),
+			return arm.NewConflictError(
+				doc.ResourceID,
 				"Cannot update resource while resource is %s",
 				strings.ToLower(string(doc.ProvisioningState)))
 		}
@@ -58,10 +54,8 @@ func (f *Frontend) CheckForProvisioningStateConflict(ctx context.Context, operat
 		}
 
 		if parentDoc.ProvisioningState == arm.ProvisioningStateDeleting {
-			return arm.NewCloudError(
-				http.StatusConflict,
-				arm.CloudErrorCodeConflict,
-				doc.ResourceID.String(),
+			return arm.NewConflictError(
+				doc.ResourceID,
 				"Cannot %s resource while parent resource is deleting",
 				strings.ToLower(string(operationRequest)))
 		}

--- a/frontend/pkg/frontend/helpers.go
+++ b/frontend/pkg/frontend/helpers.go
@@ -35,10 +35,30 @@ func (f *Frontend) CheckForProvisioningStateConflict(ctx context.Context, operat
 				"Resource is already deleting")
 		}
 	case database.OperationRequestUpdate:
+		// Defer to Cluster Service for ProvisioningStateFailed since
+		// it is ambiguous about whether the resource is functional.
 		if !doc.ProvisioningState.IsTerminal() {
 			return arm.NewConflictError(
 				doc.ResourceID,
 				"Cannot update resource while resource is %s",
+				strings.ToLower(string(doc.ProvisioningState)))
+		}
+	case database.OperationRequestRequestCredential:
+		// Defer to Cluster Service for ProvisioningStateFailed since
+		// it is ambiguous about whether the resource is functional.
+		if !doc.ProvisioningState.IsTerminal() {
+			return arm.NewConflictError(
+				doc.ResourceID,
+				"Cannot request credential while resource is %s",
+				strings.ToLower(string(doc.ProvisioningState)))
+		}
+	case database.OperationRequestRevokeCredentials:
+		// Defer to Cluster Service for ProvisioningStateFailed since
+		// it is ambiguous about whether the resource is functional.
+		if !doc.ProvisioningState.IsTerminal() {
+			return arm.NewConflictError(
+				doc.ResourceID,
+				"Cannot revoke credentials while resource is %s",
 				strings.ToLower(string(doc.ProvisioningState)))
 		}
 	}

--- a/frontend/pkg/frontend/helpers_test.go
+++ b/frontend/pkg/frontend/helpers_test.go
@@ -47,6 +47,18 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 			directConflict:   func(s arm.ProvisioningState) bool { return !s.IsTerminal() },
 		},
 		{
+			name:             "Request cluster credential",
+			resourceID:       clusterResourceID,
+			operationRequest: database.OperationRequestRequestCredential,
+			directConflict:   func(s arm.ProvisioningState) bool { return !s.IsTerminal() },
+		},
+		{
+			name:             "Revoke cluster credentials",
+			resourceID:       clusterResourceID,
+			operationRequest: database.OperationRequestRevokeCredentials,
+			directConflict:   func(s arm.ProvisioningState) bool { return !s.IsTerminal() },
+		},
+		{
 			name:             "Create node pool",
 			resourceID:       nodePoolResourceID,
 			operationRequest: database.OperationRequestCreate,

--- a/frontend/pkg/frontend/helpers_test.go
+++ b/frontend/pkg/frontend/helpers_test.go
@@ -25,119 +25,47 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 		name             string
 		resourceID       string
 		operationRequest database.OperationRequest
-		directConflicts  map[arm.ProvisioningState]bool
-		parentConflicts  map[arm.ProvisioningState]bool
+		directConflict   func(arm.ProvisioningState) bool
+		parentConflict   func(arm.ProvisioningState) bool
 	}{
 		{
 			name:             "Create cluster",
 			resourceID:       clusterResourceID,
 			operationRequest: database.OperationRequestCreate,
-			directConflicts: map[arm.ProvisioningState]bool{
-				arm.ProvisioningStateSucceeded:    false,
-				arm.ProvisioningStateFailed:       false,
-				arm.ProvisioningStateCanceled:     false,
-				arm.ProvisioningStateAccepted:     false,
-				arm.ProvisioningStateDeleting:     false,
-				arm.ProvisioningStateProvisioning: false,
-				arm.ProvisioningStateUpdating:     false,
-			},
+			directConflict:   func(s arm.ProvisioningState) bool { return false },
 		},
 		{
 			name:             "Delete cluster",
 			resourceID:       clusterResourceID,
 			operationRequest: database.OperationRequestDelete,
-			directConflicts: map[arm.ProvisioningState]bool{
-				arm.ProvisioningStateSucceeded:    false,
-				arm.ProvisioningStateFailed:       false,
-				arm.ProvisioningStateCanceled:     false,
-				arm.ProvisioningStateAccepted:     false,
-				arm.ProvisioningStateDeleting:     true,
-				arm.ProvisioningStateProvisioning: false,
-				arm.ProvisioningStateUpdating:     false,
-			},
+			directConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
 		},
 		{
 			name:             "Update cluster",
 			resourceID:       clusterResourceID,
 			operationRequest: database.OperationRequestUpdate,
-			directConflicts: map[arm.ProvisioningState]bool{
-				arm.ProvisioningStateSucceeded:    false,
-				arm.ProvisioningStateFailed:       false,
-				arm.ProvisioningStateCanceled:     false,
-				arm.ProvisioningStateAccepted:     true,
-				arm.ProvisioningStateDeleting:     true,
-				arm.ProvisioningStateProvisioning: true,
-				arm.ProvisioningStateUpdating:     true,
-			},
+			directConflict:   func(s arm.ProvisioningState) bool { return !s.IsTerminal() },
 		},
 		{
 			name:             "Create node pool",
 			resourceID:       nodePoolResourceID,
 			operationRequest: database.OperationRequestCreate,
-			directConflicts: map[arm.ProvisioningState]bool{
-				arm.ProvisioningStateSucceeded:    false,
-				arm.ProvisioningStateFailed:       false,
-				arm.ProvisioningStateCanceled:     false,
-				arm.ProvisioningStateAccepted:     false,
-				arm.ProvisioningStateDeleting:     false,
-				arm.ProvisioningStateProvisioning: false,
-				arm.ProvisioningStateUpdating:     false,
-			},
-			parentConflicts: map[arm.ProvisioningState]bool{
-				arm.ProvisioningStateSucceeded:    false,
-				arm.ProvisioningStateFailed:       false,
-				arm.ProvisioningStateCanceled:     false,
-				arm.ProvisioningStateAccepted:     false,
-				arm.ProvisioningStateDeleting:     true,
-				arm.ProvisioningStateProvisioning: false,
-				arm.ProvisioningStateUpdating:     false,
-			},
+			directConflict:   func(s arm.ProvisioningState) bool { return false },
+			parentConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
 		},
 		{
 			name:             "Delete node pool",
 			resourceID:       nodePoolResourceID,
 			operationRequest: database.OperationRequestDelete,
-			directConflicts: map[arm.ProvisioningState]bool{
-				arm.ProvisioningStateSucceeded:    false,
-				arm.ProvisioningStateFailed:       false,
-				arm.ProvisioningStateCanceled:     false,
-				arm.ProvisioningStateAccepted:     false,
-				arm.ProvisioningStateDeleting:     true,
-				arm.ProvisioningStateProvisioning: false,
-				arm.ProvisioningStateUpdating:     false,
-			},
-			parentConflicts: map[arm.ProvisioningState]bool{
-				arm.ProvisioningStateSucceeded:    false,
-				arm.ProvisioningStateFailed:       false,
-				arm.ProvisioningStateCanceled:     false,
-				arm.ProvisioningStateAccepted:     false,
-				arm.ProvisioningStateDeleting:     true,
-				arm.ProvisioningStateProvisioning: false,
-				arm.ProvisioningStateUpdating:     false,
-			},
+			directConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
+			parentConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
 		},
 		{
 			name:             "Update node pool",
 			resourceID:       nodePoolResourceID,
 			operationRequest: database.OperationRequestUpdate,
-			directConflicts: map[arm.ProvisioningState]bool{
-				arm.ProvisioningStateSucceeded:    false,
-				arm.ProvisioningStateFailed:       false,
-				arm.ProvisioningStateCanceled:     false,
-				arm.ProvisioningStateAccepted:     true,
-				arm.ProvisioningStateDeleting:     true,
-				arm.ProvisioningStateProvisioning: true,
-				arm.ProvisioningStateUpdating:     true,
-			},
-			parentConflicts: map[arm.ProvisioningState]bool{
-				arm.ProvisioningStateSucceeded:    false,
-				arm.ProvisioningStateFailed:       false,
-				arm.ProvisioningStateCanceled:     false,
-				arm.ProvisioningStateAccepted:     false,
-				arm.ProvisioningStateDeleting:     true,
-				arm.ProvisioningStateProvisioning: false,
-				arm.ProvisioningStateUpdating:     false,
-			},
+			directConflict:   func(s arm.ProvisioningState) bool { return !s.IsTerminal() },
+			parentConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
 		},
 	}
 
@@ -149,8 +77,8 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		for directState, directConflict := range tt.directConflicts {
-			name = fmt.Sprintf("%s (directState=%s)", tt.name, directState)
+		for provisioningState := range arm.ListProvisioningStates() {
+			name = fmt.Sprintf("%s (provisioningState=%s)", tt.name, provisioningState)
 			t.Run(name, func(t *testing.T) {
 				ctx := ContextWithLogger(context.Background(), testLogger)
 				ctrl := gomock.NewController(t)
@@ -161,7 +89,7 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 				}
 
 				doc := database.NewResourceDocument(resourceID)
-				doc.ProvisioningState = directState
+				doc.ProvisioningState = provisioningState
 
 				parentResourceID := resourceID.Parent
 				parentDoc := database.NewResourceDocument(parentResourceID)
@@ -176,58 +104,60 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 				cloudError := frontend.CheckForProvisioningStateConflict(ctx, tt.operationRequest, doc)
 
 				if cloudError == nil {
-					if directConflict {
+					if tt.directConflict(provisioningState) {
 						t.Errorf("Expected %d %s but got no error", http.StatusConflict, http.StatusText(http.StatusConflict))
 					}
 				} else {
-					if !directConflict || cloudError.StatusCode != http.StatusConflict {
+					if !tt.directConflict(provisioningState) || cloudError.StatusCode != http.StatusConflict {
 						t.Errorf("Got unexpected error: %d %s", cloudError.StatusCode, http.StatusText(cloudError.StatusCode))
 					}
 				}
 			})
 		}
 
-		for parentState, parentConflict := range tt.parentConflicts {
-			name = fmt.Sprintf("%s (parentState=%s)", tt.name, parentState)
-			t.Run(name, func(t *testing.T) {
-				ctx := ContextWithLogger(context.Background(), testLogger)
-				ctrl := gomock.NewController(t)
-				mockDBClient := mocks.NewMockDBClient(ctrl)
+		if tt.parentConflict != nil {
+			for provisioningState := range arm.ListProvisioningStates() {
+				name = fmt.Sprintf("%s (parent provisioningState=%s)", tt.name, provisioningState)
+				t.Run(name, func(t *testing.T) {
+					ctx := ContextWithLogger(context.Background(), testLogger)
+					ctrl := gomock.NewController(t)
+					mockDBClient := mocks.NewMockDBClient(ctrl)
 
-				frontend := &Frontend{
-					dbClient: mockDBClient,
-				}
-
-				doc := database.NewResourceDocument(resourceID)
-				// Hold the provisioning state to something benign.
-				doc.ProvisioningState = arm.ProvisioningStateSucceeded
-
-				parentResourceID := resourceID.Parent
-				if parentResourceID.ResourceType.Namespace == resourceID.ResourceType.Namespace {
-					parentDoc := database.NewResourceDocument(parentResourceID)
-					parentDoc.ProvisioningState = parentState
-
-					mockDBClient.EXPECT().
-						GetResourceDoc(gomock.Any(), equalResourceID(parentResourceID)). // defined in frontend_test.go
-						Return(parentDoc, nil)
-				} else {
-					t.Fatalf("Parent resource type namespace (%s) differs from child namespace (%s)",
-						parentResourceID.ResourceType.Namespace,
-						resourceID.ResourceType.Namespace)
-				}
-
-				cloudError := frontend.CheckForProvisioningStateConflict(ctx, tt.operationRequest, doc)
-
-				if cloudError == nil {
-					if parentConflict {
-						t.Errorf("Expected %d %s but got no error", http.StatusConflict, http.StatusText(http.StatusConflict))
+					frontend := &Frontend{
+						dbClient: mockDBClient,
 					}
-				} else {
-					if !parentConflict || cloudError.StatusCode != http.StatusConflict {
-						t.Errorf("Got unexpected error: %d %s", cloudError.StatusCode, http.StatusText(cloudError.StatusCode))
+
+					doc := database.NewResourceDocument(resourceID)
+					// Hold the provisioning state to something benign.
+					doc.ProvisioningState = arm.ProvisioningStateSucceeded
+
+					parentResourceID := resourceID.Parent
+					if parentResourceID.ResourceType.Namespace == resourceID.ResourceType.Namespace {
+						parentDoc := database.NewResourceDocument(parentResourceID)
+						parentDoc.ProvisioningState = provisioningState
+
+						mockDBClient.EXPECT().
+							GetResourceDoc(gomock.Any(), equalResourceID(parentResourceID)). // defined in frontend_test.go
+							Return(parentDoc, nil)
+					} else {
+						t.Fatalf("Parent resource type namespace (%s) differs from child namespace (%s)",
+							parentResourceID.ResourceType.Namespace,
+							resourceID.ResourceType.Namespace)
 					}
-				}
-			})
+
+					cloudError := frontend.CheckForProvisioningStateConflict(ctx, tt.operationRequest, doc)
+
+					if cloudError == nil {
+						if tt.parentConflict(provisioningState) {
+							t.Errorf("Expected %d %s but got no error", http.StatusConflict, http.StatusText(http.StatusConflict))
+						}
+					} else {
+						if !tt.parentConflict(provisioningState) || cloudError.StatusCode != http.StatusConflict {
+							t.Errorf("Got unexpected error: %d %s", cloudError.StatusCode, http.StatusText(cloudError.StatusCode))
+						}
+					}
+				})
+			}
 		}
 	}
 }

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -280,5 +280,5 @@ func marshalCSNodePool(csNodePool *cmv1.NodePool, doc *database.ResourceDocument
 	hcpNodePool.TrackedResource.Tags = maps.Clone(doc.Tags)
 	hcpNodePool.Properties.ProvisioningState = doc.ProvisioningState
 
-	return arm.MarshalJSON(versionedInterface.NewHCPOpenShiftClusterNodePool(hcpNodePool))
+	return versionedInterface.MarshalHCPOpenShiftClusterNodePool(hcpNodePool)
 }

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -280,5 +280,5 @@ func marshalCSNodePool(csNodePool *cmv1.NodePool, doc *database.ResourceDocument
 	hcpNodePool.TrackedResource.Tags = maps.Clone(doc.Tags)
 	hcpNodePool.Properties.ProvisioningState = doc.ProvisioningState
 
-	return arm.Marshal(versionedInterface.NewHCPOpenShiftClusterNodePool(hcpNodePool))
+	return arm.MarshalJSON(versionedInterface.NewHCPOpenShiftClusterNodePool(hcpNodePool))
 }

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -405,6 +405,14 @@ func (f *Frontend) BuildCSNodePool(ctx context.Context, nodePool *api.HCPOpenShi
 	return npBuilder.Build()
 }
 
+// ConvertCStoAdminCredential converts a CS BreakGlassCredential object into an HCPOpenShiftClusterAdminCredential.
+func ConvertCStoAdminCredential(breakGlassCredential *cmv1.BreakGlassCredential) *api.HCPOpenShiftClusterAdminCredential {
+	return &api.HCPOpenShiftClusterAdminCredential{
+		ExpirationTimestamp: breakGlassCredential.ExpirationTimestamp(),
+		Kubeconfig:          breakGlassCredential.Kubeconfig(),
+	}
+}
+
 // transportFunc implements the http.RoundTripper interface.
 type transportFunc func(*http.Request) (*http.Response, error)
 

--- a/frontend/pkg/frontend/operations.go
+++ b/frontend/pkg/frontend/operations.go
@@ -116,7 +116,7 @@ func (f *Frontend) ExposeOperation(writer http.ResponseWriter, request *http.Req
 
 		// Add callback header(s) based on the request method.
 		switch request.Method {
-		case http.MethodDelete, http.MethodPatch:
+		case http.MethodDelete, http.MethodPatch, http.MethodPost:
 			f.AddLocationHeader(writer, request, updateDoc)
 			fallthrough
 		case http.MethodPut:

--- a/frontend/pkg/frontend/operations.go
+++ b/frontend/pkg/frontend/operations.go
@@ -140,7 +140,11 @@ func (f *Frontend) CancelActiveOperation(ctx context.Context, resourceDoc *datab
 	if resourceDoc.ActiveOperationID != "" {
 		pk := database.NewPartitionKey(resourceDoc.ResourceID.SubscriptionID)
 		updated, err := f.dbClient.UpdateOperationDoc(ctx, pk, resourceDoc.ActiveOperationID, func(updateDoc *database.OperationDocument) bool {
-			return updateDoc.UpdateStatus(arm.ProvisioningStateCanceled, nil)
+			var cloudError = arm.CloudErrorBody{
+				Code:    arm.CloudErrorCodeCanceled,
+				Message: "This operation was superseded by another",
+			}
+			return updateDoc.UpdateStatus(arm.ProvisioningStateCanceled, &cloudError)
 		})
 		// Disregard "not found" errors; a missing operation is effectively canceled.
 		if err != nil && !errors.Is(err, database.ErrNotFound) {

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -30,6 +30,9 @@ const (
 	PatternResourceGroups   = "resourcegroups/" + WildcardResourceGroupName
 	PatternOperationResults = api.OperationResultResourceTypeName + "/" + WildcardOperationID
 	PatternOperationsStatus = api.OperationStatusResourceTypeName + "/" + WildcardOperationID
+
+	ActionRequestAdminCredential = "requestadmincredential"
+	ActionRevokeCredentials      = "revokecredentials"
 )
 
 // MuxPattern forms a URL pattern suitable for passing to http.ServeMux.
@@ -98,6 +101,12 @@ func (f *Frontend) routes(r prometheus.Registerer) *MiddlewareMux {
 	mux.Handle(
 		MuxPattern(http.MethodDelete, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceDelete))
+	mux.Handle(
+		MuxPattern(http.MethodPost, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, ActionRequestAdminCredential),
+		postMuxMiddleware.HandlerFunc(f.ArmResourceActionRequestAdminCredential))
+	mux.Handle(
+		MuxPattern(http.MethodPost, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, ActionRevokeCredentials),
+		postMuxMiddleware.HandlerFunc(f.ArmResourceActionRevokeCredentials))
 	mux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, PatternNodePools),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceRead))

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	WildcardActionName        = "{" + PathSegmentActionName + "}"
 	WildcardDeploymentName    = "{" + PathSegmentDeploymentName + "}"
 	WildcardLocation          = "{" + PathSegmentLocation + "}"
 	WildcardNodePoolName      = "{" + PathSegmentNodePoolName + "}"
@@ -99,9 +98,6 @@ func (f *Frontend) routes(r prometheus.Registerer) *MiddlewareMux {
 	mux.Handle(
 		MuxPattern(http.MethodDelete, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceDelete))
-	mux.Handle(
-		MuxPattern(http.MethodPost, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, WildcardActionName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceAction))
 	mux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, PatternNodePools),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceRead))

--- a/internal/api/arm/error.go
+++ b/internal/api/arm/error.go
@@ -122,6 +122,20 @@ func WriteInternalServerError(w http.ResponseWriter) {
 	WriteCloudError(w, NewInternalServerError())
 }
 
+// NewConflictError creates a CloudError for a conflict error
+func NewConflictError(resourceID *azcorearm.ResourceID, format string, a ...interface{}) *CloudError {
+	return NewCloudError(
+		http.StatusConflict,
+		CloudErrorCodeConflict,
+		resourceID.String(),
+		format, a...)
+}
+
+// WriteConflictError writes a conflict error to the given ResponseWriter
+func WriteConflictError(w http.ResponseWriter, resourceID *azcorearm.ResourceID, format string, a ...interface{}) {
+	WriteCloudError(w, NewConflictError(resourceID, format, a...))
+}
+
 // NewResourceNotFoundError creates a CloudError for a nonexistent resource error
 func NewResourceNotFoundError(resourceID *azcorearm.ResourceID) *CloudError {
 	var code string

--- a/internal/api/arm/error.go
+++ b/internal/api/arm/error.go
@@ -20,6 +20,7 @@ const (
 	CloudErrorCodeInvalidResourceType      = "InvalidResourceType"
 	CloudErrorCodeMultipleErrorsOccurred   = "MultipleErrorsOccurred"
 	CloudErrorCodeUnsupportedMediaType     = "UnsupportedMediaType"
+	CloudErrorCodeCanceled                 = "Canceled"
 	CloudErrorCodeConflict                 = "Conflict"
 	CloudErrorCodeNotFound                 = "NotFound"
 	CloudErrorCodeInvalidSubscriptionState = "InvalidSubscriptionState"

--- a/internal/api/arm/resource.go
+++ b/internal/api/arm/resource.go
@@ -4,7 +4,9 @@ package arm
 // Licensed under the Apache License 2.0.
 
 import (
+	"iter"
 	"maps"
+	"slices"
 	"time"
 )
 
@@ -112,4 +114,18 @@ func (s ProvisioningState) IsTerminal() bool {
 	default:
 		return false
 	}
+}
+
+// ListProvisioningStates returns an iterator that yields all recognized
+// ProvisioningState values. This function is intended as a test aid.
+func ListProvisioningStates() iter.Seq[ProvisioningState] {
+	return slices.Values([]ProvisioningState{
+		ProvisioningStateSucceeded,
+		ProvisioningStateFailed,
+		ProvisioningStateCanceled,
+		ProvisioningStateAccepted,
+		ProvisioningStateDeleting,
+		ProvisioningStateProvisioning,
+		ProvisioningStateUpdating,
+	})
 }

--- a/internal/api/arm/response.go
+++ b/internal/api/arm/response.go
@@ -14,7 +14,7 @@ const (
 	indent string = "    " // 4 spaces
 )
 
-// Marshal returns the JSON encoding of v.
+// MarshalJSON returns the JSON encoding of v.
 //
 // Call this function instead of the marshal functions in "encoding/json" for
 // HTTP responses to ensure the formatting is consistent.
@@ -22,7 +22,7 @@ const (
 // Note, there is nothing ARM-specific about this function other than all ARM
 // response bodies are JSON-formatted. But the "arm" package is currently the
 // lowest layer insofar as it has no dependencies on other ARO-HCP packages.
-func Marshal(v any) ([]byte, error) {
+func MarshalJSON(v any) ([]byte, error) {
 	return json.MarshalIndent(v, prefix, indent)
 }
 
@@ -45,7 +45,7 @@ func WriteJSONResponse(writer http.ResponseWriter, statusCode int, body any) (in
 		data = v // write a byte slice verbatim
 	default:
 		var err error
-		data, err = Marshal(body)
+		data, err = MarshalJSON(body)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/api/arm/response_test.go
+++ b/internal/api/arm/response_test.go
@@ -26,7 +26,7 @@ func TestWriteJSONResponse(t *testing.T) {
 		},
 	}
 
-	resourceBytes, err := Marshal(resourceStruct)
+	resourceBytes, err := MarshalJSON(resourceStruct)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestWriteJSONResponse(t *testing.T) {
 				t.Errorf("Got Content-Type %s, expected application/json", contentType)
 			}
 
-			expectBody, err := Marshal(resourceStruct)
+			expectBody, err := MarshalJSON(resourceStruct)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/api/hcpopenshiftclusteradmincredential.go
+++ b/internal/api/hcpopenshiftclusteradmincredential.go
@@ -1,0 +1,13 @@
+package api
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "time"
+
+// HCPOpenShiftClusterAdminCredential represents a temporary admin
+// credential for an ARO HCP OpenShift cluster.
+type HCPOpenShiftClusterAdminCredential struct {
+	ExpirationTimestamp time.Time `json:"expirationTimestamp"`
+	Kubeconfig          string    `json:"kubeconfig"`
+}

--- a/internal/api/registry.go
+++ b/internal/api/registry.go
@@ -43,6 +43,10 @@ type Version interface {
 	// Passing a nil pointer creates a resource with default values.
 	NewHCPOpenShiftCluster(*HCPOpenShiftCluster) VersionedHCPOpenShiftCluster
 	NewHCPOpenShiftClusterNodePool(*HCPOpenShiftClusterNodePool) VersionedHCPOpenShiftClusterNodePool
+
+	// Response Marshaling
+	MarshalHCPOpenShiftCluster(*HCPOpenShiftCluster) ([]byte, error)
+	MarshalHCPOpenShiftClusterNodePool(*HCPOpenShiftClusterNodePool) ([]byte, error)
 }
 
 // apiRegistry is the map of registered API versions

--- a/internal/api/registry.go
+++ b/internal/api/registry.go
@@ -47,6 +47,7 @@ type Version interface {
 	// Response Marshaling
 	MarshalHCPOpenShiftCluster(*HCPOpenShiftCluster) ([]byte, error)
 	MarshalHCPOpenShiftClusterNodePool(*HCPOpenShiftClusterNodePool) ([]byte, error)
+	MarshalHCPOpenShiftClusterAdminCredential(*HCPOpenShiftClusterAdminCredential) ([]byte, error)
 }
 
 // apiRegistry is the map of registered API versions

--- a/internal/api/v20240610preview/admincredential_methods.go
+++ b/internal/api/v20240610preview/admincredential_methods.go
@@ -1,0 +1,21 @@
+package v20240610preview
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/v20240610preview/generated"
+)
+
+func newHCPOpenShiftClusterAdminCredential(from *api.HCPOpenShiftClusterAdminCredential) *generated.HcpOpenShiftClusterAdminCredential {
+	return &generated.HcpOpenShiftClusterAdminCredential{
+		ExpirationTimestamp: api.Ptr(from.ExpirationTimestamp),
+		Kubeconfig:          api.Ptr(from.Kubeconfig),
+	}
+}
+
+func (v version) MarshalHCPOpenShiftClusterAdminCredential(from *api.HCPOpenShiftClusterAdminCredential) ([]byte, error) {
+	return arm.MarshalJSON(newHCPOpenShiftClusterAdminCredential(from))
+}

--- a/internal/api/v20240610preview/generated/fake/hcpopenshiftclusters_server.go
+++ b/internal/api/v20240610preview/generated/fake/hcpopenshiftclusters_server.go
@@ -45,6 +45,14 @@ type HcpOpenShiftClustersServer struct {
 	// HTTP status codes to indicate success: http.StatusOK
 	NewListBySubscriptionPager func(options *generated.HcpOpenShiftClustersClientListBySubscriptionOptions) (resp azfake.PagerResponder[generated.HcpOpenShiftClustersClientListBySubscriptionResponse])
 
+	// BeginRequestAdminCredential is the fake for method HcpOpenShiftClustersClient.BeginRequestAdminCredential
+	// HTTP status codes to indicate success: http.StatusOK, http.StatusAccepted
+	BeginRequestAdminCredential func(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *generated.HcpOpenShiftClustersClientBeginRequestAdminCredentialOptions) (resp azfake.PollerResponder[generated.HcpOpenShiftClustersClientRequestAdminCredentialResponse], errResp azfake.ErrorResponder)
+
+	// BeginRevokeCredentials is the fake for method HcpOpenShiftClustersClient.BeginRevokeCredentials
+	// HTTP status codes to indicate success: http.StatusAccepted
+	BeginRevokeCredentials func(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *generated.HcpOpenShiftClustersClientBeginRevokeCredentialsOptions) (resp azfake.PollerResponder[generated.HcpOpenShiftClustersClientRevokeCredentialsResponse], errResp azfake.ErrorResponder)
+
 	// BeginUpdate is the fake for method HcpOpenShiftClustersClient.BeginUpdate
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusAccepted
 	BeginUpdate func(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, properties generated.HcpOpenShiftClusterUpdate, options *generated.HcpOpenShiftClustersClientBeginUpdateOptions) (resp azfake.PollerResponder[generated.HcpOpenShiftClustersClientUpdateResponse], errResp azfake.ErrorResponder)
@@ -60,6 +68,8 @@ func NewHcpOpenShiftClustersServerTransport(srv *HcpOpenShiftClustersServer) *Hc
 		beginDelete:                 newTracker[azfake.PollerResponder[generated.HcpOpenShiftClustersClientDeleteResponse]](),
 		newListByResourceGroupPager: newTracker[azfake.PagerResponder[generated.HcpOpenShiftClustersClientListByResourceGroupResponse]](),
 		newListBySubscriptionPager:  newTracker[azfake.PagerResponder[generated.HcpOpenShiftClustersClientListBySubscriptionResponse]](),
+		beginRequestAdminCredential: newTracker[azfake.PollerResponder[generated.HcpOpenShiftClustersClientRequestAdminCredentialResponse]](),
+		beginRevokeCredentials:      newTracker[azfake.PollerResponder[generated.HcpOpenShiftClustersClientRevokeCredentialsResponse]](),
 		beginUpdate:                 newTracker[azfake.PollerResponder[generated.HcpOpenShiftClustersClientUpdateResponse]](),
 	}
 }
@@ -72,6 +82,8 @@ type HcpOpenShiftClustersServerTransport struct {
 	beginDelete                 *tracker[azfake.PollerResponder[generated.HcpOpenShiftClustersClientDeleteResponse]]
 	newListByResourceGroupPager *tracker[azfake.PagerResponder[generated.HcpOpenShiftClustersClientListByResourceGroupResponse]]
 	newListBySubscriptionPager  *tracker[azfake.PagerResponder[generated.HcpOpenShiftClustersClientListBySubscriptionResponse]]
+	beginRequestAdminCredential *tracker[azfake.PollerResponder[generated.HcpOpenShiftClustersClientRequestAdminCredentialResponse]]
+	beginRevokeCredentials      *tracker[azfake.PollerResponder[generated.HcpOpenShiftClustersClientRevokeCredentialsResponse]]
 	beginUpdate                 *tracker[azfake.PollerResponder[generated.HcpOpenShiftClustersClientUpdateResponse]]
 }
 
@@ -97,6 +109,10 @@ func (h *HcpOpenShiftClustersServerTransport) Do(req *http.Request) (*http.Respo
 		resp, err = h.dispatchNewListByResourceGroupPager(req)
 	case "HcpOpenShiftClustersClient.NewListBySubscriptionPager":
 		resp, err = h.dispatchNewListBySubscriptionPager(req)
+	case "HcpOpenShiftClustersClient.BeginRequestAdminCredential":
+		resp, err = h.dispatchBeginRequestAdminCredential(req)
+	case "HcpOpenShiftClustersClient.BeginRevokeCredentials":
+		resp, err = h.dispatchBeginRevokeCredentials(req)
 	case "HcpOpenShiftClustersClient.BeginUpdate":
 		resp, err = h.dispatchBeginUpdate(req)
 	default:
@@ -302,6 +318,94 @@ func (h *HcpOpenShiftClustersServerTransport) dispatchNewListBySubscriptionPager
 	if !server.PagerResponderMore(newListBySubscriptionPager) {
 		h.newListBySubscriptionPager.remove(req)
 	}
+	return resp, nil
+}
+
+func (h *HcpOpenShiftClustersServerTransport) dispatchBeginRequestAdminCredential(req *http.Request) (*http.Response, error) {
+	if h.srv.BeginRequestAdminCredential == nil {
+		return nil, &nonRetriableError{errors.New("fake for method BeginRequestAdminCredential not implemented")}
+	}
+	beginRequestAdminCredential := h.beginRequestAdminCredential.get(req)
+	if beginRequestAdminCredential == nil {
+		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft\.RedHatOpenShift/hcpOpenShiftClusters/(?P<hcpOpenShiftClusterName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/requestAdminCredential`
+		regex := regexp.MustCompile(regexStr)
+		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
+		if matches == nil || len(matches) < 3 {
+			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
+		}
+		resourceGroupNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("resourceGroupName")])
+		if err != nil {
+			return nil, err
+		}
+		hcpOpenShiftClusterNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("hcpOpenShiftClusterName")])
+		if err != nil {
+			return nil, err
+		}
+		respr, errRespr := h.srv.BeginRequestAdminCredential(req.Context(), resourceGroupNameParam, hcpOpenShiftClusterNameParam, nil)
+		if respErr := server.GetError(errRespr, req); respErr != nil {
+			return nil, respErr
+		}
+		beginRequestAdminCredential = &respr
+		h.beginRequestAdminCredential.add(req, beginRequestAdminCredential)
+	}
+
+	resp, err := server.PollerResponderNext(beginRequestAdminCredential, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		h.beginRequestAdminCredential.remove(req)
+		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
+	}
+	if !server.PollerResponderMore(beginRequestAdminCredential) {
+		h.beginRequestAdminCredential.remove(req)
+	}
+
+	return resp, nil
+}
+
+func (h *HcpOpenShiftClustersServerTransport) dispatchBeginRevokeCredentials(req *http.Request) (*http.Response, error) {
+	if h.srv.BeginRevokeCredentials == nil {
+		return nil, &nonRetriableError{errors.New("fake for method BeginRevokeCredentials not implemented")}
+	}
+	beginRevokeCredentials := h.beginRevokeCredentials.get(req)
+	if beginRevokeCredentials == nil {
+		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft\.RedHatOpenShift/hcpOpenShiftClusters/(?P<hcpOpenShiftClusterName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/revokeCredentials`
+		regex := regexp.MustCompile(regexStr)
+		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
+		if matches == nil || len(matches) < 3 {
+			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
+		}
+		resourceGroupNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("resourceGroupName")])
+		if err != nil {
+			return nil, err
+		}
+		hcpOpenShiftClusterNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("hcpOpenShiftClusterName")])
+		if err != nil {
+			return nil, err
+		}
+		respr, errRespr := h.srv.BeginRevokeCredentials(req.Context(), resourceGroupNameParam, hcpOpenShiftClusterNameParam, nil)
+		if respErr := server.GetError(errRespr, req); respErr != nil {
+			return nil, respErr
+		}
+		beginRevokeCredentials = &respr
+		h.beginRevokeCredentials.add(req, beginRevokeCredentials)
+	}
+
+	resp, err := server.PollerResponderNext(beginRevokeCredentials, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		h.beginRevokeCredentials.remove(req)
+		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
+	}
+	if !server.PollerResponderMore(beginRevokeCredentials) {
+		h.beginRevokeCredentials.remove(req)
+	}
+
 	return resp, nil
 }
 

--- a/internal/api/v20240610preview/generated/hcpopenshiftclusters_client.go
+++ b/internal/api/v20240610preview/generated/hcpopenshiftclusters_client.go
@@ -381,6 +381,160 @@ func (client *HcpOpenShiftClustersClient) listBySubscriptionHandleResponse(resp 
 	return result, nil
 }
 
+// BeginRequestAdminCredential - Request a temporary admin kubeconfig for the cluster
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-06-10-preview
+//   - resourceGroupName - The name of the resource group. The name is case insensitive.
+//   - hcpOpenShiftClusterName - The name of the HcpOpenShiftCluster
+//   - options - HcpOpenShiftClustersClientBeginRequestAdminCredentialOptions contains the optional parameters for the HcpOpenShiftClustersClient.BeginRequestAdminCredential
+//     method.
+func (client *HcpOpenShiftClustersClient) BeginRequestAdminCredential(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *HcpOpenShiftClustersClientBeginRequestAdminCredentialOptions) (*runtime.Poller[HcpOpenShiftClustersClientRequestAdminCredentialResponse], error) {
+	if options == nil || options.ResumeToken == "" {
+		resp, err := client.requestAdminCredential(ctx, resourceGroupName, hcpOpenShiftClusterName, options)
+		if err != nil {
+			return nil, err
+		}
+		poller, err := runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[HcpOpenShiftClustersClientRequestAdminCredentialResponse]{
+			FinalStateVia: runtime.FinalStateViaLocation,
+			Tracer:        client.internal.Tracer(),
+		})
+		return poller, err
+	} else {
+		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.internal.Pipeline(), &runtime.NewPollerFromResumeTokenOptions[HcpOpenShiftClustersClientRequestAdminCredentialResponse]{
+			Tracer: client.internal.Tracer(),
+		})
+	}
+}
+
+// RequestAdminCredential - Request a temporary admin kubeconfig for the cluster
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-06-10-preview
+func (client *HcpOpenShiftClustersClient) requestAdminCredential(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *HcpOpenShiftClustersClientBeginRequestAdminCredentialOptions) (*http.Response, error) {
+	var err error
+	const operationName = "HcpOpenShiftClustersClient.BeginRequestAdminCredential"
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
+	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+	req, err := client.requestAdminCredentialCreateRequest(ctx, resourceGroupName, hcpOpenShiftClusterName, options)
+	if err != nil {
+		return nil, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
+		err = runtime.NewResponseError(httpResp)
+		return nil, err
+	}
+	return httpResp, nil
+}
+
+// requestAdminCredentialCreateRequest creates the RequestAdminCredential request.
+func (client *HcpOpenShiftClustersClient) requestAdminCredentialCreateRequest(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *HcpOpenShiftClustersClientBeginRequestAdminCredentialOptions) (*policy.Request, error) {
+	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/{hcpOpenShiftClusterName}/requestAdminCredential"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter client.subscriptionID cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
+	if resourceGroupName == "" {
+		return nil, errors.New("parameter resourceGroupName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
+	if hcpOpenShiftClusterName == "" {
+		return nil, errors.New("parameter hcpOpenShiftClusterName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{hcpOpenShiftClusterName}", url.PathEscape(hcpOpenShiftClusterName))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2024-06-10-preview")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+// BeginRevokeCredentials - Revoke all credentials issued by requestAdminCredential
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-06-10-preview
+//   - resourceGroupName - The name of the resource group. The name is case insensitive.
+//   - hcpOpenShiftClusterName - The name of the HcpOpenShiftCluster
+//   - options - HcpOpenShiftClustersClientBeginRevokeCredentialsOptions contains the optional parameters for the HcpOpenShiftClustersClient.BeginRevokeCredentials
+//     method.
+func (client *HcpOpenShiftClustersClient) BeginRevokeCredentials(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *HcpOpenShiftClustersClientBeginRevokeCredentialsOptions) (*runtime.Poller[HcpOpenShiftClustersClientRevokeCredentialsResponse], error) {
+	if options == nil || options.ResumeToken == "" {
+		resp, err := client.revokeCredentials(ctx, resourceGroupName, hcpOpenShiftClusterName, options)
+		if err != nil {
+			return nil, err
+		}
+		poller, err := runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[HcpOpenShiftClustersClientRevokeCredentialsResponse]{
+			FinalStateVia: runtime.FinalStateViaLocation,
+			Tracer:        client.internal.Tracer(),
+		})
+		return poller, err
+	} else {
+		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.internal.Pipeline(), &runtime.NewPollerFromResumeTokenOptions[HcpOpenShiftClustersClientRevokeCredentialsResponse]{
+			Tracer: client.internal.Tracer(),
+		})
+	}
+}
+
+// RevokeCredentials - Revoke all credentials issued by requestAdminCredential
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-06-10-preview
+func (client *HcpOpenShiftClustersClient) revokeCredentials(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *HcpOpenShiftClustersClientBeginRevokeCredentialsOptions) (*http.Response, error) {
+	var err error
+	const operationName = "HcpOpenShiftClustersClient.BeginRevokeCredentials"
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
+	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+	req, err := client.revokeCredentialsCreateRequest(ctx, resourceGroupName, hcpOpenShiftClusterName, options)
+	if err != nil {
+		return nil, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusAccepted) {
+		err = runtime.NewResponseError(httpResp)
+		return nil, err
+	}
+	return httpResp, nil
+}
+
+// revokeCredentialsCreateRequest creates the RevokeCredentials request.
+func (client *HcpOpenShiftClustersClient) revokeCredentialsCreateRequest(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *HcpOpenShiftClustersClientBeginRevokeCredentialsOptions) (*policy.Request, error) {
+	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/{hcpOpenShiftClusterName}/revokeCredentials"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter client.subscriptionID cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
+	if resourceGroupName == "" {
+		return nil, errors.New("parameter resourceGroupName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
+	if hcpOpenShiftClusterName == "" {
+		return nil, errors.New("parameter hcpOpenShiftClusterName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{hcpOpenShiftClusterName}", url.PathEscape(hcpOpenShiftClusterName))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2024-06-10-preview")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
 // BeginUpdate - Update a HcpOpenShiftCluster
 // If the operation fails it returns an *azcore.ResponseError type.
 //

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -139,6 +139,15 @@ type HcpOpenShiftCluster struct {
 	Type *string
 }
 
+// HcpOpenShiftClusterAdminCredential - HCP cluster admin credential
+type HcpOpenShiftClusterAdminCredential struct {
+	// READ-ONLY; Expiration timestamp for the kubeconfig's client certificate
+	ExpirationTimestamp *time.Time
+
+	// READ-ONLY; Admin kubeconfig with a temporary client certificate
+	Kubeconfig *string
+}
+
 // HcpOpenShiftClusterListResult - The response of a HcpOpenShiftCluster list operation.
 type HcpOpenShiftClusterListResult struct {
 	// REQUIRED; The HcpOpenShiftCluster items on this page

--- a/internal/api/v20240610preview/generated/models_serde.go
+++ b/internal/api/v20240610preview/generated/models_serde.go
@@ -414,6 +414,39 @@ func (h *HcpOpenShiftCluster) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type HcpOpenShiftClusterAdminCredential.
+func (h HcpOpenShiftClusterAdminCredential) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populateDateTimeRFC3339(objectMap, "expirationTimestamp", h.ExpirationTimestamp)
+	populate(objectMap, "kubeconfig", h.Kubeconfig)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type HcpOpenShiftClusterAdminCredential.
+func (h *HcpOpenShiftClusterAdminCredential) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", h, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "expirationTimestamp":
+			err = unpopulateDateTimeRFC3339(val, "ExpirationTimestamp", &h.ExpirationTimestamp)
+			delete(rawMsg, key)
+		case "kubeconfig":
+			err = unpopulate(val, "Kubeconfig", &h.Kubeconfig)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", h, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", h, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type HcpOpenShiftClusterListResult.
 func (h HcpOpenShiftClusterListResult) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)

--- a/internal/api/v20240610preview/generated/options.go
+++ b/internal/api/v20240610preview/generated/options.go
@@ -21,6 +21,20 @@ type HcpOpenShiftClustersClientBeginDeleteOptions struct {
 	ResumeToken string
 }
 
+// HcpOpenShiftClustersClientBeginRequestAdminCredentialOptions contains the optional parameters for the HcpOpenShiftClustersClient.BeginRequestAdminCredential
+// method.
+type HcpOpenShiftClustersClientBeginRequestAdminCredentialOptions struct {
+	// Resumes the LRO from the provided token.
+	ResumeToken string
+}
+
+// HcpOpenShiftClustersClientBeginRevokeCredentialsOptions contains the optional parameters for the HcpOpenShiftClustersClient.BeginRevokeCredentials
+// method.
+type HcpOpenShiftClustersClientBeginRevokeCredentialsOptions struct {
+	// Resumes the LRO from the provided token.
+	ResumeToken string
+}
+
 // HcpOpenShiftClustersClientBeginUpdateOptions contains the optional parameters for the HcpOpenShiftClustersClient.BeginUpdate
 // method.
 type HcpOpenShiftClustersClientBeginUpdateOptions struct {

--- a/internal/api/v20240610preview/generated/responses.go
+++ b/internal/api/v20240610preview/generated/responses.go
@@ -36,6 +36,17 @@ type HcpOpenShiftClustersClientListBySubscriptionResponse struct {
 	HcpOpenShiftClusterListResult
 }
 
+// HcpOpenShiftClustersClientRequestAdminCredentialResponse contains the response from method HcpOpenShiftClustersClient.BeginRequestAdminCredential.
+type HcpOpenShiftClustersClientRequestAdminCredentialResponse struct {
+	// HCP cluster admin credential
+	HcpOpenShiftClusterAdminCredential
+}
+
+// HcpOpenShiftClustersClientRevokeCredentialsResponse contains the response from method HcpOpenShiftClustersClient.BeginRevokeCredentials.
+type HcpOpenShiftClustersClientRevokeCredentialsResponse struct {
+	// placeholder for future response values
+}
+
 // HcpOpenShiftClustersClientUpdateResponse contains the response from method HcpOpenShiftClustersClient.BeginUpdate.
 type HcpOpenShiftClustersClientUpdateResponse struct {
 	// HCP cluster resource

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -79,6 +79,18 @@ func newUserAssignedIdentitiesProfile(from *api.UserAssignedIdentitiesProfile) *
 	}
 }
 
+func newClusterCapabilitiesProfile(from *api.ClusterCapabilitiesProfile) *generated.ClusterCapabilitiesProfile {
+	out := &generated.ClusterCapabilitiesProfile{
+		Disabled: make([]*generated.OptionalClusterCapability, len(from.Disabled)),
+	}
+
+	for index, item := range from.Disabled {
+		out.Disabled[index] = api.Ptr(generated.OptionalClusterCapability(item))
+	}
+
+	return out
+}
+
 func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.VersionedHCPOpenShiftCluster {
 	if from == nil {
 		from = api.NewDefaultHCPOpenShiftCluster()
@@ -126,16 +138,8 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 	return out
 }
 
-func newClusterCapabilitiesProfile(from *api.ClusterCapabilitiesProfile) *generated.ClusterCapabilitiesProfile {
-	out := &generated.ClusterCapabilitiesProfile{
-		Disabled: make([]*generated.OptionalClusterCapability, len(from.Disabled)),
-	}
-
-	for index, item := range from.Disabled {
-		out.Disabled[index] = api.Ptr(generated.OptionalClusterCapability(item))
-	}
-
-	return out
+func (v version) MarshalHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) ([]byte, error) {
+	return arm.MarshalJSON(v.NewHCPOpenShiftCluster(from))
 }
 
 func (c *HcpOpenShiftCluster) Normalize(out *api.HCPOpenShiftCluster) {

--- a/internal/api/v20240610preview/nodepools_methods.go
+++ b/internal/api/v20240610preview/nodepools_methods.go
@@ -266,3 +266,7 @@ func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNod
 
 	return out
 }
+
+func (v version) MarshalHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNodePool) ([]byte, error) {
+	return arm.MarshalJSON(v.NewHCPOpenShiftClusterNodePool(from))
+}

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -74,6 +74,10 @@ const (
 	OperationRequestCreate OperationRequest = "Create"
 	OperationRequestUpdate OperationRequest = "Update"
 	OperationRequestDelete OperationRequest = "Delete"
+
+	// These are for POST actions on resources.
+	OperationRequestRequestCredential OperationRequest = "RequestCredential"
+	OperationRequestRevokeCredentials OperationRequest = "RevokeCredentials"
 )
 
 // OperationResourceType is an artificial resource type for OperationDocuments

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -530,17 +530,17 @@ func (c *MockDBClientGetSubscriptionDocCall) DoAndReturn(f func(context.Context,
 }
 
 // ListActiveOperationDocs mocks base method.
-func (m *MockDBClient) ListActiveOperationDocs(pk azcosmos.PartitionKey) database.DBClientIterator[database.OperationDocument] {
+func (m *MockDBClient) ListActiveOperationDocs(pk azcosmos.PartitionKey, options *database.DBClientListActiveOperationDocsOptions) database.DBClientIterator[database.OperationDocument] {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListActiveOperationDocs", pk)
+	ret := m.ctrl.Call(m, "ListActiveOperationDocs", pk, options)
 	ret0, _ := ret[0].(database.DBClientIterator[database.OperationDocument])
 	return ret0
 }
 
 // ListActiveOperationDocs indicates an expected call of ListActiveOperationDocs.
-func (mr *MockDBClientMockRecorder) ListActiveOperationDocs(pk any) *MockDBClientListActiveOperationDocsCall {
+func (mr *MockDBClientMockRecorder) ListActiveOperationDocs(pk, options any) *MockDBClientListActiveOperationDocsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActiveOperationDocs", reflect.TypeOf((*MockDBClient)(nil).ListActiveOperationDocs), pk)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActiveOperationDocs", reflect.TypeOf((*MockDBClient)(nil).ListActiveOperationDocs), pk, options)
 	return &MockDBClientListActiveOperationDocsCall{Call: call}
 }
 
@@ -556,13 +556,13 @@ func (c *MockDBClientListActiveOperationDocsCall) Return(arg0 database.DBClientI
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockDBClientListActiveOperationDocsCall) Do(f func(azcosmos.PartitionKey) database.DBClientIterator[database.OperationDocument]) *MockDBClientListActiveOperationDocsCall {
+func (c *MockDBClientListActiveOperationDocsCall) Do(f func(azcosmos.PartitionKey, *database.DBClientListActiveOperationDocsOptions) database.DBClientIterator[database.OperationDocument]) *MockDBClientListActiveOperationDocsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDBClientListActiveOperationDocsCall) DoAndReturn(f func(azcosmos.PartitionKey) database.DBClientIterator[database.OperationDocument]) *MockDBClientListActiveOperationDocsCall {
+func (c *MockDBClientListActiveOperationDocsCall) DoAndReturn(f func(azcosmos.PartitionKey, *database.DBClientListActiveOperationDocsOptions) database.DBClientIterator[database.OperationDocument]) *MockDBClientListActiveOperationDocsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -529,6 +529,44 @@ func (c *MockDBClientGetSubscriptionDocCall) DoAndReturn(f func(context.Context,
 	return c
 }
 
+// ListActiveOperationDocs mocks base method.
+func (m *MockDBClient) ListActiveOperationDocs(pk azcosmos.PartitionKey) database.DBClientIterator[database.OperationDocument] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListActiveOperationDocs", pk)
+	ret0, _ := ret[0].(database.DBClientIterator[database.OperationDocument])
+	return ret0
+}
+
+// ListActiveOperationDocs indicates an expected call of ListActiveOperationDocs.
+func (mr *MockDBClientMockRecorder) ListActiveOperationDocs(pk any) *MockDBClientListActiveOperationDocsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActiveOperationDocs", reflect.TypeOf((*MockDBClient)(nil).ListActiveOperationDocs), pk)
+	return &MockDBClientListActiveOperationDocsCall{Call: call}
+}
+
+// MockDBClientListActiveOperationDocsCall wrap *gomock.Call
+type MockDBClientListActiveOperationDocsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDBClientListActiveOperationDocsCall) Return(arg0 database.DBClientIterator[database.OperationDocument]) *MockDBClientListActiveOperationDocsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDBClientListActiveOperationDocsCall) Do(f func(azcosmos.PartitionKey) database.DBClientIterator[database.OperationDocument]) *MockDBClientListActiveOperationDocsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDBClientListActiveOperationDocsCall) DoAndReturn(f func(azcosmos.PartitionKey) database.DBClientIterator[database.OperationDocument]) *MockDBClientListActiveOperationDocsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ListAllSubscriptionDocs mocks base method.
 func (m *MockDBClient) ListAllSubscriptionDocs() database.DBClientIterator[arm.Subscription] {
 	m.ctrl.T.Helper()
@@ -563,44 +601,6 @@ func (c *MockDBClientListAllSubscriptionDocsCall) Do(f func() database.DBClientI
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockDBClientListAllSubscriptionDocsCall) DoAndReturn(f func() database.DBClientIterator[arm.Subscription]) *MockDBClientListAllSubscriptionDocsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ListOperationDocs mocks base method.
-func (m *MockDBClient) ListOperationDocs(pk azcosmos.PartitionKey) database.DBClientIterator[database.OperationDocument] {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOperationDocs", pk)
-	ret0, _ := ret[0].(database.DBClientIterator[database.OperationDocument])
-	return ret0
-}
-
-// ListOperationDocs indicates an expected call of ListOperationDocs.
-func (mr *MockDBClientMockRecorder) ListOperationDocs(pk any) *MockDBClientListOperationDocsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOperationDocs", reflect.TypeOf((*MockDBClient)(nil).ListOperationDocs), pk)
-	return &MockDBClientListOperationDocsCall{Call: call}
-}
-
-// MockDBClientListOperationDocsCall wrap *gomock.Call
-type MockDBClientListOperationDocsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockDBClientListOperationDocsCall) Return(arg0 database.DBClientIterator[database.OperationDocument]) *MockDBClientListOperationDocsCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockDBClientListOperationDocsCall) Do(f func(azcosmos.PartitionKey) database.DBClientIterator[database.OperationDocument]) *MockDBClientListOperationDocsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDBClientListOperationDocsCall) DoAndReturn(f func(azcosmos.PartitionKey) database.DBClientIterator[database.OperationDocument]) *MockDBClientListOperationDocsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/ocm/internalid.go
+++ b/internal/ocm/internalid.go
@@ -24,11 +24,15 @@ const (
 )
 
 func GenerateClusterHREF(clusterName string) string {
-	return v1Pattern + "/clusters/" + clusterName
+	return path.Join(v1Pattern, "clusters", clusterName)
 }
 
 func GenerateNodePoolHREF(clusterPath string, nodePoolName string) string {
-	return clusterPath + "/node_pools/" + nodePoolName
+	return path.Join(clusterPath, "node_pools", nodePoolName)
+}
+
+func GenerateBreakGlassCredentialHREF(clusterPath string, credentialName string) string {
+	return path.Join(clusterPath, "break_glass_credentials", credentialName)
 }
 
 // InternalID represents a Cluster Service resource.

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -266,11 +266,15 @@ func (csc *ClusterServiceClient) PostBreakGlassCredential(ctx context.Context, c
 	if !ok {
 		return nil, fmt.Errorf("OCM path is not a cluster: %s", clusterInternalID)
 	}
-	breakGlassCredentialsAddResponse, err := client.BreakGlassCredentials().Add().SendContext(ctx)
+	breakGlassCredential, err := cmv1.NewBreakGlassCredential().Build()
 	if err != nil {
 		return nil, err
 	}
-	breakGlassCredential, ok := breakGlassCredentialsAddResponse.GetBody()
+	breakGlassCredentialsAddResponse, err := client.BreakGlassCredentials().Add().Body(breakGlassCredential).SendContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	breakGlassCredential, ok = breakGlassCredentialsAddResponse.GetBody()
 	if !ok {
 		return nil, fmt.Errorf("empty response body")
 	}


### PR DESCRIPTION
Jira: [ARO-11587 - Frontend Changes for Providing Cluster Creds to Customers](https://issues.redhat.com/browse/ARO-11587)

### What

This implements new `POST` endpoints on `hcpOpenShiftCluster` resources.  One for generating an admin kubeconfig and another for revoking all kubeconfigs.

See [SD-DDR-0059: An ARO-HCP endpoint for admin kubeconfig credentials](https://docs.google.com/document/d/19_nFU0DtakGIoyA247SiMlQLQ1vfOHw98iMJu10dPlE/edit?tab=t.0) for details.