### PR TITLE
NO-JIRA: add missing permission to network operator role

### DIFF
--- a/dev-infrastructure/configurations/dev-operator-roles.bicepparam
+++ b/dev-infrastructure/configurations/dev-operator-roles.bicepparam
@@ -96,6 +96,7 @@ param roles = [
       'Microsoft.Network/networkInterfaces/write'
       'Microsoft.Network/virtualNetworks/read'
       'Microsoft.Network/virtualNetworks/subnets/join/action'
+      'Microsoft.Network/loadBalancers/backendAddressPools/read'
       'Microsoft.Network/loadBalancers/backendAddressPools/join/action'
       'Microsoft.Compute/virtualMachines/read'
     ]


### PR DESCRIPTION
As reported on slack:
```
ERROR CODE: AuthorizationFailed
--------------------------------------------------------------------------------
{
  "error": {
    "code": "AuthorizationFailed",
    "message": "The client 'd0b8ec0d-263d-4f0e-b013-d32de8bbbf92' with object id 'd0b8ec0d-263d-4f0e-b013-d32de8bbbf92' does not have authorization to perform action 'Microsoft.Network/loadBalancers/backendAddressPools/read' over scope '/subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/ci-op-ki0cmnqg-eeed2-rg/providers/Microsoft.Network/loadBalancers/170f3538790c50126db9-l9289/backendAddressPools/170f3538790c50126db9-l9289' or the scope is invalid. If access was recently granted, please refresh your credentials."
  }
}
```

This adds the permission to the dev role.