### PR TITLE
ARO-15755 | Display inflight check errors

### DIFF
--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -22,6 +22,9 @@ type ClusterServiceClientSpec interface {
 	// GetClusterStatus sends a GET request to fetch a cluster's status from Cluster Service.
 	GetClusterStatus(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.ClusterStatus, error)
 
+	// GetClusterInflightChecks sends a GET request to fetch a cluster's inflight checks from Cluster Service.
+	GetClusterInflightChecks(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.InflightCheckList, error)
+
 	// PostCluster sends a POST request to create a cluster in Cluster Service.
 	PostCluster(ctx context.Context, cluster *arohcpv1alpha1.Cluster) (*arohcpv1alpha1.Cluster, error)
 
@@ -129,6 +132,22 @@ func (csc *ClusterServiceClient) GetClusterStatus(ctx context.Context, internalI
 		return nil, fmt.Errorf("empty response body")
 	}
 	return status, nil
+}
+
+func (csc *ClusterServiceClient) GetClusterInflightChecks(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.InflightCheckList, error) {
+	client, ok := internalID.GetAroHCPClusterClient(csc.Conn)
+	if !ok {
+		return nil, fmt.Errorf("OCM path is not a cluster: %s", internalID)
+	}
+	clusterInflightChecksResponse, err := client.InflightChecks().List().SendContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	inflightChecks, ok := clusterInflightChecksResponse.GetItems()
+	if !ok {
+		return nil, fmt.Errorf("empty response body")
+	}
+	return inflightChecks, nil
 }
 
 func (csc *ClusterServiceClient) PostCluster(ctx context.Context, cluster *arohcpv1alpha1.Cluster) (*arohcpv1alpha1.Cluster, error) {


### PR DESCRIPTION
If the cluster got into an error state with status code OCM4001, fetch the inflight check errors and populate the `CloudErrorBody` with the details.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
