### PR TITLE
make CX parent zone delegation optional

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -17,4 +17,4 @@ jobs:
     - name: Linters
       uses: oxsecurity/megalinter/flavors/ci_light@v8
       env:
-        FILTER_REGEX_EXCLUDE: 'hypershiftoperator/deploy/crds/|maestro/server/deploy/templates/allow-cluster-service.authorizationpolicy.yaml|acm/deploy/helm/multicluster-engine-config/charts/policy/charts'
+        FILTER_REGEX_EXCLUDE: 'hypershiftoperator/deploy/crds/|maestro/server/deploy/templates/allow-cluster-service.authorizationpolicy.yaml|acm/deploy/helm/multicluster-engine-config/charts/policy/charts|dev-infrastructure/global-pipeline.yaml'

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -17,4 +17,4 @@ jobs:
     - name: Linters
       uses: oxsecurity/megalinter/flavors/ci_light@v8
       env:
-        FILTER_REGEX_EXCLUDE: 'hypershiftoperator/deploy/crds/|maestro/server/deploy/templates/allow-cluster-service.authorizationpolicy.yaml|acm/deploy/helm/multicluster-engine-config/charts/policy/charts|dev-infrastructure/global-pipeline.yaml'
+        FILTER_REGEX_EXCLUDE: 'hypershiftoperator/deploy/crds/|maestro/server/deploy/templates/allow-cluster-service.authorizationpolicy.yaml|acm/deploy/helm/multicluster-engine-config/charts/policy/charts|dev-infrastructure/global-pipeline.yaml|tooling/templatize/testdata/pipeline.yaml'

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -341,6 +341,7 @@ clouds:
           # DNS
           dns:
             cxParentZoneName: aroapp-hcp.azure-test.net
+            cxParentZoneDelegation: true
             svcParentZoneName: aro-hcp.azure-test.net
             parentZoneName: azure-test.net
           # ACR
@@ -466,6 +467,7 @@ clouds:
             # in order to avoid a conflict with the production environment
             regionalSubdomain: "{{ .ctx.region }}staging"
             cxParentZoneName: aroapp-hcp.io
+            cxParentZoneDelegation: false
             svcParentZoneName: aro-hcp.azure.com
             parentZoneName: azure.com
           # ACR

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -193,6 +193,10 @@
           "type": "string",
           "description": "The parent DNS zone name for regional HCP cluster DNS zones"
         },
+        "cxParentZoneDelegation": {
+          "type": "boolean",
+          "description": "Whether to manage the CX parent zone delegation on the parents parent."
+        },
         "svcParentZoneName": {
           "type": "string",
           "description": "The parent DNS zone name for regional ARO-HCP infrastructure, e.g. the RP"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -199,6 +199,7 @@ clouds:
       dns:
         baseDnsZoneRG: global
         cxParentZoneName: hcp.osadev.cloud
+        cxParentZoneDelegation: false
         svcParentZoneName: hcpsvc.osadev.cloud
         parentZoneName: osadev.cloud
       # 1P app

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -80,6 +80,7 @@
   },
   "dns": {
     "baseDnsZoneRG": "global",
+    "cxParentZoneDelegation": false,
     "cxParentZoneName": "hcp.osadev.cloud",
     "parentZoneName": "osadev.cloud",
     "regionalSubdomain": "westus3-cs",

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -80,6 +80,7 @@
   },
   "dns": {
     "baseDnsZoneRG": "global",
+    "cxParentZoneDelegation": false,
     "cxParentZoneName": "hcp.osadev.cloud",
     "parentZoneName": "osadev.cloud",
     "regionalSubdomain": "westus3",

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -80,6 +80,7 @@
   },
   "dns": {
     "baseDnsZoneRG": "global-shared-resources",
+    "cxParentZoneDelegation": true,
     "cxParentZoneName": "aroapp-hcp.azure-test.net",
     "parentZoneName": "azure-test.net",
     "regionalSubdomain": "westus3",

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -80,6 +80,7 @@
   },
   "dns": {
     "baseDnsZoneRG": "global-shared-resources",
+    "cxParentZoneDelegation": false,
     "cxParentZoneName": "aroapp-hcp.io",
     "parentZoneName": "azure.com",
     "regionalSubdomain": "westus3staging",

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -80,6 +80,7 @@
   },
   "dns": {
     "baseDnsZoneRG": "global",
+    "cxParentZoneDelegation": false,
     "cxParentZoneName": "hcp.osadev.cloud",
     "parentZoneName": "osadev.cloud",
     "regionalSubdomain": "nightly",

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -80,6 +80,7 @@
   },
   "dns": {
     "baseDnsZoneRG": "global",
+    "cxParentZoneDelegation": false,
     "cxParentZoneName": "hcp.osadev.cloud",
     "parentZoneName": "osadev.cloud",
     "regionalSubdomain": "usw3tst",

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -32,14 +32,16 @@ resourceGroups:
     dependsOn:
     - global-infra
   # creates DNS delegation for the ARO HCP global CX zone
-  - name: cxChildZone
-    action: DelegateChildZone
-    parentZone:
-      configRef: dns.parentZoneName
-    childZone:
-      configRef: dns.cxParentZoneName
-    dependsOn:
-    - global-infra
+  {{- if .dns.cxParentZoneDelegation }}
+    - name: cxChildZone
+      action: DelegateChildZone
+      parentZone:
+        configRef: dns.parentZoneName
+      childZone:
+        configRef: dns.cxParentZoneName
+      dependsOn:
+      - global-infra
+  {{- end }}
   # create global ARO HCP ACRs for OCP and SVC images
   - name: global-acrs
     action: ARM

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -33,14 +33,14 @@ resourceGroups:
     - global-infra
   # creates DNS delegation for the ARO HCP global CX zone
   {{- if .dns.cxParentZoneDelegation }}
-    - name: cxChildZone
-      action: DelegateChildZone
-      parentZone:
-        configRef: dns.parentZoneName
-      childZone:
-        configRef: dns.cxParentZoneName
-      dependsOn:
-      - global-infra
+  - name: cxChildZone
+    action: DelegateChildZone
+    parentZone:
+      configRef: dns.parentZoneName
+    childZone:
+      configRef: dns.cxParentZoneName
+    dependsOn:
+    - global-infra
   {{- end }}
   # create global ARO HCP ACRs for OCP and SVC images
   - name: global-acrs

--- a/tooling/templatize/pkg/ev2/utils_test.go
+++ b/tooling/templatize/pkg/ev2/utils_test.go
@@ -32,6 +32,7 @@ func TestScopeBindingVariables(t *testing.T) {
 		"__vaultBaseUrl__":                  "$config(vaultBaseUrl)",
 		"__clusterService.imageTag__":       "$config(clusterService.imageTag)",
 		"__clusterService.replicas__":       "$config(clusterService.replicas)",
+		"__enableOptionalStep__":            "$config(enableOptionalStep)",
 	}
 
 	if diff := cmp.Diff(expectedVars, vars); diff != "" {

--- a/tooling/templatize/testdata/config.yaml
+++ b/tooling/templatize/testdata/config.yaml
@@ -16,6 +16,7 @@ defaults:
   childZone: child.example.com
   vaultBaseUrl: myvault.azure.com
   provider: Self
+  enableOptionalStep: false
 clouds:
   fairfax:
     defaults:

--- a/tooling/templatize/testdata/pipeline.yaml
+++ b/tooling/templatize/testdata/pipeline.yaml
@@ -19,6 +19,11 @@ resourceGroups:
       variables:
       - name: DRY_RUN
         value: "A very dry one"
+  {{- if .enableOptionalStep }}
+  - name: optionalStep
+    action: Shell
+    command: make optional
+  {{- end }}
   - name: svc
     action: ARM
     template: templates/svc-cluster.bicep


### PR DESCRIPTION


<!-- Link to Jira issue -->

### What

the STG/PROD CX parent zone does not have a parent where we can control delegation via EV2. therefore let's make the delegation step in the global pipeline optional

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
