### PR TITLE
ARO-14906: log correlation data in Clusters Service

### DIFF
--- a/cluster-service/deploy/templates/deployment.yaml
+++ b/cluster-service/deploy/templates/deployment.yaml
@@ -188,6 +188,8 @@ spec:
         - --azure-arm-helper-identity-certificate-bundle-path=/secrets/keyvault/armHelperIndentityCertificateBundle
         - --azure-arm-helper-identity-client-id={{ .Values.azureArmHelperIdentityClientId }}
         - --azure-arm-helper-mock-fpa-principal-id={{ .Values.azureArmHelperMockFpaPrincipalId }}
+        # Baggage items are populated by the RP frontend and defined in internal/tracing/attributes.go.
+        - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
         livenessProbe:
           httpGet:
             path: /api/clusters_mgmt/v1

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -294,7 +294,7 @@ clouds:
             postgres:
               name: "arohcpint-cs-{{ .ctx.regionShort }}" # [globally-unique]
             image:
-              digest: sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b
+              digest: sha256:89a09675100b106a6e7e0b21d6841338ee229fa637abea67d32b53d8052696cd
           # Geneva Actions
           genevaActions:
             serviceTag: GenevaActionsNonProd
@@ -422,7 +422,7 @@ clouds:
             postgres:
               name: "arohcpstg-cs-{{ .ctx.regionShort }}" # [globally-unique]
             image:
-              digest: sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b
+              digest: sha256:89a09675100b106a6e7e0b21d6841338ee229fa637abea67d32b53d8052696cd
           # Geneva Actions
           genevaActions:
             serviceTag: GenevaActions

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -225,7 +225,7 @@ clouds:
       # Cluster Service
       clusterService:
         image:
-          digest: sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b
+          digest: sha256:89a09675100b106a6e7e0b21d6841338ee229fa637abea67d32b53d8052696cd
         azureOperatorsManagedIdentities:
           clusterApiAzure:
             roleName: Azure Red Hat OpenShift Control Plane Operator Role - Dev

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -58,7 +58,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b",
+      "digest": "sha256:89a09675100b106a6e7e0b21d6841338ee229fa637abea67d32b53d8052696cd",
       "repository": "app-sre/uhc-clusters-service"
     },
     "k8s": {

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -58,7 +58,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b",
+      "digest": "sha256:89a09675100b106a6e7e0b21d6841338ee229fa637abea67d32b53d8052696cd",
       "repository": "app-sre/uhc-clusters-service"
     },
     "k8s": {

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -58,7 +58,7 @@
     },
     "environment": "arohcpint",
     "image": {
-      "digest": "sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b",
+      "digest": "sha256:89a09675100b106a6e7e0b21d6841338ee229fa637abea67d32b53d8052696cd",
       "repository": "app-sre/uhc-clusters-service"
     },
     "k8s": {

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -58,7 +58,7 @@
     },
     "environment": "arohcpstg",
     "image": {
-      "digest": "sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b",
+      "digest": "sha256:89a09675100b106a6e7e0b21d6841338ee229fa637abea67d32b53d8052696cd",
       "repository": "app-sre/uhc-clusters-service"
     },
     "k8s": {

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -58,7 +58,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b",
+      "digest": "sha256:89a09675100b106a6e7e0b21d6841338ee229fa637abea67d32b53d8052696cd",
       "repository": "app-sre/uhc-clusters-service"
     },
     "k8s": {

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -58,7 +58,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:c8de5ac6f2000ee185b42442c3b7f29e2b6b1068849f48620075cd811834202b",
+      "digest": "sha256:89a09675100b106a6e7e0b21d6841338ee229fa637abea67d32b53d8052696cd",
       "repository": "app-sre/uhc-clusters-service"
     },
     "k8s": {


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-14906

### What

This change bumps the digest of the CS image to benefit from the `--log-fields-from-baggage` argument.

### Why

CS will log the correlation ID and client request ID received from the RP frontend.

### Special notes for your reviewer

<!-- optional -->
