### PR TITLE
ARO-15755 | Display inflight check errors

### DIFF
--- a/backend/operations_scanner_test.go
+++ b/backend/operations_scanner_test.go
@@ -335,6 +335,7 @@ func TestConvertClusterStatus(t *testing.T) {
 		updatedProvisioningState arm.ProvisioningState
 		expectCloudError         bool
 		expectConversionError    bool
+		internalId               ocm.InternalID
 	}{
 		{
 			name:                     "Convert ClusterStateError",
@@ -451,6 +452,7 @@ func TestConvertClusterStatus(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		var operationsScanner *OperationsScanner
 		t.Run(tt.name, func(t *testing.T) {
 			clusterStatus, err := arohcpv1alpha1.NewClusterStatus().
 				State(tt.clusterState).
@@ -459,7 +461,8 @@ func TestConvertClusterStatus(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			opState, opError, err := convertClusterStatus(clusterStatus, tt.currentProvisioningState)
+			opState, opError, err := operationsScanner.convertClusterStatus(context.Background(), slog.Default(),
+				clusterStatus, tt.currentProvisioningState, tt.internalId)
 
 			assert.Equal(t, tt.updatedProvisioningState, opState)
 

--- a/internal/mocks/ocm.go
+++ b/internal/mocks/ocm.go
@@ -274,6 +274,45 @@ func (c *MockClusterServiceClientSpecGetClusterCall) DoAndReturn(f func(context.
 	return c
 }
 
+// GetClusterInflightChecks mocks base method.
+func (m *MockClusterServiceClientSpec) GetClusterInflightChecks(ctx context.Context, internalID ocm.InternalID) (*v1alpha1.InflightCheckList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterInflightChecks", ctx, internalID)
+	ret0, _ := ret[0].(*v1alpha1.InflightCheckList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterInflightChecks indicates an expected call of GetClusterInflightChecks.
+func (mr *MockClusterServiceClientSpecMockRecorder) GetClusterInflightChecks(ctx, internalID any) *MockClusterServiceClientSpecGetClusterInflightChecksCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterInflightChecks", reflect.TypeOf((*MockClusterServiceClientSpec)(nil).GetClusterInflightChecks), ctx, internalID)
+	return &MockClusterServiceClientSpecGetClusterInflightChecksCall{Call: call}
+}
+
+// MockClusterServiceClientSpecGetClusterInflightChecksCall wrap *gomock.Call
+type MockClusterServiceClientSpecGetClusterInflightChecksCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockClusterServiceClientSpecGetClusterInflightChecksCall) Return(arg0 *v1alpha1.InflightCheckList, arg1 error) *MockClusterServiceClientSpecGetClusterInflightChecksCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockClusterServiceClientSpecGetClusterInflightChecksCall) Do(f func(context.Context, ocm.InternalID) (*v1alpha1.InflightCheckList, error)) *MockClusterServiceClientSpecGetClusterInflightChecksCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockClusterServiceClientSpecGetClusterInflightChecksCall) DoAndReturn(f func(context.Context, ocm.InternalID) (*v1alpha1.InflightCheckList, error)) *MockClusterServiceClientSpecGetClusterInflightChecksCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetClusterStatus mocks base method.
 func (m *MockClusterServiceClientSpec) GetClusterStatus(ctx context.Context, internalID ocm.InternalID) (*v1alpha1.ClusterStatus, error) {
 	m.ctrl.T.Helper()

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -33,6 +33,9 @@ type ClusterServiceClientSpec interface {
 	// GetClusterStatus sends a GET request to fetch a cluster's status from Cluster Service.
 	GetClusterStatus(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.ClusterStatus, error)
 
+	// GetClusterInflightChecks sends a GET request to fetch a cluster's inflight checks from Cluster Service.
+	GetClusterInflightChecks(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.InflightCheckList, error)
+
 	// PostCluster sends a POST request to create a cluster in Cluster Service.
 	PostCluster(ctx context.Context, cluster *arohcpv1alpha1.Cluster) (*arohcpv1alpha1.Cluster, error)
 
@@ -143,6 +146,22 @@ func (csc *ClusterServiceClient) GetClusterStatus(ctx context.Context, internalI
 		return nil, fmt.Errorf("empty response body")
 	}
 	return status, nil
+}
+
+func (csc *ClusterServiceClient) GetClusterInflightChecks(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.InflightCheckList, error) {
+	client, ok := internalID.GetAroHCPClusterClient(csc.Conn)
+	if !ok {
+		return nil, fmt.Errorf("OCM path is not a cluster: %s", internalID)
+	}
+	clusterInflightChecksResponse, err := client.InflightChecks().List().SendContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	inflightChecks, ok := clusterInflightChecksResponse.GetItems()
+	if !ok {
+		return nil, fmt.Errorf("empty response body")
+	}
+	return inflightChecks, nil
 }
 
 func (csc *ClusterServiceClient) PostCluster(ctx context.Context, cluster *arohcpv1alpha1.Cluster) (*arohcpv1alpha1.Cluster, error) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-15755

### What

If the cluster got into an error state with status code OCM4001, fetch the inflight check errors and populate the `CloudErrorBody` with the details.

### Why

Improve the UX.

### Special notes for your reviewer
e.g.
```
curl http://localhost:8443/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/providers/Microsoft.RedHatOpenShift/locations/westus3/hcpOperationsStatus/53b18a92-ddb6-43fc-8b8b-c354d3d24baf?api-version=2024-06-10-preview
{
    "id": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/providers/Microsoft.RedHatOpenShift/locations/westus3/hcpOperationsStatus/53b18a92-ddb6-43fc-8b8b-c354d3d24baf",
    "name": "53b18a92-ddb6-43fc-8b8b-c354d3d24baf",
    "status": "Failed",
    "startTime": "2025-04-20T13:42:19.101376032Z",
    "endTime": "2025-04-20T13:42:48.096984902Z",
    "error": {
        "code": "InternalServerError",
        "message": "Managed resource group 'oadler-rg' should not exist prior to cluster creation"
    }
}
```
