### PR TITLE
add option to deploy admin role in grafana

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -252,6 +252,7 @@ defaults:
   monitoring:
     grafanaZoneRedundantMode: Disabled
     workspaceName: "arohcp-{{ .ctx.regionShort }}"
+    deployAdminRole: false
   # Mock Managed Identities - not relevant for most MSFT envs
   miMockClientId: ""
   miMockPrincipalId: ""

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -886,6 +886,9 @@
         },
         "workspaceName": {
           "type": "string"
+        },
+        "deployAdminRole": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -274,6 +274,7 @@
     "validAppId1": ""
   },
   "monitoring": {
+    "deployAdminRole": false,
     "grafanaAdminGroupPrincipalId": "2fdb57d4-3fd3-415d-b604-1d0e37a188fe",
     "grafanaName": "arohcp-int",
     "grafanaZoneRedundantMode": "Disabled",

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -272,6 +272,7 @@
     "validAppId1": ""
   },
   "monitoring": {
+    "deployAdminRole": false,
     "grafanaAdminGroupPrincipalId": "18d30381-f780-4915-8e55-de67daf7fb04",
     "grafanaName": "arohcp-stg",
     "grafanaZoneRedundantMode": "Disabled",

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -112,7 +112,7 @@
     "globalMSIName": "global-rollout-identity",
     "region": "westus3",
     "rg": "global",
-    "safeDnsIntAppObjectId": "c54b6bce-1cd3-4d37-bebe-aa22f4ce4fbc",
+    "safeDnsIntAppObjectId": "",
     "subscription": "ARO Hosted Control Planes (EA Subscription 1)"
   },
   "hypershift": {

--- a/dev-infrastructure/configurations/global-infra.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-infra.tmpl.bicepparam
@@ -10,3 +10,4 @@ param safeDnsIntAppObjectId = '{{ .global.safeDnsIntAppObjectId }}'
 param grafanaName = '{{ .monitoring.grafanaName }}'
 param grafanaAdminGroupPrincipalId = '{{ .monitoring.grafanaAdminGroupPrincipalId }}'
 param grafanaZoneRedundantMode = '{{ .monitoring.grafanaZoneRedundantMode }}'
+param deployAdminRole = {{ .monitoring.deployAdminRole }}

--- a/dev-infrastructure/modules/grafana/instance.bicep
+++ b/dev-infrastructure/modules/grafana/instance.bicep
@@ -15,6 +15,9 @@ param zoneRedundancy bool
 @description('The azure monitor workspace IDs to integrate with Grafana')
 param azureMonitorWorkspaceIds array
 
+@description('Whether to deploy the Grafana admin role to the Grafana admin group')
+param deployAdminRole bool = true
+
 // Azure Managed Grafana Workspace Contributor: Can manage Azure Managed Grafana resources, without providing access to the workspaces themselves.
 // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/monitor#azure-managed-grafana-workspace-contributor
 var grafanaContributor = '5c2d7e57-b7c2-4d8a-be4f-82afa42c6e95'
@@ -64,7 +67,7 @@ resource grafanaManagerAdmin 'Microsoft.Authorization/roleAssignments@2022-04-01
   }
 }
 
-resource adminRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource adminRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (deployAdminRole){
   name: guid(grafana.id, grafanaAdminGroupPrincipalId, grafanaAdminRole)
   scope: grafana
   properties: {

--- a/dev-infrastructure/templates/global-infra.bicep
+++ b/dev-infrastructure/templates/global-infra.bicep
@@ -28,6 +28,9 @@ param grafanaZoneRedundantMode string
 param locationAvailabilityZones string = getLocationAvailabilityZonesCSV(location)
 var locationAvailabilityZoneList = csvToArray(locationAvailabilityZones)
 
+
+@description('Whether to deploy the Grafana admin role to the Grafana admin group')
+param deployAdminRole bool
 //
 //  G L O B A L   M S I
 //
@@ -126,5 +129,6 @@ module grafana '../modules/grafana/instance.bicep' = {
     grafanaManagerPrincipalId: globalMSI.properties.principalId
     zoneRedundancy: determineZoneRedundancy(locationAvailabilityZoneList, grafanaZoneRedundantMode)
     azureMonitorWorkspaceIds: grafanaWorkspaceIdLookup.outputs.azureMonitorWorkspaceIds
+    deployAdminRole: deployAdminRole
   }
 }


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What
EV2 currently only allows service principal role assignment. This PR added the option to disable grafana admin role deployment in the config. 
<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
