### PR TITLE
Remove debug input in workflow_dispatch

### DIFF
--- a/.github/workflows/runbook-cicd.yml
+++ b/.github/workflows/runbook-cicd.yml
@@ -6,6 +6,7 @@ on:
     - 'dev-infrastructure/modules/automation-account/**'
     - 'dev-infrastructure/Makefile'
     - 'dev-infrastructure/configurations/dev-automation-account.bicepparam'
+    - '.github/workflows/runbook-cicd.yml'
   push:
     branches:
     - main
@@ -90,4 +91,4 @@ jobs:
     - name: Deploy Automation Account
       run: |
         cd dev-infrastructure/
-        make automation-account --debug=${{ inputs.debug }}
+        make automation-account


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What
Remove the --debug flag from the workflow, as it is not being used.

To fix the failure in deploying automation account 
 https://github.com/Azure/ARO-HCP/actions/runs/13859166393

```
Run cd dev-infrastructure/
make: the '--debug' option requires a non-empty string argument
Usage: make [options] [target] ...
```

[ARO-15539](https://issues.redhat.com/browse/ARO-15539)

<!-- Briefly describe what this PR does -->