### PR TITLE
Adding healthz endpoint to backend 

### DIFF
--- a/backend/deploy/templates/backend.deployment.yaml
+++ b/backend/deploy/templates/backend.deployment.yaml
@@ -51,6 +51,8 @@ spec:
           ports:
             - containerPort: 8081
               protocol: TCP
+            - containerPort: 8080
+              protocol: TCP              
           resources:
             limits:
               memory: 1Gi
@@ -65,5 +67,18 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10              
       restartPolicy: Always
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What
Adding healthz endpoint to backend and exposing the healthz metric as well  . This will be used in the Leader Election logic of Backend .

### Why
Currently the Backend Leader election doesn't make use of the watchdog feature due to the lack of healthz endpoint . This PR should fix the problem .

### Special notes for your reviewer
Currently Testing it . I will update this PR as i test .
