### PR TITLE
Revert "ARO-15874: Update image sync to include 4.18.9"

### DIFF
--- a/dev-infrastructure/templates/global-image-sync.bicep
+++ b/dev-infrastructure/templates/global-image-sync.bicep
@@ -417,8 +417,8 @@ var ocpMirrorConfig = {
           name: 'stable-4.18'
           type: 'ocp'
           full: true
-          minVersion: '4.18.9'
-          maxVersion: '4.18.9'
+          minVersion: '4.18.1'
+          maxVersion: '4.18.1'
         }
       ]
       graph: true

--- a/image-sync/oc-mirror/test/ocp-image-set-config.yml
+++ b/image-sync/oc-mirror/test/ocp-image-set-config.yml
@@ -12,7 +12,7 @@ mirror:
       maxVersion: 4.17.0
       type: ocp
     - name: stable-4.18
-      minVersion: 4.18.9
+      minVersion: 4.18.1
       full: true
       type: ocp
     graph: true


### PR DESCRIPTION
Reverts Azure/ARO-HCP#1618

4.18.9 is not yet available in the release graph