### PR TITLE
MSFT INT global-resource subscription fix

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -32,7 +32,7 @@ defaults:
 
   global:
     rg: global-shared-resources
-    subscription: hcp-{{ .ctx.region }}
+    subscription: hcp-global
     globalMSIName: "global-ev2-identity"
     safeDnsIntAppObjectId: "c54b6bce-1cd3-4d37-bebe-aa22f4ce4fbc"
 

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -103,7 +103,7 @@
     "region": "uksouth",
     "rg": "global-shared-resources",
     "safeDnsIntAppObjectId": "c54b6bce-1cd3-4d37-bebe-aa22f4ce4fbc",
-    "subscription": "hcp-westus3"
+    "subscription": "hcp-global"
   },
   "hypershift": {
     "additionalInstallArg": "--tech-preview-no-upgrade",


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

the subscription for global was defined as `hcp-${.ctx.region}` while it would need to be `hcp-global`
the only reason why INT deployments worked: both hcp-uksouth and hcp-global pointed to the same subscription in INT

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
