### PR TITLE
Report status in asynchronous node pool operations

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.3.0
 	github.com/go-logr/logr v1.4.2
-	github.com/openshift-online/ocm-sdk-go v0.1.463
+	github.com/openshift-online/ocm-sdk-go v0.1.464
 	github.com/prometheus/client_golang v1.21.0
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/mock v0.5.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -136,8 +136,8 @@ github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM
 github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
 github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
-github.com/openshift-online/ocm-sdk-go v0.1.463 h1:sBk4qWSSm0W664Zr/wCt9cX/Lue2Y1L7leAeTWG0GPc=
-github.com/openshift-online/ocm-sdk-go v0.1.463/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
+github.com/openshift-online/ocm-sdk-go v0.1.464 h1:QLg2Q96gGG57SDhh6kHWW9dVGhEhrtPwW9HK7dfiHLQ=
+github.com/openshift-online/ocm-sdk-go v0.1.464/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -41,6 +41,23 @@ const (
 	pollNodePoolOperationLabel = "poll_node_pool"
 )
 
+// Copied from uhc-clusters-service, because the
+// OCM SDK does not define this for some reason.
+type NodePoolStateValue string
+
+const (
+	NodePoolStateValidating       NodePoolStateValue = "validating"
+	NodePoolStatePending          NodePoolStateValue = "pending"
+	NodePoolStateInstalling       NodePoolStateValue = "installing"
+	NodePoolStateReady            NodePoolStateValue = "ready"
+	NodePoolStateUpdating         NodePoolStateValue = "updating"
+	NodePoolStateValidatingUpdate NodePoolStateValue = "validating_update"
+	NodePoolStatePendingUpdate    NodePoolStateValue = "pending_update"
+	NodePoolStateUninstalling     NodePoolStateValue = "uninstalling"
+	NodePoolStateRecoverableError NodePoolStateValue = "recoverable_error"
+	NodePoolStateError            NodePoolStateValue = "error"
+)
+
 type operation struct {
 	id     string
 	pk     azcosmos.PartitionKey
@@ -376,7 +393,7 @@ func (s *OperationsScanner) pollClusterOperation(ctx context.Context, op operati
 func (s *OperationsScanner) pollNodePoolOperation(ctx context.Context, op operation) {
 	defer s.updateOperationMetrics(pollNodePoolOperationLabel)()
 
-	_, err := s.clusterService.GetNodePool(ctx, op.doc.InternalID)
+	nodePoolStatus, err := s.clusterService.GetNodePoolStatus(ctx, op.doc.InternalID)
 	if err != nil {
 		var ocmError *ocmerrors.Error
 		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound && op.doc.Request == database.OperationRequestDelete {
@@ -387,7 +404,22 @@ func (s *OperationsScanner) pollNodePoolOperation(ctx context.Context, op operat
 		} else {
 			op.logger.Error(fmt.Sprintf("Failed to get node pool status: %v", err))
 		}
+
+		s.operationsFailedCount.WithLabelValues(pollNodePoolOperationLabel).Inc()
 		return
+	}
+
+	opStatus, opError, err := convertNodePoolStatus(nodePoolStatus, op.doc.Status)
+	if err != nil {
+		s.operationsFailedCount.WithLabelValues(pollNodePoolOperationLabel).Inc()
+		op.logger.Warn(err.Error())
+		return
+	}
+
+	err = s.updateOperationStatus(ctx, op, opStatus, opError)
+	if err != nil {
+		s.operationsFailedCount.WithLabelValues(pollNodePoolOperationLabel).Inc()
+		op.logger.Error(fmt.Sprintf("Failed to update operation status: %v", err))
 	}
 }
 
@@ -529,10 +561,6 @@ func convertClusterStatus(clusterStatus *arohcpv1alpha1.ClusterStatus, current a
 	var opError *arm.CloudErrorBody
 	var err error
 
-	// FIXME This logic is all tenative until the new "/api/aro_hcp/v1" OCM
-	//       API is available. What's here now is a best guess at converting
-	//       ClusterStatus from the "/api/clusters_mgmt/v1" API.
-
 	switch state := clusterStatus.State(); state {
 	case arohcpv1alpha1.ClusterStateError:
 		opStatus = arm.ProvisioningStateFailed
@@ -563,6 +591,43 @@ func convertClusterStatus(clusterStatus *arohcpv1alpha1.ClusterStatus, current a
 		}
 	default:
 		err = fmt.Errorf("Unhandled ClusterState '%s'", state)
+	}
+
+	return opStatus, opError, err
+}
+
+// convertNodePoolStatus attempts to translate a NodePoolStatus object
+// from Cluster Service into an ARM provisioning state and, if necessary,
+// a structured OData error.
+func convertNodePoolStatus(nodePoolStatus *arohcpv1alpha1.NodePoolStatus, current arm.ProvisioningState) (arm.ProvisioningState, *arm.CloudErrorBody, error) {
+	var opStatus arm.ProvisioningState = current
+	var opError *arm.CloudErrorBody
+	var err error
+
+	switch state := NodePoolStateValue(nodePoolStatus.State().NodePoolStateValue()); state {
+	case NodePoolStateValidating, NodePoolStatePending, NodePoolStateValidatingUpdate, NodePoolStatePendingUpdate:
+		// These are valid node pool states for ARO-HCP but there are
+		// no unique ProvisioningState values for them. They should
+		// only occur when ProvisioningState is Accepted.
+		if current != arm.ProvisioningStateAccepted {
+			err = fmt.Errorf("Got NodePoolStatusValue '%s' while ProvisioningState was '%s' instead of '%s'", state, current, arm.ProvisioningStateAccepted)
+		}
+	case NodePoolStateInstalling:
+		opStatus = arm.ProvisioningStateProvisioning
+	case NodePoolStateReady:
+		opStatus = arm.ProvisioningStateSucceeded
+	case NodePoolStateUpdating:
+		opStatus = arm.ProvisioningStateUpdating
+	case NodePoolStateUninstalling:
+		opStatus = arm.ProvisioningStateDeleting
+	case NodePoolStateRecoverableError, NodePoolStateError:
+		// XXX OCM SDK offers no error code or message for failed node pool
+		//     operations so "Internal Server Error" is all we can do for now.
+		//     https://issues.redhat.com/browse/ARO-14969
+		opStatus = arm.ProvisioningStateFailed
+		opError = arm.NewInternalServerError().CloudErrorBody
+	default:
+		err = fmt.Errorf("Unhandled NodePoolState '%s'", state)
 	}
 
 	return opStatus, opError, err

--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel v0.4.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/openshift-online/ocm-sdk-go v0.1.463
+	github.com/openshift-online/ocm-sdk-go v0.1.464
 	github.com/prometheus/client_golang v1.21.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0

--- a/frontend/go.sum
+++ b/frontend/go.sum
@@ -124,8 +124,8 @@ github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM
 github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
 github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
-github.com/openshift-online/ocm-sdk-go v0.1.463 h1:sBk4qWSSm0W664Zr/wCt9cX/Lue2Y1L7leAeTWG0GPc=
-github.com/openshift-online/ocm-sdk-go v0.1.463/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
+github.com/openshift-online/ocm-sdk-go v0.1.464 h1:QLg2Q96gGG57SDhh6kHWW9dVGhEhrtPwW9HK7dfiHLQ=
+github.com/openshift-online/ocm-sdk-go v0.1.464/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -10,7 +10,7 @@ import (
 	"maps"
 	"net/http"
 
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -274,7 +274,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 }
 
 // the necessary conversions for the API version of the request.
-func marshalCSNodePool(csNodePool *cmv1.NodePool, doc *database.ResourceDocument, versionedInterface api.Version) ([]byte, error) {
+func marshalCSNodePool(csNodePool *arohcpv1alpha1.NodePool, doc *database.ResourceDocument, versionedInterface api.Version) ([]byte, error) {
 	hcpNodePool := ConvertCStoNodePool(doc.ResourceID, csNodePool)
 	hcpNodePool.TrackedResource.Resource.SystemData = doc.SystemData
 	hcpNodePool.TrackedResource.Tags = maps.Clone(doc.Tags)

--- a/frontend/pkg/frontend/node_pool_test.go
+++ b/frontend/pkg/frontend/node_pool_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -118,8 +118,8 @@ func TestCreateNodePool(t *testing.T) {
 			mockCSClient.EXPECT().
 				PostNodePool(gomock.Any(), clusterDoc.InternalID, gomock.Any()).
 				DoAndReturn(
-					func(ctx context.Context, clusterInternalID ocm.InternalID, nodePool *cmv1.NodePool) (*cmv1.NodePool, error) {
-						builder := cmv1.NewNodePool().
+					func(ctx context.Context, clusterInternalID ocm.InternalID, nodePool *arohcpv1alpha1.NodePool) (*arohcpv1alpha1.NodePool, error) {
+						builder := arohcpv1alpha1.NewNodePool().
 							Copy(nodePool).
 							HREF(dummyNodePoolHREF)
 						return builder.Build()

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -311,7 +311,7 @@ func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpC
 }
 
 // ConvertCStoNodePool converts a CS Node Pool object into HCPOpenShiftClusterNodePool object
-func ConvertCStoNodePool(resourceID *azcorearm.ResourceID, np *cmv1.NodePool) *api.HCPOpenShiftClusterNodePool {
+func ConvertCStoNodePool(resourceID *azcorearm.ResourceID, np *arohcpv1alpha1.NodePool) *api.HCPOpenShiftClusterNodePool {
 	nodePool := &api.HCPOpenShiftClusterNodePool{
 		TrackedResource: arm.TrackedResource{
 			Resource: arm.Resource{
@@ -363,19 +363,19 @@ func ConvertCStoNodePool(resourceID *azcorearm.ResourceID, np *cmv1.NodePool) *a
 }
 
 // BuildCSNodePool creates a CS Node Pool object from an HCPOpenShiftClusterNodePool object
-func (f *Frontend) BuildCSNodePool(ctx context.Context, nodePool *api.HCPOpenShiftClusterNodePool, updating bool) (*cmv1.NodePool, error) {
-	npBuilder := cmv1.NewNodePool()
+func (f *Frontend) BuildCSNodePool(ctx context.Context, nodePool *api.HCPOpenShiftClusterNodePool, updating bool) (*arohcpv1alpha1.NodePool, error) {
+	npBuilder := arohcpv1alpha1.NewNodePool()
 
 	// These attributes cannot be updated after node pool creation.
 	if !updating {
 		npBuilder = npBuilder.
 			ID(nodePool.Name).
-			Version(cmv1.NewVersion().
+			Version(arohcpv1alpha1.NewVersion().
 				ID(nodePool.Properties.Version.ID).
 				ChannelGroup(nodePool.Properties.Version.ChannelGroup).
 				AvailableUpgrades(nodePool.Properties.Version.AvailableUpgrades...)).
 			Subnet(nodePool.Properties.Platform.SubnetID).
-			AzureNodePool(cmv1.NewAzureNodePool().
+			AzureNodePool(arohcpv1alpha1.NewAzureNodePool().
 				ResourceName(nodePool.Name).
 				VMSize(nodePool.Properties.Platform.VMSize).
 				OSDiskSizeGibibytes(int(nodePool.Properties.Platform.DiskSizeGiB)).
@@ -388,7 +388,7 @@ func (f *Frontend) BuildCSNodePool(ctx context.Context, nodePool *api.HCPOpenShi
 		Labels(nodePool.Properties.Labels)
 
 	if nodePool.Properties.AutoScaling != nil {
-		npBuilder.Autoscaling(cmv1.NewNodePoolAutoscaling().
+		npBuilder.Autoscaling(arohcpv1alpha1.NewNodePoolAutoscaling().
 			MinReplica(int(nodePool.Properties.AutoScaling.Min)).
 			MaxReplica(int(nodePool.Properties.AutoScaling.Max)))
 	} else {
@@ -396,7 +396,7 @@ func (f *Frontend) BuildCSNodePool(ctx context.Context, nodePool *api.HCPOpenShi
 	}
 
 	for _, t := range nodePool.Properties.Taints {
-		npBuilder = npBuilder.Taints(cmv1.NewTaint().
+		npBuilder = npBuilder.Taints(arohcpv1alpha1.NewTaint().
 			Effect(string(t.Effect)).
 			Key(t.Key).
 			Value(t.Value))

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-playground/validator/v10 v10.25.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/openshift-online/ocm-sdk-go v0.1.463
+	github.com/openshift-online/ocm-sdk-go v0.1.464
 	go.opentelemetry.io/otel v1.34.0
 	go.uber.org/mock v0.5.0
 )

--- a/internal/go.sum
+++ b/internal/go.sum
@@ -108,8 +108,8 @@ github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM
 github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
 github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
-github.com/openshift-online/ocm-sdk-go v0.1.463 h1:sBk4qWSSm0W664Zr/wCt9cX/Lue2Y1L7leAeTWG0GPc=
-github.com/openshift-online/ocm-sdk-go v0.1.463/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
+github.com/openshift-online/ocm-sdk-go v0.1.464 h1:QLg2Q96gGG57SDhh6kHWW9dVGhEhrtPwW9HK7dfiHLQ=
+github.com/openshift-online/ocm-sdk-go v0.1.464/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/mocks/ocm.go
+++ b/internal/mocks/ocm.go
@@ -352,6 +352,45 @@ func (c *MockClusterServiceClientSpecGetNodePoolCall) DoAndReturn(f func(context
 	return c
 }
 
+// GetNodePoolStatus mocks base method.
+func (m *MockClusterServiceClientSpec) GetNodePoolStatus(ctx context.Context, internalID ocm.InternalID) (*v1alpha1.NodePoolStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodePoolStatus", ctx, internalID)
+	ret0, _ := ret[0].(*v1alpha1.NodePoolStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodePoolStatus indicates an expected call of GetNodePoolStatus.
+func (mr *MockClusterServiceClientSpecMockRecorder) GetNodePoolStatus(ctx, internalID any) *MockClusterServiceClientSpecGetNodePoolStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodePoolStatus", reflect.TypeOf((*MockClusterServiceClientSpec)(nil).GetNodePoolStatus), ctx, internalID)
+	return &MockClusterServiceClientSpecGetNodePoolStatusCall{Call: call}
+}
+
+// MockClusterServiceClientSpecGetNodePoolStatusCall wrap *gomock.Call
+type MockClusterServiceClientSpecGetNodePoolStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockClusterServiceClientSpecGetNodePoolStatusCall) Return(arg0 *v1alpha1.NodePoolStatus, arg1 error) *MockClusterServiceClientSpecGetNodePoolStatusCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockClusterServiceClientSpecGetNodePoolStatusCall) Do(f func(context.Context, ocm.InternalID) (*v1alpha1.NodePoolStatus, error)) *MockClusterServiceClientSpecGetNodePoolStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockClusterServiceClientSpecGetNodePoolStatusCall) DoAndReturn(f func(context.Context, ocm.InternalID) (*v1alpha1.NodePoolStatus, error)) *MockClusterServiceClientSpecGetNodePoolStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ListBreakGlassCredentials mocks base method.
 func (m *MockClusterServiceClientSpec) ListBreakGlassCredentials(clusterInternalID ocm.InternalID, searchExpression string) ocm.BreakGlassCredentialListIterator {
 	m.ctrl.T.Helper()

--- a/internal/mocks/ocm.go
+++ b/internal/mocks/ocm.go
@@ -314,10 +314,10 @@ func (c *MockClusterServiceClientSpecGetClusterStatusCall) DoAndReturn(f func(co
 }
 
 // GetNodePool mocks base method.
-func (m *MockClusterServiceClientSpec) GetNodePool(ctx context.Context, internalID ocm.InternalID) (*v1.NodePool, error) {
+func (m *MockClusterServiceClientSpec) GetNodePool(ctx context.Context, internalID ocm.InternalID) (*v1alpha1.NodePool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNodePool", ctx, internalID)
-	ret0, _ := ret[0].(*v1.NodePool)
+	ret0, _ := ret[0].(*v1alpha1.NodePool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -335,19 +335,19 @@ type MockClusterServiceClientSpecGetNodePoolCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClusterServiceClientSpecGetNodePoolCall) Return(arg0 *v1.NodePool, arg1 error) *MockClusterServiceClientSpecGetNodePoolCall {
+func (c *MockClusterServiceClientSpecGetNodePoolCall) Return(arg0 *v1alpha1.NodePool, arg1 error) *MockClusterServiceClientSpecGetNodePoolCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClusterServiceClientSpecGetNodePoolCall) Do(f func(context.Context, ocm.InternalID) (*v1.NodePool, error)) *MockClusterServiceClientSpecGetNodePoolCall {
+func (c *MockClusterServiceClientSpecGetNodePoolCall) Do(f func(context.Context, ocm.InternalID) (*v1alpha1.NodePool, error)) *MockClusterServiceClientSpecGetNodePoolCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClusterServiceClientSpecGetNodePoolCall) DoAndReturn(f func(context.Context, ocm.InternalID) (*v1.NodePool, error)) *MockClusterServiceClientSpecGetNodePoolCall {
+func (c *MockClusterServiceClientSpecGetNodePoolCall) DoAndReturn(f func(context.Context, ocm.InternalID) (*v1alpha1.NodePool, error)) *MockClusterServiceClientSpecGetNodePoolCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -545,10 +545,10 @@ func (c *MockClusterServiceClientSpecPostClusterCall) DoAndReturn(f func(context
 }
 
 // PostNodePool mocks base method.
-func (m *MockClusterServiceClientSpec) PostNodePool(ctx context.Context, clusterInternalID ocm.InternalID, nodePool *v1.NodePool) (*v1.NodePool, error) {
+func (m *MockClusterServiceClientSpec) PostNodePool(ctx context.Context, clusterInternalID ocm.InternalID, nodePool *v1alpha1.NodePool) (*v1alpha1.NodePool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PostNodePool", ctx, clusterInternalID, nodePool)
-	ret0, _ := ret[0].(*v1.NodePool)
+	ret0, _ := ret[0].(*v1alpha1.NodePool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -566,19 +566,19 @@ type MockClusterServiceClientSpecPostNodePoolCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClusterServiceClientSpecPostNodePoolCall) Return(arg0 *v1.NodePool, arg1 error) *MockClusterServiceClientSpecPostNodePoolCall {
+func (c *MockClusterServiceClientSpecPostNodePoolCall) Return(arg0 *v1alpha1.NodePool, arg1 error) *MockClusterServiceClientSpecPostNodePoolCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClusterServiceClientSpecPostNodePoolCall) Do(f func(context.Context, ocm.InternalID, *v1.NodePool) (*v1.NodePool, error)) *MockClusterServiceClientSpecPostNodePoolCall {
+func (c *MockClusterServiceClientSpecPostNodePoolCall) Do(f func(context.Context, ocm.InternalID, *v1alpha1.NodePool) (*v1alpha1.NodePool, error)) *MockClusterServiceClientSpecPostNodePoolCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClusterServiceClientSpecPostNodePoolCall) DoAndReturn(f func(context.Context, ocm.InternalID, *v1.NodePool) (*v1.NodePool, error)) *MockClusterServiceClientSpecPostNodePoolCall {
+func (c *MockClusterServiceClientSpecPostNodePoolCall) DoAndReturn(f func(context.Context, ocm.InternalID, *v1alpha1.NodePool) (*v1alpha1.NodePool, error)) *MockClusterServiceClientSpecPostNodePoolCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -623,10 +623,10 @@ func (c *MockClusterServiceClientSpecUpdateClusterCall) DoAndReturn(f func(conte
 }
 
 // UpdateNodePool mocks base method.
-func (m *MockClusterServiceClientSpec) UpdateNodePool(ctx context.Context, internalID ocm.InternalID, nodePool *v1.NodePool) (*v1.NodePool, error) {
+func (m *MockClusterServiceClientSpec) UpdateNodePool(ctx context.Context, internalID ocm.InternalID, nodePool *v1alpha1.NodePool) (*v1alpha1.NodePool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateNodePool", ctx, internalID, nodePool)
-	ret0, _ := ret[0].(*v1.NodePool)
+	ret0, _ := ret[0].(*v1alpha1.NodePool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -644,19 +644,19 @@ type MockClusterServiceClientSpecUpdateNodePoolCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClusterServiceClientSpecUpdateNodePoolCall) Return(arg0 *v1.NodePool, arg1 error) *MockClusterServiceClientSpecUpdateNodePoolCall {
+func (c *MockClusterServiceClientSpecUpdateNodePoolCall) Return(arg0 *v1alpha1.NodePool, arg1 error) *MockClusterServiceClientSpecUpdateNodePoolCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClusterServiceClientSpecUpdateNodePoolCall) Do(f func(context.Context, ocm.InternalID, *v1.NodePool) (*v1.NodePool, error)) *MockClusterServiceClientSpecUpdateNodePoolCall {
+func (c *MockClusterServiceClientSpecUpdateNodePoolCall) Do(f func(context.Context, ocm.InternalID, *v1alpha1.NodePool) (*v1alpha1.NodePool, error)) *MockClusterServiceClientSpecUpdateNodePoolCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClusterServiceClientSpecUpdateNodePoolCall) DoAndReturn(f func(context.Context, ocm.InternalID, *v1.NodePool) (*v1.NodePool, error)) *MockClusterServiceClientSpecUpdateNodePoolCall {
+func (c *MockClusterServiceClientSpecUpdateNodePoolCall) DoAndReturn(f func(context.Context, ocm.InternalID, *v1alpha1.NodePool) (*v1alpha1.NodePool, error)) *MockClusterServiceClientSpecUpdateNodePoolCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/ocm/internalid.go
+++ b/internal/ocm/internalid.go
@@ -19,8 +19,9 @@ const (
 	v1NodePoolPattern             = v1ClusterPattern + "/node_pools/*"
 	v1BreakGlassCredentialPattern = v1ClusterPattern + "/break_glass_credentials/*"
 
-	aroHcpV1Alpha1Pattern        = "/api/aro_hcp/v1alpha1"
-	aroHcpV1Alpha1ClusterPattern = aroHcpV1Alpha1Pattern + "/clusters/*"
+	aroHcpV1Alpha1Pattern         = "/api/aro_hcp/v1alpha1"
+	aroHcpV1Alpha1ClusterPattern  = aroHcpV1Alpha1Pattern + "/clusters/*"
+	aroHcpV1Alpha1NodePoolPattern = aroHcpV1Alpha1ClusterPattern + "/node_pools/*"
 )
 
 func GenerateClusterHREF(clusterName string) string {
@@ -64,6 +65,12 @@ func (id *InternalID) validate() error {
 	if match, _ = path.Match(aroHcpV1Alpha1ClusterPattern, id.path); match {
 		// Temporarily use cmv1 constant for backward-compatibility.
 		id.kind = cmv1.ClusterKind
+		return nil
+	}
+
+	if match, _ = path.Match(aroHcpV1Alpha1NodePoolPattern, id.path); match {
+		// Temporarily use cmv1 constant for backward-compatibility.
+		id.kind = cmv1.NodePoolKind
 		return nil
 	}
 
@@ -161,13 +168,13 @@ func matchClusterPath(clusterPath string) string {
 	return ""
 }
 
-// GetNodePoolClient returns a v1 NodePoolClient from the InternalID.
+// GetNodePoolClient returns a arohcpv1alpha1 NodePoolClient from the InternalID.
 // The transport is most likely to be a Connection object from the SDK.
-func (id *InternalID) GetNodePoolClient(transport http.RoundTripper) (*cmv1.NodePoolClient, bool) {
-	if id.Kind() != cmv1.NodePoolKind {
+func (id *InternalID) GetNodePoolClient(transport http.RoundTripper) (*arohcpv1alpha1.NodePoolClient, bool) {
+	if id.Kind() != arohcpv1alpha1.NodePoolKind {
 		return nil, false
 	}
-	return cmv1.NewNodePoolClient(transport, id.path), true
+	return arohcpv1alpha1.NewNodePoolClient(transport, id.path), true
 }
 
 // GetBreakGlassCredentialClient returns a v1 BreakGlassCredentialClient

--- a/internal/ocm/iterators.go
+++ b/internal/ocm/iterators.go
@@ -67,14 +67,14 @@ func (iter ClusterListIterator) GetError() error {
 }
 
 type NodePoolListIterator struct {
-	request *cmv1.NodePoolsListRequest
+	request *arohcpv1alpha1.NodePoolsListRequest
 	err     error
 }
 
 // Items returns a push iterator that can be used directly in for/range loops.
 // If an error occurs during paging, iteration stops and the error is recorded.
-func (iter NodePoolListIterator) Items(ctx context.Context) iter.Seq[*cmv1.NodePool] {
-	return func(yield func(*cmv1.NodePool) bool) {
+func (iter NodePoolListIterator) Items(ctx context.Context) iter.Seq[*arohcpv1alpha1.NodePool] {
+	return func(yield func(*arohcpv1alpha1.NodePool) bool) {
 		// Request can be nil to allow for mocking.
 		if iter.request != nil {
 			var page int = 0

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -39,6 +39,9 @@ type ClusterServiceClientSpec interface {
 	// GetNodePool sends a GET request to fetch a node pool from Cluster Service.
 	GetNodePool(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.NodePool, error)
 
+	// GetNodePoolStatus sends a GET request to fetch a node pool's status from Cluster Service.
+	GetNodePoolStatus(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.NodePoolStatus, error)
+
 	// PostNodePool sends a POST request to create a node pool in Cluster Service.
 	PostNodePool(ctx context.Context, clusterInternalID InternalID, nodePool *arohcpv1alpha1.NodePool) (*arohcpv1alpha1.NodePool, error)
 
@@ -190,6 +193,22 @@ func (csc *ClusterServiceClient) GetNodePool(ctx context.Context, internalID Int
 		return nil, fmt.Errorf("empty response body")
 	}
 	return nodePool, nil
+}
+
+func (csc *ClusterServiceClient) GetNodePoolStatus(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.NodePoolStatus, error) {
+	client, ok := internalID.GetNodePoolClient(csc.Conn)
+	if !ok {
+		return nil, fmt.Errorf("OCM path is not a node pool: %s", internalID)
+	}
+	nodePoolStatusGetResponse, err := client.Status().Get().SendContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	status, ok := nodePoolStatusGetResponse.GetBody()
+	if !ok {
+		return nil, fmt.Errorf("empty response body")
+	}
+	return status, nil
 }
 
 func (csc *ClusterServiceClient) PostNodePool(ctx context.Context, clusterInternalID InternalID, nodePool *arohcpv1alpha1.NodePool) (*arohcpv1alpha1.NodePool, error) {

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -37,13 +37,13 @@ type ClusterServiceClientSpec interface {
 	ListClusters(searchExpression string) ClusterListIterator
 
 	// GetNodePool sends a GET request to fetch a node pool from Cluster Service.
-	GetNodePool(ctx context.Context, internalID InternalID) (*cmv1.NodePool, error)
+	GetNodePool(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.NodePool, error)
 
 	// PostNodePool sends a POST request to create a node pool in Cluster Service.
-	PostNodePool(ctx context.Context, clusterInternalID InternalID, nodePool *cmv1.NodePool) (*cmv1.NodePool, error)
+	PostNodePool(ctx context.Context, clusterInternalID InternalID, nodePool *arohcpv1alpha1.NodePool) (*arohcpv1alpha1.NodePool, error)
 
 	// UpdateNodePool sends a PATCH request to update a node pool in Cluster Service.
-	UpdateNodePool(ctx context.Context, internalID InternalID, nodePool *cmv1.NodePool) (*cmv1.NodePool, error)
+	UpdateNodePool(ctx context.Context, internalID InternalID, nodePool *arohcpv1alpha1.NodePool) (*arohcpv1alpha1.NodePool, error)
 
 	// DeleteNodePool sends a DELETE request to delete a node pool from Cluster Service.
 	DeleteNodePool(ctx context.Context, internalID InternalID) error
@@ -176,7 +176,7 @@ func (csc *ClusterServiceClient) ListClusters(searchExpression string) ClusterLi
 	return ClusterListIterator{request: clustersListRequest}
 }
 
-func (csc *ClusterServiceClient) GetNodePool(ctx context.Context, internalID InternalID) (*cmv1.NodePool, error) {
+func (csc *ClusterServiceClient) GetNodePool(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.NodePool, error) {
 	client, ok := internalID.GetNodePoolClient(csc.Conn)
 	if !ok {
 		return nil, fmt.Errorf("OCM path is not a node pool: %s", internalID)
@@ -192,8 +192,8 @@ func (csc *ClusterServiceClient) GetNodePool(ctx context.Context, internalID Int
 	return nodePool, nil
 }
 
-func (csc *ClusterServiceClient) PostNodePool(ctx context.Context, clusterInternalID InternalID, nodePool *cmv1.NodePool) (*cmv1.NodePool, error) {
-	client, ok := clusterInternalID.GetClusterClient(csc.Conn)
+func (csc *ClusterServiceClient) PostNodePool(ctx context.Context, clusterInternalID InternalID, nodePool *arohcpv1alpha1.NodePool) (*arohcpv1alpha1.NodePool, error) {
+	client, ok := clusterInternalID.GetAroHCPClusterClient(csc.Conn)
 	if !ok {
 		return nil, fmt.Errorf("OCM path is not a cluster: %s", clusterInternalID)
 	}
@@ -208,7 +208,7 @@ func (csc *ClusterServiceClient) PostNodePool(ctx context.Context, clusterIntern
 	return nodePool, nil
 }
 
-func (csc *ClusterServiceClient) UpdateNodePool(ctx context.Context, internalID InternalID, nodePool *cmv1.NodePool) (*cmv1.NodePool, error) {
+func (csc *ClusterServiceClient) UpdateNodePool(ctx context.Context, internalID InternalID, nodePool *arohcpv1alpha1.NodePool) (*arohcpv1alpha1.NodePool, error) {
 	client, ok := internalID.GetNodePoolClient(csc.Conn)
 	if !ok {
 		return nil, fmt.Errorf("OCM path is not a node pool: %s", internalID)
@@ -234,7 +234,7 @@ func (csc *ClusterServiceClient) DeleteNodePool(ctx context.Context, internalID 
 }
 
 func (csc *ClusterServiceClient) ListNodePools(clusterInternalID InternalID, searchExpression string) NodePoolListIterator {
-	client, ok := clusterInternalID.GetClusterClient(csc.Conn)
+	client, ok := clusterInternalID.GetAroHCPClusterClient(csc.Conn)
 	if !ok {
 		return NodePoolListIterator{err: fmt.Errorf("OCM path is not a cluster: %s", clusterInternalID)}
 	}


### PR DESCRIPTION
[ARO-15560 - Update the RP to check against node pool status](https://issues.redhat.com/browse/ARO-15560)

### What

Cluster Service recently added a status endpoint for node pools, so we can finally complete* this missing piece of the RP backend.

\* Major caveat: Cluster Service does not yet provide error messages for failed node pool operations, so at the moment all we can report is an opaque "Internal Server Error".  This is being tracked in [ARO-14969 - Node Pool error handling design and implementation](https://issues.redhat.com/browse/ARO-14969).