### PR TITLE
Align node pool defaults with Cluster Service

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -411,7 +411,7 @@ model NodePoolPlatformProfile {
   vmSize: string;
 
   /** The OS disk size in GiB */
-  diskSizeGiB?: int32;
+  diskSizeGiB?: int32 = 64;
 
   /** The type of the disk storage account
    * - https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types

--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -323,7 +323,7 @@ model NodePoolProperties {
 
   /** Auto-repair */
   @visibility(Lifecycle.Read, Lifecycle.Create)
-  autoRepair?: boolean = false;
+  autoRepair?: boolean = true;
 
   /** Representation of a autoscaling in a node pool. */
   autoScaling?: NodePoolAutoScaling;

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1457,7 +1457,7 @@
         "autoRepair": {
           "type": "boolean",
           "description": "Auto-repair",
-          "default": false,
+          "default": true,
           "x-ms-mutability": [
             "read",
             "create"

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1377,7 +1377,8 @@
         "diskSizeGiB": {
           "type": "integer",
           "format": "int32",
-          "description": "The OS disk size in GiB"
+          "description": "The OS disk size in GiB",
+          "default": 64
         },
         "diskStorageAccountType": {
           "type": "string",

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -77,6 +77,7 @@ func NewDefaultHCPOpenShiftClusterNodePool() *HCPOpenShiftClusterNodePool {
 			Platform: NodePoolPlatformProfile{
 				DiskStorageAccountType: DiskStorageAccountTypePremium_LRS,
 			},
+			AutoRepair: true,
 		},
 	}
 }

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -50,7 +50,7 @@ type NodePoolVersionProfile struct {
 type NodePoolPlatformProfile struct {
 	SubnetID               string                 `json:"subnetId,omitempty"               validate:"omitempty,resource_id=Microsoft.Network/virtualNetworks/subnets"`
 	VMSize                 string                 `json:"vmSize,omitempty"                 validate:"required_for_put"`
-	DiskSizeGiB            int32                  `json:"diskSizeGiB,omitempty"            validate:"omitempty,gt=0"`
+	DiskSizeGiB            int32                  `json:"diskSizeGiB,omitempty"            validate:"min=1"`
 	DiskStorageAccountType DiskStorageAccountType `json:"diskStorageAccountType,omitempty" validate:"omitempty,enum_diskstorageaccounttype"`
 	AvailabilityZone       string                 `json:"availabilityZone,omitempty"`
 }
@@ -75,6 +75,7 @@ func NewDefaultHCPOpenShiftClusterNodePool() *HCPOpenShiftClusterNodePool {
 				ChannelGroup: "stable",
 			},
 			Platform: NodePoolPlatformProfile{
+				DiskSizeGiB:            64,
 				DiskStorageAccountType: DiskStorageAccountTypePremium_LRS,
 			},
 			AutoRepair: true,


### PR DESCRIPTION
Related to [ARO-15570 - NodePool Static Validation](https://issues.redhat.com/browse/ARO-15570)

### What

Corrects a couple default value inconsistencies with Cluster Service.

- `NodePoolProperties.autoRepair` : [Cluster Service defaults to true](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/blob/master/cmd/clusters-service/service/azure/node_pool_defaults.go?ref_type=heads#L43-47)
  ARM API has had the default set to **false** for some reason since its initial draft.  I'm assuming the default CS chose had more intention behind it than our initial API draft.

- `NodePoolPlatformProfile.diskSizeGiB` : [Cluster Service defaults to 64](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/blob/master/cmd/clusters-service/service/azure/node_pool_defaults.go?ref_type=heads#L60-69)
  ARM API has no default, nor does it mark the field as required.  So 64 GiB is currently an _implicit_ default that CS assigns.  But changing a default, whether it's explicit or implicit, has the same downstream impacts which is why Microsoft considers it a breaking change.  There's no real benefit to leaving it implicit so we may as well declare it in the API, imo.