### PR TITLE
Add ID of MSI Mock to cluster-service-config

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -86,7 +86,8 @@ deploy:
 deploy-pr-env-deps:
 	AZURE_CS_MI_CLIENT_ID=$(shell az identity show -g ${RESOURCEGROUP} -n clusters-service --query clientId -o tsv) && \
 	oc process --local -f cspr/cluster-service-namespace.yaml \
-		-p CLIENT_ID=$${AZURE_CS_MI_CLIENT_ID} | oc apply -f -
+		-p CLIENT_ID=$${AZURE_CS_MI_CLIENT_ID} \
+		-p MSI_MOCK_ID="e8723db7-9b9e-46a4-9f7d-64d75c3534f0" | oc apply -f -
 
 create-pr-env-sp:
 	CLUSTER_ID=$(shell az aks show -g ${RESOURCEGROUP} -n ${AKS_NAME} --query id -o tsv) && \

--- a/cluster-service/cspr/cluster-service-namespace.yaml
+++ b/cluster-service/cspr/cluster-service-namespace.yaml
@@ -11,6 +11,9 @@ parameters:
   - name: CLIENT_ID
     description: The Azure Client ID used for federation
     required: true
+  - name: MSI_MOCK_ID
+    description: ID of MSI Mock
+    required: true
   - name: ORPHANED_NAMESPACE_CLEANER_NAMESPACE
     description: The namespace to create to have a cronjob which will delete the orphaned namespace which are not deleted due to any issues with the jenkins job.
     value: orphaned-namespace-cleaner
@@ -78,6 +81,7 @@ objects:
       namespace: ${NAMESPACE}
     data:
       cs-client-id: ${CLIENT_ID}
+      msi-mock-id: ${MSI_MOCK_ID}
   - apiVersion: v1
     kind: Namespace
     metadata:


### PR DESCRIPTION


### Why

Cluster service PR scripts need this ID during runtime. However it can not look it up, cause this would require elevated AD permissions. If read was possible we'd still need to pass information on the name, cause the name might change, i.e. if we have to recreate the SP. So simply passing the ID here to proceed.


