### PR TITLE
outbound service tags for image sync container app

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -227,6 +227,7 @@ defaults:
   # Image Sync
   imageSync:
     environmentName: aro-hcp-image-sync
+    outboundServiceTags: "FirstPartyUsage:/Unprivileged"
     componentSync:
       enabled: false # we rely on on-demand sync within the respective pipelines
       image:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -595,6 +595,9 @@
         "environmentName": {
           "type": "string"
         },
+        "outboundServiceTags": {
+          "$ref": "#/definitions/keyColonValueCSV"
+        },
         "componentSync": {
           "type": "object",
           "properties": {
@@ -647,6 +650,7 @@
       "additionalProperties": false,
       "required": [
         "environmentName",
+        "outboundServiceTags",
         "componentSync",
         "ocMirror"
       ]

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -156,6 +156,7 @@ defaults:
   # Image Sync
   imageSync:
     environmentName: aro-hcp-image-sync
+    outboundServiceTags: ""
     componentSync:
       enabled: true
       image:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -160,7 +160,8 @@
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"
-    }
+    },
+    "outboundServiceTags": ""
   },
   "kvCertOfficerPrincipalId": "c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb",
   "logs": {

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -160,7 +160,8 @@
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"
-    }
+    },
+    "outboundServiceTags": ""
   },
   "kvCertOfficerPrincipalId": "c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb",
   "logs": {

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -160,7 +160,8 @@
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"
-    }
+    },
+    "outboundServiceTags": "FirstPartyUsage:/Unprivileged"
   },
   "kvCertOfficerPrincipalId": "32af88de-a61c-4f71-b709-50538598c4f2",
   "logs": {

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -160,7 +160,8 @@
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"
-    }
+    },
+    "outboundServiceTags": "FirstPartyUsage:/Unprivileged"
   },
   "kvCertOfficerPrincipalId": "ce4e50ef-1059-4b6f-a53a-53001d517513",
   "logs": {

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -160,7 +160,8 @@
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"
-    }
+    },
+    "outboundServiceTags": ""
   },
   "kvCertOfficerPrincipalId": "c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb",
   "logs": {

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -160,7 +160,8 @@
         "repository": "image-sync/oc-mirror"
       },
       "pullSecretName": "ocmirror-pull-secret"
-    }
+    },
+    "outboundServiceTags": ""
   },
   "kvCertOfficerPrincipalId": "c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb",
   "logs": {

--- a/dev-infrastructure/configurations/global-image-sync.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-image-sync.tmpl.bicepparam
@@ -1,6 +1,7 @@
 using '../templates/global-image-sync.bicep'
 
 param containerAppEnvName = '{{ .imageSync.environmentName }}'
+param containerAppOutboundServiceTags = '{{ .imageSync.outboundServiceTags }}'
 param location = '{{ .global.region }}'
 
 param acrResourceGroup = '{{ .global.rg }}'

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -1,3 +1,8 @@
+import {
+  csvToArray
+  parseIPServiceTag
+} from '../modules/common.bicep'
+
 // Constants
 param aksClusterName string
 param aksNodeResourceGroupName string
@@ -45,19 +50,13 @@ param istioIngressGatewayIPAddressName string = ''
 @description('IPTags to be set on the cluster outbound IP address in the format of ipTagType:tag,ipTagType:tag')
 param aksClusterOutboundIPAddressIPTags string = ''
 var aksClusterOutboundIPAddressIPTagsArray = [
-  for tag in (aksClusterOutboundIPAddressIPTags == '') ? [] : split(aksClusterOutboundIPAddressIPTags, ','): {
-    ipTagType: split(tag, ':')[0]
-    tag: split(tag, ':')[1]
-  }
+  for tag in csvToArray(aksClusterOutboundIPAddressIPTags): parseIPServiceTag(tag)
 ]
 
 @description('IPTags to be set on the Istio Ingress Gateway IP address in the format of ipTagType:tag,ipTagType:tag')
 param istioIngressGatewayIPAddressIPTags string = ''
 var istioIngressGatewayIPAddressIPTagsArray = [
-  for tag in (istioIngressGatewayIPAddressIPTags == '') ? [] : split(istioIngressGatewayIPAddressIPTags, ','): {
-    ipTagType: split(tag, ':')[0]
-    tag: split(tag, ':')[1]
-  }
+  for tag in csvToArray(istioIngressGatewayIPAddressIPTags): parseIPServiceTag(tag)
 ]
 
 @maxLength(24)

--- a/dev-infrastructure/modules/common.bicep
+++ b/dev-infrastructure/modules/common.bicep
@@ -429,3 +429,15 @@ func determineZoneRedundancyForRegion(region string, mode string) bool =>
 @export()
 func determineZoneRedundancy(availabilityZones array, mode string) bool =>
   mode == 'Auto' ? length(availabilityZones) > 0 : mode == 'Enabled' && length(availabilityZones) > 0
+
+@export()
+type IPServiceTag = {
+  ipTagType: string
+  tag: string
+}
+
+@export()
+func parseIPServiceTag(tag string) IPServiceTag => {
+  ipTagType: split(tag, ':')[0]
+  tag: split(tag, ':')[1]
+}

--- a/dev-infrastructure/modules/network/publicipaddress.bicep
+++ b/dev-infrastructure/modules/network/publicipaddress.bicep
@@ -41,3 +41,4 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = i
 }
 
 output ipAddress string = publicIPAddress.properties.ipAddress
+output resourceId string = publicIPAddress.id

--- a/dev-infrastructure/modules/private-endpoint.bicep
+++ b/dev-infrastructure/modules/private-endpoint.bicep
@@ -6,6 +6,7 @@ param location string
   'keyvault'
   'cosmosdb'
   'postgres'
+  'acr'
 ])
 param serviceType string
 
@@ -15,6 +16,7 @@ param serviceType string
   'vault'
   'Sql'
   'postgresqlServer'
+  'registry'
 ])
 param groupId string
 
@@ -39,6 +41,9 @@ var endpointConfig = {
   }
   postgres: {
     postgresqlServer: 'privatelink.postgres.database.azure.com'
+  }
+  acr: {
+    registry: 'privatelink.azurecr.io'
   }
 }
 


### PR DESCRIPTION
### What

as per security wave 5, the azure container app for image sync needs to
* have no default outbound route on the vnet/subnet
* use outbound service tags (which implies a NAT GW on the subnet)

since we will use the `/Unprivileged` service tag, we need to make our communication to our 1p service dependencies non-outbound. hence we need a privatelink for our ACRs so that the image sync components can push without going through the output IP. this way, the unprivileged outbound IP is only used to pull from the source registries like quay.io or registry.redhat.com

https://link.excalidraw.com/l/1NnYvmogbSd/1Q5jwVNiotJ

https://issues.redhat.com/browse/ARO-16029

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
