### PR TITLE
Fix cluster container logging for dev/cspr

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -313,6 +313,16 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-04-02-previ
           rotationPollInterval: '5m'
         }
       }
+      omsagent: (logAnalyticsWorkspaceId != '')
+        ? {
+            enabled: true
+            config: {
+              logAnalyticsWorkspaceResourceID: logAnalyticsWorkspaceId
+            }
+          }
+        : {
+            enabled: false
+          }
     }
     agentPoolProfiles: [
       {
@@ -527,6 +537,7 @@ resource aksClusterDcr 'Microsoft.Insights/dataCollectionRules@2023-03-11' = if 
           'Microsoft-ContainerLog'
           'Microsoft-ContainerLogV2'
           'Microsoft-KubeEvents'
+          'Microsoft-KubePodInventory'
         ]
       }
     ]


### PR DESCRIPTION
### What

Ensure the monitoring agent addon is provisioned on the cluster if logging is expected

Also adds a missing log stream to the DCR

### Why

The current config does not work as expected due to the agent not being provisioned

### Special notes for your reviewer

<!-- optional -->
