### PR TITLE
Unit test refactoring

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/openshift-online/ocm-sdk-go v0.1.464
 	github.com/prometheus/client_golang v1.21.0
 	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.5.0
 	golang.org/x/sync v0.13.0
 	k8s.io/client-go v0.32.3
@@ -59,6 +60,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -18,6 +18,7 @@ require (
 )
 
 require (
+	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.9.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -33,8 +33,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
-github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
+github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
+github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=

--- a/backend/operations_scanner_test.go
+++ b/backend/operations_scanner_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/mocks"
@@ -58,10 +59,10 @@ func TestSetDeleteOperationAsCompleted(t *testing.T) {
 	internalID, err := ocm.NewInternalID("/api/clusters_mgmt/v1/clusters/placeholder")
 	require.NoError(t, err)
 
-	resourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/testCluster")
+	resourceID, err := azcorearm.ParseResourceID(api.TestClusterResourceID)
 	require.NoError(t, err)
 
-	operationID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift/locations/oz/hcpOperationsStatus/operationID")
+	operationID, err := azcorearm.ParseResourceID("/subscriptions/" + api.TestSubscriptionID + "/providers/" + api.ProviderNamespace + "/locations/oz/" + api.OperationStatusResourceTypeName + "/operationID")
 	require.NoError(t, err)
 
 	for _, tt := range tests {
@@ -210,10 +211,10 @@ func TestUpdateOperationStatus(t *testing.T) {
 	internalID, err := ocm.NewInternalID("/api/clusters_mgmt/v1/clusters/placeholder")
 	require.NoError(t, err)
 
-	resourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/testCluster")
+	resourceID, err := azcorearm.ParseResourceID(api.TestClusterResourceID)
 	require.NoError(t, err)
 
-	operationID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift/locations/oz/hcpOperationsStatus/operationID")
+	operationID, err := azcorearm.ParseResourceID("/subscriptions/" + api.TestSubscriptionID + "/providers/" + api.ProviderNamespace + "/locations/oz/" + api.OperationStatusResourceTypeName + "/operationID")
 	require.NoError(t, err)
 
 	for _, tt := range tests {

--- a/backend/operations_scanner_test.go
+++ b/backend/operations_scanner_test.go
@@ -13,6 +13,8 @@ import (
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -54,9 +56,13 @@ func TestSetDeleteOperationAsCompleted(t *testing.T) {
 
 	// Placeholder InternalID for NewOperationDocument
 	internalID, err := ocm.NewInternalID("/api/clusters_mgmt/v1/clusters/placeholder")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
+	resourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/testCluster")
+	require.NoError(t, err)
+
+	operationID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift/locations/oz/hcpOperationsStatus/operationID")
+	require.NoError(t, err)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -65,16 +71,6 @@ func TestSetDeleteOperationAsCompleted(t *testing.T) {
 			ctx := context.Background()
 			ctrl := gomock.NewController(t)
 			mockDBClient := mocks.NewMockDBClient(ctrl)
-
-			resourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/testCluster")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			operationID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift/locations/oz/hcpOperationsStatus/operationID")
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method == http.MethodPost {
@@ -120,27 +116,19 @@ func TestSetDeleteOperationAsCompleted(t *testing.T) {
 
 			err = scanner.setDeleteOperationAsCompleted(ctx, op)
 
-			if request == nil && tt.expectAsyncNotification {
-				t.Error("Did not POST to async notification URI")
-			} else if request != nil && !tt.expectAsyncNotification {
-				t.Error("Unexpected POST to async notification URI")
-			}
+			if tt.expectError {
+				assert.Error(t, err)
 
-			if err == nil && tt.expectError {
-				t.Error("Expected error but got none")
-			} else if err != nil && !tt.expectError {
-				t.Errorf("Got unexpected error: %v", err)
-			}
+			} else if assert.NoError(t, err) {
+				if tt.resourceDocPresent {
+					assert.True(t, resourceDocDeleted)
+				}
 
-			if err == nil && tt.resourceDocPresent && !resourceDocDeleted {
-				t.Error("Expected resource document to be deleted")
-			}
-
-			if err == nil && tt.expectAsyncNotification {
-				if operationDoc.Status != arm.ProvisioningStateSucceeded {
-					t.Errorf("Expected updated operation status to be %s but got %s",
-						arm.ProvisioningStateSucceeded,
-						operationDoc.Status)
+				if tt.expectAsyncNotification {
+					assert.Equal(t, arm.ProvisioningStateSucceeded, operationDoc.Status)
+					assert.NotNil(t, request, "Did not POST to async notification URI")
+				} else {
+					assert.Nil(t, request, "Unexpected POST to async notification URI")
 				}
 			}
 		})
@@ -220,9 +208,13 @@ func TestUpdateOperationStatus(t *testing.T) {
 
 	// Placeholder InternalID for NewOperationDocument
 	internalID, err := ocm.NewInternalID("/api/clusters_mgmt/v1/clusters/placeholder")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
+	resourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/testCluster")
+	require.NoError(t, err)
+
+	operationID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift/locations/oz/hcpOperationsStatus/operationID")
+	require.NoError(t, err)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -231,16 +223,6 @@ func TestUpdateOperationStatus(t *testing.T) {
 			ctx := context.Background()
 			ctrl := gomock.NewController(t)
 			mockDBClient := mocks.NewMockDBClient(ctrl)
-
-			resourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/testCluster")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			operationID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift/locations/oz/hcpOperationsStatus/operationID")
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method == http.MethodPost {
@@ -299,36 +281,25 @@ func TestUpdateOperationStatus(t *testing.T) {
 
 			err = scanner.updateOperationStatus(ctx, op, tt.updatedOperationStatus, nil)
 
-			if request == nil && tt.expectAsyncNotification {
-				t.Error("Did not POST to async notification URI")
-			} else if request != nil && !tt.expectAsyncNotification {
-				t.Error("Unexpected POST to async notification URI")
-			}
+			if tt.expectError {
+				assert.Error(t, err)
 
-			if err == nil && tt.expectError {
-				t.Error("Expected error but got none")
-			} else if err != nil && !tt.expectError {
-				t.Errorf("Got unexpected error: %v", err)
-			}
+			} else if assert.NoError(t, err) {
+				if tt.resourceDocPresent {
+					if tt.expectResourceOperationIDCleared {
+						assert.Empty(t, resourceDoc.ActiveOperationID, "Resource's active operation ID was not cleared")
+					} else {
+						assert.NotEmpty(t, resourceDoc.ActiveOperationID, "Resource's active operation ID is unexpectedly empty")
+					}
 
-			if err == nil && tt.expectAsyncNotification {
-				if operationDoc.Status != tt.updatedOperationStatus {
-					t.Errorf("Expected updated operation status to be %s but got %s",
-						tt.updatedOperationStatus,
-						operationDoc.Status)
+					assert.Equal(t, tt.expectResourceProvisioningState, resourceDoc.ProvisioningState)
 				}
-			}
 
-			if err == nil && tt.resourceDocPresent {
-				if resourceDoc.ActiveOperationID == "" && !tt.expectResourceOperationIDCleared {
-					t.Error("Resource's active operation ID is unexpectedly empty")
-				} else if resourceDoc.ActiveOperationID != "" && tt.expectResourceOperationIDCleared {
-					t.Errorf("Resource's active operation ID was not cleared; has '%s'", resourceDoc.ActiveOperationID)
-				}
-				if resourceDoc.ProvisioningState != tt.expectResourceProvisioningState {
-					t.Errorf("Expected updated provisioning state to be %s but got %s",
-						tt.expectResourceProvisioningState,
-						resourceDoc.ProvisioningState)
+				if tt.expectAsyncNotification {
+					assert.Equal(t, tt.updatedOperationStatus, operationDoc.Status)
+					assert.NotNil(t, request, "Did not POST to async notification URI")
+				} else {
+					assert.Nil(t, request, "Unexpected POST to async notification URI")
 				}
 			}
 		})
@@ -477,18 +448,19 @@ func TestConvertClusterStatus(t *testing.T) {
 			}
 
 			opState, opError, err := convertClusterStatus(clusterStatus, tt.currentProvisioningState)
-			if opState != tt.updatedProvisioningState {
-				t.Errorf("Expected provisioning state '%s' but got '%s'", tt.updatedProvisioningState, opState)
+
+			assert.Equal(t, tt.updatedProvisioningState, opState)
+
+			if tt.expectCloudError {
+				assert.NotNil(t, opError)
+			} else {
+				assert.Nil(t, opError)
 			}
-			if opError == nil && tt.expectCloudError {
-				t.Error("Expected a cloud error but got none")
-			} else if opError != nil && !tt.expectCloudError {
-				t.Errorf("Got unexpected cloud error: %v", opError)
-			}
-			if err == nil && tt.expectConversionError {
-				t.Error("Expected a conversion error but got none")
-			} else if err != nil && !tt.expectConversionError {
-				t.Errorf("Got unexpected conversion error: %v", err)
+
+			if tt.expectConversionError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -21,6 +21,7 @@ require (
 )
 
 require (
+	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/frontend/go.sum
+++ b/frontend/go.sum
@@ -35,8 +35,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
-github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
-github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
+github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
+github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
@@ -128,8 +128,6 @@ github.com/openshift-online/ocm-sdk-go v0.1.464 h1:QLg2Q96gGG57SDhh6kHWW9dVGhEhr
 github.com/openshift-online/ocm-sdk-go v0.1.464/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -180,7 +180,7 @@ func TestSubscriptionsGET(t *testing.T) {
 			}
 			ts := newHTTPServer(f, ctrl, mockDBClient, subs)
 
-			rs, err := ts.Client().Get(ts.URL + "/subscriptions/" + subscriptionID + "?api-version=2.0")
+			rs, err := ts.Client().Get(ts.URL + "/subscriptions/" + subscriptionID + "?api-version=" + arm.SubscriptionAPIVersion)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -205,7 +205,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 	}{
 		{
 			name:    "PUT Subscription - Doc does not exist",
-			urlPath: "/subscriptions/" + subscriptionID + "?api-version=2.0",
+			urlPath: "/subscriptions/" + subscriptionID,
 			subscription: &arm.Subscription{
 				State:            arm.SubscriptionStateRegistered,
 				RegistrationDate: api.Ptr(time.Now().String()),
@@ -216,7 +216,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 		},
 		{
 			name:    "PUT Subscription - Doc Exists",
-			urlPath: "/subscriptions/" + subscriptionID + "?api-version=2.0",
+			urlPath: "/subscriptions/" + subscriptionID,
 			subscription: &arm.Subscription{
 				State:            arm.SubscriptionStateRegistered,
 				RegistrationDate: api.Ptr(time.Now().String()),
@@ -231,7 +231,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 		},
 		{
 			name:    "PUT Subscription - Invalid Subscription",
-			urlPath: "/subscriptions/oopsie-i-no-good0?api-version=2.0",
+			urlPath: "/subscriptions/oopsie-i-no-good0",
 			subscription: &arm.Subscription{
 				State:            arm.SubscriptionStateRegistered,
 				RegistrationDate: api.Ptr(time.Now().String()),
@@ -242,7 +242,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 		},
 		{
 			name:    "PUT Subscription - Missing State",
-			urlPath: "/subscriptions/" + subscriptionID + "?api-version=2.0",
+			urlPath: "/subscriptions/" + subscriptionID,
 			subscription: &arm.Subscription{
 				RegistrationDate: api.Ptr(time.Now().String()),
 				Properties:       nil,
@@ -252,7 +252,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 		},
 		{
 			name:    "PUT Subscription - Invalid State",
-			urlPath: "/subscriptions/" + subscriptionID + "?api-version=2.0",
+			urlPath: "/subscriptions/" + subscriptionID,
 			subscription: &arm.Subscription{
 				State:            "Bogus",
 				RegistrationDate: api.Ptr(time.Now().String()),
@@ -263,7 +263,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 		},
 		{
 			name:    "PUT Subscription - Missing RegistrationDate",
-			urlPath: "/subscriptions/" + subscriptionID + "?api-version=2.0",
+			urlPath: "/subscriptions/" + subscriptionID,
 			subscription: &arm.Subscription{
 				State:      arm.SubscriptionStateRegistered,
 				Properties: nil,
@@ -320,7 +320,8 @@ func TestSubscriptionsPUT(t *testing.T) {
 			}
 			ts := newHTTPServer(f, ctrl, mockDBClient, subs)
 
-			req, err := http.NewRequest(http.MethodPut, ts.URL+test.urlPath, bytes.NewReader(body))
+			urlPath := test.urlPath + "?api-version=" + arm.SubscriptionAPIVersion
+			req, err := http.NewRequest(http.MethodPut, ts.URL+urlPath, bytes.NewReader(body))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -181,13 +181,9 @@ func TestSubscriptionsGET(t *testing.T) {
 			ts := newHTTPServer(f, ctrl, mockDBClient, subs)
 
 			rs, err := ts.Client().Get(ts.URL + "/subscriptions/" + subscriptionID + "?api-version=" + arm.SubscriptionAPIVersion)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
-			if rs.StatusCode != test.expectedStatusCode {
-				t.Errorf("expected status code %d, got %d", test.expectedStatusCode, rs.StatusCode)
-			}
+			assert.Equal(t, test.expectedStatusCode, rs.StatusCode)
 
 			lintMetrics(t, reg)
 			assertHTTPMetrics(t, reg, test.subDoc)
@@ -290,9 +286,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 			)
 
 			body, err := json.Marshal(&test.subscription)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			// MiddlewareLockSubscription
 			// (except when MiddlewareValidateStatic fails)
@@ -322,9 +316,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 
 			urlPath := test.urlPath + "?api-version=" + arm.SubscriptionAPIVersion
 			req, err := http.NewRequest(http.MethodPut, ts.URL+urlPath, bytes.NewReader(body))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
 
 			rs, err := ts.Client().Do(req)

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -31,13 +30,6 @@ import (
 	"github.com/Azure/ARO-HCP/internal/ocm"
 )
 
-var testLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
-
-const (
-	apiVersion     = "2024-06-10-preview"
-	subscriptionID = "00000000-0000-0000-0000-000000000000"
-)
-
 func getMockDBDoc[T any](t *T) (*T, error) {
 	if t != nil {
 		return t, nil
@@ -49,7 +41,7 @@ func getMockDBDoc[T any](t *T) (*T, error) {
 func newClusterResourceID(t *testing.T) *azcorearm.ResourceID {
 	resourceID, err := azcorearm.ParseResourceID(path.Join(
 		"/",
-		"subscriptions", subscriptionID,
+		"subscriptions", api.TestSubscriptionID,
 		"resourceGroups", "myResourceGroup",
 		"providers", api.ProviderNamespace,
 		api.ClusterResourceTypeName, "myCluster"))
@@ -102,7 +94,7 @@ func TestReadiness(t *testing.T) {
 			reg := prometheus.NewRegistry()
 
 			f := NewFrontend(
-				testLogger,
+				api.NewTestLogger(),
 				nil,
 				nil,
 				reg,
@@ -158,7 +150,7 @@ func TestSubscriptionsGET(t *testing.T) {
 			reg := prometheus.NewRegistry()
 
 			f := NewFrontend(
-				testLogger,
+				api.NewTestLogger(),
 				nil,
 				nil,
 				reg,
@@ -176,11 +168,11 @@ func TestSubscriptionsGET(t *testing.T) {
 			// The subscription collector lists all documents once.
 			subs := make(map[string]*arm.Subscription)
 			if test.subDoc != nil {
-				subs[subscriptionID] = test.subDoc
+				subs[api.TestSubscriptionID] = test.subDoc
 			}
 			ts := newHTTPServer(f, ctrl, mockDBClient, subs)
 
-			rs, err := ts.Client().Get(ts.URL + "/subscriptions/" + subscriptionID + "?api-version=" + arm.SubscriptionAPIVersion)
+			rs, err := ts.Client().Get(ts.URL + "/subscriptions/" + api.TestSubscriptionID + "?api-version=" + arm.SubscriptionAPIVersion)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expectedStatusCode, rs.StatusCode)
@@ -201,7 +193,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 	}{
 		{
 			name:    "PUT Subscription - Doc does not exist",
-			urlPath: "/subscriptions/" + subscriptionID,
+			urlPath: "/subscriptions/" + api.TestSubscriptionID,
 			subscription: &arm.Subscription{
 				State:            arm.SubscriptionStateRegistered,
 				RegistrationDate: api.Ptr(time.Now().String()),
@@ -212,7 +204,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 		},
 		{
 			name:    "PUT Subscription - Doc Exists",
-			urlPath: "/subscriptions/" + subscriptionID,
+			urlPath: "/subscriptions/" + api.TestSubscriptionID,
 			subscription: &arm.Subscription{
 				State:            arm.SubscriptionStateRegistered,
 				RegistrationDate: api.Ptr(time.Now().String()),
@@ -238,7 +230,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 		},
 		{
 			name:    "PUT Subscription - Missing State",
-			urlPath: "/subscriptions/" + subscriptionID,
+			urlPath: "/subscriptions/" + api.TestSubscriptionID,
 			subscription: &arm.Subscription{
 				RegistrationDate: api.Ptr(time.Now().String()),
 				Properties:       nil,
@@ -248,7 +240,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 		},
 		{
 			name:    "PUT Subscription - Invalid State",
-			urlPath: "/subscriptions/" + subscriptionID,
+			urlPath: "/subscriptions/" + api.TestSubscriptionID,
 			subscription: &arm.Subscription{
 				State:            "Bogus",
 				RegistrationDate: api.Ptr(time.Now().String()),
@@ -259,7 +251,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 		},
 		{
 			name:    "PUT Subscription - Missing RegistrationDate",
-			urlPath: "/subscriptions/" + subscriptionID,
+			urlPath: "/subscriptions/" + api.TestSubscriptionID,
 			subscription: &arm.Subscription{
 				State:      arm.SubscriptionStateRegistered,
 				Properties: nil,
@@ -276,7 +268,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 			reg := prometheus.NewRegistry()
 
 			f := NewFrontend(
-				testLogger,
+				api.NewTestLogger(),
 				nil,
 				nil,
 				reg,
@@ -310,7 +302,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 
 			subs := make(map[string]*arm.Subscription)
 			if test.subDoc != nil {
-				subs[subscriptionID] = test.subDoc
+				subs[api.TestSubscriptionID] = test.subDoc
 			}
 			ts := newHTTPServer(f, ctrl, mockDBClient, subs)
 
@@ -365,7 +357,7 @@ func TestDeploymentPreflight(t *testing.T) {
 				"name":       "my-hcp-cluster",
 				"type":       api.ClusterResourceType.String(),
 				"location":   "eastus",
-				"apiVersion": "2024-06-10-preview",
+				"apiVersion": api.TestAPIVersion,
 				"properties": map[string]any{
 					"version": map[string]any{
 						"id":           "4.0.0",
@@ -388,7 +380,7 @@ func TestDeploymentPreflight(t *testing.T) {
 				"name":       "my-hcp-cluster",
 				"type":       api.ClusterResourceType.String(),
 				"location":   "eastus",
-				"apiVersion": "2024-06-10-preview",
+				"apiVersion": api.TestAPIVersion,
 				"properties": map[string]any{
 					"version": map[string]any{
 						"channelGroup": "stable",
@@ -415,7 +407,7 @@ func TestDeploymentPreflight(t *testing.T) {
 				"name":       "my-node-pool",
 				"type":       api.NodePoolResourceType.String(),
 				"location":   "eastus",
-				"apiVersion": "2024-06-10-preview",
+				"apiVersion": api.TestAPIVersion,
 				"properties": map[string]any{
 					"version": map[string]any{
 						"channelGroup": "stable",
@@ -433,7 +425,7 @@ func TestDeploymentPreflight(t *testing.T) {
 				"name":       "my-node-pool",
 				"type":       api.NodePoolResourceType.String(),
 				"location":   "eastus",
-				"apiVersion": "2024-06-10-preview",
+				"apiVersion": api.TestAPIVersion,
 				"properties": map[string]any{
 					"version": map[string]any{
 						"channelGroup": "stable",
@@ -461,14 +453,14 @@ func TestDeploymentPreflight(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			preflightPath := fmt.Sprintf("/subscriptions/%s/resourceGroups/myRG/providers/%s/deployments/myDeployment/preflight", subscriptionID, api.ProviderNamespace)
+			preflightPath := fmt.Sprintf("/subscriptions/%s/resourceGroups/myRG/providers/%s/deployments/myDeployment/preflight", api.TestSubscriptionID, api.ProviderNamespace)
 
 			ctrl := gomock.NewController(t)
 			mockDBClient := mocks.NewMockDBClient(ctrl)
 			reg := prometheus.NewRegistry()
 
 			f := NewFrontend(
-				testLogger,
+				api.NewTestLogger(),
 				nil,
 				nil,
 				reg,
@@ -479,14 +471,14 @@ func TestDeploymentPreflight(t *testing.T) {
 
 			// MiddlewareValidateSubscriptionState and MetricsMiddleware
 			mockDBClient.EXPECT().
-				GetSubscriptionDoc(gomock.Any(), subscriptionID).
+				GetSubscriptionDoc(gomock.Any(), api.TestSubscriptionID).
 				Return(&arm.Subscription{
 					State: arm.SubscriptionStateRegistered,
 				}, nil).
 				MaxTimes(2)
 
 			subs := map[string]*arm.Subscription{
-				subscriptionID: &arm.Subscription{
+				api.TestSubscriptionID: &arm.Subscription{
 					State: arm.SubscriptionStateRegistered,
 				},
 			}
@@ -574,7 +566,7 @@ func TestRequestAdminCredential(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			clusterResourceID := newClusterResourceID(t)
 			clusterInternalID := newClusterInternalID(t)
-			pk := database.NewPartitionKey(subscriptionID)
+			pk := database.NewPartitionKey(api.TestSubscriptionID)
 
 			requestPath := path.Join(clusterResourceID.String(), "requestAdminCredential")
 
@@ -584,7 +576,7 @@ func TestRequestAdminCredential(t *testing.T) {
 			mockCSClient := mocks.NewMockClusterServiceClientSpec(ctrl)
 
 			f := NewFrontend(
-				testLogger,
+				api.NewTestLogger(),
 				nil,
 				nil,
 				reg,
@@ -595,7 +587,7 @@ func TestRequestAdminCredential(t *testing.T) {
 
 			// MiddlewareValidateSubscriptionState and MetricsMiddleware
 			mockDBClient.EXPECT().
-				GetSubscriptionDoc(gomock.Any(), subscriptionID).
+				GetSubscriptionDoc(gomock.Any(), api.TestSubscriptionID).
 				Return(&arm.Subscription{
 					State: arm.SubscriptionStateRegistered,
 				}, nil).
@@ -653,13 +645,13 @@ func TestRequestAdminCredential(t *testing.T) {
 			}
 
 			subs := map[string]*arm.Subscription{
-				subscriptionID: &arm.Subscription{
+				api.TestSubscriptionID: &arm.Subscription{
 					State: arm.SubscriptionStateRegistered,
 				},
 			}
 			ts := newHTTPServer(f, ctrl, mockDBClient, subs)
 
-			url := ts.URL + requestPath + "?api-version=" + apiVersion
+			url := ts.URL + requestPath + "?api-version=" + api.TestAPIVersion
 			resp, err := ts.Client().Post(url, "", nil)
 			require.NoError(t, err)
 
@@ -710,7 +702,7 @@ func TestRevokeCredentials(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			clusterResourceID := newClusterResourceID(t)
 			clusterInternalID := newClusterInternalID(t)
-			pk := database.NewPartitionKey(subscriptionID)
+			pk := database.NewPartitionKey(api.TestSubscriptionID)
 
 			requestPath := path.Join(clusterResourceID.String(), "revokeCredentials")
 
@@ -720,7 +712,7 @@ func TestRevokeCredentials(t *testing.T) {
 			mockCSClient := mocks.NewMockClusterServiceClientSpec(ctrl)
 
 			f := NewFrontend(
-				testLogger,
+				api.NewTestLogger(),
 				nil,
 				nil,
 				reg,
@@ -731,7 +723,7 @@ func TestRevokeCredentials(t *testing.T) {
 
 			// MiddlewareValidateSubscriptionState and MetricsMiddleware
 			mockDBClient.EXPECT().
-				GetSubscriptionDoc(gomock.Any(), subscriptionID).
+				GetSubscriptionDoc(gomock.Any(), api.TestSubscriptionID).
 				Return(&arm.Subscription{
 					State: arm.SubscriptionStateRegistered,
 				}, nil).
@@ -814,13 +806,13 @@ func TestRevokeCredentials(t *testing.T) {
 			}
 
 			subs := map[string]*arm.Subscription{
-				subscriptionID: &arm.Subscription{
+				api.TestSubscriptionID: &arm.Subscription{
 					State: arm.SubscriptionStateRegistered,
 				},
 			}
 			ts := newHTTPServer(f, ctrl, mockDBClient, subs)
 
-			url := ts.URL + requestPath + "?api-version=" + apiVersion
+			url := ts.URL + requestPath + "?api-version=" + api.TestAPIVersion
 			resp, err := ts.Client().Post(url, "", nil)
 			require.NoError(t, err)
 
@@ -925,7 +917,7 @@ func newHTTPServer(f *Frontend, ctrl *gomock.Controller, mockDBClient *mocks.Moc
 	// executed here.
 	stop := make(chan struct{})
 	close(stop)
-	f.collector.Run(testLogger, stop)
+	f.collector.Run(api.NewTestLogger(), stop)
 
 	return ts
 }

--- a/frontend/pkg/frontend/helpers_test.go
+++ b/frontend/pkg/frontend/helpers_test.go
@@ -13,15 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/mocks"
 )
 
 func TestCheckForProvisioningStateConflict(t *testing.T) {
-	const clusterResourceID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/testCluster"
-	const nodePoolResourceID = clusterResourceID + "/nodePools/testNodePool"
-
 	tests := []struct {
 		name             string
 		resourceID       string
@@ -31,51 +29,51 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 	}{
 		{
 			name:             "Create cluster",
-			resourceID:       clusterResourceID,
+			resourceID:       api.TestClusterResourceID,
 			operationRequest: database.OperationRequestCreate,
 			directConflict:   func(s arm.ProvisioningState) bool { return false },
 		},
 		{
 			name:             "Delete cluster",
-			resourceID:       clusterResourceID,
+			resourceID:       api.TestClusterResourceID,
 			operationRequest: database.OperationRequestDelete,
 			directConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
 		},
 		{
 			name:             "Update cluster",
-			resourceID:       clusterResourceID,
+			resourceID:       api.TestClusterResourceID,
 			operationRequest: database.OperationRequestUpdate,
 			directConflict:   func(s arm.ProvisioningState) bool { return !s.IsTerminal() },
 		},
 		{
 			name:             "Request cluster credential",
-			resourceID:       clusterResourceID,
+			resourceID:       api.TestClusterResourceID,
 			operationRequest: database.OperationRequestRequestCredential,
 			directConflict:   func(s arm.ProvisioningState) bool { return !s.IsTerminal() },
 		},
 		{
 			name:             "Revoke cluster credentials",
-			resourceID:       clusterResourceID,
+			resourceID:       api.TestClusterResourceID,
 			operationRequest: database.OperationRequestRevokeCredentials,
 			directConflict:   func(s arm.ProvisioningState) bool { return !s.IsTerminal() },
 		},
 		{
 			name:             "Create node pool",
-			resourceID:       nodePoolResourceID,
+			resourceID:       api.TestNodePoolResourceID,
 			operationRequest: database.OperationRequestCreate,
 			directConflict:   func(s arm.ProvisioningState) bool { return false },
 			parentConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
 		},
 		{
 			name:             "Delete node pool",
-			resourceID:       nodePoolResourceID,
+			resourceID:       api.TestNodePoolResourceID,
 			operationRequest: database.OperationRequestDelete,
 			directConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
 			parentConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
 		},
 		{
 			name:             "Update node pool",
-			resourceID:       nodePoolResourceID,
+			resourceID:       api.TestNodePoolResourceID,
 			operationRequest: database.OperationRequestUpdate,
 			directConflict:   func(s arm.ProvisioningState) bool { return !s.IsTerminal() },
 			parentConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
@@ -91,7 +89,7 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 		for provisioningState := range arm.ListProvisioningStates() {
 			name = fmt.Sprintf("%s (provisioningState=%s)", tt.name, provisioningState)
 			t.Run(name, func(t *testing.T) {
-				ctx := ContextWithLogger(context.Background(), testLogger)
+				ctx := ContextWithLogger(context.Background(), api.NewTestLogger())
 				ctrl := gomock.NewController(t)
 				mockDBClient := mocks.NewMockDBClient(ctrl)
 
@@ -130,7 +128,7 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 			for provisioningState := range arm.ListProvisioningStates() {
 				name = fmt.Sprintf("%s (parent provisioningState=%s)", tt.name, provisioningState)
 				t.Run(name, func(t *testing.T) {
-					ctx := ContextWithLogger(context.Background(), testLogger)
+					ctx := ContextWithLogger(context.Background(), api.NewTestLogger())
 					ctrl := gomock.NewController(t)
 					mockDBClient := mocks.NewMockDBClient(ctrl)
 

--- a/frontend/pkg/frontend/helpers_test.go
+++ b/frontend/pkg/frontend/helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -85,9 +86,7 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 		var name string
 
 		resourceID, err := azcorearm.ParseResourceID(tt.resourceID)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		for provisioningState := range arm.ListProvisioningStates() {
 			name = fmt.Sprintf("%s (provisioningState=%s)", tt.name, provisioningState)

--- a/frontend/pkg/frontend/middleware_correlation_test.go
+++ b/frontend/pkg/frontend/middleware_correlation_test.go
@@ -148,17 +148,9 @@ func TestMiddlewareCorrelation(t *testing.T) {
 
 			// Check that the correlation data was found in the next handler.
 			assert.NotNil(t, data)
-			if data.RequestID.String() == "" {
-				t.Fatalf("got empty request ID in the context")
-			}
-
-			if data.CorrelationRequestID != tt.expectedCorrelationID {
-				t.Fatalf("expected correlation ID %q, got %q", tt.expectedCorrelationID, data.CorrelationRequestID)
-			}
-
-			if data.ClientRequestID != tt.expectedClientRequestID {
-				t.Fatalf("expected client request ID %q, got %q", tt.expectedClientRequestID, data.ClientRequestID)
-			}
+			assert.NotEmpty(t, data.RequestID.String())
+			assert.Equal(t, tt.expectedCorrelationID, data.CorrelationRequestID)
+			assert.Equal(t, tt.expectedClientRequestID, data.ClientRequestID)
 
 			// Check that the contextual logger had the expected attributes.
 			lines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")

--- a/frontend/pkg/frontend/middleware_logging.go
+++ b/frontend/pkg/frontend/middleware_logging.go
@@ -107,7 +107,7 @@ func (a *attributes) resourceID() string {
 	}
 
 	return fmt.Sprintf(
-		"/subscriptions/%s/resourcegroups/%s/providers/%s/%s",
+		"/subscriptions/%s/resourceGroups/%s/providers/%s/%s",
 		a.subscriptionID,
 		a.resourceGroup,
 		api.ClusterResourceType,

--- a/frontend/pkg/frontend/middleware_logging_test.go
+++ b/frontend/pkg/frontend/middleware_logging_test.go
@@ -3,7 +3,6 @@ package frontend
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -26,10 +25,6 @@ func noModifyReqfunc(req *http.Request) {
 }
 
 func TestMiddlewareLoggingPostMux(t *testing.T) {
-	fakeSubscriptionId := "the_subscription_id"
-	fakeResourceGroupName := "the_resource_group_name"
-	fakeResourceName := "the_resource_name"
-
 	type testCase struct {
 		name            string
 		wantLogAttrs    []slog.Attr
@@ -45,49 +40,42 @@ func TestMiddlewareLoggingPostMux(t *testing.T) {
 		},
 		{
 			name:          "handles the common attributes and the attributes for the subscription_id segment path",
-			wantLogAttrs:  []slog.Attr{slog.String("subscription_id", fakeSubscriptionId)},
-			wantSpanAttrs: map[string]string{"aro.subscription.id": fakeSubscriptionId},
+			wantLogAttrs:  []slog.Attr{slog.String("subscription_id", api.TestSubscriptionID)},
+			wantSpanAttrs: map[string]string{"aro.subscription.id": api.TestSubscriptionID},
 			setReqPathValue: func(req *http.Request) {
-				req.SetPathValue(PathSegmentSubscriptionID, fakeSubscriptionId)
+				req.SetPathValue(PathSegmentSubscriptionID, api.TestSubscriptionID)
 			},
 		},
 		{
 			name:          "handles the common attributes and the attributes for the resourcegroupname path",
-			wantLogAttrs:  []slog.Attr{slog.String("resource_group", fakeResourceGroupName)},
-			wantSpanAttrs: map[string]string{"aro.resource_group.name": fakeResourceGroupName},
+			wantLogAttrs:  []slog.Attr{slog.String("resource_group", api.TestResourceGroupName)},
+			wantSpanAttrs: map[string]string{"aro.resource_group.name": api.TestResourceGroupName},
 			setReqPathValue: func(req *http.Request) {
-				req.SetPathValue(PathSegmentResourceGroupName, fakeResourceGroupName)
+				req.SetPathValue(PathSegmentResourceGroupName, api.TestResourceGroupName)
 			},
 		},
 		{
 			name: "handles the common attributes and the attributes for the resourcename path, and produces the correct resourceID attribute",
 			wantLogAttrs: []slog.Attr{
-				slog.String("subscription_id", fakeSubscriptionId),
-				slog.String("resource_group", fakeResourceGroupName),
-				slog.String("resource_name", fakeResourceName),
-				slog.String(
-					"resource_id",
-					fmt.Sprintf(
-						"/subscriptions/%s/resourcegroups/%s/providers/%s/%s",
-						fakeSubscriptionId,
-						fakeResourceGroupName,
-						api.ClusterResourceType,
-						fakeResourceName)),
+				slog.String("subscription_id", api.TestSubscriptionID),
+				slog.String("resource_group", api.TestResourceGroupName),
+				slog.String("resource_name", api.TestClusterName),
+				slog.String("resource_id", api.TestClusterResourceID),
 			},
 			wantSpanAttrs: map[string]string{
-				"aro.subscription.id":     fakeSubscriptionId,
-				"aro.resource_group.name": fakeResourceGroupName,
-				"aro.resource.name":       fakeResourceName,
+				"aro.subscription.id":     api.TestSubscriptionID,
+				"aro.resource_group.name": api.TestResourceGroupName,
+				"aro.resource.name":       api.TestClusterName,
 			},
 			setReqPathValue: func(req *http.Request) {
 				// assuming the PathSegmentResourceName is present in the Path
-				req.SetPathValue(PathSegmentResourceName, fakeResourceName)
+				req.SetPathValue(PathSegmentResourceName, api.TestClusterName)
 
 				// assuming the PathSegmentSubscriptionID is present in the Path
-				req.SetPathValue(PathSegmentSubscriptionID, fakeSubscriptionId)
+				req.SetPathValue(PathSegmentSubscriptionID, api.TestSubscriptionID)
 
 				// assuming the PathSegmentResourceGroupName is present in the Path
-				req.SetPathValue(PathSegmentResourceGroupName, fakeResourceGroupName)
+				req.SetPathValue(PathSegmentResourceGroupName, api.TestResourceGroupName)
 			},
 		},
 	}

--- a/frontend/pkg/frontend/middleware_lowercase_test.go
+++ b/frontend/pkg/frontend/middleware_lowercase_test.go
@@ -7,15 +7,16 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMiddlewareLowercase(t *testing.T) {
 	writer := httptest.NewRecorder()
 
 	request, err := http.NewRequest(http.MethodGet, "/TEST", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	next := func(w http.ResponseWriter, r *http.Request) {
 		request = r // capture modified request
@@ -23,15 +24,10 @@ func TestMiddlewareLowercase(t *testing.T) {
 
 	MiddlewareLowercase(writer, request, next)
 
-	if request.URL.Path != "/test" {
-		t.Error(request.URL.Path)
-	}
+	assert.Equal(t, "/test", request.URL.Path)
 
 	originalPath, err := OriginalPathFromContext(request.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if originalPath != "/TEST" {
-		t.Error(originalPath)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "/TEST", originalPath)
 	}
 }

--- a/frontend/pkg/frontend/middleware_resourceid_test.go
+++ b/frontend/pkg/frontend/middleware_resourceid_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
@@ -28,8 +29,8 @@ func TestMiddlewareResourceID(t *testing.T) {
 			name: "subscription resource",
 			path: "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000",
 			resourceTypes: []string{
-				"Microsoft.Resources/subscriptions",
-				"Microsoft.Resources/tenants",
+				azcorearm.SubscriptionResourceType.String(),
+				azcorearm.TenantResourceType.String(),
 			},
 		},
 		{
@@ -37,9 +38,9 @@ func TestMiddlewareResourceID(t *testing.T) {
 			path: "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/MyResourceGroup/PROVIDERS/MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS/myCluster",
 			resourceTypes: []string{
 				"MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS",
-				"Microsoft.Resources/resourceGroups",
-				"Microsoft.Resources/subscriptions",
-				"Microsoft.Resources/tenants",
+				azcorearm.ResourceGroupResourceType.String(),
+				azcorearm.SubscriptionResourceType.String(),
+				azcorearm.TenantResourceType.String(),
 			},
 		},
 		{
@@ -49,9 +50,9 @@ func TestMiddlewareResourceID(t *testing.T) {
 			resourceTypes: []string{
 				"MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS/myAction",
 				"MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS",
-				"Microsoft.Resources/resourceGroups",
-				"Microsoft.Resources/subscriptions",
-				"Microsoft.Resources/tenants",
+				azcorearm.ResourceGroupResourceType.String(),
+				azcorearm.SubscriptionResourceType.String(),
+				azcorearm.TenantResourceType.String(),
 			},
 		},
 		{
@@ -60,9 +61,9 @@ func TestMiddlewareResourceID(t *testing.T) {
 			resourceTypes: []string{
 				"MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS/NODEPOOLS",
 				"MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS",
-				"Microsoft.Resources/resourceGroups",
-				"Microsoft.Resources/subscriptions",
-				"Microsoft.Resources/tenants",
+				azcorearm.ResourceGroupResourceType.String(),
+				azcorearm.SubscriptionResourceType.String(),
+				azcorearm.TenantResourceType.String(),
 			},
 		},
 		{
@@ -71,9 +72,9 @@ func TestMiddlewareResourceID(t *testing.T) {
 			resourceTypes: []string{
 				"MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS/NODEPOOLS",
 				"MICROSOFT.REDHATOPENSHIFT/HCPOPENSHIFTCLUSTERS",
-				"Microsoft.Resources/resourceGroups",
-				"Microsoft.Resources/subscriptions",
-				"Microsoft.Resources/tenants",
+				azcorearm.ResourceGroupResourceType.String(),
+				azcorearm.SubscriptionResourceType.String(),
+				azcorearm.TenantResourceType.String(),
 			},
 		},
 		{
@@ -81,9 +82,9 @@ func TestMiddlewareResourceID(t *testing.T) {
 			path: "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/MyResourceGroup/PROVIDERS/MICROSOFT.REDHATOPENSHIFT/DEPLOYMENTS/preflight",
 			resourceTypes: []string{
 				"MICROSOFT.REDHATOPENSHIFT/DEPLOYMENTS",
-				"Microsoft.Resources/resourceGroups",
-				"Microsoft.Resources/subscriptions",
-				"Microsoft.Resources/tenants",
+				azcorearm.ResourceGroupResourceType.String(),
+				azcorearm.SubscriptionResourceType.String(),
+				azcorearm.TenantResourceType.String(),
 			},
 		},
 		{
@@ -92,8 +93,8 @@ func TestMiddlewareResourceID(t *testing.T) {
 			resourceTypes: []string{
 				"MICROSOFT.REDHATOPENSHIFT/LOCATIONS/HCPOPERATIONSSTATUS",
 				"MICROSOFT.REDHATOPENSHIFT/LOCATIONS",
-				"Microsoft.Resources/subscriptions",
-				"Microsoft.Resources/tenants",
+				azcorearm.SubscriptionResourceType.String(),
+				azcorearm.TenantResourceType.String(),
 			},
 		},
 		{

--- a/frontend/pkg/frontend/middleware_systemdata_test.go
+++ b/frontend/pkg/frontend/middleware_systemdata_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
@@ -29,9 +30,7 @@ func TestMiddlewareSystemData(t *testing.T) {
 }`
 
 	timestamp, err := time.Parse(time.RFC3339, "2024-01-01T12:34:54.0000000Z")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	tests := []struct {
 		name               string
@@ -67,9 +66,7 @@ func TestMiddlewareSystemData(t *testing.T) {
 			writer := httptest.NewRecorder()
 
 			request, err := http.NewRequest(http.MethodPut, "", bytes.NewReader([]byte("")))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			if tt.systemData != "" {
 				request.Header = http.Header{

--- a/frontend/pkg/frontend/node_pool_test.go
+++ b/frontend/pkg/frontend/node_pool_test.go
@@ -4,8 +4,6 @@ package frontend
 // Licensed under the Apache License 2.0.
 
 import (
-	// This will invoke the init() function in each
-	// API version package so it can register itself.
 	"bytes"
 	"context"
 	"encoding/json"
@@ -20,27 +18,20 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	// This will invoke the init() function in each
+	// API version package so it can register itself.
+	_ "github.com/Azure/ARO-HCP/internal/api/v20240610preview"
+
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	_ "github.com/Azure/ARO-HCP/internal/api/v20240610preview"
 	"github.com/Azure/ARO-HCP/internal/api/v20240610preview/generated"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/mocks"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 )
 
-const dummyTenantId = "dummy-tenant-id"
-const dummySubscriptionId = "00000000-0000-0000-0000-000000000000"
-const dummyResourceGroupId = "dummy_resource_group_name"
-const dummyClusterName = "dev-test-cluster"
-const dummyNodePoolName = "dev-nodepool"
-
-const dummyClusterID = ("/subscriptions/" + dummySubscriptionId + "/resourcegroups/" + dummyResourceGroupId +
-	"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + dummyClusterName)
-const dummyNodePoolID = dummyClusterID + "/nodePools/" + dummyNodePoolName
-
-var dummyClusterHREF = ocm.GenerateClusterHREF(dummyClusterName)
-var dummyNodePoolHREF = ocm.GenerateNodePoolHREF(dummyClusterHREF, dummyNodePoolName)
+var dummyClusterHREF = ocm.GenerateClusterHREF(api.TestClusterName)
+var dummyNodePoolHREF = ocm.GenerateNodePoolHREF(dummyClusterHREF, api.TestNodePoolName)
 
 var dummyLocation = "Spain"
 var dummyVMSize = "Big"
@@ -48,11 +39,11 @@ var dummyChannelGroup = "dummyChannelGroup"
 var dummyVersionID = "dummy"
 
 func TestCreateNodePool(t *testing.T) {
-	clusterResourceID, _ := azcorearm.ParseResourceID(dummyClusterID)
+	clusterResourceID, _ := azcorearm.ParseResourceID(api.TestClusterResourceID)
 	clusterDoc := database.NewResourceDocument(clusterResourceID)
 	clusterDoc.InternalID, _ = ocm.NewInternalID(dummyClusterHREF)
 
-	nodePoolResourceID, _ := azcorearm.ParseResourceID(dummyNodePoolID)
+	nodePoolResourceID, _ := azcorearm.ParseResourceID(api.TestNodePoolResourceID)
 	nodePoolDoc := database.NewResourceDocument(nodePoolResourceID)
 	nodePoolDoc.InternalID, _ = ocm.NewInternalID(dummyNodePoolHREF)
 
@@ -80,7 +71,7 @@ func TestCreateNodePool(t *testing.T) {
 	}{
 		{
 			name:    "PUT Node Pool - Create a new Node Pool",
-			urlPath: dummyNodePoolID + "?api-version=2024-06-10-preview",
+			urlPath: api.TestNodePoolResourceID + "?api-version=2024-06-10-preview",
 			subDoc: &arm.Subscription{
 				State:            arm.SubscriptionStateRegistered,
 				RegistrationDate: api.Ptr(time.Now().String()),
@@ -100,7 +91,7 @@ func TestCreateNodePool(t *testing.T) {
 			reg := prometheus.NewRegistry()
 
 			f := NewFrontend(
-				testLogger,
+				api.NewTestLogger(),
 				nil,
 				nil,
 				reg,
@@ -110,11 +101,11 @@ func TestCreateNodePool(t *testing.T) {
 			)
 
 			requestHeader := make(http.Header)
-			requestHeader.Add(arm.HeaderNameHomeTenantID, dummyTenantId)
+			requestHeader.Add(arm.HeaderNameHomeTenantID, api.TestTenantID)
 
 			body, _ := json.Marshal(requestBody)
 
-			subs := map[string]*arm.Subscription{dummySubscriptionId: test.subDoc}
+			subs := map[string]*arm.Subscription{api.TestSubscriptionID: test.subDoc}
 			ts := newHTTPServer(f, ctrl, mockDBClient, subs)
 
 			// CreateOrUpdateNodePool
@@ -134,7 +125,7 @@ func TestCreateNodePool(t *testing.T) {
 				GetLockClient()
 			// MiddlewareValidateSubscriptionState
 			mockDBClient.EXPECT().
-				GetSubscriptionDoc(gomock.Any(), dummySubscriptionId).
+				GetSubscriptionDoc(gomock.Any(), api.TestSubscriptionID).
 				Return(test.subDoc, nil).
 				Times(1)
 			// CreateOrUpdateNodePool
@@ -176,11 +167,11 @@ func TestCreateNodePool(t *testing.T) {
 // TODO: Fix the update logic for this test.
 
 // func TestUpdateNodePool(t *testing.T) {
-// 	clusterResourceID, _ := arm.ParseResourceID(dummyClusterID)
+// 	clusterResourceID, _ := arm.ParseResourceID(api.TestClusterResourceID)
 // 	clusterDoc := database.NewResourceDocument(clusterResourceID)
 // 	clusterDoc.InternalID, _ = ocm.NewInternalID(dummyClusterHREF)
 
-// 	nodePoolResourceID, _ := arm.ParseResourceID(dummyNodePoolID)
+// 	nodePoolResourceID, _ := arm.ParseResourceID(api.TestNodePoolResourceID)
 // 	nodePoolDoc := database.NewResourceDocument(nodePoolResourceID)
 // 	nodePoolDoc.InternalID, _ = ocm.NewInternalID(dummyNodePoolHREF)
 
@@ -209,7 +200,7 @@ func TestCreateNodePool(t *testing.T) {
 // 	}{
 // 		{
 // 			name:    "PUT Node Pool - Update an existing Node Pool",
-// 			urlPath: dummyNodePoolID + "?api-version=2024-06-10-preview",
+// 			urlPath: api.TestNodePoolResourceID + "?api-version=2024-06-10-preview",
 // 			subDoc: &arm.Subscription{
 // 				State:            arm.SubscriptionStateRegistered,
 // 				RegistrationDate: api.Ptr(time.Now().String()),
@@ -227,20 +218,20 @@ func TestCreateNodePool(t *testing.T) {
 // 		t.Run(test.name, func(t *testing.T) {
 // 			f := &Frontend{
 // 				dbClient:             database.NewCache(),
-// 				logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+// 				logger:               api.NewTestLogger(),
 // 				metrics:              NewPrometheusEmitter(),
 // 				clusterServiceClient: &mockCSClient,
 // 			}
 // 			hcpCluster := api.NewDefaultHCPOpenShiftCluster()
 // 			hcpCluster.Name = dummyCluster
-// 			csCluster, _ := f.BuildCSCluster(clusterResourceID, dummyTenantId, hcpCluster, false)
+// 			csCluster, _ := f.BuildCSCluster(clusterResourceID, api.TestTenantID, hcpCluster, false)
 
 // 			hcpNodePool := api.NewDefaultHCPOpenShiftClusterNodePool()
 // 			hcpNodePool.Name = dummyNodePool
 // 			csNodePool, _ := f.BuildCSNodePool(context.TODO(), hcpNodePool, false)
 
 // 			if test.subDoc != nil {
-// 				err := f.dbClient.CreateSubscriptionDoc(context.TODO(), dummySubscriptionId, test.subDoc)
+// 				err := f.dbClient.CreateSubscriptionDoc(context.TODO(), api.TestSubscriptionID, test.subDoc)
 // 				if err != nil {
 // 					t.Fatal(err)
 // 				}

--- a/frontend/pkg/frontend/node_pool_test.go
+++ b/frontend/pkg/frontend/node_pool_test.go
@@ -1,5 +1,8 @@
 package frontend
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	// This will invoke the init() function in each
 	// API version package so it can register itself.
@@ -154,9 +157,7 @@ func TestCreateNodePool(t *testing.T) {
 				CreateResourceDoc(gomock.Any(), gomock.Any())
 
 			req, err := http.NewRequest(http.MethodPut, ts.URL+test.urlPath, bytes.NewReader(body))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set(arm.HeaderNameARMResourceSystemData, "{}")
 

--- a/frontend/pkg/frontend/ocm_test.go
+++ b/frontend/pkg/frontend/ocm_test.go
@@ -175,7 +175,7 @@ func TestWithImmutableAttributes(t *testing.T) {
 }
 
 func testResourceID(t *testing.T) *azcorearm.ResourceID {
-	resourceID, err := azcorearm.ParseResourceID("/subscriptions/test/resourceGroups/test/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test")
+	resourceID, err := azcorearm.ParseResourceID(api.TestClusterResourceID)
 	require.NoError(t, err)
 	return resourceID
 }
@@ -184,9 +184,9 @@ func clusterResource(opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCl
 	c := &api.HCPOpenShiftCluster{
 		TrackedResource: arm.TrackedResource{
 			Resource: arm.Resource{
-				ID:   "/subscriptions/test/resourceGroups/test/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test",
-				Name: "test",
-				Type: "Microsoft.RedHatOpenShift/hcpOpenShiftClusters",
+				ID:   api.TestClusterResourceID,
+				Name: api.TestClusterName,
+				Type: api.ClusterResourceType.String(),
 			},
 		},
 		Properties: api.HCPOpenShiftClusterProperties{},

--- a/frontend/pkg/frontend/ocm_test.go
+++ b/frontend/pkg/frontend/ocm_test.go
@@ -1,5 +1,8 @@
 package frontend
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"bytes"
 	"context"
@@ -20,9 +23,6 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
 
-// Copyright (c) Microsoft Corporation.
-// Licensed under the Apache License 2.0.
-
 func TestRequestIDPropagator(t *testing.T) {
 	const testRequestID = "00000000-0000-0000-0000-000000000000"
 
@@ -36,41 +36,29 @@ func TestRequestIDPropagator(t *testing.T) {
 
 		ctx := context.Background()
 		r, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
+		require.NoError(t, err)
 		correlationData := arm.NewCorrelationData(r)
 		correlationData.RequestID = uuid.MustParse(testRequestID)
 		r = r.WithContext(ContextWithCorrelationData(ctx, correlationData))
 
 		rs, err := c.Do(r)
-		if err != nil {
-			t.Fatalf("unexpected error from server: %s", err)
-		}
+		require.NoError(t, err)
 
-		if rs.StatusCode != http.StatusOK {
-			t.Fatalf("unexpected status code: %d", rs.StatusCode)
-		}
+		require.Equal(t, http.StatusOK, rs.StatusCode)
 
 		b, err := io.ReadAll(rs.Body)
-		if err != nil {
-			t.Fatalf("unexpected error reading response: %s", err)
-		}
+		require.NoError(t, err)
 
 		return string(b)
 	}
 
 	// Without the transport wrapper, the request ID isn't echoed.
 	c := ts.Client()
-	if ret := do(c); ret != "" {
-		t.Fatalf("expecting an empty response, got %q", ret)
-	}
+	assert.Empty(t, do(c))
 
 	// With the transport wrapper, the request ID is echoed.
 	c.Transport = RequestIDPropagator(c.Transport)
-	if ret := do(c); ret != testRequestID {
-		t.Fatalf("expecting %q, got %q", testRequestID, ret)
-	}
+	assert.Equal(t, testRequestID, do(c))
 }
 
 func TestConvertCStoHCPOpenShiftCluster(t *testing.T) {

--- a/frontend/pkg/metrics/metrics_test.go
+++ b/frontend/pkg/metrics/metrics_test.go
@@ -6,8 +6,6 @@ package metrics
 import (
 	"bytes"
 	"errors"
-	"io"
-	"log/slog"
 	"maps"
 	"testing"
 	"time"
@@ -24,7 +22,7 @@ import (
 )
 
 func TestSubscriptionCollector(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := api.NewTestLogger()
 	nosubs := maps.All(map[string]*arm.Subscription{})
 	subs := maps.All(map[string]*arm.Subscription{
 		"00000000-0000-0000-0000-000000000000": &arm.Subscription{

--- a/internal/api/arm/correlation_test.go
+++ b/internal/api/arm/correlation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewCorrelationData(t *testing.T) {
@@ -32,17 +33,9 @@ func TestNewCorrelationData(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			correlationData := NewCorrelationData(tt.request)
 
-			if correlationData.RequestID == uuid.Nil {
-				t.Fatalf("correlationData.RequestID is nil")
-			}
-
-			if correlationData.ClientRequestID != client_request_id {
-				t.Errorf("got %v, but want %v", correlationData.ClientRequestID, client_request_id)
-			}
-
-			if correlationData.CorrelationRequestID != correlation_request_id {
-				t.Errorf("got %v, but want %v", correlationData.CorrelationRequestID, correlation_request_id)
-			}
+			assert.NotEqual(t, uuid.Nil, correlationData.RequestID)
+			assert.Equal(t, client_request_id, correlationData.ClientRequestID)
+			assert.Equal(t, correlation_request_id, correlationData.CorrelationRequestID)
 		})
 	}
 }

--- a/internal/api/arm/error_test.go
+++ b/internal/api/arm/error_test.go
@@ -1,6 +1,13 @@
 package arm
 
-import "testing"
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestCloudErrorBody_String(t *testing.T) {
 	tests := []struct {
@@ -51,10 +58,7 @@ func TestCloudErrorBody_String(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := test.body.String()
-			if test.expected != actual {
-				t.Errorf("expected: %v\ngot: %v", test.expected, actual)
-			}
+			assert.Equal(t, test.expected, test.body.String())
 		})
 	}
 }

--- a/internal/api/arm/response_test.go
+++ b/internal/api/arm/response_test.go
@@ -17,8 +17,8 @@ func TestWriteJSONResponse(t *testing.T) {
 	resourceStruct := &TrackedResource{
 		Resource: Resource{
 			ID:   "00000000-0000-0000-0000-000000000000",
-			Name: "testCluster",
-			Type: "Microsoft.RedHatOpenShift/hcpOpenShiftClusters",
+			Name: "testVM",
+			Type: "Microsoft.Compute/virtualMachines",
 		},
 		Location: "eastus1",
 		Tags: map[string]string{

--- a/internal/api/arm/subscription.go
+++ b/internal/api/arm/subscription.go
@@ -7,6 +7,9 @@ import (
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 )
 
+// SubscriptionAPIVersion is the system API version for the subscription endpoint.
+const SubscriptionAPIVersion = "2.0"
+
 type Subscription struct {
 	// The resource provider contract gives an example RegistrationDate
 	// in RFC1123 format but does not explicitly state a required format

--- a/internal/api/hcpopenshiftcluster_test.go
+++ b/internal/api/hcpopenshiftcluster_test.go
@@ -11,6 +11,7 @@ import (
 	validator "github.com/go-playground/validator/v10"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
@@ -324,9 +325,7 @@ func TestClusterValidateTags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resource := minimumValidCluster()
 			err := mergo.Merge(resource, tt.tweaks, mergo.WithOverride)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			actualErrors := ValidateRequest(validate, http.MethodPut, resource)
 

--- a/internal/api/hcpopenshiftclusternodepool_test.go
+++ b/internal/api/hcpopenshiftclusternodepool_test.go
@@ -7,25 +7,8 @@ import (
 	"net/http"
 	"testing"
 
-	"dario.cat/mergo"
-	"github.com/stretchr/testify/require"
-
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
-
-func minimumValidNodePool() *HCPOpenShiftClusterNodePool {
-	// Values are meaningless but need to pass validation.
-	return &HCPOpenShiftClusterNodePool{
-		Properties: HCPOpenShiftClusterNodePoolProperties{
-			Version: NodePoolVersionProfile{
-				ChannelGroup: "stable",
-			},
-			Platform: NodePoolPlatformProfile{
-				VMSize: "Standard_D8s_v3",
-			},
-		},
-	}
-}
 
 func TestNodePoolRequiredForPut(t *testing.T) {
 	tests := []struct {
@@ -55,12 +38,11 @@ func TestNodePoolRequiredForPut(t *testing.T) {
 		},
 		{
 			name:     "Minimum valid node pool",
-			resource: minimumValidNodePool(),
+			resource: MinimumValidNodePoolTestCase(),
 		},
 	}
 
-	// from hcpopenshiftcluster_test.go
-	validate := newTestValidator()
+	validate := NewTestValidator()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -145,14 +127,11 @@ func TestNodePoolValidateTags(t *testing.T) {
 		},
 	}
 
-	// from hcpopenshiftcluster_test.go
-	validate := newTestValidator()
+	validate := NewTestValidator()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resource := minimumValidNodePool()
-			err := mergo.Merge(resource, tt.tweaks, mergo.WithOverride)
-			require.NoError(t, err)
+			resource := NodePoolTestCase(t, tt.tweaks)
 
 			actualErrors := ValidateRequest(validate, http.MethodPut, resource)
 

--- a/internal/api/hcpopenshiftclusternodepool_test.go
+++ b/internal/api/hcpopenshiftclusternodepool_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"dario.cat/mergo"
+	"github.com/stretchr/testify/require"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
@@ -151,9 +152,7 @@ func TestNodePoolValidateTags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resource := minimumValidNodePool()
 			err := mergo.Merge(resource, tt.tweaks, mergo.WithOverride)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			actualErrors := ValidateRequest(validate, http.MethodPut, resource)
 

--- a/internal/api/registry_test.go
+++ b/internal/api/registry_test.go
@@ -53,11 +53,11 @@ func TestGetJSONTagName(t *testing.T) {
 	}
 }
 
-type TestAPIVersion struct {
+type TestAPIVersionTag struct {
 	APIVersion string `validate:"api_version"`
 }
 
-type TestRequiredForPut struct {
+type TestRequiredForPutTag struct {
 	StructField any `json:"field" validate:"required_for_put"`
 }
 
@@ -78,7 +78,7 @@ func TestNewValidator(t *testing.T) {
 			name: "Validation passes on known API version",
 			context: validateContext{
 				Method: http.MethodPost, // not relevant
-				Resource: TestAPIVersion{
+				Resource: TestAPIVersionTag{
 					APIVersion: "valid-api-version",
 				},
 			},
@@ -87,7 +87,7 @@ func TestNewValidator(t *testing.T) {
 			name: "Validation fails on unknown API version",
 			context: validateContext{
 				Method: http.MethodPost, // not relevant
-				Resource: TestAPIVersion{
+				Resource: TestAPIVersionTag{
 					APIVersion: "bogus-api-version",
 				},
 			},
@@ -104,7 +104,7 @@ func TestNewValidator(t *testing.T) {
 			name: "Zero value on required field is error when method is PUT",
 			context: validateContext{
 				Method: http.MethodPut,
-				Resource: TestRequiredForPut{
+				Resource: TestRequiredForPutTag{
 					StructField: int(0),
 				},
 			},
@@ -114,7 +114,7 @@ func TestNewValidator(t *testing.T) {
 			name: "Zero value on required field is ok when method is not PUT",
 			context: validateContext{
 				Method: http.MethodGet,
-				Resource: TestRequiredForPut{
+				Resource: TestRequiredForPutTag{
 					StructField: int(0),
 				},
 			},
@@ -123,7 +123,7 @@ func TestNewValidator(t *testing.T) {
 			name: "Validation fails on nil slice",
 			context: validateContext{
 				Method: http.MethodPut,
-				Resource: TestRequiredForPut{
+				Resource: TestRequiredForPutTag{
 					StructField: nilSlice,
 				},
 			},
@@ -133,7 +133,7 @@ func TestNewValidator(t *testing.T) {
 			name: "Validation passes on empty slice",
 			context: validateContext{
 				Method: http.MethodPut,
-				Resource: TestRequiredForPut{
+				Resource: TestRequiredForPutTag{
 					StructField: []int{},
 				},
 			},
@@ -142,7 +142,7 @@ func TestNewValidator(t *testing.T) {
 			name: "Validation fails on nil map",
 			context: validateContext{
 				Method: http.MethodPut,
-				Resource: TestRequiredForPut{
+				Resource: TestRequiredForPutTag{
 					StructField: nilMap,
 				},
 			},
@@ -152,7 +152,7 @@ func TestNewValidator(t *testing.T) {
 			name: "Validation passes on empty map",
 			context: validateContext{
 				Method: http.MethodPut,
-				Resource: TestRequiredForPut{
+				Resource: TestRequiredForPutTag{
 					StructField: map[int]int{},
 				},
 			},
@@ -161,7 +161,7 @@ func TestNewValidator(t *testing.T) {
 			name: "Validation fails on nil pointer",
 			context: validateContext{
 				Method: http.MethodPut,
-				Resource: TestRequiredForPut{
+				Resource: TestRequiredForPutTag{
 					StructField: nilPointer,
 				},
 			},
@@ -172,7 +172,7 @@ func TestNewValidator(t *testing.T) {
 			name: "Validation fails on pointer to zero value",
 			context: validateContext{
 				Method: http.MethodPut,
-				Resource: TestRequiredForPut{
+				Resource: TestRequiredForPutTag{
 					StructField: Ptr(nilSlice),
 				},
 			},
@@ -183,7 +183,7 @@ func TestNewValidator(t *testing.T) {
 			name: "Validation passes on pointer to non-zero value",
 			context: validateContext{
 				Method: http.MethodPut,
-				Resource: TestRequiredForPut{
+				Resource: TestRequiredForPutTag{
 					StructField: Ptr([]int{}),
 				},
 			},

--- a/internal/api/testhelpers.go
+++ b/internal/api/testhelpers.go
@@ -1,0 +1,97 @@
+package api
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"io"
+	"log/slog"
+	"path"
+	"testing"
+
+	"dario.cat/mergo"
+	validator "github.com/go-playground/validator/v10"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+// The definitions in this file are meant for unit tests.
+
+const (
+	TestAPIVersion        = "2024-06-10-preview"
+	TestTenantID          = "00000000-0000-0000-0000-000000000000"
+	TestSubscriptionID    = "11111111-1111-1111-1111-111111111111"
+	TestResourceGroupName = "testResourceGroup"
+	TestClusterName       = "testCluster"
+	TestNodePoolName      = "testNodePool"
+)
+
+var (
+	TestGroupResourceID    = path.Join("/subscriptions", TestSubscriptionID, "resourceGroups", TestResourceGroupName)
+	TestClusterResourceID  = path.Join(TestGroupResourceID, "providers", ProviderNamespace, ClusterResourceTypeName, TestClusterName)
+	TestNodePoolResourceID = path.Join(TestClusterResourceID, NodePoolResourceTypeName, TestNodePoolName)
+)
+
+func NewTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func NewTestValidator() *validator.Validate {
+	validate := NewValidator()
+
+	validate.RegisterAlias("enum_diskstorageaccounttype", EnumValidateTag(
+		DiskStorageAccountTypePremium_LRS,
+		DiskStorageAccountTypeStandardSSD_LRS,
+		DiskStorageAccountTypeStandard_LRS))
+	validate.RegisterAlias("enum_effect", EnumValidateTag(
+		EffectNoExecute,
+		EffectNoSchedule,
+		EffectPreferNoSchedule))
+	validate.RegisterAlias("enum_networktype", EnumValidateTag(
+		NetworkTypeOVNKubernetes,
+		NetworkTypeOther))
+	validate.RegisterAlias("enum_outboundtype", EnumValidateTag(
+		OutboundTypeLoadBalancer))
+	validate.RegisterAlias("enum_visibility", EnumValidateTag(
+		VisibilityPublic,
+		VisibilityPrivate))
+	validate.RegisterAlias("enum_managedserviceidentitytype", EnumValidateTag(
+		arm.ManagedServiceIdentityTypeNone,
+		arm.ManagedServiceIdentityTypeSystemAssigned,
+		arm.ManagedServiceIdentityTypeSystemAssignedUserAssigned,
+		arm.ManagedServiceIdentityTypeUserAssigned))
+	validate.RegisterAlias("enum_optionalclustercapability", EnumValidateTag(
+		OptionalClusterCapabilityImageRegistry))
+
+	return validate
+}
+
+func NewTestUserAssignedIdentity(name string) string {
+	return path.Join(TestGroupResourceID, "providers", "Microsoft.ManagedIdentity", "userAssignedIdentities", name)
+}
+
+func MinimumValidClusterTestCase() *HCPOpenShiftCluster {
+	resource := NewDefaultHCPOpenShiftCluster()
+	resource.Properties.Platform.SubnetID = path.Join(TestGroupResourceID, "providers", "Microsoft.Network", "virtualNetworks", "testVirtualNetwork", "subnets")
+	resource.Properties.Platform.NetworkSecurityGroupID = path.Join(TestGroupResourceID, "providers", "Microsoft.Network", "networkSecurityGroups", "testNetworkSecurityGroup")
+	return resource
+}
+
+func ClusterTestCase(t *testing.T, tweaks *HCPOpenShiftCluster) *HCPOpenShiftCluster {
+	resource := MinimumValidClusterTestCase()
+	require.NoError(t, mergo.Merge(resource, tweaks, mergo.WithOverride))
+	return resource
+}
+
+func MinimumValidNodePoolTestCase() *HCPOpenShiftClusterNodePool {
+	resource := NewDefaultHCPOpenShiftClusterNodePool()
+	resource.Properties.Platform.VMSize = "Standard_D8s_v3"
+	return resource
+}
+
+func NodePoolTestCase(t *testing.T, tweaks *HCPOpenShiftClusterNodePool) *HCPOpenShiftClusterNodePool {
+	nodePool := MinimumValidNodePoolTestCase()
+	require.NoError(t, mergo.Merge(nodePool, tweaks, mergo.WithOverride))
+	return nodePool
+}

--- a/internal/api/visibility_test.go
+++ b/internal/api/visibility_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVisibilityFlags(t *testing.T) {
@@ -72,18 +72,10 @@ func TestVisibilityFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			flags, _ := GetVisibilityFlags(tt.tag)
-			if flags.String() != tt.expectString {
-				t.Errorf("Expected flags.String() to be %q, got %q", tt.expectString, flags.String())
-			}
-			if flags.ReadOnly() != tt.expectReadOnly {
-				t.Errorf("Expected flags.ReadOnly() to be %v, got %v", tt.expectReadOnly, flags.ReadOnly())
-			}
-			if flags.CanUpdate() != tt.expectCanUpdate {
-				t.Errorf("Expected flags.CanUpdate() to be %v, got %v", tt.expectCanUpdate, flags.CanUpdate())
-			}
-			if flags.CaseInsensitive() != tt.expectCaseInsensitive {
-				t.Errorf("Expected flags.CaseInsensitive() to be %v, got %v", tt.expectCaseInsensitive, flags.CaseInsensitive())
-			}
+			assert.Equal(t, tt.expectString, flags.String())
+			assert.Equal(t, tt.expectReadOnly, flags.ReadOnly())
+			assert.Equal(t, tt.expectCanUpdate, flags.CanUpdate())
+			assert.Equal(t, tt.expectCaseInsensitive, flags.CaseInsensitive())
 		})
 	}
 }
@@ -147,11 +139,7 @@ func TestStructTagMap(t *testing.T) {
 	}
 
 	// The test cases are encoded into the type itself.
-	if !cmp.Equal(TestModelTypeStructTagMap, expectedStructTagMap, nil) {
-		t.Errorf(
-			"StructTagMap had unexpected differences:\n%s",
-			cmp.Diff(expectedStructTagMap, TestModelTypeStructTagMap, nil))
-	}
+	assert.Equal(t, expectedStructTagMap, TestModelTypeStructTagMap)
 }
 
 func TestValidateVisibility(t *testing.T) {
@@ -1061,9 +1049,7 @@ func TestValidateVisibility(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cloudErrors := ValidateVisibility(tt.v, tt.w, tt.m, tt.updating)
-			if len(cloudErrors) != tt.errorsExpected {
-				t.Errorf("Expected %d errors, got %d: %v", tt.errorsExpected, len(cloudErrors), cloudErrors)
-			}
+			assert.Len(t, cloudErrors, tt.errorsExpected)
 		})
 	}
 }

--- a/internal/database/typeddocument_test.go
+++ b/internal/database/typeddocument_test.go
@@ -6,6 +6,8 @@ package database
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const testResourceType = "test"
@@ -49,16 +51,12 @@ func TestTypedDocumentMarshal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			innerDoc := &testProperties{testPropertiesValue}
-
 			data, err := typedDocumentMarshal[testProperties](tt.typedDoc, innerDoc)
-			if err != nil {
-				if err.Error() != tt.err {
-					t.Errorf("unexpected error: %v", err)
-				}
-			} else if tt.err != "" {
-				t.Error("expected error but got none")
-			} else if len(data) == 0 {
-				t.Error("marshalled data is empty")
+
+			if tt.err != "" {
+				assert.EqualError(t, err, tt.err)
+			} else if assert.NoError(t, err) {
+				assert.NotEmpty(t, data)
 			}
 		})
 	}
@@ -90,19 +88,12 @@ func TestTypedDocumentUnmarshal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			typedDoc, innerDoc, err := typedDocumentUnmarshal[testProperties]([]byte(tt.data))
-			if err != nil {
-				if err.Error() != tt.err {
-					t.Errorf("unexpected error: %v", err)
-				}
-			} else if tt.err != "" {
-				t.Error("expected error but got none")
-			} else {
-				if typedDoc.ResourceType != testResourceType {
-					t.Errorf("expected resourceType '%s' but got '%s'", testResourceType, typedDoc.ResourceType)
-				}
-				if innerDoc.Value != testPropertiesValue {
-					t.Errorf("expected value '%s' but got '%s'", testPropertiesValue, innerDoc.Value)
-				}
+
+			if tt.err != "" {
+				assert.EqualError(t, err, tt.err)
+			} else if assert.NoError(t, err) {
+				assert.Equal(t, testResourceType, typedDoc.ResourceType)
+				assert.Equal(t, testPropertiesValue, innerDoc.Value)
 			}
 		})
 	}

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
+	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/openshift-online/ocm-sdk-go v0.1.464
+	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/trace v1.35.0
 	go.uber.org/mock v0.5.0

--- a/internal/go.sum
+++ b/internal/go.sum
@@ -30,8 +30,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
-github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
-github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
+github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
+github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
@@ -112,8 +112,6 @@ github.com/openshift-online/ocm-sdk-go v0.1.464 h1:QLg2Q96gGG57SDhh6kHWW9dVGhEhr
 github.com/openshift-online/ocm-sdk-go v0.1.464/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/ocm/internalid_test.go
+++ b/internal/ocm/internalid_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/stretchr/testify/assert"
 )
 
 type FakeTransport struct{}
@@ -58,17 +59,17 @@ func TestInternalID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			internalID, err := NewInternalID(tt.path)
-			if err != nil && !tt.expectErr || err == nil && tt.expectErr {
-				t.Error(err)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 
 			transport := &FakeTransport{}
-			if _, ok := internalID.GetClusterClient(transport); ok == tt.expectErr {
-				t.Errorf("failed to get cluster client")
-			}
-			if _, ok := internalID.GetAroHCPClusterClient(transport); ok == tt.expectErr {
-				t.Errorf("failed to get cluster client")
-			}
+			_, ok := internalID.GetClusterClient(transport)
+			assert.NotEqual(t, tt.expectErr, ok)
+			_, ok = internalID.GetAroHCPClusterClient(transport)
+			assert.NotEqual(t, tt.expectErr, ok)
 
 			if tt.expectErr {
 				// test ends here if error is expected
@@ -76,34 +77,24 @@ func TestInternalID(t *testing.T) {
 			}
 
 			id := internalID.ID()
-			if id != tt.id {
-				t.Errorf("expected id '%s', got '%s'", tt.id, id)
-			}
+			assert.Equal(t, tt.id, id)
 
 			kind := internalID.Kind()
-			if kind != tt.kind {
-				t.Errorf("expected kind '%s', got '%s'", tt.kind, kind)
-			}
+			assert.Equal(t, tt.kind, kind)
 
 			str := internalID.String()
-			if str != tt.path {
-				t.Errorf("expected string '%s', got '%s'", tt.path, str)
-			}
+			assert.Equal(t, tt.path, str)
 
 			if kind == cmv1.NodePoolKind {
-				if _, ok := internalID.GetNodePoolClient(transport); !ok {
-					t.Errorf("failed to get node pool client")
-				}
+				_, ok := internalID.GetNodePoolClient(transport)
+				assert.True(t, ok, "failed to get node pool client")
 			}
 
 			bytes, err := json.Marshal(internalID)
-			if err != nil {
-				t.Error(err)
-			}
-			fmt.Printf("Bytes: %s\n", bytes)
-			err = json.Unmarshal(bytes, &internalID)
-			if err != nil {
-				t.Error(err)
+			if assert.NoError(t, err) {
+				fmt.Printf("Bytes: %s\n", bytes)
+				err = json.Unmarshal(bytes, &internalID)
+				assert.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
### What

Refactoring unit tests to be easier to maintain.  Changes here fall into four categories:

1. Use available constants in tests instead of writing out the constant value.

2. Use the package "[github.com/stretchr/testify/require](https://pkg.go.dev/github.com/stretchr/testify/require)" during test setup where an unexpected condition should abort the whole test.  Just makes the test code more compact and consistent.

3. Use the package "[github.com/stretchr/testify/assert](https://pkg.go.dev/github.com/stretchr/testify/assert)" with functions being tested where an unexpected condition should fail the test case but continue the test.  Just makes the test code more compact and consistent.

4. Establish `/internal/api/testhelpers.go` as a place to share common constants and helper functions for unit tests.