### PR TITLE
introduce AKS nodepool labels to distinguish node roles

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -408,6 +408,9 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-10-01' = {
           enableSecureBoot: false
           enableVTPM: false
         }
+        nodeLabels: {
+          'aro-hcp.azure.com/role': 'system'
+        }
         nodeTaints: [
           'CriticalAddonsOnly=true:NoSchedule'
         ]
@@ -638,6 +641,9 @@ resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2
         enableSecureBoot: false
         enableVTPM: false
       }
+      nodeLabels: {
+        'aro-hcp.azure.com/role': 'worker'
+      }
       tags: enableSwiftV2
         ? {
             'aks-nic-enable-multi-tenancy': 'true'
@@ -679,7 +685,7 @@ resource infraAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@
         enableVTPM: false
       }
       nodeLabels: {
-        infra: 'true'
+        'aro-hcp.azure.com/role': 'infra'
       }
       nodeTaints: [
         'infra=true:NoSchedule'

--- a/mgmt-fixes/deploy/templates/ds-kubelet-parameters.yaml
+++ b/mgmt-fixes/deploy/templates/ds-kubelet-parameters.yaml
@@ -21,7 +21,7 @@ spec:
         tier: node
     spec:
       nodeSelector:
-        kubernetes.azure.com/mode: user
+        aro-hcp.azure.com/role: worker
       containers:
       - command:
         - nsenter

--- a/observability/prometheus/values.yaml
+++ b/observability/prometheus/values.yaml
@@ -92,10 +92,10 @@ prometheusOperator:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: infra
+          - key: aro-hcp.azure.com/role
             operator: In
             values:
-            - "true"
+            - "infra"
   tolerations:
   - key: "infra"
     operator: "Equal"
@@ -201,10 +201,10 @@ prometheus:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
           - matchExpressions:
-            - key: infra
+            - key: aro-hcp.azure.com/role
               operator: In
               values:
-              - "true"
+              - "infra"
     tolerations:
     - key: "infra"
       operator: "Equal"


### PR DESCRIPTION
###What

the `aro-hcp.azure.com/role` label will be available on all AKS nodes, having one of the following values: `system`, `worker`, `infra`

these can be used for nodeselectors, e.g. for the kubelet patches DS

### Why

previously the kubelet patches DS was targeting all nodes of `kubernetes.azure.com/mode: user`. with the introduction of infra nodes, that selector is not sufficient anymore. while we could use a combination of other AKS default labels to narrow the DS placement down, using something explicit that is under our control is more stable.

### Special notes for your reviewer

<!-- optional -->
