### PR TITLE
Add Nightly Infra Automation Scripts

### DIFF
--- a/tooling/azure-automation/nightly-infra/create-nightly-infra.ps1
+++ b/tooling/azure-automation/nightly-infra/create-nightly-infra.ps1
@@ -1,0 +1,67 @@
+param (
+    [Parameter(Mandatory=$true)]
+    [Hashtable] $subscriptions = @{
+        "svc" = "0ef1ad54-9296-44cd-9600-5dc8e9a74034"
+        "mgnt" = "e8c5a115-842d-4d7e-98ad-cfb2c50b209e"
+        "global" = "974ebd46-8ad3-41e3-afef-7ef25fd5c371"
+    },
+    [Parameter(Mandatory=$true)]
+    [string] $ManagedIdentityClientId,
+
+    [Parameter(Mandatory=$true)]
+    [string] $ContainerImage,
+
+    [Parameter(Mandatory=$true)]
+    [string] $EnvName
+)
+
+$resourceGroup = "hcp-dev-automation-account"
+$location = "eastus"
+
+Write-Output "[INFO] Logging in with Managed Identity..."
+az login --identity --username $ManagedIdentityClientId | Out-Null
+
+
+function Invoke-ContainerJob {
+    param (
+        [string] $subscriptionId,
+        [string] $envType,          # svc, mgnt, global
+        [string] $command           # deploy or delete
+    )
+
+    $jobName = "${command}-${envType}-${EnvName}"
+    $resourceGroupName = "rg-${envType}-${EnvName}"
+
+
+    Write-Output "[INFO] Switching to subscription $subscriptionId"
+    az account set --subscription $subscriptionId
+
+    Write-Output "[INFO] Launching $command container job: $jobName"
+
+    az container create `
+        --resource-group $resourceGroup `
+        --name $jobName `
+        --image $ContainerImage `
+        --location $location `
+        --restart-policy Never `
+        --environment-variables `
+            TARGET_SUBSCRIPTION_ID=$subscriptionId `
+            ENV_NAME=$envType `
+            RESOURCE_GROUP=$resourceGroupName `
+        --command-line "/nightly-infra/$command.sh $resourceGroupName $envType $subscriptionId"
+}
+
+
+foreach ($envType in $subscriptions.Keys) {
+    $subId = $subscriptions[$envType]
+    Invoke-ContainerJob -subscriptionId $subId -envType $envType -command "delete"
+}
+
+Start-Sleep -Seconds 60
+
+foreach ($envType in $subscriptions.Keys) {
+    $subId = $subscriptions[$envType]
+    Invoke-ContainerJob -subscriptionId $subId -envType $envType -command "deploy"
+}
+
+Write-Output "[SUCCESS] All jobs triggered across svc/mgnt/global subscriptions."

--- a/tooling/azure-automation/nightly-infra/delete.sh
+++ b/tooling/azure-automation/nightly-infra/delete.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -xe
+echo "[INFO] Starting delete.sh..."
+
+if [ "$#" -lt 2 ]; then
+  echo "[ERROR] Usage: $0 <RESOURCE_GROUP> <TARGET_SUBSCRIPTION_ID>"
+  exit 1
+fi
+
+RESOURCE_GROUP=$1
+TARGET_SUBSCRIPTION_ID=$2
+
+echo "[INFO] Logging in with Managed Identity..."
+az login --identity || { echo "[ERROR] Login failed"; exit 1; }
+
+echo "[INFO] Switching to subscription: $TARGET_SUBSCRIPTION_ID"
+az account set --subscription "$TARGET_SUBSCRIPTION_ID"
+
+RESOURCE_GROUP="rg-${ENV_NAME}"
+
+if az group show --name "$RESOURCE_GROUP" &>/dev/null; then
+    echo "[INFO] Deleting resource group: $RESOURCE_GROUP"
+    az group delete --name "$RESOURCE_GROUP" --yes --no-wait
+    echo "[SUCCESS] Deletion triggered."
+else
+    echo "[INFO] Resource group $RESOURCE_GROUP does not exist. Skipping deletion."
+fi

--- a/tooling/azure-automation/nightly-infra/deploy.sh
+++ b/tooling/azure-automation/nightly-infra/deploy.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# bash will report what is happening and stop in case of non zero return code
+set -xe
+echo "[INFO] Starting deploy.sh..."
+
+if [ "$#" -lt 3 ]; then
+  echo "[ERROR] Usage: $0 <RESOURCE_GROUP> <ENV_NAME> <TARGET_SUBSCRIPTION_ID>"
+  exit 1
+fi
+
+RESOURCE_GROUP=$1
+ENV_NAME=$2           # svc | mgnt | global
+TARGET_SUBSCRIPTION_ID=$3
+
+LOCATION="eastus"
+DEPLOYMENT_NAME="deploy-${ENV_NAME}"
+
+case "$ENV_NAME" in
+  "svc")
+    TEMPLATE_FILE="../../../dev-infrastructure/templates/svc-infra.bicep"
+    PARAM_FILE="svc-infra.parameters.json"
+    ;;
+  "mgnt")
+    TEMPLATE_FILE="../../../dev-infrastructure/templates/mgmt-infra.bicep"
+    ;;
+  "global")
+    TEMPLATE_FILE="../../../dev-infrastructure/templates/global-infra.bicep"
+    PARAM_FILE="../../../dev-infrastructure/configurations/global-infra.tmpl.bicepparam"
+    ;;
+  *)
+    echo "[ERROR] Unknown ENV_NAME: $ENV_NAME. Must be one of: svc, mgnt, global"
+    exit 1
+    ;;
+esac
+
+echo "[INFO] Logging in with Managed Identity..."
+az login --identity || { echo "[ERROR] Login failed"; exit 1; }
+
+echo "[INFO] Switching to subscription: $TARGET_SUBSCRIPTION_ID"
+az account set --subscription "$TARGET_SUBSCRIPTION_ID"
+
+echo "[INFO] Creating resource group: $RESOURCE_GROUP in $LOCATION"
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION"
+
+echo "[INFO] Deploying Bicep template..."
+az deployment group create \
+  --name "$DEPLOYMENT_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --template-file "$TEMPLATE_FILE" \
+  --parameters @"$PARAM_FILE" \
+              #  location="$LOCATION" \
+              #  envName="$ENV_NAME"
+
+echo "[SUCCESS] Deployment completed for environment: $ENV_NAME"

--- a/tooling/azure-automation/nightly-infra/svc-infra.parameters.json
+++ b/tooling/azure-automation/nightly-infra/svc-infra.parameters.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "serviceKeyVaultName": {
+      "value": "{{ .serviceKeyVault.name }}"
+    },
+    "serviceKeyVaultResourceGroup": {
+      "value": "{{ .serviceKeyVault.rg }}"
+    },
+    "serviceKeyVaultLocation": {
+      "value": "{{ .serviceKeyVault.region }}"
+    },
+    "serviceKeyVaultSoftDelete": {
+      "value": {{ .serviceKeyVault.softDelete }}
+    },
+    "aroDevopsMsiId": {
+      "value": "{{ .aroDevopsMsiId }}"
+    },
+    "kvCertOfficerPrincipalId": {
+      "value": "{{ .kvCertOfficerPrincipalId }}"
+    },
+    "logAnalyticsWorkspaceId": {
+      "value": "__logAnalyticsWorkspaceId__"
+    }
+  }
+}


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

Introduces a automated workflow for provisioning and tearing down nightly infrastructure across svc, mgnt, and global subscriptions. 

- create-nightly-infra.ps1

  -   Logs in with a user-assigned managed identity, iterates over each subscription, and launches container jobs for cleanup (delete.sh) and deployment (deploy.sh).


- delete.sh

  - To delete the target resource group if it exists.


- deploy.sh

  - Switches on svc | mgnt | global, sets the subscription context, creates the RG, and runs az deployment group create with the corresponding Bicep templates.

- svc-infra.parameters.json

  - converted from the original .bicepparam to get all required Bicep parameters.


[ARO-15624](https://issues.redhat.com/browse/ARO-15624)