### PR TITLE
[API] Remove NodePool TuningConfigs

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/NodePools_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/NodePools_CreateOrUpdate_MaximumSet_Gen.json
@@ -41,9 +41,6 @@
               "value": "x",
               "effect": "NoSchedule"
             }
-          ],
-          "tuningConfigs": [
-            "m"
           ]
         }
       },
@@ -77,10 +74,7 @@
             "autoScaling": {
               "min": 6,
               "max": 29
-            },
-            "tuningConfigs": [
-              "m"
-            ]
+            }
           }
         },
         "tags": {
@@ -126,10 +120,7 @@
             "autoScaling": {
               "min": 6,
               "max": 29
-            },
-            "tuningConfigs": [
-              "m"
-            ]
+            }
           }
         },
         "tags": {

--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/NodePools_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/NodePools_Get_MaximumSet_Gen.json
@@ -32,10 +32,7 @@
             "autoScaling": {
               "min": 6,
               "max": 29
-            },
-            "tuningConfigs": [
-              "m"
-            ]
+            }
           }
         },
         "tags": {

--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/NodePools_ListByHcpOpenShiftClusterResource_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/NodePools_ListByHcpOpenShiftClusterResource_MaximumSet_Gen.json
@@ -33,10 +33,7 @@
                 "autoScaling": {
                   "min": 6,
                   "max": 29
-                },
-                "tuningConfigs": [
-                  "m"
-                ]
+                }
               }
             },
             "tags": {

--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/NodePools_Update_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/NodePools_Update_MaximumSet_Gen.json
@@ -39,9 +39,6 @@
               "value": "x",
               "effect": "NoSchedule"
             }
-          ],
-          "tuningConfigs": [
-            "dvoeaysltfusyb"
           ]
         }
       }
@@ -71,10 +68,7 @@
             "autoScaling": {
               "min": 6,
               "max": 29
-            },
-            "tuningConfigs": [
-              "m"
-            ]
+            }
           }
         },
         "tags": {

--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -377,22 +377,6 @@ model NodePoolProperties {
   @visibility("create", "update", "read")
   @OpenAPI.extension("x-ms-identifiers", ["key", "value", "effect"])
   taints?: Taint[];
-
-  /*
-   * The Tuned API is defined here:
-   * - https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go
-   *
-   * The PerformanceProfile API is defined here:
-   * - https://github.com/openshift/cluster-node-tuning-operator/tree/b41042d42d4ba5bb2e99960248cf1d6ae4935018/pkg/apis/performanceprofile/v2
-   */
-  /** Tuning configs, TODO provide meaningful explanation
-   * TuningConfig is a list of references to ConfigMaps containing serialized
-   * Tuned resources to define the tuning configuration to be applied to
-   * nodes in the NodePool.
-   * Each ConfigMap must have a single key named "tuned" whose value is the
-   * JSON or YAML of a serialized Tuned or PerformanceProfile.
-   */
-  tuningConfigs?: string[];
 }
 
 /** Represents the patchable node pool properties */
@@ -421,22 +405,6 @@ model NodePoolPatchProperties {
   @visibility("update", "read")
   @OpenAPI.extension("x-ms-identifiers", ["key", "value", "effect"])
   taints?: Taint[];
-
-  /*
-   * The Tuned API is defined here:
-   * - https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go
-   *
-   * The PerformanceProfile API is defined here:
-   * - https://github.com/openshift/cluster-node-tuning-operator/tree/b41042d42d4ba5bb2e99960248cf1d6ae4935018/pkg/apis/performanceprofile/v2
-   */
-  /** Tuning configs, TODO provide meaningful explanation
-   * TuningConfig is a list of references to ConfigMaps containing serialized
-   * Tuned resources to define the tuning configuration to be applied to
-   * nodes in the NodePool.
-   * Each ConfigMap must have a single key named "tuned" whose value is the
-   * JSON or YAML of a serialized Tuned or PerformanceProfile.
-   */
-  tuningConfigs?: string[];
 }
 
 /** taintKey is the k8s valid key of the taint type on the nodepool nodes

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/NodePools_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/NodePools_CreateOrUpdate_MaximumSet_Gen.json
@@ -41,9 +41,6 @@
               "value": "x",
               "effect": "NoSchedule"
             }
-          ],
-          "tuningConfigs": [
-            "m"
           ]
         }
       },
@@ -77,10 +74,7 @@
             "autoScaling": {
               "min": 6,
               "max": 29
-            },
-            "tuningConfigs": [
-              "m"
-            ]
+            }
           }
         },
         "tags": {
@@ -126,10 +120,7 @@
             "autoScaling": {
               "min": 6,
               "max": 29
-            },
-            "tuningConfigs": [
-              "m"
-            ]
+            }
           }
         },
         "tags": {

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/NodePools_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/NodePools_Get_MaximumSet_Gen.json
@@ -32,10 +32,7 @@
             "autoScaling": {
               "min": 6,
               "max": 29
-            },
-            "tuningConfigs": [
-              "m"
-            ]
+            }
           }
         },
         "tags": {

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/NodePools_Update_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/NodePools_Update_MaximumSet_Gen.json
@@ -39,9 +39,6 @@
               "value": "x",
               "effect": "NoSchedule"
             }
-          ],
-          "tuningConfigs": [
-            "dvoeaysltfusyb"
           ]
         }
       }
@@ -71,10 +68,7 @@
             "autoScaling": {
               "min": 6,
               "max": 29
-            },
-            "tuningConfigs": [
-              "m"
-            ]
+            }
           }
         },
         "tags": {

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1397,13 +1397,6 @@
             "read",
             "update"
           ]
-        },
-        "tuningConfigs": {
-          "type": "array",
-          "description": "Tuning configs, TODO provide meaningful explanation\nTuningConfig is a list of references to ConfigMaps containing serialized\nTuned resources to define the tuning configuration to be applied to\nnodes in the NodePool.\nEach ConfigMap must have a single key named \"tuned\" whose value is the\nJSON or YAML of a serialized Tuned or PerformanceProfile.",
-          "items": {
-            "type": "string"
-          }
         }
       }
     },
@@ -1529,13 +1522,6 @@
             "update",
             "create"
           ]
-        },
-        "tuningConfigs": {
-          "type": "array",
-          "description": "Tuning configs, TODO provide meaningful explanation\nTuningConfig is a list of references to ConfigMaps containing serialized\nTuned resources to define the tuning configuration to be applied to\nnodes in the NodePool.\nEach ConfigMap must have a single key named \"tuned\" whose value is the\nJSON or YAML of a serialized Tuned or PerformanceProfile.",
-          "items": {
-            "type": "string"
-          }
         }
       },
       "required": [

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -288,9 +288,8 @@ func ConvertCStoNodePool(resourceID *azcorearm.ResourceID, np *cmv1.NodePool) *a
 				DiskEncryptionSetID:    "", // TODO: Not implemented in OCM
 				EphemeralOSDisk:        np.AzureNodePool().EphemeralOSDiskEnabled(),
 			},
-			AutoRepair:    np.AutoRepair(),
-			Labels:        np.Labels(),
-			TuningConfigs: np.TuningConfigs(),
+			AutoRepair: np.AutoRepair(),
+			Labels:     np.Labels(),
 		},
 	}
 
@@ -346,8 +345,7 @@ func (f *Frontend) BuildCSNodePool(ctx context.Context, nodePool *api.HCPOpenShi
 	}
 
 	npBuilder = npBuilder.
-		Labels(nodePool.Properties.Labels).
-		TuningConfigs(nodePool.Properties.TuningConfigs...)
+		Labels(nodePool.Properties.Labels)
 
 	if nodePool.Properties.AutoScaling != nil {
 		npBuilder.Autoscaling(cmv1.NewNodePoolAutoscaling().

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -25,7 +25,6 @@ type HCPOpenShiftClusterNodePoolProperties struct {
 	AutoScaling       *NodePoolAutoScaling    `json:"autoScaling,omitempty" visibility:"read create update"`
 	Labels            map[string]string       `json:"labels,omitempty" visibility:"read create update"`
 	Taints            []*Taint                `json:"taints,omitempty" visibility:"read create update"   validate:"dive"`
-	TuningConfigs     []string                `json:"tuningConfigs,omitempty" visibility:"read create update"`
 }
 
 // NodePoolPlatformProfile represents a worker node pool configuration.

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -324,12 +324,6 @@ type NodePoolPatchProperties struct {
 	// Taints for the nodes
 	Taints []*Taint
 
-	// Tuning configs, TODO provide meaningful explanation TuningConfig is a list of references to ConfigMaps containing serialized
-	// Tuned resources to define the tuning configuration to be applied to nodes
-	// in the NodePool. Each ConfigMap must have a single key named "tuned" whose value is the JSON or YAML of a serialized Tuned
-	// or PerformanceProfile.
-	TuningConfigs []*string
-
 	// READ-ONLY; Provisioning state
 	ProvisioningState *ResourceProvisioningState
 }
@@ -388,12 +382,6 @@ type NodePoolProperties struct {
 
 	// Taints for the nodes
 	Taints []*Taint
-
-	// Tuning configs, TODO provide meaningful explanation TuningConfig is a list of references to ConfigMaps containing serialized
-	// Tuned resources to define the tuning configuration to be applied to nodes
-	// in the NodePool. Each ConfigMap must have a single key named "tuned" whose value is the JSON or YAML of a serialized Tuned
-	// or PerformanceProfile.
-	TuningConfigs []*string
 
 	// READ-ONLY; Provisioning state
 	ProvisioningState *ProvisioningState

--- a/internal/api/v20240610preview/generated/models_serde.go
+++ b/internal/api/v20240610preview/generated/models_serde.go
@@ -898,7 +898,6 @@ func (n NodePoolPatchProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "provisioningState", n.ProvisioningState)
 	populate(objectMap, "replicas", n.Replicas)
 	populate(objectMap, "taints", n.Taints)
-	populate(objectMap, "tuningConfigs", n.TuningConfigs)
 	return json.Marshal(objectMap)
 }
 
@@ -925,9 +924,6 @@ func (n *NodePoolPatchProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "taints":
 			err = unpopulate(val, "Taints", &n.Taints)
-			delete(rawMsg, key)
-		case "tuningConfigs":
-			err = unpopulate(val, "TuningConfigs", &n.TuningConfigs)
 			delete(rawMsg, key)
 		default:
 			err = fmt.Errorf("unmarshalling type %T, unknown field %q", n, key)
@@ -1006,7 +1002,6 @@ func (n NodePoolProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "provisioningState", n.ProvisioningState)
 	populate(objectMap, "replicas", n.Replicas)
 	populate(objectMap, "taints", n.Taints)
-	populate(objectMap, "tuningConfigs", n.TuningConfigs)
 	populate(objectMap, "version", n.Version)
 	return json.Marshal(objectMap)
 }
@@ -1040,9 +1035,6 @@ func (n *NodePoolProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "taints":
 			err = unpopulate(val, "Taints", &n.Taints)
-			delete(rawMsg, key)
-		case "tuningConfigs":
-			err = unpopulate(val, "TuningConfigs", &n.TuningConfigs)
 			delete(rawMsg, key)
 		case "version":
 			err = unpopulate(val, "Version", &n.Version)

--- a/internal/api/v20240610preview/nodepools_methods.go
+++ b/internal/api/v20240610preview/nodepools_methods.go
@@ -96,11 +96,6 @@ func (h *HcpOpenShiftClusterNodePoolResource) Normalize(out *api.HCPOpenShiftClu
 				out.Properties.Taints[i].Value = *h.Properties.Taints[i].Value
 			}
 		}
-
-		out.Properties.TuningConfigs = make([]string, len(h.Properties.TuningConfigs))
-		for i := range h.Properties.TuningConfigs {
-			out.Properties.TuningConfigs[i] = *h.Properties.TuningConfigs[i]
-		}
 	}
 }
 
@@ -233,7 +228,6 @@ func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNod
 				Labels:            []*generated.Label{},
 				Replicas:          api.Ptr(from.Properties.Replicas),
 				Taints:            make([]*generated.Taint, len(from.Properties.Taints)),
-				TuningConfigs:     make([]*string, len(from.Properties.TuningConfigs)),
 			},
 		},
 	}
@@ -258,9 +252,6 @@ func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNod
 
 	for i := range from.Properties.Taints {
 		out.Properties.Taints[i] = newNodePoolTaint(from.Properties.Taints[i])
-	}
-	for i := range from.Properties.TuningConfigs {
-		out.Properties.TuningConfigs[i] = api.Ptr(from.Properties.TuningConfigs[i])
 	}
 
 	return out


### PR DESCRIPTION
<!-- Link to Jira issue -->
Per https://docs.google.com/document/d/1k6sqn7uFe46pnweQU_BPu07ux6U_gAiZPVYdGKKCKww/edit?tab=t.0, remove the NodePoolSpec.tuningConfigs array since we haven't implemented the feature yet.

Jira: https://issues.redhat.com/browse/ARO-15668
### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
