### PR TITLE
fix templatize e2e test after environment rename

### DIFF
--- a/tooling/templatize/internal/end2end/e2e_test.go
+++ b/tooling/templatize/internal/end2end/e2e_test.go
@@ -82,9 +82,9 @@ func TestE2EKubernetes(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	e2eImpl := newE2E(tmpDir)
-	e2eImpl.AddStep(types.NewShellStep("test", "kubectl get namespaces").WithAKSCluster("dev-svc"), 0)
+	e2eImpl.AddStep(types.NewShellStep("test", "kubectl get namespaces").WithAKSCluster("dev-westus3-svc-1"), 0)
 
-	e2eImpl.SetConfig(config.Configuration{"defaults": config.Configuration{"rg": "hcp-underlay-dev-svc"}})
+	e2eImpl.SetConfig(config.Configuration{"defaults": config.Configuration{"rg": "hcp-underlay-dev-westus3-svc"}})
 
 	persistAndRun(t, &e2eImpl)
 }


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

fixes templatize e2e by updating resource group / cluster name to match new names

### Why

Values are hard coded and recent redeploy broke the e2e tests.  Will follow up to make this dynamic.

### Special notes for your reviewer

<!-- optional -->
