### PR TITLE
add KAS ingress rules to MC NSG

### DIFF
--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -115,7 +115,34 @@ resource mgmtClusterNSG 'Microsoft.Network/networkSecurityGroups@2023-11-01' = {
   location: location
   name: 'mgmt-cluster-node-nsg'
   properties: {
-    securityRules: []
+    securityRules: [
+      {
+        name: 'kas-443-in-internet'
+        properties: {
+          access: 'Allow'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '443'
+          direction: 'Inbound'
+          priority: 120
+          protocol: 'Tcp'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+        }
+      }
+      {
+        name: 'kas-6443-in-internet'
+        properties: {
+          access: 'Allow'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '6443'
+          direction: 'Inbound'
+          priority: 130
+          protocol: 'Tcp'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+        }
+      }
+    ]
   }
 }
 


### PR DESCRIPTION
### What

the MC NSG was missing the KAS inbound rules

### Why

VNET NSG attachment was introduced just recently to protect the SVC istio ingress. for the MC an empty NSG was provided, but even an empty NSG has some deny rules attached, which prevented ingress

### Special notes for your reviewer

<!-- optional -->
