### PR TITLE
api: Add PtrOrNil helper function

### DIFF
--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"iter"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -28,6 +29,30 @@ const (
 
 // Ptr returns a pointer to p.
 func Ptr[T any](p T) *T {
+	return &p
+}
+
+// Copied from Go's src/encoding/json/encode.go
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64,
+		reflect.Interface, reflect.Pointer:
+		return v.IsZero()
+	}
+	return false
+}
+
+// PtrOrNil returns a pointer to p or nil if p is an empty value as
+// would be determined by the "omitempty" option in json.Marshal.
+func PtrOrNil[T any](p T) *T {
+	if isEmptyValue(reflect.ValueOf(p)) {
+		return nil
+	}
 	return &p
 }
 

--- a/internal/api/v20240610preview/admincredential_methods.go
+++ b/internal/api/v20240610preview/admincredential_methods.go
@@ -22,8 +22,8 @@ import (
 
 func newHCPOpenShiftClusterAdminCredential(from *api.HCPOpenShiftClusterAdminCredential) *generated.HcpOpenShiftClusterAdminCredential {
 	return &generated.HcpOpenShiftClusterAdminCredential{
-		ExpirationTimestamp: api.Ptr(from.ExpirationTimestamp),
-		Kubeconfig:          api.Ptr(from.Kubeconfig),
+		ExpirationTimestamp: api.PtrOrNil(from.ExpirationTimestamp),
+		Kubeconfig:          api.PtrOrNil(from.Kubeconfig),
 	}
 }
 

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -28,50 +28,50 @@ type HcpOpenShiftCluster struct {
 
 func newVersionProfile(from *api.VersionProfile) *generated.VersionProfile {
 	return &generated.VersionProfile{
-		ID:                api.Ptr(from.ID),
-		ChannelGroup:      api.Ptr(from.ChannelGroup),
+		ID:                api.PtrOrNil(from.ID),
+		ChannelGroup:      api.PtrOrNil(from.ChannelGroup),
 		AvailableUpgrades: api.StringSliceToStringPtrSlice(from.AvailableUpgrades),
 	}
 }
 
 func newDNSProfile(from *api.DNSProfile) *generated.DNSProfile {
 	return &generated.DNSProfile{
-		BaseDomain:       api.Ptr(from.BaseDomain),
-		BaseDomainPrefix: api.Ptr(from.BaseDomainPrefix),
+		BaseDomain:       api.PtrOrNil(from.BaseDomain),
+		BaseDomainPrefix: api.PtrOrNil(from.BaseDomainPrefix),
 	}
 }
 
 func newNetworkProfile(from *api.NetworkProfile) *generated.NetworkProfile {
 	return &generated.NetworkProfile{
-		NetworkType: api.Ptr(generated.NetworkType(from.NetworkType)),
-		PodCidr:     api.Ptr(from.PodCIDR),
-		ServiceCidr: api.Ptr(from.ServiceCIDR),
-		MachineCidr: api.Ptr(from.MachineCIDR),
-		HostPrefix:  api.Ptr(from.HostPrefix),
+		NetworkType: api.PtrOrNil(generated.NetworkType(from.NetworkType)),
+		PodCidr:     api.PtrOrNil(from.PodCIDR),
+		ServiceCidr: api.PtrOrNil(from.ServiceCIDR),
+		MachineCidr: api.PtrOrNil(from.MachineCIDR),
+		HostPrefix:  api.PtrOrNil(from.HostPrefix),
 	}
 }
 
 func newConsoleProfile(from *api.ConsoleProfile) *generated.ConsoleProfile {
 	return &generated.ConsoleProfile{
-		URL: api.Ptr(from.URL),
+		URL: api.PtrOrNil(from.URL),
 	}
 }
 
 func newAPIProfile(from *api.APIProfile) *generated.APIProfile {
 	return &generated.APIProfile{
-		URL:        api.Ptr(from.URL),
-		Visibility: api.Ptr(generated.Visibility(from.Visibility)),
+		URL:        api.PtrOrNil(from.URL),
+		Visibility: api.PtrOrNil(generated.Visibility(from.Visibility)),
 	}
 }
 
 func newPlatformProfile(from *api.PlatformProfile) *generated.PlatformProfile {
 	return &generated.PlatformProfile{
-		ManagedResourceGroup:    api.Ptr(from.ManagedResourceGroup),
-		SubnetID:                api.Ptr(from.SubnetID),
-		OutboundType:            api.Ptr(generated.OutboundType(from.OutboundType)),
-		NetworkSecurityGroupID:  api.Ptr(from.NetworkSecurityGroupID),
+		ManagedResourceGroup:    api.PtrOrNil(from.ManagedResourceGroup),
+		SubnetID:                api.PtrOrNil(from.SubnetID),
+		OutboundType:            api.PtrOrNil(generated.OutboundType(from.OutboundType)),
+		NetworkSecurityGroupID:  api.PtrOrNil(from.NetworkSecurityGroupID),
 		OperatorsAuthentication: newOperatorsAuthenticationProfile(&from.OperatorsAuthentication),
-		IssuerURL:               api.Ptr(from.IssuerURL),
+		IssuerURL:               api.PtrOrNil(from.IssuerURL),
 	}
 }
 
@@ -85,7 +85,7 @@ func newUserAssignedIdentitiesProfile(from *api.UserAssignedIdentitiesProfile) *
 	return &generated.UserAssignedIdentitiesProfile{
 		ControlPlaneOperators:  api.StringMapToStringPtrMap(from.ControlPlaneOperators),
 		DataPlaneOperators:     api.StringMapToStringPtrMap(from.DataPlaneOperators),
-		ServiceManagedIdentity: api.Ptr(from.ServiceManagedIdentity),
+		ServiceManagedIdentity: api.PtrOrNil(from.ServiceManagedIdentity),
 	}
 }
 
@@ -95,7 +95,7 @@ func newClusterCapabilitiesProfile(from *api.ClusterCapabilitiesProfile) *genera
 	}
 
 	for index, item := range from.Disabled {
-		out.Disabled[index] = api.Ptr(generated.OptionalClusterCapability(item))
+		out.Disabled[index] = api.PtrOrNil(generated.OptionalClusterCapability(item))
 	}
 
 	return out
@@ -108,20 +108,20 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 
 	out := &HcpOpenShiftCluster{
 		generated.HcpOpenShiftCluster{
-			ID:       api.Ptr(from.ID),
-			Name:     api.Ptr(from.Name),
-			Type:     api.Ptr(from.Type),
-			Location: api.Ptr(from.Location),
+			ID:       api.PtrOrNil(from.ID),
+			Name:     api.PtrOrNil(from.Name),
+			Type:     api.PtrOrNil(from.Type),
+			Location: api.PtrOrNil(from.Location),
 			Tags:     api.StringMapToStringPtrMap(from.Tags),
 			Identity: &generated.ManagedServiceIdentity{
-				Type:        api.Ptr(generated.ManagedServiceIdentityType(from.Identity.Type)),
-				PrincipalID: api.Ptr(from.Identity.PrincipalID),
-				TenantID:    api.Ptr(from.Identity.TenantID),
+				Type:        api.PtrOrNil(generated.ManagedServiceIdentityType(from.Identity.Type)),
+				PrincipalID: api.PtrOrNil(from.Identity.PrincipalID),
+				TenantID:    api.PtrOrNil(from.Identity.TenantID),
 				//as UserAssignedIdentities is of a different type so using convertUserAssignedIdentities instead of StringMapToStringPtrMap
 				UserAssignedIdentities: convertUserAssignedIdentities(from.Identity.UserAssignedIdentities),
 			},
 			Properties: &generated.HcpOpenShiftClusterProperties{
-				ProvisioningState: api.Ptr(generated.ProvisioningState(from.Properties.ProvisioningState)),
+				ProvisioningState: api.PtrOrNil(generated.ProvisioningState(from.Properties.ProvisioningState)),
 				Version:           newVersionProfile(&from.Properties.Version),
 				DNS:               newDNSProfile(&from.Properties.DNS),
 				Network:           newNetworkProfile(&from.Properties.Network),
@@ -135,11 +135,11 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 
 	if from.SystemData != nil {
 		out.SystemData = &generated.SystemData{
-			CreatedBy:          api.Ptr(from.SystemData.CreatedBy),
-			CreatedByType:      api.Ptr(generated.CreatedByType(from.SystemData.CreatedByType)),
+			CreatedBy:          api.PtrOrNil(from.SystemData.CreatedBy),
+			CreatedByType:      api.PtrOrNil(generated.CreatedByType(from.SystemData.CreatedByType)),
 			CreatedAt:          from.SystemData.CreatedAt,
-			LastModifiedBy:     api.Ptr(from.SystemData.LastModifiedBy),
-			LastModifiedByType: api.Ptr(generated.CreatedByType(from.SystemData.LastModifiedByType)),
+			LastModifiedBy:     api.PtrOrNil(from.SystemData.LastModifiedBy),
+			LastModifiedByType: api.PtrOrNil(generated.CreatedByType(from.SystemData.LastModifiedByType)),
 			LastModifiedAt:     from.SystemData.LastModifiedAt,
 		}
 	}

--- a/internal/api/v20240610preview/nodepools_methods.go
+++ b/internal/api/v20240610preview/nodepools_methods.go
@@ -178,20 +178,20 @@ type NodePoolAutoScaling struct {
 
 func newNodePoolVersionProfile(from *api.NodePoolVersionProfile) *generated.NodePoolVersionProfile {
 	return &generated.NodePoolVersionProfile{
-		ID:                api.Ptr(from.ID),
-		ChannelGroup:      api.Ptr(from.ChannelGroup),
+		ID:                api.PtrOrNil(from.ID),
+		ChannelGroup:      api.PtrOrNil(from.ChannelGroup),
 		AvailableUpgrades: api.StringSliceToStringPtrSlice(from.AvailableUpgrades),
 	}
 }
 
 func newNodePoolPlatformProfile(from *api.NodePoolPlatformProfile) *generated.NodePoolPlatformProfile {
 	return &generated.NodePoolPlatformProfile{
-		VMSize:                 api.Ptr(from.VMSize),
-		AvailabilityZone:       api.Ptr(from.AvailabilityZone),
-		EnableEncryptionAtHost: api.Ptr(from.EnableEncryptionAtHost),
-		DiskSizeGiB:            api.Ptr(from.DiskSizeGiB),
-		DiskStorageAccountType: api.Ptr(generated.DiskStorageAccountType(from.DiskStorageAccountType)),
-		SubnetID:               api.Ptr(from.SubnetID),
+		VMSize:                 api.PtrOrNil(from.VMSize),
+		AvailabilityZone:       api.PtrOrNil(from.AvailabilityZone),
+		EnableEncryptionAtHost: api.PtrOrNil(from.EnableEncryptionAtHost),
+		DiskSizeGiB:            api.PtrOrNil(from.DiskSizeGiB),
+		DiskStorageAccountType: api.PtrOrNil(generated.DiskStorageAccountType(from.DiskStorageAccountType)),
+		SubnetID:               api.PtrOrNil(from.SubnetID),
 	}
 }
 
@@ -200,8 +200,8 @@ func newNodePoolAutoScaling(from *api.NodePoolAutoScaling) *generated.NodePoolAu
 
 	if from != nil {
 		autoScaling = &generated.NodePoolAutoScaling{
-			Max: api.Ptr(from.Max),
-			Min: api.Ptr(from.Min),
+			Max: api.PtrOrNil(from.Max),
+			Min: api.PtrOrNil(from.Min),
 		}
 	}
 
@@ -215,19 +215,19 @@ func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNod
 
 	out := &NodePool{
 		generated.NodePool{
-			ID:       api.Ptr(from.ID),
-			Name:     api.Ptr(from.Name),
-			Type:     api.Ptr(from.Type),
-			Location: api.Ptr(from.Location),
+			ID:       api.PtrOrNil(from.ID),
+			Name:     api.PtrOrNil(from.Name),
+			Type:     api.PtrOrNil(from.Type),
+			Location: api.PtrOrNil(from.Location),
 			Tags:     api.StringMapToStringPtrMap(from.Tags),
 			Properties: &generated.NodePoolProperties{
-				ProvisioningState: api.Ptr(generated.ProvisioningState(from.Properties.ProvisioningState)),
+				ProvisioningState: api.PtrOrNil(generated.ProvisioningState(from.Properties.ProvisioningState)),
 				Platform:          newNodePoolPlatformProfile(&from.Properties.Platform),
 				Version:           newNodePoolVersionProfile(&from.Properties.Version),
-				AutoRepair:        api.Ptr(from.Properties.AutoRepair),
+				AutoRepair:        api.PtrOrNil(from.Properties.AutoRepair),
 				AutoScaling:       newNodePoolAutoScaling(from.Properties.AutoScaling),
 				Labels:            []*generated.Label{},
-				Replicas:          api.Ptr(from.Properties.Replicas),
+				Replicas:          api.PtrOrNil(from.Properties.Replicas),
 				Taints:            []*generated.Taint{},
 			},
 		},
@@ -235,27 +235,27 @@ func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNod
 
 	if from.SystemData != nil {
 		out.SystemData = &generated.SystemData{
-			CreatedBy:          api.Ptr(from.SystemData.CreatedBy),
-			CreatedByType:      api.Ptr(generated.CreatedByType(from.SystemData.CreatedByType)),
+			CreatedBy:          api.PtrOrNil(from.SystemData.CreatedBy),
+			CreatedByType:      api.PtrOrNil(generated.CreatedByType(from.SystemData.CreatedByType)),
 			CreatedAt:          from.SystemData.CreatedAt,
-			LastModifiedBy:     api.Ptr(from.SystemData.LastModifiedBy),
-			LastModifiedByType: api.Ptr(generated.CreatedByType(from.SystemData.LastModifiedByType)),
+			LastModifiedBy:     api.PtrOrNil(from.SystemData.LastModifiedBy),
+			LastModifiedByType: api.PtrOrNil(generated.CreatedByType(from.SystemData.LastModifiedByType)),
 			LastModifiedAt:     from.SystemData.LastModifiedAt,
 		}
 	}
 
 	for k, v := range from.Properties.Labels {
 		out.Properties.Labels = append(out.Properties.Labels, &generated.Label{
-			Key:   api.Ptr(k),
-			Value: api.Ptr(v),
+			Key:   api.PtrOrNil(k),
+			Value: api.PtrOrNil(v),
 		})
 	}
 
 	for _, t := range from.Properties.Taints {
 		out.Properties.Taints = append(out.Properties.Taints, &generated.Taint{
-			Effect: api.Ptr(generated.Effect(t.Effect)),
-			Key:    api.Ptr(t.Key),
-			Value:  api.Ptr(t.Value),
+			Effect: api.PtrOrNil(generated.Effect(t.Effect)),
+			Key:    api.PtrOrNil(t.Key),
+			Value:  api.PtrOrNil(t.Value),
 		})
 	}
 


### PR DESCRIPTION
### What

`PtrOrNil(p)` returns a pointer to `p` or `nil` if `p` is an empty value as would be determined by the `"omitempty"` option in [json.Marshal](https://pkg.go.dev/encoding/json#Marshal).

This function is used when converting a "normalized" API model to a "versioned" API model which consists entirely of pointer fields. If a value in a normalized model is empty, it is omitted from the versioned model as it would be when marshaling to JSON.

### Why

This turns out to be important for correct handling of read-only fields when updating a resource.

`api.ValidateVisibility` is supposed to disregard `nil` input values from a request payload, but we were previously never passing `nil` input values.

When processing a resource update via PUT, the frontend handler:

1. Creates a normalized API model containing only default values.
2. Converts the normalized API model to a versioned API model.
3. Unmarshals the request payload onto the versioned API model.

Step 2 is where the problem occurs. Fields in the normalized model with no default value will have an empty value. Previously we were using `api.Ptr` in the conversion which meant all those empty values would become _pointers_ to empty values in the versioned model. Then `api.ValidateVisibility` would handle those pointers to empty values as though they were explicitly provided in the request payload.

We now use `api.PtrOrNil` during conversion so empty values in the normalized model become `nil` pointers in the versioned model, and `api.ValidateVisiblity` handles them correctly.