### PR TITLE
backend: add subscription metrics

### DIFF
--- a/internal/api/arm/subscription.go
+++ b/internal/api/arm/subscription.go
@@ -15,6 +15,9 @@
 package arm
 
 import (
+	"iter"
+	"slices"
+
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 )
 
@@ -80,3 +83,15 @@ const (
 	SubscriptionStateDeleted      SubscriptionState = "Deleted"
 	SubscriptionStateSuspended    SubscriptionState = "Suspended"
 )
+
+// ListSubscriptionStates returns an iterator that yields all recognized
+// SubscriptionState values. This function is intended as a test aid.
+func ListSubscriptionStates() iter.Seq[SubscriptionState] {
+	return slices.Values([]SubscriptionState{
+		SubscriptionStateRegistered,
+		SubscriptionStateUnregistered,
+		SubscriptionStateWarned,
+		SubscriptionStateDeleted,
+		SubscriptionStateSuspended,
+	})
+}


### PR DESCRIPTION
### What

This commit adds a new metric to the backend RP
(`backend_subscriptions`) reporting the number of subscriptions per state.

Example

```
backend_subscriptions{state="Deleted"} 0
backend_subscriptions{state="Registered"} 1
backend_subscriptions{state="Suspended"} 0
backend_subscriptions{state="Unregistered"} 0
backend_subscriptions{state="Warned"} 0
```

<!-- Link to Jira issue -->


<!-- Briefly describe what this PR does -->

### Why

Provide more metrics on subscriptions.

### Special notes for your reviewer

<!-- optional -->
