### PR TITLE
introduce a cloud named dev to the configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GOTAGS?='containers_image_openpgp'
 LINT_GOTAGS?='${GOTAGS},E2Etests'
 TOOLS_BIN_DIR := tooling/bin
 DEPLOY_ENV ?= pers
+CLOUD ?= dev
 
 .DEFAULT_GOAL := all
 
@@ -177,21 +178,21 @@ services_svc_pipelines = istio acrpull backend frontend cluster-service maestro.
 services_mgmt_pipelines = hypershiftoperator maestro.agent acm
 %.deploy_pipeline:
 	$(eval export dirname=$(subst .,/,$(basename $@)))
-	./templatize.sh $(DEPLOY_ENV) -p ./$(dirname)/pipeline.yaml -P run -c public
+	./templatize.sh $(DEPLOY_ENV) -p ./$(dirname)/pipeline.yaml -P run -c $(CLOUD)
 
 %.dry_run:
 	$(eval export dirname=$(subst .,/,$(basename $@)))
-	./templatize.sh $(DEPLOY_ENV) -p ./$(dirname)/pipeline.yaml -P run -c public -d
+	./templatize.sh $(DEPLOY_ENV) -p ./$(dirname)/pipeline.yaml -P run -c $(CLOUD) -d
 
 svc.deployall: $(addsuffix .deploy_pipeline, $(services_svc_pipelines)) $(addsuffix .deploy, $(services_svc))
 mgmt.deployall: $(addsuffix .deploy, $(services_mgmt)) $(addsuffix .deploy_pipeline, $(services_mgmt_pipelines))
 deployall: svc.deployall mgmt.deployall
 
 acrpull.mgmt.deploy:
-	./templatize.sh $(DEPLOY_ENV) -p ./acrpull/pipeline.yaml -s deploy-mgmt -P run -c public
+	./templatize.sh $(DEPLOY_ENV) -p ./acrpull/pipeline.yaml -s deploy-mgmt -P run -c $(CLOUD)
 
 acrpull.mgmt.dry_run:
-	./templatize.sh $(DEPLOY_ENV) -p ./acrpull/pipeline.yaml -s deploy-mgmt -P run -c public -d
+	./templatize.sh $(DEPLOY_ENV) -p ./acrpull/pipeline.yaml -s deploy-mgmt -P run -c $(CLOUD) -d
 
 listall:
 	@echo svc: ${services_svc}

--- a/config/Makefile
+++ b/config/Makefile
@@ -7,18 +7,18 @@
 REGION=southwestus
 
 materialize:
-	@echo "Materializing public cloud int env of config/config.yaml"
+	@echo "Materializing dev cloud int env of config/config.yaml"
 	@REGION=$(REGION) ../templatize.sh dev > public-cloud-dev.json
-	@echo "Materializing public cloud cspr env of config/config.yaml"
+	@echo "Materializing dev cloud cspr env of config/config.yaml"
 	@REGION=$(REGION) ../templatize.sh cspr > public-cloud-cspr.json
-	@echo "Materializing ntly env of config/config.yaml"
+	@echo "Materializing dev cloud ntly env of config/config.yaml"
 	@REGION=$(REGION) ../templatize.sh ntly > public-cloud-ntly.json
-	@echo "Materializing public cloud personal dev env of config/config.yaml"
+	@echo "Materializing dev cloud personal dev env of config/config.yaml"
 	@USER=tst REGION=$(REGION) ../templatize.sh pers > public-cloud-pers.json
 	@echo "Materializing public cloud int env of config/config.msft.yaml"
-	@CONFIG_FILE=../config/config.msft.yaml REGION=$(REGION) ../templatize.sh int > public-cloud-msft-int.json
+	@CONFIG_FILE=../config/config.msft.yaml REGION=$(REGION) ../templatize.sh int -c public > public-cloud-msft-int.json
 	@echo "Materializing public cloud stg env of config/config.msft.yaml"
-	@CONFIG_FILE=../config/config.msft.yaml REGION=$(REGION) ../templatize.sh stg > public-cloud-msft-stg.json
+	@CONFIG_FILE=../config/config.msft.yaml REGION=$(REGION) ../templatize.sh stg -c public > public-cloud-msft-stg.json
 .PHONY: materialize
 
 detect-change: materialize

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -263,9 +263,8 @@ defaults:
     softDelete: true
     private: true
 clouds:
-  public:
+  dev:
     # this configuration serves as a template for for all RH DEV subscription deployments
-    # the following vars need approprivate overrides:
     defaults:
       # DNS
       dns:

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -1,5 +1,6 @@
 SHELL = /bin/bash
 DEPLOY_ENV ?= pers
+CLOUD ?= dev
 PRINCIPAL_ID ?= $(shell az ad signed-in-user show -o json | jq -r '.id')
 $(shell ./create-config.sh $(DEPLOY_ENV))
 include config.mk
@@ -84,11 +85,11 @@ create-mock-identities:
 #
 
 global:
-	../templatize.sh $(DEPLOY_ENV) -p global-pipeline.yaml -P run -c public
+	../templatize.sh $(DEPLOY_ENV) -p global-pipeline.yaml -P run -c $(CLOUD)
 .PHONY: global
 
 global.what-if:
-	../templatize.sh $(DEPLOY_ENV) -p global-pipeline.yaml -P run -c public -d
+	../templatize.sh $(DEPLOY_ENV) -p global-pipeline.yaml -P run -c $(CLOUD) -d
 .PHONY: global.what-if
 
 #
@@ -96,7 +97,7 @@ global.what-if:
 #
 
 region:
-	../templatize.sh $(DEPLOY_ENV) -p region-pipeline.yaml -P run -c public
+	../templatize.sh $(DEPLOY_ENV) -p region-pipeline.yaml -P run -c $(CLOUD)
 .PHONY: region
 
 region.clean:
@@ -107,7 +108,7 @@ region.clean:
 .PHONY: region.clean
 
 region.what-if:
-	../templatize.sh $(DEPLOY_ENV) -p region-pipeline.yaml -P run -c public -d
+	../templatize.sh $(DEPLOY_ENV) -p region-pipeline.yaml -P run -c $(CLOUD) -d
 .PHONY: region.what-if
 
 #
@@ -115,7 +116,7 @@ region.what-if:
 #
 
 svc:
-	../templatize.sh $(DEPLOY_ENV) -p svc-pipeline.yaml -P run -c public
+	../templatize.sh $(DEPLOY_ENV) -p svc-pipeline.yaml -P run -c $(CLOUD)
 .PHONY: svc
 
 svc.cs-pr-check-msi:
@@ -164,7 +165,7 @@ svc.init: region svc svc.aks.admin-access svc.aks.kubeconfig svc.dev.permissions
 .PHONY: svc.init
 
 svc.what-if:
-	../templatize.sh $(DEPLOY_ENV) -p svc-pipeline.yaml -P run -c public -d
+	../templatize.sh $(DEPLOY_ENV) -p svc-pipeline.yaml -P run -c $(CLOUD) -d
 .PHONY: svc.what-if
 
 svc.dev-role-assignments:
@@ -188,7 +189,7 @@ svc.clean:
 #
 
 mgmt:
-	../templatize.sh $(DEPLOY_ENV) -p mgmt-pipeline.yaml -P run -c public
+	../templatize.sh $(DEPLOY_ENV) -p mgmt-pipeline.yaml -P run -c $(CLOUD)
 .PHONY: mgmt
 
 mgmt.aks.admin-access:
@@ -208,7 +209,7 @@ mgmt.init: region mgmt mgmt.aks.admin-access mgmt.aks.kubeconfig mgmt.dev.permis
 .PHONY: mgmt.init
 
 mgmt.what-if:
-	../templatize.sh $(DEPLOY_ENV) -p mgmt-pipeline.yaml -P run -c public -d
+	../templatize.sh $(DEPLOY_ENV) -p mgmt-pipeline.yaml -P run -c $(CLOUD) -d
 .PHONY: mgmt.what-if
 
 mgmt.clean:
@@ -230,7 +231,7 @@ mgmt.dev.permissions: mgmt.kv.permission
 mgmt.solo.init: region mgmt.solo mgmt.aks.admin-access mgmt.aks.kubeconfig mgmt.dev.permissions
 
 mgmt.solo:
-	../templatize.sh $(DEPLOY_ENV) -p mgmt-solo-pipeline.yaml -P run -c public
+	../templatize.sh $(DEPLOY_ENV) -p mgmt-solo-pipeline.yaml -P run -c $(CLOUD)
 .PHONY: mgmt.solo
 
 # ACR DEV customizations

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ Configuration properties are embedded into a layered structure within the config
 ### Layers
 
 - **Default**: This is the base layer of the configuration. It should contain options that apply to most clouds, environments, and regions.
-- **Cloud**: This layer holds overrides relevant to a specific Azure cloud, such as `public` or `fairfax`.
+- **Cloud**: This layer holds overrides relevant to a specific Azure cloud, such as `public` or `fairfax`. There is a dedicated cloud named `dev` that can be used to dev purposes in the public cloud. The main purpose of `dev` is to keep `public` cloud settings clean and free of development-related overrides.
 - **Environments**: This layer provides overrides for a specific deployment environment within a cloud. Examples include `dev`, `pers`, `integration`, `stage`, and `production`.
 - **Region**: This layer holds overrides for a specific region within a deployment environment, allowing for fine-tuned configuration adjustments.
 

--- a/docs/pipeline-concept.md
+++ b/docs/pipeline-concept.md
@@ -195,16 +195,16 @@ In addition, some shared ARO HCP instances are continuously reconciled on each c
 
 The custom pipeline runner can be found in [tooling/templatize](tooling/templatize).
 
-To manually run a pipeline you can use the `templatize.sh` script, e.g. to deploy `my-pipeline.yaml` with the `pers` environment architetype in the `public` cloud, run
+To manually run a pipeline you can use the `templatize.sh` script, e.g. to deploy `my-pipeline.yaml` with the `pers` environment architetype in the `dev` cloud (which is basically `public` cloud - see [configuration documentation](configuration.md)), run
 
 ```sh
-./templatize.sh pers -p my-pipeline.yaml -P run -c public
+./templatize.sh pers -p my-pipeline.yaml -P run -c dev
 ```
 
 The pipeline runner supports a dry-run mode that allows you to simulate the execution of a pipeline without actually deploying any resources. This is useful for verifying the correctness of the pipeline file and the expected behavior of the steps. Add the `-d` option to the `templatize.sh` command to enable dry-run mode:
 
 ```sh
-./templatize.sh pers -p my-pipeline.yaml -P run -c public -d
+./templatize.sh pers -p my-pipeline.yaml -P run -c dev -d
 ```
 
 > [!IMPORTANT]

--- a/templatize.sh
+++ b/templatize.sh
@@ -3,7 +3,7 @@
 PROJECT_ROOT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 
 # Default values
-CLOUD="${CLOUD:-public}"
+CLOUD="${CLOUD:-dev}"
 REGION="${REGION:-westus3}"
 CXSTAMP="${CXSTAMP:-1}"
 EXTRA_ARGS=""
@@ -21,7 +21,7 @@ usage() {
     echo "  -d          Dry run"
     echo "  -i          Set the input file same as second arg"
     echo "  -o          Set the output file same as third arg"
-    echo "  -c          Set the cloud (default: public)"
+    echo "  -c          Set the cloud (default: dev)"
     echo "  -r          Set the region (default: westus3)"
     echo "  -x          Set the cxstamp (default: 1)"
     echo "  -e          Extra args for config interpolation"

--- a/tooling/templatize/cmd/options.go
+++ b/tooling/templatize/cmd/options.go
@@ -29,7 +29,7 @@ func DefaultOptions() *RawOptions {
 
 func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.ConfigFile, "config-file", opts.ConfigFile, "config file path")
-	cmd.Flags().StringVar(&opts.Cloud, "cloud", opts.Cloud, "the cloud (public, fairfax)")
+	cmd.Flags().StringVar(&opts.Cloud, "cloud", opts.Cloud, "the cloud (public, fairfax, dev)")
 	cmd.Flags().StringVar(&opts.DeployEnv, "deploy-env", opts.DeployEnv, "the deploy environment")
 	return nil
 }
@@ -42,7 +42,7 @@ type RawOptions struct {
 }
 
 func (o *RawOptions) Validate() (*ValidatedOptions, error) {
-	validClouds := sets.NewString("public", "fairfax")
+	validClouds := sets.NewString("public", "fairfax", "dev")
 	if !validClouds.Has(o.Cloud) {
 		return nil, fmt.Errorf("invalid cloud %s, must be one of %v", o.Cloud, validClouds.List())
 	}


### PR DESCRIPTION
### What

right now, both DEV and MSFT configurations target the public cloud when defining cloud specific settings. since we want to harmonize a commong core of both configurations while keeping certain specifics for each set of envs cloud specific, we will introduce a cloud named `dev`, which holds all defaults for all RH DEV related environments.

this is another step towards harmonizing configuration between DEV and MSFT envs

https://issues.redhat.com/browse/ARO-17629

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
