### PR TITLE
fix deployment script issue by correcting passing parameters from bicep 

### DIFF
--- a/dev-infrastructure/modules/automation-account/runbook.bicep
+++ b/dev-infrastructure/modules/automation-account/runbook.bicep
@@ -34,7 +34,8 @@ param startTime string = '${substring(dateTimeAdd(utcNow(), 'P1D'), 0, 10)}T00:0
 param identityName string = 'hcp-dev-automation'
 
 @description('Runbook parameter')
-param runbookParameter string = ''
+param subscriptionId string = ''
+param managedIdentityId string = ''
 
 resource automationAccount 'Microsoft.Automation/automationAccounts@2022-08-08' existing = {
   name: automationAccountName
@@ -75,7 +76,9 @@ resource runbookSchedule 'Microsoft.Automation/automationAccounts/schedules@2022
 }
 
 var baseArguments = '-ResourceGroupName ${resourceGroup().name} -AutomationAccountName ${automationAccountName} -RunbookName ${accountRunbook.name} -ScheduleName ${runbookSchedule.name}'
-var arguments = length(runbookParameter) > 0 ? '${baseArguments} -Parameters ${runbookParameter}' : baseArguments
+var arguments = (subscriptionId != '' && managedIdentityId != '')
+  ? '${baseArguments} -SubscriptionId ${subscriptionId} -ManagedIdentityId ${managedIdentityId}'
+  : baseArguments
 
 // Link Schedule to Runbook
 resource registerScheduledRunbook 'Microsoft.Resources/deploymentScripts@2023-08-01' = if (!empty(scheduleName)) {

--- a/dev-infrastructure/scripts/register-scheduledrunbook.ps1
+++ b/dev-infrastructure/scripts/register-scheduledrunbook.ps1
@@ -34,10 +34,13 @@ param(
     [string]$RunbookName,
 
     [Parameter(Mandatory = $true)]
-    [string]$ScheduleName
+    [string]$ScheduleName,
 
-    [Parameter(Mandatory = $false)]
-    [object]$Parameters
+    [Parameter(Mandatory=$false)]
+    [string] $SubscriptionId,
+
+    [Parameter(Mandatory=$false)]
+    [string] $ManagedIdentityId
 )
 
 $ErrorActionPreference = 'Stop'
@@ -54,10 +57,12 @@ try {
     Write-Verbose @"
 Parameters:
     Automation Account: $AutomationAccountName
-    Runbook:           $RunbookName
-    Schedule:          $ScheduleName
-    Resource Group:    $ResourceGroupName
-    Parameters:        $Parameters
+    Runbook:            $RunbookName
+    Schedule:           $ScheduleName
+    Resource Group:     $ResourceGroupName
+    Parameters:         $Parameters
+    SubscriptionId:     $SubscriptionId,
+    ManagedIdentityId:  $ManagedIdentityId
 "@
 
     # Validate that the runbook exists and is published.

--- a/dev-infrastructure/templates/dev-automation-account.bicep
+++ b/dev-infrastructure/templates/dev-automation-account.bicep
@@ -66,8 +66,6 @@ module permissions '../modules/automation-account/permissions.bicep' = {
   }
 }
 
-var runbookParameter = '@{"parameter1": ${subscription()}, "parameter2": ${automationAccount.outputs.automationAccountManagedIdentityId}}'
-
 module resouceCleanup '../modules/automation-account/runbook.bicep' = {
   name: 'resourceCleanup'
   params: {
@@ -82,11 +80,9 @@ module resouceCleanup '../modules/automation-account/runbook.bicep' = {
       path: 'tooling/azure-automation/resources-cleanup/src/resources_cleanup.py'
     }
     scheduleName: 'nightly-schedule'
-    runbookParameter: runbookParameter
+    subscriptionId: subscription().subscriptionId
+    managedIdentityId: automationAccount.outputs.automationAccountManagedIdentityId
   }
-  dependsOn: [
-    automationAccount
-  ]
 }
 
 module roleAssignmentsCleanup '../modules/automation-account/runbook.bicep' = {


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->
Fixed deployment script issue caused by incorrect parameter passing to the PowerShell script from bicep.

Deployment error when running `make automation-account`:

```
… -Parameters @{parameter1: {'id': …}}
                          ~
Missing '=' operator after key in hash literal.
```


[ARO-16555](https://issues.redhat.com/browse/ARO-16555)

