### PR TITLE
Add Scheduled Runbook Registration ps Script for Automation

### DIFF
--- a/dev-infrastructure/modules/automation-account/runbook.bicep
+++ b/dev-infrastructure/modules/automation-account/runbook.bicep
@@ -30,6 +30,9 @@ param interval int = 1
 @description('Start time for the scheduled execution (12:00 AM the next day)')
 param startTime string = '${substring(dateTimeAdd(utcNow(), 'P1D'), 0, 10)}T00:00:00Z'
 
+@description('Name of the managed identity')
+param identityName string = 'hcp-dev-automation'
+
 resource automationAccount 'Microsoft.Automation/automationAccounts@2022-08-08' existing = {
   name: automationAccountName
 }
@@ -69,15 +72,22 @@ resource runbookSchedule 'Microsoft.Automation/automationAccounts/schedules@2022
 }
 
 // Link Schedule to Runbook
-resource jobSchedule 'Microsoft.Automation/automationAccounts/jobSchedules@2022-08-08' = if (!empty(scheduleName)) {
-  name: guid(resourceGroup().name, runbookSchedule.name)
-  parent: automationAccount
+resource registerScheduledRunbook 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+  name: 'registerScheduledRunbook_${uniqueString(runbookName, scheduleName)}'
+  location: resourceGroup().location
+  kind: 'AzurePowerShell'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${subscription().id}/resourceGroups/${resourceGroup().name}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${identityName}': {}
+    }
+  }
   properties: {
-    schedule: {
-      name: runbookSchedule.name
-    }
-    runbook: {
-      name: accountRunbook.name
-    }
+    azPowerShellVersion: '12.0.0'
+    scriptContent: loadTextContent('../../scripts/register-scheduledrunbook.ps1')
+    arguments: '-ResourceGroupName ${resourceGroup().name} -AutomationAccountName ${automationAccountName} -RunbookName ${accountRunbook.name} -ScheduleName ${runbookSchedule.name}'
+    retentionInterval: 'P1D'
+    cleanupPreference: 'OnSuccess'
+    timeout: 'PT30M'
   }
 }

--- a/dev-infrastructure/modules/automation-account/runbook.bicep
+++ b/dev-infrastructure/modules/automation-account/runbook.bicep
@@ -72,7 +72,7 @@ resource runbookSchedule 'Microsoft.Automation/automationAccounts/schedules@2022
 }
 
 // Link Schedule to Runbook
-resource registerScheduledRunbook 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+resource registerScheduledRunbook 'Microsoft.Resources/deploymentScripts@2023-08-01' = if (!empty(scheduleName)) {
   name: 'registerScheduledRunbook_${uniqueString(runbookName, scheduleName)}'
   location: resourceGroup().location
   kind: 'AzurePowerShell'

--- a/dev-infrastructure/scripts/register-scheduledrunbook.ps1
+++ b/dev-infrastructure/scripts/register-scheduledrunbook.ps1
@@ -1,0 +1,108 @@
+<#
+.SYNOPSIS
+    Registers a scheduled runbook in an Azure Automation Account.
+.DESCRIPTION
+    This script verifies that the specified runbook exists and is published, that the given schedule exists,
+    and then registers the scheduled runbook by linking the runbook to the schedule.
+    If a job schedule for the runbook already exists, it is removed before the new one is created.
+.PARAMETER ResourceGroupName
+    The name of the resource group that contains the Automation Account.
+.PARAMETER AutomationAccountName
+    The name of the Azure Automation Account.
+.PARAMETER RunbookName
+    The name of the runbook to register.
+.PARAMETER ScheduleName
+    The name of the schedule to link to the runbook.
+.EXAMPLE
+    .\register-scheduledrunbook.ps1 -ResourceGroupName ${resourceGroupName} -AutomationAccountName ${automationAccountName} -RunbookName ${runbookName} -ScheduleName ${scheduleName}
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ResourceGroupName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$AutomationAccountName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RunbookName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ScheduleName
+)
+
+$ErrorActionPreference = 'Stop'
+
+$output = @{
+    success = $false
+    message = ''
+}
+Write-Output "##[PS Version] $($PSVersionTable.PSVersion)"
+Write-Output "##[Az Modules] $(Get-Module Az* | Select Name,Version | Out-String)"
+
+try {
+    # Ensure required Az modules are installed and imported
+    if (-not (Get-Module -ListAvailable -Name Az)) {
+        Install-Module -Name Az -Scope CurrentUser -Force -AllowClobber
+    }
+    Import-Module Az
+
+    if (-not (Get-Module -ListAvailable -Name Az.Automation)) {
+        Install-Module -Name Az.Automation -Scope CurrentUser -Force -AllowClobber
+    }
+    Import-Module Az.Automation
+
+    Write-Host "Automation Account: $AutomationAccountName"
+    Write-Host "Runbook: $RunbookName"
+    Write-Host "Schedule: $ScheduleName"
+    Write-Host "Resource Group: $ResourceGroupName"
+
+    # Validate that the runbook exists and is published
+    $runbook = Get-AzAutomationRunbook -AutomationAccountName $AutomationAccountName `
+                -ResourceGroupName $ResourceGroupName `
+                -Name $RunbookName -ErrorAction SilentlyContinue
+    if (-not $runbook) {
+        throw "Runbook '$RunbookName' not found in Automation Account '$AutomationAccountName' within resource group '$ResourceGroupName'."
+    }
+    if ($runbook.State -ne "Published") {
+        throw "Runbook '$RunbookName' is not published. Please publish the runbook before registering a schedule."
+    }
+
+    # Validate that the schedule exists
+    $schedule = Get-AzAutomationSchedule -AutomationAccountName $AutomationAccountName `
+                  -ResourceGroupName $ResourceGroupName `
+                  -Name $ScheduleName -ErrorAction SilentlyContinue
+    if (-not $schedule) {
+        throw "Schedule '$ScheduleName' not found in Automation Account '$AutomationAccountName' within resource group '$ResourceGroupName'."
+    }
+
+    # Remove an existing job schedule (if any) for the runbook to avoid conflicts
+    $existingJob = Get-AzAutomationScheduledRunbook -AutomationAccountName $AutomationAccountName `
+                    -ResourceGroupName $ResourceGroupName `
+                    -Name $RunbookName -ErrorAction SilentlyContinue
+    if ($existingJob) {
+        Write-Host "Existing scheduled runbook found for '$RunbookName'. Removing..."
+        $existingJob | Unregister-AzAutomationScheduledRunbook -Force
+    }
+
+    # Register new schedule
+    $jobSchedule = Register-AzAutomationScheduledRunbook -ResourceGroupName $ResourceGroupName `
+                        -AutomationAccountName $AutomationAccountName `
+                        -RunbookName $RunbookName `
+                        -ScheduleName $ScheduleName
+
+    $output.success = $true
+    $output.message = "Successfully registered Runbook '$RunbookName' to Schedule '$ScheduleName'"
+    $output.jobScheduleId = $jobSchedule.JobScheduleId
+}
+catch {
+    $output.message = "ERROR: $_"
+    $output.errorDetails = $_.Exception.Message
+}
+
+if (-not $output.success) {
+    throw $output.message
+}
+
+Write-Output $output.message
+exit 0


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->
Introduces a new PowerShell script (`register-scheduledrunbook.ps1`) that links a scheduled runbook to an existing schedule in our Azure Automation Account. Leverage an Azure DeploymentScripts resource to invoke the PowerShell script for scheduled runbook registration.


### Changes
- **New Script: register-scheduledrunbook.ps1**
  - Validates that the specified runbook exists and is published.
  - Checks that the target schedule exists.
  - Unregisters any existing scheduled runbook association to avoid conflicts.
  - Registers the scheduled runbook using the `Register-AzAutomationScheduledRunbook` cmdlet.
  
- **Bicep Template Updates**
  - Removed the direct jobSchedule resource from the runbook module.
  - Added a new deployment script resource (`registerScheduledRunbook`) that executes the PowerShell script.
  - Updated identity configuration to reference a fully qualified user-assigned managed identity.
  
[ARO-15539](https://issues.redhat.com/browse/ARO-15539)