### PR TITLE
setup new int identities

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -401,12 +401,12 @@ clouds:
           # 1P app - from RH Tenant
           firstPartyAppClientId: b8c3986a-6f66-4905-a935-03763eb9fbb3
           firstPartyAppCertificate:
-            name: intFirstPartyCert 
+            name: intFirstPartyCert
             manage: false # we have the cert from RH for int
           # Mock Managed Identities Service Princiapl - from RH Tenant
           miMockClientId: f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
           miMockPrincipalId: a5c120f7-50c3-4cf6-84b4-57517f60630d
-          miMockCertName: intMsiMockCert 
+          miMockCertName: intMsiMockCert
           # ARM Helper - from RH Tenant
           armHelperClientId: 356c7253-24f3-4dc5-b4e1-498c73331cf4
           armHelperFPAPrincipalId: d663e08c-31a0-488a-8ecb-03af4fce5e83

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -399,18 +399,18 @@ clouds:
             image:
               digest: sha256:223f332a11d336b49243d886217a76809142b30f9ab8ef27bec80a4458b3c3a5
           # 1P app - from RH Tenant
-          firstPartyAppClientId: b3cb2fab-15cb-4583-ad06-f91da9bfe2d1
+          firstPartyAppClientId: b8c3986a-6f66-4905-a935-03763eb9fbb3
           firstPartyAppCertificate:
-            name: firstPartyCert2
+            name: intFirstPartyCert 
             manage: false # we have the cert from RH for int
           # Mock Managed Identities Service Princiapl - from RH Tenant
-          miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-          miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
-          miMockCertName: msiMockCert2
+          miMockClientId: f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+          miMockPrincipalId: a5c120f7-50c3-4cf6-84b4-57517f60630d
+          miMockCertName: intMsiMockCert 
           # ARM Helper - from RH Tenant
-          armHelperClientId: 3331e670-0804-48e8-a086-6241671ddc93
-          armHelperFPAPrincipalId: 47f69502-0065-4d9a-b19b-d403e183d2f4
-          armHelperCertName: armHelperCert2
+          armHelperClientId: 356c7253-24f3-4dc5-b4e1-498c73331cf4
+          armHelperFPAPrincipalId: d663e08c-31a0-488a-8ecb-03af4fce5e83
+          armHelperCertName: intArmHelperCert
           # Grafana
           monitoring:
             grafanaName: "arohcp-int"

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -16,9 +16,9 @@
       "repository": "aks/msi-acrpull"
     }
   },
-  "armHelperCertName": "armHelperCert2",
-  "armHelperClientId": "3331e670-0804-48e8-a086-6241671ddc93",
-  "armHelperFPAPrincipalId": "47f69502-0065-4d9a-b19b-d403e183d2f4",
+  "armHelperCertName": "intArmHelperCert",
+  "armHelperClientId": "356c7253-24f3-4dc5-b4e1-498c73331cf4",
+  "armHelperFPAPrincipalId": "d663e08c-31a0-488a-8ecb-03af4fce5e83",
   "aroDevopsMsiId": "/subscriptions/5299e6b7-b23b-46c8-8277-dc1147807117/resourcegroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity",
   "backend": {
     "image": {
@@ -93,9 +93,9 @@
   "firstPartyAppCertificate": {
     "issuer": "OneCertV2-PrivateCA",
     "manage": false,
-    "name": "firstPartyCert2"
+    "name": "intFirstPartyCert"
   },
-  "firstPartyAppClientId": "b3cb2fab-15cb-4583-ad06-f91da9bfe2d1",
+  "firstPartyAppClientId": "b8c3986a-6f66-4905-a935-03763eb9fbb3",
   "frontend": {
     "cert": {
       "issuer": "OneCertV2-PublicCA",
@@ -274,9 +274,9 @@
     "private": false,
     "softDelete": false
   },
-  "miMockCertName": "msiMockCert2",
-  "miMockClientId": "e8723db7-9b9e-46a4-9f7d-64d75c3534f0",
-  "miMockPrincipalId": "d6b62dfa-87f5-49b3-bbcb-4a687c4faa96",
+  "miMockCertName": "intMsiMockCert",
+  "miMockClientId": "f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a",
+  "miMockPrincipalId": "a5c120f7-50c3-4cf6-84b4-57517f60630d",
   "mise": {
     "armAppId": "e2c2ff5c-e5b4-4e79-8c3e-1da8c48461e7",
     "armInstance": "https://management.azure.com",

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -49,6 +49,53 @@ feature-registration: # hardcoded to eastus as this is a subscription deployment
 		$(PROMPT_TO_CONFIRM)
 .PHONY: feature-registration
 
+create-int-mock-identities:
+	MSI_MOCK_ROLE_NAME=int-msi-mock && \
+	FIRST_PARTY_ROLE_NAME=int-first-party && \
+	FIRST_PARTY_CERT_NAME=intFirstPartyCert && \
+	FIRST_PARTY_CERT_DNS=intfirstparty.hcp.osadev.cloud && \
+	MSI_MOCK_CERT_NAME=intMsiMockCert && \
+	MSI_MOCK_CERT_DNS=intmsimock.hcp.osadev.cloud && \
+	ARM_HELPER_CERT_NAME=intArmHelperCert && \
+	ARM_HELPER_CERT_DNS=intarmhelper.hcp.osadev.cloud && \
+	az deployment group create \
+		--name "aro-hcp-int-mock-certificates" \
+		--resource-group $(GLOBAL_RESOURCEGROUP) \
+		--template-file templates/mock-identities.bicep \
+		--parameters configurations/mock-identities.bicepparam \
+		keyVaultName=aro-hcp-int-kv \
+		msiMockRoleName=$${MSI_MOCK_ROLE_NAME} \
+		firstPartyRoleName=$${FIRST_PARTY_ROLE_NAME} \
+		firstPartyCertName=$${FIRST_PARTY_CERT_NAME} \
+		firstPartyCertDns=$${FIRST_PARTY_CERT_DNS} \
+		msiMockCertName=$${MSI_MOCK_CERT_NAME} \
+		msiMockCertDns=$${MSI_MOCK_CERT_DNS} \
+		armHelperCertName=$${ARM_HELPER_CERT_NAME} \
+		armHelperCertDns=$${ARM_HELPER_CERT_DNS}
+
+# APPLICATION_NAME=aro-dev-first-party2 \
+# KEY_VAULT_NAME=aro-hcp-dev-svc-kv \
+# CERTIFICATE_NAME=firstPartyCert2 \
+# ROLE_DEFINITION_NAME=dev-first-party-mock \
+# SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
+# ./scripts/create-sp-for-rbac.sh
+
+# APPLICATION_NAME=aro-dev-arm-helper2 \
+# KEY_VAULT_NAME=aro-hcp-dev-svc-kv \
+# CERTIFICATE_NAME=armHelperCert2 \
+# ROLE_DEFINITION_NAME='Role Based Access Control Administrator' \
+# SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
+# ./scripts/create-sp-for-rbac.sh
+
+# APPLICATION_NAME=aro-dev-msi-mock2 \
+# KEY_VAULT_NAME=aro-hcp-dev-svc-kv \
+# CERTIFICATE_NAME=msiMockCert2 \
+# ROLE_DEFINITION_NAME=dev-msi-mock \
+# SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
+# ./scripts/create-sp-for-rbac.sh
+
+.PHONY: create-mock-identities
+
 create-mock-identities:
 	az deployment group wait --created --name "aro-hcp-dev-mock-certificates" --resource-group $(GLOBAL_RESOURCEGROUP) --interval 10
 	az deployment group create \

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -49,6 +49,9 @@ feature-registration: # hardcoded to eastus as this is a subscription deployment
 		$(PROMPT_TO_CONFIRM)
 .PHONY: feature-registration
 
+# Create mock identities for the INT environment
+# This is done within the subscription the customer MRG / nodepools would be created
+# Manually lift/shift the cert/keys to the MSIT environment keyvault
 create-int-mock-identities:
 	MSI_MOCK_ROLE_NAME=int-msi-mock && \
 	FIRST_PARTY_ROLE_NAME=int-first-party && \
@@ -71,28 +74,25 @@ create-int-mock-identities:
 		msiMockCertName=$${MSI_MOCK_CERT_NAME} \
 		msiMockCertDns=$${MSI_MOCK_CERT_DNS} \
 		armHelperCertName=$${ARM_HELPER_CERT_NAME} \
-		armHelperCertDns=$${ARM_HELPER_CERT_DNS}
-
-# APPLICATION_NAME=aro-dev-first-party2 \
-# KEY_VAULT_NAME=aro-hcp-dev-svc-kv \
-# CERTIFICATE_NAME=firstPartyCert2 \
-# ROLE_DEFINITION_NAME=dev-first-party-mock \
-# SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
-# ./scripts/create-sp-for-rbac.sh
-
-# APPLICATION_NAME=aro-dev-arm-helper2 \
-# KEY_VAULT_NAME=aro-hcp-dev-svc-kv \
-# CERTIFICATE_NAME=armHelperCert2 \
-# ROLE_DEFINITION_NAME='Role Based Access Control Administrator' \
-# SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
-# ./scripts/create-sp-for-rbac.sh
-
-# APPLICATION_NAME=aro-dev-msi-mock2 \
-# KEY_VAULT_NAME=aro-hcp-dev-svc-kv \
-# CERTIFICATE_NAME=msiMockCert2 \
-# ROLE_DEFINITION_NAME=dev-msi-mock \
-# SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
-# ./scripts/create-sp-for-rbac.sh
+		armHelperCertDns=$${ARM_HELPER_CERT_DNS} && \
+	APPLICATION_NAME=aro-hcp-int-fp \
+	KEY_VAULT_NAME=aro-hcp-int-kv \
+	CERTIFICATE_NAME=$${FIRST_PARTY_CERT_NAME} \
+	ROLE_DEFINITION_NAME=$${FIRST_PARTY_ROLE_NAME} \
+	SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
+	./scripts/create-sp-for-rbac.sh && \
+	APPLICATION_NAME=aro-hcp-int-arm-helper \
+	KEY_VAULT_NAME=aro-hcp-int-kv \
+	CERTIFICATE_NAME=$${ARM_HELPER_CERT_NAME} \
+	ROLE_DEFINITION_NAME='Role Based Access Control Administrator' \
+	SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
+	./scripts/create-sp-for-rbac.sh && \
+	APPLICATION_NAME=aro-hcp-int-msi-mock \
+	KEY_VAULT_NAME=aro-hcp-int-kv \
+	CERTIFICATE_NAME=$${MSI_MOCK_CERT_NAME} \
+	ROLE_DEFINITION_NAME=$${MSI_MOCK_ROLE_NAME} \
+	SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
+	./scripts/create-sp-for-rbac.sh
 
 .PHONY: create-mock-identities
 

--- a/dev-infrastructure/scripts/create-sp-for-rbac.sh
+++ b/dev-infrastructure/scripts/create-sp-for-rbac.sh
@@ -1,16 +1,20 @@
 set -euo pipefail
 
 APP_ID=$(az ad app list --display-name ${APPLICATION_NAME} --query '[*]'.appId -o tsv)
-if [[ $(echo ${APP_ID} | wc -l ) == 1 ]];
+if [[ -n "${APP_ID}" ]];
 then
-    echo "Application exists, resetting certificate."
+    echo "Resetting credentials for existing application ${APPLICATION_NAME} with appId ${APP_ID}"
 
     az ad app credential reset \
-        --id "${APPLICATION_NAME}" \
+        --id "${APP_ID}" \
         --keyvault "${KEY_VAULT_NAME}" \
-        --cert "${CERTIFICATE_NAME}" \
+        --cert "${CERTIFICATE_NAME}"
+
+    echo "Assigning role ${ROLE_DEFINITION_NAME} to appId ${APP_ID}"
+    az role assignment create \
+        --assignee "${APP_ID}" \
         --role "${ROLE_DEFINITION_NAME}" \
-        --scopes "/subscriptions/${SUBSCRIPTION_ID}"
+        --scope "/subscriptions/${SUBSCRIPTION_ID}"
 
     exit 0
 fi

--- a/dev-infrastructure/scripts/create-sp-for-rbac.sh
+++ b/dev-infrastructure/scripts/create-sp-for-rbac.sh
@@ -1,15 +1,24 @@
 set -euo pipefail
 
-if [[ $(az ad app list --display-name ${APPLICATION_NAME} --query '[*]'.appId -o tsv | wc -l ) == 1 ]];
+APP_ID=$(az ad app list --display-name ${APPLICATION_NAME} --query '[*]'.appId -o tsv)
+if [[ $(echo ${APP_ID} | wc -l ) == 1 ]];
 then
-    echo "Application exists, existing"
+    echo "Application exists, resetting certificate."
+
+    az ad app credential reset \
+        --id "${APPLICATION_NAME}" \
+        --keyvault "${KEY_VAULT_NAME}" \
+        --cert "${CERTIFICATE_NAME}" \
+        --role "${ROLE_DEFINITION_NAME}" \
+        --scopes "/subscriptions/${SUBSCRIPTION_ID}"
+
     exit 0
 fi
 
 az ad sp create-for-rbac \
---years 10 \
---display-name "${APPLICATION_NAME}" \
---keyvault "${KEY_VAULT_NAME}" \
---cert "${CERTIFICATE_NAME}" \
---role "${ROLE_DEFINITION_NAME}" \
---scopes "/subscriptions/${SUBSCRIPTION_ID}"
+    --years 10 \
+    --display-name "${APPLICATION_NAME}" \
+    --keyvault "${KEY_VAULT_NAME}" \
+    --cert "${CERTIFICATE_NAME}" \
+    --role "${ROLE_DEFINITION_NAME}" \
+    --scopes "/subscriptions/${SUBSCRIPTION_ID}"

--- a/dev-infrastructure/templates/mock-identities.bicep
+++ b/dev-infrastructure/templates/mock-identities.bicep
@@ -10,6 +10,30 @@ param keyVaultName string
 @description('Global resource group name')
 param globalResourceGroupName string = 'global'
 
+@description('The name of the first party identity role')
+param firstPartyRoleName string = 'dev-first-party-mock'
+
+@description('The name of the first party certificate')
+param firstPartyCertName string = 'firstPartyCert2'
+
+@description('The DNS of the first party certificate, used for subject and DNS names.')
+param firstPartyCertDns string = 'firstparty.hcp.osadev.cloud'
+
+@description('The name of the msi mock identity role')
+param msiMockRoleName string = 'dev-msi-mock'
+
+@description('The name of the msi mock certificate')
+param msiMockCertName string = 'msiMockCert2'
+
+@description('The DNS of the msi mock certificate, used for subject and DNS names.')
+param msiMockCertDns string = 'msimock.hcp.osadev.cloud'
+
+@description('The name of the arm helper mock certificate')
+param armHelperCertName string = 'armHelperCert2'
+
+@description('The DNS of the arm helper mock certificate, used for subject and DNS names.')
+param armHelperCertDns string = 'armhelper.hcp.osadev.cloud'
+
 //
 // F I R S T   P A R T Y   I D E N T I T Y
 //
@@ -20,18 +44,18 @@ module firstPartyIdentity '../modules/keyvault/key-vault-cert.bicep' = {
     location: location
     keyVaultManagedIdentityId: aroDevopsMsiId
     keyVaultName: keyVaultName
-    certName: 'firstPartyCert2'
-    subjectName: 'CN=firstparty.hcp.osadev.cloud'
+    certName: firstPartyCertName 
+    subjectName: 'CN=${firstPartyCertDns}'
     issuerName: 'Self'
-    dnsNames: ['firstparty.hcp.osadev.cloud']
+    dnsNames: [firstPartyCertDns]
     validityInMonths: 120
   }
 }
 
 resource customRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
-  name: guid(subscription().id, 'dev-first-party-mock')
+  name: guid(subscription().id, firstPartyRoleName)
   properties: {
-    roleName: 'dev-first-party-mock'
+    roleName: firstPartyRoleName
     description: 'ARO HCP Dev Role for mock 1p service principal'
     type: 'CustomRole'
     permissions: [
@@ -61,9 +85,9 @@ module armHelperIdentity '../modules/keyvault/key-vault-cert.bicep' = {
     location: location
     keyVaultManagedIdentityId: aroDevopsMsiId
     keyVaultName: keyVaultName
-    certName: 'armHelperCert2'
-    subjectName: 'CN=armhelper.hcp.osadev.cloud'
-    dnsNames: ['armhelper.hcp.osadev.cloud']
+    certName: armHelperCertName
+    subjectName: 'CN=${armHelperCertDns}'
+    dnsNames: [armHelperCertDns]
     issuerName: 'Self'
     validityInMonths: 120
   }
@@ -79,18 +103,18 @@ module msiRPMockIdentity '../modules/keyvault/key-vault-cert.bicep' = {
     location: location
     keyVaultManagedIdentityId: aroDevopsMsiId
     keyVaultName: keyVaultName
-    certName: 'msiMockCert2'
-    subjectName: 'CN=msimock.hcp.osadev.cloud'
-    dnsNames: ['msimock.hcp.osadev.cloud']
+    certName: msiMockCertName
+    subjectName: 'CN=${msiMockCertDns}'
+    dnsNames: [msiMockCertDns]
     issuerName: 'Self'
     validityInMonths: 120
   }
 }
 
 resource msiCustomRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
-  name: guid(subscription().id, 'dev-msi-mock')
+  name: guid(subscription().id, msiMockRoleName)
   properties: {
-    roleName: 'dev-msi-mock'
+    roleName: msiMockRoleName
     description: 'ARO HCP Dev Role for MSI mock principal'
     type: 'CustomRole'
     permissions: [

--- a/dev-infrastructure/templates/mock-identities.bicep
+++ b/dev-infrastructure/templates/mock-identities.bicep
@@ -44,7 +44,7 @@ module firstPartyIdentity '../modules/keyvault/key-vault-cert.bicep' = {
     location: location
     keyVaultManagedIdentityId: aroDevopsMsiId
     keyVaultName: keyVaultName
-    certName: firstPartyCertName 
+    certName: firstPartyCertName
     subjectName: 'CN=${firstPartyCertDns}'
     issuerName: 'Self'
     dnsNames: [firstPartyCertDns]


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What
Adds a make target and updates bicep module for creating new identities for the INT environment.

### Why

Previously the INT environment was using the current development EntraId Apps (fp, msi mock, arm helper).

### Special notes for your reviewer

Creating / setting up the identities is complete, need to deploy CS (from this branch) to INT to make them active/test.  Before that hosted clusters should be deleted as the RP will lose access to them after these identities become active.  The new Entra Id Apps have permissions over `ARO SRE Team - INT (EA Subscription 3)`.
<!-- optional -->
