### PR TITLE
update conditional runbook schedule creation

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -377,7 +377,8 @@ automation-account:
 		--template-file templates/dev-automation-account.bicep \
 		$(PROMPT_TO_CONFIRM) \
 		--parameters \
-			configurations/dev-automation-account.bicepparam
+			configurations/dev-automation-account.bicepparam \
+		--mode Incremental
 .PHONY: automation-account
 
 automation-account.what-if:
@@ -386,5 +387,6 @@ automation-account.what-if:
 		--resource-group $(AUTOMATION_ACCOUNT_RG) \
 		--template-file templates/dev-automation-account.bicep \
 		--parameters \
-			configurations/dev-automation-account.bicepparam
-.PHONY: automation-account.what-if
+			configurations/dev-automation-account.bicepparam \
+		--mode Incremental
+.PHONY: automation-account.what-if 

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -377,8 +377,7 @@ automation-account:
 		--template-file templates/dev-automation-account.bicep \
 		$(PROMPT_TO_CONFIRM) \
 		--parameters \
-			configurations/dev-automation-account.bicepparam \
-		--mode Incremental
+			configurations/dev-automation-account.bicepparam
 .PHONY: automation-account
 
 automation-account.what-if:
@@ -387,6 +386,5 @@ automation-account.what-if:
 		--resource-group $(AUTOMATION_ACCOUNT_RG) \
 		--template-file templates/dev-automation-account.bicep \
 		--parameters \
-			configurations/dev-automation-account.bicepparam \
-		--mode Incremental
+			configurations/dev-automation-account.bicepparam
 .PHONY: automation-account.what-if 

--- a/dev-infrastructure/modules/automation-account/runbook.bicep
+++ b/dev-infrastructure/modules/automation-account/runbook.bicep
@@ -70,7 +70,7 @@ resource runbookSchedule 'Microsoft.Automation/automationAccounts/schedules@2022
 
 // Link Schedule to Runbook
 resource jobSchedule 'Microsoft.Automation/automationAccounts/jobSchedules@2022-08-08' = if (!empty(scheduleName)) {
-  name: guid(automationAccountName, runbookName, scheduleName, runbookType)
+  name: guid(resourceGroup().name, runbookSchedule.name)
   parent: automationAccount
   properties: {
     schedule: {

--- a/dev-infrastructure/modules/automation-account/runbook.bicep
+++ b/dev-infrastructure/modules/automation-account/runbook.bicep
@@ -57,7 +57,7 @@ resource accountRunbook 'Microsoft.Automation/automationAccounts/runbooks@2022-0
 }
 
 // Create the Schedule
-resource runbookSchedule 'Microsoft.Automation/automationAccounts/schedules@2022-08-08' = {
+resource runbookSchedule 'Microsoft.Automation/automationAccounts/schedules@2022-08-08' = if (!empty(scheduleName)) {
   name: '${automationAccountName}_${scheduleName}'
   parent: automationAccount
   properties: {
@@ -69,8 +69,8 @@ resource runbookSchedule 'Microsoft.Automation/automationAccounts/schedules@2022
 }
 
 // Link Schedule to Runbook
-resource jobSchedule 'Microsoft.Automation/automationAccounts/jobSchedules@2022-08-08' = {
-  name: guid(automationAccountName, runbookName, scheduleName)
+resource jobSchedule 'Microsoft.Automation/automationAccounts/jobSchedules@2022-08-08' = if (!empty(scheduleName)) {
+  name: guid(automationAccountName, runbookName, scheduleName, runbookType)
   parent: automationAccount
   properties: {
     schedule: {

--- a/dev-infrastructure/templates/dev-automation-account.bicep
+++ b/dev-infrastructure/templates/dev-automation-account.bicep
@@ -81,6 +81,9 @@ module resouceCleanup '../modules/automation-account/runbook.bicep' = {
     }
     scheduleName: 'nightly-schedule'
   }
+  dependsOn:[
+    automationAccount
+  ]
 }
 
 module assetManagement '../modules/automation-account/runbook.bicep' = {
@@ -97,6 +100,9 @@ module assetManagement '../modules/automation-account/runbook.bicep' = {
       path: 'tooling/azure-automation/resources-cleanup/src/automationassets.py'
     }
   }
+  dependsOn:[
+    automationAccount
+  ]
 }
 
 module roleAssignmentsCleanup '../modules/automation-account/runbook.bicep' = {
@@ -114,4 +120,7 @@ module roleAssignmentsCleanup '../modules/automation-account/runbook.bicep' = {
     }
     scheduleName: 'nightly-schedule'
   }
+  dependsOn: [
+    automationAccount
+  ]
 }

--- a/dev-infrastructure/templates/dev-automation-account.bicep
+++ b/dev-infrastructure/templates/dev-automation-account.bicep
@@ -81,7 +81,7 @@ module resouceCleanup '../modules/automation-account/runbook.bicep' = {
     }
     scheduleName: 'nightly-schedule'
   }
-  dependsOn:[
+  dependsOn: [
     automationAccount
   ]
 }
@@ -100,7 +100,7 @@ module assetManagement '../modules/automation-account/runbook.bicep' = {
       path: 'tooling/azure-automation/resources-cleanup/src/automationassets.py'
     }
   }
-  dependsOn:[
+  dependsOn: [
     automationAccount
   ]
 }


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

Conditional Creation of Schedule:

The runbook schedule resource is created only if scheduleName is not empty `(if (!empty(scheduleName)))`.

If scheduleName is empty, the deployment will not attempt to create a schedule.

[ARO-15556](https://issues.redhat.com/browse/ARO-15556)
