### PR TITLE
deploy acm policies

### DIFF
--- a/acm/Makefile
+++ b/acm/Makefile
@@ -7,9 +7,11 @@ REGISTRY ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
 MCE_OPERATOR_BUNDLE_FILE = mce-operator-bundle.tgz
 HELM_BASE_DIR = deploy/helm
 MCE_CHART_DIR = ${HELM_BASE_DIR}/multicluster-engine
+POLICY_CHART_DIR = ${HELM_BASE_DIR}/policies
 CLC_CHART_DIR = ${HELM_BASE_DIR}/clc-state-metrics
 MCE_CONFIG_DIR = ${HELM_BASE_DIR}/multicluster-engine-config
 MCE_NS = multicluster-engine
+POLICY_NS = open-cluster-management-policies
 POLICY_HELM_REPO = https://github.com/stolostron/mce-install-kube.git
 POLICY_HELM_REPO_BRANCH = release-2.12
 
@@ -28,7 +30,12 @@ deploy:
 		--namespace ${MCE_NS} \
 		--set global.imageOverrides.clusterlifecycle_state_metrics=${REGISTRY}/multicluster-engine/clusterlifecycle-state-metrics-rhel9@sha256:${CLC_STATE_METRICS_IMAGE_DIGEST} \
 		--set global.namespace=${MCE_NS}
+	$(MAKE) deploy-policies
 
+deploy-policies:
+	${HELM_CMD} \
+		policy ${POLICY_CHART_DIR} \
+		--namespace ${POLICY_NS}
 
 helm-chart:
 	@podman pull --arch amd64 ${MCE_OPERATOR_BUNDLE_IMAGE}

--- a/acm/deploy/helm/policies/Chart.yaml
+++ b/acm/deploy/helm/policies/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: AcmPolicies
+description: A Helm chart for deploying ACM Policies
+version: 0.1.0
+appVersion: "1.0.0"

--- a/acm/deploy/helm/policies/README.md
+++ b/acm/deploy/helm/policies/README.md
@@ -1,0 +1,64 @@
+# Policies helm chart
+
+The policy helm chart allows the deployment of ACM Policies to Managed Clusters.
+
+Policies are deployed after ACM/MCE installation is complete but before any hosted clusters are installed.
+
+This helm chart deploys the following:
+- **ManagedClusterSetBinding** is created to bind the **ManagedClusterSet** "hypershift-managed-clusters" to the **namespace** "open-cluster-management-policies".
+- **Placement** object 'all-hosted-clusters' references the **ManagedClusterSet** "hypershift-management-clusters" so that policies can be bound it.
+
+Add policies to this helm chart by creating a <policy-name>.policy.yaml file that includes:
+- A **Policy** object.
+- A **PlacementBinding**
+
+Below is an example policy that would create a config map in the hosted cluster kube-system namespace.
+```yaml
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: demo-config-policy
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  disabled: false
+  remediationAction: enforce 
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: demo-config
+        spec:
+          evaluationInterval:
+            compliant: 2h
+            noncompliant: 45s
+          object-templates:
+          - complianceType: MustHave
+            objectDefinition:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: demo-config
+                namespace: kube-system
+              data:
+                key: value
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: configmap-placement-binding
+  namespace: '{{ .Release.Namespace }}'
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+  name: all-hosted-clusters
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: demo-config-policy
+```

--- a/acm/deploy/helm/policies/templates/all-hosted-clusters.placement.yaml
+++ b/acm/deploy/helm/policies/templates/all-hosted-clusters.placement.yaml
@@ -1,0 +1,8 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: all-hosted-clusters
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  clusterSets:
+  - hypershift-management-clusters

--- a/acm/deploy/helm/policies/templates/managedclustersetbinding.yaml
+++ b/acm/deploy/helm/policies/templates/managedclustersetbinding.yaml
@@ -1,0 +1,8 @@
+# Makes the hypershift-management-clusters clusterset available in the open-cluster-management-policies namespace
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: hypershift-management-clusters
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  clusterSet: hypershift-management-clusters


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-16984

### What

Adds a make target `deploy-policies` that deploys a helm chart containing ACM Policies.  The deployment of policies will occur after ACM/MCE installation is complete but before any hosted clusters are installed.

The ManagedClusterSetBinding is created to bind the ManagedClusterSet "hypershift-managed-clusters" to the namespace "open-cluster-management-policies".

The Placement object 'all-hosted-clusters' references the ManagedClusterSet "hypershift-management-clusters" so that policies can be bound to it.

Add policies by creating a `<policy-name>.policy.yaml` file int the helm chart `templates/` directory that includes a Policy object and a PlacementBinding.  `README.md` added in this PR includes an example for reference.

### Why
Other HCP features depend on the ability to deploy ACM Policies.

### Special notes for your reviewer

<!-- optional -->
