### PR TITLE
Added a separate template for namespace cleaner

### DIFF
--- a/cluster-service/cspr/cluster-service-namespace.yaml
+++ b/cluster-service/cspr/cluster-service-namespace.yaml
@@ -11,12 +11,6 @@ parameters:
   - name: CLIENT_ID
     description: The Azure Client ID used for federation
     required: true
-  - name: ORPHANED_NAMESPACE_CLEANER_NAMESPACE
-    description: The namespace to create to have a cronjob which will delete the orphaned namespace which are not deleted due to any issues with the jenkins job.
-    value: orphaned-namespace-cleaner
-  - name: KUBECTL_IMAGE
-    description: An image which have the `kubectl` binary in it.
-    value: quay.io/rhn_support_ansverma/ubi8-minimal-kubectl:latest
 
 objects:
   - apiVersion: v1
@@ -78,49 +72,3 @@ objects:
       namespace: ${NAMESPACE}
     data:
       cs-client-id: ${CLIENT_ID}
-  - apiVersion: v1
-    kind: Namespace
-    metadata:
-      name: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
-  - apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: orphaned-namespace-cleaner-cronjob
-      namespace: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
-  - apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: orphaned-namespace-cleaner-cronjob
-    subjects:
-      - kind: ServiceAccount
-        name: orphaned-namespace-cleaner-cronjob
-        namespace: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
-    roleRef:
-      kind: ClusterRole
-      name: namespace-admin
-      apiGroup: rbac.authorization.k8s.io
-  - apiVersion: batch/v1
-    kind: CronJob
-    metadata:
-      name: orphaned-namespace-cleaner
-      namespace: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
-    spec:
-      schedule: "0 0 * * *"
-      successfulJobsHistoryLimit: 3
-      failedJobsHistoryLimit: 1
-      jobTemplate:
-        spec:
-          template:
-            spec:
-              serviceAccountName: orphaned-namespace-cleaner-cronjob
-              containers:
-                - name: kubectl-container
-                  image: ${KUBECTL_IMAGE}
-                  command: ["/bin/sh", "-c"]
-                  args:
-                    - |
-                      echo "Starting to clear orphaned namespaces"
-                      echo "deleting the orphaned namespaces"
-                      kubectl get namespaces -o json | jq -r '.items[] | select(.metadata.labels."sandbox-jenkins-type"=="aro-hcp") | select((now - (.metadata.creationTimestamp | fromdate)) / 60 > 60) | .metadata.name' | xargs kubectl delete namespace
-                      echo "Script execution completed."
-              restartPolicy: Never

--- a/cluster-service/cspr/namespace-cleaner.yaml
+++ b/cluster-service/cspr/namespace-cleaner.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: namespace-cleaner
+parameters:
+  - name: ORPHANED_NAMESPACE_CLEANER_NAMESPACE
+    description: The namespace to create to have a cronjob which will delete the orphaned namespace which are not deleted due to any issues with the jenkins job.
+    value: orphaned-namespace-cleaner
+  - name: NAMESPACE_CLEANER_CLUSTERROLE_NAME
+    value: namespace-cleaner
+  - name: KUBECTL_IMAGE
+    description: An image which have the `kubectl` binary in it.
+    value: quay.io/rhn_support_ansverma/ubi8-minimal-kubectl:latest
+objects:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: ${NAMESPACE_CLEANER_CLUSTERROLE_NAME}
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+        verbs: ["get", "list", "delete", "watch"]
+  - apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: orphaned-namespace-cleaner-cronjob
+      namespace: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: orphaned-namespace-cleaner-cronjob
+    subjects:
+      - kind: ServiceAccount
+        name: orphaned-namespace-cleaner-cronjob
+        namespace: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
+    roleRef:
+      kind: ClusterRole
+      name: ${NAMESPACE_CLEANER_CLUSTERROLE_NAME}
+      apiGroup: rbac.authorization.k8s.io
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: orphaned-namespace-cleaner
+      namespace: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
+    spec:
+      schedule: "*/1 * * * *"
+      successfulJobsHistoryLimit: 3
+      failedJobsHistoryLimit: 1
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              serviceAccountName: orphaned-namespace-cleaner-cronjob
+              containers:
+                - name: kubectl-container
+                  image: ${KUBECTL_IMAGE}
+                  command: ["/bin/sh", "-c"]
+                  args:
+                    - |
+                      echo "Starting to clear orphaned namespaces"
+                      # `select((now - (.metadata.creationTimestamp | fromdate)) / 60 > 60)` selects the namespaces which are older than 60 minutes.
+                      NUMBER_OF_NAMESPACES=$(kubectl get namespaces -o json | jq -r '.items[] | select(.metadata.labels."sandbox-jenkins-type"=="aro-hcp") | select((now - (.metadata.creationTimestamp | fromdate)) / 1 > 1) | .metadata.name' | wc -l);
+                      if [ $NUMBER_OF_NAMESPACES -lt 1 ]; then
+                        echo "no namespaces matching the criteria to delete, exiting"
+                        exit 0
+                      fi
+                      echo "deleting the orphaned namespaces"
+                      kubectl get namespaces -o json | jq -r '.items[] | select(.metadata.labels."sandbox-jenkins-type"=="aro-hcp") | select((now - (.metadata.creationTimestamp | fromdate)) / 1 > 1) | .metadata.name' | xargs kubectl delete namespace
+                      echo "Script execution completed."
+              restartPolicy: Never


### PR DESCRIPTION
Fixes: [ARO-15555](https://issues.redhat.com/browse/ARO-15555)

### What

This separates the template for the namespace cleaner and modified the cronjob to handle the error gracefully when 0 namespaces are there for deletion.
