### PR TITLE
enable swift on AKS

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -133,6 +133,7 @@ defaults:
         kvSoftDelete: true
       #clusterOutboundIPAddressIPTags: "FirstPartyUsage:aro-hcp-prod-outbound-cx"
       clusterOutboundIPAddressIPTags: ""
+      enableSwiftV2: true
     applyKubeletFixes: true
     logs:
       namespace: HCPCustomerLogs

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -170,6 +170,9 @@
         },
         "clusterOutboundIPAddressIPTags": {
           "$ref": "#/definitions/keyColonValueCSV"
+        },
+        "enableSwiftV2": {
+          "type": "boolean"
         }
       },
       "required": [
@@ -182,7 +185,8 @@
         "networkDataplane",
         "networkPolicy",
         "userAgentPool",
-        "systemAgentPool"
+        "systemAgentPool",
+        "clusterOutboundIPAddressIPTags"
       ]
     },
     "containerImage": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -79,6 +79,7 @@ defaults:
         kvName: arohcp-etcd-{{ .ctx.regionShort }}-{{ .ctx.stamp }}
         kvSoftDelete: true
       clusterOutboundIPAddressIPTags: ""
+      enableSwiftV2: false
   # Frontend
   frontend:
     tracing:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -248,6 +248,7 @@
   "mgmt": {
     "aks": {
       "clusterOutboundIPAddressIPTags": "",
+      "enableSwiftV2": false,
       "etcd": {
         "kvName": "arohcp-etcd-cspr-1",
         "kvSoftDelete": false

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -248,6 +248,7 @@
   "mgmt": {
     "aks": {
       "clusterOutboundIPAddressIPTags": "",
+      "enableSwiftV2": false,
       "etcd": {
         "kvName": "arohcp-etcd-dev-1",
         "kvSoftDelete": false

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -241,6 +241,7 @@
   "mgmt": {
     "aks": {
       "clusterOutboundIPAddressIPTags": "FirstPartyUsage:/NonProd",
+      "enableSwiftV2": true,
       "etcd": {
         "kvName": "arohcpint-etcd-usw3-1",
         "kvSoftDelete": true

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -239,6 +239,7 @@
   "mgmt": {
     "aks": {
       "clusterOutboundIPAddressIPTags": "",
+      "enableSwiftV2": true,
       "etcd": {
         "kvName": "arohcpstg-etcd-usw3-1",
         "kvSoftDelete": true

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -248,6 +248,7 @@
   "mgmt": {
     "aks": {
       "clusterOutboundIPAddressIPTags": "",
+      "enableSwiftV2": false,
       "etcd": {
         "kvName": "arohcp-etcd-nightly-1",
         "kvSoftDelete": false

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -248,6 +248,7 @@
   "mgmt": {
     "aks": {
       "clusterOutboundIPAddressIPTags": "",
+      "enableSwiftV2": false,
       "etcd": {
         "kvName": "arohcp-etcd-usw3tst-1",
         "kvSoftDelete": false

--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -20,6 +20,7 @@ param aksUserOsDiskSizeGB = {{ .mgmt.aks.userAgentPool.osDiskSizeGB }}
 param aksClusterOutboundIPAddressIPTags = '{{ .mgmt.aks.clusterOutboundIPAddressIPTags }}'
 param aksNetworkDataplane = '{{ .mgmt.aks.networkDataplane }}'
 param aksNetworkPolicy = '{{ .mgmt.aks.networkDataplane }}'
+param aksEnableSwift = {{ .mgmt.aks.enableSwiftV2 }}
 
 // Maestro
 param maestroConsumerName = '{{ .maestro.agent.consumerName }}'

--- a/dev-infrastructure/modules/network/vnet.bicep
+++ b/dev-infrastructure/modules/network/vnet.bicep
@@ -1,0 +1,98 @@
+param location string
+
+@description('The VNET that should be tagged')
+param vnetName string
+
+@description('Enable swift')
+param enableSwift bool
+
+@description('The address space for the VNET')
+param vnetAddressPrefix string
+
+@description('The resource ID of the user-assigned managed identity that will be used to execute the script')
+param deploymentMsiId string
+
+// Enabling a VNET for Swift is a matter of placing the stampcreatorserviceinfo=true tag on it.
+// The tagging itself needs to be done by an identity that is registered with the Network/Swift RP.
+// All bicep code deployed via EV2 is executed by an EV2 identity that is not and cannot be registered
+// for Swift usage. Hence we use a deployment script for the tagging where we are in control of the
+// identity used to execute the script and tag the VNET.
+
+//
+//  D E P L O Y   V N E T   W I T H O U T   S W I F T
+//
+
+// for non-swift deployments, we create the VNET regularly... so much faster
+resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' = if (!enableSwift) {
+  location: location
+  name: vnetName
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnetAddressPrefix
+      ]
+    }
+  }
+}
+
+//
+//  D E P L O Y   V N E T   W I T H   S W I F T
+//
+
+// for swift deployments we use a deployment script to create the VNET or just
+// tag it when it already exists. The identity used for this needs to be registered
+// for swift usage with the network RP.
+resource vnetWithSwiftDeployment 'Microsoft.Resources/deploymentScripts@2020-10-01' = if (enableSwift) {
+  name: 'vnet-${vnetName}'
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${deploymentMsiId}': {}
+    }
+  }
+  kind: 'AzureCLI'
+  properties: {
+    azCliVersion: '2.53.1'
+    scriptContent: '''
+      az network vnet show \
+        --resource-group "${VNET_RG}" \
+        --name "${VNET_NAME}" \
+        --output none 2>/dev/null
+
+      if [ $? -ne 0 ]; then
+        echo "VNet does not exist. Creating..."
+        az network vnet create \
+          --resource-group "${VNET_RG}" \
+          --name "${VNET_NAME}" \
+          --address-prefixes "${VNET_ADDRESS_PREFIX}" \
+          --tags stampcreatorserviceinfo=true
+      else
+        echo "VNet exists. Updating tags..."
+        az resource tag \
+          --tags stampcreatorserviceinfo=true \
+          --resource-group "${VNET_RG}" \
+          --name "${VNET_NAME}" --resource-type Microsoft.Network/virtualnetworks
+      fi
+    '''
+    timeout: 'PT5M'
+    cleanupPreference: 'OnSuccess'
+    retentionInterval: 'P1D'
+    environmentVariables: [
+      {
+        name: 'VNET_NAME'
+        value: vnetName
+      }
+      {
+        name: 'VNET_RG'
+        value: resourceGroup().name
+      }
+      {
+        name: 'VNET_ADDRESS_PREFIX'
+        value: vnetAddressPrefix
+      }
+    ]
+  }
+}
+
+output vnetName string = vnetName

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -74,6 +74,9 @@ param aksEtcdKVEnableSoftDelete bool = true
 @description('IPTags to be set on the cluster outbound IP address in the format of ipTagType:tag,ipTagType:tag')
 param aksClusterOutboundIPAddressIPTags string = ''
 
+@description('Enable Swift V2 for the AKS cluster and VNET')
+param aksEnableSwift bool
+
 @description('The name of the maestro consumer.')
 param maestroConsumerName string
 
@@ -200,8 +203,9 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     networkDataplane: aksNetworkDataplane
     networkPolicy: aksNetworkPolicy
     userOsDiskSizeGB: aksUserOsDiskSizeGB
-    aroDevopsMsiId: aroDevopsMsiId
+    deploymentMsiId: aroDevopsMsiId
     dcrId: dataCollection.outputs.dcrId
+    enableSwiftV2: aksEnableSwift
   }
 }
 

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -347,8 +347,9 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     aksKeyVaultName: aksKeyVaultName
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
     pullAcrResourceIds: [svcAcrResourceId]
-    aroDevopsMsiId: aroDevopsMsiId
+    deploymentMsiId: aroDevopsMsiId
     dcrId: dataCollection.outputs.dcrId
+    enableSwiftV2: false
   }
 }
 


### PR DESCRIPTION
### What

if swiftv2 is enabled via `mgmt.aks.enableSwiftV2`, the AKS vnet and user nodepools are tagged accordingly for swift integration.

⚠️ enableing swift on an existing nodepools does not work

https://issues.redhat.com/browse/ARO-14851

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
