### PR TITLE
ARO-15874: Update image sync to include 4.18.9

### DIFF
--- a/dev-infrastructure/templates/global-image-sync.bicep
+++ b/dev-infrastructure/templates/global-image-sync.bicep
@@ -418,7 +418,7 @@ var ocpMirrorConfig = {
           type: 'ocp'
           full: true
           minVersion: '4.18.1'
-          maxVersion: '4.18.1'
+          maxVersion: '4.18.9'
         }
       ]
       graph: true


### PR DESCRIPTION
[<!-- Link to Jira issue -->](https://issues.redhat.com/browse/ARO-15874)

### What

4.18.9 support

### Why

We need to update the ocp release image used in CS, to use the latest hypershift changes.

### Special notes for your reviewer

<!-- optional -->
