### PR TITLE
implicitly use the SVC registry for MISE

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -137,7 +137,6 @@ defaults:
     validAppId0: ""
     validAppId1: ""
     image:
-      registry: arohcpsvcint.azurecr.io
       repository: mise
       digest: sha256:ad3f7efeeb6691c25bf31d46d7b879e06093ec2ff43c05ad32b5bc5315ab96a7
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -99,7 +99,6 @@ defaults:
     validAppId0: ""
     validAppId1: ""
     image:
-      registry: ""
       repository: ""
       digest: ""
 

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -251,7 +251,6 @@
     "deploy": false,
     "image": {
       "digest": "",
-      "registry": "",
       "repository": ""
     },
     "validAppId0": "",

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -251,7 +251,6 @@
     "deploy": false,
     "image": {
       "digest": "",
-      "registry": "",
       "repository": ""
     },
     "validAppId0": "",

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -258,7 +258,6 @@
     "deploy": true,
     "image": {
       "digest": "sha256:ad3f7efeeb6691c25bf31d46d7b879e06093ec2ff43c05ad32b5bc5315ab96a7",
-      "registry": "arohcpsvcint.azurecr.io",
       "repository": "mise"
     },
     "validAppId0": "",

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -251,7 +251,6 @@
     "deploy": false,
     "image": {
       "digest": "",
-      "registry": "",
       "repository": ""
     },
     "validAppId0": "",

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -89,7 +89,7 @@ deploy:
 		--set clusterService.serviceAccount=${CS_SERVICE_ACCOUNT_NAME} \
 		--set deployMise=${DEPLOY_MISE} \
 		--set mise.namespace=mise \
-		--set mise.imageRegistry=${MISE_IMAGE_REGISTRY} \
+		--set mise.imageRegistry=${ARO_HCP_IMAGE_REGISTRY} \
 		--set mise.imageRepository=${MISE_IMAGE_REPOSITORY} \
 		--set mise.imageDigest=${MISE_IMAGE_DIGEST} \
 		--set mise.tenantId=$${TENANT_ID} \

--- a/frontend/pipeline.yaml
+++ b/frontend/pipeline.yaml
@@ -44,8 +44,6 @@ resourceGroups:
       configRef: mise.validAppId0
     - name: MISE_VALID_APP_ID_1
       configRef: mise.validAppId1
-    - name: MISE_IMAGE_REGISTRY
-      configRef: mise.image.registry
     - name: MISE_IMAGE_REPOSITORY
       configRef: mise.image.repository
     - name: MISE_IMAGE_DIGEST


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-11585

### What
by defaulting to the SVC registry for the MISE image, we don't need any deployenv overrides for it

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
