### PR TITLE
fix: creation of demo cluster

### DIFF
--- a/demo/03-create-cluster.sh
+++ b/demo/03-create-cluster.sh
@@ -164,7 +164,6 @@ main() {
     "file-csi-driver"
     "image-registry"
     "cloud-network-config"
-    "kms"
   )
 
   # data plane operator names required for OCP 4.18.


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Seems we no longer can use the openshift kms?
```json
{
    "error": {
        "code": "InvalidRequestContent",
        "message": "Invalid control plane managed identities detected. Please remove these identities: Unsupported managed identities for 4.18.1 openshift version: [kms]."
    }
}
```

### Why

Removed KMS CP to provision a dev cluster cluster creation.

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

![image](https://github.com/user-attachments/assets/1a6c6d15-23c7-4bed-9352-3cb56eb9d1ca)

---

cc @geoberle 
