### PR TITLE
frontend: Add a trivial /location endpoint

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -177,6 +177,13 @@ func (f *Frontend) Healthz(writer http.ResponseWriter, request *http.Request) {
 	f.healthGauge.Set(0.0)
 }
 
+func (f *Frontend) Location(writer http.ResponseWriter, request *http.Request) {
+	// This is strictly for development environments to help discover
+	// the frontend's Azure region when port forwarding with kubectl.
+	// e.g. LOCATION=$(curl http://localhost:8443/location)
+	_, _ = writer.Write([]byte(f.location))
+}
+
 func (f *Frontend) ArmResourceList(writer http.ResponseWriter, request *http.Request) {
 	ctx := request.Context()
 	logger := LoggerFromContext(ctx)

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -80,6 +80,7 @@ func (f *Frontend) routes(r prometheus.Registerer) *MiddlewareMux {
 	// Unauthenticated routes
 	mux.HandleFunc("/", f.NotFound)
 	mux.HandleFunc(MuxPattern(http.MethodGet, "healthz"), f.Healthz)
+	mux.HandleFunc(MuxPattern(http.MethodGet, "location"), f.Location)
 
 	// List endpoints
 	postMuxMiddleware := NewMiddleware(


### PR DESCRIPTION
### What

This is strictly for development environments to help discover the frontend's Azure region when port forwarding with kubectl.

e.g. `LOCATION=$(curl http://localhost:8443/location)`

### Why

@geoberle asked me about it today and I couldn't think of a better alternative than an endpoint.