### PR TITLE
postgres support for regions without availability zones

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -169,6 +169,7 @@ defaults:
       private: false
       minTLSVersion: 'TLSV1.2'
       databaseName: maestro
+      zoneRedundantMode: 'Auto'
     restrictIstioIngress: true
     image:
       repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
@@ -200,6 +201,7 @@ defaults:
       deploy: true
       private: false
       minTLSVersion: 'TLSV1.2'
+      zoneRedundantMode: 'Auto'
     managedIdentityName: clusters-service
     k8s:
       namespace: cluster-service

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -287,13 +287,17 @@
                 "TLSV1.2",
                 "TLSV1.3"
               ]
+            },
+            "zoneRedundantMode": {
+              "$ref": "#/definitions/zoneRedundantMode"
             }
           },
           "required": [
             "deploy",
             "name",
             "private",
-            "minTLSVersion"
+            "minTLSVersion",
+            "zoneRedundantMode"
           ]
         },
         "azureOperatorsManagedIdentities": {
@@ -781,6 +785,9 @@
             },
             "databaseName": {
               "type": "string"
+            },
+            "zoneRedundantMode": {
+              "$ref": "#/definitions/zoneRedundantMode"
             }
           },
           "additionalProperties": false,
@@ -791,7 +798,8 @@
             "serverStorageSizeGB",
             "serverVersion",
             "minTLSVersion",
-            "databaseName"
+            "databaseName",
+            "zoneRedundantMode"
           ]
         },
         "restrictIstioIngress": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -123,6 +123,7 @@ defaults:
       private: false
       minTLSVersion: 'TLSV1.2'
       databaseName: maestro
+      zoneRedundantMode: 'Auto'
     restrictIstioIngress: true
     image:
       repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
@@ -140,6 +141,7 @@ defaults:
       deploy: true
       private: false
       minTLSVersion: 'TLSV1.2'
+      zoneRedundantMode: 'Auto'
     managedIdentityName: clusters-service
     k8s:
       namespace: cluster-service

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -70,7 +70,8 @@
       "deploy": true,
       "minTLSVersion": "TLSV1.2",
       "name": "arohcp-cs-cspr",
-      "private": false
+      "private": false,
+      "zoneRedundantMode": "Auto"
     }
   },
   "cxKeyVault": {
@@ -199,7 +200,8 @@
       "name": "arohcp-maestro-cspr",
       "private": false,
       "serverStorageSizeGB": 32,
-      "serverVersion": "15"
+      "serverVersion": "15",
+      "zoneRedundantMode": "Auto"
     },
     "restrictIstioIngress": false,
     "server": {

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -70,7 +70,8 @@
       "deploy": true,
       "minTLSVersion": "TLSV1.2",
       "name": "arohcp-cs-dev",
-      "private": false
+      "private": false,
+      "zoneRedundantMode": "Auto"
     }
   },
   "cxKeyVault": {
@@ -199,7 +200,8 @@
       "name": "arohcp-maestro-dev",
       "private": false,
       "serverStorageSizeGB": 32,
-      "serverVersion": "15"
+      "serverVersion": "15",
+      "zoneRedundantMode": "Auto"
     },
     "restrictIstioIngress": true,
     "server": {

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -70,7 +70,8 @@
       "deploy": true,
       "minTLSVersion": "TLSV1.2",
       "name": "arohcpint-cs-usw3",
-      "private": false
+      "private": false,
+      "zoneRedundantMode": "Auto"
     }
   },
   "cxKeyVault": {
@@ -201,7 +202,8 @@
       "name": "arohcpint-maestro-usw3",
       "private": false,
       "serverStorageSizeGB": 32,
-      "serverVersion": "15"
+      "serverVersion": "15",
+      "zoneRedundantMode": "Auto"
     },
     "restrictIstioIngress": true,
     "server": {

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -70,7 +70,8 @@
       "deploy": true,
       "minTLSVersion": "TLSV1.2",
       "name": "arohcpstg-cs-usw3",
-      "private": false
+      "private": false,
+      "zoneRedundantMode": "Auto"
     }
   },
   "cxKeyVault": {
@@ -199,7 +200,8 @@
       "name": "arohcpstg-maestro-usw3",
       "private": false,
       "serverStorageSizeGB": 32,
-      "serverVersion": "15"
+      "serverVersion": "15",
+      "zoneRedundantMode": "Auto"
     },
     "restrictIstioIngress": true,
     "server": {

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -70,7 +70,8 @@
       "deploy": false,
       "minTLSVersion": "TLSV1.2",
       "name": "arohcp-cs-nightly",
-      "private": false
+      "private": false,
+      "zoneRedundantMode": "Auto"
     }
   },
   "cxKeyVault": {
@@ -199,7 +200,8 @@
       "name": "arohcp-maestro-nightly",
       "private": false,
       "serverStorageSizeGB": 32,
-      "serverVersion": "15"
+      "serverVersion": "15",
+      "zoneRedundantMode": "Auto"
     },
     "restrictIstioIngress": true,
     "server": {

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -70,7 +70,8 @@
       "deploy": false,
       "minTLSVersion": "TLSV1.2",
       "name": "arohcp-cs-usw3tst",
-      "private": false
+      "private": false,
+      "zoneRedundantMode": "Auto"
     }
   },
   "cxKeyVault": {
@@ -199,7 +200,8 @@
       "name": "arohcp-maestro-usw3tst",
       "private": false,
       "serverStorageSizeGB": 32,
-      "serverVersion": "15"
+      "serverVersion": "15",
+      "zoneRedundantMode": "Auto"
     },
     "restrictIstioIngress": true,
     "server": {

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -42,9 +42,11 @@ param maestroPostgresServerVersion = '{{ .maestro.postgres.serverVersion }}'
 param maestroPostgresServerStorageSizeGB = {{ .maestro.postgres.serverStorageSizeGB }}
 param maestroPostgresDatabaseName = '{{ .maestro.postgres.databaseName }}'
 param deployMaestroPostgres = {{ .maestro.postgres.deploy }}
+param maestroPostgresZoneRedundantMode = '{{ .maestro.postgres.zoneRedundantMode }}'
 param maestroPostgresPrivate = {{ .maestro.postgres.private }}
 
 param csPostgresDeploy = {{ .clusterService.postgres.deploy }}
+param csPostgresZoneRedundantMode = '{{ .clusterService.postgres.zoneRedundantMode }}'
 param csPostgresServerName = '{{ .clusterService.postgres.name }}'
 param csPostgresServerMinTLSVersion = '{{ .clusterService.postgres.minTLSVersion }}'
 param clusterServicePostgresPrivate = {{ .clusterService.postgres.private }}

--- a/dev-infrastructure/modules/cluster-service.bicep
+++ b/dev-infrastructure/modules/cluster-service.bicep
@@ -46,6 +46,8 @@ param ocpAcrResourceId string
 @description('The resource ID of the managed identity used to manage the Postgres server')
 param postgresAdministrationManagedIdentityId string
 
+param postgresZoneRedundantMode string
+
 //
 //   P O S T G R E S
 //
@@ -56,6 +58,7 @@ module postgres 'postgres/postgres.bicep' = if (deployPostgres) {
   name: '${deployment().name}-postgres'
   params: {
     name: postgresServerName
+    postgresZoneRedundantMode: postgresZoneRedundantMode
     databaseAdministrators: [
       {
         principalId: reference(postgresAdministrationManagedIdentityId, '2023-01-31').principalId

--- a/dev-infrastructure/modules/maestro/maestro-server.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-server.bicep
@@ -64,6 +64,8 @@ param maestroServerManagedIdentityPrincipalId string
 @description('The resource ID of the managed identity used to manage the Postgres server')
 param postgresAdministrationManagedIdentityId string
 
+param postgresZoneRedundantMode string
+
 //
 //   P O S T G R E S
 //
@@ -74,6 +76,7 @@ module postgres '../postgres/postgres.bicep' = if (deployPostgres) {
   name: '${deployment().name}-postgres'
   params: {
     name: postgresServerName
+    postgresZoneRedundantMode: postgresZoneRedundantMode
     minTLSVersion: postgresServerMinTLSVersion
     databaseAdministrators: [
       // add the dedicated admin managed identity as administrator

--- a/dev-infrastructure/modules/postgres/postgres.bicep
+++ b/dev-infrastructure/modules/postgres/postgres.bicep
@@ -35,6 +35,9 @@ type DatabaseProperties = {
 @description('The databases to create on the server.')
 param databases DatabaseProperties[] = []
 
+@description('The zone redundant mode of the Postgres Database')
+param postgresZoneRedundantMode string
+
 type MaintenanceWindow = {
   customWindow: string
   dayOfWeek: int
@@ -100,7 +103,7 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview'
       type: 'SystemManaged'
     }
     highAvailability: {
-      mode: 'ZoneRedundant'
+      mode: postgresZoneRedundantMode
     }
     maintenanceWindow: maintenanceWindow
     storage: {


### PR DESCRIPTION
[<!-- Link to Jira issue -->](https://issues.redhat.com/browse/ARO-15928)

### What

This change enables deploying postgres to regions without zone availability, using the `SameZone` method which enabled basic high availability

https://learn.microsoft.com/en-us/azure/reliability/reliability-postgresql-flexible-server#availability-zone-support

### Why

Postgres currently fails deploying to regions without availability zones due to the highAvailability mode `ZoneRedundant` value being hardcoded.

### Special notes for your reviewer

<!-- optional -->
