### PR TITLE
Bump maestro and update liveness probe

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -401,7 +401,7 @@ clouds:
             postgres:
               name: "arohcpint-maestro-{{ .ctx.regionShort }}" # [globally-unique]
             image:
-              digest: sha256:223f332a11d336b49243d886217a76809142b30f9ab8ef27bec80a4458b3c3a5
+              digest: sha256:d9a10f96c0b6f80c380c4ebcf25fccc4ab212ff165267b6c7feb74c88b6d0db5
           # 1P app - from RH Tenant
           firstPartyAppClientId: b3cb2fab-15cb-4583-ad06-f91da9bfe2d1
           firstPartyAppCertificate:
@@ -538,7 +538,7 @@ clouds:
             postgres:
               name: "arohcpstg-maestro-{{ .ctx.regionShort }}" # [globally-unique]
             image:
-              digest: sha256:223f332a11d336b49243d886217a76809142b30f9ab8ef27bec80a4458b3c3a5
+              digest: sha256:d9a10f96c0b6f80c380c4ebcf25fccc4ab212ff165267b6c7feb74c88b6d0db5
           # 1P app - from RH Tenant
           firstPartyAppClientId: "7f4a113a-c61d-412a-bea1-85dee5baf4a8"
           firstPartyAppCertificate:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -234,7 +234,7 @@ clouds:
       # Maestro
       maestro:
         image:
-          digest: sha256:223f332a11d336b49243d886217a76809142b30f9ab8ef27bec80a4458b3c3a5
+          digest: sha256:d9a10f96c0b6f80c380c4ebcf25fccc4ab212ff165267b6c7feb74c88b6d0db5
       # Cluster Service
       clusterService:
         image:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -215,7 +215,7 @@
       "private": false
     },
     "image": {
-      "digest": "sha256:223f332a11d336b49243d886217a76809142b30f9ab8ef27bec80a4458b3c3a5",
+      "digest": "sha256:d9a10f96c0b6f80c380c4ebcf25fccc4ab212ff165267b6c7feb74c88b6d0db5",
       "registry": "quay.io",
       "repository": "redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro"
     },

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -215,7 +215,7 @@
       "private": false
     },
     "image": {
-      "digest": "sha256:223f332a11d336b49243d886217a76809142b30f9ab8ef27bec80a4458b3c3a5",
+      "digest": "sha256:d9a10f96c0b6f80c380c4ebcf25fccc4ab212ff165267b6c7feb74c88b6d0db5",
       "registry": "quay.io",
       "repository": "redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro"
     },

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -208,7 +208,7 @@
       "private": false
     },
     "image": {
-      "digest": "sha256:223f332a11d336b49243d886217a76809142b30f9ab8ef27bec80a4458b3c3a5",
+      "digest": "sha256:d9a10f96c0b6f80c380c4ebcf25fccc4ab212ff165267b6c7feb74c88b6d0db5",
       "registry": "quay.io",
       "repository": "redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro"
     },

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -206,7 +206,7 @@
       "private": false
     },
     "image": {
-      "digest": "sha256:223f332a11d336b49243d886217a76809142b30f9ab8ef27bec80a4458b3c3a5",
+      "digest": "sha256:d9a10f96c0b6f80c380c4ebcf25fccc4ab212ff165267b6c7feb74c88b6d0db5",
       "registry": "quay.io",
       "repository": "redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro"
     },

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -215,7 +215,7 @@
       "private": false
     },
     "image": {
-      "digest": "sha256:223f332a11d336b49243d886217a76809142b30f9ab8ef27bec80a4458b3c3a5",
+      "digest": "sha256:d9a10f96c0b6f80c380c4ebcf25fccc4ab212ff165267b6c7feb74c88b6d0db5",
       "registry": "quay.io",
       "repository": "redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro"
     },

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -215,7 +215,7 @@
       "private": false
     },
     "image": {
-      "digest": "sha256:223f332a11d336b49243d886217a76809142b30f9ab8ef27bec80a4458b3c3a5",
+      "digest": "sha256:d9a10f96c0b6f80c380c4ebcf25fccc4ab212ff165267b6c7feb74c88b6d0db5",
       "registry": "quay.io",
       "repository": "redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro"
     },

--- a/maestro/server/deploy/templates/maestro.deployment.yaml
+++ b/maestro/server/deploy/templates/maestro.deployment.yaml
@@ -123,11 +123,11 @@ spec:
             memory: '{{ .Values.deployment.limits.memory  }}'
         livenessProbe:
           httpGet:
-            path: /api/maestro
-            port: {{ .Values.maestro.httpBindPort }}
+            path: /healthcheck
+            port: {{ .Values.maestro.healthCheckBindPort }}
             scheme: HTTP
-          initialDelaySeconds: 15
-          periodSeconds: 5
+          initialDelaySeconds: 25
+          periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /healthcheck
@@ -137,4 +137,4 @@ spec:
             - name: User-Agent
               value: Probe
           initialDelaySeconds: 20
-          periodSeconds: 10
+          periodSeconds: 5


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What
Maestro server deployments updates to use health check as liveness probe to ensure the pod can be restarted if the DB connection has problem.  Deploys new maestro image, which adds additional logs to observe access token issues.
ref https://github.com/openshift-online/maestro/pull/294
### Why

https://issues.redhat.com/browse/ACM-19936#

### Special notes for your reviewer

<!-- optional -->
