### PR TITLE
bugfix: support to marshal additionalProperties unformed types

### DIFF
--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -211,7 +211,21 @@ func TestSubscriptionsPUT(t *testing.T) {
 			subscription: &arm.Subscription{
 				State:            arm.SubscriptionStateRegistered,
 				RegistrationDate: api.Ptr(time.Now().String()),
-				Properties:       nil,
+				Properties: &arm.SubscriptionProperties{
+					TenantId: api.Ptr("12345678-1234-1234-1234-123456789abc"),
+					AdditionalProperties: &map[string]any{
+						"foo": "bar",
+						"baz": []int{1, 2, 3, 4},
+						"test": struct{ blah string }{
+							"hello",
+						},
+					},
+					ManagedByTenants: &[]map[string]string{
+						{
+							"tenantId": "12345678-1234-1234-1234-123456789abc",
+						},
+					},
+				},
 			},
 			subDoc:             nil,
 			expectedStatusCode: http.StatusOK,

--- a/internal/api/arm/subscription.go
+++ b/internal/api/arm/subscription.go
@@ -48,7 +48,7 @@ type SubscriptionProperties struct {
 	SpendingLimit        *string              `json:"spendingLimit,omitempty"`
 	AccountOwner         *AccountOwner        `json:"accountOwner,omitempty"`
 	ManagedByTenants     *[]map[string]string `json:"managedByTenants,omitempty"`
-	AdditionalProperties *map[string]string   `json:"additionalProperties,omitempty"`
+	AdditionalProperties any                  `json:"additionalProperties,omitempty"`
 }
 
 type Feature struct {
@@ -58,7 +58,7 @@ type Feature struct {
 
 type AvailabilityZone struct {
 	Location     *string        `json:"location,omitempty"`
-	ZoneMappings *[]ZoneMapping `json:"zoneMppings,omitempty"`
+	ZoneMappings *[]ZoneMapping `json:"zoneMappings,omitempty"`
 }
 
 type ZoneMapping struct {


### PR DESCRIPTION
no jira

### Why
When attempting to re-register the subscription with the resource provider, we failed to marshal the sent PUT request `additionalProperties` section.

`cannot unmarshal object into Go struct field SubscriptionProperties.properties.additionalProperties of type string`

The resource provider contract says the below, hence why we just make it an `any` type.  
> Resource Providers should develop code that can handle modifications, and should not strongly parse this dictionary.
