### PR TITLE
Grafana dashboard sync

### DIFF
--- a/.github/workflows/aro-hcp-dev-what-if.yml
+++ b/.github/workflows/aro-hcp-dev-what-if.yml
@@ -16,6 +16,7 @@ on:
     - 'dev-infrastructure/data'
     - 'dev-infrastructure/**/*.bicepparam'
     - 'dev-infrastructure/Makefile'
+    - 'grafana'
     - '.github/workflows/aro-hcp-dev-what-if.yml'
 jobs:
   what-if:

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -22,6 +22,20 @@ resourceGroups:
     template: templates/global-infra.bicep
     parameters: configurations/global-infra.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+  - name: grafana-dashboards
+    action: Shell
+    command: cd ../grafana && ./deploy.sh
+    dependsOn:
+    - global-infra
+    dryRun:
+      variables:
+      - name: DRY_RUN
+        value: "true"
+    variables:
+      - name: GRAFANA_NAME
+        configRef: monitoring.grafanaName
+      - name: GLOBAL_RESOURCEGROUP
+        configRef: global.rg
   # creates DNS delegation for the ARO HCP global SVC zone
   - name: svcChildZone
     action: DelegateChildZone

--- a/grafana/dashboards/testing/test.json
+++ b/grafana/dashboards/testing/test.json
@@ -1,0 +1,41 @@
+{
+  "dashboard": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 20,
+    "links": [],
+    "panels": [],
+    "schemaVersion": 39,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-10h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "FxooBar",
+    "version": 1,
+    "weekStart": ""
+  },
+  "folderUid": "XYZTOBESETBYPIPELINEZYX"
+}

--- a/grafana/deploy.sh
+++ b/grafana/deploy.sh
@@ -41,6 +41,7 @@ do
         then
             echo "would create/update dashboard '${dashboard_name}' on managed grafana ${GRAFANA_NAME} in rg ${RESOURCEGROUP}"
         else
+            grep -q XYZTOBESETBYPIPELINEZYX ${dashboard} || echo "Magic string XYZTOBESETBYPIPELINEZYX not found in dashboard file ${dashboard} >&2
             sed -i "s/XYZTOBESETBYPIPELINEZYX/${folderUid}/" ${dashboard}
             az grafana dashboard update --overwrite true -g ${RESOURCEGROUP}  -n ${GRAFANA_NAME} --definition ${dashboard}
         fi

--- a/grafana/deploy.sh
+++ b/grafana/deploy.sh
@@ -6,7 +6,7 @@
 #  - check if stale folder needs to be deleted
 #  - check if stale dashboard needs to be deleted 
 
-set -eu
+set -euo pipefail
 
 export RESOURCEGROUP=${GLOBAL_RESOURCEGROUP:-global}
 

--- a/grafana/deploy.sh
+++ b/grafana/deploy.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This is a super simple approach to syncing dashboards
+# TODO:
+#  - check if dashboard really needs update (will cause many versions in grafana db)
+#  - check if stale folder needs to be deleted
+#  - check if stale dashboard needs to be deleted 
+
+set -eu
+
+export RESOURCEGROUP=${GLOBAL_RESOURCEGROUP:-global}
+
+if [[ -z ${GRAFANA_NAME} ]];
+then
+    echo "GRAFANA_NAME needs to be set"
+    exit 1
+fi
+
+cd dashboards
+
+existing_folders=$(az grafana folder list -g ${RESOURCEGROUP}  -n ${GRAFANA_NAME})
+
+IFS=$'\n'; for d in $(ls -1)
+do
+    if [[ $(echo $existing_folders | jq --arg TITLE "$d"  -c '.[] | select( .title == $TITLE )' |wc -l )  -gt 0 ]];
+    then
+        folderUid=$(echo $existing_folders | jq --arg TITLE "$d"  -r '.[] | select( .title == $TITLE ) | .uid' )
+    else
+        if [[ ${DRY_RUN} == "true" ]];
+        then
+            echo "would create folder '${d}' on managed grafana ${GRAFANA_NAME} in rg ${RESOURCEGROUP}"
+        else
+            folderUid=$(az grafana folder create --only-show-errors  -g ${RESOURCEGROUP}  -n ${GRAFANA_NAME} --title ${d} |jq -r '.uid')
+        fi
+    fi
+    cd ${d}
+    IFS=$'\n'; for dashboard in $(ls -1)
+    do
+        dashboard_name=$(cat ${dashboard} | jq '.dashboard.title' )
+        if [[ ${DRY_RUN} == "true" ]];
+        then
+            echo "would create/update dashboard '${dashboard_name}' on managed grafana ${GRAFANA_NAME} in rg ${RESOURCEGROUP}"
+        else
+            sed -i "s/XYZTOBESETBYPIPELINEZYX/${folderUid}/" ${dashboard}
+            az grafana dashboard update --overwrite true -g ${RESOURCEGROUP}  -n ${GRAFANA_NAME} --definition ${dashboard}
+        fi
+    done
+    cd - >/dev/null
+done

--- a/grafana/deploy.sh
+++ b/grafana/deploy.sh
@@ -20,7 +20,7 @@ cd dashboards
 
 existing_folders=$(az grafana folder list -g ${RESOURCEGROUP}  -n ${GRAFANA_NAME})
 
-IFS=$'\n'; for d in $(ls -1)
+for d in $(find . -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
 do
     if [[ $(echo $existing_folders | jq --arg TITLE "$d"  -c '.[] | select( .title == $TITLE )' |wc -l )  -gt 0 ]];
     then


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Add Grafana dashboard sync

### Why

Want to sync dashboards to managed grafana instances

### Special notes for your reviewer

Dry run output:

```
WARNING: Preview version of extension is disabled by default for extension installation, enabled for modules without stable versions. 
WARNING: Please run 'az config set extension.dynamic_install_allow_preview=true or false' to config it specifically. 
WARNING: The command requires the extension amg. It will be installed first.
would create folder 'testing' on managed grafana arohcp-dev in rg global
would create/update dashboard '"FxooBar"' on managed grafana arohcp-dev in rg global
```
