### PR TITLE
bicep lint/fmt should run in parallel to reduce run time

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -11,6 +11,7 @@ PROMPT_TO_CONFIRM = "--confirm-with-what-if"
 endif
 
 PERSIST ?= false
+NPROC ?= $(shell command -v nproc > /dev/null 2>&1 && nproc || echo 4)
 
 MGMT_KUBECONFIG_FILE ?= ${HOME}/.kube/${MGMT_RESOURCEGROUP}.kubeconfig
 SVC_KUBECONFIG_FILE ?= ${HOME}/.kube/${SVC_RESOURCEGROUP}.kubeconfig
@@ -31,15 +32,21 @@ templates := $(wildcard ./templates/*.bicep)
 modules := $(shell find ./modules -name "*.bicep")
 parameters := $(filter-out $(wildcard ./templates/*.tmpl.bicepparam),$(wildcard ./templates/*.bicepparam))
 
-fmt: $(templates:.bicep=.bicep.fmt) $(modules:.bicep=.bicep.fmt) $(parameters:.bicepparam=.biceparam.fmt)
+_fmt: $(templates:.bicep=.bicep.fmt) $(modules:.bicep=.bicep.fmt) $(parameters:.bicepparam=.biceparam.fmt)
+fmt:
+	@echo "Running make fmt in parallel across $(NPROC) cores"
+	@$(MAKE) -j$(NPROC) _fmt
 
-lint: $(templates:.bicep=.bicep.lint) $(modules:.bicep=.bicep.lint) $(parameters:.bicepparam=.biceparam.lint)
+_lint: $(templates:.bicep=.bicep.lint) $(modules:.bicep=.bicep.lint) $(parameters:.bicepparam=.biceparam.lint)
+lint:
+	@echo "Running make lint in parallel across $(NPROC) cores"
+	@$(MAKE) -j$(NPROC) _lint
 
 %.bicep.fmt %.bicepparam.fmt:
-	az bicep format --file $(basename $@)
+	@AZURE_BICEP_CHECK_VERSION=False az bicep format --file $(basename $@) 2>&1 | awk 'NF'
 
 %.bicep.lint %.bicepparam.lint:
-	az bicep lint --file $(basename $@)
+	@AZURE_BICEP_CHECK_VERSION=False az bicep lint --file $(basename $@) 2>&1 | awk 'NF'
 
 feature-registration: # hardcoded to eastus as this is a subscription deployment, not a resource group
 	@az deployment sub create \


### PR DESCRIPTION
### What

Improve bicep linting and formatting with the following changes:
- Use `AZURE_BICEP_CHECK_VERSION=False` to skip version check on every run of `az bicep` (saves a few seconds overall)
- Remove empty lines in output so it is easier to read
- Run lint/fmt make targets in parallel to speed up the process (using detected CPU cores minus 2 to avoid overloading the system)

The changes should be backward compatible with wherever we already use the make targets

Performance comparison before and after the changes on a 12-core system:

```
BEFORE
make fmt  106.76s user 32.07s system 98% cpu 2:21.19 total
make lint  146.68s user 32.37s system 105% cpu 2:50.30 total

AFTER
make fmt  169.38s user 67.47s system 771% cpu 30.700 total
make lint  244.80s user 70.59s system 871% cpu 36.171 total
```

The ` Bicep Lint / validate_bicep` workflow step went from **10 minutes** to **5 minutes** (GitHub runners have 4 cores)
 
### Special notes for your reviewer

<!-- optional -->
