### PR TITLE
tracing: enable tracing for backend in personal envs

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -54,6 +54,8 @@ deploy:
 		--set clustersService.namespace=${CS_NAMESPACE} \
 		--set clustersService.serviceAccount=${CS_SERVICE_ACCOUNT_NAME} \
 		--set deployment.imageName=${ARO_HCP_BACKEND_IMAGE}@$${DIGEST} \
+		--set tracing.address=${TRACING_ADDRESS} \
+		--set tracing.exporter=${TRACING_EXPORTER} \
 		--namespace aro-hcp
 .PHONY: deploy
 

--- a/backend/deploy/templates/backend.deployment.yaml
+++ b/backend/deploy/templates/backend.deployment.yaml
@@ -48,6 +48,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "{{ .Values.tracing.address }}"
+        - name: OTEL_TRACES_EXPORTER
+          value: "{{ .Values.tracing.exporter }}"
         ports:
         - containerPort: 8081
           protocol: TCP

--- a/backend/deploy/values.yaml
+++ b/backend/deploy/values.yaml
@@ -11,3 +11,6 @@ serviceAccount:
 clustersService:
   namespace: ""
   serviceAccount: ""
+tracing:
+  address: ""
+  exporter: ""

--- a/backend/pipeline.yaml
+++ b/backend/pipeline.yaml
@@ -59,3 +59,7 @@ resourceGroups:
       configRef: clustersService.k8s.namespace
     - name: CS_SERVICE_ACCOUNT_NAME
       configRef: clustersService.k8s.serviceAccountName
+    - name: TRACING_ADDRESS
+      configRef: backend.tracing.address
+    - name: TRACING_EXPORTER
+      configRef: backend.tracing.exporter

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -212,6 +212,9 @@ defaults:
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: arohcpbackend
+    tracing:
+      address: ""
+      exporter: ""
   # Maestro
   maestro:
     server:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -529,11 +529,15 @@
       "properties": {
         "image": {
           "$ref": "#/definitions/containerImage"
+        },
+        "tracing": {
+          "$ref": "#/definitions/tracing"
         }
       },
       "additionalProperties": false,
       "required": [
-        "image"
+        "image",
+        "tracing"
       ]
     },
     "frontend": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -123,6 +123,11 @@ defaults:
         version: "v2.55.1-3"
         replicas: 2
         shards: 1
+  # Backend
+  backend:
+    tracing:
+      address: ""
+      exporter: ""
   # Frontend
   frontend:
     tracing:
@@ -539,6 +544,11 @@ clouds:
               deploy: false
             server:
               mqttClientName: 'maestro-server-{{ .ctx.regionShort }}'
+          # Backend
+          backend:
+            tracing:
+              address: "http://ingest.observability:4318"
+              exporter: "otlp"
           # Frontend
           frontend:
             cosmosDB:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -25,6 +25,10 @@
       "digest": "",
       "registry": "arohcpsvcdev.azurecr.io",
       "repository": "arohcpbackend"
+    },
+    "tracing": {
+      "address": "",
+      "exporter": ""
     }
   },
   "backplaneAPI": {

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -25,6 +25,10 @@
       "digest": "",
       "registry": "arohcpsvcdev.azurecr.io",
       "repository": "arohcpbackend"
+    },
+    "tracing": {
+      "address": "",
+      "exporter": ""
     }
   },
   "backplaneAPI": {

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -25,6 +25,10 @@
       "digest": "sha256:02a32af8d34c5725d0096ee7f94adf2ef151d0634e8682fe7517e6f9ebba9bdc",
       "registry": "arohcpsvcdev.azurecr.io",
       "repository": "arohcpbackend"
+    },
+    "tracing": {
+      "address": "",
+      "exporter": ""
     }
   },
   "backplaneAPI": {

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -25,6 +25,10 @@
       "digest": "sha256:02a32af8d34c5725d0096ee7f94adf2ef151d0634e8682fe7517e6f9ebba9bdc",
       "registry": "arohcpsvcdev.azurecr.io",
       "repository": "arohcpbackend"
+    },
+    "tracing": {
+      "address": "",
+      "exporter": ""
     }
   },
   "backplaneAPI": {

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -25,6 +25,10 @@
       "digest": "",
       "registry": "arohcpsvcdev.azurecr.io",
       "repository": "arohcpbackend"
+    },
+    "tracing": {
+      "address": "",
+      "exporter": ""
     }
   },
   "backplaneAPI": {

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -25,6 +25,10 @@
       "digest": "",
       "registry": "arohcpsvcdev.azurecr.io",
       "repository": "arohcpbackend"
+    },
+    "tracing": {
+      "address": "http://ingest.observability:4318",
+      "exporter": "otlp"
     }
   },
   "backplaneAPI": {


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-16039

### What

Configure the backend to send traces to the local Jaeger instance in personal dev environments. 

### Why

This is similar to https://github.com/Azure/ARO-HCP/pull/1645 which enabled tracing for the RP frontend and CS.

### Special notes for your reviewer

<!-- optional -->
