### PR TITLE
Add timestamp to guid() to avoid JobSchedule conflict during deployment

### DIFF
--- a/dev-infrastructure/modules/automation-account/runbook.bicep
+++ b/dev-infrastructure/modules/automation-account/runbook.bicep
@@ -30,6 +30,9 @@ param interval int = 1
 @description('Start time for the scheduled execution (12:00 AM the next day)')
 param startTime string = '${substring(dateTimeAdd(utcNow(), 'P1D'), 0, 10)}T00:00:00Z'
 
+@description('Name of the deployment with timestamp for unique suffix')
+param deploymentName string = 'deploy-${utcNow()}'
+
 resource automationAccount 'Microsoft.Automation/automationAccounts@2022-08-08' existing = {
   name: automationAccountName
 }
@@ -70,7 +73,7 @@ resource runbookSchedule 'Microsoft.Automation/automationAccounts/schedules@2022
 
 // Link Schedule to Runbook
 resource jobSchedule 'Microsoft.Automation/automationAccounts/jobSchedules@2022-08-08' = if (!empty(scheduleName)) {
-  name: guid(resourceGroup().name, runbookSchedule.name)
+  name: guid(resourceGroup().name, runbookSchedule.name, deploymentName)
   parent: automationAccount
   properties: {
     schedule: {


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->
Modify the `guid()` function to include a unique timestamp identifier,  to ensure that each deployment generates a unique JobSchedule ID. Without it, the deployment fails due to a conflict with an existing JobSchedule.

This approach triggers a nondeterministic warning. However, it does not interrupt the deployment process, and deployments can still be repeated successfully.
```
Warning use-stable-resource-identifiers: Resource identifiers should be reproducible outside of their initial deployment context. Resource jobSchedule's 'name' identifier is potentially nondeterministic due to its use of the 'utcNow' function (jobSchedule.name -> deploymentName (default value) -> utcNow()). [https://aka.ms/bicep/linter/use-stable-resource-identifiers]
```
