### PR TITLE
chore: use consts from OCM v1alpha1 package

### DIFF
--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -350,14 +350,14 @@ func (s *OperationsScanner) processOperations(ctx context.Context, subscriptionI
 		op := operation{operationID, pk, operationDoc, operationLogger}
 
 		switch operationDoc.InternalID.Kind() {
-		case cmv1.ClusterKind:
+		case arohcpv1alpha1.ClusterKind:
 			switch operationDoc.Request {
 			case database.OperationRequestRevokeCredentials:
 				s.pollBreakGlassCredentialRevoke(ctx, op)
 			default:
 				s.pollClusterOperation(ctx, op)
 			}
-		case cmv1.NodePoolKind:
+		case arohcpv1alpha1.NodePoolKind:
 			s.pollNodePoolOperation(ctx, op)
 		case cmv1.BreakGlassCredentialKind:
 			s.pollBreakGlassCredential(ctx, op)

--- a/frontend/pkg/frontend/helpers.go
+++ b/frontend/pkg/frontend/helpers.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -136,10 +136,10 @@ func (f *Frontend) DeleteResource(ctx context.Context, resourceDoc *database.Res
 	logger := LoggerFromContext(ctx)
 
 	switch resourceDoc.InternalID.Kind() {
-	case cmv1.ClusterKind:
+	case arohcpv1alpha1.ClusterKind:
 		err = f.clusterServiceClient.DeleteCluster(ctx, resourceDoc.InternalID)
 
-	case cmv1.NodePoolKind:
+	case arohcpv1alpha1.NodePoolKind:
 		err = f.clusterServiceClient.DeleteNodePool(ctx, resourceDoc.InternalID)
 
 	default:
@@ -257,7 +257,7 @@ func (f *Frontend) MarshalResource(ctx context.Context, resourceID *azcorearm.Re
 	}
 
 	switch doc.InternalID.Kind() {
-	case cmv1.ClusterKind:
+	case arohcpv1alpha1.ClusterKind:
 		csCluster, err := f.clusterServiceClient.GetCluster(ctx, doc.InternalID)
 		if err != nil {
 			logger.Error(err.Error())
@@ -271,7 +271,7 @@ func (f *Frontend) MarshalResource(ctx context.Context, resourceID *azcorearm.Re
 			return nil, arm.NewInternalServerError()
 		}
 
-	case cmv1.NodePoolKind:
+	case arohcpv1alpha1.NodePoolKind:
 		csNodePool, err := f.clusterServiceClient.GetNodePool(ctx, doc.InternalID)
 		if err != nil {
 			logger.Error(err.Error())

--- a/internal/ocm/internalid.go
+++ b/internal/ocm/internalid.go
@@ -78,14 +78,12 @@ func (id *InternalID) validate() error {
 	}
 
 	if match, _ = path.Match(aroHcpV1Alpha1ClusterPattern, id.path); match {
-		// Temporarily use cmv1 constant for backward-compatibility.
-		id.kind = cmv1.ClusterKind
+		id.kind = arohcpv1alpha1.ClusterKind
 		return nil
 	}
 
 	if match, _ = path.Match(aroHcpV1Alpha1NodePoolPattern, id.path); match {
-		// Temporarily use cmv1 constant for backward-compatibility.
-		id.kind = cmv1.NodePoolKind
+		id.kind = arohcpv1alpha1.NodePoolKind
 		return nil
 	}
 

--- a/internal/ocm/internalid_test.go
+++ b/internal/ocm/internalid_test.go
@@ -16,10 +16,10 @@ package ocm
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/stretchr/testify/assert"
 )
@@ -52,10 +52,10 @@ func TestInternalID(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:      "parse v1 cluster",
+			name:      "parse aro_hcp v1alpha1 cluster",
 			path:      "/api/aro_hcp/v1alpha1/clusters/abc",
 			id:        "abc",
-			kind:      cmv1.ClusterKind,
+			kind:      arohcpv1alpha1.ClusterKind,
 			expectErr: false,
 		},
 		{
@@ -63,6 +63,13 @@ func TestInternalID(t *testing.T) {
 			path:      "/api/clusters_mgmt/v1/clusters/abc/node_pools/def",
 			id:        "def",
 			kind:      cmv1.NodePoolKind,
+			expectErr: false,
+		},
+		{
+			name:      "parse aro_hcp v1alpha1 node pool",
+			path:      "/api/aro_hcp/v1alpha1/clusters/abc/node_pools/def",
+			id:        "def",
+			kind:      arohcpv1alpha1.NodePoolKind,
 			expectErr: false,
 		},
 	}
@@ -96,14 +103,13 @@ func TestInternalID(t *testing.T) {
 			str := internalID.String()
 			assert.Equal(t, tt.path, str)
 
-			if kind == cmv1.NodePoolKind {
+			if kind == arohcpv1alpha1.NodePoolKind {
 				_, ok := internalID.GetNodePoolClient(transport)
 				assert.True(t, ok, "failed to get node pool client")
 			}
 
 			bytes, err := json.Marshal(internalID)
 			if assert.NoError(t, err) {
-				fmt.Printf("Bytes: %s\n", bytes)
 				err = json.Unmarshal(bytes, &internalID)
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
### What

This PR updates the RP frontend and backend to use constants from the `github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1` package instead of `github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1` whenever applicable.

### Why

While the constant values are the same, it's more consistent to import them from the "right" package.

### Special notes for your reviewer

<!-- optional -->
