### PR TITLE
fix: detect no-op exporter properly

### DIFF
--- a/internal/tracing/otel_sdk.go
+++ b/internal/tracing/otel_sdk.go
@@ -55,10 +55,8 @@ func ConfigureOpenTelemetryTracer(ctx context.Context, logger *slog.Logger, reso
 		return nil, fmt.Errorf("failed to create OTEL exporter: %w", err)
 	}
 
-	var isNoop bool
-	if _, isNoop = exp.(*noopSpanExporter); !isNoop || autoexport.IsNoneSpanExporter(exp) {
-		isNoop = true
-	}
+	_, isNoop := exp.(*noopSpanExporter)
+	isNoop = isNoop || autoexport.IsNoneSpanExporter(exp)
 	logger.InfoContext(ctx, "initialising OpenTelemetry tracer", "isNoop", isNoop)
 
 	opts := []resource.Option{resource.WithHost()}


### PR DESCRIPTION
### What

I noticed that the log message was always claiming `"isNoop":true`. 

I've verified the change locally. With OTEL* environment variables defined:

````
{"time":"2025-05-15T09:22:29.569496413Z","level":"INFO","msg":"initialising OpenTelemetry tracer","isNoop":false}
````

Without OTEL* environment variables:

````
{"time":"2025-05-15T09:23:17.541893935Z","level":"INFO","msg":"initialising OpenTelemetry tracer","isNoop":true}
````

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
