### PR TITLE
Tweaks related to Typespec and code generation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,8 @@
                 "gopls": {
                     "ui.semanticTokens": true
                 },
-                "go.lintTool": "golangci-lint"
+                "go.lintTool": "golangci-lint",
+                "typespec.tsp-server.path": "${workspaceFolder}/ARO-HCP/api/node-modules/.bin"
             }
         }
     },

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -30,6 +30,8 @@ jobs:
     - name: make generate
       run: make generate
       working-directory: './api'
+    - name: make fmt
+      run: make fmt
     - name: Check for Uncommitted Changes
       run: |
         git diff --exit-code || (echo "::error::Uncommitted changes detected in OpenAPI spec. Please regenerate and commit them." && exit 1)


### PR DESCRIPTION
### What

Couple small fixes:

- The VSCode devcontainer has been complaining about not being able to find the TypeSpec language server (`tsp-server`) on startup.  This is because it was installed in a location that VSCode does not check by default.  I figured out how to tell VSCode where to find `tsp-server`. 

- Since [`fmt` was recently added as a `make` dependency to `all-tidy`](https://github.com/Azure/ARO-HCP/pull/1498), the "Validate API Spec" CI check has been failing because `autorest`-generated Golang code often has improper formatting.  Add a step to "Validate API Spec" to run `make fmt` to clean up the formatting after code generation.
