### PR TITLE
Add billing documents to Cosmos DB

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -258,7 +258,7 @@ func Run(cmd *cobra.Command, args []string) error {
 	group.Go(func() error {
 		var (
 			startedLeading    atomic.Bool
-			operationsScanner = NewOperationsScanner(dbClient, ocmConnection)
+			operationsScanner = NewOperationsScanner(argLocation, dbClient, ocmConnection)
 		)
 
 		le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{

--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -130,6 +130,7 @@ func (o *operation) setSpanAttributes(span trace.Span) {
 }
 
 type OperationsScanner struct {
+	location            string
 	dbClient            database.DBClient
 	lockClient          *database.LockClient
 	clusterService      ocm.ClusterServiceClient
@@ -148,8 +149,9 @@ type OperationsScanner struct {
 	subscriptionsByState   *prometheus.GaugeVec
 }
 
-func NewOperationsScanner(dbClient database.DBClient, ocmConnection *ocmsdk.Connection) *OperationsScanner {
+func NewOperationsScanner(location string, dbClient database.DBClient, ocmConnection *ocmsdk.Connection) *OperationsScanner {
 	s := &OperationsScanner{
+		location:           location,
 		dbClient:           dbClient,
 		lockClient:         dbClient.GetLockClient(),
 		clusterService:     ocm.ClusterServiceClient{Conn: ocmConnection},

--- a/backend/operations_scanner_test.go
+++ b/backend/operations_scanner_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -95,6 +96,7 @@ func TestSetDeleteOperationAsCompleted(t *testing.T) {
 			scanner := &OperationsScanner{
 				dbClient:           mockDBClient,
 				notificationClient: server.Client(),
+				newTimestamp:       func() time.Time { return time.Now().UTC() },
 			}
 
 			operationDoc := database.NewOperationDocument(database.OperationRequestDelete, resourceID, internalID)
@@ -256,6 +258,7 @@ func TestUpdateOperationStatus(t *testing.T) {
 			scanner := &OperationsScanner{
 				dbClient:           mockDBClient,
 				notificationClient: server.Client(),
+				newTimestamp:       func() time.Time { return time.Now().UTC() },
 			}
 
 			operationDoc := database.NewOperationDocument(database.OperationRequestCreate, resourceID, internalID)

--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -19,6 +19,7 @@ var containers = [
   }
   {
     name: 'Billing'
+    partitionKeyPaths: ['/subscriptionId']
   }
   {
     name: 'Locks'

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -172,10 +172,15 @@ type cosmosDBClient struct {
 // NewDBClient instantiates a DBClient from a Cosmos DatabaseClient instance
 // targeting the Frontends async database.
 func NewDBClient(ctx context.Context, database *azcosmos.DatabaseClient) (DBClient, error) {
-	// NewContainer only fails if the container ID argument is
-	// empty, so we can safely disregard the error return value.
-	resources, _ := database.NewContainer(resourcesContainer)
-	locks, _ := database.NewContainer(locksContainer)
+	resources, err := database.NewContainer(resourcesContainer)
+	if err != nil {
+		return nil, err
+	}
+
+	locks, err := database.NewContainer(locksContainer)
+	if err != nil {
+		return nil, err
+	}
 
 	lockClient, err := NewLockClient(ctx, locks)
 	if err != nil {

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -53,22 +53,44 @@ type DocumentProperties interface {
 	GetValidTypes() []string
 }
 
+// BillingDocument records timestamps of Hosted Control Plane OpenShift cluster
+// creation and deletion for the purpose of customer billing.
 type BillingDocument struct {
+	baseDocument
+
 	// The cluster creation time represents the time when the cluster was provisioned successfully
 	CreationTime time.Time `json:"creationTime,omitempty"`
 	// The cluster deletion time
 	DeletionTime *time.Time `json:"deletionTime,omitempty"`
-	// The cluster last billing time
-	LastBillingTime *time.Time `json:"lastBillingTime,omitempty"`
 
 	// The location of the HCP cluster
 	Location string `json:"location,omitempty"`
 	// The tenant ID of the HCP cluster
 	TenantID string `json:"tenantId,omitempty"`
-	// The hcp cluster ARM resource ID
-	ResourceID string `json:"resourceId,omitempty"`
-	// The ARM resource ID of the managed resource group of the hcp cluster
+	// The subscription ID of the HCP cluster (also the partition key)
+	SubscriptionID string `json:"subscriptionId,omitempty"`
+	// The HCP cluster ARM resource ID
+	ResourceID *azcorearm.ResourceID `json:"resourceId,omitempty"`
+	// The ARM resource ID of the managed resource group of the HCP cluster
 	ManagedResourceGroup string `json:"managedResourceGroup,omitempty"`
+}
+
+func NewBillingDocument(resourceID *azcorearm.ResourceID) *BillingDocument {
+	return &BillingDocument{
+		baseDocument:   newBaseDocument(),
+		SubscriptionID: resourceID.SubscriptionID,
+		ResourceID:     resourceID,
+	}
+}
+
+// BillingDocumentPatchOperations represents a patch request for a BillingDocument.
+type BillingDocumentPatchOperations struct {
+	azcosmos.PatchOperations
+}
+
+// SetDeletionTime appends a set operation for the DeletionTime field.
+func (p *BillingDocumentPatchOperations) SetDeletionTime(deletionTime time.Time) {
+	p.AppendSet("/deletionTime", deletionTime)
 }
 
 // ResourceDocument captures the mapping of an Azure resource ID

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -183,6 +183,44 @@ func (m *MockDBClient) EXPECT() *MockDBClientMockRecorder {
 	return m.recorder
 }
 
+// CreateBillingDoc mocks base method.
+func (m *MockDBClient) CreateBillingDoc(ctx context.Context, doc *database.BillingDocument) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateBillingDoc", ctx, doc)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateBillingDoc indicates an expected call of CreateBillingDoc.
+func (mr *MockDBClientMockRecorder) CreateBillingDoc(ctx, doc any) *MockDBClientCreateBillingDocCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBillingDoc", reflect.TypeOf((*MockDBClient)(nil).CreateBillingDoc), ctx, doc)
+	return &MockDBClientCreateBillingDocCall{Call: call}
+}
+
+// MockDBClientCreateBillingDocCall wrap *gomock.Call
+type MockDBClientCreateBillingDocCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDBClientCreateBillingDocCall) Return(arg0 error) *MockDBClientCreateBillingDocCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDBClientCreateBillingDocCall) Do(f func(context.Context, *database.BillingDocument) error) *MockDBClientCreateBillingDocCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDBClientCreateBillingDocCall) DoAndReturn(f func(context.Context, *database.BillingDocument) error) *MockDBClientCreateBillingDocCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CreateOperationDoc mocks base method.
 func (m *MockDBClient) CreateOperationDoc(ctx context.Context, doc *database.OperationDocument) (string, error) {
 	m.ctrl.T.Helper()
@@ -678,6 +716,44 @@ func (c *MockDBClientNewTransactionCall) Do(f func(azcosmos.PartitionKey) databa
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockDBClientNewTransactionCall) DoAndReturn(f func(azcosmos.PartitionKey) database.DBTransaction) *MockDBClientNewTransactionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// PatchBillingDoc mocks base method.
+func (m *MockDBClient) PatchBillingDoc(ctx context.Context, resourceID *arm0.ResourceID, ops database.BillingDocumentPatchOperations) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchBillingDoc", ctx, resourceID, ops)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PatchBillingDoc indicates an expected call of PatchBillingDoc.
+func (mr *MockDBClientMockRecorder) PatchBillingDoc(ctx, resourceID, ops any) *MockDBClientPatchBillingDocCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchBillingDoc", reflect.TypeOf((*MockDBClient)(nil).PatchBillingDoc), ctx, resourceID, ops)
+	return &MockDBClientPatchBillingDocCall{Call: call}
+}
+
+// MockDBClientPatchBillingDocCall wrap *gomock.Call
+type MockDBClientPatchBillingDocCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDBClientPatchBillingDocCall) Return(arg0 error) *MockDBClientPatchBillingDocCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDBClientPatchBillingDocCall) Do(f func(context.Context, *arm0.ResourceID, database.BillingDocumentPatchOperations) error) *MockDBClientPatchBillingDocCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDBClientPatchBillingDocCall) DoAndReturn(f func(context.Context, *arm0.ResourceID, database.BillingDocumentPatchOperations) error) *MockDBClientPatchBillingDocCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
Jira: unknown

### What

I don't know if this has been carded up in Jira yet, but there's a [long-running Slack thread about billing](https://redhat-external.slack.com/archives/C075PHEFZKQ/p1739288836782679) where we pretty much worked out all the details with the Microsoft team implementing the billing service.

The RP side is fairly simple.  The backend component creates a new billing document upon successful completion of a cluster creation.  When the cluster is deleted, the backend updates the same billing document with a deletion timestamp.

### Why

See the [ARO-HCP OpenShift License Fee Billing Design Doc ](https://microsoft-my.sharepoint.com/:w:/r/personal/gniranjan_microsoft_com/_layouts/15/Doc.aspx?sourcedoc=%7B00BBF806-45C7-43D5-8268-24A9D278DB22%7D&file=ARO-HCP%20OpenShift%20License%20Fee%20Billing%20Design%20Doc.docx&nav=eyJjIjo3NDkzMDQyODB9&action=default&mobileredirect=true&share=IQEG-LsAx0XVQ4JoJKnSeNsiAXT6HBRQu9xQ_dRwX3lqw2A) for an overview, the shared Cosmos DB document structure, and RP requirements.

There's a couple deviations in the final Cosmos DB document structure:
- The addition of a ~~`partitionKey`~~ (now `subscriptionId`) JSON field, the value of which is the Azure subscription ID.
- The time fields are RFC 3339 timestamps rather than integer Unix times in seconds.
- We omit timestamps added by the billing service from our document definition, since the RP's interaction with the Billing container is write-only.