### PR TITLE
ARO-17011: bump hypershift image digest

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -459,7 +459,7 @@ clouds:
           hypershift:
             additionalInstallArg: ''
             image:
-              digest: sha256:930a2851e0ed5144901eabdb1247096fea527231a990ea764b27754b766ef821
+              digest: sha256:607dcc3e795a1fb8e7647aa6ccf5b19dbfba8b4387f8eac9e304b33265a80d05
           # Maestro
           maestro:
             image:
@@ -559,7 +559,7 @@ clouds:
           # Hypershift
           hypershift:
             image:
-              digest: sha256:930a2851e0ed5144901eabdb1247096fea527231a990ea764b27754b766ef821
+              digest: sha256:607dcc3e795a1fb8e7647aa6ccf5b19dbfba8b4387f8eac9e304b33265a80d05
           # Maestro
           maestro:
             image:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -319,7 +319,7 @@ clouds:
         image:
           registry: quay.io
           repository: acm-d/rhtap-hypershift-operator
-          digest: sha256:0e6706e3bbc058a65f34dad7ccf048e56b1f32ca610c6f39f085ddb8bb1169ef
+          digest: sha256:607dcc3e795a1fb8e7647aa6ccf5b19dbfba8b4387f8eac9e304b33265a80d05
       # Backplane API
       backplaneAPI:
         image:

--- a/config/public-cloud-cspr.json
+++ b/config/public-cloud-cspr.json
@@ -156,7 +156,7 @@
   "hypershift": {
     "additionalInstallArg": "",
     "image": {
-      "digest": "sha256:0e6706e3bbc058a65f34dad7ccf048e56b1f32ca610c6f39f085ddb8bb1169ef",
+      "digest": "sha256:607dcc3e795a1fb8e7647aa6ccf5b19dbfba8b4387f8eac9e304b33265a80d05",
       "registry": "quay.io",
       "repository": "acm-d/rhtap-hypershift-operator"
     },

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -156,7 +156,7 @@
   "hypershift": {
     "additionalInstallArg": "",
     "image": {
-      "digest": "sha256:0e6706e3bbc058a65f34dad7ccf048e56b1f32ca610c6f39f085ddb8bb1169ef",
+      "digest": "sha256:607dcc3e795a1fb8e7647aa6ccf5b19dbfba8b4387f8eac9e304b33265a80d05",
       "registry": "quay.io",
       "repository": "acm-d/rhtap-hypershift-operator"
     },

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -151,7 +151,7 @@
   "hypershift": {
     "additionalInstallArg": "",
     "image": {
-      "digest": "sha256:930a2851e0ed5144901eabdb1247096fea527231a990ea764b27754b766ef821",
+      "digest": "sha256:607dcc3e795a1fb8e7647aa6ccf5b19dbfba8b4387f8eac9e304b33265a80d05",
       "registry": "quay.io",
       "repository": "acm-d/rhtap-hypershift-operator"
     },

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -151,7 +151,7 @@
   "hypershift": {
     "additionalInstallArg": "--limit-crd-install=Azure",
     "image": {
-      "digest": "sha256:930a2851e0ed5144901eabdb1247096fea527231a990ea764b27754b766ef821",
+      "digest": "sha256:607dcc3e795a1fb8e7647aa6ccf5b19dbfba8b4387f8eac9e304b33265a80d05",
       "registry": "quay.io",
       "repository": "acm-d/rhtap-hypershift-operator"
     },

--- a/config/public-cloud-ntly.json
+++ b/config/public-cloud-ntly.json
@@ -156,7 +156,7 @@
   "hypershift": {
     "additionalInstallArg": "",
     "image": {
-      "digest": "sha256:0e6706e3bbc058a65f34dad7ccf048e56b1f32ca610c6f39f085ddb8bb1169ef",
+      "digest": "sha256:607dcc3e795a1fb8e7647aa6ccf5b19dbfba8b4387f8eac9e304b33265a80d05",
       "registry": "quay.io",
       "repository": "acm-d/rhtap-hypershift-operator"
     },

--- a/config/public-cloud-pers.json
+++ b/config/public-cloud-pers.json
@@ -156,7 +156,7 @@
   "hypershift": {
     "additionalInstallArg": "",
     "image": {
-      "digest": "sha256:0e6706e3bbc058a65f34dad7ccf048e56b1f32ca610c6f39f085ddb8bb1169ef",
+      "digest": "sha256:607dcc3e795a1fb8e7647aa6ccf5b19dbfba8b4387f8eac9e304b33265a80d05",
       "registry": "quay.io",
       "repository": "acm-d/rhtap-hypershift-operator"
     },


### PR DESCRIPTION
This update to the image digest correlates to [d0f84e895c01a9fc4c39a440adfec3ca45aed067](https://github.com/openshift/hypershift/commit/d0f84e895c01a9fc4c39a440adfec3ca45aed067) which is latest available commit in Hypershift.

This bump is to include the changes in [PR](https://github.com/openshift/hypershift/pull/6103). Using some of the commits between this PR and the latest commit caused issues when creating a hosted cluster in the ARO-HCP dev environment[caused the cluster to be stuck in installing state]. . Therefore, the latest commit was used instead.

### Special notes for your reviewer

<!-- optional -->
