### PR TITLE
Update visibility tags in Go models and add tests

### DIFF
--- a/internal/api/arm/resource.go
+++ b/internal/api/arm/resource.go
@@ -23,10 +23,10 @@ import (
 
 // Resource represents a basic ARM resource
 type Resource struct {
-	ID         string      `json:"id,omitempty"`
-	Name       string      `json:"name,omitempty"`
-	Type       string      `json:"type,omitempty"`
-	SystemData *SystemData `json:"systemData,omitempty"`
+	ID         string      `json:"id,omitempty"         visibility:"read"`
+	Name       string      `json:"name,omitempty"       visibility:"read"`
+	Type       string      `json:"type,omitempty"       visibility:"read"`
+	SystemData *SystemData `json:"systemData,omitempty" visibility:"read"`
 }
 
 func (src *Resource) Copy(dst *Resource) {
@@ -44,8 +44,8 @@ func (src *Resource) Copy(dst *Resource) {
 // TrackedResource represents a tracked ARM resource
 type TrackedResource struct {
 	Resource
-	Location string            `json:"location,omitempty"`
-	Tags     map[string]string `json:"tags,omitempty"`
+	Location string            `json:"location,omitempty" visibility:"read create"`
+	Tags     map[string]string `json:"tags,omitempty"     visibility:"read create update"`
 }
 
 func (src *TrackedResource) Copy(dst *TrackedResource) {

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -28,11 +28,11 @@ type HCPOpenShiftCluster struct {
 // HCPOpenShiftClusterProperties represents the property bag of a HCPOpenShiftCluster resource.
 type HCPOpenShiftClusterProperties struct {
 	ProvisioningState arm.ProvisioningState      `json:"provisioningState,omitempty"             visibility:"read"`
-	Version           VersionProfile             `json:"version,omitempty"                       visibility:"read create"`
-	DNS               DNSProfile                 `json:"dns,omitempty"                           visibility:"read create update"`
+	Version           VersionProfile             `json:"version,omitempty"`
+	DNS               DNSProfile                 `json:"dns,omitempty"`
 	Network           NetworkProfile             `json:"network,omitempty"                       visibility:"read create"`
 	Console           ConsoleProfile             `json:"console,omitempty"                       visibility:"read"`
-	API               APIProfile                 `json:"api,omitempty"                           visibility:"read create"`
+	API               APIProfile                 `json:"api,omitempty"`
 	Platform          PlatformProfile            `json:"platform,omitempty"                      visibility:"read create"`
 	Capabilities      ClusterCapabilitiesProfile `json:"capabilities,omitempty"                  visibility:"read create"`
 }
@@ -73,7 +73,7 @@ type APIProfile struct {
 }
 
 // PlatformProfile represents the Azure platform configuration.
-// Visibility for the entire struct is "read create".
+// Visibility for (almost) the entire struct is "read create".
 type PlatformProfile struct {
 	ManagedResourceGroup    string                         `json:"managedResourceGroup,omitempty"`
 	SubnetID                string                         `json:"subnetId,omitempty"                                  validate:"required_for_put,resource_id=Microsoft.Network/virtualNetworks/subnets"`
@@ -85,12 +85,14 @@ type PlatformProfile struct {
 
 // OperatorsAuthenticationProfile represents authentication configuration for
 // OpenShift operators.
+// Visibility for the entire struct is "read create".
 type OperatorsAuthenticationProfile struct {
 	UserAssignedIdentities UserAssignedIdentitiesProfile `json:"userAssignedIdentities,omitempty"`
 }
 
 // UserAssignedIdentitiesProfile represents authentication configuration for
 // OpenShift operators using user-assigned managed identities.
+// Visibility for the entire struct is "read create".
 type UserAssignedIdentitiesProfile struct {
 	ControlPlaneOperators  map[string]string `json:"controlPlaneOperators,omitempty"  validate:"dive,resource_id=Microsoft.ManagedIdentity/userAssignedIdentities"`
 	DataPlaneOperators     map[string]string `json:"dataPlaneOperators,omitempty"     validate:"dive,resource_id=Microsoft.ManagedIdentity/userAssignedIdentities"`
@@ -98,6 +100,7 @@ type UserAssignedIdentitiesProfile struct {
 }
 
 // ClusterCapabilitiesProfile - Cluster capabilities configuration.
+// Visibility for the entire struct is "read create".
 type ClusterCapabilitiesProfile struct {
 	// Disabled cluter capabilities.
 	Disabled []OptionalClusterCapability `json:"disabled,omitempty" validate:"dive,enum_optionalclustercapability"`

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -29,7 +29,7 @@ type HCPOpenShiftClusterNodePool struct {
 // HCPOpenShiftClusterNodePool resource.
 type HCPOpenShiftClusterNodePoolProperties struct {
 	ProvisioningState arm.ProvisioningState   `json:"provisioningState,omitempty" visibility:"read"`
-	Version           NodePoolVersionProfile  `json:"version,omitempty"           visibility:"read create"`
+	Version           NodePoolVersionProfile  `json:"version,omitempty"`
 	Platform          NodePoolPlatformProfile `json:"platform,omitempty"          visibility:"read create"`
 	Replicas          int32                   `json:"replicas,omitempty"          visibility:"read create update" validate:"min=0,excluded_with=AutoScaling"`
 	AutoRepair        bool                    `json:"autoRepair,omitempty"        visibility:"read create"`
@@ -62,6 +62,8 @@ type NodePoolAutoScaling struct {
 	Max int32 `json:"max,omitempty" validate:"gtefield=Min"`
 }
 
+// Taint represents a Kubernetes taint for a node.
+// Visibility for the entire struct is "read create update".
 type Taint struct {
 	Effect Effect `json:"effect,omitempty" validate:"required_for_put,enum_effect"`
 	Key    string `json:"key,omitempty"    validate:"required_for_put,k8s_qualified_name"`

--- a/internal/api/v20240610preview/register_test.go
+++ b/internal/api/v20240610preview/register_test.go
@@ -1,0 +1,166 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v20240610preview
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+// skip is for fields that are not validated but may set
+// a default visibility value for its descendant fields.
+const skip = api.VisibilityFlags(0)
+
+func getEffectiveVisibility(t *testing.T, structTagMap api.StructTagMap, path string) api.VisibilityFlags {
+	t.Helper()
+
+	parts := strings.Split(path, ".")
+
+	for i := len(parts); i > 0; i-- {
+		if tag, ok := structTagMap[strings.Join(parts[:i], ".")]; ok {
+			if flags, ok := api.GetVisibilityFlags(tag); ok {
+				return flags
+			}
+		}
+	}
+
+	return api.VisibilityDefault
+}
+
+func testStructTagMap(t *testing.T, structTagMap api.StructTagMap, expectedVisibility map[string]api.VisibilityFlags) {
+	t.Helper()
+
+	for path, expectedFlags := range expectedVisibility {
+		if expectedFlags != skip {
+			actualFlags := getEffectiveVisibility(t, structTagMap, path)
+			assert.Equalf(t, expectedFlags, actualFlags, "%s: expected %q, actual %q", path, expectedFlags, actualFlags)
+		}
+	}
+
+	// Make sure the StructTagMap was fully tested.
+	for path := range expectedVisibility {
+		delete(structTagMap, path)
+	}
+	assert.Empty(t, structTagMap)
+}
+
+func TestClusterStructTagMap(t *testing.T) {
+	// This should include any clusterStructTagMap
+	// overrides from the package's init() function.
+	expectedVisibility := map[string]api.VisibilityFlags{
+		"TrackedResource.Resource.ID":                                        api.VisibilityRead,
+		"TrackedResource.Resource.Name":                                      api.VisibilityRead,
+		"TrackedResource.Resource.Type":                                      api.VisibilityRead,
+		"TrackedResource.Resource.SystemData":                                skip,
+		"TrackedResource.Resource.SystemData.CreatedBy":                      api.VisibilityRead,
+		"TrackedResource.Resource.SystemData.CreatedByType":                  api.VisibilityRead,
+		"TrackedResource.Resource.SystemData.CreatedAt":                      api.VisibilityRead,
+		"TrackedResource.Resource.SystemData.LastModifiedBy":                 api.VisibilityRead,
+		"TrackedResource.Resource.SystemData.LastModifiedByType":             api.VisibilityRead,
+		"TrackedResource.Resource.SystemData.LastModifiedAt":                 api.VisibilityRead,
+		"TrackedResource.Location":                                           api.VisibilityRead | api.VisibilityCreate,
+		"TrackedResource.Tags":                                               api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
+		"Properties":                                                         skip,
+		"Properties.ProvisioningState":                                       api.VisibilityRead,
+		"Properties.Version":                                                 skip,
+		"Properties.Version.ID":                                              api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Version.ChannelGroup":                                    api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
+		"Properties.Version.AvailableUpgrades":                               api.VisibilityRead,
+		"Properties.DNS":                                                     skip,
+		"Properties.DNS.BaseDomain":                                          api.VisibilityRead,
+		"Properties.DNS.BaseDomainPrefix":                                    api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Network":                                                 skip,
+		"Properties.Network.NetworkType":                                     api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Network.PodCIDR":                                         api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Network.ServiceCIDR":                                     api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Network.MachineCIDR":                                     api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Network.HostPrefix":                                      api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Console":                                                 skip,
+		"Properties.Console.URL":                                             api.VisibilityRead,
+		"Properties.API":                                                     skip,
+		"Properties.API.URL":                                                 skip,
+		"Properties.API.Visibility":                                          api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Platform":                                                skip,
+		"Properties.Platform.ManagedResourceGroup":                           api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Platform.SubnetID":                                       api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Platform.OutboundType":                                   api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Platform.NetworkSecurityGroupID":                         api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Platform.OperatorsAuthentication":                        skip,
+		"Properties.Platform.OperatorsAuthentication.UserAssignedIdentities": skip,
+		"Properties.Platform.OperatorsAuthentication.UserAssignedIdentities.ControlPlaneOperators":  api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Platform.OperatorsAuthentication.UserAssignedIdentities.DataPlaneOperators":     api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Platform.OperatorsAuthentication.UserAssignedIdentities.ServiceManagedIdentity": api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Platform.IssuerURL":               api.VisibilityRead,
+		"Properties.Capabilities":                     skip,
+		"Properties.Capabilities.Disabled":            api.VisibilityRead | api.VisibilityCreate,
+		"Identity":                                    skip,
+		"Identity.PrincipalID":                        api.VisibilityRead,
+		"Identity.TenantID":                           api.VisibilityRead,
+		"Identity.Type":                               skip,
+		"Identity.UserAssignedIdentities":             skip,
+		"Identity.UserAssignedIdentities.ClientID":    api.VisibilityRead,
+		"Identity.UserAssignedIdentities.PrincipalID": api.VisibilityRead,
+	}
+
+	testStructTagMap(t, clusterStructTagMap, expectedVisibility)
+}
+
+func TestNodePoolStructTagMap(t *testing.T) {
+	// This should include any nodePoolStructTagMap
+	// overrides from the package's init() function.
+	expectedVisibility := map[string]api.VisibilityFlags{
+		"TrackedResource.Resource.ID":                            api.VisibilityRead,
+		"TrackedResource.Resource.Name":                          api.VisibilityRead,
+		"TrackedResource.Resource.Type":                          api.VisibilityRead,
+		"TrackedResource.Resource.SystemData":                    skip,
+		"TrackedResource.Resource.SystemData.CreatedBy":          api.VisibilityRead,
+		"TrackedResource.Resource.SystemData.CreatedByType":      api.VisibilityRead,
+		"TrackedResource.Resource.SystemData.CreatedAt":          api.VisibilityRead,
+		"TrackedResource.Resource.SystemData.LastModifiedBy":     api.VisibilityRead,
+		"TrackedResource.Resource.SystemData.LastModifiedByType": api.VisibilityRead,
+		"TrackedResource.Resource.SystemData.LastModifiedAt":     api.VisibilityRead,
+		"TrackedResource.Location":                               api.VisibilityRead | api.VisibilityCreate,
+		"TrackedResource.Tags":                                   api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
+		"Properties":                                             skip,
+		"Properties.ProvisioningState":                           api.VisibilityRead,
+		"Properties.Version":                                     skip,
+		"Properties.Version.ID":                                  api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
+		"Properties.Version.ChannelGroup":                        api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
+		"Properties.Version.AvailableUpgrades":                   api.VisibilityRead,
+		"Properties.Platform":                                    skip,
+		"Properties.Platform.ManagedResourceGroup":               api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Platform.SubnetID":                           api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Platform.VMSize":                             api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Platform.DiskSizeGiB":                        api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Platform.DiskStorageAccountType":             api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Platform.AvailabilityZone":                   api.VisibilityRead | api.VisibilityCreate,
+		"Properties.Replicas":                                    api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
+		"Properties.AutoRepair":                                  api.VisibilityRead | api.VisibilityCreate,
+		"Properties.AutoScaling":                                 skip,
+		"Properties.AutoScaling.Min":                             api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
+		"Properties.AutoScaling.Max":                             api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
+		"Properties.Labels":                                      api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
+		"Properties.Taints":                                      skip,
+		"Properties.Taints.Effect":                               api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
+		"Properties.Taints.Key":                                  api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
+		"Properties.Taints.Value":                                api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
+	}
+
+	testStructTagMap(t, nodePoolStructTagMap, expectedVisibility)
+}


### PR DESCRIPTION
### What

This updates visibility tags in the Go API models and adds more unit tests around them.

### Why

It's been a minute since I've been focused on visibility validation logic and the API has changed a good bit.

The extra unit tests are mainly to put my mind at ease that visibility tag inheritance is working correctly.