### PR TITLE
bump cbl-mariner images

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 ENV CGO_ENABLED=1 GOFLAGS='-tags=requirefips'
 RUN go build -o aro-hcp-admin
 
-FROM --platform=linux/amd64 mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot@sha256:ce44fc29db88c9aba8041a50c1abcd19a54f997c2b99a8c513e8ec113261374a
+FROM --platform=linux/amd64 mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot@sha256:a5d5928601847a40c81fa397df33136c285866c974bf91ed94d688390fcc33f3
 WORKDIR /
 COPY --from=builder /app/admin/aro-hcp-admin .
 ENTRYPOINT ["/aro-hcp-admin"]

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,5 +1,5 @@
 # Base and builder image will need to be replaced by Fips compliant one
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0@sha256:a6a9c72282cc8e689c79b393bf875aa8e02e224e6d8928d7b366dfe62389d072 as builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0@sha256:374281fe968134a44bcc7bd4b9e2d55dda61dcaa942fee5dda28cd38d54619cd as builder
 
 WORKDIR /app/admin
 COPY . . 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,7 @@ RUN cd backend && make backend
 
 
 # Deployment image copies aro-hcp-backend from builder image
-FROM --platform=linux/amd64 mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot@sha256:c83be1ce06e4f27f664db7b23551a7a6fef5d0bc49d6781a0f5a61815e682239
+FROM --platform=linux/amd64 mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot@sha256:a5d5928601847a40c81fa397df33136c285866c974bf91ed94d688390fcc33f3
 WORKDIR /
 COPY --from=builder /app/backend/aro-hcp-backend .
 ENTRYPOINT ["/aro-hcp-backend"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Builder image installs tools needed to build aro-hcp-backend
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0@sha256:a6a9c72282cc8e689c79b393bf875aa8e02e224e6d8928d7b366dfe62389d072 as builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0@sha256:374281fe968134a44bcc7bd4b9e2d55dda61dcaa942fee5dda28cd38d54619cd as builder
 WORKDIR /app
 ADD archive.tar.gz .
 # https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips#build-option-to-require-fips-mode

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Base and builder image will need to be replaced by Fips compliant one
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0@sha256:a6a9c72282cc8e689c79b393bf875aa8e02e224e6d8928d7b366dfe62389d072 as builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0@sha256:374281fe968134a44bcc7bd4b9e2d55dda61dcaa942fee5dda28cd38d54619cd as builder
 
 WORKDIR /app
 ADD archive.tar.gz .

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ ADD archive.tar.gz .
 ENV CGO_ENABLED=1 GOFLAGS='-tags=requirefips'
 RUN cd frontend && make frontend
 
-FROM --platform=linux/amd64 mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot@sha256:c83be1ce06e4f27f664db7b23551a7a6fef5d0bc49d6781a0f5a61815e682239
+FROM --platform=linux/amd64 mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot@sha256:a5d5928601847a40c81fa397df33136c285866c974bf91ed94d688390fcc33f3
 WORKDIR /
 COPY --from=builder /app/frontend/aro-hcp-frontend .
 ENTRYPOINT ["/aro-hcp-frontend"]

--- a/tooling/image-sync/Dockerfile
+++ b/tooling/image-sync/Dockerfile
@@ -5,7 +5,7 @@ ADD . .
 # https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips#build-option-to-require-fips-mode
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -tags=containers_image_openpgp,requirefips .
 
-FROM --platform=linux/amd64 mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot@sha256:ce44fc29db88c9aba8041a50c1abcd19a54f997c2b99a8c513e8ec113261374a
+FROM --platform=linux/amd64 mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot@sha256:a5d5928601847a40c81fa397df33136c285866c974bf91ed94d688390fcc33f3
 WORKDIR /
 
 COPY --from=builder /app/image-sync .

--- a/tooling/image-sync/Dockerfile
+++ b/tooling/image-sync/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0@sha256:a6a9c72282cc8e689c79b393bf875aa8e02e224e6d8928d7b366dfe62389d072 as builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0@sha256:374281fe968134a44bcc7bd4b9e2d55dda61dcaa942fee5dda28cd38d54619cd as builder
 
 WORKDIR /app
 ADD . .


### PR DESCRIPTION
### What

lifecycle CBL mariner images

mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0 - state april 21st 2025
mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot - state april 5th 2025

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
