### PR TITLE
Add cleanup before create automation account

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -366,18 +366,39 @@ modules/metrics/rules/generatedPrometheusAlertingRules.bicep:
 	$(MAKE) -C ./../tooling/prometheus-rules/ prometheus-rules
 	./../tooling/prometheus-rules/prometheus-rules --input-rules ./../tooling/prometheus-rules/kubernetesControlPlane-prometheusRule.yaml --output-bicep $@
 
-#
+# Delete the existing schedule
+cleanup-jobSchedules:
+	@for SCHED in $$(az automation schedule list \
+		--automation-account-name hcp-dev-automation \
+		--resource-group $(AUTOMATION_ACCOUNT_RG) \
+		--query "[].name" -o tsv); do \
+		echo "Deleting schedule: $$SCHED"; \
+		az automation schedule delete \
+			--automation-account-name hcp-dev-automation \
+			--name $$SCHED \
+			--resource-group $(AUTOMATION_ACCOUNT_RG) \
+			--yes || true; \
+	done
+.PHONY: cleanup-jobSchedules
+
 # Automation Account creation
-#
-automation-account:
+automation-account: cleanup-jobSchedules
+	@if [ "$$(az group exists --name ${AUTOMATION_ACCOUNT_RG})" = "true" ]; then \
+		echo "Resource group ${AUTOMATION_ACCOUNT_RG} exists. Deleting automation account..."; \
+		az resource delete \
+			--resource-group ${AUTOMATION_ACCOUNT_RG}  \
+			--resource-type "Microsoft.Automation/automationAccounts" \
+			--name hcp-dev-automation; \
+			--name hcp-dev-automation || true; \
+	fi
 	az group create -g ${AUTOMATION_ACCOUNT_RG} -l eastus && \
 	az deployment group create \
 		--name dev-automation-account \
 		--resource-group $(AUTOMATION_ACCOUNT_RG) \
 		--template-file templates/dev-automation-account.bicep \
 		$(PROMPT_TO_CONFIRM) \
-		--parameters \
-			configurations/dev-automation-account.bicepparam
+		--parameters configurations/dev-automation-account.bicepparam \
+		--mode Incremental
 .PHONY: automation-account
 
 automation-account.what-if:
@@ -385,6 +406,6 @@ automation-account.what-if:
 		--name dev-automation-account \
 		--resource-group $(AUTOMATION_ACCOUNT_RG) \
 		--template-file templates/dev-automation-account.bicep \
-		--parameters \
-			configurations/dev-automation-account.bicepparam
+		--parameters configurations/dev-automation-account.bicepparam \
+		--mode Incremental
 .PHONY: automation-account.what-if


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->
To fix the error when running make automation-account,  added a two-step cleanup process:

- Clean up existing schedules
- Clean up the Automation Account


There isn’t a CLI command available like:
```
az automation job-schedule delete \
  --automation-account-name hcp-dev-automation \
  --resource-group hcp-dev-automation-account \
  --name <job-schedule-name>
```
Also, the result of the query below returns empty, which makes it difficult to identify existing job schedules.
```
az resource list --resource-group hcp-dev-automation-account --resource-type "Microsoft.Automation/automationAccounts/jobSchedules" --query "[].{Name:name, Type:type}"
```
So added schedule deletion to the cleanup-jobSchedules target before the creation step.

Alternatively, the two step cleanup —first for the schedules, then for the Automation Account, to fix the resource conflict error during deployment.


To fix the error when running `make automation-account`
```
{"status":"Failed","error":{"code":"DeploymentFailed","target":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/hcp-dev-automation-account/providers/Microsoft.Resources/deployments/dev-automation-account","message":"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.","details":[{"code":"ResourceDeploymentFailure","target":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/hcp-dev-automation-account/providers/Microsoft.Resources/deployments/assetManagement","message":"The resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'.","details":[{"code":"DeploymentFailed","target":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/hcp-dev-automation-account/providers/Microsoft.Resources/deployments/assetManagement","message":"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.","details":[{"code":"ParentResourceNotFound","message":"Failed to perform 'write' on resource(s) of type 'automationAccounts/runbooks', because the parent resource '/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/hcp-dev-automation-account/providers/Microsoft.Automation/automationAccounts/hcp-dev-automation' could not be found."},{"code":"ResourceNotFound","message":"The Resource 'Microsoft.Automation/automationAccounts/hcp-dev-automation' under resource group 'hcp-dev-automation-account' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"}]}]},{"code":"ResourceDeploymentFailure","target":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/hcp-dev-automation-account/providers/Microsoft.Resources/deployments/resourceCleanup","message":"The resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'.","details":[{"code":"DeploymentFailed","target":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/hcp-dev-automation-account/providers/Microsoft.Resources/deployments/resourceCleanup","message":"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.","details":[{"code":"ParentResourceNotFound","message":"Failed to perform 'write' on resource(s) of type 'automationAccounts/runbooks', because the parent resource '/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/hcp-dev-automation-account/providers/Microsoft.Automation/automationAccounts/hcp-dev-automation' could not be found."},{"code":"ResourceNotFound","message":"The Resource 'Microsoft.Automation/automationAccounts/hcp-dev-automation' under resource group 'hcp-dev-automation-account' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"}]}]},{"code":"ResourceDeploymentFailure","target":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/hcp-dev-automation-account/providers/Microsoft.Resources/deployments/roleAssignmentsCleanup","message":"The resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'.","details":[{"code":"DeploymentFailed","target":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/hcp-dev-automation-account/providers/Microsoft.Resources/deployments/roleAssignmentsCleanup","message":"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.","details":[{"code":"ParentResourceNotFound","message":"Failed to perform 'write' on resource(s) of type 'automationAccounts/runbooks', because the parent resource '/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/hcp-dev-automation-account/providers/Microsoft.Automation/automationAccounts/hcp-dev-automation' could not be found."},{"code":"ResourceNotFound","message":"The Resource 'Microsoft.Automation/automationAccounts/hcp-dev-automation' under resource group 'hcp-dev-automation-account' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"}]}]}]}}
```

[ARO-15539](https://issues.redhat.com/browse/ARO-15539)
