### PR TITLE
Fix roleassignment cleanup bug

### DIFF
--- a/dev-infrastructure/templates/dev-automation-account.bicep
+++ b/dev-infrastructure/templates/dev-automation-account.bicep
@@ -99,8 +99,7 @@ module roleAssignmentsCleanup '../modules/automation-account/runbook.bicep' = {
       path: 'tooling/azure-automation/resources-cleanup/src/clean-orphaned-role-assignments.ps1'
     }
     scheduleName: 'nightly-schedule'
+    subscriptionId: subscription().subscriptionId
+    managedIdentityId: automationAccount.outputs.automationAccountManagedIdentityId
   }
-  dependsOn: [
-    automationAccount
-  ]
 }

--- a/tooling/azure-automation/resources-cleanup/src/clean-orphaned-role-assignments.ps1
+++ b/tooling/azure-automation/resources-cleanup/src/clean-orphaned-role-assignments.ps1
@@ -1,19 +1,23 @@
 Param
 (
   [Parameter (Mandatory= $false)]
-  [System.Boolean] $dryRun = $false
+  [System.Boolean] $dryRun = $false,
+  [Parameter (Mandatory= $false)]
+  [string] $SubscriptionId = "1d3378d3-5a3f-4712-85a1-2485495dfc4b",
+  [Parameter (Mandatory= $false)]
+  [string] $ManagedIdentityId
 )
 
-Connect-AzAccount -Identity
+Connect-AzAccount -Identity -SubscriptionId $SubscriptionId -AccountId "4579fe55-83eb-45a5-ba5e-ca90ffadd763"
 
-Select-AzSubscription 1d3378d3-5a3f-4712-85a1-2485495dfc4b | Out-Null
+Set-AzContext -SubscriptionId $SubscriptionId
 
 $x = (Get-AzRoleAssignment |
     Where-Object DisplayName -eq "aro-hcp-engineering-App Developer" |
-    Where-Object Scope -eq /subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b |
+    Where-Object Scope -eq /subscriptions/$SubscriptionId |
     Where-Object RoleDefinitionName -eq "Contributor").ObjectType
 
-if ($x -ne "Group" ) { 
+if ($x -ne "Group" ) {
     Write-Error "Wrong value for Objecttype, perhaps missing Directory Reader permissions on identity or IDs changed"
     exit 1
 }


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

Add `-SubscriptionId `and `-AccountId` parameters to `Connect-AzAccount -Identity` so it login with the managed identity and directly sets the subscription context.

Fix the error:

```
Error
Please provide a valid tenant or a valid subscription.
Error
No subscription was found in the default profile and no scope was specified. Either specify a scope or use a tenant with a subscription to run the command.
Error
Wrong value for Objecttype, perhaps missing Directory Reader permissions on identity or IDs changed

```