### PR TITLE
Improve handling of Cluster Service errors in RP frontend

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -407,14 +407,14 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 		return
 	}
 
-	doc, err := f.dbClient.GetResourceDoc(ctx, resourceID)
+	resourceDoc, err := f.dbClient.GetResourceDoc(ctx, resourceID)
 	if err != nil && !errors.Is(err, database.ErrNotFound) {
 		logger.Error(err.Error())
 		arm.WriteInternalServerError(writer)
 		return
 	}
 
-	var updating = (doc != nil)
+	var updating = (resourceDoc != nil)
 	var operationRequest database.OperationRequest
 
 	var versionedCurrentCluster api.VersionedHCPOpenShiftCluster
@@ -428,7 +428,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 		// No special treatment here for "not found" errors. A "not found"
 		// error indicates the database has gotten out of sync and so it's
 		// appropriate to fail.
-		csCluster, err := f.clusterServiceClient.GetCluster(ctx, doc.InternalID)
+		csCluster, err := f.clusterServiceClient.GetCluster(ctx, resourceDoc.InternalID)
 		if err != nil {
 			logger.Error(fmt.Sprintf("failed to fetch CS cluster for %s: %v", resourceID, err))
 			arm.WriteInternalServerError(writer)
@@ -469,12 +469,12 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 			return
 		}
 
-		doc = database.NewResourceDocument(resourceID)
+		resourceDoc = database.NewResourceDocument(resourceID)
 	}
 
 	// CheckForProvisioningStateConflict does not log conflict errors
 	// but does log unexpected errors like database failures.
-	cloudError := f.CheckForProvisioningStateConflict(ctx, operationRequest, doc)
+	cloudError := f.CheckForProvisioningStateConflict(ctx, operationRequest, resourceDoc)
 	if cloudError != nil {
 		arm.WriteCloudError(writer, cloudError)
 		return
@@ -512,7 +512,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 
 	if updating {
 		logger.Info(fmt.Sprintf("updating resource %s", resourceID))
-		csCluster, err = f.clusterServiceClient.UpdateCluster(ctx, doc.InternalID, csCluster)
+		csCluster, err = f.clusterServiceClient.UpdateCluster(ctx, resourceDoc.InternalID, csCluster)
 		if err != nil {
 			logger.Error(err.Error())
 			arm.WriteInternalServerError(writer)
@@ -527,7 +527,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 			return
 		}
 
-		doc.InternalID, err = ocm.NewInternalID(csCluster.HREF())
+		resourceDoc.InternalID, err = ocm.NewInternalID(csCluster.HREF())
 		if err != nil {
 			logger.Error(err.Error())
 			arm.WriteInternalServerError(writer)
@@ -536,7 +536,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 	}
 	tracing.SetClusterAttributes(trace.SpanFromContext(ctx), csCluster)
 
-	operationDoc := database.NewOperationDocument(operationRequest, doc.ResourceID, doc.InternalID)
+	operationDoc := database.NewOperationDocument(operationRequest, resourceDoc.ResourceID, resourceDoc.InternalID)
 
 	operationID, err := f.dbClient.CreateOperationDoc(ctx, operationDoc)
 	if err != nil {
@@ -555,14 +555,14 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 
 	// This is called directly when creating a resource, and indirectly from
 	// within a retry loop when updating a resource.
-	updateResourceMetadata := func(doc *database.ResourceDocument) bool {
-		doc.ActiveOperationID = operationID
-		doc.ProvisioningState = operationDoc.Status
+	updateResourceMetadata := func(updateDoc *database.ResourceDocument) bool {
+		updateDoc.ActiveOperationID = operationID
+		updateDoc.ProvisioningState = operationDoc.Status
 
 		// Record managed identity type and any system-assigned identifiers.
 		// Omit the user-assigned identities map since that is reconstructed
 		// from Cluster Service data.
-		doc.Identity = &arm.ManagedServiceIdentity{
+		updateDoc.Identity = &arm.ManagedServiceIdentity{
 			PrincipalID: hcpCluster.Identity.PrincipalID,
 			TenantID:    hcpCluster.Identity.TenantID,
 			Type:        hcpCluster.Identity.Type,
@@ -570,7 +570,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 
 		// Record the latest system data values from ARM, if present.
 		if systemData != nil {
-			doc.SystemData = systemData
+			updateDoc.SystemData = systemData
 		}
 
 		// Here the difference between a nil map and an empty map is significant.
@@ -579,15 +579,15 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 		// empty, that means it was specified in the request body and should fully
 		// replace any existing tags.
 		if hcpCluster.Tags != nil {
-			doc.Tags = hcpCluster.Tags
+			updateDoc.Tags = hcpCluster.Tags
 		}
 
 		return true
 	}
 
 	if !updating {
-		updateResourceMetadata(doc)
-		err = f.dbClient.CreateResourceDoc(ctx, doc)
+		updateResourceMetadata(resourceDoc)
+		err = f.dbClient.CreateResourceDoc(ctx, resourceDoc)
 		if err != nil {
 			logger.Error(err.Error())
 			arm.WriteInternalServerError(writer)
@@ -605,7 +605,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 			logger.Info(fmt.Sprintf("document updated for %s", resourceID))
 		}
 		// Get the updated resource document for the response.
-		doc, err = f.dbClient.GetResourceDoc(ctx, resourceID)
+		resourceDoc, err = f.dbClient.GetResourceDoc(ctx, resourceID)
 		if err != nil {
 			logger.Error(err.Error())
 			arm.WriteInternalServerError(writer)
@@ -613,7 +613,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 		}
 	}
 
-	responseBody, err := marshalCSCluster(csCluster, doc, versionedInterface)
+	responseBody, err := marshalCSCluster(csCluster, resourceDoc, versionedInterface)
 	if err != nil {
 		logger.Error(err.Error())
 		arm.WriteInternalServerError(writer)

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -68,14 +68,14 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		return
 	}
 
-	doc, err := f.dbClient.GetResourceDoc(ctx, resourceID)
+	resourceDoc, err := f.dbClient.GetResourceDoc(ctx, resourceID)
 	if err != nil && !errors.Is(err, database.ErrNotFound) {
 		logger.Error(err.Error())
 		arm.WriteInternalServerError(writer)
 		return
 	}
 
-	var updating = (doc != nil)
+	var updating = (resourceDoc != nil)
 	var operationRequest database.OperationRequest
 
 	var versionedCurrentNodePool api.VersionedHCPOpenShiftClusterNodePool
@@ -89,7 +89,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		// No special treatment here for "not found" errors. A "not found"
 		// error indicates the database has gotten out of sync and so it's
 		// appropriate to fail.
-		csNodePool, err := f.clusterServiceClient.GetNodePool(ctx, doc.InternalID)
+		csNodePool, err := f.clusterServiceClient.GetNodePool(ctx, resourceDoc.InternalID)
 		if err != nil {
 			logger.Error(fmt.Sprintf("failed to fetch CS node pool for %s: %v", resourceID, err))
 			arm.WriteInternalServerError(writer)
@@ -130,12 +130,12 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 			return
 		}
 
-		doc = database.NewResourceDocument(resourceID)
+		resourceDoc = database.NewResourceDocument(resourceID)
 	}
 
 	// CheckForProvisioningStateConflict does not log conflict errors
 	// but does log unexpected errors like database failures.
-	cloudError := f.CheckForProvisioningStateConflict(ctx, operationRequest, doc)
+	cloudError := f.CheckForProvisioningStateConflict(ctx, operationRequest, resourceDoc)
 	if cloudError != nil {
 		arm.WriteCloudError(writer, cloudError)
 		return
@@ -173,7 +173,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 
 	if updating {
 		logger.Info(fmt.Sprintf("updating resource %s", resourceID))
-		csNodePool, err = f.clusterServiceClient.UpdateNodePool(ctx, doc.InternalID, csNodePool)
+		csNodePool, err = f.clusterServiceClient.UpdateNodePool(ctx, resourceDoc.InternalID, csNodePool)
 		if err != nil {
 			logger.Error(err.Error())
 			arm.WriteInternalServerError(writer)
@@ -195,7 +195,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 			return
 		}
 
-		doc.InternalID, err = ocm.NewInternalID(csNodePool.HREF())
+		resourceDoc.InternalID, err = ocm.NewInternalID(csNodePool.HREF())
 		if err != nil {
 			logger.Error(err.Error())
 			arm.WriteInternalServerError(writer)
@@ -203,7 +203,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		}
 	}
 
-	operationDoc := database.NewOperationDocument(operationRequest, doc.ResourceID, doc.InternalID)
+	operationDoc := database.NewOperationDocument(operationRequest, resourceDoc.ResourceID, resourceDoc.InternalID)
 
 	operationID, err := f.dbClient.CreateOperationDoc(ctx, operationDoc)
 	if err != nil {
@@ -222,13 +222,13 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 
 	// This is called directly when creating a resource, and indirectly from
 	// within a retry loop when updating a resource.
-	updateResourceMetadata := func(doc *database.ResourceDocument) bool {
-		doc.ActiveOperationID = operationID
-		doc.ProvisioningState = operationDoc.Status
+	updateResourceMetadata := func(updateDoc *database.ResourceDocument) bool {
+		updateDoc.ActiveOperationID = operationID
+		updateDoc.ProvisioningState = operationDoc.Status
 
 		// Record the latest system data values from ARM, if present.
 		if systemData != nil {
-			doc.SystemData = systemData
+			updateDoc.SystemData = systemData
 		}
 
 		// Here the difference between a nil map and an empty map is significant.
@@ -237,15 +237,15 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		// empty, that means it was specified in the request body and should fully
 		// replace any existing tags.
 		if hcpNodePool.Tags != nil {
-			doc.Tags = hcpNodePool.Tags
+			updateDoc.Tags = hcpNodePool.Tags
 		}
 
 		return true
 	}
 
 	if !updating {
-		updateResourceMetadata(doc)
-		err = f.dbClient.CreateResourceDoc(ctx, doc)
+		updateResourceMetadata(resourceDoc)
+		err = f.dbClient.CreateResourceDoc(ctx, resourceDoc)
 		if err != nil {
 			logger.Error(err.Error())
 			arm.WriteInternalServerError(writer)
@@ -263,7 +263,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 			logger.Info(fmt.Sprintf("document updated for %s", resourceID))
 		}
 		// Get the updated resource document for the response.
-		doc, err = f.dbClient.GetResourceDoc(ctx, resourceID)
+		resourceDoc, err = f.dbClient.GetResourceDoc(ctx, resourceID)
 		if err != nil {
 			logger.Error(err.Error())
 			arm.WriteInternalServerError(writer)
@@ -271,7 +271,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		}
 	}
 
-	responseBody, err := marshalCSNodePool(csNodePool, doc, versionedInterface)
+	responseBody, err := marshalCSNodePool(csNodePool, resourceDoc, versionedInterface)
 	if err != nil {
 		logger.Error(err.Error())
 		arm.WriteInternalServerError(writer)

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -83,16 +83,10 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 	var successStatusCode int
 
 	if updating {
-		// Note that because we found a database document for the cluster,
-		// we expect Cluster Service to return us a node pool object.
-		//
-		// No special treatment here for "not found" errors. A "not found"
-		// error indicates the database has gotten out of sync and so it's
-		// appropriate to fail.
 		csNodePool, err := f.clusterServiceClient.GetNodePool(ctx, resourceDoc.InternalID)
 		if err != nil {
 			logger.Error(fmt.Sprintf("failed to fetch CS node pool for %s: %v", resourceID, err))
-			arm.WriteInternalServerError(writer)
+			arm.WriteCloudError(writer, CSErrorToCloudError(err, resourceID))
 			return
 		}
 
@@ -176,7 +170,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		csNodePool, err = f.clusterServiceClient.UpdateNodePool(ctx, resourceDoc.InternalID, csNodePool)
 		if err != nil {
 			logger.Error(err.Error())
-			arm.WriteInternalServerError(writer)
+			arm.WriteCloudError(writer, CSErrorToCloudError(err, resourceID))
 			return
 		}
 	} else {
@@ -191,7 +185,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		csNodePool, err = f.clusterServiceClient.PostNodePool(ctx, clusterDoc.InternalID, csNodePool)
 		if err != nil {
 			logger.Error(err.Error())
-			arm.WriteInternalServerError(writer)
+			arm.WriteCloudError(writer, CSErrorToCloudError(err, resourceID))
 			return
 		}
 

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -16,6 +16,7 @@ package frontend
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -24,6 +25,7 @@ import (
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -421,6 +423,58 @@ func ConvertCStoAdminCredential(breakGlassCredential *cmv1.BreakGlassCredential)
 		ExpirationTimestamp: breakGlassCredential.ExpirationTimestamp(),
 		Kubeconfig:          breakGlassCredential.Kubeconfig(),
 	}
+}
+
+// CSErrorToCloudError attempts to convert various 4xx status codes from
+// Cluster Service to an ARM-compliant error structure, with 500 Internal
+// Server Error as a last-ditch fallback.
+func CSErrorToCloudError(err error, resourceID *azcorearm.ResourceID) *arm.CloudError {
+	var ocmError *ocmerrors.Error
+
+	if errors.As(err, &ocmError) {
+		switch statusCode := ocmError.Status(); statusCode {
+		case http.StatusBadRequest:
+			// BadRequest can be returned when an object fails validation.
+			//
+			// We try our best to mimic Cluster Service's validation for a
+			// couple reasons:
+			//
+			// 1) Whereas Cluster Service aborts on the first validation error,
+			//    we try to report as many validation errors as possible at once
+			//    for a better user experience.
+			//
+			// 2) CloudErrorBody.Target should reference the erroneous field but
+			//    validation errors from Cluster Service cannot easily be mapped
+			//    to a field without extensive pattern matching of the reason.
+			//
+			// That said, Cluster Service's validation is more comprehensive and
+			// probably always will be. So it's important we try to handle their
+			// errors as best we can.
+			return arm.NewCloudError(
+				statusCode,
+				arm.CloudErrorCodeInvalidRequestContent,
+				"", "%s", ocmError.Reason())
+		case http.StatusNotFound:
+			if resourceID != nil {
+				return arm.NewResourceNotFoundError(resourceID)
+			}
+			return arm.NewCloudError(
+				statusCode,
+				arm.CloudErrorCodeNotFound,
+				"", "%s", ocmError.Reason())
+		case http.StatusConflict:
+			var target string
+			if resourceID != nil {
+				target = resourceID.String()
+			}
+			return arm.NewCloudError(
+				statusCode,
+				arm.CloudErrorCodeConflict,
+				target, "%s", ocmError.Reason())
+		}
+	}
+
+	return arm.NewInternalServerError()
 }
 
 // transportFunc implements the http.RoundTripper interface.


### PR DESCRIPTION
Related to [ARO-15570 - NodePool Static Validation](https://issues.redhat.com/browse/ARO-15570)

### What

This is an attempt to improve handling of Cluster Service error responses, primarily for the purpose of propagating validation errors that the RP does not catch.

### Why

But for a few cases where we check for a "404 Not Found" response, any error from Cluster Service currently triggers an opaque "500 Internal Server Error" response from the RP.  This needs improved upon.

This PR introduces a `CSErrorToCloudError` helper function that attempts to preserve select status codes from Cluster Service and turn them into compliant ARM error responses:

- **400 Bad Request**
  This status code has a broad range of applications but in lieu of a distinct secondary code from Cluster Service we assume this means a validation error and propagate the "[reason](https://pkg.go.dev/github.com/openshift-online/ocm-sdk-go/errors#Error.Reason)" message from Cluster Service with an "[InvalidRequestContent](https://github.com/Azure/ARO-HCP/blob/b1e287d13121c677a48a10942471ad3ac18ce0b1/internal/api/arm/error.go#L29)" Azure error code.

- **404 Not Found**
  If this error occurs in the context of an ARM resource request, we use our own error message that references the resource ID.  Otherwise we propagate the "[reason](https://pkg.go.dev/github.com/openshift-online/ocm-sdk-go/errors#Error.Reason)" message from Cluster Service.

- **409 Conflict**
  Cluster Service will soon return this status code in the context of [break-glass credentials](https://docs.google.com/document/d/1Qttlxpnv_d5zsoj4LAgLpr8ZUMCne92e8-prn8G5ILY/edit?tab=t.0).  There may be other cases I'm not aware of where Cluster Service returns this status code.  Here too we propagate the "[reason](https://pkg.go.dev/github.com/openshift-online/ocm-sdk-go/errors#Error.Reason)" message from Cluster Service.

Any other status code becomes an opaque "500 Internal Server Error" response, as before.

The list of recognized status codes and the particulars of how they're handled may change over time.  The main motivation here was to establish a centralized place to do these kinds of error conversions.