### PR TITLE
move cosmosdb from svc RG to regional RG

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -12,7 +12,7 @@ backend:
 .PHONY: backend
 
 run:
-	DB_URL=$$(az cosmosdb show -n ${DB_NAME} -g ${RESOURCEGROUP} --query documentEndpoint -o tsv) && \
+	DB_URL=$$(az cosmosdb show -n ${DB_NAME} -g ${REGION_RG} --query documentEndpoint -o tsv) && \
 	./aro-hcp-backend --location ${LOCATION} \
 		--clusters-service-url http://localhost:8000 \
 		--cosmos-name ${DB_NAME} \
@@ -40,7 +40,7 @@ deploy:
 			-g ${RESOURCEGROUP} \
 			-n backend \
 			--query clientId -o tsv) && \
-	DB_URL=$$(az cosmosdb show -n ${DB_NAME} -g ${RESOURCEGROUP} --query documentEndpoint -o tsv) && \
+	DB_URL=$$(az cosmosdb show -n ${DB_NAME} -g ${REGION_RG} --query documentEndpoint -o tsv) && \
 	kubectl create namespace aro-hcp --dry-run=client -o json | kubectl apply -f - && \
 	kubectl label namespace aro-hcp "istio.io/rev=${ISTO_TAG}" --overwrite=true && \
 	${HELM_CMD} aro-hcp-backend-dev \

--- a/backend/pipeline.yaml
+++ b/backend/pipeline.yaml
@@ -43,6 +43,8 @@ resourceGroups:
       configRef: acr.svc.name
     - name: LOCATION
       configRef: region
+    - name: REGION_RG
+      configRef: regionRG
     - name: RESOURCEGROUP
       configRef: svc.rg
     - name: AKS_NAME

--- a/dev-infrastructure/modules/private-endpoint.bicep
+++ b/dev-infrastructure/modules/private-endpoint.bicep
@@ -98,7 +98,7 @@ resource privateEndpointDnsGroup 'Microsoft.Network/privateEndpoints/privateDnsZ
 ]
 
 resource privateDnsZoneVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
-  name: uniqueString('eventgrid-${uniqueString(vnetId)}')
+  name: uniqueString('${serviceType}-${uniqueString(vnetId)}')
   parent: privateEndpointDnsZone
   location: 'global'
   properties: {

--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -6,8 +6,6 @@ param disableLocalAuth bool = true
 // Passed Params and Overrides
 param location string
 param zoneRedundant bool
-param aksNodeSubnetId string
-param vnetId string
 param userAssignedMIs array
 param private bool
 
@@ -78,18 +76,6 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' = {
   }
 }
 
-module serviceCosmosdbPrivateEndpoint '../modules/private-endpoint.bicep' = {
-  name: '${deployment().name}-svcs-kv-pe'
-  params: {
-    location: location
-    subnetIds: [aksNodeSubnetId]
-    vnetId: vnetId
-    privateLinkServiceId: cosmosDbAccount.id
-    serviceType: 'cosmosdb'
-    groupId: 'Sql'
-  }
-}
-
 resource cosmosDb 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2023-11-15' = {
   name: name
   parent: cosmosDbAccount
@@ -154,4 +140,4 @@ resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignm
 ]
 
 output cosmosDBName string = name
-output cosmosDbAccountId string = cosmosDbAccount.id
+output cosmosDBAccountId string = cosmosDbAccount.id

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -14,7 +14,7 @@ info:
 	@echo "COMMIT: ${CURRENT_COMMIT}"
 
 run:
-	DB_URL=$$(az cosmosdb show -n ${DB_NAME} -g ${RESOURCEGROUP} --query documentEndpoint -o tsv) && \
+	DB_URL=$$(az cosmosdb show -n ${DB_NAME} -g ${REGION_RG} --query documentEndpoint -o tsv) && \
 	./aro-hcp-frontend --location ${LOCATION} \
 		--clusters-service-url http://localhost:8000 \
 		--cosmos-name ${DB_NAME} \
@@ -60,7 +60,7 @@ deploy:
 			--query addonProfiles.azureKeyvaultSecretsProvider.identity.clientId \
 			--output tsv) && \
 	TENANT_ID=$(shell az account show --query tenantId --output tsv) && \
-	DB_URL=$$(az cosmosdb show -n ${DB_NAME} -g ${RESOURCEGROUP} --query documentEndpoint -o tsv) && \
+	DB_URL=$$(az cosmosdb show -n ${DB_NAME} -g ${REGION_RG} --query documentEndpoint -o tsv) && \
 	kubectl create namespace aro-hcp --dry-run=client -o json | kubectl apply -f - && \
 	kubectl label namespace aro-hcp "istio.io/rev=${ISTO_TAG}" --overwrite=true && \
 	kubectl create namespace mise --dry-run=client -o json | kubectl apply -f - && \

--- a/frontend/pipeline.yaml
+++ b/frontend/pipeline.yaml
@@ -43,6 +43,8 @@ resourceGroups:
       configRef: acr.svc.name
     - name: LOCATION
       configRef: region
+    - name: REGION_RG
+      configRef: regionRG
     - name: RESOURCEGROUP
       configRef: svc.rg
     - name: AKS_NAME


### PR DESCRIPTION
[ARO-16089](https://issues.redhat.com/browse/ARO-16089)

### What

Deploys the CosmosDB Account/DB to the regional RG

Moves the cosmosdb private endpoint creation out of the cosmosdb module as that remains to be created in the svc RG along the AKS cluster 

### Why

MSFT prefers the SVC cluster RG to be about the AKS cluster. All other resources like DBs, storage accounts, managed identities for service, etc should be in the regional RG.

See [ARO-16089](https://issues.redhat.com/browse/ARO-16089)

### Special notes for your reviewer

The service cluster PR checks will fail due to the resource being moved
```
ERROR: (ResourceNotFound) The Resource 'Microsoft.DocumentDB/databaseAccounts/arohcp-rp-dev' under resource group 'hcp-underlay-dev' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix
```

As this will require a rebuild of the dev & cspr environments we should only merge this when we are ready to do so