### PR TITLE
add cluster label to oss Prometheus scraped metrics

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -169,6 +169,8 @@ resourceGroups:
       configRef: mgmt.prometheus.namespaceLabel
     - name: RESOURCE_GROUP
       configRef: mgmt.rg
+    - name: CLUSTER_NAME
+      configRef: mgmt.aks.name
     dependsOn:
     - mgmt-cluster
   # Install ACRpull

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -136,6 +136,8 @@ resourceGroups:
       configRef: svc.prometheus.namespaceLabel
     - name: RESOURCE_GROUP
       configRef: svc.rg
+    - name: CLUSTER_NAME
+      configRef: svc.aks.name
     dependsOn:
     - svc
   # configure istio

--- a/observability/prometheus/Makefile
+++ b/observability/prometheus/Makefile
@@ -39,7 +39,8 @@ deploy: pull-chart
 		--set prometheus.prometheusSpec.shards=${PROMETHEUS_SPEC_SHARDS} \
 		--set prometheus.prometheusSpec.replicas=${PROMETHEUS_SPEC_REPLICAS} \
 		--set prometheus.prometheusSpec.remoteWrite[0].url=$${PROMETHEUS_RW_ENDPOINT} \
-		--set prometheus.prometheusSpec.topologySpreadConstraints[0].topologyKey=${TOPOLOGY_KEY}
+		--set prometheus.prometheusSpec.topologySpreadConstraints[0].topologyKey=${TOPOLOGY_KEY} \
+		--set prometheus.prometheusSpec.externalLabels.cluster=${CLUSTER_NAME}
 .PHONY: deploy
 
 pull-chart:

--- a/observability/prometheus/values.yaml
+++ b/observability/prometheus/values.yaml
@@ -234,6 +234,8 @@ prometheus:
         maxBackoff: 256s
       metadataConfig:
         send: false
+    externalLabels:
+      cluster: ""
     ## Resource limits & requests
     ##
     resources: {}


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-16995

### What
Adds a relabel config to remote write configuration to add a "cluster" label
### Why

This label was provided by default through Azure Managed Prometheus but was lost when moving to OSS Prometheus.

### Special notes for your reviewer

<!-- optional -->
