### PR TITLE
only run ci-go workflow if changes were made to go-related files

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -3,6 +3,14 @@ on:
   pull_request:
     branches:
     - 'main'
+    paths:
+    - '**/*.go'
+    - '**/go.mod'
+    - '**/go.sum'
+    - '**/go.work'
+    - '**/go.work.sum'
+    - '**/Makefile'
+    - '**/.golangci.{yml,yaml}'
 jobs:
   test:
     permissions:

--- a/.github/workflows/ci-yaml.yml
+++ b/.github/workflows/ci-yaml.yml
@@ -1,0 +1,32 @@
+name: 'ci-yaml'
+on:
+  pull_request:
+    branches:
+    - 'main'
+    paths:
+    - '**/*.{yml,yaml}'
+    - '**/Makefile'
+    - 'yamlfmt.{wrap,unwrap}.sh'
+jobs:
+  format:
+    permissions:
+      contents: 'read'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 1
+    - name: 'Set up Go'
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      with:
+        go-version-file: 'go.work'
+        check-latest: true
+    - name: 'Check YAML formatting'
+      run: |
+        make yamlfmt
+        if [[ ! -z "$(git status --short)" ]]
+        then
+          echo "there are some modified files, rerun 'make yamlfmt' to update them and check the changes in"
+          git status
+          exit 1
+        fi

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ tidy: $(MODULES:/...=.tidy)
 %.tidy:
 	cd $(basename $@) && go mod tidy
 
-all-tidy: tidy fmt yamlfmt licenses
+all-tidy: tidy fmt licenses
 	go work sync
 
 mega-lint:
@@ -68,7 +68,7 @@ mega-lint:
 		-e FILTER_REGEX_EXCLUDE='hypershiftoperator/deploy/crds/|maestro/server/deploy/templates/allow-cluster-service.authorizationpolicy.yaml|acm/deploy/helm/multicluster-engine-config/charts/policy/charts' \
 		-e REPORT_OUTPUT_FOLDER=/tmp/report \
 		-v $${PWD}:/tmp/lint:Z \
-		oxsecurity/megalinter:v8 
+		oxsecurity/megalinter:v8
 .PHONY: mega-lint
 
 #


### PR DESCRIPTION
### What

ci-go workflow should only run when changes were made to files which relate or may relate to go code

### Why

ci-go workflow can take upward of 10-15 minutes to run so we should not run it when not necessary

### Special notes for your reviewer

<!-- optional -->
