### PR TITLE
Use Azure CLI to replace Bicep for linking the job schedule to the Automation Runbook.

### DIFF
--- a/.github/workflows/runbook-cicd.yml
+++ b/.github/workflows/runbook-cicd.yml
@@ -24,6 +24,11 @@ on:
 permissions:
   id-token: write
   contents: read
+env:
+  AUTOMATION_ACCOUNT_RG: hcp-dev-automation-account
+  AUTOMATION_ACCOUNT_NAME: hcp-dev-automation
+  RUNBOOK_NAME: hcp-dev-automation_roleAssignmentsCleanup
+  SCHEDULE_NAME: hcp-dev-automation_nightly-schedule
 jobs:
   ci:
     name: Lint & Test Runbook
@@ -72,6 +77,55 @@ jobs:
       run: |
         cd dev-infrastructure/
         make automation-account.what-if
+    - name: Register Scheduled Runbook via PowerShell
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+
+        if (-not (Get-Module -ListAvailable -Name Az)) {
+          Install-Module -Name Az -Scope CurrentUser -Force -AllowClobber
+        }
+        Import-Module Az
+
+        if (-not (Get-Module -ListAvailable -Name Az.Automation)) {
+          Install-Module -Name Az.Automation -Scope CurrentUser -Force -AllowClobber
+        }
+        Import-Module Az.Automation
+
+        $params = @{
+            ResourceGroupName     = $env:AUTOMATION_ACCOUNT_RG
+            AutomationAccountName = $env:AUTOMATION_ACCOUNT_NAME
+            RunbookName           = $env:RUNBOOK_NAME
+            ScheduleName          = $env:SCHEDULE_NAME
+        }
+
+        $runbook = Get-AzAutomationRunbook -AutomationAccountName $params.AutomationAccountName `
+                    -ResourceGroupName $params.ResourceGroupName `
+                    -Name $params.RunbookName -ErrorAction SilentlyContinue
+        if (-not $runbook) {
+            throw "Runbook $($params.RunbookName) not found"
+        }
+        if ($runbook.Properties.State -ne "Published") {
+            throw "Runbook $($params.RunbookName) is not published"
+        }
+
+        $schedule = Get-AzAutomationSchedule -AutomationAccountName $params.AutomationAccountName `
+                      -ResourceGroupName $params.ResourceGroupName `
+                      -Name $params.ScheduleName -ErrorAction SilentlyContinue
+        if (-not $schedule) {
+            throw "Schedule $($params.ScheduleName) not found"
+        }
+
+        $existingJob = Get-AzAutomationScheduledRunbook -AutomationAccountName $params.AutomationAccountName `
+                        -ResourceGroupName $params.ResourceGroupName `
+                        -Name $params.RunbookName -ErrorAction SilentlyContinue
+        if ($existingJob) {
+            Write-Host "Removing existing schedule association..."
+            $existingJob | Remove-AzAutomationScheduledRunbook -Force
+        }
+
+        Register-AzAutomationScheduledRunbook @params
+
   cd:
     name: Deploy Runbook to Azure Automation
     runs-on: ubuntu-latest

--- a/dev-infrastructure/modules/automation-account/runbook.bicep
+++ b/dev-infrastructure/modules/automation-account/runbook.bicep
@@ -67,17 +67,3 @@ resource runbookSchedule 'Microsoft.Automation/automationAccounts/schedules@2022
     timeZone: 'UTC'
   }
 }
-
-// Link Schedule to Runbook
-resource jobSchedule 'Microsoft.Automation/automationAccounts/jobSchedules@2022-08-08' = if (!empty(scheduleName)) {
-  name: guid(resourceGroup().name, runbookSchedule.name)
-  parent: automationAccount
-  properties: {
-    schedule: {
-      name: runbookSchedule.name
-    }
-    runbook: {
-      name: accountRunbook.name
-    }
-  }
-}


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

Since Bicep has limitations in handling job schedule linkage, particularly due to guid() conflicts and the immutability of job schedules, it's better to switch to CLI for this part of the deployment. However, Azure CLI does not provide a direct command for managing jobSchedules in Azure Automation.

To work around this, add a PowerShell CLI step in the GitHub Actions workflow to run the `Register-AzureAutomationScheduledRunbook` command. This allows for manually linking a runbook to a schedule, which is currently not supported directly via Azure CLI.


[ARO-15539](https://issues.redhat.com/browse/ARO-15539)