### PR TITLE
revert config.mk var quoting

### DIFF
--- a/tooling/templatize/pkg/pipeline/inspect.go
+++ b/tooling/templatize/pkg/pipeline/inspect.go
@@ -135,7 +135,7 @@ func aquireOutputChainingInputs(ctx context.Context, steps []string, pipeline *P
 
 func printMakefileVars(vars map[string]string, writer io.Writer) {
 	for k, v := range vars {
-		fmt.Fprintf(writer, "%s ?= \"%s\"\n", k, v)
+		fmt.Fprintf(writer, "%s ?= %s\n", k, v)
 	}
 }
 

--- a/tooling/templatize/pkg/pipeline/inspect_test.go
+++ b/tooling/templatize/pkg/pipeline/inspect_test.go
@@ -58,7 +58,7 @@ func TestInspectVars(t *testing.T) {
 				},
 				Format: "makefile",
 			},
-			expected: "FOO ?= \"bar\"\n",
+			expected: "FOO ?= bar\n",
 		},
 		{
 			name:     "failed action",


### PR DESCRIPTION
### What

all makefile related shell scripts apply quoting already for strings where whitespace chars are allowed and expect unquoted ENV var strings. therefore this PR reverts the quoting in the config.mk generation (`templatize inspect`) that was recently introduced.

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
