### PR TITLE
MSFT fixes

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -7,6 +7,8 @@ materialize:
 	@USER=tst ../templatize.sh personal-dev > public-cloud-personal-dev.json
 	@echo "Materializing public cloud int env of config/config.msft.yaml"
 	@CONFIG_FILE=../config/config.msft.yaml ../templatize.sh int > public-cloud-msft-int.json
+	@echo "Materializing public cloud stg env of config/config.msft.yaml"
+	@CONFIG_FILE=../config/config.msft.yaml ../templatize.sh stg > public-cloud-msft-stg.json
 .PHONY: materialize
 
 detect-change: materialize

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -254,14 +254,14 @@ defaults:
 
   # Management Cluster KV
   cxKeyVault:
-    softDelete: true
-    private: true
+    softDelete: false
+    private: false
   msiKeyVault:
-    softDelete: true
-    private: true
+    softDelete: false
+    private: false
   mgmtKeyVault:
-    softDelete: true
-    private: true
+    softDelete: false
+    private: false
 
   # DNS
   dns:
@@ -272,6 +272,14 @@ defaults:
   monitoring:
     grafanaZoneRedundantMode: Disabled
     workspaceName: 'arohcp-{{ .ctx.regionShort }}'
+
+  # Mock Managed Identities - not relevant for most MSFT envs
+  miMockClientId: ""
+  miMockPrincipalId: ""
+  miMockCertName: ""
+  armHelperClientId: ""
+  armHelperFPAPrincipalId: ""
+  armHelperCertName: ""
 
 clouds:
   public:
@@ -320,16 +328,10 @@ clouds:
           # Management Cluster KV
           cxKeyVault:
             name: arohcpint-cx-{{ .ctx.regionShort }}-{{ .ctx.stamp }} # [globally-unique]
-            softDelete: false
-            private: false
           msiKeyVault:
             name: arohcpint-msi-{{ .ctx.regionShort }}-{{ .ctx.stamp }} # [globally-unique]
-            softDelete: false
-            private: false
           mgmtKeyVault:
             name: arohcpint-mgmt-{{ .ctx.regionShort }}-{{ .ctx.stamp }} # [globally-unique]
-            softDelete: false
-            private: false
 
           # SVC cluster settings
           svc:
@@ -343,7 +345,7 @@ clouds:
                 azCount: 3
               clusterOutboundIPAddressIPTags: "FirstPartyUsage:/NonProd"
               etcd:
-                kvName: arohcp-etcd-{{ .ctx.regionShort }} # [globally-unique]
+                kvName: arohcpint-etcd-{{ .ctx.regionShort }} # [globally-unique]
             istio:
               ingressGatewayIPAddressIPTags: "FirstPartyUsage:/NonProd"
             logs:
@@ -436,3 +438,133 @@ clouds:
             mdsd:
               subscriptions:
               - 5299e6b7-b23b-46c8-8277-dc1147807117
+      stg:
+        # this is the MSFT STAGE environment
+        defaults:
+
+          # Region for global resources in STAGE is uksouth
+          global:
+            region: uksouth
+
+          # Cluster Service
+          clusterService:
+            environment: "arohcpstg"
+            postgres:
+              name: arohcpstg-cs-{{ .ctx.regionShort }} # [globally-unique]
+            image:
+              digest: sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b
+
+          # Geneva Actions
+          genevaActions:
+            serviceTag: GenevaActions
+
+          # OIDC
+          oidcStorageAccountName: arohcpstgoidc{{ .ctx.regionShort }} # [globally-unique]
+
+          # Image Sync
+          imageSync:
+            keyVault:
+              name: arohcpstg-imagesync # [globally-unique]
+
+          # SVC KV
+          serviceKeyVault:
+            name: arohcpstg-svc-{{ .ctx.regionShort }} # [globally-unique]
+
+          # Management Cluster KV
+          cxKeyVault:
+            name: arohcpstg-cx-{{ .ctx.regionShort }}-{{ .ctx.stamp }} # [globally-unique]
+          msiKeyVault:
+            name: arohcpstg-msi-{{ .ctx.regionShort }}-{{ .ctx.stamp }} # [globally-unique]
+          mgmtKeyVault:
+            name: arohcpstg-mgmt-{{ .ctx.regionShort }}-{{ .ctx.stamp }} # [globally-unique]
+
+          # SVC cluster settings
+          svc:
+            aks:
+              systemAgentPool:
+                minCount: 1
+                maxCount: 3
+              userAgentPool:
+                minCount: 1
+                maxCount: 3
+                azCount: 3
+              etcd:
+                kvName: arohcpstg-etcd-{{ .ctx.regionShort }} # [globally-unique]
+            logs:
+              san: SVC.GENEVA.KEYVAULT.ARO-HCP-STG.AZURE.COM # TBD
+              configVersion: "1.0"
+
+          # MC cluster settings
+          mgmt:
+            aks:
+              # MGMTM AKS nodepools
+              systemAgentPool:
+                minCount: 1
+                maxCount: 4
+              userAgentPool:
+                minCount: 1
+                maxCount: 12
+                azCount: 3
+              etcd:
+                kvName: arohcpstg-etcd-{{ .ctx.regionShort }}-{{ .ctx.stamp }} # [globally-unique]
+            logs:
+              san: MGMT.GENEVA.KEYVAULT.ARO-HCP-STG.AZURE.COM # TBD
+              configVersion: "1.0"
+
+          # DNS
+          dns:
+            cxParentZoneName: aroapp-hcp.TBD.com
+            svcParentZoneName: aro-hcp.TBD.com
+            parentZoneName: TBD.com
+
+          # ACR
+          svcAcrName: arohcpsvcstg # [globally-unique]
+          ocpAcrName: arohcpocpstg # [globally-unique]
+          svcAcrZoneRedundantMode: Enabled
+          ocpAcrZoneRedundantMode: Enabled
+
+          # RP Frontend
+          frontend:
+            cosmosDB:
+              name: arohcpstg-rp-{{ .ctx.regionShort }} # [globally-unique]
+              private: false
+            image:
+              digest: sha256:343bb768e38a829f13c4893e381c83fa602944809509b64e841f317ec2bf539b
+
+          # RP Backend
+          backend:
+            image:
+              digest: sha256:d7365c2638febc9d008e5246c8829fb51e866a54519d84fb4f077c8e7f4eb79c
+
+          # Hypershift
+          hypershift:
+            image:
+              digest: sha256:305f45bf036f84255d41c20517c70a9cb18af3dcdfa71a82a5716dde77c9e2c3
+
+          # Maestro
+          maestro:
+            eventGrid:
+              name: arohcpstg-maestro-{{ .ctx.regionShort }} # [globally-unique]
+            postgres:
+              name: arohcpstg-maestro-{{ .ctx.regionShort }} # [globally-unique]
+            image:
+              digest: sha256:223f332a11d336b49243d886217a76809142b30f9ab8ef27bec80a4458b3c3a5
+
+          # 1P app - from RH Tenant
+          firstPartyAppClientId: "TBD"
+          firstPartyAppCertName: firstPartyCert
+
+          # Grafana
+          monitoring:
+            grafanaName: 'arohcp-stg'
+            grafanaAdminGroupPrincipalId: '' # TBD
+
+          # Global MSI
+          aroDevopsMsiId: 'chicken-egg-value-to-be-filled-later'
+          # Cert Officer used for KV signer registration
+          kvCertOfficerPrincipalId: ''  # TBD
+
+          # Logs
+          logs:
+            mdsd:
+              subscriptions: [] # TBD

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -279,10 +279,10 @@ clouds:
       imageSync:
         componentSync:
           image:
-            digest: sha256:d838c4910bc53a5583dd501ed7e3ab08aa7c08b45b5997c90764c65ceef01a8f
+            digest: sha256:6a212720d25f270073318b1b480f326fcda08fbf6a1e435b7651e0336c72caee
         ocMirror:
           image:
-            digest: sha256:4affed9ff6397a5c44e9d1451fd58667f56e826b122819ccb6e1e8e045803c18
+            digest: sha256:574ebb57e70c46ba3bc34db4776fd64b63a52e04afc1dddba7b91e0c5f247952
 
     environments:
       int:

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -133,7 +133,7 @@ defaults:
       deploy: true
       disableLocalAuth: true
       private: true
-      zoneRedundantMode: 'Auto'
+      zoneRedundantMode: Auto
 
   # RP Backend
   backend:
@@ -270,7 +270,7 @@ defaults:
 
   # Metrics
   monitoring:
-    grafanaZoneRedundantMode: Enabled
+    grafanaZoneRedundantMode: Auto
     workspaceName: 'arohcp-{{ .ctx.regionShort }}'
 
 clouds:

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -377,6 +377,8 @@ clouds:
           # ACR
           svcAcrName: arohcpsvcint # [globally-unique]
           ocpAcrName: arohcpocpint # [globally-unique]
+          svcAcrZoneRedundantMode: Disabled
+          ocpAcrZoneRedundantMode: Disabled
 
           # RP Frontend
           frontend:

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -270,7 +270,7 @@ defaults:
 
   # Metrics
   monitoring:
-    grafanaZoneRedundantMode: Auto
+    grafanaZoneRedundantMode: Disabled
     workspaceName: 'arohcp-{{ .ctx.regionShort }}'
 
 clouds:

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -118,7 +118,7 @@
     "componentSync": {
       "enabled": true,
       "image": {
-        "digest": "sha256:d838c4910bc53a5583dd501ed7e3ab08aa7c08b45b5997c90764c65ceef01a8f",
+        "digest": "sha256:6a212720d25f270073318b1b480f326fcda08fbf6a1e435b7651e0336c72caee",
         "repository": "image-sync/component-sync"
       },
       "pullSecretName": "component-sync-pull-secret",
@@ -134,7 +134,7 @@
     "ocMirror": {
       "enabled": true,
       "image": {
-        "digest": "sha256:4affed9ff6397a5c44e9d1451fd58667f56e826b122819ccb6e1e8e045803c18",
+        "digest": "sha256:574ebb57e70c46ba3bc34db4776fd64b63a52e04afc1dddba7b91e0c5f247952",
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocp-pull-secret"
@@ -267,7 +267,7 @@
   "monitoring": {
     "grafanaAdminGroupPrincipalId": "2fdb57d4-3fd3-415d-b604-1d0e37a188fe",
     "grafanaName": "arohcp-int",
-    "grafanaZoneRedundantMode": "Auto",
+    "grafanaZoneRedundantMode": "Disabled",
     "workspaceName": "arohcp-usw3"
   },
   "msiKeyVault": {

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -276,7 +276,7 @@
     "softDelete": false
   },
   "ocpAcrName": "arohcpocpint",
-  "ocpAcrZoneRedundantMode": "Enabled",
+  "ocpAcrZoneRedundantMode": "Disabled",
   "oidcStorageAccountName": "arohcpintoidcusw3",
   "oidcZoneRedundantMode": "Auto",
   "region": "westus3",
@@ -331,5 +331,5 @@
     "subscription": "hcp-westus3"
   },
   "svcAcrName": "arohcpsvcint",
-  "svcAcrZoneRedundantMode": "Enabled"
+  "svcAcrZoneRedundantMode": "Disabled"
 }

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -267,7 +267,7 @@
   "monitoring": {
     "grafanaAdminGroupPrincipalId": "2fdb57d4-3fd3-415d-b604-1d0e37a188fe",
     "grafanaName": "arohcp-int",
-    "grafanaZoneRedundantMode": "Enabled",
+    "grafanaZoneRedundantMode": "Auto",
     "workspaceName": "arohcp-usw3"
   },
   "msiKeyVault": {

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -6,10 +6,10 @@
       "repository": "aks/msi-acrpull"
     }
   },
-  "armHelperCertName": "armHelperCert2",
-  "armHelperClientId": "3331e670-0804-48e8-a086-6241671ddc93",
-  "armHelperFPAPrincipalId": "47f69502-0065-4d9a-b19b-d403e183d2f4",
-  "aroDevopsMsiId": "/subscriptions/5299e6b7-b23b-46c8-8277-dc1147807117/resourcegroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity",
+  "armHelperCertName": "",
+  "armHelperClientId": "",
+  "armHelperFPAPrincipalId": "",
+  "aroDevopsMsiId": "chicken-egg-value-to-be-filled-later",
   "backend": {
     "image": {
       "digest": "sha256:d7365c2638febc9d008e5246c8829fb51e866a54519d84fb4f077c8e7f4eb79c",
@@ -46,7 +46,7 @@
         "roleName": "Key Vault Crypto User"
       }
     },
-    "environment": "arohcpint",
+    "environment": "arohcpstg",
     "image": {
       "digest": "sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b",
       "repository": "app-sre/uhc-clusters-service"
@@ -59,25 +59,25 @@
     "postgres": {
       "deploy": true,
       "minTLSVersion": "TLSV1.2",
-      "name": "arohcpint-cs-usw3",
+      "name": "arohcpstg-cs-usw3",
       "private": false
     }
   },
   "cxKeyVault": {
-    "name": "arohcpint-cx-usw3-1",
+    "name": "arohcpstg-cx-usw3-1",
     "private": false,
     "softDelete": false
   },
   "dns": {
     "baseDnsZoneRG": "global-shared-resources",
-    "cxParentZoneName": "aroapp-hcp.azure-test.net",
-    "parentZoneName": "azure-test.net",
+    "cxParentZoneName": "aroapp-hcp.TBD.com",
+    "parentZoneName": "TBD.com",
     "regionalSubdomain": "westus3",
-    "svcParentZoneName": "aro-hcp.azure-test.net"
+    "svcParentZoneName": "aro-hcp.TBD.com"
   },
   "extraVars": {},
-  "firstPartyAppCertName": "firstPartyCert2",
-  "firstPartyAppClientId": "b3cb2fab-15cb-4583-ad06-f91da9bfe2d1",
+  "firstPartyAppCertName": "firstPartyCert",
+  "firstPartyAppClientId": "TBD",
   "frontend": {
     "cert": {
       "issuer": "OneCertV2-PublicCA",
@@ -86,7 +86,7 @@
     "cosmosDB": {
       "deploy": true,
       "disableLocalAuth": true,
-      "name": "arohcpint-rp-usw3",
+      "name": "arohcpstg-rp-usw3",
       "private": false,
       "zoneRedundantMode": "Auto"
     },
@@ -96,7 +96,7 @@
     }
   },
   "genevaActions": {
-    "serviceTag": "GenevaActionsNonProd"
+    "serviceTag": "GenevaActions"
   },
   "global": {
     "globalMSIName": "global-ev2-identity",
@@ -127,7 +127,7 @@
     },
     "environmentName": "global-shared-resources",
     "keyVault": {
-      "name": "arohcpint-imagesync",
+      "name": "arohcpstg-imagesync",
       "private": false,
       "softDelete": true
     },
@@ -142,7 +142,7 @@
     "rg": "global-shared-resources",
     "secretsToSync": ""
   },
-  "kvCertOfficerPrincipalId": "32af88de-a61c-4f71-b709-50538598c4f2",
+  "kvCertOfficerPrincipalId": "",
   "logs": {
     "loganalytics": {
       "enable": false
@@ -156,9 +156,7 @@
       "msiName": "logs-mdsd",
       "namespace": "logs",
       "serviceAccountName": "genevabit-aggregator",
-      "subscriptions": [
-        "5299e6b7-b23b-46c8-8277-dc1147807117"
-      ]
+      "subscriptions": []
     }
   },
   "maestro": {
@@ -177,7 +175,7 @@
     "certIssuer": "OneCertV2-PrivateCA",
     "eventGrid": {
       "maxClientSessionsPerAuthName": 6,
-      "name": "arohcpint-maestro-usw3",
+      "name": "arohcpstg-maestro-usw3",
       "private": false
     },
     "image": {
@@ -188,7 +186,7 @@
       "databaseName": "maestro",
       "deploy": true,
       "minTLSVersion": "TLSV1.2",
-      "name": "arohcpint-maestro-usw3",
+      "name": "arohcpstg-maestro-usw3",
       "private": false,
       "serverStorageSizeGB": 32,
       "serverVersion": "15"
@@ -211,9 +209,9 @@
   },
   "mgmt": {
     "aks": {
-      "clusterOutboundIPAddressIPTags": "FirstPartyUsage:/NonProd",
+      "clusterOutboundIPAddressIPTags": "FirstPartyUsage:arohcpprodoutboundcx",
       "etcd": {
-        "kvName": "arohcpint-etcd-usw3-1",
+        "kvName": "arohcpstg-etcd-usw3-1",
         "kvSoftDelete": true
       },
       "kubernetesVersion": "1.31.5",
@@ -239,19 +237,19 @@
     "logs": {
       "configVersion": "1.0",
       "namespace": "HCPManagementLogs",
-      "san": "MGMT.GENEVA.KEYVAULT.ARO-HCP-INT.AZURE.COM"
+      "san": "MGMT.GENEVA.KEYVAULT.ARO-HCP-STG.AZURE.COM"
     },
     "rg": "hcp-underlay-westus3-mgmt-1",
     "subscription": "hcp-westus3"
   },
   "mgmtKeyVault": {
-    "name": "arohcpint-mgmt-usw3-1",
+    "name": "arohcpstg-mgmt-usw3-1",
     "private": false,
     "softDelete": false
   },
-  "miMockCertName": "msiMockCert2",
-  "miMockClientId": "e8723db7-9b9e-46a4-9f7d-64d75c3534f0",
-  "miMockPrincipalId": "d6b62dfa-87f5-49b3-bbcb-4a687c4faa96",
+  "miMockCertName": "",
+  "miMockClientId": "",
+  "miMockPrincipalId": "",
   "mise": {
     "armInstance": "https://management.core.windows.net/",
     "azureAdClientId": "",
@@ -265,24 +263,24 @@
     "validAppId1": ""
   },
   "monitoring": {
-    "grafanaAdminGroupPrincipalId": "2fdb57d4-3fd3-415d-b604-1d0e37a188fe",
-    "grafanaName": "arohcp-int",
+    "grafanaAdminGroupPrincipalId": "",
+    "grafanaName": "arohcp-stg",
     "grafanaZoneRedundantMode": "Disabled",
     "workspaceName": "arohcp-usw3"
   },
   "msiKeyVault": {
-    "name": "arohcpint-msi-usw3-1",
+    "name": "arohcpstg-msi-usw3-1",
     "private": false,
     "softDelete": false
   },
-  "ocpAcrName": "arohcpocpint",
-  "ocpAcrZoneRedundantMode": "Disabled",
-  "oidcStorageAccountName": "arohcpintoidcusw3",
+  "ocpAcrName": "arohcpocpstg",
+  "ocpAcrZoneRedundantMode": "Enabled",
+  "oidcStorageAccountName": "arohcpstgoidcusw3",
   "oidcZoneRedundantMode": "Auto",
   "region": "westus3",
   "regionRG": "westus3-shared-resources",
   "serviceKeyVault": {
-    "name": "arohcpint-svc-usw3",
+    "name": "arohcpstg-svc-usw3",
     "private": false,
     "region": "westus3",
     "rg": "hcp-underlay-westus3-svc",
@@ -290,9 +288,9 @@
   },
   "svc": {
     "aks": {
-      "clusterOutboundIPAddressIPTags": "FirstPartyUsage:/NonProd",
+      "clusterOutboundIPAddressIPTags": "FirstPartyUsage:arohcpprodoutboundsvc",
       "etcd": {
-        "kvName": "arohcpint-etcd-usw3",
+        "kvName": "arohcpstg-etcd-usw3",
         "kvSoftDelete": true
       },
       "kubernetesVersion": "1.31.5",
@@ -315,7 +313,7 @@
       "vnetAddressPrefix": "10.128.0.0/14"
     },
     "istio": {
-      "ingressGatewayIPAddressIPTags": "FirstPartyUsage:/NonProd",
+      "ingressGatewayIPAddressIPTags": "FirstPartyUsage:arohcpprodinboundsvc",
       "ingressGatewayIPAddressName": "aro-hcp-istio-ingress",
       "istioctlVersion": "1.24.1",
       "tag": "prod-stable",
@@ -325,11 +323,11 @@
     "logs": {
       "configVersion": "1.0",
       "namespace": "HCPServiceLogs",
-      "san": "SVC.GENEVA.KEYVAULT.ARO-HCP-INT.AZURE.COM"
+      "san": "SVC.GENEVA.KEYVAULT.ARO-HCP-STG.AZURE.COM"
     },
     "rg": "hcp-underlay-westus3-svc",
     "subscription": "hcp-westus3"
   },
-  "svcAcrName": "arohcpsvcint",
-  "svcAcrZoneRedundantMode": "Disabled"
+  "svcAcrName": "arohcpsvcstg",
+  "svcAcrZoneRedundantMode": "Enabled"
 }

--- a/dev-infrastructure/configurations/global-infra.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-infra.tmpl.bicepparam
@@ -1,5 +1,6 @@
 using '../templates/global-infra.bicep'
 
+param location = '{{ .global.region }}'
 param globalMSIName = '{{ .global.globalMSIName }}'
 param cxParentZoneName = '{{ .dns.cxParentZoneName }}'
 param svcParentZoneName = '{{ .dns.svcParentZoneName }}'

--- a/dev-infrastructure/modules/acr/acr.bicep
+++ b/dev-infrastructure/modules/acr/acr.bicep
@@ -4,7 +4,7 @@
 param acrName string
 
 @description('Location of the registry.')
-param location string = resourceGroup().location
+param location string
 
 @description('Service tier of the Azure Container Registry.')
 param acrSku string
@@ -48,7 +48,7 @@ var acrPullRoleId = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
 
 resource acrMsi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: '${acrName}-pull-identity'
-  location: resourceGroup().location
+  location: location
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {

--- a/dev-infrastructure/modules/grafana/instance.bicep
+++ b/dev-infrastructure/modules/grafana/instance.bicep
@@ -44,13 +44,23 @@ resource grafana 'Microsoft.Dashboard/grafana@2023-09-01' = {
   }
 }
 
-resource contributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource grafanaManagerContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(grafana.id, grafanaManagerPrincipalId, grafanaContributor)
   scope: grafana
   properties: {
     principalId: grafanaManagerPrincipalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', grafanaContributor)
+  }
+}
+
+resource grafanaManagerAdmin 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(grafana.id, grafanaManagerPrincipalId, grafanaAdminRole)
+  scope: grafana
+  properties: {
+    principalId: grafanaManagerPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', grafanaAdminRole)
   }
 }
 

--- a/dev-infrastructure/modules/grafana/instance.bicep
+++ b/dev-infrastructure/modules/grafana/instance.bicep
@@ -1,4 +1,3 @@
-
 param location string
 
 @description('Metrics global Grafana name')

--- a/dev-infrastructure/modules/grafana/instance.bicep
+++ b/dev-infrastructure/modules/grafana/instance.bicep
@@ -1,3 +1,6 @@
+
+param location string
+
 @description('Metrics global Grafana name')
 param grafanaName string
 
@@ -23,7 +26,7 @@ var grafanaAdminRole = '22926164-76b3-42b3-bc55-97df8dab3e41'
 
 resource grafana 'Microsoft.Dashboard/grafana@2023-09-01' = {
   name: grafanaName
-  location: resourceGroup().location
+  location: location
   sku: {
     name: 'Standard'
   }

--- a/dev-infrastructure/modules/grafana/integration-lookup.bicep
+++ b/dev-infrastructure/modules/grafana/integration-lookup.bicep
@@ -5,11 +5,27 @@ param grafanaName string
 
 param deploymentScriptIdentityId string
 
+param location string
+
 param _now string = utcNow('F')
+
+// Azure Managed Grafana Workspace Contributor: Can manage Azure Managed Grafana resources, without providing access to the workspaces themselves.
+// https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/monitor#azure-managed-grafana-workspace-contributor
+var grafanaContributor = '5c2d7e57-b7c2-4d8a-be4f-82afa42c6e95'
+
+resource contributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, deploymentScriptIdentityId, grafanaContributor)
+  scope: resourceGroup()
+  properties: {
+    principalId: reference(deploymentScriptIdentityId, '2023-01-31').principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', grafanaContributor)
+  }
+}
 
 resource grafanaIntegrationsLookup 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   name: 'grafana-workspace-lookup-script'
-  location: resourceGroup().location
+  location: location
   identity: {
     type: 'UserAssigned'
     userAssignedIdentities: {
@@ -26,6 +42,9 @@ resource grafanaIntegrationsLookup 'Microsoft.Resources/deploymentScripts@2020-1
     arguments: '-grafanaResourceGroup ${resourceGroup().name} -grafanaName ${grafanaName}'
     forceUpdateTag: _now
   }
+  dependsOn: [
+    contributorRole
+  ]
 }
 
 output azureMonitorWorkspaceIds array = grafanaIntegrationsLookup.properties.outputs.workspaceIds ?? []

--- a/dev-infrastructure/templates/global-infra.bicep
+++ b/dev-infrastructure/templates/global-infra.bicep
@@ -108,13 +108,13 @@ resource svcParentZoneRoleAssignment 'Microsoft.Authorization/roleAssignments@20
 // we might want to have another source of truth for the integrations in the future, e.g.
 // some sort of inventory of the regions of ARO HCP
 
-module grafanaWorkspaceIdLookup '../modules/grafana/integration-lookup.bicep' = {
+/*module grafanaWorkspaceIdLookup '../modules/grafana/integration-lookup.bicep' = {
   name: 'grafana-workspace-lookup'
   params: {
     grafanaName: grafanaName
     deploymentScriptIdentityId: globalMSI.id
   }
-}
+}*/
 
 module grafana '../modules/grafana/instance.bicep' = {
   name: 'grafana'
@@ -123,6 +123,7 @@ module grafana '../modules/grafana/instance.bicep' = {
     grafanaAdminGroupPrincipalId: grafanaAdminGroupPrincipalId
     grafanaManagerPrincipalId: globalMSI.properties.principalId
     zoneRedundancy: determineZoneRedundancy(locationAvailabilityZoneList, grafanaZoneRedundantMode)
-    azureMonitorWorkspaceIds: grafanaWorkspaceIdLookup.outputs.azureMonitorWorkspaceIds
+    //azureMonitorWorkspaceIds: grafanaWorkspaceIdLookup.outputs.azureMonitorWorkspaceIds
+    azureMonitorWorkspaceIds: []
   }
 }

--- a/dev-infrastructure/templates/global-infra.bicep
+++ b/dev-infrastructure/templates/global-infra.bicep
@@ -108,15 +108,14 @@ resource svcParentZoneRoleAssignment 'Microsoft.Authorization/roleAssignments@20
 // we might want to have another source of truth for the integrations in the future, e.g.
 // some sort of inventory of the regions of ARO HCP
 
-
-
-/*module grafanaWorkspaceIdLookup '../modules/grafana/integration-lookup.bicep' = {
+module grafanaWorkspaceIdLookup '../modules/grafana/integration-lookup.bicep' = {
   name: 'grafana-workspace-lookup'
   params: {
+    location: location
     grafanaName: grafanaName
     deploymentScriptIdentityId: globalMSI.id
   }
-}*/
+}
 
 module grafana '../modules/grafana/instance.bicep' = {
   name: 'grafana'
@@ -126,7 +125,6 @@ module grafana '../modules/grafana/instance.bicep' = {
     grafanaAdminGroupPrincipalId: grafanaAdminGroupPrincipalId
     grafanaManagerPrincipalId: globalMSI.properties.principalId
     zoneRedundancy: determineZoneRedundancy(locationAvailabilityZoneList, grafanaZoneRedundantMode)
-    //azureMonitorWorkspaceIds: grafanaWorkspaceIdLookup.outputs.azureMonitorWorkspaceIds
-    azureMonitorWorkspaceIds: []
+    azureMonitorWorkspaceIds: grafanaWorkspaceIdLookup.outputs.azureMonitorWorkspaceIds
   }
 }

--- a/dev-infrastructure/templates/global-infra.bicep
+++ b/dev-infrastructure/templates/global-infra.bicep
@@ -1,7 +1,7 @@
 import { getLocationAvailabilityZonesCSV, determineZoneRedundancy, csvToArray } from '../modules/common.bicep'
 
 @description('Azure Global Location')
-param location string = resourceGroup().location
+param location string
 
 @description('The global msi name')
 param globalMSIName string
@@ -34,7 +34,7 @@ var locationAvailabilityZoneList = csvToArray(locationAvailabilityZones)
 
 resource globalMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: globalMSIName
-  location: resourceGroup().location
+  location: location
 }
 
 //
@@ -108,6 +108,8 @@ resource svcParentZoneRoleAssignment 'Microsoft.Authorization/roleAssignments@20
 // we might want to have another source of truth for the integrations in the future, e.g.
 // some sort of inventory of the regions of ARO HCP
 
+
+
 /*module grafanaWorkspaceIdLookup '../modules/grafana/integration-lookup.bicep' = {
   name: 'grafana-workspace-lookup'
   params: {
@@ -119,6 +121,7 @@ resource svcParentZoneRoleAssignment 'Microsoft.Authorization/roleAssignments@20
 module grafana '../modules/grafana/instance.bicep' = {
   name: 'grafana'
   params: {
+    location: location
     grafanaName: grafanaName
     grafanaAdminGroupPrincipalId: grafanaAdminGroupPrincipalId
     grafanaManagerPrincipalId: globalMSI.properties.principalId


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

* introduce `int` infix for INT resource names
* introduce preliminary MSFT stage settings
* remove soft-deletion from all INT KVs for easier recreation of envs
* disable INT grafana zone redundancy as the uksouth region does not offer it right now
* fix global-infra templates (honor global.rg settings)
* fix missing globalMSI permissions to read/modify grafana integrations (list current azure monitoring integrations)

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
