### PR TITLE
Devops msi output chaining

### DIFF
--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -568,8 +568,6 @@ clouds:
           # Grafana
           monitoring:
             grafanaAdminGroupPrincipalId: '' # object id for group 'RH-AROAPPR'. EV2 currently only allows service principal role assignment, so leave it empty for now
-          # Global MSI
-          aroDevopsMsiId: '/subscriptions/9a53d80e-dae0-4c8a-af90-30575d253127/resourceGroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity'
           # Cert Officer used for KV signer registration
           kvCertOfficerPrincipalId: ce4e50ef-1059-4b6f-a53a-53001d517513 # objectId for 'aro-ev2-admin-prod-sp'
           # Logs

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -479,8 +479,6 @@ clouds:
           # Grafana
           monitoring:
             grafanaAdminGroupPrincipalId: "2fdb57d4-3fd3-415d-b604-1d0e37a188fe" # Azure Red Hat OpenShift MSFT Engineering.
-          # Global MSI
-          aroDevopsMsiId: "/subscriptions/5299e6b7-b23b-46c8-8277-dc1147807117/resourcegroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity"
           # Cert Officer used for KV signer registration
           kvCertOfficerPrincipalId: "32af88de-a61c-4f71-b709-50538598c4f2" # aro-ev2-admin-int-sp
           # Logs

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -291,9 +291,6 @@
     }
   },
   "properties": {
-    "aroDevopsMsiId": {
-      "type": "string"
-    },
     "kvCertOfficerPrincipalId": {
       "type": "string",
       "description": "The principal ID of the cert officer that will be used to manage KV certificate issuers"
@@ -1276,7 +1273,6 @@
   },
   "additionalProperties": false,
   "required": [
-    "aroDevopsMsiId",
     "kvCertOfficerPrincipalId",
     "backplaneAPI",
     "clustersService",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -419,7 +419,6 @@ clouds:
         grafanaMajorVersion: '11'
         grafanaZoneRedundantMode: Disabled
         grafanaAdminGroupPrincipalId: 6b6d3adf-8476-4727-9812-20ffdef2b85c
-
       kvCertOfficerPrincipalId: 'c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb'
     environments:
       dev:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -419,8 +419,7 @@ clouds:
         grafanaMajorVersion: '11'
         grafanaZoneRedundantMode: Disabled
         grafanaAdminGroupPrincipalId: 6b6d3adf-8476-4727-9812-20ffdef2b85c
-      # DEVOPS MSI
-      aroDevopsMsiId: '/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-rollout-identity'
+
       kvCertOfficerPrincipalId: 'c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb'
     environments:
       dev:

--- a/config/public-cloud-cs-pr.json
+++ b/config/public-cloud-cs-pr.json
@@ -19,7 +19,6 @@
   "armHelperCertName": "armHelperCert2",
   "armHelperClientId": "3331e670-0804-48e8-a086-6241671ddc93",
   "armHelperFPAPrincipalId": "47f69502-0065-4d9a-b19b-d403e183d2f4",
-  "aroDevopsMsiId": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-rollout-identity",
   "backend": {
     "image": {
       "digest": "",

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -19,7 +19,6 @@
   "armHelperCertName": "armHelperCert2",
   "armHelperClientId": "3331e670-0804-48e8-a086-6241671ddc93",
   "armHelperFPAPrincipalId": "47f69502-0065-4d9a-b19b-d403e183d2f4",
-  "aroDevopsMsiId": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-rollout-identity",
   "backend": {
     "image": {
       "digest": "",

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -19,7 +19,6 @@
   "armHelperCertName": "armHelperCert2",
   "armHelperClientId": "3331e670-0804-48e8-a086-6241671ddc93",
   "armHelperFPAPrincipalId": "47f69502-0065-4d9a-b19b-d403e183d2f4",
-  "aroDevopsMsiId": "/subscriptions/5299e6b7-b23b-46c8-8277-dc1147807117/resourcegroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity",
   "backend": {
     "image": {
       "digest": "sha256:02a32af8d34c5725d0096ee7f94adf2ef151d0634e8682fe7517e6f9ebba9bdc",

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -19,7 +19,6 @@
   "armHelperCertName": "",
   "armHelperClientId": "",
   "armHelperFPAPrincipalId": "",
-  "aroDevopsMsiId": "/subscriptions/9a53d80e-dae0-4c8a-af90-30575d253127/resourceGroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity",
   "backend": {
     "image": {
       "digest": "sha256:02a32af8d34c5725d0096ee7f94adf2ef151d0634e8682fe7517e6f9ebba9bdc",

--- a/config/public-cloud-nightly.json
+++ b/config/public-cloud-nightly.json
@@ -19,7 +19,6 @@
   "armHelperCertName": "armHelperCert2",
   "armHelperClientId": "3331e670-0804-48e8-a086-6241671ddc93",
   "armHelperFPAPrincipalId": "47f69502-0065-4d9a-b19b-d403e183d2f4",
-  "aroDevopsMsiId": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-rollout-identity",
   "backend": {
     "image": {
       "digest": "",

--- a/config/public-cloud-personal-dev.json
+++ b/config/public-cloud-personal-dev.json
@@ -19,7 +19,6 @@
   "armHelperCertName": "armHelperCert2",
   "armHelperClientId": "3331e670-0804-48e8-a086-6241671ddc93",
   "armHelperFPAPrincipalId": "47f69502-0065-4d9a-b19b-d403e183d2f4",
-  "aroDevopsMsiId": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-rollout-identity",
   "backend": {
     "image": {
       "digest": "",

--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -49,7 +49,7 @@ param msiKeyVaultName = '{{ .msiKeyVault.name }}'
 param mgmtKeyVaultName = '{{ .mgmtKeyVault.name }}'
 
 // MI for deployment scripts
-param aroDevopsMsiId = '{{ .aroDevopsMsiId }}'
+param globalMsiId = '__globalMsiId__'
 
 // Azure Monitor Workspace
 param azureMonitoringWorkspaceId = '__azureMonitoringWorkspaceId__'

--- a/dev-infrastructure/configurations/mgmt-infra.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-infra.tmpl.bicepparam
@@ -19,7 +19,7 @@ param mgmtKeyVaultSoftDelete = {{ .mgmtKeyVault.softDelete }}
 param kvCertOfficerPrincipalId = '{{ .kvCertOfficerPrincipalId }}'
 
 // MI for resource access during pipeline runs
-param aroDevopsMsiId = '{{ .aroDevopsMsiId }}'
+param globalMsiId = '__globalMsiId__'
 
 // Cluster Service identity
 // used for Key Vault access

--- a/dev-infrastructure/configurations/mock-identities.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mock-identities.tmpl.bicepparam
@@ -1,5 +1,5 @@
 using '../templates/mock-identities.bicep'
 
-param aroDevopsMsiId = '{{ .aroDevopsMsiId }}'
+param globalMsiName = '{{ .global.globalMSIName }}'
 
 param keyVaultName = '{{ .serviceKeyVault.name }}'

--- a/dev-infrastructure/configurations/output-global.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/output-global.tmpl.bicepparam
@@ -1,5 +1,6 @@
 using '../templates/output-global.bicep'
 
+param globalMSIName = '{{ .global.globalMSIName }}'
 param svcAcrName = '{{ .acr.svc.name }}'
 param ocpAcrName = '{{ .acr.ocp.name }}'
 param cxParentZoneName = '{{ .dns.cxParentZoneName }}'

--- a/dev-infrastructure/configurations/region.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/region.tmpl.bicepparam
@@ -20,7 +20,7 @@ param maestroEventGridPrivate = {{ .maestro.eventGrid.private }}
 param maestroCertificateIssuer = '{{ .maestro.certIssuer }}'
 
 // MI for resource access during pipeline runs
-param aroDevopsMsiId = '{{ .aroDevopsMsiId }}'
+param globalMsiId = '__globalMsiId__'
 
 // Log Analytics
 param enableLogAnalytics = {{ .logs.loganalytics.enable }}

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -72,7 +72,7 @@ param svcAcrResourceId = '__svcAcrResourceId__'
 param oidcStorageAccountName = '{{ .oidcStorageAccountName }}'
 param oidcZoneRedundantMode = '{{ .oidcZoneRedundantMode }}'
 
-param aroDevopsMsiId = '{{ .aroDevopsMsiId }}'
+param globalMsiId = '__globalMsiId__'
 
 param svcDNSZoneName = '{{ .dns.svcParentZoneName }}'
 param regionalCXDNSZoneName = '{{ .dns.regionalSubdomain }}.{{ .dns.cxParentZoneName }}'

--- a/dev-infrastructure/configurations/svc-infra.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-infra.tmpl.bicepparam
@@ -7,7 +7,7 @@ param serviceKeyVaultSoftDelete = {{ .serviceKeyVault.softDelete }}
 param serviceKeyVaultPrivate = {{ .serviceKeyVault.private }}
 
 // MI for resource access during pipeline runs
-param aroDevopsMsiId = '{{ .aroDevopsMsiId }}'
+param globalMsiId = '__globalMsiId__'
 
 // SP for KV certificate issuer registration
 param kvCertOfficerPrincipalId = '{{ .kvCertOfficerPrincipalId }}'

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -51,6 +51,10 @@ resourceGroups:
     parameters: configurations/mgmt-infra.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     variables:
+    - name: globalMsiId
+      input:
+        step: global-output
+        name: globalMsiId
     - name: clusterServiceMIResourceId
       input:
         step: svc-output
@@ -60,6 +64,7 @@ resourceGroups:
         step: region-output
         name: logAnalyticsWorkspaceId
     dependsOn:
+    - global-output
     - region-output
     - svc-output
     - rpRegistration
@@ -109,6 +114,10 @@ resourceGroups:
       input:
         step: global-output
         name: svcAcrResourceId
+    - name: globalMsiId
+      input:
+        step: global-output
+        name: globalMsiId
     - name: azureMonitoringWorkspaceId
       input:
         step: region-output

--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -43,6 +43,10 @@ resourceGroups:
       input:
         step: global-output
         name: svcAcrResourceId
+    - name: globalMsiId
+      input:
+        step: global-output
+        name: globalMsiId
     - name: cxParentZoneResourceId
       input:
         step: global-output

--- a/dev-infrastructure/scripts/service-image-backfill.sh.bak
+++ b/dev-infrastructure/scripts/service-image-backfill.sh.bak
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+
+DEPLOY_ENV=$1
+TARGET_REGISTRY=$2
+MODE=$3
+
+TARGET_REGISTRY_URL="${TARGET_REGISTRY}.azurecr.io"
+
+get_image_tag() {
+    $SCRIPT_DIR/../../templatize.sh $DEPLOY_ENV | jq ".$1" -r
+}
+
+mirror_image() {
+    local full_image_ref=$1
+    local relative_image_ref=$(echo $full_image_ref | cut -d'/' -f2-)
+    if [[ $MODE == "pull" ]]; then
+        echo "Pull $full_image_ref with x86 architecture"
+        podman pull --arch x86_64 $full_image_ref
+    elif [[ $MODE == "push" ]]; then
+        echo "Push $full_image_ref to ${TARGET_REGISTRY_URL}/${relative_image_ref}"
+        podman tag $full_image_ref ${TARGET_REGISTRY_URL}/${relative_image_ref}
+        podman push ${TARGET_REGISTRY_URL}/${relative_image_ref}
+    fi
+    echo
+}
+
+# CS
+#mirror_image "quay.io/app-sre/uhc-clusters-service:$(get_image_tag 'clusterService.imageTag')"
+
+# Maestro
+mirror_image "quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro:$(get_image_tag 'maestro.imageTag')"
+
+# RP
+#mirror_image "arohcpsvcdev.azurecr.io/arohcpbackend:$(get_image_tag 'backend.imageTag')"
+#mirror_image "arohcpsvcdev.azurecr.io/arohcpfrontend:$(get_image_tag 'frontend.imageTag')"
+
+# Imagesync
+#mirror_image "arohcpsvcdev.azurecr.io/image-sync/component-sync:$(get_image_tag 'imageSync.componentSync.imageTag')"
+#mirror_image "arohcpsvcdev.azurecr.io/image-sync/oc-mirror:$(get_image_tag 'imageSync.ocMirror.imageTag')"
+
+# Hypershift
+#mirror_image "quay.io/acm-d/rhtap-hypershift-operator:$(get_image_tag 'hypershiftOperator.imageTag')"

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -46,11 +46,16 @@ resourceGroups:
     parameters: configurations/svc-infra.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     variables:
+    - name: globalMsiId
+      input:
+        step: global-output
+        name: globalMsiId
     - name: logAnalyticsWorkspaceId
       input:
         step: region-output
         name: logAnalyticsWorkspaceId
     dependsOn:
+    - global-output
     - region-output
   # Configure certificate issuers for the SVC KV
   - name: svc-oncert-private-kv-issuer
@@ -88,6 +93,10 @@ resourceGroups:
       input:
         step: global-output
         name: svcAcrResourceId
+    - name: globalMsiId
+      input:
+        step: global-output
+        name: globalMsiId
     - name: azureMonitoringWorkspaceId
       input:
         step: region-output

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -117,7 +117,7 @@ param msiKeyVaultName string
 param mgmtKeyVaultName string
 
 @description('MSI that will be used to run deploymentScripts')
-param aroDevopsMsiId string
+param globalMsiId string
 
 @description('The Azure resource ID of the Azure Monitor Workspace (stores prometheus metrics)')
 param azureMonitoringWorkspaceId string
@@ -228,8 +228,7 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     networkDataplane: aksNetworkDataplane
     networkPolicy: aksNetworkPolicy
     userOsDiskSizeGB: aksUserOsDiskSizeGB
-    deploymentMsiId: aroDevopsMsiId
-    enableSwiftV2: aksEnableSwift
+    aroDevopsMsiId: globalMsiId
   }
 }
 
@@ -326,7 +325,7 @@ module maestroConsumer '../modules/maestro/maestro-consumer.bicep' = if (maestro
     maestroConsumerName: maestroConsumerName
     maestroEventGridNamespaceId: maestroEventGridNamespaceId
     certKeyVaultName: mgmtKeyVaultName
-    keyVaultOfficerManagedIdentityName: aroDevopsMsiId
+    keyVaultOfficerManagedIdentityName: globalMsiId
     maestroCertificateDomain: effectiveMaestroCertDomain
     maestroCertificateIssuer: maestroCertIssuer
   }

--- a/dev-infrastructure/templates/mgmt-infra.bicep
+++ b/dev-infrastructure/templates/mgmt-infra.bicep
@@ -38,7 +38,7 @@ param clusterServiceMIResourceId string
 param kvCertOfficerPrincipalId string
 
 @description('MSI that will be used during pipeline runs')
-param aroDevopsMsiId string
+param globalMsiId string
 
 // Log Analytics Workspace ID will be passed from region pipeline if enabled in config
 param logAnalyticsWorkspaceId string = ''
@@ -63,9 +63,9 @@ var readerRoleId = subscriptionResourceId(
 // service deployments running as the aroDevopsMsi need to lookup metadata about all kinds
 // of resources, e.g. AKS metadata, database metadata, MI metadata, etc.
 resource aroDevopsMSIReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, aroDevopsMsiId, readerRoleId)
+  name: guid(resourceGroup().id, globalMsiId, readerRoleId)
   properties: {
-    principalId: reference(aroDevopsMsiId, '2023-01-31').principalId
+    principalId: reference(globalMsiId, '2023-01-31').principalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: readerRoleId
   }

--- a/dev-infrastructure/templates/mock-identities.bicep
+++ b/dev-infrastructure/templates/mock-identities.bicep
@@ -1,14 +1,18 @@
 @description('Azure Region Location')
 param location string = resourceGroup().location
 
-@description('The resource ID of the managed identity that will be used for Key Vault operations')
-param aroDevopsMsiId string
+@description('The name of the MSI used for Key Vault operations')
+param globalMsiName string
 
 @description('The name of the key vault')
 param keyVaultName string
 
 @description('Global resource group name')
 param globalResourceGroupName string = 'global'
+
+resource globalMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: globalMsiName
+}
 
 //
 // F I R S T   P A R T Y   I D E N T I T Y
@@ -18,7 +22,7 @@ module firstPartyIdentity '../modules/keyvault/key-vault-cert.bicep' = {
   name: 'first-party-identity'
   params: {
     location: location
-    keyVaultManagedIdentityId: aroDevopsMsiId
+    keyVaultManagedIdentityId: globalMSI.id
     keyVaultName: keyVaultName
     certName: 'firstPartyCert2'
     subjectName: 'CN=firstparty.hcp.osadev.cloud'
@@ -59,7 +63,7 @@ module armHelperIdentity '../modules/keyvault/key-vault-cert.bicep' = {
   name: 'arm-helper-identity'
   params: {
     location: location
-    keyVaultManagedIdentityId: aroDevopsMsiId
+    keyVaultManagedIdentityId: globalMSI.id
     keyVaultName: keyVaultName
     certName: 'armHelperCert2'
     subjectName: 'CN=armhelper.hcp.osadev.cloud'
@@ -77,7 +81,7 @@ module msiRPMockIdentity '../modules/keyvault/key-vault-cert.bicep' = {
   name: 'msi-mock-identity'
   params: {
     location: location
-    keyVaultManagedIdentityId: aroDevopsMsiId
+    keyVaultManagedIdentityId: globalMSI.id
     keyVaultName: keyVaultName
     certName: 'msiMockCert2'
     subjectName: 'CN=msimock.hcp.osadev.cloud'

--- a/dev-infrastructure/templates/output-global.bicep
+++ b/dev-infrastructure/templates/output-global.bicep
@@ -13,6 +13,9 @@ param svcParentZoneName string
 @description('Metrics global Grafana name')
 param grafanaName string
 
+@description('The global msi name')
+param globalMSIName string
+
 //
 //   A C R
 //
@@ -54,3 +57,13 @@ resource grafana 'Microsoft.Dashboard/grafana@2023-09-01' existing = {
 }
 
 output grafanaResourceId string = grafana.id
+
+//
+//  G L O B A L   M S I
+//
+
+resource globalMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: globalMSIName
+}
+
+output globalMsiId string = globalMSI.id

--- a/dev-infrastructure/templates/region.bicep
+++ b/dev-infrastructure/templates/region.bicep
@@ -40,7 +40,7 @@ param ocpAcrResourceId string
 param svcAcrResourceId string
 
 @description('MSI that will be used during pipeline runs')
-param aroDevopsMsiId string
+param globalMsiId string
 
 @description('Enable Log Analytics')
 param enableLogAnalytics bool
@@ -68,9 +68,9 @@ var readerRoleId = subscriptionResourceId(
 // service deployments running as the aroDevopsMsi need to lookup metadata about all kinds
 // of resources, e.g. AKS metadata, database metadata, MI metadata, etc.
 resource aroDevopsMSIReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, aroDevopsMsiId, readerRoleId)
+  name: guid(resourceGroup().id, globalMsiId, readerRoleId)
   properties: {
-    principalId: reference(aroDevopsMsiId, '2023-01-31').principalId
+    principalId: reference(globalMsiId, '2023-01-31').principalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: readerRoleId
   }

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -197,7 +197,7 @@ param oidcStorageAccountName string
 param oidcZoneRedundantMode string
 
 @description('MSI that will be used to run the deploymentScript')
-param aroDevopsMsiId string
+param globalMsiId string
 
 @description('The parent SVC DNS zone name')
 param svcDNSZoneName string
@@ -381,7 +381,7 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     aksKeyVaultName: aksKeyVaultName
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
     pullAcrResourceIds: [svcAcrResourceId]
-    deploymentMsiId: aroDevopsMsiId
+    aroDevopsMsiId: globalMsiId
     enableSwiftV2: false
   }
 }
@@ -450,7 +450,7 @@ module maestroServer '../modules/maestro/maestro-server.bicep' = {
     mqttClientName: maestroServerMqttClientName
     certKeyVaultName: serviceKeyVaultName
     certKeyVaultResourceGroup: serviceKeyVaultResourceGroup
-    keyVaultOfficerManagedIdentityName: aroDevopsMsiId
+    keyVaultOfficerManagedIdentityName: globalMsiId
     maestroCertificateDomain: effectiveMaestroCertDomain
     maestroCertificateIssuer: maestroCertIssuer
     deployPostgres: deployMaestroPostgres
@@ -465,7 +465,7 @@ module maestroServer '../modules/maestro/maestro-server.bicep' = {
     privateEndpointVnetId: svcCluster.outputs.aksVnetId
     maestroDatabaseName: maestroPostgresDatabaseName
     postgresServerPrivate: maestroPostgresPrivate
-    postgresAdministrationManagedIdentityId: aroDevopsMsiId
+    postgresAdministrationManagedIdentityId: globalMsiId
     maestroServerManagedIdentityPrincipalId: filter(
       svcCluster.outputs.userAssignedIdentities,
       id => id.uamiName == maestroMIName
@@ -531,7 +531,7 @@ module cs '../modules/cluster-service.bicep' = {
     regionalCXDNSZoneName: regionalCXDNSZoneName
     regionalResourceGroup: regionalResourceGroup
     ocpAcrResourceId: ocpAcrResourceId
-    postgresAdministrationManagedIdentityId: aroDevopsMsiId
+    postgresAdministrationManagedIdentityId: globalMsiId
   }
   dependsOn: [
     maestroServer
@@ -549,7 +549,7 @@ module oidc '../modules/oidc/main.bicep' = {
     skuName: determineZoneRedundancy(locationAvailabilityZoneList, oidcZoneRedundantMode)
       ? 'Standard_ZRS'
       : 'Standard_LRS'
-    msiId: aroDevopsMsiId
+    msiId: globalMsiId
     deploymentScriptLocation: location
   }
   dependsOn: [
@@ -593,7 +593,7 @@ module frontendIngressCert '../modules/keyvault/key-vault-cert.bicep' = {
     keyVaultName: serviceKeyVaultName
     subjectName: 'CN=${frontendDnsFQDN}'
     certName: frontendIngressCertName
-    keyVaultManagedIdentityId: aroDevopsMsiId
+    keyVaultManagedIdentityId: globalMsiId
     dnsNames: [
       frontendDnsFQDN
     ]

--- a/dev-infrastructure/templates/svc-infra.bicep
+++ b/dev-infrastructure/templates/svc-infra.bicep
@@ -17,7 +17,7 @@ param serviceKeyVaultPrivate bool = true
 param kvCertOfficerPrincipalId string
 
 @description('MSI that will be used during pipeline runs')
-param aroDevopsMsiId string
+param globalMsiId string
 
 @description('Set to true to prevent resources from being pruned after 48 hours')
 param persist bool = false
@@ -46,9 +46,9 @@ var readerRoleId = subscriptionResourceId(
 // service deployments running as the aroDevopsMsi need to lookup metadata about all kinds
 // of resources, e.g. AKS metadata, database metadata, MI metadata, etc.
 resource aroDevopsMSIReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, aroDevopsMsiId, readerRoleId)
+  name: guid(resourceGroup().id, globalMsiId, readerRoleId)
   properties: {
-    principalId: reference(aroDevopsMsiId, '2023-01-31').principalId
+    principalId: reference(globalMsiId, '2023-01-31').principalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: readerRoleId
   }
@@ -109,7 +109,7 @@ module serviceKeyVaultDevopsSecretsOfficer '../modules/keyvault/keyvault-secret-
   params: {
     keyVaultName: serviceKeyVaultName
     roleName: 'Key Vault Secrets Officer'
-    managedIdentityPrincipalId: reference(aroDevopsMsiId, '2023-01-31').principalId
+    managedIdentityPrincipalId: reference(globalMsiId, '2023-01-31').principalId
   }
   dependsOn: [
     serviceKeyVault

--- a/docs/pipeline-concept.md
+++ b/docs/pipeline-concept.md
@@ -144,7 +144,7 @@ All steps share a common execution context:
 
 #### Azure session
 
-When executing step, an Azure session is provided for the defined subscription (`resourceGroups.subscription`) and resourcegroup (`resourceGroups.name`), allowing authenticated Azure operations. The identity used for this session is provided in the [configuration](configuration.md) as `aroDevopsMsiId`.
+When executing step, an Azure session is provided for the defined subscription (`resourceGroups.subscription`) and resourcegroup (`resourceGroups.name`), allowing authenticated Azure operations. The identity used for this session is provided in the [configuration](configuration.md) as `global.globalMSIName` hosted in the `global.subscription` subscription. and `global.rg` Azure resourcegroup.
 
 > [!IMPORTANT]
 > Please note that this identity does not have access to all Azure resources in our subscriptions and resourcegroups by default. The necessary permissions need to be granted explicitly. You can observe this in various Bicep templates, where this identity is granted specific permissions, e.g. on Key Vaults or storage accounts.


### PR DESCRIPTION
What
the ID of the global MSI used for deployment scripts and helm deployments is statically defined in the configuration right now. since this identity is also created by our bicep templates (global-infra.bicep) based on the configuration und global, this is an annoying two-pass setup in an environment:

run global pipeline
update config again with the ID from the freshly created global MSI
to prevent this, we will not store the ID in the config anymore but use output chaining for the lookup instead.

@whober0521 this is a draft and i'm not entirely sure if this is even feasible to be used for shell extension in its current form.

Why
Special notes for your reviewer