### PR TITLE
Add Nightly Infra Recreation

### DIFF
--- a/.github/workflows/nightly-recreate.yml
+++ b/.github/workflows/nightly-recreate.yml
@@ -1,0 +1,46 @@
+name: Nightly Infra Recreation
+on:
+  schedule:
+  - cron: '0 3 * * *'
+  workflow_dispatch:
+env:
+  REGION: eastus2
+  DEPLOY_ENV: ntly
+jobs:
+  nightly-dry-run:
+    name: Dry-Run Nightly Infra
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 1
+    - name: Azure CLI Login
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - name: Dry-run deploy
+      run: make ntly.what-if
+  nightly-recreate:
+    name: Delete & Recreate Nightly Infra
+    runs-on: ubuntu-latest
+    needs: nightly-dry-run
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 1
+    - name: Az CLI login
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - name: Delete previous infra
+      run: make ntly.clean
+    - name: Wait for deletion
+      run: sleep 60
+    - name: Recreate nightly infra
+      run: make ntly

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -61,7 +61,7 @@
           "$ref": "#/definitions/zoneRedundantMode"
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": [
         "name",
         "zoneRedundantMode"
@@ -1300,7 +1300,7 @@
           "$ref": "#/definitions/acr"
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": [
         "svc",
         "ocp"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -610,6 +610,9 @@ clouds:
       ntly:
         # this is an environment to test the deployability of infra nightly
         defaults:
+          monitoring:
+            svcWorkspaceName: 'aro-hcp-{{ .ctx.regionShort }}'
+            hcpWorkspaceName: 'aro-hcp-hcp-{{ .ctx.regionShort }}'
           # Cluster Service
           clustersService:
             postgres:
@@ -626,9 +629,13 @@ clouds:
             cosmosDB:
               private: false
               zoneRedundantMode: 'Disabled'
+          serviceKeyVault:
+            assignNSP: false
           # MC
           mgmt:
             applyKubeletFixes: false
+          svc:
+            subscription: ARO HCP nightly service (EA Subscription)
       pers:
         # this is the personal DEV environment
         defaults:

--- a/config/public-cloud-ntly.json
+++ b/config/public-cloud-ntly.json
@@ -349,12 +349,12 @@
     "grafanaMajorVersion": "11",
     "grafanaName": "arohcp-dev",
     "grafanaZoneRedundantMode": "Disabled",
-    "hcpWorkspaceName": "arohcp-hcp-ntly-ussw1",
+    "hcpWorkspaceName": "aro-hcp-hcp-ussw1",
     "sev1ActionGroupIDs": "",
     "sev2ActionGroupIDs": "",
     "sev3ActionGroupIDs": "",
     "sev4ActionGroupIDs": "",
-    "svcWorkspaceName": "arohcp-ntly-ussw1"
+    "svcWorkspaceName": "aro-hcp-ussw1"
   },
   "msiKeyVault": {
     "name": "ah-ntly-mi-ussw1-999",
@@ -379,7 +379,7 @@
   "region": "southwestus",
   "regionRG": "hcp-underlay-ntly-ussw1",
   "serviceKeyVault": {
-    "assignNSP": true,
+    "assignNSP": false,
     "name": "aro-hcp-dev-svc-kv",
     "private": false,
     "region": "westus3",
@@ -461,6 +461,6 @@
       }
     },
     "rg": "hcp-underlay-ntly-southwestus-svc",
-    "subscription": "ARO Hosted Control Planes (EA Subscription 1)"
+    "subscription": "ARO HCP nightly service (EA Subscription)"
   }
 }

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -399,6 +399,19 @@ infra: region svc.init mgmt.init
 clean: svc.clean mgmt.clean region.clean
 .PHONY: clean
 
+ntly:
+ntly: DEPLOY_ENV = ntly
+ntly: global acr-svc-cfg acr-ocp-cfg infra
+.PHONY: ntly
+
+ntly.what-if: DEPLOY_ENV = ntly
+ntly.what-if: what-if
+.PHONY: ntly.what-if
+
+ntly.clean: DEPLOY_ENV = ntly
+ntly.clean: clean
+.PHONY: ntly.clean
+
 #
 # Local CS Development
 #


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

Add automated nightly infrastructure recreation by:

- Define a nightly environment in `config.yaml` with global, svc and mgmt cluster overrides

- Introduce nightly and nightly.what-if Makefile targets to provision deletes/recreates sequences

- Provide a GitHub Actions workflow that runs a dry-run and then deletes/recreates infra on a daily schedule

[ARO-15624](https://issues.redhat.com/browse/ARO-15624)
