### PR TITLE
oc-mirror image lifecycle and enhancements

### DIFF
--- a/dev-infrastructure/templates/global-image-sync.bicep
+++ b/dev-infrastructure/templates/global-image-sync.bicep
@@ -481,7 +481,7 @@ var acmMirrorConfig = {
 var ocMirrorJobConfiguration = ocMirrorEnabled
   ? [
       {
-        name: 'oc-mirror-tmp'
+        name: 'oc-mirror'
         cron: '0 * * * *'
         timeout: 4 * 60 * 60
         targetRegistry: ocpAcrName
@@ -489,7 +489,7 @@ var ocMirrorJobConfiguration = ocMirrorEnabled
         compatibility: 'LATEST'
       }
       {
-        name: 'acm-mirror-tmp'
+        name: 'acm-mirror'
         cron: '0 10 * * *'
         timeout: 4 * 60 * 60
         targetRegistry: svcAcrName

--- a/image-sync/oc-mirror/Dockerfile
+++ b/image-sync/oc-mirror/Dockerfile
@@ -9,7 +9,7 @@ RUN set -eux; \
 ENV OC_MIRROR_4_16_VERSION=4.16.3
 ENV OC_MIRROR_4_18_VERSION=4.18.7
 ENV OC_VERSION=4.18.0-rc.9
-ENV YQ_VERSION=v4.2.0
+ENV YQ_VERSION=v4.45.1
 
 RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz -o oc.tar.gz  && \
     tar -zvxf oc.tar.gz && \
@@ -30,12 +30,13 @@ RUN curl -sfL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq
     tar -zvxf yq.tar.gz && \
     mv yq_linux_amd64 /usr/local/bin/yq
 
-FROM --platform=linux/amd64 mcr.microsoft.com/azure-cli:cbl-mariner2.0
+# azurelinux3.0 from Apr 1st 2025
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-cli@sha256:18ec5cf02ba6b46e9858ddff1125baaa1f14ba919f77ebc67c918c891f8df4a2
 
 RUN mkdir --mode=777 /workspace; \
     mkdir --mode=777 /config; \
     tdnf update -y; \
-    tdnf -y install ca-certificates yq; \
+    tdnf -y install ca-certificates bind-utils; \
     tdnf clean all
 
 WORKDIR /workspace

--- a/image-sync/oc-mirror/mirror.sh
+++ b/image-sync/oc-mirror/mirror.sh
@@ -1,17 +1,25 @@
 #!/bin/sh
-az login --identity -u ${AZURE_CLIENT_ID}
-DOCKER_COMMAND=/usr/local/bin/docker-login.sh az acr login -n ${REGISTRY}
+echo "Azure login"
+az login --identity --client-id "${AZURE_CLIENT_ID}"
 
+echo "ACR login"
+DOCKER_COMMAND=/usr/local/bin/docker-login.sh az acr login -n "${REGISTRY}"
+
+# Prepare configuration
 IMAGE_SET_CONFIG_FILE="/config/imageset-config.yaml"
-echo ${IMAGE_SET_CONFIG} | base64 -d | yq eval -P > ${IMAGE_SET_CONFIG_FILE}
+echo "${IMAGE_SET_CONFIG}" | base64 -d | yq eval -P > ${IMAGE_SET_CONFIG_FILE}
 API_VERSION=$(yq eval '.apiVersion' ${IMAGE_SET_CONFIG_FILE})
-
 if echo "$API_VERSION" | grep -q "^mirror.openshift.io/v2"; then
     ADDITIONAL_FLAGS="--workspace file:///oc-mirror-workspace --v2"
 else
     ADDITIONAL_FLAGS="--continue-on-error"
 fi
 
+# switching between versions of oc-mirror is a temporary fix until
+# all oc-mirror related problems have been resolved
+# * https://issues.redhat.com/browse/OCPBUGS-54340 - storage issue
+# * https://issues.redhat.com/browse/CLID-325 - CPU bug
+# * https://issues.redhat.com/browse/OCPBUGS-52471 - memory bug
 if [ "$OC_MIRROR_COMPATIBILITY" = "NOCATALOG" ]; then
     export OC_MIRROR_VERSION="4.16"
 else
@@ -19,4 +27,8 @@ else
 fi
 echo "Using oc-mirror version: ${OC_MIRROR_VERSION}"
 
+echo "Inspecting DNS for target registry"
+dig "${REGISTRY_URL}"
+
+echo "Start mirroring"
 /usr/local/bin/oc-mirror-${OC_MIRROR_VERSION} --config ${IMAGE_SET_CONFIG_FILE} ${ADDITIONAL_FLAGS} docker://${REGISTRY_URL} @$


### PR DESCRIPTION
### What

* use newer azure-cli image from MCR
* ... and pin it by digest
* shell script hygiene
* update `yq`
* add DNS diagnostics for target ACR (validate privatelink setup)
* use `--client-id` instead of `-u` for `az login` to mitigate deprecation warning
* fix a naming bug in the mirror jobs (remove `-tmp` suffix)

https://issues.redhat.com/browse/ARO-16123

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
