### PR TITLE
Map action groups in prometheus-rules

### DIFF
--- a/dev-infrastructure/modules/metrics/actiongroups.bicep
+++ b/dev-infrastructure/modules/metrics/actiongroups.bicep
@@ -39,7 +39,7 @@ resource emailActions 'Microsoft.Insights/actionGroups@2023-01-01' = [
 
 var actionGroupsCreated = [for (j, index) in emailAdresses: emailActions[index].id]
 
-output allSev1ActionGroups array = union(sev1ActionGroups, actionGroupsCreated)
-output allSev2ActionGroups array = union(sev2ActionGroups, actionGroupsCreated)
-output allSev3ActionGroups array = union(sev3ActionGroups, actionGroupsCreated)
-output allSev4ActionGroups array = union(sev4ActionGroups, actionGroupsCreated)
+output allSev1ActionGroups array = union(filter(sev1ActionGroups, a => (a != '')), actionGroupsCreated)
+output allSev2ActionGroups array = union(filter(sev2ActionGroups, a => (a != '')), actionGroupsCreated)
+output allSev3ActionGroups array = union(filter(sev3ActionGroups, a => (a != '')), actionGroupsCreated)
+output allSev4ActionGroups array = union(filter(sev4ActionGroups, a => (a != '')), actionGroupsCreated)

--- a/dev-infrastructure/modules/metrics/monitor.bicep
+++ b/dev-infrastructure/modules/metrics/monitor.bicep
@@ -76,6 +76,10 @@ module generatedAlerts 'rules/generatedPrometheusAlertingRules.bicep' = {
   name: 'generatedPrometheusAlertingRules'
   params: {
     azureMonitoring: monitor.id
+    allSev1ActionGroups: actionGroups.outputs.allSev1ActionGroups
+    allSev2ActionGroups: actionGroups.outputs.allSev2ActionGroups
+    allSev3ActionGroups: actionGroups.outputs.allSev3ActionGroups
+    allSev4ActionGroups: actionGroups.outputs.allSev4ActionGroups
   }
 }
 

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1,11 +1,20 @@
 param azureMonitoring string
 
+param allSev1ActionGroups array
+
+param allSev2ActionGroups array
+
+param allSev3ActionGroups array
+
+param allSev4ActionGroups array
+
 resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
   name: 'kubernetes-apps'
   location: resourceGroup().location
   properties: {
     rules: [
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubePodCrashLooping'
         enabled: true
         labels: {
@@ -21,6 +30,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubePodNotReady'
         enabled: true
         labels: {
@@ -36,6 +46,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeDeploymentGenerationMismatch'
         enabled: true
         labels: {
@@ -51,6 +62,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeDeploymentReplicasMismatch'
         enabled: true
         labels: {
@@ -66,6 +78,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeDeploymentRolloutStuck'
         enabled: true
         labels: {
@@ -81,6 +94,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeStatefulSetReplicasMismatch'
         enabled: true
         labels: {
@@ -96,6 +110,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeStatefulSetGenerationMismatch'
         enabled: true
         labels: {
@@ -111,6 +126,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeStatefulSetUpdateNotRolledOut'
         enabled: true
         labels: {
@@ -126,6 +142,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeDaemonSetRolloutStuck'
         enabled: true
         labels: {
@@ -141,6 +158,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeContainerWaiting'
         enabled: true
         labels: {
@@ -156,6 +174,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeDaemonSetNotScheduled'
         enabled: true
         labels: {
@@ -171,6 +190,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeDaemonSetMisScheduled'
         enabled: true
         labels: {
@@ -186,6 +206,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeJobNotCompleted'
         enabled: true
         labels: {
@@ -200,6 +221,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeJobFailed'
         enabled: true
         labels: {
@@ -215,6 +237,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeHpaReplicasMismatch'
         enabled: true
         labels: {
@@ -230,6 +253,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeHpaMaxedOut'
         enabled: true
         labels: {
@@ -257,6 +281,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
   properties: {
     rules: [
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeCPUOvercommit'
         enabled: true
         labels: {
@@ -272,6 +297,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeMemoryOvercommit'
         enabled: true
         labels: {
@@ -287,6 +313,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeCPUQuotaOvercommit'
         enabled: true
         labels: {
@@ -302,6 +329,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeMemoryQuotaOvercommit'
         enabled: true
         labels: {
@@ -317,6 +345,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         severity: 3
       }
       {
+        actions: [for g in allSev4ActionGroups: { actionGroupId: g }]
         alert: 'KubeQuotaAlmostFull'
         enabled: true
         labels: {
@@ -332,6 +361,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         severity: 4
       }
       {
+        actions: [for g in allSev4ActionGroups: { actionGroupId: g }]
         alert: 'KubeQuotaFullyUsed'
         enabled: true
         labels: {
@@ -347,6 +377,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         severity: 4
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeQuotaExceeded'
         enabled: true
         labels: {
@@ -362,6 +393,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         severity: 3
       }
       {
+        actions: [for g in allSev4ActionGroups: { actionGroupId: g }]
         alert: 'CPUThrottlingHigh'
         enabled: true
         labels: {
@@ -389,6 +421,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
   properties: {
     rules: [
       {
+        actions: [for g in allSev2ActionGroups: { actionGroupId: g }]
         alert: 'KubePersistentVolumeFillingUp'
         enabled: true
         labels: {
@@ -404,6 +437,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         severity: 2
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubePersistentVolumeFillingUp'
         enabled: true
         labels: {
@@ -419,6 +453,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         severity: 3
       }
       {
+        actions: [for g in allSev2ActionGroups: { actionGroupId: g }]
         alert: 'KubePersistentVolumeInodesFillingUp'
         enabled: true
         labels: {
@@ -434,6 +469,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         severity: 2
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubePersistentVolumeInodesFillingUp'
         enabled: true
         labels: {
@@ -449,6 +485,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         severity: 3
       }
       {
+        actions: [for g in allSev2ActionGroups: { actionGroupId: g }]
         alert: 'KubePersistentVolumeErrors'
         enabled: true
         labels: {
@@ -476,6 +513,7 @@ resource kubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-
   properties: {
     rules: [
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeVersionMismatch'
         enabled: true
         labels: {
@@ -491,6 +529,7 @@ resource kubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeClientErrors'
         enabled: true
         labels: {
@@ -518,6 +557,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
   properties: {
     rules: [
       {
+        actions: [for g in allSev2ActionGroups: { actionGroupId: g }]
         alert: 'KubeAPIErrorBudgetBurn'
         enabled: true
         labels: {
@@ -535,6 +575,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         severity: 2
       }
       {
+        actions: [for g in allSev2ActionGroups: { actionGroupId: g }]
         alert: 'KubeAPIErrorBudgetBurn'
         enabled: true
         labels: {
@@ -552,6 +593,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         severity: 2
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeAPIErrorBudgetBurn'
         enabled: true
         labels: {
@@ -569,6 +611,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeAPIErrorBudgetBurn'
         enabled: true
         labels: {
@@ -598,6 +641,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
   properties: {
     rules: [
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeClientCertificateExpiration'
         enabled: true
         labels: {
@@ -613,6 +657,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         severity: 3
       }
       {
+        actions: [for g in allSev2ActionGroups: { actionGroupId: g }]
         alert: 'KubeClientCertificateExpiration'
         enabled: true
         labels: {
@@ -628,6 +673,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         severity: 2
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeAggregatedAPIErrors'
         enabled: true
         labels: {
@@ -642,6 +688,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeAggregatedAPIDown'
         enabled: true
         labels: {
@@ -657,6 +704,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         severity: 3
       }
       {
+        actions: [for g in allSev2ActionGroups: { actionGroupId: g }]
         alert: 'KubeAPIDown'
         enabled: true
         labels: {
@@ -672,6 +720,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         severity: 2
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeAPITerminatedRequests'
         enabled: true
         labels: {
@@ -699,6 +748,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
   properties: {
     rules: [
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeNodeNotReady'
         enabled: true
         labels: {
@@ -714,6 +764,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeNodeUnreachable'
         enabled: true
         labels: {
@@ -729,6 +780,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         severity: 3
       }
       {
+        actions: [for g in allSev4ActionGroups: { actionGroupId: g }]
         alert: 'KubeletTooManyPods'
         enabled: true
         labels: {
@@ -744,6 +796,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         severity: 4
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeNodeReadinessFlapping'
         enabled: true
         labels: {
@@ -759,6 +812,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeletPlegDurationHigh'
         enabled: true
         labels: {
@@ -774,6 +828,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeletPodStartUpLatencyHigh'
         enabled: true
         labels: {
@@ -789,6 +844,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeletClientCertificateExpiration'
         enabled: true
         labels: {
@@ -803,6 +859,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         severity: 3
       }
       {
+        actions: [for g in allSev2ActionGroups: { actionGroupId: g }]
         alert: 'KubeletClientCertificateExpiration'
         enabled: true
         labels: {
@@ -817,6 +874,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         severity: 2
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeletServerCertificateExpiration'
         enabled: true
         labels: {
@@ -831,6 +889,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         severity: 3
       }
       {
+        actions: [for g in allSev2ActionGroups: { actionGroupId: g }]
         alert: 'KubeletServerCertificateExpiration'
         enabled: true
         labels: {
@@ -845,6 +904,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         severity: 2
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeletClientCertificateRenewalErrors'
         enabled: true
         labels: {
@@ -860,6 +920,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         severity: 3
       }
       {
+        actions: [for g in allSev3ActionGroups: { actionGroupId: g }]
         alert: 'KubeletServerCertificateRenewalErrors'
         enabled: true
         labels: {
@@ -875,6 +936,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         severity: 3
       }
       {
+        actions: [for g in allSev2ActionGroups: { actionGroupId: g }]
         alert: 'KubeletDown'
         enabled: true
         labels: {
@@ -902,6 +964,7 @@ resource kubernetesSystemScheduler 'Microsoft.AlertsManagement/prometheusRuleGro
   properties: {
     rules: [
       {
+        actions: [for g in allSev2ActionGroups: { actionGroupId: g }]
         alert: 'KubeSchedulerDown'
         enabled: true
         labels: {
@@ -929,6 +992,7 @@ resource kubernetesSystemControllerManager 'Microsoft.AlertsManagement/prometheu
   properties: {
     rules: [
       {
+        actions: [for g in allSev2ActionGroups: { actionGroupId: g }]
         alert: 'KubeControllerManagerDown'
         enabled: true
         labels: {

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -217,6 +217,14 @@ func (o *Options) Generate() error {
 	}()
 
 	if _, err := output.Write([]byte(`param azureMonitoring string
+
+param allSev1ActionGroups array
+
+param allSev2ActionGroups array
+
+param allSev3ActionGroups array
+
+param allSev4ActionGroups array
 `)); err != nil {
 		return err
 	}
@@ -290,6 +298,7 @@ resource {{.name}} 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' 
     rules: [
 {{- range .groups.Properties.Rules}}
       {
+        actions: [for g in allSev{{.Severity}}ActionGroups: { actionGroupId: g }]
         alert: '{{.Alert}}'
         enabled: {{.Enabled}}
 {{- if .Labels}}

--- a/tooling/prometheus-rules/testdata/generated.bicep
+++ b/tooling/prometheus-rules/testdata/generated.bicep
@@ -1,11 +1,20 @@
 param azureMonitoring string
 
+param allSev1ActionGroups array
+
+param allSev2ActionGroups array
+
+param allSev3ActionGroups array
+
+param allSev4ActionGroups array
+
 resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
   name: 'InstancesDownV1'
   location: resourceGroup().location
   properties: {
     rules: [
       {
+        actions: [for g in allSev2ActionGroups: { actionGroupId: g }]
         alert: 'InstancesDownV1'
         enabled: true
         labels: {


### PR DESCRIPTION

## What

Redo: https://github.com/Azure/ARO-HCP/pull/1782

### Why

Enable notifications using severity mapping and pre-configured action groups. 

Added fix that filters empty strings

### Special notes for your reviewer

Previous PR failed during deployment, cause it contained an empty string for preconfigured Action Groups.