### PR TITLE
update istio to 1.25

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -117,8 +117,8 @@ defaults:
     istio:
       istioctlVersion: "1.24.1"
       tag: "prod-stable"
-      targetVersion: "asm-1-23"
-      versions: "asm-1-23"
+      targetVersion: "asm-1-25"
+      versions: "asm-1-23,asm-1-25"
       ingressGatewayIPAddressName: "aro-hcp-istio-ingress"
       ingressGatewayIPAddressIPTags: "FirstPartyUsage:/aro-hcp-prod-inbound-svc"
     logs:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -58,8 +58,8 @@ defaults:
     istio:
       istioctlVersion: "1.23.1"
       tag: "prod-stable"
-      targetVersion: "asm-1-23"
-      versions: "asm-1-23"
+      targetVersion: "asm-1-25"
+      versions: "asm-1-23,asm-1-25"
       ingressGatewayIPAddressName: "aro-hcp-istio-ingress"
       ingressGatewayIPAddressIPTags: ""
     aks:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -413,8 +413,8 @@
       "ingressGatewayIPAddressName": "aro-hcp-istio-ingress",
       "istioctlVersion": "1.23.1",
       "tag": "prod-stable",
-      "targetVersion": "asm-1-23",
-      "versions": "asm-1-23"
+      "targetVersion": "asm-1-25",
+      "versions": "asm-1-23,asm-1-25"
     },
     "nsp": {
       "accessMode": "Learning",

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -413,8 +413,8 @@
       "ingressGatewayIPAddressName": "aro-hcp-istio-ingress",
       "istioctlVersion": "1.23.1",
       "tag": "prod-stable",
-      "targetVersion": "asm-1-23",
-      "versions": "asm-1-23"
+      "targetVersion": "asm-1-25",
+      "versions": "asm-1-23,asm-1-25"
     },
     "nsp": {
       "accessMode": "Learning",

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -414,8 +414,8 @@
       "ingressGatewayIPAddressName": "aro-hcp-istio-ingress",
       "istioctlVersion": "1.24.1",
       "tag": "prod-stable",
-      "targetVersion": "asm-1-23",
-      "versions": "asm-1-23"
+      "targetVersion": "asm-1-25",
+      "versions": "asm-1-23,asm-1-25"
     },
     "logs": {
       "configVersion": "1.0",

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -412,8 +412,8 @@
       "ingressGatewayIPAddressName": "aro-hcp-istio-ingress",
       "istioctlVersion": "1.24.1",
       "tag": "prod-stable",
-      "targetVersion": "asm-1-23",
-      "versions": "asm-1-23"
+      "targetVersion": "asm-1-25",
+      "versions": "asm-1-23,asm-1-25"
     },
     "logs": {
       "configVersion": "1.0",

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -413,8 +413,8 @@
       "ingressGatewayIPAddressName": "aro-hcp-istio-ingress",
       "istioctlVersion": "1.23.1",
       "tag": "prod-stable",
-      "targetVersion": "asm-1-23",
-      "versions": "asm-1-23"
+      "targetVersion": "asm-1-25",
+      "versions": "asm-1-23,asm-1-25"
     },
     "nsp": {
       "accessMode": "Learning",

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -416,8 +416,8 @@
       "ingressGatewayIPAddressName": "aro-hcp-istio-ingress",
       "istioctlVersion": "1.23.1",
       "tag": "prod-stable",
-      "targetVersion": "asm-1-23",
-      "versions": "asm-1-23"
+      "targetVersion": "asm-1-25",
+      "versions": "asm-1-23,asm-1-25"
     },
     "jaeger": {
       "deploy": true


### PR DESCRIPTION
### What

* add 1.25 istio to SVC
* 1.23 will be removed after the upgrade

### Why

1.23 will be EOL in June 

### Special notes for your reviewer

<!-- optional -->
