### PR TITLE
move install bicep to the whatif step

### DIFF
--- a/.github/workflows/runbook-cicd.yml
+++ b/.github/workflows/runbook-cicd.yml
@@ -65,11 +65,11 @@ jobs:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-    - name: Install Bicep CLI
-      run: |
-        az bicep install
     - name: Deploy Automation Account What If
       run: |
+        # https://github.com/actions/runner-images/issues/11987
+        az config set bicep.use_binary_from_path=false
+        az bicep install
         cd dev-infrastructure/
         make automation-account.what-if
   cd:


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->
Move the `az bicep install` to the whatif step. Even though Bicep was installed in a previous step, the Azure CLI cannot locate the Bicep binary at the expected path.

Fix the error when the workflow runs the `az deployment group what-if` command.
```
az deployment group what-if \
	--name dev-automation-account \
	--resource-group "hcp-dev-automation-account" \
	--template-file templates/dev-automation-account.bicep \
	--parameters \
		configurations/dev-automation-account.bicepparam
ERROR: [Errno 2] No such file or directory: '/home/runner/.azure/bin/bicep'
make: *** [Makefile:384: automation-account.what-if] Error 1
Error: Process completed with exit code 2.
```
