### PR TITLE
multiple oc-mirror versions for different usecases

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -278,7 +278,7 @@ clouds:
             digest: sha256:6a212720d25f270073318b1b480f326fcda08fbf6a1e435b7651e0336c72caee
         ocMirror:
           image:
-            digest: sha256:574ebb57e70c46ba3bc34db4776fd64b63a52e04afc1dddba7b91e0c5f247952
+            digest: sha256:9e2c19a88985aca7fef8061506a61c6519ad19c1a4dab9a46ac707dcf6bb05ac
     environments:
       int:
         # this is the MSFT INT environment

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -166,7 +166,7 @@ defaults:
       enabled: true
       image:
         repository: image-sync/oc-mirror
-        digest: sha256:4affed9ff6397a5c44e9d1451fd58667f56e826b122819ccb6e1e8e045803c18
+        digest: sha256:9e2c19a88985aca7fef8061506a61c6519ad19c1a4dab9a46ac707dcf6bb05ac
       pullSecretName: ocmirror-pull-secret
   # MCE
   mce:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -150,7 +150,7 @@
     "ocMirror": {
       "enabled": true,
       "image": {
-        "digest": "sha256:036126b18521dfb3ee740022331a75b33c8b1668e9f67350787165382c7d21a1",
+        "digest": "sha256:9e2c19a88985aca7fef8061506a61c6519ad19c1a4dab9a46ac707dcf6bb05ac",
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -150,7 +150,7 @@
     "ocMirror": {
       "enabled": true,
       "image": {
-        "digest": "sha256:4affed9ff6397a5c44e9d1451fd58667f56e826b122819ccb6e1e8e045803c18",
+        "digest": "sha256:036126b18521dfb3ee740022331a75b33c8b1668e9f67350787165382c7d21a1",
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -150,7 +150,7 @@
     "ocMirror": {
       "enabled": true,
       "image": {
-        "digest": "sha256:036126b18521dfb3ee740022331a75b33c8b1668e9f67350787165382c7d21a1",
+        "digest": "sha256:9e2c19a88985aca7fef8061506a61c6519ad19c1a4dab9a46ac707dcf6bb05ac",
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -150,7 +150,7 @@
     "ocMirror": {
       "enabled": true,
       "image": {
-        "digest": "sha256:4affed9ff6397a5c44e9d1451fd58667f56e826b122819ccb6e1e8e045803c18",
+        "digest": "sha256:036126b18521dfb3ee740022331a75b33c8b1668e9f67350787165382c7d21a1",
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -150,7 +150,7 @@
     "ocMirror": {
       "enabled": true,
       "image": {
-        "digest": "sha256:036126b18521dfb3ee740022331a75b33c8b1668e9f67350787165382c7d21a1",
+        "digest": "sha256:9e2c19a88985aca7fef8061506a61c6519ad19c1a4dab9a46ac707dcf6bb05ac",
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -150,7 +150,7 @@
     "ocMirror": {
       "enabled": true,
       "image": {
-        "digest": "sha256:574ebb57e70c46ba3bc34db4776fd64b63a52e04afc1dddba7b91e0c5f247952",
+        "digest": "sha256:036126b18521dfb3ee740022331a75b33c8b1668e9f67350787165382c7d21a1",
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -150,7 +150,7 @@
     "ocMirror": {
       "enabled": true,
       "image": {
-        "digest": "sha256:036126b18521dfb3ee740022331a75b33c8b1668e9f67350787165382c7d21a1",
+        "digest": "sha256:9e2c19a88985aca7fef8061506a61c6519ad19c1a4dab9a46ac707dcf6bb05ac",
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -150,7 +150,7 @@
     "ocMirror": {
       "enabled": true,
       "image": {
-        "digest": "sha256:574ebb57e70c46ba3bc34db4776fd64b63a52e04afc1dddba7b91e0c5f247952",
+        "digest": "sha256:036126b18521dfb3ee740022331a75b33c8b1668e9f67350787165382c7d21a1",
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -150,7 +150,7 @@
     "ocMirror": {
       "enabled": true,
       "image": {
-        "digest": "sha256:036126b18521dfb3ee740022331a75b33c8b1668e9f67350787165382c7d21a1",
+        "digest": "sha256:9e2c19a88985aca7fef8061506a61c6519ad19c1a4dab9a46ac707dcf6bb05ac",
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -150,7 +150,7 @@
     "ocMirror": {
       "enabled": true,
       "image": {
-        "digest": "sha256:4affed9ff6397a5c44e9d1451fd58667f56e826b122819ccb6e1e8e045803c18",
+        "digest": "sha256:036126b18521dfb3ee740022331a75b33c8b1668e9f67350787165382c7d21a1",
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -150,7 +150,7 @@
     "ocMirror": {
       "enabled": true,
       "image": {
-        "digest": "sha256:036126b18521dfb3ee740022331a75b33c8b1668e9f67350787165382c7d21a1",
+        "digest": "sha256:9e2c19a88985aca7fef8061506a61c6519ad19c1a4dab9a46ac707dcf6bb05ac",
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -150,7 +150,7 @@
     "ocMirror": {
       "enabled": true,
       "image": {
-        "digest": "sha256:4affed9ff6397a5c44e9d1451fd58667f56e826b122819ccb6e1e8e045803c18",
+        "digest": "sha256:036126b18521dfb3ee740022331a75b33c8b1668e9f67350787165382c7d21a1",
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"

--- a/dev-infrastructure/templates/global-image-sync.bicep
+++ b/dev-infrastructure/templates/global-image-sync.bicep
@@ -314,6 +314,8 @@ var ocpMirrorConfig = {
   }
 }
 
+// this is v2alpha1 syntax for oc-mirror 4.16, which we use until 4.18+ offers
+// a way to not rebuild the catalogs, which fails in ACA
 var acmMirrorConfig = {
   kind: 'ImageSetConfiguration'
   apiVersion: 'mirror.openshift.io/v2alpha1'
@@ -324,21 +326,17 @@ var acmMirrorConfig = {
         packages: [
           {
             name: 'multicluster-engine'
-            channels: [
+            bundles: [
               {
-                name: 'stable-2.7'
-                minVersion: '2.7.0'
-                maxVersion: '2.7.0'
+                name: 'multicluster-engine.v2.7.0'
               }
             ]
           }
           {
             name: 'advanced-cluster-management'
-            channels: [
+            bundles: [
               {
-                name: 'release-2.12'
-                minVersion: '2.12.0'
-                maxVersion: '2.12.0'
+                name: 'advanced-cluster-management.v2.12.0'
               }
             ]
           }
@@ -356,6 +354,7 @@ var ocMirrorJobConfiguration = ocMirrorEnabled
         timeout: 4 * 60 * 60
         targetRegistry: ocpAcrName
         imageSetConfig: ocpMirrorConfig
+        compatibility: 'LATEST'
       }
       {
         name: 'acm-mirror'
@@ -363,6 +362,7 @@ var ocMirrorJobConfiguration = ocMirrorEnabled
         timeout: 4 * 60 * 60
         targetRegistry: svcAcrName
         imageSetConfig: acmMirrorConfig
+        compatibility: 'NOCATALOG'
       }
     ]
   : []
@@ -425,6 +425,7 @@ resource ocMirrorJobs 'Microsoft.App/jobs@2024-03-01' = [
                 name: 'APPSETTING_WEBSITE_SITE_NAME'
                 value: 'workaround - https://github.com/microsoft/azure-container-apps/issues/502'
               }
+              { name: 'OC_MIRROR_COMPATIBILITY', value: ocMirrorJobConfiguration[i].compatibility }
             ]
             resources: {
               cpu: 2

--- a/image-sync/oc-mirror/Dockerfile
+++ b/image-sync/oc-mirror/Dockerfile
@@ -6,6 +6,8 @@ RUN set -eux; \
     tdnf -y install unzip wget tar ca-certificates; \
     tdnf clean all
 
+ENV OC_MIRROR_4_16_VERSION=4.16.3
+ENV OC_MIRROR_4_18_VERSION=4.18.7
 ENV OC_VERSION=4.18.0-rc.9
 ENV YQ_VERSION=v4.2.0
 
@@ -13,10 +15,15 @@ RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VER
     tar -zvxf oc.tar.gz && \
     mv oc kubectl /usr/local/bin
 
-RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/oc-mirror.tar.gz \
+RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_MIRROR_4_16_VERSION}/oc-mirror.tar.gz \
     -o oc-mirror.tar.gz && \
     tar -zvxf oc-mirror.tar.gz && \
-    mv oc-mirror /usr/local/bin
+    mv oc-mirror /usr/local/bin/oc-mirror-4.16
+
+RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_MIRROR_4_18_VERSION}/oc-mirror.tar.gz \
+    -o oc-mirror.tar.gz && \
+    tar -zvxf oc-mirror.tar.gz && \
+    mv oc-mirror /usr/local/bin/oc-mirror-4.18
 
 RUN curl -sfL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz \
     -o yq.tar.gz && \
@@ -37,7 +44,8 @@ ADD mirror.sh /usr/local/bin/mirror.sh
 ADD docker-login.sh /usr/local/bin/docker-login.sh
 
 COPY --chown=0:0 --chmod=755 --from=downloader \
-    /usr/local/bin/oc-mirror \
+    /usr/local/bin/oc-mirror-4.16 \
+    /usr/local/bin/oc-mirror-4.18 \
     /usr/local/bin/oc \
     /usr/local/bin/kubectl \
     /usr/local/bin/yq \

--- a/image-sync/oc-mirror/Makefile
+++ b/image-sync/oc-mirror/Makefile
@@ -32,6 +32,7 @@ acm-dry-run: image
 		-e IMAGE_SET_CONFIG=$(shell cat ${PWD}/test/acm-image-set-config.yml | base64) \
 		-e REGISTRY=${ARO_HCP_IMAGE_ACR} \
 		-e REGISTRY_URL=${ARO_HCP_IMAGE_ACR_URL} \
+		-e OC_MIRROR_COMPATIBILITY="NOCATALOG" \
 		${OC_MIRROR_IMAGE_TAGGED} --dry-run
 .PHONY: acm-dry-run
 
@@ -43,5 +44,6 @@ ocp-dry-run: image
 		-e IMAGE_SET_CONFIG=$(shell cat ${PWD}/test/ocp-image-set-config.yml | base64) \
 		-e REGISTRY=${ARO_HCP_OCP_IMAGE_ACR} \
 		-e REGISTRY_URL=${ARO_HCP_OCP_IMAGE_ACR_URL} \
+		-e OC_MIRROR_COMPATIBILITY="LATEST" \
 		${OC_MIRROR_IMAGE_TAGGED} --dry-run
 .PHONY: ocp-dry-run

--- a/image-sync/oc-mirror/mirror.sh
+++ b/image-sync/oc-mirror/mirror.sh
@@ -12,4 +12,11 @@ else
     ADDITIONAL_FLAGS="--continue-on-error"
 fi
 
-/usr/local/bin/oc-mirror --config ${IMAGE_SET_CONFIG_FILE} ${ADDITIONAL_FLAGS} docker://${REGISTRY_URL} @$
+if [ "$OC_MIRROR_COMPATIBILITY" = "NOCATALOG" ]; then
+    export OC_MIRROR_VERSION="4.16"
+else
+    export OC_MIRROR_VERSION="4.18"
+fi
+echo "Using oc-mirror version: ${OC_MIRROR_VERSION}"
+
+/usr/local/bin/oc-mirror-${OC_MIRROR_VERSION} --config ${IMAGE_SET_CONFIG_FILE} ${ADDITIONAL_FLAGS} docker://${REGISTRY_URL} @$

--- a/image-sync/oc-mirror/test/acm-image-set-config.yml
+++ b/image-sync/oc-mirror/test/acm-image-set-config.yml
@@ -5,12 +5,8 @@ mirror:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.16
     packages:
     - name: multicluster-engine
-      channels:
-      - name: stable-2.7
-        minVersion: "2.7.0"
-        maxVersion: "2.7.0"
+      bundles:
+      - name: multicluster-engine.v2.7.0
     - name: advanced-cluster-management
-      channels:
-      - name: release-2.12
-        minVersion: "2.12.0"
-        maxVersion: "2.12.0"
+      bundles:
+      - name: advanced-cluster-management.v2.12.0


### PR DESCRIPTION
### What

oc-mirror 4.18 currently suffers from two bugs that prevent us from using it for ACM operator mirroring

* https://issues.redhat.com/browse/OCPBUGS-52471 - high memory consumption -> OOM kill in Azure Container App
* https://issues.redhat.com/browse/OCPBUGS-54340 -> high disk consumption -> job eviction when 8Gi of disk are used in Azure Container App

oc-mirror 4.16 works nicely for ACM operator mirroring, but we can't use it for the OCP image mirror because there is a bug from OCP 4.18 onwards where certain images are missing after a successful sync.

this PR adds both versions of oc-mirror to the image and uses one or the other depending on usecase. when both OCPBUGS are resolved, we can harmonize again on one.

https://issues.redhat.com/browse/ARO-16030

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
