### PR TITLE
add option to deploy admin role in grafana and make CX parent zone delegation optional

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -17,4 +17,4 @@ jobs:
     - name: Linters
       uses: oxsecurity/megalinter/flavors/ci_light@v8
       env:
-        FILTER_REGEX_EXCLUDE: 'hypershiftoperator/deploy/crds/|maestro/server/deploy/templates/allow-cluster-service.authorizationpolicy.yaml|acm/deploy/helm/multicluster-engine-config/charts/policy/charts'
+        FILTER_REGEX_EXCLUDE: 'hypershiftoperator/deploy/crds/|maestro/server/deploy/templates/allow-cluster-service.authorizationpolicy.yaml|acm/deploy/helm/multicluster-engine-config/charts/policy/charts|dev-infrastructure/global-pipeline.yaml'

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -17,4 +17,4 @@ jobs:
     - name: Linters
       uses: oxsecurity/megalinter/flavors/ci_light@v8
       env:
-        FILTER_REGEX_EXCLUDE: 'hypershiftoperator/deploy/crds/|maestro/server/deploy/templates/allow-cluster-service.authorizationpolicy.yaml|acm/deploy/helm/multicluster-engine-config/charts/policy/charts|dev-infrastructure/global-pipeline.yaml'
+        FILTER_REGEX_EXCLUDE: 'hypershiftoperator/deploy/crds/|maestro/server/deploy/templates/allow-cluster-service.authorizationpolicy.yaml|acm/deploy/helm/multicluster-engine-config/charts/policy/charts|dev-infrastructure/global-pipeline.yaml|tooling/templatize/testdata/pipeline.yaml'

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -341,6 +341,7 @@ clouds:
           # DNS
           dns:
             cxParentZoneName: aroapp-hcp.azure-test.net
+            cxParentZoneDelegation: true
             svcParentZoneName: aro-hcp.azure-test.net
             parentZoneName: azure-test.net
           # ACR
@@ -466,6 +467,7 @@ clouds:
             # in order to avoid a conflict with the production environment
             regionalSubdomain: "{{ .ctx.region }}staging"
             cxParentZoneName: aroapp-hcp.io
+            cxParentZoneDelegation: false
             svcParentZoneName: aro-hcp.azure.com
             parentZoneName: azure.com
           # ACR

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -387,7 +387,7 @@ clouds:
           # Grafana
           monitoring:
             grafanaName: "arohcp-int"
-            grafanaAdminGroupPrincipalId: "2fdb57d4-3fd3-415d-b604-1d0e37a188fe" # Azure Red Hat OpenShift MSFT Engineering
+            grafanaAdminGroupPrincipalId: "2fdb57d4-3fd3-415d-b604-1d0e37a188fe" # Azure Red Hat OpenShift MSFT Engineering.
           # Global MSI
           aroDevopsMsiId: "/subscriptions/5299e6b7-b23b-46c8-8277-dc1147807117/resourcegroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity"
           # Cert Officer used for KV signer registration
@@ -505,7 +505,7 @@ clouds:
           # Grafana
           monitoring:
             grafanaName: 'arohcp-stg'
-            grafanaAdminGroupPrincipalId: '18d30381-f780-4915-8e55-de67daf7fb04' # object id for group 'RH-AROAPPR'
+            grafanaAdminGroupPrincipalId: '' # object id for group 'RH-AROAPPR'. EV2 currently only allows service principal role assignment, so leave it empty for now
           # Global MSI
           aroDevopsMsiId: '/subscriptions/9a53d80e-dae0-4c8a-af90-30575d253127/resourceGroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity'
           # Cert Officer used for KV signer registration

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -193,6 +193,10 @@
           "type": "string",
           "description": "The parent DNS zone name for regional HCP cluster DNS zones"
         },
+        "cxParentZoneDelegation": {
+          "type": "boolean",
+          "description": "Whether to manage the CX parent zone delegation on the parents parent."
+        },
         "svcParentZoneName": {
           "type": "string",
           "description": "The parent DNS zone name for regional ARO-HCP infrastructure, e.g. the RP"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -199,6 +199,7 @@ clouds:
       dns:
         baseDnsZoneRG: global
         cxParentZoneName: hcp.osadev.cloud
+        cxParentZoneDelegation: false
         svcParentZoneName: hcpsvc.osadev.cloud
         parentZoneName: osadev.cloud
       # 1P app

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -80,6 +80,7 @@
   },
   "dns": {
     "baseDnsZoneRG": "global",
+    "cxParentZoneDelegation": false,
     "cxParentZoneName": "hcp.osadev.cloud",
     "parentZoneName": "osadev.cloud",
     "regionalSubdomain": "westus3-cs",

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -80,6 +80,7 @@
   },
   "dns": {
     "baseDnsZoneRG": "global",
+    "cxParentZoneDelegation": false,
     "cxParentZoneName": "hcp.osadev.cloud",
     "parentZoneName": "osadev.cloud",
     "regionalSubdomain": "westus3",

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -80,6 +80,7 @@
   },
   "dns": {
     "baseDnsZoneRG": "global-shared-resources",
+    "cxParentZoneDelegation": true,
     "cxParentZoneName": "aroapp-hcp.azure-test.net",
     "parentZoneName": "azure-test.net",
     "regionalSubdomain": "westus3",

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -273,7 +273,7 @@
     "validAppId1": ""
   },
   "monitoring": {
-    "grafanaAdminGroupPrincipalId": "18d30381-f780-4915-8e55-de67daf7fb04",
+    "grafanaAdminGroupPrincipalId": "",
     "grafanaName": "arohcp-stg",
     "grafanaZoneRedundantMode": "Disabled",
     "workspaceName": "arohcp-usw3"

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -80,6 +80,7 @@
   },
   "dns": {
     "baseDnsZoneRG": "global-shared-resources",
+    "cxParentZoneDelegation": false,
     "cxParentZoneName": "aroapp-hcp.io",
     "parentZoneName": "azure.com",
     "regionalSubdomain": "westus3staging",

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -80,6 +80,7 @@
   },
   "dns": {
     "baseDnsZoneRG": "global",
+    "cxParentZoneDelegation": false,
     "cxParentZoneName": "hcp.osadev.cloud",
     "parentZoneName": "osadev.cloud",
     "regionalSubdomain": "nightly",

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -80,6 +80,7 @@
   },
   "dns": {
     "baseDnsZoneRG": "global",
+    "cxParentZoneDelegation": false,
     "cxParentZoneName": "hcp.osadev.cloud",
     "parentZoneName": "osadev.cloud",
     "regionalSubdomain": "usw3tst",

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -32,14 +32,16 @@ resourceGroups:
     dependsOn:
     - global-infra
   # creates DNS delegation for the ARO HCP global CX zone
-  - name: cxChildZone
-    action: DelegateChildZone
-    parentZone:
-      configRef: dns.parentZoneName
-    childZone:
-      configRef: dns.cxParentZoneName
-    dependsOn:
-    - global-infra
+  {{- if .dns.cxParentZoneDelegation }}
+    - name: cxChildZone
+      action: DelegateChildZone
+      parentZone:
+        configRef: dns.parentZoneName
+      childZone:
+        configRef: dns.cxParentZoneName
+      dependsOn:
+      - global-infra
+  {{- end }}
   # create global ARO HCP ACRs for OCP and SVC images
   - name: global-acrs
     action: ARM

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -33,14 +33,14 @@ resourceGroups:
     - global-infra
   # creates DNS delegation for the ARO HCP global CX zone
   {{- if .dns.cxParentZoneDelegation }}
-    - name: cxChildZone
-      action: DelegateChildZone
-      parentZone:
-        configRef: dns.parentZoneName
-      childZone:
-        configRef: dns.cxParentZoneName
-      dependsOn:
-      - global-infra
+  - name: cxChildZone
+    action: DelegateChildZone
+    parentZone:
+      configRef: dns.parentZoneName
+    childZone:
+      configRef: dns.cxParentZoneName
+    dependsOn:
+    - global-infra
   {{- end }}
   # create global ARO HCP ACRs for OCP and SVC images
   - name: global-acrs

--- a/dev-infrastructure/modules/grafana/instance.bicep
+++ b/dev-infrastructure/modules/grafana/instance.bicep
@@ -64,7 +64,7 @@ resource grafanaManagerAdmin 'Microsoft.Authorization/roleAssignments@2022-04-01
   }
 }
 
-resource adminRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource adminRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(grafanaAdminGroupPrincipalId)) {
   name: guid(grafana.id, grafanaAdminGroupPrincipalId, grafanaAdminRole)
   scope: grafana
   properties: {

--- a/tooling/templatize/pkg/ev2/utils_test.go
+++ b/tooling/templatize/pkg/ev2/utils_test.go
@@ -32,6 +32,7 @@ func TestScopeBindingVariables(t *testing.T) {
 		"__vaultBaseUrl__":                  "$config(vaultBaseUrl)",
 		"__clusterService.imageTag__":       "$config(clusterService.imageTag)",
 		"__clusterService.replicas__":       "$config(clusterService.replicas)",
+		"__enableOptionalStep__":            "$config(enableOptionalStep)",
 	}
 
 	if diff := cmp.Diff(expectedVars, vars); diff != "" {

--- a/tooling/templatize/testdata/config.yaml
+++ b/tooling/templatize/testdata/config.yaml
@@ -16,6 +16,7 @@ defaults:
   childZone: child.example.com
   vaultBaseUrl: myvault.azure.com
   provider: Self
+  enableOptionalStep: false
 clouds:
   fairfax:
     defaults:

--- a/tooling/templatize/testdata/pipeline.yaml
+++ b/tooling/templatize/testdata/pipeline.yaml
@@ -19,6 +19,11 @@ resourceGroups:
       variables:
       - name: DRY_RUN
         value: "A very dry one"
+  {{- if .enableOptionalStep }}
+  - name: optionalStep
+    action: Shell
+    command: make optional
+  {{- end }}
   - name: svc
     action: ARM
     template: templates/svc-cluster.bicep


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

EV2 currently only allows service principal role assignment. This PR added the option to disable grafana admin role deployment in the config.
Production DNS are for Cx parent zone are owned by ARO team so we don't need to delegate it through SafeDNSZone. Therefore, this PR has make the delegation of CxParentZone optional and not run for production environment. 
Pipeline run : https://dev.azure.com/msazure/AzureRedHatOpenShift/_build?definitionId=409617
<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
