### PR TITLE
ARO-17125: refactor tracing config for CS

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -77,7 +77,6 @@ deploy:
 	  --set pullBinding.registry=${ACR_NAME}.azurecr.io \
 	  --set pullBinding.scope=repository:${IMAGE_REPO}:pull \
 	  --set tracing.address=${TRACING_ADDRESS} \
-	  --set tracing.exporter=${TRACING_EXPORTER} \
 	  --set azureOperatorsMI.kms.roleName="${OP_KMS_ROLE_NAME}" \
 	  --set azureOperatorsMI.kms.roleId="$${OP_KMS_ROLE_ID}"
 

--- a/cluster-service/deploy/templates/deployment.yaml
+++ b/cluster-service/deploy/templates/deployment.yaml
@@ -141,11 +141,6 @@ spec:
         - name: azure-operators-managed-identities-config
           mountPath: /configs/azure-operators-managed-identities-config.yaml
           subPath: azure-operators-managed-identities-config.yaml
-        env:
-        - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: '{{ .Values.tracing.address  }}'
-        - name: OTEL_TRACES_EXPORTER
-          value: '{{ .Values.tracing.exporter  }}'
         command:
         - /usr/local/bin/clusters-service
         - serve
@@ -204,6 +199,9 @@ spec:
         {{- end }}
         # Baggage items are populated by the RP frontend and defined in internal/tracing/attributes.go.
         - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
+        {{ if .Values.tracing.address }}
+        - --tracing-otlp-url={{ .Values.tracing.address }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /api/clusters_mgmt/v1

--- a/cluster-service/deploy/values.yaml
+++ b/cluster-service/deploy/values.yaml
@@ -243,4 +243,3 @@ pullBinding:
   workloadIdentityTenantId: ""
 tracing:
   address: ""
-  exporter: ""

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -138,5 +138,3 @@ resourceGroups:
       configRef: msiKeyVault.name
     - name: TRACING_ADDRESS
       configRef: clustersService.tracing.address
-    - name: TRACING_EXPORTER
-      configRef: clustersService.tracing.exporter

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -284,7 +284,7 @@ clouds:
       # Cluster Service
       clustersService:
         image:
-          digest: sha256:777e6f7be92f113b9c188de36b6925dff2537c23fd2efca115b21d42fa9d29e5
+          digest: sha256:ec301b5cdd705c5bc07812f5d6628bf8ffe792a3a38f3876ac4fdc669d7f8485
         azureOperatorsManagedIdentities:
           clusterApiAzure:
             roleName: Azure Red Hat OpenShift Cluster API Role - Dev

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -66,7 +66,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:777e6f7be92f113b9c188de36b6925dff2537c23fd2efca115b21d42fa9d29e5",
+      "digest": "sha256:ec301b5cdd705c5bc07812f5d6628bf8ffe792a3a38f3876ac4fdc669d7f8485",
       "registry": "quay.io",
       "repository": "app-sre/uhc-clusters-service"
     },

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -66,7 +66,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:777e6f7be92f113b9c188de36b6925dff2537c23fd2efca115b21d42fa9d29e5",
+      "digest": "sha256:ec301b5cdd705c5bc07812f5d6628bf8ffe792a3a38f3876ac4fdc669d7f8485",
       "registry": "quay.io",
       "repository": "app-sre/uhc-clusters-service"
     },

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -66,7 +66,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:777e6f7be92f113b9c188de36b6925dff2537c23fd2efca115b21d42fa9d29e5",
+      "digest": "sha256:ec301b5cdd705c5bc07812f5d6628bf8ffe792a3a38f3876ac4fdc669d7f8485",
       "registry": "quay.io",
       "repository": "app-sre/uhc-clusters-service"
     },

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -66,7 +66,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:777e6f7be92f113b9c188de36b6925dff2537c23fd2efca115b21d42fa9d29e5",
+      "digest": "sha256:ec301b5cdd705c5bc07812f5d6628bf8ffe792a3a38f3876ac4fdc669d7f8485",
       "registry": "quay.io",
       "repository": "app-sre/uhc-clusters-service"
     },

--- a/observability/tracing/Makefile
+++ b/observability/tracing/Makefile
@@ -23,6 +23,7 @@ patch-frontend:
 .PHONY: patch-frontend
 
 patch-clusterservice:
-	@kubectl set env -n ${CS_NAMESPACE} deployment clusters-service --containers service OTEL_EXPORTER_OTLP_ENDPOINT=http://ingest.observability:4318 OTEL_TRACES_EXPORTER=otlp
+	kubectl patch -n ${CS_NAMESPACE} deployment clusters-service --type json \
+		--patch="[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/command/-\", \"value\": \"--tracing-otlp-url=http://ingest.observability:4318\"}]"
 	@kubectl wait --for=condition=Available -n ${CS_NAMESPACE} deployment clusters-service --timeout=30s
 .PHONY: patch-clusterservice

--- a/observability/tracing/README.md
+++ b/observability/tracing/README.md
@@ -8,9 +8,9 @@ This page explains how you can enable tracing for ARO HCP in your [development s
 
 ## Tracing
 
-The ARO frontend, cluster service and other components are instrumented with
-the OpenTelemetry SDK but by default, there's no backend configured to collect
-and visualize the traces.
+The ARO resource provider frontend, Clusters Service and other components are
+instrumented with the OpenTelemetry SDK but by default, there's no backend
+configured to collect and visualize the traces.
 
 ### Deploy Jaeger all-in-one testing backend
 
@@ -40,21 +40,13 @@ make patch-frontend
 make patch-clusterservice
 ```
 
-The export of the trace information is configured via environment variables. Existing deployments are patched as follows:
-
-```diff
-+        env:
-+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
-+          value: https://ingest.observability:4318
-+        - name: OTEL_TRACES_EXPORTER
-+          value: otlp
-```
+The export of the trace information is configured via environment variables for the RP Frontend and command-line arguments for the Clusters Service.
 
 ### Correlate with ARM requests
 
 #### Generate Traces
 
-Traces are automatically generated for every incoming HTTP request (sampling rate: 100%). A simple way to generate incoming requests is to follow the [demo instructions](../demo/README.md).
+Traces are automatically generated for every incoming HTTP request (sampling rate: 100%). A simple way to generate incoming requests is to follow the [demo instructions](../../demo/README.md).
 
 #### Common Attributes
 


### PR DESCRIPTION
This commit updates the tracing configuration of Clusters Service to be in sync with the latest changes [1] which moved from environment variables to CLI arguments.

[1] https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/9553

https://issues.redhat.com/browse/ARO-17125

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
