### PR TITLE
Add install bicep to deploy step

### DIFF
--- a/.github/workflows/runbook-cicd.yml
+++ b/.github/workflows/runbook-cicd.yml
@@ -90,5 +90,8 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     - name: Deploy Automation Account
       run: |
+        # https://github.com/actions/runner-images/issues/11987
+        az config set bicep.use_binary_from_path=false
+        az bicep install
         cd dev-infrastructure/
         make automation-account


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

Add  `az config set bicep.use_binary_from_path=false` to the workflow as a workaround for the Bicep error
```
ERROR: [Errno 2] No such file or directory: '/home/runner/.azure/bin/bicep'
make: *** [Makefile:373: automation-account] Error 1
Error: Process completed with exit code 2.
```

