### PR TITLE
dev-infrastructure: fix bicep lint warnings

### DIFF
--- a/dev-infrastructure/modules/network/nsp-profile.bicep
+++ b/dev-infrastructure/modules/network/nsp-profile.bicep
@@ -22,7 +22,7 @@ param serviceTags array = []
 @description('Array of Subscription ids that will be allowd to access NSP')
 param subscriptions array = []
 
-var subscriptionObjects = [for s in subscriptions: { 'id': s }]
+var subscriptionObjects = [for s in subscriptions: { id: s }]
 
 resource nsp 'Microsoft.Network/networkSecurityPerimeters@2024-06-01-preview' existing = {
   name: nspName

--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -10,13 +10,20 @@ param userAssignedMIs array
 param private bool
 
 // Local Params
-var containers = [
+type Container = {
+  name: string
+  defaultTtl: int
+  partitionKeyPaths: array
+}
+var containers Container[] = [
   {
     name: 'Resources'
-    defaultTtl: -1 // enable ttl on items
+    defaultTtl: -1 // On, no default expiration
+    partitionKeyPaths: ['/partitionKey']
   }
   {
     name: 'Billing'
+    defaultTtl: -1 // On, no default expiration
     partitionKeyPaths: ['/subscriptionId']
   }
   {
@@ -95,7 +102,7 @@ resource cosmosDbContainers 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/
     properties: {
       resource: {
         id: c.name
-        defaultTtl: c.?defaultTtl ?? -1 // no expiration
+        defaultTtl: c.defaultTtl
         indexingPolicy: {
           indexingMode: 'consistent'
           automatic: true
@@ -111,7 +118,7 @@ resource cosmosDbContainers 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/
           ]
         }
         partitionKey: {
-          paths: c.?partitionKeyPaths ?? ['/partitionKey']
+          paths: c.partitionKeyPaths
           kind: 'Hash'
           version: 2
         }

--- a/dev-infrastructure/templates/global-image-sync.bicep
+++ b/dev-infrastructure/templates/global-image-sync.bicep
@@ -1,7 +1,5 @@
 import {
   csvToArray
-  determineZoneRedundancy
-  determineZoneRedundancyForRegion
   getLocationAvailabilityZonesCSV
   parseIPServiceTag
 } from '../modules/common.bicep'


### PR DESCRIPTION
### What

This fixes a bunch of bicep linting warnings
- `dev-infrastructure/modules/network/nsp-profile.bicep`: Change property name from string to identifier
- `dev-infrastructure/modules/rp-cosmos.bicep`: Refactored the container array to use a user-defined type, enforcing the object keys and moving the default from within the code into the actual definitions. The result is values are more obvious and easier to find
- `dev-infrastructure/templates/global-image-sync.bicep`: Remove unused imports

### Why

Clean code is happy code

### Special notes for your reviewer

```
WARNING: dev-infrastructure/modules/network/nsp-profile.bicep(25,54)
Warning prefer-unquoted-property-names: Property names that are valid identifiers should be declared without quotation marks and accessed using dot notation. [https://aka.ms/bicep/linter/prefer-unquoted-property-names]

INFO: dev-infrastructure/modules/rp-cosmos.bicep(97,24)
Info BCP187: The property "defaultTtl" does not exist in the resource or type definition, although it might still be valid. If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues. [https://aka.ms/bicep/core-diagnostics#BCP187]

INFO: dev-infrastructure/modules/rp-cosmos.bicep(113,21)
Info BCP187: The property "partitionKeyPaths" does not exist in the resource or type definition, although it might still be valid. If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues. [https://aka.ms/bicep/core-diagnostics#BCP187]
```