### PR TITLE
Remove bicep version pin in linter

### DIFF
--- a/.github/workflows/bicep-lint.yml
+++ b/.github/workflows/bicep-lint.yml
@@ -20,8 +20,6 @@ jobs:
       run: |
         # https://github.com/actions/runner-images/issues/11987
         az config set bicep.use_binary_from_path=false
-        # Install specific version due to https://github.com/Azure/bicep/issues/16676
-        az bicep install -v v0.33.93
         az bicep version
         make fmt
         make lint


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

$TITLE

### Why

The issue which required the version pinning has been fixed

Also allow updating to new bicep version which provides some nice features

### Special notes for your reviewer

<!-- optional -->
