### PR TITLE
Set SKIP_CONFIRM=true in the runbook cd workflow

### DIFF
--- a/.github/workflows/runbook-cicd.yml
+++ b/.github/workflows/runbook-cicd.yml
@@ -1,4 +1,6 @@
 name: Azure Automation Runbook CI/CD
+env:
+  SKIP_CONFIRM: true
 on:
   pull_request:
     paths:


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

Set `SKIP_CONFIRM=true` so the runbook cd pipeline doesn’t exit and continues to deploy the Automation Account.
```
ERROR: 
Resource changes: 10 to modify, 4 no change, 3 to ignore.
make: *** [Makefile:366: automation-account] Error 1
Error: Process completed with exit code 2.
```
[ARO-15539](https://issues.redhat.com/browse/ARO-15539)
