### PR TITLE
AKS fix advanced network settings

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -329,7 +329,7 @@ var advancedNetworking = networkDataplane == 'cilium'
         enabled: true
       }
     }
-  : {}
+  : null
 
 resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-10-01' = {
   location: location


### PR DESCRIPTION
### What

in case advanced networking is not used (e.g. azure CNI) the respective AKS networkprofile settings must be set to `null` instead of `{}`

follows up on https://github.com/Azure/ARO-HCP/pull/1724

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
