### PR TITLE
image-sync/oc-mirror should retry when it fails

### DIFF
--- a/dev-infrastructure/templates/global-image-sync.bicep
+++ b/dev-infrastructure/templates/global-image-sync.bicep
@@ -484,6 +484,7 @@ var ocMirrorJobConfiguration = ocMirrorEnabled
         name: 'oc-mirror'
         cron: '0 * * * *'
         timeout: 4 * 60 * 60
+        retryLimit: 3
         targetRegistry: ocpAcrName
         imageSetConfig: ocpMirrorConfig
         compatibility: 'LATEST'
@@ -492,6 +493,7 @@ var ocMirrorJobConfiguration = ocMirrorEnabled
         name: 'acm-mirror'
         cron: '0 10 * * *'
         timeout: 4 * 60 * 60
+        retryLimit: 3
         targetRegistry: svcAcrName
         imageSetConfig: acmMirrorConfig
         compatibility: 'NOCATALOG'
@@ -522,6 +524,7 @@ resource ocMirrorJobs 'Microsoft.App/jobs@2024-03-01' = [
           parallelism: 1
         }
         replicaTimeout: ocMirrorJobConfiguration[i].timeout
+        replicaRetryLimit: ocMirrorJobConfiguration[i].retryLimit
         registries: [
           {
             identity: uami.id


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

oc-mirror job should retry when it fails

### Why

As of #1667 oc-mirror will fail if it encounters an error instead of succeeding. This is good. 

However when an error is encountered, it'll take up to 1 hour before the job runs again (with current cron expression `0 * * * *`)

This change make it so the job will retry up to 3 times

### Special notes for your reviewer

<!-- optional -->
