### PR TITLE
Added new attributes to the managed identities config according to the new schema

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -72,13 +72,31 @@ deploy:
 	  --set azureOperatorsMI.imageRegistry.roleId="$${OP_IMAGE_REGISTRY_DRIVER_ROLE_ID}" \
 	  --set azureOperatorsMI.cloudNetworkConfig.roleName="${OP_CLOUD_NETWORK_CONFIG_ROLE_NAME}" \
 	  --set azureOperatorsMI.cloudNetworkConfig.roleId="$${OP_CLOUD_NETWORK_CONFIG_ROLE_ID}" \
+	  --set azureOperatorsMI.kms.roleName="${OP_KMS_ROLE_NAME}" \
+	  --set azureOperatorsMI.kms.roleId="$${OP_KMS_ROLE_ID}" \
+	  --set azureOperatorsMI.clusterApiAzure.roleDefinitions[0].name="${OP_CLUSTER_API_AZURE_ROLE_NAME}" \
+	  --set azureOperatorsMI.clusterApiAzure.roleDefinitions[0].id="$${OP_CLUSTER_API_AZURE_ROLE_ID}" \
+	  --set azureOperatorsMI.controlPlane.roleDefinitions[0].name="${OP_CONTROL_PLANE_ROLE_NAME}" \
+	  --set azureOperatorsMI.controlPlane.roleDefinitions[0].id="$${OP_CONTROL_PLANE_ROLE_ID}" \
+	  --set azureOperatorsMI.cloudControllerManager.roleDefinitions[0].name="${OP_CLOUD_CONTROLLER_MANAGER_ROLE_NAME}" \
+	  --set azureOperatorsMI.cloudControllerManager.roleDefinitions[0].id="$${OP_CLOUD_CONTROLLER_MANAGER_ROLE_ID}" \
+	  --set azureOperatorsMI.ingress.roleDefinitions[0].name="${OP_INGRESS_ROLE_NAME}" \
+	  --set azureOperatorsMI.ingress.roleDefinitions[0].id="$${OP_INGRESS_ROLE_ID}" \
+	  --set azureOperatorsMI.diskCsiDriver.roleDefinitions[0].name="${OP_DISK_CSI_DRIVER_ROLE_NAME}" \
+	  --set azureOperatorsMI.diskCsiDriver.roleDefinitions[0].id="$${OP_DISK_CSI_DRIVER_ROLE_ID}" \
+	  --set azureOperatorsMI.fileCsiDriver.roleDefinitions[0].name="${OP_FILE_CSI_DRIVER_ROLE_NAME}" \
+	  --set azureOperatorsMI.fileCsiDriver.roleDefinitions[0].id="$${OP_FILE_CSI_DRIVER_ROLE_ID}" \
+	  --set azureOperatorsMI.imageRegistry.roleDefinitions[0].name="${OP_IMAGE_REGISTRY_DRIVER_ROLE_NAME}" \
+	  --set azureOperatorsMI.imageRegistry.roleDefinitions[0].id="$${OP_IMAGE_REGISTRY_DRIVER_ROLE_ID}" \
+	  --set azureOperatorsMI.cloudNetworkConfig.roleDefinitions[0].name="${OP_CLOUD_NETWORK_CONFIG_ROLE_NAME}" \
+	  --set azureOperatorsMI.cloudNetworkConfig.roleDefinitions[0].id="$${OP_CLOUD_NETWORK_CONFIG_ROLE_ID}" \
+	  --set azureOperatorsMI.kms.roleDefinitions[0].name="${OP_KMS_ROLE_NAME}" \
+	  --set azureOperatorsMI.kms.roleDefinitions[0].id="$${OP_KMS_ROLE_ID}" \
 	  --set pullBinding.workloadIdentityClientId="$${IMAGE_PULLER_MI_CLIENT_ID}" \
 	  --set pullBinding.workloadIdentityTenantId="$${IMAGE_PULLER_MI_TENANT_ID}" \
 	  --set pullBinding.registry=${ACR_NAME}.azurecr.io \
 	  --set pullBinding.scope=repository:${IMAGE_REPO}:pull \
-	  --set tracing.address=${TRACING_ADDRESS} \
-	  --set azureOperatorsMI.kms.roleName="${OP_KMS_ROLE_NAME}" \
-	  --set azureOperatorsMI.kms.roleId="$${OP_KMS_ROLE_ID}"
+	  --set tracing.address=${TRACING_ADDRESS} 
 
 deploy-pr-env-deps:
 	AZURE_CS_MI_CLIENT_ID=$(shell az identity show -g ${RESOURCEGROUP} -n clusters-service --query clientId -o tsv) && \
@@ -153,6 +171,24 @@ local-azure-operators-managed-identities-config:
 	  --set azureOperatorsMI.cloudNetworkConfig.roleId="$${OP_CLOUD_NETWORK_CONFIG_ROLE_ID}" \
 	  --set azureOperatorsMI.kms.roleName="${OP_KMS_ROLE_NAME}" \
 	  --set azureOperatorsMI.kms.roleId="$${OP_KMS_ROLE_ID}" \
+	  --set azureOperatorsMI.clusterApiAzure.roleDefinitions[0].name="${OP_CLUSTER_API_AZURE_ROLE_NAME}" \
+	  --set azureOperatorsMI.clusterApiAzure.roleDefinitions[0].id="$${OP_CLUSTER_API_AZURE_ROLE_ID}" \
+	  --set azureOperatorsMI.controlPlane.roleDefinitions[0].name="${OP_CONTROL_PLANE_ROLE_NAME}" \
+	  --set azureOperatorsMI.controlPlane.roleDefinitions[0].id="$${OP_CONTROL_PLANE_ROLE_ID}" \
+	  --set azureOperatorsMI.cloudControllerManager.roleDefinitions[0].name="${OP_CLOUD_CONTROLLER_MANAGER_ROLE_NAME}" \
+	  --set azureOperatorsMI.cloudControllerManager.roleDefinitions[0].id="$${OP_CLOUD_CONTROLLER_MANAGER_ROLE_ID}" \
+	  --set azureOperatorsMI.ingress.roleDefinitions[0].name="${OP_INGRESS_ROLE_NAME}" \
+	  --set azureOperatorsMI.ingress.roleDefinitions[0].id="$${OP_INGRESS_ROLE_ID}" \
+	  --set azureOperatorsMI.diskCsiDriver.roleDefinitions[0].name="${OP_DISK_CSI_DRIVER_ROLE_NAME}" \
+	  --set azureOperatorsMI.diskCsiDriver.roleDefinitions[0].id="$${OP_DISK_CSI_DRIVER_ROLE_ID}" \
+	  --set azureOperatorsMI.fileCsiDriver.roleDefinitions[0].name="${OP_FILE_CSI_DRIVER_ROLE_NAME}" \
+	  --set azureOperatorsMI.fileCsiDriver.roleDefinitions[0].id="$${OP_FILE_CSI_DRIVER_ROLE_ID}" \
+	  --set azureOperatorsMI.imageRegistry.roleDefinitions[0].name="${OP_IMAGE_REGISTRY_DRIVER_ROLE_NAME}" \
+	  --set azureOperatorsMI.imageRegistry.roleDefinitions[0].id="$${OP_IMAGE_REGISTRY_DRIVER_ROLE_ID}" \
+	  --set azureOperatorsMI.cloudNetworkConfig.roleDefinitions[0].name="${OP_CLOUD_NETWORK_CONFIG_ROLE_NAME}" \
+	  --set azureOperatorsMI.cloudNetworkConfig.roleDefinitions[0].id="$${OP_CLOUD_NETWORK_CONFIG_ROLE_ID}" \
+	  --set azureOperatorsMI.kms.roleDefinitions[0].name="${OP_KMS_ROLE_NAME}" \
+	  --set azureOperatorsMI.kms.roleDefinitions[0].id="$${OP_KMS_ROLE_ID}" \
 	  | yq '.data."azure-operators-managed-identities-config.yaml"' > ./azure-operators-managed-identities-config.yaml
 .PHONY: local-azure-operators-managed-identities-config
 

--- a/cluster-service/deploy/templates/azure-operators-managed-identities-config.configmap.yaml
+++ b/cluster-service/deploy/templates/azure-operators-managed-identities-config.configmap.yaml
@@ -8,52 +8,102 @@ data:
     controlPlaneOperatorsIdentities:
       cluster-api-azure:
         minOpenShiftVersion: 4.18
+        roleDefinitions:
+        {{- range .Values.azureOperatorsMI.clusterApiAzure.roleDefinitions }}
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
+            name: '{{ .name }}'
+        {{- end }}
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.clusterApiAzure.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.clusterApiAzure.roleName }}'
         optional: false
       control-plane:
         minOpenShiftVersion: 4.18
+        roleDefinitions:
+        {{- range .Values.azureOperatorsMI.controlPlane.roleDefinitions }}
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
+            name: '{{ .name }}'
+        {{- end }}
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.controlPlane.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.controlPlane.roleName }}'
         optional: false
       cloud-controller-manager:
         minOpenShiftVersion: 4.18
+        roleDefinitions:
+        {{- range .Values.azureOperatorsMI.cloudControllerManager.roleDefinitions }}
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
+            name: '{{ .name }}'
+        {{- end }}
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.cloudControllerManager.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.cloudControllerManager.roleName }}'
         optional: false
       ingress:
         minOpenShiftVersion: 4.18
+        roleDefinitions:
+        {{- range .Values.azureOperatorsMI.ingress.roleDefinitions }}
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
+            name: '{{ .name }}'
+        {{- end }}
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.ingress.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.ingress.roleName }}'
         optional: false
       disk-csi-driver:
         minOpenShiftVersion: 4.18
+        roleDefinitions:
+        {{- range .Values.azureOperatorsMI.diskCsiDriver.roleDefinitions }}
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
+            name: '{{ .name }}'
+        {{- end }}
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.diskCsiDriver.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.diskCsiDriver.roleName }}'
         optional: false
       file-csi-driver:
         minOpenShiftVersion: 4.18
+        roleDefinitions:
+        {{- range .Values.azureOperatorsMI.fileCsiDriver.roleDefinitions }}
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
+            name: '{{ .name }}'
+        {{- end }}
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.fileCsiDriver.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.fileCsiDriver.roleName }}'
         optional: false
       image-registry:
         minOpenShiftVersion: 4.18
+        roleDefinitions:
+        {{- range .Values.azureOperatorsMI.imageRegistry.roleDefinitions }}
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
+            name: '{{ .name }}'
+        {{- end }}
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.imageRegistry.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.imageRegistry.roleName }}'
         optional: false
       cloud-network-config:
         minOpenShiftVersion: 4.18
+        roleDefinitions:
+        {{- range .Values.azureOperatorsMI.cloudNetworkConfig.roleDefinitions }}
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
+            name: '{{ .name }}'
+        {{- end }}
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.cloudNetworkConfig.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.cloudNetworkConfig.roleName }}'
         optional: false
       kms:
         minOpenShiftVersion: 4.18
+        roleDefinitions:
+        {{- range .Values.azureOperatorsMI.kms.roleDefinitions }}
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
+            name: '{{ .name }}'
+        {{- end }}
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.kms.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.kms.roleName }}'
         optional: true
     dataPlaneOperatorsIdentities:
       disk-csi-driver:
         minOpenShiftVersion: 4.18
+        roleDefinitions:
+        {{- range .Values.azureOperatorsMI.diskCsiDriver.roleDefinitions }}
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
+            name: '{{ .name }}'
+        {{- end }}
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.diskCsiDriver.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.diskCsiDriver.roleName }}'
         k8sServiceAccounts:
@@ -64,6 +114,11 @@ data:
         optional: false
       image-registry:
         minOpenShiftVersion: 4.18
+        roleDefinitions:
+        {{- range .Values.azureOperatorsMI.imageRegistry.roleDefinitions }}
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
+            name: '{{ .name }}'
+        {{- end }}
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.imageRegistry.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.imageRegistry.roleName }}'
         k8sServiceAccounts:
@@ -74,6 +129,11 @@ data:
         optional: false
       file-csi-driver:
         minOpenShiftVersion: 4.18
+        roleDefinitions:
+        {{- range .Values.azureOperatorsMI.fileCsiDriver.roleDefinitions }}
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
+            name: '{{ .name }}'
+        {{- end }}
         azureRoleDefinitionResourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .Values.azureOperatorsMI.fileCsiDriver.roleId }}'
         azureRoleDefinitionName: '{{ .Values.azureOperatorsMI.fileCsiDriver.roleName }}'
         k8sServiceAccounts:

--- a/cluster-service/deploy/values.yaml
+++ b/cluster-service/deploy/values.yaml
@@ -209,30 +209,39 @@ managedIdentitiesDataPlaneAudienceResource: "https://dummy.org"
 # The Azure Operator Managed Identities.
 azureOperatorsMI:
   clusterApiAzure:
+    roleDefinitions: []
     roleName: ''
     roleId: ''
   controlPlane:
+    roleDefinitions: []
     roleName: ''
     roleId: ''
   cloudControllerManager:
+    roleDefinitions: []
     roleName: ''
     roleId: ''
   ingress:
+    roleDefinitions: []
     roleName: ''
     roleId: ''
   diskCsiDriver:
+    roleDefinitions: []
     roleName: ''
     roleId: ''
   fileCsiDriver:
+    roleDefinitions: []
     roleName: ''
     roleId: ''
   imageRegistry:
+    roleDefinitions: []
     roleName: ''
     roleId: ''
   cloudNetworkConfig:
+    roleDefinitions: []
     roleName: ''
     roleId: ''
   kms:
+    roleDefinitions: []
     roleName: ''
     roleId: ''
 # Pull binding configuration for ACR Pull Operator


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-17371

### What

To support multiple azure role definition for both the defined control plane and data plane operators managed identities, a new schema has been finalized and this is to add attributes for the clusters-service managed identities config according to the new schema. This is to make sure the successful deployed after the clusters-service code change to support multiple managed identities for the azure operators.
