### PR TITLE
add persist tag to automation account resource group

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -370,7 +370,7 @@ modules/metrics/rules/generatedPrometheusAlertingRules.bicep:
 # Automation Account creation
 #
 automation-account:
-	az group create -g ${AUTOMATION_ACCOUNT_RG} -l eastus && \
+	az group create -g ${AUTOMATION_ACCOUNT_RG} -l eastus --tags persist=true && \
 	az deployment group create \
 		--name dev-automation-account \
 		--resource-group $(AUTOMATION_ACCOUNT_RG) \
@@ -387,4 +387,4 @@ automation-account.what-if:
 		--template-file templates/dev-automation-account.bicep \
 		--parameters \
 			configurations/dev-automation-account.bicepparam
-.PHONY: automation-account.what-if 
+.PHONY: automation-account.what-if


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

Apply `persist=true` tag to automation account resource group ensures that resource cleanup scripts do not delete the Azure Automation Account.

[ARO-15539](https://issues.redhat.com/browse/ARO-15539)