### PR TITLE
NO-JIRA: add missing permission for storage operator

### DIFF
--- a/dev-infrastructure/configurations/dev-operator-roles.bicepparam
+++ b/dev-infrastructure/configurations/dev-operator-roles.bicepparam
@@ -59,6 +59,7 @@ param roles = [
       'Microsoft.Compute/disks/write'
       'Microsoft.Compute/disks/read'
       'Microsoft.Compute/disks/delete'
+      'Microsoft.Compute/disks/beginGetAccess/action'
       'Microsoft.Resources/subscriptions/resourceGroups/read'
     ]
     notActions: []


### PR DESCRIPTION

### What

There was a report by QE that this permission was missing.
