### PR TITLE
Add userAccessAdminRole to Automation account

### DIFF
--- a/dev-infrastructure/modules/automation-account/permissions.bicep
+++ b/dev-infrastructure/modules/automation-account/permissions.bicep
@@ -7,12 +7,26 @@ param automationAccountName string
 param automationAccountManagedIdentityId string
 
 var contributorRole = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+var userAccessAdminRole = '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
 
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(automationAccountName, automationAccountManagedIdentityId, contributorRole)
-  properties: {
-    principalId: automationAccountManagedIdentityId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', contributorRole)
+var roleAssignmentsToCreate = [
+  {
+    roleId: contributorRole
+    scope: subscription()
   }
-}
+  {
+    roleId: userAccessAdminRole
+    scope: subscription()
+  }
+]
+resource roleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for ra in roleAssignmentsToCreate: {
+    name: guid(automationAccountName, automationAccountManagedIdentityId, ra.roleId)
+    scope: ra.scope
+    properties: {
+      principalId: automationAccountManagedIdentityId
+      principalType: 'ServicePrincipal'
+      roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', ra.roleId)
+    }
+  }
+]


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

Add `userAccessAdminRole` to Automation account `hcp-dev-automation`, so it can clean up orphaned role assignments.

Current error is 
```
Remove-AzRoleAssignment : Operation returned an invalid status code 'Forbidden' At line:29 char:68 + ... ent | Where-Object ObjectType -eq "Unknown" | Remove-AzRoleAssignment + ~~~~~~~~~~~~~~~~~~~~~~~ + CategoryInfo : CloseError: (:) [Remove-AzRoleAssignment], ErrorResponseException + FullyQualifiedErrorId : Microsoft.Azure.Commands.Resources.RemoveAzureRoleAssignmentCommand
```


https://issues.redhat.com/browse/ARO-17422
