### PR TITLE
chore: remove kms managed identity creation from cluster creation in demo mode scripts

### DIFF
--- a/cluster-service/cluster-creation.md
+++ b/cluster-service/cluster-creation.md
@@ -89,7 +89,6 @@ Replace `resource-group`, `vnet-name`, `nsg-name` and `subnet-name` with any val
     az identity create -n ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX} -g <resource-group>
     az identity create -n ${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX} -g <resource-group>
     az identity create -n ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX} -g <resource-group>
-    az identity create -n ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX} -g <resource-group>
 
     # And then we create variables containing their Azure resource IDs and export them to be used later
     export CP_CONTROL_PLANE_UAMI=$(az identity show -n ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX} -g <resource-group> | jq -r '.id')
@@ -100,7 +99,6 @@ Replace `resource-group`, `vnet-name`, `nsg-name` and `subnet-name` with any val
     export CP_FILE_CSI_DRIVER_UAMI=$(az identity show -n ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX} -g <resource-group> | jq -r '.id')
     export CP_IMAGE_REGISTRY_UAMI=$(az identity show -n ${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX} -g <resource-group> | jq -r '.id')
     export CP_CNC_UAMI=$(az identity show -n ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX} -g <resource-group> | jq -r '.id')
-    export CP_KMS_UAMI=$(az identity show -n ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX} -g <resource-group> | jq -r '.id')
     ```
 
 * Create the User-Assigned Managed Identities for the Data Plane operators. This assumes OCP 4.18 clusters will be created.
@@ -196,9 +194,6 @@ Replace `resource-group`, `vnet-name`, `nsg-name` and `subnet-name` with any val
               "cloud-network-config": {
                 "resource_id": "$CP_CNC_UAMI"
               },
-              "kms": {
-                "resource_id": "$CP_KMS_UAMI"
-              }
             },
             "data_plane_operators_managed_identities": {
               "disk-csi-driver": {
@@ -278,7 +273,6 @@ ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/node_pools/$UID
    az identity delete --ids "${CP_FILE_CSI_DRIVER_UAMI}"
    az identity delete --ids "${CP_IMAGE_REGISTRY_UAMI}"
    az identity delete --ids "${CP_CNC_UAMI}"
-   az identity delete --ids "${CP_KMS_UAMI}"
    az identity delete --ids "${DP_DISK_CSI_DRIVER_UAMI}"
    az identity delete --ids "${DP_IMAGE_REGISTRY_UAMI}"
    az identity delete --ids "${DP_FILE_CSI_DRIVER_UAMI}"

--- a/demo/03-create-cluster.sh
+++ b/demo/03-create-cluster.sh
@@ -164,7 +164,6 @@ main() {
     "file-csi-driver"
     "image-registry"
     "cloud-network-config"
-    "kms"
   )
 
   # data plane operator names required for OCP 4.18.


### PR DESCRIPTION
Although it is a recognized identity by CS, we are still not supporting it. Additionally, it is not a MI that is required unconditionally so we should not create it and include it unconditionally.
This MR removes the kms managed identity creation from cluster creation in demo mode scripts.