### PR TITLE
missing az bicep install in bicep-lint gh action

### DIFF
--- a/.github/workflows/bicep-lint.yml
+++ b/.github/workflows/bicep-lint.yml
@@ -20,6 +20,7 @@ jobs:
       run: |
         # https://github.com/actions/runner-images/issues/11987
         az config set bicep.use_binary_from_path=false
+        az bicep install
         az bicep version
         make fmt
         make lint


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

follows up on #1731 to fix bicep-lint errors like https://github.com/Azure/ARO-HCP/actions/runs/14883051555/job/41795488872?pr=1734



### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
