### PR TITLE
ensure kubelet patching DS runs only on MC user pool

### DIFF
--- a/mgmt-fixes/deploy/helm/mgmt-fixes/templates/ds-kubelet-parameters.yaml
+++ b/mgmt-fixes/deploy/helm/mgmt-fixes/templates/ds-kubelet-parameters.yaml
@@ -20,6 +20,8 @@ spec:
         component: kubelet-parameters
         tier: node
     spec:
+      nodeSelector:
+        kubernetes.azure.com/mode: user
       containers:
       - command:
         - nsenter


### PR DESCRIPTION
### What

the system pool does not require the kubelet patch

https://issues.redhat.com/browse/ARO-13357

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
