### PR TITLE
api: Add examples for cluster credential POST operations

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_RequestAdminCredential_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_RequestAdminCredential_MaximumSet_Gen.json
@@ -1,0 +1,22 @@
+{
+  "title": "HcpOpenShiftClusters_RequestAdminCredential_MaximumSet",
+  "operationId": "HcpOpenShiftClusters_RequestAdminCredential",
+  "parameters": {
+    "api-version": "2024-06-10-preview",
+    "subscriptionId": "FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D",
+    "resourceGroupName": "rgopenapi",
+    "hcpOpenShiftClusterName": "hcpCluster-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "expirationTimestamp": "2025-04-23T05:55:13.791Z"
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_RevokeCredentials_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_RevokeCredentials_MaximumSet_Gen.json
@@ -1,0 +1,17 @@
+{
+  "title": "HcpOpenShiftClusters_RevokeCredentials_MaximumSet",
+  "operationId": "HcpOpenShiftClusters_RevokeCredentials",
+  "parameters": {
+    "api-version": "2024-06-10-preview",
+    "subscriptionId": "FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D",
+    "resourceGroupName": "rgopenapi",
+    "hcpOpenShiftClusterName": "hcpCluster-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster.tsp
@@ -25,9 +25,6 @@ interface HcpOpenShiftClusters {
   listByResourceGroup is ArmResourceListByParent<HcpOpenShiftCluster>;
   listBySubscription is ArmListBySubscription<HcpOpenShiftCluster>;
 
-  // ------------------------------
-  // The requestAdminCredential and revokeAdminCredentials are
-  // asynchronous POST actions on an HcpOpenShiftClusterResource.
   /** Request a temporary admin kubeconfig for the cluster */
   requestAdminCredential is ArmResourceActionAsync<
     HcpOpenShiftCluster,

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_RequestAdminCredential_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_RequestAdminCredential_MaximumSet_Gen.json
@@ -1,0 +1,22 @@
+{
+  "title": "HcpOpenShiftClusters_RequestAdminCredential_MaximumSet",
+  "operationId": "HcpOpenShiftClusters_RequestAdminCredential",
+  "parameters": {
+    "api-version": "2024-06-10-preview",
+    "subscriptionId": "FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D",
+    "resourceGroupName": "rgopenapi",
+    "hcpOpenShiftClusterName": "hcpCluster-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "expirationTimestamp": "2025-04-23T05:55:13.791Z"
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_RevokeCredentials_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_RevokeCredentials_MaximumSet_Gen.json
@@ -1,0 +1,17 @@
+{
+  "title": "HcpOpenShiftClusters_RevokeCredentials_MaximumSet",
+  "operationId": "HcpOpenShiftClusters_RevokeCredentials",
+  "parameters": {
+    "api-version": "2024-06-10-preview",
+    "subscriptionId": "FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D",
+    "resourceGroupName": "rgopenapi",
+    "hcpOpenShiftClusterName": "hcpCluster-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -814,6 +814,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "HcpOpenShiftClusters_RequestAdminCredential_MaximumSet": {
+            "$ref": "./examples/HcpOpenShiftClusters_RequestAdminCredential_MaximumSet_Gen.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -866,6 +871,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "HcpOpenShiftClusters_RevokeCredentials_MaximumSet": {
+            "$ref": "./examples/HcpOpenShiftClusters_RevokeCredentials_MaximumSet_Gen.json"
           }
         },
         "x-ms-long-running-operation-options": {


### PR DESCRIPTION
### What

The cluster credential endpoints barely missed the cut for the [first azure-rest-api-specs-pr pull request](https://github.com/Azure/azure-rest-api-specs-pr/pull/22123), so I submitted them in a [second pull request](https://github.com/Azure/azure-rest-api-specs-pr/pull/22410) which fully passed CI and was given an **ARMSignedOff** label without requiring manual review.

The changes here are backports from that second pull request.  Primarily adds API examples for the two credential endpoints.