### PR TITLE
Fix container logs for dev/cspr environments

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -375,6 +375,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-10-01' = {
             enabled: true
             config: {
               logAnalyticsWorkspaceResourceID: logAnalyticsWorkspaceId
+              useAADAuth: 'true'
             }
           }
         : {
@@ -529,87 +530,6 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-10-01' = {
     aks_keyvault_crypto_user
     aksClusterOutboundIPAddress
   ]
-}
-
-//
-//   O B S E R V A B I L I T Y
-//
-
-resource aksDiagnosticSettings 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = if (logAnalyticsWorkspaceId != '') {
-  scope: aksCluster
-  name: aksClusterName
-  properties: {
-    logs: [
-      {
-        category: 'kube-audit'
-        enabled: true
-      }
-      {
-        category: 'kube-audit-admin'
-        enabled: true
-      }
-    ]
-    workspaceId: logAnalyticsWorkspaceId
-  }
-}
-
-resource aksClusterDcr 'Microsoft.Insights/dataCollectionRules@2023-03-11' = if (logAnalyticsWorkspaceId != '') {
-  name: '${aksClusterName}-dcr'
-  location: location
-  kind: 'Linux'
-  properties: {
-    dataSources: {
-      extensions: [
-        {
-          name: 'ContainerInsightsExtension'
-          streams: [
-            'Microsoft-ContainerLog'
-            'Microsoft-ContainerLogV2'
-            'Microsoft-KubeEvents'
-            'Microsoft-KubePodInventory'
-          ]
-          extensionSettings: {
-            dataCollectionSettings: {
-              interval: '1m'
-              namespaceFilteringMode: 'Off'
-              enableContainerLogV2: true
-            }
-          }
-          extensionName: 'ContainerInsights'
-        }
-      ]
-    }
-    destinations: {
-      logAnalytics: [
-        {
-          name: 'ContainerInsightsWorkspace'
-          workspaceResourceId: logAnalyticsWorkspaceId
-        }
-      ]
-    }
-    dataFlows: [
-      {
-        destinations: [
-          'ContainerInsightsWorkspace'
-        ]
-        streams: [
-          'Microsoft-ContainerLog'
-          'Microsoft-ContainerLogV2'
-          'Microsoft-KubeEvents'
-          'Microsoft-KubePodInventory'
-        ]
-      }
-    ]
-  }
-}
-
-resource aksClusterDcra 'Microsoft.Insights/dataCollectionRuleAssociations@2023-03-11' = if (logAnalyticsWorkspaceId != '') {
-  name: '${aksClusterName}-dcra'
-  scope: aksCluster
-  properties: {
-    description: 'Association of data collection rule. Deleting this association will break the data collection for this AKS Cluster.'
-    dataCollectionRuleId: aksClusterDcr.id
-  }
 }
 
 resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2024-10-01' = [

--- a/dev-infrastructure/modules/logs/collection.bicep
+++ b/dev-infrastructure/modules/logs/collection.bicep
@@ -1,0 +1,78 @@
+param aksClusterName string
+param logAnalyticsWorkspaceId string
+
+param dcrStreams array = [
+  'Microsoft-ContainerLog'
+  'Microsoft-ContainerLogV2'
+  'Microsoft-KubeEvents'
+  'Microsoft-KubePodInventory'
+]
+
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2023-03-01' existing = {
+  name: aksClusterName
+}
+
+resource aksDiagnosticSettings 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = {
+  scope: aksCluster
+  name: aksClusterName
+  properties: {
+    logs: [
+      {
+        category: 'kube-audit'
+        enabled: true
+      }
+      {
+        category: 'kube-audit-admin'
+        enabled: true
+      }
+    ]
+    workspaceId: logAnalyticsWorkspaceId
+  }
+}
+
+resource aksClusterDcr 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
+  name: '${aksClusterName}-dcr'
+  location: resourceGroup().location
+  kind: 'Linux'
+  properties: {
+    dataSources: {
+      extensions: [
+        {
+          name: 'ContainerInsightsExtension'
+          streams: dcrStreams
+          extensionSettings: {
+            dataCollectionSettings: {
+              interval: '1m'
+              namespaceFilteringMode: 'Off'
+              enableContainerLogV2: true
+            }
+          }
+          extensionName: 'ContainerInsights'
+        }
+      ]
+    }
+    destinations: {
+      logAnalytics: [
+        {
+          name: 'ciworkspace'
+          workspaceResourceId: logAnalyticsWorkspaceId
+        }
+      ]
+    }
+    dataFlows: [
+      {
+        destinations: ['ciworkspace']
+        streams: dcrStreams
+      }
+    ]
+  }
+}
+
+resource aksClusterDcra 'Microsoft.Insights/dataCollectionRuleAssociations@2023-03-11' = {
+  name: '${aksClusterName}-logs-dcra'
+  scope: aksCluster
+  properties: {
+    description: 'AKS Cluster DCRA for logs DCR'
+    dataCollectionRuleId: aksClusterDcr.id
+  }
+}

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -236,6 +236,19 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
 output aksClusterName string = mgmtCluster.outputs.aksClusterName
 
 //
+// L O G S
+//
+
+// NOTE: This is only enabled for non-prod environments
+module logsCollection '../modules/logs/collection.bicep' = if (logAnalyticsWorkspaceId != '') {
+  name: 'logs-collection'
+  params: {
+    aksClusterName: mgmtCluster.outputs.aksClusterName
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
+  }
+}
+
+//
 // M E T R I C S
 //
 

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -389,6 +389,19 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
 output aksClusterName string = svcCluster.outputs.aksClusterName
 
 //
+// L O G S
+//
+
+// NOTE: This is only enabled for non-prod environments
+module logsCollection '../modules/logs/collection.bicep' = if (logAnalyticsWorkspaceId != '') {
+  name: 'logs-collection'
+  params: {
+    aksClusterName: svcCluster.outputs.aksClusterName
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
+  }
+}
+
+//
 // M E T R I C S
 //
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-16978

### What

Aside from moving log collection resources into its own module, the following changes should fix container logs
- Add `useAADAuth: true` to `omsagent` config on the AKS cluster
- Change the DCRA resource name to something unique - previously the name was the same as the prometheus DCRA and they were overwriting each other

### Why

We want container logs in V2 format which has a better schema

### Special notes for your reviewer

This should apply cleanly to existing dev/cspr infra