### PR TITLE
add region short names to serviceconfig.json + related scripts

### DIFF
--- a/templatize.sh
+++ b/templatize.sh
@@ -86,36 +86,13 @@ while getopts "c:dr:x:e:i:o:p:P:s:" opt; do
     esac
 done
 
-# short names from EV2 prod ServiceConfig
-case ${REGION} in
-    eastus)
-        REGION_SHORT="use"
-        ;;
-    westus)
-        REGION_SHORT="usw"
-        ;;
-    centralus)
-        REGION_SHORT="usc"
-        ;;
-    northcentralus)
-        REGION_SHORT="usnc"
-        ;;
-    southcentralus)
-        REGION_SHORT="ussc"
-        ;;
-    westus2)
-        REGION_SHORT="usw2"
-        ;;
-    westus3)
-        REGION_SHORT="usw3"
-        ;;
-    uksouth)
-        REGION_SHORT="ln"
-        ;;
-    *)
-        echo "unsupported region: ${REGION}"
-        exit 1
-esac
+# Read region name from our sanitized serviceconfig.json and returns the region short name
+REGION_SHORT=$(
+    "${PROJECT_ROOT_DIR}/tooling/templatize/serviceconfig-get-region-short-name.sh" "${REGION}"
+)
+if [ -z "$REGION_SHORT" ]; then
+    echo "Failed to get region short name for region: $REGION" >&2
+fi
 
 if [ "$DEPLOY_ENV" == "personal-dev" ]; then
     REGION_STAMP="${REGION_SHORT}${USER:0:4}"

--- a/tooling/templatize/serviceconfig-get-region-short-name.sh
+++ b/tooling/templatize/serviceconfig-get-region-short-name.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# This script reads an EV2 ServiceConfig json file and gets a region short name
+#
+
+set -euo pipefail
+
+# Bash current file directory
+SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+
+
+REGION=${1:-}
+
+if [ -z "${REGION}" ]; then
+  echo "Usage: $0 <region>"
+  exit 1
+fi
+
+REGION_SHORT=$(
+  jq -r --arg region "${REGION}" '
+    .Geographies[].Regions[]
+    | select(.Name == $region)
+    | .Settings.regionShortName
+  ' "${SCRIPT_DIR}/serviceconfig.json"
+)
+
+if [[ -z "$REGION_SHORT" ]]; then
+    echo "Region name (or short name) not found for region: $REGION" >&2
+    echo "Please check the region name in the serviceconfig.json file and update the file as necessary" >&2
+    exit 1
+fi
+
+printf "%s" "${REGION_SHORT}"

--- a/tooling/templatize/serviceconfig-sanitizer.sh
+++ b/tooling/templatize/serviceconfig-sanitizer.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# This script reads an EV2 ServiceConfig json file and sanitizes it for use in our own tooling
+#
+
+set -euo pipefail
+
+INPUT_FILE=${1:-}
+
+if [ -z "${INPUT_FILE}" ]; then
+  echo "Usage: $0 <ServiceConfig.json>"
+  exit 1
+fi
+
+jq -r '
+{
+  Settings: {},
+  Geographies: [
+    .Geographies[] | {
+      Name,
+      Settings: {
+        geoShortId: .Settings.geoShortId
+      },
+      Regions: [
+        .Regions[] | {
+          Name,
+          Settings: {
+            regionShortName: .Settings.regionShortName
+          }
+        }
+      ]
+    }
+  ]
+}' "${INPUT_FILE}"

--- a/tooling/templatize/serviceconfig.json
+++ b/tooling/templatize/serviceconfig.json
@@ -3,503 +3,727 @@
   "Geographies": [
     {
       "Name": "Asia Pacific",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "ap"
+      },
       "Regions": [
         {
           "Name": "apacsoutheast2",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "kul"
+          }
         },
         {
           "Name": "eastasia",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "hk"
+          }
         },
         {
           "Name": "southeastasia",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "sg"
+          }
         }
       ]
     },
     {
       "Name": "Australia",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "au"
+      },
       "Regions": [
         {
           "Name": "australiacentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "cbr"
+          }
         },
         {
           "Name": "australiacentral2",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "cbr2"
+          }
         },
         {
           "Name": "australiaeast",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "sy"
+          }
         },
         {
           "Name": "australiasoutheast",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "ml"
+          }
         }
       ]
     },
     {
       "Name": "Austria",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "at"
+      },
       "Regions": [
         {
           "Name": "austriaeast",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "ate"
+          }
         }
       ]
     },
     {
       "Name": "Belgium",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "be"
+      },
       "Regions": [
         {
           "Name": "belgiumcentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "bec"
+          }
         }
       ]
     },
     {
       "Name": "Brazil",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "br"
+      },
       "Regions": [
         {
           "Name": "brazilnortheast",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "brne"
+          }
         },
         {
           "Name": "brazilsouth",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "cq"
+          }
         },
         {
           "Name": "brazilsoutheast",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "brse"
+          }
         }
       ]
     },
     {
       "Name": "Canada",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "ca"
+      },
       "Regions": [
         {
           "Name": "canadacentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "yt"
+          }
         },
         {
           "Name": "canadaeast",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "yq"
+          }
         }
       ]
     },
     {
       "Name": "Canary (US)",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "usc"
+      },
       "Regions": [
         {
           "Name": "centraluseuap",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "cdm"
+          }
         },
         {
           "Name": "eastus2euap",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "cbn"
+          }
         }
       ]
     },
     {
       "Name": "Chile",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "cl"
+      },
       "Regions": [
         {
           "Name": "chilecentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "clc"
+          }
         }
       ]
     },
     {
       "Name": "Denmark",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "dk"
+      },
       "Regions": [
         {
           "Name": "denmarkeast",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "dke"
+          }
         }
       ]
     },
     {
       "Name": "Europe",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "eu"
+      },
       "Regions": [
         {
           "Name": "northeurope",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "db"
+          }
         },
         {
           "Name": "westeurope",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "am"
+          }
         }
       ]
     },
     {
       "Name": "France",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "fr"
+      },
       "Regions": [
         {
           "Name": "francecentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "par"
+          }
         },
         {
           "Name": "francesouth",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "mrs"
+          }
         }
       ]
     },
     {
       "Name": "Germany",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "de"
+      },
       "Regions": [
         {
           "Name": "germanynorth",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "den"
+          }
         },
         {
           "Name": "germanywestcentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "dewc"
+          }
         }
       ]
     },
     {
       "Name": "India",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "in"
+      },
       "Regions": [
         {
           "Name": "centralindia",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "pn"
+          }
         },
         {
           "Name": "jioindiacentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "jinc"
+          }
         },
         {
           "Name": "jioindiawest",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "jinw"
+          }
         },
         {
           "Name": "southindia",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "ma"
+          }
         },
         {
           "Name": "westindia",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "bm"
+          }
         }
       ]
     },
     {
       "Name": "Indonesia",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "id"
+      },
       "Regions": [
         {
           "Name": "indonesiacentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "idc"
+          }
         }
       ]
     },
     {
       "Name": "Israel",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "il"
+      },
       "Regions": [
         {
           "Name": "israelcentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "ilc"
+          }
         },
         {
           "Name": "israelnorthwest",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "ilnw"
+          }
         }
       ]
     },
     {
       "Name": "Italy",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "it"
+      },
       "Regions": [
         {
           "Name": "italynorth",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "itn"
+          }
         }
       ]
     },
     {
       "Name": "Japan",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "jp"
+      },
       "Regions": [
         {
           "Name": "japaneast",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "ty"
+          }
         },
         {
           "Name": "japanwest",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "os"
+          }
         }
       ]
     },
     {
       "Name": "Korea",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "kr"
+      },
       "Regions": [
         {
           "Name": "koreacentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "se"
+          }
         },
         {
           "Name": "koreasouth",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "ps"
+          }
         },
         {
           "Name": "koreasouth2",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "krs2"
+          }
         }
       ]
     },
     {
       "Name": "Malaysia",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "my"
+      },
       "Regions": [
         {
           "Name": "malaysiasouth",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "mys"
+          }
         },
         {
           "Name": "malaysiawest",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "myw"
+          }
         }
       ]
     },
     {
       "Name": "Mexico",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "mx"
+      },
       "Regions": [
         {
           "Name": "mexicocentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "mxc"
+          }
         }
       ]
     },
     {
       "Name": "New Zealand",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "nz"
+      },
       "Regions": [
         {
           "Name": "newzealandnorth",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "nzn"
+          }
         }
       ]
     },
     {
       "Name": "Norway",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "no"
+      },
       "Regions": [
         {
           "Name": "norwayeast",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "noe"
+          }
         },
         {
           "Name": "norwaywest",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "now"
+          }
         }
       ]
     },
     {
       "Name": "Poland",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "pl"
+      },
       "Regions": [
         {
           "Name": "polandcentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "plc"
+          }
         }
       ]
     },
     {
       "Name": "Qatar",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "qa"
+      },
       "Regions": [
         {
           "Name": "qatarcentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "qac"
+          }
         }
       ]
     },
     {
       "Name": "South Africa",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "za"
+      },
       "Regions": [
         {
           "Name": "southafricanorth",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "jnb"
+          }
         },
         {
           "Name": "southafricawest",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "cpt"
+          }
         }
       ]
     },
     {
       "Name": "Spain",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "es"
+      },
       "Regions": [
         {
           "Name": "spaincentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "esc"
+          }
         }
       ]
     },
     {
       "Name": "Stage (US)",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "ust"
+      },
       "Regions": [
         {
           "Name": "eastusslv",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "use"
+          }
         },
         {
           "Name": "eastusstg",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "uste"
+          }
         },
         {
           "Name": "southcentralusstg",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "ustsc"
+          }
         }
       ]
     },
     {
       "Name": "Sweden",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "se"
+      },
       "Regions": [
         {
           "Name": "swedencentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "sec"
+          }
         },
         {
           "Name": "swedensouth",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "ses"
+          }
         }
       ]
     },
     {
       "Name": "Switzerland",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "ch"
+      },
       "Regions": [
         {
           "Name": "switzerlandnorth",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "chn"
+          }
         },
         {
           "Name": "switzerlandwest",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "chw"
+          }
         }
       ]
     },
     {
       "Name": "Taiwan",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "tw"
+      },
       "Regions": [
         {
           "Name": "taiwannorth",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "twn"
+          }
         },
         {
           "Name": "taiwannorthwest",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "twnw"
+          }
         }
       ]
     },
     {
       "Name": "UAE",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "ae"
+      },
       "Regions": [
         {
           "Name": "uaecentral",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "auh"
+          }
         },
         {
           "Name": "uaenorth",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "dxb"
+          }
         }
       ]
     },
     {
       "Name": "United Kingdom",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "uk"
+      },
       "Regions": [
         {
           "Name": "uksouth",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "ln"
+          }
         },
         {
           "Name": "ukwest",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "cw"
+          }
         }
       ]
     },
     {
       "Name": "United States",
-      "Settings": {},
+      "Settings": {
+        "geoShortId": "us"
+      },
       "Regions": [
         {
           "Name": "centralus",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "dm"
+          }
         },
         {
           "Name": "eastus",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "bl"
+          }
         },
         {
           "Name": "eastus2",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "bn"
+          }
+        },
+        {
+          "Name": "eastus3",
+          "Settings": {
+            "regionShortName": "use3"
+          }
         },
         {
           "Name": "northcentralus",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "ch"
+          }
         },
         {
           "Name": "southcentralus",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "sn"
+          }
         },
         {
           "Name": "southcentralus2",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "ussc2"
+          }
         },
         {
           "Name": "southeastus",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "usse1"
+          }
         },
         {
           "Name": "southeastus3",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "usse3"
+          }
         },
         {
           "Name": "southeastus5",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "usse5"
+          }
         },
         {
           "Name": "southwestus",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "ussw1"
+          }
         },
         {
           "Name": "westcentralus",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "cy"
+          }
         },
         {
           "Name": "westus",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "by"
+          }
         },
         {
           "Name": "westus2",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "mwh"
+          }
         },
         {
           "Name": "westus3",
-          "Settings": {}
+          "Settings": {
+            "regionShortName": "usw3"
+          }
         }
       ]
     }


### PR DESCRIPTION
### What

Instead of having a hardcoded list of region names and short names, this allows us to get and maintain the data from the source of truth

Note that this changes the short names we are used to, to the ones used by EV2

The main benefit is that we get the ability to provision to all regions, without maintaining a list of our own short names

This also adds the Geographies short codes which is not used but might be useful later

### Why

Enables provisioning in all regions for local development environments

### Special notes for your reviewer

<!-- optional -->
