### PR TITLE
ARO-17063: configure CAPI and CPO builtin roles

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -240,6 +240,12 @@ defaults:
       registry: quay.io
       repository: app-sre/uhc-clusters-service
     azureOperatorsManagedIdentities:
+      # newly configured ARO-HCP builtin roles:
+      clusterApiAzure:
+        roleName: Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider
+      controlPlane:
+        roleName: Azure Red Hat OpenShift Hosted Control Planes Control Plane Operator
+      # Classic roles:
       cloudControllerManager:
         roleName: Azure Red Hat OpenShift Cloud Controller Manager
       ingress:
@@ -254,11 +260,6 @@ defaults:
         roleName: Azure Red Hat OpenShift Network Operator
       kms:
         roleName: Key Vault Crypto User
-      # below two are supposed to be replaced with ARO-specific builtin roles
-      clusterApiAzure:
-        roleName: Contributor
-      controlPlane:
-        roleName: Contributor
     postgres:
       deploy: true
       private: false

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -286,9 +286,9 @@ clouds:
           digest: sha256:777e6f7be92f113b9c188de36b6925dff2537c23fd2efca115b21d42fa9d29e5
         azureOperatorsManagedIdentities:
           clusterApiAzure:
-            roleName: Azure Red Hat OpenShift Control Plane Operator Role - Dev
-          controlPlane:
             roleName: Azure Red Hat OpenShift Cluster API Role - Dev
+          controlPlane:
+            roleName: Azure Red Hat OpenShift Control Plane Operator Role - Dev
           cloudControllerManager:
             roleName: Azure Red Hat OpenShift Cloud Controller Manager - Dev
           ingress:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -43,10 +43,10 @@
         "roleName": "Azure Red Hat OpenShift Network Operator - Dev"
       },
       "clusterApiAzure": {
-        "roleName": "Azure Red Hat OpenShift Control Plane Operator Role - Dev"
+        "roleName": "Azure Red Hat OpenShift Cluster API Role - Dev"
       },
       "controlPlane": {
-        "roleName": "Azure Red Hat OpenShift Cluster API Role - Dev"
+        "roleName": "Azure Red Hat OpenShift Control Plane Operator Role - Dev"
       },
       "diskCsiDriver": {
         "roleName": "Azure Red Hat OpenShift Disk Storage Operator - Dev"

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -43,10 +43,10 @@
         "roleName": "Azure Red Hat OpenShift Network Operator - Dev"
       },
       "clusterApiAzure": {
-        "roleName": "Azure Red Hat OpenShift Control Plane Operator Role - Dev"
+        "roleName": "Azure Red Hat OpenShift Cluster API Role - Dev"
       },
       "controlPlane": {
-        "roleName": "Azure Red Hat OpenShift Cluster API Role - Dev"
+        "roleName": "Azure Red Hat OpenShift Control Plane Operator Role - Dev"
       },
       "diskCsiDriver": {
         "roleName": "Azure Red Hat OpenShift Disk Storage Operator - Dev"

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -42,10 +42,10 @@
         "roleName": "Azure Red Hat OpenShift Network Operator"
       },
       "clusterApiAzure": {
-        "roleName": "Contributor"
+        "roleName": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider"
       },
       "controlPlane": {
-        "roleName": "Contributor"
+        "roleName": "Azure Red Hat OpenShift Hosted Control Planes Control Plane Operator"
       },
       "diskCsiDriver": {
         "roleName": "Azure Red Hat OpenShift Disk Storage Operator"

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -42,10 +42,10 @@
         "roleName": "Azure Red Hat OpenShift Network Operator"
       },
       "clusterApiAzure": {
-        "roleName": "Contributor"
+        "roleName": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider"
       },
       "controlPlane": {
-        "roleName": "Contributor"
+        "roleName": "Azure Red Hat OpenShift Hosted Control Planes Control Plane Operator"
       },
       "diskCsiDriver": {
         "roleName": "Azure Red Hat OpenShift Disk Storage Operator"

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -43,10 +43,10 @@
         "roleName": "Azure Red Hat OpenShift Network Operator - Dev"
       },
       "clusterApiAzure": {
-        "roleName": "Azure Red Hat OpenShift Control Plane Operator Role - Dev"
+        "roleName": "Azure Red Hat OpenShift Cluster API Role - Dev"
       },
       "controlPlane": {
-        "roleName": "Azure Red Hat OpenShift Cluster API Role - Dev"
+        "roleName": "Azure Red Hat OpenShift Control Plane Operator Role - Dev"
       },
       "diskCsiDriver": {
         "roleName": "Azure Red Hat OpenShift Disk Storage Operator - Dev"

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -43,10 +43,10 @@
         "roleName": "Azure Red Hat OpenShift Network Operator - Dev"
       },
       "clusterApiAzure": {
-        "roleName": "Azure Red Hat OpenShift Control Plane Operator Role - Dev"
+        "roleName": "Azure Red Hat OpenShift Cluster API Role - Dev"
       },
       "controlPlane": {
-        "roleName": "Azure Red Hat OpenShift Cluster API Role - Dev"
+        "roleName": "Azure Red Hat OpenShift Control Plane Operator Role - Dev"
       },
       "diskCsiDriver": {
         "roleName": "Azure Red Hat OpenShift Disk Storage Operator - Dev"


### PR DESCRIPTION
This PR will configure the CAPI and CPO builtin roles for all non-dev envs. While working on it, I noticed the dev roles for those two are inadvertently swapped - this also fixes that.

https://issues.redhat.com/browse/ARO-17063

