### PR TITLE
Conditionally create NSP profile for SVC KeyVault

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -61,6 +61,9 @@
             "Enforced",
             "Learning"
           ]
+        },
+        "rhDevFixSVCKVAsignNSP":{
+          "type":"boolean"
         }
       },
       "additionalProperties": false

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -49,6 +49,7 @@ defaults:
     nsp:
       name: nsp-{{ .ctx.regionShort }}-svc
       accessMode: 'Learning'
+      rhDevFixSVCKVAsignNSP: false
     istio:
       istioctlVersion: "1.23.1"
       tag: "prod-stable"
@@ -405,6 +406,9 @@ clouds:
           logs:
             loganalytics:
               enable: true
+          svc:
+            nsp:
+              rhDevFixSVCKVAsignNSP: true
           mgmt:
             aks:
               systemAgentPool:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -394,7 +394,8 @@
     },
     "nsp": {
       "accessMode": "Learning",
-      "name": "nsp-cspr-svc"
+      "name": "nsp-cspr-svc",
+      "rhDevFixSVCKVAsignNSP": false
     },
     "prometheus": {
       "namespace": "prometheus",

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -394,7 +394,8 @@
     },
     "nsp": {
       "accessMode": "Learning",
-      "name": "nsp-dev-svc"
+      "name": "nsp-dev-svc",
+      "rhDevFixSVCKVAsignNSP": true
     },
     "prometheus": {
       "namespace": "prometheus",

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -394,7 +394,8 @@
     },
     "nsp": {
       "accessMode": "Learning",
-      "name": "nsp-nightly-svc"
+      "name": "nsp-nightly-svc",
+      "rhDevFixSVCKVAsignNSP": false
     },
     "prometheus": {
       "namespace": "prometheus",

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -400,7 +400,8 @@
     },
     "nsp": {
       "accessMode": "Learning",
-      "name": "nsp-usw3tst-svc"
+      "name": "nsp-usw3tst-svc",
+      "rhDevFixSVCKVAsignNSP": false
     },
     "prometheus": {
       "namespace": "prometheus",

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -97,3 +97,4 @@ param logAnalyticsWorkspaceId = '__logAnalyticsWorkspaceId__'
 
 param svcNSPName = '{{ .svc.nsp.name }}'
 param svcNSPAccessMode = '{{ .svc.nsp.accessMode }}'
+param rhDevFixSVCKVAsignNSP = {{ .svc.nsp.rhDevFixSVCKVAsignNSP }}

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -239,6 +239,9 @@ param svcNSPName string
 @description('Access mode for this NSP')
 param svcNSPAccessMode string
 
+@description('Access mode for this NSP')
+param rhDevFixSVCKVAsignNSP bool = true
+
 // Log Analytics Workspace ID will be passed from region pipeline if enabled in config
 param logAnalyticsWorkspaceId string = ''
 
@@ -619,7 +622,7 @@ module svcNSP '../modules/network/nsp.bicep' = {
   }
 }
 
-module svcNSPProfile '../modules/network/nsp-profile.bicep' = {
+module svcClusterNSPProfile '../modules/network/nsp-profile.bicep' = {
   name: 'profile-${uniqueString(resourceGroup().name)}'
   params: {
     accessMode: svcNSPAccessMode
@@ -629,6 +632,23 @@ module svcNSPProfile '../modules/network/nsp-profile.bicep' = {
     associatedResources: [
       svcCluster.outputs.etcKeyVaultId
       rpCosmosDb.outputs.cosmosDbAccountId
+    ]
+    // TODO Add EV2 access here
+    subscriptions: [
+      subscription().id
+    ]
+  }
+}
+
+module svcKVNSPProfile '../modules/network/nsp-profile.bicep' = if (rhDevFixSVCKVAsignNSP) {
+ 
+  name: 'profile-svc-kv-${uniqueString(resourceGroup().name)}'
+  params: {
+    accessMode: svcNSPAccessMode
+    nspName: svcNSPName
+    profileName: '${svcNSPName}-svc-kv'
+    location: location
+    associatedResources: [
       serviceKeyVault.id
     ]
     // TODO Add EV2 access here


### PR DESCRIPTION

<!-- Link to Jira issue -->

### What
Conditionally create NSP profile for SVC KeyVault
### Why

Key vault is shared. A resource can only be assigned to one NSP in learning mode. Hence ensure it is only associated to an NSP once. Since in integrated dev all resources share the same subscription access should still work

### Special notes for your reviewer

<!-- optional -->
