### PR TITLE
Enable otel tracing for maestro server

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -232,6 +232,9 @@ defaults:
       k8s:
         namespace: maestro
         serviceAccountName: maestro
+      tracing:
+        address: ""
+        exporter: ""
     agent:
       consumerName: "hcp-underlay-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}" # [env-unique]
       loglevel: 4

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -838,6 +838,9 @@
             "loglevel": {
               "type": "integer"
             },
+            "tracing": {
+              "$ref": "#/definitions/tracing"
+            },
             "k8s": {
               "type": "object",
               "properties": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -162,6 +162,9 @@ defaults:
   # Maestro
   maestro:
     server:
+      tracing:
+        address: ""
+        exporter: ""
       mqttClientName: maestro-server
       loglevel: 4
       managedIdentityName: maestro-server
@@ -459,6 +462,9 @@ clouds:
           maestro:
             server:
               mqttClientName: 'maestro-server-{{ .ctx.regionShort }}-dev'
+              tracing:
+                address: "http://ingest.observability:4318"
+                exporter: "otlp"
           # Frontend
           frontend:
             cosmosDB:
@@ -556,6 +562,9 @@ clouds:
               deploy: false
             server:
               mqttClientName: 'maestro-server-{{ .ctx.regionShort }}'
+              tracing:
+                address: "http://ingest.observability:4318"
+                exporter: "otlp"
           # Backend
           backend:
             tracing:

--- a/config/public-cloud-cspr.json
+++ b/config/public-cloud-cspr.json
@@ -245,7 +245,11 @@
       },
       "loglevel": 4,
       "managedIdentityName": "maestro-server",
-      "mqttClientName": "maestro-server-cspr-cs"
+      "mqttClientName": "maestro-server-cspr-cs",
+      "tracing": {
+        "address": "",
+        "exporter": ""
+      }
     }
   },
   "mce": {

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -245,7 +245,11 @@
       },
       "loglevel": 4,
       "managedIdentityName": "maestro-server",
-      "mqttClientName": "maestro-server-dev-dev"
+      "mqttClientName": "maestro-server-dev-dev",
+      "tracing": {
+        "address": "http://ingest.observability:4318",
+        "exporter": "otlp"
+      }
     }
   },
   "mce": {

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -242,7 +242,11 @@
       },
       "loglevel": 4,
       "managedIdentityName": "maestro-server",
-      "mqttClientName": "maestro-server"
+      "mqttClientName": "maestro-server",
+      "tracing": {
+        "address": "",
+        "exporter": ""
+      }
     }
   },
   "mce": {

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -240,7 +240,11 @@
       },
       "loglevel": 4,
       "managedIdentityName": "maestro-server",
-      "mqttClientName": "maestro-server"
+      "mqttClientName": "maestro-server",
+      "tracing": {
+        "address": "",
+        "exporter": ""
+      }
     }
   },
   "mce": {

--- a/config/public-cloud-ntly.json
+++ b/config/public-cloud-ntly.json
@@ -245,7 +245,11 @@
       },
       "loglevel": 4,
       "managedIdentityName": "maestro-server",
-      "mqttClientName": "maestro-server-ntly"
+      "mqttClientName": "maestro-server-ntly",
+      "tracing": {
+        "address": "",
+        "exporter": ""
+      }
     }
   },
   "mce": {

--- a/config/public-cloud-pers.json
+++ b/config/public-cloud-pers.json
@@ -245,7 +245,11 @@
       },
       "loglevel": 4,
       "managedIdentityName": "maestro-server",
-      "mqttClientName": "maestro-server-ussw1tst"
+      "mqttClientName": "maestro-server-ussw1tst",
+      "tracing": {
+        "address": "http://ingest.observability:4318",
+        "exporter": "otlp"
+      }
     }
   },
   "mce": {

--- a/maestro/server/Makefile
+++ b/maestro/server/Makefile
@@ -29,5 +29,8 @@ deploy:
 		--set pullBinding.workloadIdentityClientId="$${IMAGE_PULLER_MI_CLIENT_ID}" \
 		--set pullBinding.workloadIdentityTenantId="$${TENANT_ID}" \
 		--set pullBinding.registry=${ACR_NAME}.azurecr.io \
+		--set tracing.address=${TRACING_ADDRESS} \
+		--set tracing.exporter=${TRACING_EXPORTER} \
 		--set pullBinding.scope=repository:${IMAGE_BASE}:pull
+
 .PHONY: deploy

--- a/maestro/server/deploy/templates/maestro.deployment.yaml
+++ b/maestro/server/deploy/templates/maestro.deployment.yaml
@@ -72,6 +72,10 @@ spec:
           mountPath: /secrets/mqtt-creds
           readOnly: true
         env:
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: '{{ .Values.tracing.address  }}'
+        - name: OTEL_TRACES_EXPORTER
+          value: '{{ .Values.tracing.exporter  }}'
         - name: "AMS_ENV"
           value: "production"
         - name: POD_NAME

--- a/maestro/server/deploy/values.yaml
+++ b/maestro/server/deploy/values.yaml
@@ -6,6 +6,9 @@ deployment:
   limits:
     cpu: 1
     memory: 1Gi
+tracing:
+  address: ""
+  exporter: ""
 broker:
   host: ""
   port: 8883

--- a/maestro/server/pipeline.yaml
+++ b/maestro/server/pipeline.yaml
@@ -79,3 +79,7 @@ resourceGroups:
       configRef: clustersService.k8s.serviceAccountName
     - name: ACR_NAME
       configRef: acr.svc.name
+    - name: TRACING_ADDRESS
+      configRef: maestro.server.tracing.address
+    - name: TRACING_EXPORTER
+      configRef: maestro.server.tracing.exporter

--- a/observability/tracing/Makefile
+++ b/observability/tracing/Makefile
@@ -22,6 +22,11 @@ patch-frontend:
 	@kubectl wait --for=condition=Available -n aro-hcp deployment aro-hcp-frontend --timeout=30s
 .PHONY: patch-frontend
 
+patch-maestro-server:
+	@kubectl set env -n maestro deployment maestro --containers service OTEL_EXPORTER_OTLP_ENDPOINT=http://ingest.observability:4318 OTEL_TRACES_EXPORTER=otlp
+	@kubectl wait --for=condition=Available -n maestro deployment maestro --timeout=30s
+.PHONY: patch-maestro-server
+
 patch-clusterservice:
 	kubectl patch -n ${CS_NAMESPACE} deployment clusters-service --type json \
 		--patch="[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/command/-\", \"value\": \"--tracing-otlp-url=http://ingest.observability:4318\"}]"

--- a/observability/tracing/README.md
+++ b/observability/tracing/README.md
@@ -38,9 +38,10 @@ Run the following commands:
 ```
 make patch-frontend
 make patch-clusterservice
+make patch-maestro-server
 ```
 
-The export of the trace information is configured via environment variables for the RP Frontend and command-line arguments for the Clusters Service.
+The export of the trace information is configured via environment variables for the RP Frontend, maestro server and command-line arguments for the Clusters Service.
 
 ### Correlate with ARM requests
 


### PR DESCRIPTION
[ARO-16033](https://issues.redhat.com/browse/ARO-16033)

### What

Enable otel tracing for maestro server

Update maestro server deployment and config to inject otel-specific env variables. The tracing feature is only enabled in selected deployment environments such as dev, nightly and cs-pr.

### Why

Otel tracing is already enabled for RP frontend and cluster service. Now, maestro server is the next component that is ready for otel tracing enablement. Otel traces can be collected among these components if enabled.

### Special notes for your reviewer

<!-- optional -->
