### PR TITLE
frontend: Add MiddlewareReferer

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -310,6 +310,7 @@ func (f *Frontend) ArmResourceList(writer http.ResponseWriter, request *http.Req
 		return
 	}
 
+	// MiddlewareReferer ensures Referer is present.
 	err = pagedResponse.SetNextLink(request.Referer(), dbIterator.GetContinuationToken())
 	if err != nil {
 		logger.Error(err.Error())

--- a/frontend/pkg/frontend/middleware_logging.go
+++ b/frontend/pkg/frontend/middleware_logging.go
@@ -62,6 +62,7 @@ func MiddlewareLogging(w http.ResponseWriter, r *http.Request, next http.Handler
 		"request_path", r.URL.Path,
 		"request_proto", r.Proto,
 		"request_query", r.URL.RawQuery,
+		"request_referer", r.Referer(),
 		"request_remote_addr", r.RemoteAddr,
 		"request_user_agent", r.UserAgent())
 

--- a/frontend/pkg/frontend/middleware_referer.go
+++ b/frontend/pkg/frontend/middleware_referer.go
@@ -1,0 +1,42 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"net/http"
+)
+
+// MiddlewareReferer ensures a Referer header is present in the request.
+// This header is always added by ARM but is often forgotten in testing
+// environments. If missing, derive a Referer from the http.Request.
+//
+// Referer headers are used in a few places:
+// - The "nextLink" field in a paginated response body
+// - "Location" and "Azure-AsyncOperation" response headers
+func MiddlewareReferer(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if r.Referer() == "" && r.URL != nil {
+		var refererURL = *r.URL
+
+		if refererURL.Scheme == "" {
+			if r.TLS != nil {
+				refererURL.Scheme = "https"
+			} else {
+				refererURL.Scheme = "http"
+			}
+		}
+
+		if refererURL.Host == "" {
+			refererURL.Host = r.Host
+		}
+
+		// Referer headers never include fragments or userinfo.
+		// https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.2
+		refererURL.User = nil
+		refererURL.Fragment = ""
+
+		r.Header.Set("Referer", refererURL.String())
+	}
+
+	next(w, r)
+}

--- a/frontend/pkg/frontend/operations.go
+++ b/frontend/pkg/frontend/operations.go
@@ -25,15 +25,8 @@ import (
 func (f *Frontend) AddAsyncOperationHeader(writer http.ResponseWriter, request *http.Request, doc *database.OperationDocument) {
 	logger := LoggerFromContext(request.Context())
 
-	// ARM will always add a Referer header, but
-	// requests from test environments might not.
-	referer := request.Referer()
-	if referer == "" {
-		logger.Info("Omitting " + arm.HeaderNameAsyncOperation + " header: no referer")
-		return
-	}
-
-	u, err := url.ParseRequestURI(referer)
+	// MiddlewareReferer ensures Referer is present.
+	u, err := url.ParseRequestURI(request.Referer())
 	if err != nil {
 		logger.Error(err.Error())
 		return
@@ -56,15 +49,8 @@ func (f *Frontend) AddAsyncOperationHeader(writer http.ResponseWriter, request *
 func (f *Frontend) AddLocationHeader(writer http.ResponseWriter, request *http.Request, doc *database.OperationDocument) {
 	logger := LoggerFromContext(request.Context())
 
-	// ARM will always add a Referer header, but
-	// requests from test environments might not.
-	referer := request.Referer()
-	if referer == "" {
-		logger.Info("Omitting Location header: no referer")
-		return
-	}
-
-	u, err := url.ParseRequestURI(referer)
+	// MiddlewareReferer ensures Referer is present.
+	u, err := url.ParseRequestURI(request.Referer())
 	if err != nil {
 		logger.Error(err.Error())
 		return

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -48,6 +48,7 @@ func (f *Frontend) routes(r prometheus.Registerer) *MiddlewareMux {
 
 	mux := NewMiddlewareMux(
 		MiddlewarePanic,
+		MiddlewareReferer,
 		metricsMiddleware.Metrics(),
 		MiddlewareCorrelationData,
 		MiddlewareTracing,


### PR DESCRIPTION
### What

`MiddlewareReferer` ensures a `Referer` header is present in the request. This header is always added by ARM but is often forgotten in testing environments. If missing, derive a `Referer` from the `http.Request`.

`Referer` header is required for RP responses to include operation status or result endpoints in `Azure-AsyncOperation` or `Location` headers.  Currently if there's no `Referer` header the RP just omits these response headers but that's not ideal for testing.

No JIRA, this is just a test aid.