### PR TITLE
fix prometheus chart values

### DIFF
--- a/observability/prometheus/values.yaml
+++ b/observability/prometheus/values.yaml
@@ -129,6 +129,9 @@ prometheus:
   ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#prometheusspec
   ##
   prometheusSpec:
+    ## The time to wait for Prometheus to start up before considering it failed.
+    ##
+    maximumStartupDurationSeconds: 360
     ## Image of Prometheus.
     ##
     image:


### PR DESCRIPTION

### What

the `maximumStartupDurationSeconds` parameter requires a value >= 60

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
