### PR TITLE
Draft PR for backplane ACM policies-ARO-17573

### DIFF
--- a/acm/deploy/helm/policies/templates/backplane-sre-role.placement.yaml
+++ b/acm/deploy/helm/policies/templates/backplane-sre-role.placement.yaml
@@ -1,0 +1,9 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: backplane-sre-placement
+  namespace: open-cluster-management
+spec:
+  clusterSelector:
+    matchLabels:
+      cluster-role: management

--- a/acm/deploy/helm/policies/templates/backplane-sre-role.placementbinding.yaml
+++ b/acm/deploy/helm/policies/templates/backplane-sre-role.placementbinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: backplane-sre-placement-binding
+  namespace: open-cluster-management
+placementRef:
+  name: backplane-sre-placement
+  kind: Placement
+  apiGroup: cluster.open-cluster-management.io
+subjects:
+  - name: backplane-sre-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io

--- a/acm/deploy/helm/policies/templates/backplane-sre-role.policy.yaml
+++ b/acm/deploy/helm/policies/templates/backplane-sre-role.policy.yaml
@@ -1,0 +1,61 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: backplane-sre-policy
+  namespace: open-cluster-management
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: backplane-sre-rbac
+      spec:
+        remediationAction: enforce
+        pruneObjectBehavior: DeleteIfCreated
+        evaluationInterval:
+          compliant: 1m
+          noncompliant: 30s
+        object-templates:
+        - complianceType: MustHave
+          objectDefinition:
+            kind: ClusterRole
+            apiVersion: rbac.authorization.k8s.io/v1
+            metadata:
+              name: backplane-sre-readonly
+            rules:
+              - apiGroups: [""]
+                resources: ["pods", "services", "endpoints", "configmaps", "secrets", "namespaces", "nodes"]
+                verbs: ["get", "list", "watch"]
+              - apiGroups: ["apps"]
+                resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+                verbs: ["get", "list", "watch"]
+              - apiGroups: ["batch"]
+                resources: ["jobs", "cronjobs"]
+                verbs: ["get", "list", "watch"]
+              - apiGroups: ["policy", "rbac.authorization.k8s.io"]
+                resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
+                verbs: ["get", "list", "watch"]
+              - apiGroups: ["*"]
+                resources: ["events", "persistentvolumes", "persistentvolumeclaims", "networkpolicies", "ingresses"]
+                verbs: ["get", "list", "watch"]
+        - complianceType: MustHave
+          objectDefinition:
+            kind: ClusterRoleBinding
+            apiVersion: rbac.authorization.k8s.io/v1
+            metadata:
+              name: backplane-sre-readonly-binding
+            roleRef:
+              kind: ClusterRole
+              name: backplane-sre-readonly
+              apiGroup: rbac.authorization.k8s.io
+            subjects:
+              - kind: Group
+                name: aro:platform:backplane-sre
+                apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
<!-- Link to Jira issue -->
[ARO-17573](https://issues.redhat.com/browse/ARO-17573)
- This is a draft PR to determine if ACM policy are needed for back-plane SRE access. The Idea is to give read-only access to all namespaces in the management clusters.

Please don-not merge 

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
