### PR TITLE
Deprecate commercial endpoint

### DIFF
--- a/backend/operations_scanner_test.go
+++ b/backend/operations_scanner_test.go
@@ -67,7 +67,7 @@ func TestSetDeleteOperationAsCompleted(t *testing.T) {
 	}
 
 	// Placeholder InternalID for NewOperationDocument
-	internalID, err := ocm.NewInternalID("/api/clusters_mgmt/v1/clusters/placeholder")
+	internalID, err := ocm.NewInternalID("/api/aro_hcp/v1alpha1/clusters/placeholder")
 	require.NoError(t, err)
 
 	resourceID, err := azcorearm.ParseResourceID(api.TestClusterResourceID)
@@ -219,7 +219,7 @@ func TestUpdateOperationStatus(t *testing.T) {
 	}
 
 	// Placeholder InternalID for NewOperationDocument
-	internalID, err := ocm.NewInternalID("/api/clusters_mgmt/v1/clusters/placeholder")
+	internalID, err := ocm.NewInternalID("/api/aro_hcp/v1alpha1/clusters/placeholder")
 	require.NoError(t, err)
 
 	resourceID, err := azcorearm.ParseResourceID(api.TestClusterResourceID)
@@ -321,7 +321,7 @@ func TestUpdateOperationStatus(t *testing.T) {
 func TestConvertClusterStatus(t *testing.T) {
 	// FIXME These tests are all tentative until the new "/api/aro_hcp/v1" OCM
 	//       API is available. What's here now is a best guess at converting
-	//       ClusterStatus from the "/api/clusters_mgmt/v1" API.
+	//       ClusterStatus from the "/api/aro_hcp/v1alpha1" API.
 	//
 	//       Also note, the particular error codes and messages to expect from
 	//       Cluster Service is complete guesswork at the moment so we're only

--- a/cluster-service/arohcp.devenv.md
+++ b/cluster-service/arohcp.devenv.md
@@ -95,7 +95,7 @@ Simple `curl` commands without any RH token work fine:
 
 ```shell
 
-$ curl http://localhost:8000/api/clusters_mgmt/v1/clusters | jq
+$ curl http://localhost:8000/api/aro_hcp/v1alpha1/clusters | jq
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100    61  100    61    0     0    649      0 --:--:-- --:--:-- --:--:--   655
@@ -121,7 +121,7 @@ $ ocm list clusters
 ID                                NAME                                                    API URL                                                     OPENSHIFT_VERSION   PRODUCT ID  HCP      CLOUD_PROVIDER  REGION ID       STATE        
 
 
-$ ocm post /api/clusters_mgmt/v1/clusters  << EOF
+$ ocm post /api/aro_hcp/v1alpha1/clusters  << EOF
 {
     "name": "yourfakecluster",
     "region": {
@@ -144,7 +144,7 @@ $ ocm post /api/clusters_mgmt/v1/clusters  << EOF
 }
 EOF
 
-ocm post /api/clusters_mgmt/v1/clusters << EOF
+ocm post /api/aro_hcp/v1alpha1/clusters << EOF
 {
   "name": "hcp-1",
   "product": {

--- a/cluster-service/cluster-creation.md
+++ b/cluster-service/cluster-creation.md
@@ -8,7 +8,7 @@ This document outlines the process of creating an HCP via the Cluster Service ru
 * If running CS on the AKS cluster, port-forward the CS service to your local machine
 
     ```bash
-    kubectl port-forward svc/clusters-service 8000:8000 -n clusters-service
+    kubectl port-forward svc/clusters-service 8000:8000 -n cluster-service
     ```
 
 * Otherwise start CS on your local machine
@@ -20,7 +20,7 @@ This document outlines the process of creating an HCP via the Cluster Service ru
 * Access your CS deployment locally
 
     ```bash
-    KUBECONFIG=$(make infra.svc.aks.kubeconfigfile) kubectl port-forward svc/clusters-service 8000:8000 -n clusters-service
+    KUBECONFIG=$(make infra.svc.aks.kubeconfigfile) kubectl port-forward svc/clusters-service 8000:8000 -n cluster-service
     ```
 
   Alternative: if you run CS on your local machine, this step is not necessary.
@@ -220,7 +220,7 @@ Replace `resource-group`, `vnet-name`, `nsg-name` and `subnet-name` with any val
     }
     EOF
 
-    cat cluster-test.json | ocm post /api/clusters_mgmt/v1/clusters
+    cat cluster-test.json | ocm post /api/aro_hcp/v1alpha1/clusters
     ```
 
     You should now have a cluster in OCM. You can verify using `ocm list clusters` or `ocm get cluster CLUSTERID`
@@ -249,13 +249,13 @@ cat <<EOF > nodepool-test.json
 }
 EOF
 
-cat nodepool-test.json | ocm post /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/node_pools
+cat nodepool-test.json | ocm post /api/aro_hcp/v1alpha1/clusters/$CLUSTER_ID/node_pools
 ```
 
 You should now have a nodepool for your cluster in Cluster Service. You can verify using:
 
 ```bash
-ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/node_pools/$UID
+ocm get /api/aro_hcp/v1alpha1/clusters/$CLUSTER_ID/node_pools/$UID
 ```
 
 ### Cleaning up a Cluster
@@ -263,7 +263,7 @@ ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/node_pools/$UID
 1. Delete the cluster
 
    ```bash
-   ocm delete /api/clusters_mgmt/v1/clusters/$CLUSTER_ID
+   ocm delete /api/aro_hcp/v1alpha1/clusters/$CLUSTER_ID
    ```
 
    > [!NOTE] Deleting it will also delete all of its associated node pools.

--- a/demo/README.md
+++ b/demo/README.md
@@ -4,7 +4,7 @@
 
 * have a `KUBECONFIG` for a SC and MC, e.g. for the [integrated DEV environment](../dev-infrastructure/docs/development-setup.md#access-integrated-dev-environment)
 * port-forward RP running on SC: `kubectl port-forward -n aro-hcp svc/aro-hcp-frontend 8443:8443`
-* (optional but useful) port-forward CS running on SC: `kubectl port-forward -n clusters-service svc/clusters-service 8001:8000`
+* (optional but useful) port-forward CS running on SC: `kubectl port-forward -n cluster-service svc/clusters-service 8001:8000`
 * (optional but useful) port-forward Maestro running on SC: `kubectl port-forward -n maestro svc/maestro 8002:8000`
 
 ## Register the subscription with the RP
@@ -90,7 +90,7 @@ kubectl logs deployment/clusters-service -c service -f
 ### Check cluster state in CS
 
 ```bash
-curl localhost:8001/api/clusters_mgmt/v1/clusters | jq
+curl localhost:8001/api/aro_hcp/v1alpha1/clusters | jq
 ```
 
 ### Check Maestro logs
@@ -114,7 +114,7 @@ curl localhost:8002/api/maestro/v1/resource-bundles | jq
 ### Check for manifestwork on MC
 
 ```bash
-CS_CLUSTER_ID=$(curl localhost:8001/api/clusters_mgmt/v1/clusters | jq .items[0].id -r)
+CS_CLUSTER_ID=$(curl localhost:8001/api/aro_hcp/v1alpha1/clusters | jq .items[0].id -r)
 kubectl get manifestwork -n local-cluster | grep ^${CS_CLUSTER_ID}
 ```
 

--- a/docs/ops/hcp-cluster-creation-flow.md
+++ b/docs/ops/hcp-cluster-creation-flow.md
@@ -136,7 +136,7 @@ To query the state of an HCP on the Clusters Service, you can use the following 
 export HCP_SUBSCRIPTION_ID=$(echo "$RESOURCE_ID" | cut -d'/' -f3)
 export HCP_RESOURCE_GROUP_NAME=$(echo "$RESOURCE_ID" | cut -d'/' -f5)
 
-curl -sG http://localhost:8001/api/clusters_mgmt/v1/clusters --data-urlencode "search=azure.subscription_id='$HCP_SUBSCRIPTION_ID' and azure.resource_group_name='$HCP_RESOURCE_GROUP_NAME'" | jq
+curl -sG http://localhost:8001/api/aro_hcp/v1alpha1/clusters --data-urlencode "search=azure.subscription_id='$HCP_SUBSCRIPTION_ID' and azure.resource_group_name='$HCP_RESOURCE_GROUP_NAME'" | jq
 ```
 
 >[!NOTE]

--- a/docs/personal-dev.md
+++ b/docs/personal-dev.md
@@ -56,10 +56,10 @@ The process described in the previous section takes a lot of time. In case you w
 
 | Command           | Description                                                                                                     |
 | :---------------- | :-------------------------------------------------------------------------------------------------------------- |
-| make infra.all    | Deploiys or updates a full environment with regional, service and management infrastructure resources           |
-| make infra.region | Deploiys or updates the regional resources like eventgrid, DNS zones etc                                        |
-| make infra.svc    | Deploiys or updates the service cluster including the supporting infrastructure for the services (postgres, KV) |
-| make infra.mgmt   | Deploiys or updates the management cluster including the supporting infrastructure for the services (KVs)       |
+| make infra.all    | Deploys or updates a full environment with regional, service and management infrastructure resources           |
+| make infra.region | Deploys or updates the regional resources like eventgrid, DNS zones etc                                        |
+| make infra.svc    | Deploys or updates the service cluster including the supporting infrastructure for the services (postgres, KV) |
+| make infra.mgmt   | Deploys or updates the management cluster including the supporting infrastructure for the services (KVs)       |
 
 ### Services Commands
 

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -41,7 +41,7 @@ type HCPOpenShiftClusterNodePoolProperties struct {
 // NodePoolVersionProfile represents the worker node pool version.
 type NodePoolVersionProfile struct {
 	ID                string   `json:"id,omitempty"                visibility:"read create update" validate:"required_unless=ChannelGroup stable,omitempty,openshift_version"`
-	ChannelGroup      string   `json:"channelGroup,omitempty"      visibility:"read create update"`
+	ChannelGroup      string   `json:"channelGroup,omitempty"      visibility:"read create"`
 	AvailableUpgrades []string `json:"availableUpgrades,omitempty" visibility:"read"`
 }
 

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -41,7 +41,7 @@ type HCPOpenShiftClusterNodePoolProperties struct {
 // NodePoolVersionProfile represents the worker node pool version.
 type NodePoolVersionProfile struct {
 	ID                string   `json:"id,omitempty"                visibility:"read create update" validate:"required_unless=ChannelGroup stable,omitempty,openshift_version"`
-	ChannelGroup      string   `json:"channelGroup,omitempty"      visibility:"read create"`
+	ChannelGroup      string   `json:"channelGroup,omitempty"      visibility:"read create update"`
 	AvailableUpgrades []string `json:"availableUpgrades,omitempty" visibility:"read"`
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-17720

### What

This commit changes the reference to clusters_mgmt to aro_hcp endpoints to manage ARO-HCP clusters. 

### Why

This is part of deprecating the use of the commercial endpoint to handler ARO-HCP cluster related resources. 

### Notes
I have spotted some additional errors in documentation:

-  Minor spelling issue
- references to a namespace that doesn't exist

