### PR TITLE
ARO-16033: Enable otel tracing for maestro server

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -812,6 +812,9 @@
             "loglevel": {
               "type": "integer"
             },
+            "tracing": {
+              "$ref": "#/definitions/tracing"
+            },
             "k8s": {
               "type": "object",
               "properties": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -152,6 +152,9 @@ defaults:
   # Maestro
   maestro:
     server:
+      tracing:
+        address: ""
+        exporter: ""
       mqttClientName: maestro-server
       loglevel: 4
       managedIdentityName: maestro-server
@@ -532,6 +535,9 @@ clouds:
             regionalSubdomain: '{{ .ctx.regionShort }}'
           # Maestro
           maestro:
+            tracing:
+              address: "http://ingest.observability:4318"
+              exporter: "otlp"
             postgres:
               deploy: false
             server:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -235,6 +235,10 @@
     },
     "restrictIstioIngress": false,
     "server": {
+      "tracing": {
+        "address": "",
+        "exporter": ""
+      },
       "k8s": {
         "namespace": "maestro",
         "serviceAccountName": "maestro"

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -235,6 +235,10 @@
     },
     "restrictIstioIngress": true,
     "server": {
+      "tracing": {
+        "address": "",
+        "exporter": ""
+      },
       "k8s": {
         "namespace": "maestro",
         "serviceAccountName": "maestro"

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -235,6 +235,10 @@
     },
     "restrictIstioIngress": true,
     "server": {
+      "tracing": {
+        "address": "",
+        "exporter": ""
+      },
       "k8s": {
         "namespace": "maestro",
         "serviceAccountName": "maestro"

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -235,6 +235,10 @@
     },
     "restrictIstioIngress": true,
     "server": {
+      "tracing": {
+        "address": "",
+        "exporter": ""
+      },
       "k8s": {
         "namespace": "maestro",
         "serviceAccountName": "maestro"

--- a/maestro/server/Makefile
+++ b/maestro/server/Makefile
@@ -29,5 +29,7 @@ deploy:
 		--set pullBinding.workloadIdentityClientId="$${IMAGE_PULLER_MI_CLIENT_ID}" \
 		--set pullBinding.workloadIdentityTenantId="$${TENANT_ID}" \
 		--set pullBinding.registry=${ACR_NAME}.azurecr.io \
-		--set pullBinding.scope=repository:${IMAGE_BASE}:pull
+		--set pullBinding.scope=repository:${IMAGE_BASE}:pull \
+	    --set tracing.address=${TRACING_ADDRESS} \
+	    --set tracing.exporter=${TRACING_EXPORTER} \
 .PHONY: deploy

--- a/maestro/server/deploy/templates/maestro.deployment.yaml
+++ b/maestro/server/deploy/templates/maestro.deployment.yaml
@@ -72,6 +72,10 @@ spec:
           mountPath: /secrets/mqtt-creds
           readOnly: true
         env:
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: '{{ .Values.tracing.address  }}'
+        - name: OTEL_TRACES_EXPORTER
+          value: '{{ .Values.tracing.exporter  }}'
         - name: "AMS_ENV"
           value: "production"
         - name: POD_NAME

--- a/maestro/server/deploy/values.yaml
+++ b/maestro/server/deploy/values.yaml
@@ -6,6 +6,9 @@ deployment:
   limits:
     cpu: 1
     memory: 1Gi
+tracing:
+  address: ""
+  exporter: ""
 broker:
   host: ""
   port: 8883

--- a/maestro/server/pipeline.yaml
+++ b/maestro/server/pipeline.yaml
@@ -79,3 +79,7 @@ resourceGroups:
       configRef: clustersService.k8s.serviceAccountName
     - name: ACR_NAME
       configRef: acr.svc.name
+    - name: TRACING_ADDRESS
+      configRef: maestro.server.tracing.address
+    - name: TRACING_EXPORTER
+      configRef: maestro.server.tracing.exporter

--- a/observability/tracing/Makefile
+++ b/observability/tracing/Makefile
@@ -22,6 +22,11 @@ patch-frontend:
 	@kubectl wait --for=condition=Available -n aro-hcp deployment aro-hcp-frontend --timeout=30s
 .PHONY: patch-frontend
 
+patch-maestro-server:
+	@kubectl set env -n maestro deployment maestro --containers service OTEL_EXPORTER_OTLP_ENDPOINT=http://ingest.observability:4318 OTEL_TRACES_EXPORTER=otlp
+	@kubectl wait --for=condition=Available -n maestro deployment maestro --timeout=30s
+.PHONY: patch-maestro-server
+
 patch-clusterservice:
 	kubectl patch -n ${CS_NAMESPACE} deployment clusters-service --type json \
 		--patch="[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/command/-\", \"value\": \"--tracing-otlp-url=http://ingest.observability:4318\"}]"

--- a/observability/tracing/README.md
+++ b/observability/tracing/README.md
@@ -40,7 +40,7 @@ make patch-frontend
 make patch-clusterservice
 ```
 
-The export of the trace information is configured via environment variables for the RP Frontend and command-line arguments for the Clusters Service.
+The export of the trace information is configured via environment variables for the RP Frontend, maestro server and command-line arguments for the Clusters Service.
 
 ### Correlate with ARM requests
 


### PR DESCRIPTION
[ARO-16033
](https://issues.redhat.com/browse/ARO-16033)

### What

Enable otel tracing for maestro server

Update maestro server deployment and config to inject otel-specific env variables. The tracing feature is only enabled in selected deployment environments such as dev, nightly and cs-pr.

### Why

Otel tracing is already enabled for RP frontend and cluster service. Now, maestro server is the next component that is ready for otel tracing enablement. Otel traces can be collected among these components if enabled.

### Special notes for your reviewer

<!-- optional -->
