### PR TITLE
move PIPs from svc RG to regional RG

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -29,6 +29,9 @@ param dnsServiceIP string = '10.130.0.10'
 // Passed Params and Overrides
 param location string
 
+@description('The regional resource group')
+param regionalResourceGroup string
+
 @description('List of Availability Zones to use for the AKS cluster')
 param locationAvailabilityZones array
 var locationHasAvailabilityZones = length(locationAvailabilityZones) > 0
@@ -286,6 +289,7 @@ resource aksNetworkContributorRoleAssignment 'Microsoft.Authorization/roleAssign
 
 module istioIngressGatewayIPAddress '../modules/network/publicipaddress.bicep' = if (deployIstio) {
   name: istioIngressGatewayIPAddressName
+  scope: resourceGroup(regionalResourceGroup)
   params: {
     name: istioIngressGatewayIPAddressName
     ipTags: istioIngressGatewayIPAddressIPTagsArray
@@ -303,6 +307,7 @@ module istioIngressGatewayIPAddress '../modules/network/publicipaddress.bicep' =
 var aksClusterOutboundIPAddressName = 'aro-hcp-cluster-egress'
 module aksClusterOutboundIPAddress '../modules/network/publicipaddress.bicep' = {
   name: aksClusterOutboundIPAddressName
+  scope: resourceGroup(regionalResourceGroup)
   params: {
     name: aksClusterOutboundIPAddressName
     ipTags: aksClusterOutboundIPAddressIPTagsArray
@@ -450,7 +455,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-10-01' = {
         outboundIPs: {
           publicIPs: [
             {
-              id: resourceId('Microsoft.Network/publicIPAddresses', aksClusterOutboundIPAddressName)
+              id: resourceId(regionalResourceGroup, 'Microsoft.Network/publicIPAddresses', aksClusterOutboundIPAddressName)
             }
           ]
         }

--- a/dev-infrastructure/scripts/istio.sh
+++ b/dev-infrastructure/scripts/istio.sh
@@ -62,7 +62,7 @@ echo "==========================================================================
 
 echo "********** ISTIO IngressGateway IP Address assignment **************"
 ISTIO_IG_ANNOTATIONS="
-  service.beta.kubernetes.io/azure-load-balancer-resource-group=${SVC_RESOURCEGROUP}
+  service.beta.kubernetes.io/azure-load-balancer-resource-group=${REGION_RESOURCEGROUP}
   service.beta.kubernetes.io/azure-pip-name=${ISTIO_INGRESS_GATEWAY_IP_ADDRESS_NAME}
 "
 for annotation in $ISTIO_IG_ANNOTATIONS; do

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -165,8 +165,8 @@ resourceGroups:
       configRef: svc.istio.ingressGatewayIPAddressName
     - name: TAG
       configRef: svc.istio.tag
-    - name: SVC_RESOURCEGROUP
-      configRef: svc.rg
+    - name: REGION_RESOURCEGROUP
+      configRef: regionRG
     dependsOn:
     - istio-config
   # Install ACRpull

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -290,6 +290,7 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
   scope: resourceGroup()
   params: {
     location: location
+    regionalResourceGroup: regionalResourceGroup
     locationAvailabilityZones: locationAvailabilityZoneList
     aksClusterName: aksClusterName
     aksNodeResourceGroupName: aksNodeResourceGroupName


### PR DESCRIPTION
[ARO-16089](https://issues.redhat.com/browse/ARO-16089)

### What

Move the PIP resources used by the AKS cluster from the SVC resource group to the regional resource group

### Why

MSFT prefers the SVC cluster RG to be about the AKS cluster. All other resources like DBs, storage accounts, managed identities for service, etc should be in the regional RG.

See [ARO-16089](https://issues.redhat.com/browse/ARO-16089)

### Special notes for your reviewer

As this will require a rebuild of the dev & cspr environments we should only merge this when we are ready to do so