### PR TITLE
Added a separate template for namespace cleaner

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -92,6 +92,7 @@ deploy-pr-env-deps:
 		-p ARM_HELPER_MOCK_FPA_PRINCIPAL_ID=${AZURE_ARM_HELPER_MOCK_FPA_PRINCIPAL_ID} \
 		-p MSI_MOCK_CLIENT_ID=${AZURE_MI_MOCK_SERVICE_PRINCIPAL_CLIENT_ID} \
 		-p MSI_MOCK_PRINCIPAL_ID=${AZURE_MI_MOCK_SERVICE_PRINCIPAL_PRINCIPAL_ID} | oc apply -f -
+	oc process --local -f cspr/orphaned-namespace-cleaner.yaml | oc apply -f -
 
 create-pr-env-sp:
 	CLUSTER_ID=$(shell az aks show -g ${RESOURCEGROUP} -n ${AKS_NAME} --query id -o tsv) && \

--- a/cluster-service/cspr/cluster-service-namespace.yaml
+++ b/cluster-service/cspr/cluster-service-namespace.yaml
@@ -25,12 +25,6 @@ parameters:
 - name: MSI_MOCK_PRINCIPAL_ID
   description: Principal ID of MSI Mock
   required: true
-- name: ORPHANED_NAMESPACE_CLEANER_NAMESPACE
-  description: The namespace to create to have a cronjob which will delete the orphaned namespace which are not deleted due to any issues with the jenkins job.
-  value: orphaned-namespace-cleaner
-- name: KUBECTL_IMAGE
-  description: An image which have the `kubectl` binary in it.
-  value: quay.io/rhn_support_ansverma/ubi8-minimal-kubectl:latest
 objects:
 - apiVersion: v1
   kind: Namespace
@@ -96,49 +90,3 @@ objects:
     arm-helper-mock-fpa-principal-id: ${ARM_HELPER_MOCK_FPA_PRINCIPAL_ID}
     fpa-client-id: ${FPA_CLIENT_ID}
     cs-client-id: ${CLIENT_ID}
-- apiVersion: v1
-  kind: Namespace
-  metadata:
-    name: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    name: orphaned-namespace-cleaner-cronjob
-    namespace: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRoleBinding
-  metadata:
-    name: orphaned-namespace-cleaner-cronjob
-  subjects:
-  - kind: ServiceAccount
-    name: orphaned-namespace-cleaner-cronjob
-    namespace: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
-  roleRef:
-    kind: ClusterRole
-    name: namespace-admin
-    apiGroup: rbac.authorization.k8s.io
-- apiVersion: batch/v1
-  kind: CronJob
-  metadata:
-    name: orphaned-namespace-cleaner
-    namespace: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
-  spec:
-    schedule: "0 0 * * *"
-    successfulJobsHistoryLimit: 3
-    failedJobsHistoryLimit: 1
-    jobTemplate:
-      spec:
-        template:
-          spec:
-            serviceAccountName: orphaned-namespace-cleaner-cronjob
-            containers:
-            - name: kubectl-container
-              image: ${KUBECTL_IMAGE}
-              command: ["/bin/sh", "-c"]
-              args:
-              - |
-                echo "Starting to clear orphaned namespaces"
-                echo "deleting the orphaned namespaces"
-                kubectl get namespaces -o json | jq -r '.items[] | select(.metadata.labels."sandbox-jenkins-type"=="aro-hcp") | select((now - (.metadata.creationTimestamp | fromdate)) / 60 > 60) | .metadata.name' | xargs kubectl delete namespace
-                echo "Script execution completed."
-            restartPolicy: Never

--- a/cluster-service/cspr/orphaned-namespace-cleaner.yaml
+++ b/cluster-service/cspr/orphaned-namespace-cleaner.yaml
@@ -1,0 +1,78 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: orphaned-namespace-cleaner
+parameters:
+- name: ORPHANED_NAMESPACE_CLEANER_NAMESPACE
+  description: The namespace to create to have a cronjob which will delete the orphaned namespace which are not deleted due to any issues with the jenkins job.
+  value: orphaned-namespace-cleaner
+- name: ORPHANED_NAMESPACE_CLEANER_CLUSTERROLE_NAME
+  value: orphaned-namespace-cleaner
+- name: KUBECTL_IMAGE
+  description: An image which have the `kubectl` binary in it.
+  value: quay.io/rhn_support_ansverma/ubi8-minimal-kubectl:latest
+objects:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: ${ORPHANED_NAMESPACE_CLEANER_CLUSTERROLE_NAME}
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    verbs: ["get", "list", "delete", "watch"]
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: orphaned-namespace-cleaner-cronjob
+    namespace: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: orphaned-namespace-cleaner-cronjob
+  subjects:
+  - kind: ServiceAccount
+    name: orphaned-namespace-cleaner-cronjob
+    namespace: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
+  roleRef:
+    kind: ClusterRole
+    name: ${ORPHANED_NAMESPACE_CLEANER_CLUSTERROLE_NAME}
+    apiGroup: rbac.authorization.k8s.io
+- apiVersion: batch/v1
+  kind: CronJob
+  metadata:
+    name: orphaned-namespace-cleaner
+    namespace: ${ORPHANED_NAMESPACE_CLEANER_NAMESPACE}
+  spec:
+    schedule: "0 0 * * *"
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 1
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            serviceAccountName: orphaned-namespace-cleaner-cronjob
+            containers:
+            - name: kubectl-container
+              image: ${KUBECTL_IMAGE}
+              command: ["/bin/sh", "-c"]
+              args:
+              - |
+                echo "Starting to clear orphaned namespaces"
+                # `select((now - (.metadata.creationTimestamp | fromdate)) / 120 > 120)` selects the namespaces which are older than 120 minutes.
+                NAMESPACES=$(kubectl get namespaces -o json | jq -r '.items[] | select(.metadata.labels."sandbox-jenkins-type"=="aro-hcp") | select((now - (.metadata.creationTimestamp | fromdate)) / 120 > 120) | .metadata.name')
+                NUMBER_OF_NAMESPACES=$(printf "%s" "$NAMESPACES" | wc -l);
+                if [ $NUMBER_OF_NAMESPACES -lt 1 ]; then
+                  echo "no namespaces matching the criteria to delete, exiting"
+                  exit 0
+                fi
+                echo "following orphaned namespaces will be delete - \n$NAMESPACES"
+                echo "deleting the orphaned namespaces"
+                echo $NAMESPACES | xargs kubectl delete namespace
+                echo "Script execution completed."
+            restartPolicy: Never


### PR DESCRIPTION
Fixes: [ARO-15555](https://issues.redhat.com/browse/ARO-15555)

What

This separates the template for the namespace cleaner and modified the cronjob to handle the error gracefully when 0 namespaces are there for deletion.

Prev Closed PR: https://github.com/Azure/ARO-HCP/pull/1499