### PR TITLE
manual SRE breakglass script

### DIFF
--- a/acm/deploy/helm/policies/templates/sre-breakglass-role.placementbinding.yaml
+++ b/acm/deploy/helm/policies/templates/sre-breakglass-role.placementbinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: sre-role-placement-binding
+  namespace: '{{ .Release.Namespace }}'
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+  name: all-hosted-clusters
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: sre-role-policy

--- a/acm/deploy/helm/policies/templates/sre-breakglass-role.policy.yaml
+++ b/acm/deploy/helm/policies/templates/sre-breakglass-role.policy.yaml
@@ -1,0 +1,59 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: sre-role-policy
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  disabled: false
+  remediationAction: enforce
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: sre-role
+        spec:
+          evaluationInterval:
+            compliant: 1m
+            noncompliant: 45s
+          pruneObjectBehavior: DeleteIfCreated
+          remediationAction: enforce
+          object-templates:
+          - complianceType: MustHave
+            objectDefinition:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                creationTimestamp: null
+                name: sre-role
+              rules:
+              - apiGroups:
+                - ""
+                resources:
+                  - namespaces
+                verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+          - complianceType: MustHave
+            objectDefinition:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: sre-group-sre-role-rolebinding
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: sre-role
+              subjects:
+              - kind: Group
+                name: sre-group
+                apiGroup: rbac.authorization.k8s.io

--- a/hack/hcp-sre-breakglass.sh
+++ b/hack/hcp-sre-breakglass.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+#
+# E X P E R I M E N T A L   -   N O T   I N T E N D E D   F O R   P R O D U C T I O N
+#
+# Use at your own risk. This script does not do sanity checks and does not have error handling.
+# In case of errors, resources may be left behind, etc.
+# TLDR: this script is the worst but good enough for a quick and dirty POC.
+#
+# This is an experiment script that creates a kubeconfig for an HCP using the sre-break-glass signer.
+# This script is intended to be run towards the management cluster that hosts the HCP we want to access.
+#
+# The resulting kubeconfig will grant membership in the sre-group group within the HCP.
+# An ACM policy grants that group access to the sre-role, which is a simple dummy role that allows listing all namespace.
+#
+# Example usage:
+# ./hcp-sre-breakglass.sh <cs-cluster-id>
+#
+
+SUBJECT="/CN=system:sre-break-glass:${USER}/O=sre-group"
+
+CS_CLUSTER_ID=$1
+HOSTED_CLUSTER_CR=$(kubectl get hostedcluster -A -l "api.openshift.com/id=${CS_CLUSTER_ID}" -o yaml | yq -r '.items[0]')
+HCP_NAMESPACE=$(echo "${HOSTED_CLUSTER_CR}" | yq '.metadata.namespace + "-" + (.metadata.labels["api.openshift.com/name"] | tostring)')
+HCP_API_SERVER=$(echo "${HOSTED_CLUSTER_CR}" | yq '.status.controlPlaneEndpoint.host')
+
+# download the API server CA from the HCP_API_SERVER_URL
+echo "Downloading the API server CA from ${HCP_API_SERVER}"
+HCP_ROOT_CA_CRT=$(openssl s_client -servername "${HCP_API_SERVER}" -connect "${HCP_API_SERVER}:443" </dev/null 2>/dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | base64 | tr -d '\n')
+
+KEY_FILE="sre-breakglass-${CS_CLUSTER_ID}-${USER}.key"
+CSR_NAME="sre-breakglass-${CS_CLUSTER_ID}-${USER}"
+CSR_FILE="${CSR_NAME}.csr"
+KUBECONFIG_FILE="${CSR_NAME}.kubeconfig"
+
+# Generate a private key
+echo "Create private key"
+openssl genrsa -out "${KEY_FILE}" 2048
+
+# Generate a CSR using the private key and subject
+echo "Create CSR with subject ${SUBJECT}"
+openssl req -new -key "${KEY_FILE}" -subj "${SUBJECT}" -out "${CSR_FILE}"
+
+# Base64 encode the CSR
+CSR_BASE64=$(base64 -i "${CSR_FILE}" | tr -d '\n')
+
+# Create a Kubernetes CSR manifest
+cat <<EOF | kubectl apply -f -
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: ${CSR_NAME}
+  labels:
+    api.openshift.com/id: $CS_CLUSTER_ID
+    api.openshift.com/name: $USER
+    api.openshift.com/type: break-glass-credential
+spec:
+  expirationSeconds: 86353
+  request: ${CSR_BASE64}
+  signerName: hypershift.openshift.io/${HCP_NAMESPACE}.sre-break-glass
+  usages:
+  - client auth
+  - digital signature
+EOF
+
+echo "Kubernetes CSR ${CSR_NAME} applied to the cluster."
+
+cat <<EOF | kubectl apply -f -
+apiVersion: certificates.hypershift.openshift.io/v1alpha1
+kind: CertificateSigningRequestApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    api.openshift.com/id: $CS_CLUSTER_ID
+    api.openshift.com/name: $USER
+    api.openshift.com/type: break-glass-credential
+  name: ${CSR_NAME}
+  namespace: ${HCP_NAMESPACE}
+EOF
+
+echo "Hypershift CSR Approval ${CSR_NAME} applied to the cluster."
+
+# wait for the CSR to be approved
+while true; do
+  STATUS=$(kubectl get csr "${CSR_NAME}" -o jsonpath='{.status.conditions[?(@.type=="Approved")].status}')
+  if [ "$STATUS" == "True" ]; then
+    echo "CSR ${CSR_NAME} approved."
+    break
+  else
+    echo "Waiting for CSR ${CSR_NAME} to be approved..."
+    sleep 5
+  fi
+done
+
+# Check status of CSR
+CERTIFICATE=$(kubectl get csr "${CSR_NAME}" -o jsonpath='{.status.certificate}')
+kubectl delete csr "${CSR_NAME}"
+kubectl delete CertificateSigningRequestApproval "${CSR_NAME}" -n "${HCP_NAMESPACE}"
+if [ -z "$CERTIFICATE" ]; then
+  echo "CSR ${CSR_NAME} not signed yet."
+  # cleanup
+  exit 1
+fi
+echo "CSR ${CSR_NAME} signed."
+
+# build a kubeconfig from it
+cat <<EOF > "${KUBECONFIG_FILE}"
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ${HCP_ROOT_CA_CRT}
+    server: https://${HCP_API_SERVER}:443
+  name: ${CS_CLUSTER_ID}
+contexts:
+- context:
+    cluster: ${CS_CLUSTER_ID}
+    user: ${CSR_NAME}
+  name: ${CSR_NAME}
+current-context: ${CSR_NAME}
+kind: Config
+preferences: {}
+users:
+- name: ${CSR_NAME}
+  user:
+    client-certificate-data: ${CERTIFICATE}
+    client-key-data: $(base64 -i "${KEY_FILE}" -w 0)
+EOF
+echo "Kubeconfig ${KUBECONFIG_FILE} created."
+echo "export KUBECONFIG=$(realpath "${KUBECONFIG_FILE}")"


### PR DESCRIPTION
### What

this PR contains a quick and dirty POC for a manual SRE breakglass script, executed directly towards the MC of an HCP

TLDR:
* use the `sre-break-glass` signer to sign a CSR for an HCP
  * use the organization `O` of the CSR subject to carry the information about groupmembership
* use the resulting certificate to craft a kubeconfig
* use an ACM policy to grant the group mentioned in `O` certain permissions on the HCP
* setup kubectl portforward to the HCP KAS

(!) don't merge! this is only to show that the procedure basically works and grants access to an HCP in conjunction with an ACM policy.

https://issues.redhat.com/browse/ARO-17406

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
