### PR TITLE
templatize step inspect ignore output chaining

### DIFF
--- a/tooling/templatize/pkg/pipeline/arm.go
+++ b/tooling/templatize/pkg/pipeline/arm.go
@@ -173,7 +173,7 @@ func pollAndPrint[T any](ctx context.Context, p *runtime.Poller[T]) error {
 func doDryRun(ctx context.Context, client *armresources.DeploymentsClient, rgName string, step *ARMStep, vars config.Variables, input map[string]output) (output, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
-	inputValues, err := getInputValues(step.Variables, vars, input)
+	inputValues, err := getInputValues(step.Variables, vars, input, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get input values: %w", err)
 	}
@@ -247,7 +247,7 @@ func pollAndGetOutput[T any](ctx context.Context, p *runtime.Poller[T]) (armOutp
 func doWaitForDeployment(ctx context.Context, client *armresources.DeploymentsClient, rgName string, step *ARMStep, vars config.Variables, input map[string]output) (output, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
-	inputValues, err := getInputValues(step.Variables, vars, input)
+	inputValues, err := getInputValues(step.Variables, vars, input, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get input values: %w", err)
 	}

--- a/tooling/templatize/pkg/pipeline/inspect.go
+++ b/tooling/templatize/pkg/pipeline/inspect.go
@@ -62,7 +62,7 @@ func inspectVars(s Step, options *InspectOptions, writer io.Writer) error {
 	var err error
 	switch step := s.(type) {
 	case *ShellStep:
-		envVars, err = step.mapStepVariables(options.Vars, map[string]output{})
+		envVars, err = step.mapStepVariables(options.Vars, map[string]output{}, true)
 	default:
 		return fmt.Errorf("inspecting step variables not implemented for action type %s", s.ActionType())
 	}

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -194,7 +194,7 @@ func RunStep(s Step, ctx context.Context, kubeconfigFile string, executionTarget
 	}
 }
 
-func getInputValues(configuredVariables []Variable, cfg config.Variables, inputs map[string]output) (map[string]any, error) {
+func getInputValues(configuredVariables []Variable, cfg config.Variables, inputs map[string]output, ignoreMissingOutputChaining bool) (map[string]any, error) {
 	values := make(map[string]any)
 	for _, i := range configuredVariables {
 		if i.Input != nil {
@@ -204,7 +204,7 @@ func getInputValues(configuredVariables []Variable, cfg config.Variables, inputs
 					return nil, fmt.Errorf("failed to get value for input %s.%s: %w", i.Input.Step, i.Input.Name, err)
 				}
 				values[i.Name] = value.Value
-			} else {
+			} else if !ignoreMissingOutputChaining {
 				return nil, fmt.Errorf("step %s not found in provided outputs", i.Input.Step)
 			}
 		} else if i.ConfigRef != "" {

--- a/tooling/templatize/pkg/pipeline/run_test.go
+++ b/tooling/templatize/pkg/pipeline/run_test.go
@@ -228,7 +228,7 @@ func TestAddInputVars(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := getInputValues(tc.stepVariables, tc.cfg, tc.input)
+			result, err := getInputValues(tc.stepVariables, tc.cfg, tc.input, false)
 			t.Log(result)
 			if tc.err != "" {
 				assert.Error(t, err, tc.err)

--- a/tooling/templatize/pkg/pipeline/shell.go
+++ b/tooling/templatize/pkg/pipeline/shell.go
@@ -44,7 +44,7 @@ func runShellStep(s *ShellStep, ctx context.Context, kubeconfigFile string, opti
 	logger := logr.FromContextOrDiscard(ctx)
 
 	// build ENV vars
-	stepVars, err := s.mapStepVariables(options.Vars, inputs)
+	stepVars, err := s.mapStepVariables(options.Vars, inputs, false)
 	if err != nil {
 		return fmt.Errorf("failed to build env vars: %w", err)
 	}
@@ -75,8 +75,8 @@ func runShellStep(s *ShellStep, ctx context.Context, kubeconfigFile string, opti
 	return nil
 }
 
-func (s *ShellStep) mapStepVariables(vars config.Variables, inputs map[string]output) (map[string]string, error) {
-	values, err := getInputValues(s.Variables, vars, inputs)
+func (s *ShellStep) mapStepVariables(vars config.Variables, inputs map[string]output, ignoreMissingOutputChaining bool) (map[string]string, error) {
+	values, err := getInputValues(s.Variables, vars, inputs, ignoreMissingOutputChaining)
 	if err != nil {
 		return nil, err
 	}

--- a/tooling/templatize/pkg/pipeline/shell_test.go
+++ b/tooling/templatize/pkg/pipeline/shell_test.go
@@ -84,12 +84,13 @@ func TestCreateCommand(t *testing.T) {
 
 func TestMapStepVariables(t *testing.T) {
 	testCases := []struct {
-		name     string
-		vars     config.Variables
-		input    map[string]output
-		step     *ShellStep
-		expected map[string]string
-		err      string
+		name                        string
+		vars                        config.Variables
+		input                       map[string]output
+		step                        *ShellStep
+		ignoreMissingOutputChaining bool
+		expected                    map[string]string
+		err                         string
 	}{
 		{
 			name: "basic",
@@ -218,10 +219,27 @@ func TestMapStepVariables(t *testing.T) {
 			},
 			err: "failed to get value for input step1.output1: key \"output1\" not found",
 		},
+		{
+			name:                        "output chaining ignore step missing",
+			vars:                        config.Variables{},
+			ignoreMissingOutputChaining: true,
+			step: &ShellStep{
+				Variables: []Variable{
+					{
+						Name: "BAZ",
+						Input: &Input{
+							Name: "output1",
+							Step: "step1",
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			envVars, err := tc.step.mapStepVariables(tc.vars, tc.input)
+			envVars, err := tc.step.mapStepVariables(tc.vars, tc.input, tc.ignoreMissingOutputChaining)
 			t.Log(envVars)
 			if tc.err != "" {
 				assert.Error(t, err, tc.err)


### PR DESCRIPTION

<!-- Link to Jira issue -->

### What

for `templatize inspect` we dont support output chaining value resolution right now. and that is fine because we usually we don't call `make deploy` on targets that rely on output chaining but call the pipeline instead with `make xyz.deploy_pipeline`.

certain make actions though are called directly and if their respective pipeline.yaml uses output chaining, the make target fails, e.g. CS `make deploy-pr-env-deps` fails even though the target does not use any ENV vars from output chaining - https://github.com/Azure/ARO-HCP/actions/runs/14306222009/job/40093600970

this PR is not a proper solution but a temporary fix as it will ignore output chaining vars during `templatize inspect`. this is ok as long as the respective targets don't rely on such env vars, but will fail otherwise. this patch gives us time to work on a proper solution, e.g. run the actual output-only steps of the pipeline (or something else)

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
