### PR TITLE
Adding Healthz Adapter , Healthz Endpoint and Prometheus Metric for b…

### DIFF
--- a/backend/deploy/templates/backend.deployment.yaml
+++ b/backend/deploy/templates/backend.deployment.yaml
@@ -51,6 +51,8 @@ spec:
         ports:
         - containerPort: 8081
           protocol: TCP
+        - containerPort: 8083
+          protocol: TCP
         resources:
           limits:
             memory: 1Gi
@@ -65,5 +67,11 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8083
+          initialDelaySeconds: 5
+          periodSeconds: 10
       restartPolicy: Always
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
What
Adding Healthz endpoint to Backend and exposing the Healthz metric as well .This used to Integrate with the HealthzAdapter Check of leaderelection .

Why
Currently Backend does not have a /healthz endpoint and hence doesn't use the watchdog feature of Leaderelection .

Special notes for your reviewer
Metric :
```
# HELP backend_health backend_health is 1 when healthy
# TYPE backend_health gauge
backend_health 1
``` 
/healthz endpoint results : 

```
 curl -v localhost:8083/healthz
* Host localhost:8083 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8083...
* Connected to localhost (::1) port 8083
> GET /healthz HTTP/1.1
> Host: localhost:8083
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Thu, 20 Mar 2025 15:35:49 GMT
< Content-Length: 0
< 
* Connection #0 to host localhost left intact

``` 