### PR TITLE
helm deployment diagnostics

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -66,8 +66,7 @@ deploy:
 	kubectl label namespace aro-hcp "istio.io/rev=${ISTO_TAG}" --overwrite=true && \
 	kubectl create namespace mise --dry-run=client -o json | kubectl apply -f - && \
 	kubectl label namespace mise "istio.io/rev=${ISTO_TAG}" --overwrite=true && \
-	${HELM_CMD} aro-hcp-frontend-dev \
-		deploy/ \
+	../hack/helm.sh aro-hcp-frontend-dev deploy aro-hcp \
 		--set azure.clientId=$${SECRET_STORE_MI_CLIENT_ID} \
 		--set azure.tenantId=$${TENANT_ID} \
 		--set configMap.databaseName=${DB_NAME} \
@@ -95,8 +94,7 @@ deploy:
 		--set mise.azureAdInstance=${MISE_AZURE_AD_INSTANCE} \
 		--set mise.firstPartyAppId=${MISE_FIRST_PARTY_APP_ID} \
 		--set mise.armInstance=${MISE_ARM_INSTANCE} \
-		--set mise.armAppId=${MISE_ARM_APP_ID} \
-		--namespace aro-hcp
+		--set mise.armAppId=${MISE_ARM_APP_ID}
 .PHONY: deploy
 
 undeploy:

--- a/hack/deployment-diagnostics.sh
+++ b/hack/deployment-diagnostics.sh
@@ -62,10 +62,11 @@ for DEPLOY in $DEPLOYMENTS; do
     kubectl describe deployment "$DEPLOY" -n "$NAMESPACE"
 done
 
+# TODO - replace this with ready-to-click kusto links once kusto is ready
 PODS=$(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
 for POD in $PODS; do
     echo -e "\n>>> Logs from pod: $POD"
-    kubectl logs "$POD" -n "$NAMESPACE" --tail=50
+    kubectl logs "$POD" -n "$NAMESPACE" --previous --all-containers --tail=50
 done
 
 echo -e "\n--- ServiceAccounts in $NAMESPACE ---"

--- a/hack/deployment-diagnostics.sh
+++ b/hack/deployment-diagnostics.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ -z "${EV2:-}" ]]; then
+   # this script only executes in EV2
+   # executing this in other environments with less restricted access to CD logs
+   # can lead to leaking sensitive information
+   exit 0
+fi
+
+HELM_RELEASE_NAME="$1"
+NAMESPACE="$2"
+
+cat <<'EOF'
+
+
+  _          _                      _                       _        __
+ | |__   ___| |_ __ ___    _ __ ___| | ___  __ _ ___  ___  (_)_ __  / _| ___
+ | '_ \ / _ \ | '_ ` _ \  | '__/ _ \ |/ _ \/ _` / __|/ _ \ | | '_ \| |_ / _ \
+ | | | |  __/ | | | | | | | | |  __/ |  __/ (_| \__ \  __/ | | | | |  _| (_) |
+ |_| |_|\___|_|_| |_| |_| |_|  \___|_|\___|\__,_|___/\___| |_|_| |_|_|  \___/
+
+
+EOF
+
+# get release information as json
+RELEASE_INFO="$(helm status "$HELM_RELEASE_NAME" -n "${NAMESPACE}" -o json)"
+if [ -z "$RELEASE_INFO" ]; then
+  echo "Failed to retrieve Helm release information for release ${HELM_RELEASE_NAME} in namespace ${NAMESPACE}"
+  exit 1
+fi
+
+HELM_DEPLOYMENT_STATUS="$(jq --raw-output .info.status <<<"${RELEASE_INFO}")"
+HELM_DEPLOYMENT_DESCRIPTION="$(jq --raw-output .info.description <<<"${RELEASE_INFO}")"
+VALUES="$(jq --raw-output .config <<<"${RELEASE_INFO}")"
+echo ""
+echo "Status: ${HELM_DEPLOYMENT_STATUS}"
+echo "Description: ${HELM_DEPLOYMENT_DESCRIPTION}"
+echo "Release values:"
+echo "${VALUES}" | jq '.'
+
+cat <<'EOF'
+
+
+  _    ___            _ _                             _   _
+ | | _( _ ) ___    __| (_) __ _  __ _ _ __   ___  ___| |_(_) ___ ___
+ | |/ / _ \/ __|  / _` | |/ _` |/ _` | '_ \ / _ \/ __| __| |/ __/ __|
+ |   < (_) \__ \ | (_| | | (_| | (_| | | | | (_) \__ \ |_| | (__\__ \
+ |_|\_\___/|___/  \__,_|_|\__,_|\__, |_| |_|\___/|___/\__|_|\___|___/
+                                |___/
+
+
+EOF
+
+echo -e "\n--- Pods ---"
+kubectl get pods -n "$NAMESPACE" || echo "Could not list pods"
+
+DEPLOYMENTS=$(kubectl get deployments -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+for DEPLOY in $DEPLOYMENTS; do
+    echo -e "\n--- Describe Deployment: $DEPLOY ---"
+    kubectl describe deployment "$DEPLOY" -n "$NAMESPACE"
+done
+
+PODS=$(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+for POD in $PODS; do
+    echo -e "\n>>> Logs from pod: $POD"
+    kubectl logs "$POD" -n "$NAMESPACE" --tail=50
+done
+
+echo -e "\n--- ServiceAccounts in $NAMESPACE ---"
+SERVICE_ACCOUNTS=$(kubectl get serviceaccounts -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+if [ -n "$SERVICE_ACCOUNTS" ]; then
+  for SA in $SERVICE_ACCOUNTS; do
+    echo -e "\n>>> Describe ServiceAccount: $SA"
+    kubectl describe serviceaccount "$SA" -n "$NAMESPACE"
+  done
+else
+  echo "No ServiceAccounts found in namespace $NAMESPACE"
+fi
+
+echo -e "\n--- Events in $NAMESPACE (last 100) ---"
+kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' | tail -n 100
+
+echo -e "\n=== Finished diagnostics at $(date) ==="

--- a/hack/deployment-diagnostics.sh
+++ b/hack/deployment-diagnostics.sh
@@ -62,12 +62,7 @@ for DEPLOY in $DEPLOYMENTS; do
     kubectl describe deployment "$DEPLOY" -n "$NAMESPACE"
 done
 
-# TODO - replace this with ready-to-click kusto links once kusto is ready
-PODS=$(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
-for POD in $PODS; do
-    echo -e "\n>>> Logs from pod: $POD"
-    kubectl logs "$POD" -n "$NAMESPACE" --previous --all-containers --tail=50
-done
+# TODO - add ready-to-click kusto links once kusto is ready
 
 echo -e "\n--- ServiceAccounts in $NAMESPACE ---"
 SERVICE_ACCOUNTS=$(kubectl get serviceaccounts -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")

--- a/hack/helm.sh
+++ b/hack/helm.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+HELM_RELEASE_NAME="$1"
+CHART="$2"
+NAMESPACE="$3"
+shift 3
+
+# Check if the namespace exists
+if ! kubectl get namespace "${NAMESPACE}" &>/dev/null; then
+    echo "Namespace '${NAMESPACE}' does not exist. Please create it before running helm."
+    exit 1
+fi
+
+if [ "${DRY_RUN}" == "true" ]; then
+  helm diff upgrade --install --dry-run=server --suppress-secrets --three-way-merge "${HELM_RELEASE_NAME}" "${CHART}" --namespace "${NAMESPACE}" "$@"
+else
+  echo "Run Helm upgrade with release name ${HELM_RELEASE_NAME} in namespace ${NAMESPACE}"
+  helm upgrade --install --wait --wait-for-jobs "${HELM_RELEASE_NAME}" "${CHART}" --namespace "${NAMESPACE}" "$@"
+  HELM_EXIT_CODE=$?
+  if [ "${HELM_EXIT_CODE}" -eq 0 ]; then
+      echo "Helm upgrade succeeded with exit code: ${HELM_EXIT_CODE}"
+  else
+      echo "Helm upgrade failed with exit code: ${HELM_EXIT_CODE}"
+  fi
+
+  # run diagnostics
+  HACK_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+  "${HACK_DIR}"/deployment-diagnostics.sh "${HELM_RELEASE_NAME}" "${NAMESPACE}"
+
+  # exit with the original exit code
+  exit $HELM_EXIT_CODE
+fi

--- a/helm-cmd.mk
+++ b/helm-cmd.mk
@@ -1,5 +1,8 @@
+SHELL = /bin/bash
+PROJECT_ROOT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 ifdef DRY_RUN
 HELM_CMD ?= helm diff upgrade --install --dry-run=server --suppress-secrets --three-way-merge
 else
-HELM_CMD ?= helm upgrade --install --wait --wait-for-jobs
+HELM_CMD ?= ${PROJECT_ROOT_DIR}/hack/helm.sh
 endif


### PR DESCRIPTION
### What

observe the in-cluster state after a helm rollout, showing deployments, pods, service accounts that belong to respective namespace.
the diagnostics are only collected when running in EV2. GH action logs are unprotected and the diagnostic information might  not be suitable for being shared publicly.

### Why

having post deploy diagnostics available in the EV2 portal allows quick first-pass problem analysis in case a deployment fails without the need to aquire cluster admin.

### Special notes for your reviewer

<!-- optional -->
