### PR TITLE
tracing: log Clusters Service attributes

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -23,6 +23,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/Azure/ARO-HCP/frontend/pkg/metrics"
@@ -30,6 +31,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/tracing"
 )
 
 type Frontend struct {
@@ -520,6 +522,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 			return
 		}
 	}
+	tracing.SetClusterAttributes(trace.SpanFromContext(ctx), csCluster)
 
 	operationDoc := database.NewOperationDocument(operationRequest, doc.ResourceID, doc.InternalID)
 

--- a/frontend/pkg/frontend/helpers.go
+++ b/frontend/pkg/frontend/helpers.go
@@ -13,10 +13,12 @@ import (
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/tracing"
 )
 
 // CheckForProvisioningStateConflict returns a "409 Conflict" error response if the
@@ -254,6 +256,8 @@ func (f *Frontend) MarshalResource(ctx context.Context, resourceID *azcorearm.Re
 			}
 			return nil, arm.NewInternalServerError()
 		}
+		tracing.SetClusterAttributes(trace.SpanFromContext(ctx), csCluster)
+
 		responseBody, err = marshalCSCluster(csCluster, doc, versionedInterface)
 		if err != nil {
 			logger.Error(err.Error())

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/openshift-online/ocm-sdk-go v0.1.464
 	go.opentelemetry.io/otel v1.34.0
+	go.opentelemetry.io/otel/trace v1.34.0
 	go.uber.org/mock v0.5.0
 )
 

--- a/internal/go.sum
+++ b/internal/go.sum
@@ -137,6 +137,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.opentelemetry.io/otel v1.34.0 h1:zRLXxLCgL1WyKsPVrgbSdMN4c0FMkDAskSTQP+0hdUY=
 go.opentelemetry.io/otel v1.34.0/go.mod h1:OWFPOQ+h4G8xpyjgqo4SxJYdDQ/qmRH+wivy7zzx9oI=
+go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC8mh/k=
+go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.uber.org/mock v0.5.0 h1:KAMbZvZPyBPWgD14IrIQ38QCyjwpvVVV6K/bHl1IwQU=
 go.uber.org/mock v0.5.0/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
 golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=


### PR DESCRIPTION
This change injects the following attributes which also exist in Clusters Service:
* `cs.cluster.id`
* `cs.cluster.name`
* `cs.cluster.state`

The goal is to facilitate correlation and querying across the 2 services.

https://issues.redhat.com/browse/ARO-15044

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
