### PR TITLE
fix: Update resource group name in PostgreSQL connection script

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -342,7 +342,7 @@ cs-current-user-pg-connect:
 .PHONY: cs-current-user-pg-connect
 
 cs-miwi-pg-connect:
-	@scripts/cs-miwi-pg-connect.sh $(REGIONAL_RESOURCEGROUP) $(CS_PG_NAME) $(CS_MI_NAME) $(CS_NS_NAME) $(CS_SA_NAME)
+	@scripts/cs-miwi-pg-connect.sh $(REGIONAL_RESOURCEGROUP) $(CS_PG_NAME) $(CS_MI_NAME) $(CS_NS_NAME) $(CS_SA_NAME) $(SVC_RESOURCEGROUP)
 .PHONY: cs-miwi-pg-connect
 
 maestro-current-user-pg-connect:

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -350,7 +350,7 @@ maestro-current-user-pg-connect:
 .PHONY: maestro-current-user-pg-connect
 
 maestro-miwi-pg-connect:
-	@scripts/cs-miwi-pg-connect.sh $(REGIONAL_RESOURCEGROUP) $(MAESTRO_PG_NAME) "maestro-server" "maestro" "maestro"
+	@scripts/cs-miwi-pg-connect.sh $(REGIONAL_RESOURCEGROUP) $(MAESTRO_PG_NAME) "maestro-server" "maestro" "maestro" $(SVC_RESOURCEGROUP)
 .PHONY: maestro-miwi-pg-connect
 
 #

--- a/dev-infrastructure/scripts/cs-miwi-pg-connect.sh
+++ b/dev-infrastructure/scripts/cs-miwi-pg-connect.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-RESOURCEGROUP=$1
+PG_RESOURCEGROUP=$1
 DB_SERVER_NAME_PREFIX=$2
 MANAGED_IDENTITY_NAME=$3
 NAMESPACE=$4
 SA_NAME=$5
-SVC_RESOURCEGROUP=$6
+MI_RESOURCEGROUP=$6
 
 # prep creds and configs
-PGHOST=$(az postgres flexible-server list --resource-group ${RESOURCEGROUP} --query "[?starts_with(name, '${DB_SERVER_NAME_PREFIX}')].fullyQualifiedDomainName" -o tsv)
+PGHOST=$(az postgres flexible-server list --resource-group "${PG_RESOURCEGROUP}" --query "[?starts_with(name, '${DB_SERVER_NAME_PREFIX}')].fullyQualifiedDomainName" -o tsv)
 AZURE_TENANT_ID=$(az account show -o json | jq .homeTenantId -r)
-AZURE_CLIENT_ID=$(az identity show -g ${SVC_RESOURCEGROUP} -n ${MANAGED_IDENTITY_NAME} --query clientId -o tsv)
+AZURE_CLIENT_ID=$(az identity show -g ${MI_RESOURCEGROUP} -n ${MANAGED_IDENTITY_NAME} --query clientId -o tsv)
 SA_TOKEN=$(kubectl create token ${SA_NAME} --namespace=${NAMESPACE} --audience api://AzureADTokenExchange)
 
 # az login with managed identity via SA token
-export AZURE_CONFIG_DIR="${HOME}/.azure-profile-cs-${RESOURCEGROUP}"
+export AZURE_CONFIG_DIR="${HOME}/.azure-profile-cs-${PG_RESOURCEGROUP}"
 rm -rf $AZURE_CONFIG_DIR
 az login --federated-token ${SA_TOKEN} --service-principal -u $AZURE_CLIENT_ID -t $AZURE_TENANT_ID > /dev/null 2>&1
 

--- a/dev-infrastructure/scripts/cs-miwi-pg-connect.sh
+++ b/dev-infrastructure/scripts/cs-miwi-pg-connect.sh
@@ -5,11 +5,12 @@ DB_SERVER_NAME_PREFIX=$2
 MANAGED_IDENTITY_NAME=$3
 NAMESPACE=$4
 SA_NAME=$5
+SVC_RESOURCEGROUP=$6
 
 # prep creds and configs
 PGHOST=$(az postgres flexible-server list --resource-group ${RESOURCEGROUP} --query "[?starts_with(name, '${DB_SERVER_NAME_PREFIX}')].fullyQualifiedDomainName" -o tsv)
 AZURE_TENANT_ID=$(az account show -o json | jq .homeTenantId -r)
-AZURE_CLIENT_ID=$(az identity show -g ${RESOURCEGROUP} -n ${MANAGED_IDENTITY_NAME} --query clientId -o tsv)
+AZURE_CLIENT_ID=$(az identity show -g ${SVC_RESOURCEGROUP} -n ${MANAGED_IDENTITY_NAME} --query clientId -o tsv)
 SA_TOKEN=$(kubectl create token ${SA_NAME} --namespace=${NAMESPACE} --audience api://AzureADTokenExchange)
 
 # az login with managed identity via SA token

--- a/tooling/templatize/settings.yaml
+++ b/tooling/templatize/settings.yaml
@@ -1,63 +1,63 @@
 environments:
-  # RH development environments
-  - name: dev
-    description: |
-      Integrated development environment.
-      Bringing it all together.
-      Used for Bicep and Helm PR checks.
-    defaults:
-      region: westus3
-      cloud: dev
-      cxStamp: 1
-      regionStampTemplate: "${REGION_SHORT}"
-  - name: cspr
-    description: |
-      clusters-service PR check environment.
-      Used for testing Cluster Service PRs from Jenkins.
-    defaults:
-      region: westus3
-      cloud: dev
-      cxStamp: 1
-      regionStampTemplate: "${REGION_SHORT}"
-  - name: pers
-    description: |
-      Used for personal development and testing.
-    defaults:
-      region: westus3
-      cloud: dev
-      cxStamp: 1
-      regionStampTemplate: "${REGION_SHORT}${USER:0:4}"
-  - name: perf
-    description: |
-      Used for performance testing.
-      High resource requirements.
-    defaults:
-      region: westus3
-      cloud: dev
-      cxStamp: 1
-      regionStampTemplate: "${REGION_SHORT}p${USER:0:4}"
-  - name: ntly
-    description: |
-      Used for nightly infrastructure rebuilds.
-    defaults:
-      region: uksouth
-      cloud: dev
-      cxStamp: 1
-      regionStampTemplate: "${REGION_SHORT}"
-  # MSFT environments
-  - name: int
-    description: |
-      MSFT integration environment.
-    defaults:
-      region: uksouth
-      cloud: public
-      cxStamp: 1
-      regionStampTemplate: "${REGION_SHORT}"
-  - name: stg
-    description: |
-      MSFT stage environment.
-    defaults:
-      region: uksouth
-      cloud: public
-      cxStamp: 1
-      regionStampTemplate: "${REGION_SHORT}"
+# RH development environments
+- name: dev
+  description: |
+    Integrated development environment.
+    Bringing it all together.
+    Used for Bicep and Helm PR checks.
+  defaults:
+    region: westus3
+    cloud: dev
+    cxStamp: 1
+    regionStampTemplate: "${REGION_SHORT}"
+- name: cspr
+  description: |
+    clusters-service PR check environment.
+    Used for testing Cluster Service PRs from Jenkins.
+  defaults:
+    region: westus3
+    cloud: dev
+    cxStamp: 1
+    regionStampTemplate: "${REGION_SHORT}"
+- name: pers
+  description: |
+    Used for personal development and testing.
+  defaults:
+    region: westus3
+    cloud: dev
+    cxStamp: 1
+    regionStampTemplate: "${REGION_SHORT}${USER:0:4}"
+- name: perf
+  description: |
+    Used for performance testing.
+    High resource requirements.
+  defaults:
+    region: westus3
+    cloud: dev
+    cxStamp: 1
+    regionStampTemplate: "${REGION_SHORT}p${USER:0:4}"
+- name: ntly
+  description: |
+    Used for nightly infrastructure rebuilds.
+  defaults:
+    region: uksouth
+    cloud: dev
+    cxStamp: 1
+    regionStampTemplate: "${REGION_SHORT}"
+# MSFT environments
+- name: int
+  description: |
+    MSFT integration environment.
+  defaults:
+    region: uksouth
+    cloud: public
+    cxStamp: 1
+    regionStampTemplate: "${REGION_SHORT}"
+- name: stg
+  description: |
+    MSFT stage environment.
+  defaults:
+    region: uksouth
+    cloud: public
+    cxStamp: 1
+    regionStampTemplate: "${REGION_SHORT}"


### PR DESCRIPTION
### Why

Managed identity is created in `SVC_RESOURCEGROUP` not in `RESOURCEGROUP`. Hence update resource group to point correct managed identity location.
