### PR TITLE
POC - ACM policy to mirror an ingress TLS cert into a HCP KAS

### DIFF
--- a/acm/deploy/helm/policies/templates/ingress-tls-secret.placementbinding.yaml
+++ b/acm/deploy/helm/policies/templates/ingress-tls-secret.placementbinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: ingress-tls-secret-placement-binding
+  namespace: '{{ .Release.Namespace }}'
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+  name: all-hosted-clusters
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: ingress-tls-secret

--- a/acm/deploy/helm/policies/templates/ingress-tls-secret.policy.yaml
+++ b/acm/deploy/helm/policies/templates/ingress-tls-secret.policy.yaml
@@ -1,0 +1,35 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: ingress-tls-secret
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  disabled: false
+  remediationAction: enforce
+  hubTemplateOptions:
+    serviceAccountName: policy
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: ingress-tls-secret
+        spec:
+          evaluationInterval:
+            compliant: 10m
+            noncompliant: 10s
+          pruneObjectBehavior: DeleteIfCreated
+          remediationAction: enforce
+          object-templates:
+          - complianceType: MustHave
+            objectDefinition:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: ingress-tls
+                namespace: openshift-ingress
+              data: '{{`{{hub copySecretData (index .ManagedClusterLabels "hosted-cluster-namespace") "the-tls-secret" hub}}`}}'

--- a/acm/deploy/helm/policies/templates/policy.admin.clusterrolebinding.yaml
+++ b/acm/deploy/helm/policies/templates/policy.admin.clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: '{{ .Release.Namespace }}-admin'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - kind: ServiceAccount
+    name: policy
+    namespace: '{{ .Release.Namespace }}'

--- a/acm/deploy/helm/policies/templates/policy.serviceaccount.yaml
+++ b/acm/deploy/helm/policies/templates/policy.serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: policy
+  namespace: '{{ .Release.Namespace }}'


### PR DESCRIPTION
this PR showcases how an ACM policy can be used to copy an HCP specific secret into the HCP KAS

this relies on the ACM `copySecretData` and `policy.spec.hubTemplate.serviceAccountName` functionality, as well as the `ManagedCluster.metadata.labels.hosted-cluster-namespace` label to identify the source namespace (`ocm-xxx-$clusterID`) for the secret that is supposed to be mirrored.

(!) this PR uses a quick and dirty new service account in the `open-cluster-management-policies` namespace with cluster admin permissions. we need to narrow these permissions down to list and watch on Secrets in the relevant `ocm-xxx-$clusterID` namespaces.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
