### PR TITLE
control CNI settings for SC and MC

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -118,7 +118,7 @@ defaults:
       kubernetesVersion: 1.31.6
       # CNI
       networkDataplane: "cilium" # should be switch to azure during next rebuild
-      networkPolicy: "cilium"    # should be switch to azure during next rebuild
+      networkPolicy: "cilium" # should be switch to azure during next rebuild
       systemAgentPool:
         vmSize: 'Standard_E8s_v3'
         osDiskSizeGB: 128

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -116,8 +116,9 @@ defaults:
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
       kubernetesVersion: 1.31.6
-      networkDataplane: "azure"
-      networkPolicy: "azure"
+      # CNI
+      networkDataplane: "cilium" # should be switch to azure during next rebuild
+      networkPolicy: "cilium"    # should be switch to azure during next rebuild
       systemAgentPool:
         vmSize: 'Standard_E8s_v3'
         osDiskSizeGB: 128

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -84,6 +84,8 @@ defaults:
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
       kubernetesVersion: 1.31.6
+      networkDataplane: "cilium"
+      networkPolicy: "cilium"
       systemAgentPool:
         vmSize: 'Standard_D2s_v3'
         osDiskSizeGB: 32
@@ -114,6 +116,8 @@ defaults:
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
       kubernetesVersion: 1.31.6
+      networkDataplane: "azure"
+      networkPolicy: "azure"
       systemAgentPool:
         vmSize: 'Standard_E8s_v3'
         osDiskSizeGB: 128

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -119,6 +119,20 @@
         "kubernetesVersion": {
           "type": "string"
         },
+        "networkDataplane": {
+          "type": "string",
+          "enum": [
+            "azure",
+            "cilium"
+          ]
+        },
+        "networkPolicy": {
+          "type": "string",
+          "enum": [
+            "azure",
+            "cilium"
+          ]
+        },
         "etcd": {
           "type": "object",
           "properties": {
@@ -152,6 +166,8 @@
         "podSubnetPrefix",
         "kubernetesVersion",
         "etcd",
+        "networkDataplane",
+        "networkPolicy",
         "userAgentPool",
         "systemAgentPool"
       ]

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -361,6 +361,9 @@ clouds:
                 maxCount: 3
                 vmSize: 'Standard_D16s_v3'
                 osDiskSizeGB: 128
+              # CNI
+              networkDataplane: "cilium" # should be switch to azure during next rebuild
+              networkPolicy: "cilium"    # should be switch to azure during next rebuild
           # DNS
           dns:
             regionalSubdomain: '{{ .ctx.region }}'
@@ -400,6 +403,9 @@ clouds:
                 maxCount: 3
                 vmSize: 'Standard_D16s_v3'
                 osDiskSizeGB: 128
+              # CNI
+              networkDataplane: "cilium" # should be switch to azure during next rebuild
+              networkPolicy: "cilium"    # should be switch to azure during next rebuild
           # DNS
           dns:
             regionalSubdomain: '{{ .ctx.region }}-cs'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -363,7 +363,7 @@ clouds:
                 osDiskSizeGB: 128
               # CNI
               networkDataplane: "cilium" # should be switch to azure during next rebuild
-              networkPolicy: "cilium"    # should be switch to azure during next rebuild
+              networkPolicy: "cilium" # should be switch to azure during next rebuild
           # DNS
           dns:
             regionalSubdomain: '{{ .ctx.region }}'
@@ -405,7 +405,7 @@ clouds:
                 osDiskSizeGB: 128
               # CNI
               networkDataplane: "cilium" # should be switch to azure during next rebuild
-              networkPolicy: "cilium"    # should be switch to azure during next rebuild
+              networkPolicy: "cilium" # should be switch to azure during next rebuild
           # DNS
           dns:
             regionalSubdomain: '{{ .ctx.region }}-cs'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -56,6 +56,8 @@ defaults:
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
       kubernetesVersion: 1.31.6
+      networkDataplane: "cilium"
+      networkPolicy: "cilium"
       etcd:
         kvName: arohcp-etcd-{{ .ctx.regionShort }}
         kvSoftDelete: true
@@ -71,6 +73,8 @@ defaults:
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
       kubernetesVersion: 1.31.6
+      networkDataplane: "azure"
+      networkPolicy: "azure"
       etcd:
         kvName: arohcp-etcd-{{ .ctx.regionShort }}-{{ .ctx.stamp }}
         kvSoftDelete: true

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -239,6 +239,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "cspr-mgmt-1",
+      "networkDataplane": "azure",
+      "networkPolicy": "azure",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {
@@ -315,6 +317,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "cspr-svc",
+      "networkDataplane": "cilium",
+      "networkPolicy": "cilium",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -239,8 +239,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "cspr-mgmt-1",
-      "networkDataplane": "azure",
-      "networkPolicy": "azure",
+      "networkDataplane": "cilium",
+      "networkPolicy": "cilium",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -239,8 +239,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "dev-mgmt-1",
-      "networkDataplane": "azure",
-      "networkPolicy": "azure",
+      "networkDataplane": "cilium",
+      "networkPolicy": "cilium",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -239,6 +239,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "dev-mgmt-1",
+      "networkDataplane": "azure",
+      "networkPolicy": "azure",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {
@@ -315,6 +317,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "dev-svc",
+      "networkDataplane": "cilium",
+      "networkPolicy": "cilium",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -241,8 +241,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "westus3-mgmt-1",
-      "networkDataplane": "azure",
-      "networkPolicy": "azure",
+      "networkDataplane": "cilium",
+      "networkPolicy": "cilium",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -241,6 +241,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "westus3-mgmt-1",
+      "networkDataplane": "azure",
+      "networkPolicy": "azure",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {
@@ -321,6 +323,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "westus3-svc-1",
+      "networkDataplane": "cilium",
+      "networkPolicy": "cilium",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -239,8 +239,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "westus3-mgmt-1",
-      "networkDataplane": "azure",
-      "networkPolicy": "azure",
+      "networkDataplane": "cilium",
+      "networkPolicy": "cilium",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -239,6 +239,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "westus3-mgmt-1",
+      "networkDataplane": "azure",
+      "networkPolicy": "azure",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {
@@ -319,6 +321,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "westus3-svc-1",
+      "networkDataplane": "cilium",
+      "networkPolicy": "cilium",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -239,6 +239,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "nightly-mgmt-1",
+      "networkDataplane": "azure",
+      "networkPolicy": "azure",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {
@@ -315,6 +317,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "nightly-svc",
+      "networkDataplane": "cilium",
+      "networkPolicy": "cilium",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -239,6 +239,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "usw3tst-mgmt-1",
+      "networkDataplane": "azure",
+      "networkPolicy": "azure",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {
@@ -315,6 +317,8 @@
       },
       "kubernetesVersion": "1.31.6",
       "name": "usw3tst-svc",
+      "networkDataplane": "cilium",
+      "networkPolicy": "cilium",
       "podSubnetPrefix": "10.128.64.0/18",
       "subnetPrefix": "10.128.8.0/21",
       "systemAgentPool": {

--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -18,6 +18,8 @@ param userAgentVMSize = '{{ .mgmt.aks.userAgentPool.vmSize }}'
 param userAgentPoolAZCount = {{ .mgmt.aks.userAgentPool.azCount }}
 param aksUserOsDiskSizeGB = {{ .mgmt.aks.userAgentPool.osDiskSizeGB }}
 param aksClusterOutboundIPAddressIPTags = '{{ .mgmt.aks.clusterOutboundIPAddressIPTags }}'
+param aksNetworkDataplane = '{{ .mgmt.aks.networkDataplane }}'
+param aksNetworkPolicy = '{{ .mgmt.aks.networkDataplane }}'
 
 // Maestro
 param maestroConsumerName = '{{ .maestro.agent.consumerName }}'

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -22,6 +22,8 @@ param userAgentVMSize = '{{ .svc.aks.userAgentPool.vmSize }}'
 param userAgentPoolAZCount = {{ .svc.aks.userAgentPool.azCount }}
 param aksUserOsDiskSizeGB = {{ .svc.aks.userAgentPool.osDiskSizeGB }}
 param aksClusterOutboundIPAddressIPTags = '{{ .svc.aks.clusterOutboundIPAddressIPTags }}'
+param aksNetworkDataplane = '{{ .svc.aks.networkDataplane }}'
+param aksNetworkPolicy = '{{ .svc.aks.networkDataplane }}'
 
 param disableLocalAuth = {{ .frontend.cosmosDB.disableLocalAuth }}
 param deployFrontendCosmos = {{ .frontend.cosmosDB.deploy }}

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -43,6 +43,8 @@ param podSubnetPrefix string
 param clusterType string
 param workloadIdentities array
 param nodeSubnetNSGId string
+param networkDataplane string
+param networkPolicy string
 
 @description('Istio Ingress Gateway Public IP Address resource name')
 param istioIngressGatewayIPAddressName string = ''
@@ -404,8 +406,8 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-10-01' = {
           ]
         }
       }
-      networkDataplane: 'cilium'
-      networkPolicy: 'cilium'
+      networkDataplane: networkDataplane
+      networkPolicy: networkPolicy
       networkPlugin: 'azure'
       serviceCidr: serviceCidr
       serviceCidrs: [serviceCidr]

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -49,6 +49,12 @@ param systemAgentMaxCount int = 3
 @description('VM instance type for the system nodes')
 param systemAgentVMSize string = 'Standard_D2s_v3'
 
+@description('Network dataplane plugin for the AKS cluster')
+param aksNetworkDataplane string
+
+@description('Network policy plugin for the AKS cluster')
+param aksNetworkPolicy string
+
 @description('Subnet address prefix')
 param subnetPrefix string
 
@@ -191,6 +197,8 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     systemAgentMaxCount: systemAgentMaxCount
     systemAgentVMSize: systemAgentVMSize
     systemOsDiskSizeGB: aksSystemOsDiskSizeGB
+    networkDataplane: aksNetworkDataplane
+    networkPolicy: aksNetworkPolicy
     userOsDiskSizeGB: aksUserOsDiskSizeGB
     aroDevopsMsiId: aroDevopsMsiId
     dcrId: dataCollection.outputs.dcrId

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -30,6 +30,12 @@ param aksSystemOsDiskSizeGB int
 @description('Disk size for the AKS user nodes')
 param aksUserOsDiskSizeGB int
 
+@description('Network dataplane plugin for the AKS cluster')
+param aksNetworkDataplane string
+
+@description('Network policy plugin for the AKS cluster')
+param aksNetworkPolicy string
+
 @description('Min replicas for the worker nodes')
 param userAgentMinCount int
 
@@ -299,6 +305,8 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     systemAgentMinCount: systemAgentMinCount
     systemAgentMaxCount: systemAgentMaxCount
     systemAgentVMSize: systemAgentVMSize
+    networkDataplane: aksNetworkDataplane
+    networkPolicy: aksNetworkPolicy
     workloadIdentities: items({
       frontend_wi: {
         uamiName: 'frontend'


### PR DESCRIPTION
### What

use cilium on SC but azure CNI on MC because swift does not support cilium

this PR keeps the MGMT CNI at cilium for the following envs until we rebuild them in https://issues.redhat.com/browse/ARO-16305 and https://issues.redhat.com/browse/ARO-16306
* integrated DEV
* CS PR
* MSFT INT
* MSFT STAGE

personal dev envs will use the azure CNI for newly created MGMT clusters

https://issues.redhat.com/browse/ARO-16304


### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
