### PR TITLE
move OIDC storage from svc RG to regional RG

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -10,8 +10,8 @@ deploy:
 	kubectl label namespace ${NAMESPACE} "istio.io/rev=${ISTO_TAG}" --overwrite=true && \
 	AZURE_CS_MI_CLIENT_ID=$(shell az identity show -g ${RESOURCEGROUP} -n ${MI_NAME} --query clientId -o tsv) && \
 	TENANT_ID=$(shell az account show --query tenantId --output tsv) && \
-	OIDC_BLOB_SERVICE_ENDPOINT=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${RESOURCEGROUP} --query primaryEndpoints.blob -o tsv) && \
-	OIDC_ISSUER_BASE_ENDPOINT=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${RESOURCEGROUP} --query primaryEndpoints.web -o tsv) && \
+	OIDC_BLOB_SERVICE_ENDPOINT=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${REGIONAL_RESOURCEGROUP} --query primaryEndpoints.blob -o tsv) && \
+	OIDC_ISSUER_BASE_ENDPOINT=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${REGIONAL_RESOURCEGROUP} --query primaryEndpoints.web -o tsv) && \
 	DB_HOST=$$(if [ "${USE_AZURE_DB}" = "true" ]; then az postgres flexible-server show -g ${RESOURCEGROUP} -n ${DATABASE_SERVER_NAME} --query fullyQualifiedDomainName -o tsv; else echo "ocm-cs-db"; fi) && \
 	OVERRIDES=$$(if [ "${USE_AZURE_DB}" = "true" ]; then echo "azuredb.values.yaml"; else echo "containerdb.values.yaml"; fi) && \
 	OP_CLUSTER_API_AZURE_ROLE_ID=$(shell az role definition list --name "${OP_CLUSTER_API_AZURE_ROLE_NAME}" --query "[].name" -o tsv) && \
@@ -133,8 +133,8 @@ local-deploy-provision-shard:
 
 personal-runtime-config:
 	@TENANT_ID=$(shell az account show --query tenantId --output tsv) && \
-	OIDC_BLOB_SERVICE_ENDPOINT=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${RESOURCEGROUP} --query primaryEndpoints.blob -o tsv) && \
-	OIDC_ISSUER_BASE_ENDPOINT=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${RESOURCEGROUP} --query primaryEndpoints.web -o tsv) && \
+	OIDC_BLOB_SERVICE_ENDPOINT=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${REGIONAL_RESOURCEGROUP} --query primaryEndpoints.blob -o tsv) && \
+	OIDC_ISSUER_BASE_ENDPOINT=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${REGIONAL_RESOURCEGROUP} --query primaryEndpoints.web -o tsv) && \
 	OCP_ACR_URL=$(shell az acr show -n ${OCP_ACR_NAME} --query loginServer -o tsv) && \
 	OCP_ACR_RESOURCE_ID=$(shell az acr show -n ${OCP_ACR_NAME} --query id -o tsv) && \
 	../templatize.sh $(DEPLOY_ENV) local/azure-runtime-config.tmpl.json local/azure-runtime-config.json \

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -144,7 +144,7 @@ svc.aks.kubeconfigfile:
 svc.oidc.storage.permissions:
 	@USER_TYPE=$(shell az account show -o json | jq -r '.user.type') && \
 	if [ "$${USER_TYPE}" = "user" ]; then \
-		STORAGEACCOUNTID=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${SVC_RESOURCEGROUP} --query id -o tsv) && \
+		STORAGEACCOUNTID=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${REGIONAL_RESOURCEGROUP} --query id -o tsv) && \
 		az role assignment create \
 		--role "Storage Blob Data Contributor" \
 		--assignee ${PRINCIPAL_ID} \

--- a/dev-infrastructure/modules/oidc/main.bicep
+++ b/dev-infrastructure/modules/oidc/main.bicep
@@ -7,12 +7,14 @@ param skuName string
 param msiId string
 param deploymentScriptLocation string
 param enabledAFD bool = false
+param regionalResourceGroup string = resourceGroup().name
 
 var rpMsiResourceURI = resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', rpMsiName)
 
 // Storage deployment
 module storageAccount 'storage.bicep' = {
   name: 'storage'
+  scope: resourceGroup(regionalResourceGroup)
   params: {
     accountName: storageAccountName
     location: location

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -544,6 +544,7 @@ module oidc '../modules/oidc/main.bicep' = {
   name: '${deployment().name}-oidc'
   params: {
     location: location
+    regionalResourceGroup: regionalResourceGroup
     storageAccountName: oidcStorageAccountName
     rpMsiName: csMIName
     skuName: determineZoneRedundancy(locationAvailabilityZoneList, oidcZoneRedundantMode)


### PR DESCRIPTION
[ARO-16089](https://issues.redhat.com/browse/ARO-16089)

### What

Move the OIDC Storage Account resource used by CS from the svc RG to the regional RG

### Why

MSFT prefers the SVC cluster RG to be about the AKS cluster. All other resources like DBs, storage accounts, managed identities for service, etc should be in the regional RG.

See [ARO-16089](https://issues.redhat.com/browse/ARO-16089)

### Special notes for your reviewer

As this will require a rebuild of the dev & cspr environments we should only merge this when we are ready to do so