### PR TITLE
Don't clean up RGs that are owned by something.

### DIFF
--- a/tooling/azure-automation/resources-cleanup/src/resources_cleanup.py
+++ b/tooling/azure-automation/resources-cleanup/src/resources_cleanup.py
@@ -5,7 +5,7 @@ from typing import List
 import datetime
 
 from azure.identity import DefaultAzureCredential
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.resource.resources.v2022_09_01.models._models_py3 import GenericResourceExpanded, ResourceGroup
 
@@ -83,7 +83,13 @@ def process_resource_groups_of_subscription(subscription_id: str, resource_clien
     print(f"subscription {subscription_id} has {n_resource_groups} resource groups:\n")
 
     for resource_group in resource_groups_list:
-        process_resource_group(resource_group, resource_client)
+        try:
+            process_resource_group(resource_group, resource_client)
+        except ResourceNotFoundError as err:
+            print(f"Encountered a missing resource (probably the rg itself).")
+            print(f"This is fine, it must've gotten deleted by something else; continuing.")
+            print(f"Code: {err.error.code}")
+            print(f"Message: {err.error.message}")
         print("_"*80)
         print()
 

--- a/tooling/azure-automation/resources-cleanup/src/resources_cleanup.py
+++ b/tooling/azure-automation/resources-cleanup/src/resources_cleanup.py
@@ -96,15 +96,15 @@ def process_resource_groups_of_subscription(subscription_id: str, resource_clien
 
 def process_resource_group(resource_group: ResourceGroup, resource_client: ResourceManagementClient):
     resource_group_name = resource_group.name
-    resource_list = list(
-        resource_client.resources.list_by_resource_group(resource_group_name, expand = "createdTime,changedTime")
-    )
     
     print(f"Resource group '{resource_group_name}':")
     print(f"Tags: {resource_group.tags}\n")
-    print(f"This resource group has {len(resource_list)} resources \n")
-    
+
     if VERBOSE:
+        resource_list = list(
+            resource_client.resources.list_by_resource_group(resource_group_name, expand = "createdTime,changedTime")
+        )
+        print(f"This resource group has {len(resource_list)} resources \n")
         print_resources(resource_list)
     
     if resource_group_has_persist_tag_as_true(resource_group):

--- a/tooling/azure-automation/resources-cleanup/src/resources_cleanup.py
+++ b/tooling/azure-automation/resources-cleanup/src/resources_cleanup.py
@@ -77,6 +77,13 @@ def resource_group_has_persist_tag_as_true(resource_group: ResourceGroup):
     return resource_group.tags[persist_tag].lower() == "true"
 
 
+def resource_group_is_managed(resource_group: ResourceGroup):
+    if resource_group.managed_by is None:
+        return False
+    else:
+        return True
+
+
 def process_resource_groups_of_subscription(subscription_id: str, resource_client: ResourceManagementClient):
     resource_groups_list = list(resource_client.resource_groups.list())
     n_resource_groups = len(resource_groups_list)
@@ -98,6 +105,7 @@ def process_resource_group(resource_group: ResourceGroup, resource_client: Resou
     resource_group_name = resource_group.name
     
     print(f"Resource group '{resource_group_name}':")
+    print(f"Managed by: {resource_group.managed_by}")
     print(f"Tags: {resource_group.tags}\n")
 
     if VERBOSE:
@@ -109,6 +117,10 @@ def process_resource_group(resource_group: ResourceGroup, resource_client: Resou
     
     if resource_group_has_persist_tag_as_true(resource_group):
         print(f"Persist tag is true, this resource group should NOT be deleted, skipping.")
+        return
+
+    if resource_group_is_managed(resource_group):
+        print(f"Resource Group is managed, this resource group should NOT be deleted, skipping.")
         return
 
     now = datetime.datetime.now(datetime.timezone.utc)

--- a/tooling/azure-automation/resources-cleanup/src/test_resources_cleanup.py
+++ b/tooling/azure-automation/resources-cleanup/src/test_resources_cleanup.py
@@ -1,5 +1,6 @@
 from resources_cleanup import (
-    resource_group_has_persist_tag_as_true, 
+    resource_group_has_persist_tag_as_true,
+    resource_group_is_managed, 
     time_delta_greater_than_two_days, 
     get_date_time_from_str
 )
@@ -24,6 +25,17 @@ from azure.mgmt.resource.resources.v2022_09_01.models._models_py3 import Resourc
 )
 def test_resource_group_has_persist_tag_as_true(input_resource_group, expected):
     assert resource_group_has_persist_tag_as_true(input_resource_group) == expected
+
+
+@pytest.mark.parametrize(
+    "input_resource_group,expected",
+    [
+        (ResourceGroup(location="test_location", name="simple_resource_group", managed_by=None), False),
+        (ResourceGroup(location="test_location", name="simple_resource_group", managed_by="somebody"), True),
+    ]
+)
+def test_resource_group_is_managed(input_resource_group, expected):
+    assert resource_group_is_managed(input_resource_group) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-15214

### What

- Don't clean up RGs that are owned by something.
- Speed up execution by cutting down on api calls.
- Tolerate RGs getting deleted while the script is running.

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

PR is split into functional commits for easy review.