### PR TITLE
tooling/templatize: add a command to validate all configs

### DIFF
--- a/.github/workflows/config-change-detection.yml
+++ b/.github/workflows/config-change-detection.yml
@@ -21,3 +21,5 @@ jobs:
       run: |
         cd config/
         make detect-change
+    - name: 'Validate configurations and pipelines'
+      run: make validate-config-pipelines

--- a/Makefile
+++ b/Makefile
@@ -204,3 +204,8 @@ listall:
 
 list:
 	@grep '^[^#[:space:]].*:' Makefile
+
+validate-config-pipelines:
+	$(MAKE) -C tooling/templatize templatize
+	tooling/templatize/templatize pipeline validate --topology-config-file topology.yaml --service-config-file config/config.yaml --dev-mode --dev-region $(shell yq '.environments[] | select(.name == "dev") | .defaults.region' <tooling/templatize/settings.yaml)
+	tooling/templatize/templatize pipeline validate --topology-config-file topology.yaml --service-config-file config/config.msft.yaml

--- a/tooling/pipeline-documentation/go.mod
+++ b/tooling/pipeline-documentation/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/pipeline-documentation
 go 1.24.1
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250612124615-9e228a1204aa
+	github.com/Azure/ARO-Tools v0.0.0-20250612165309-76d904b6e84c
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.2
 	github.com/spf13/cobra v1.9.1

--- a/tooling/pipeline-documentation/go.sum
+++ b/tooling/pipeline-documentation/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250612124615-9e228a1204aa h1:86mKS0Ir15M6xJUpDQtZfZKRIiPY0dSFWM+FJrbwLlI=
-github.com/Azure/ARO-Tools v0.0.0-20250612124615-9e228a1204aa/go.mod h1:yAk9hvxTfwoU4XUyOtLA51kHzI4vvHqNfni6uQXfcVA=
+github.com/Azure/ARO-Tools v0.0.0-20250612165309-76d904b6e84c h1:UPPvSNgQyXcNKX/a0ns2lW53jmjWFhXf9WPb9kQpGCA=
+github.com/Azure/ARO-Tools v0.0.0-20250612165309-76d904b6e84c/go.mod h1:yAk9hvxTfwoU4XUyOtLA51kHzI4vvHqNfni6uQXfcVA=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dusted-go/logging v1.3.0 h1:SL/EH1Rp27oJQIte+LjWvWACSnYDTqNx5gZULin0XRY=

--- a/tooling/templatize/cmd/pipeline/cmd.go
+++ b/tooling/templatize/cmd/pipeline/cmd.go
@@ -17,6 +17,8 @@ package pipeline
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/Azure/ARO-HCP/tooling/templatize/cmd/pipeline/validate"
+
 	"github.com/Azure/ARO-HCP/tooling/templatize/cmd/pipeline/inspect"
 	"github.com/Azure/ARO-HCP/tooling/templatize/cmd/pipeline/run"
 )
@@ -36,6 +38,7 @@ func NewCommand() (*cobra.Command, error) {
 	commands := []func() (*cobra.Command, error){
 		run.NewCommand,
 		inspect.NewCommand,
+		validate.NewCommand,
 	}
 	for _, newCmd := range commands {
 		c, err := newCmd()

--- a/tooling/templatize/cmd/pipeline/validate/cmd.go
+++ b/tooling/templatize/cmd/pipeline/validate/cmd.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCommand() (*cobra.Command, error) {
+	opts := DefaultValidationOptions()
+	cmd := &cobra.Command{
+		Use:           "validate",
+		Short:         "Validate configurations and pipeline configuration references.",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInspect(cmd.Context(), opts)
+		},
+	}
+	if err := BindValidationOptions(opts, cmd); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
+func runInspect(ctx context.Context, opts *RawValidationOptions) error {
+	validated, err := opts.Validate()
+	if err != nil {
+		return err
+	}
+	completed, err := validated.Complete()
+	if err != nil {
+		return err
+	}
+	return completed.ValidatePipelineConfigReferences(ctx)
+}

--- a/tooling/templatize/cmd/pipeline/validate/options.go
+++ b/tooling/templatize/cmd/pipeline/validate/options.go
@@ -1,0 +1,394 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/Azure/ARO-Tools/pkg/config"
+	"github.com/Azure/ARO-Tools/pkg/config/ev2config"
+	"github.com/Azure/ARO-Tools/pkg/types"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/Azure/ARO-Tools/pkg/topology"
+)
+
+func DefaultValidationOptions() *RawValidationOptions {
+	return &RawValidationOptions{
+		DevMode:   false,
+		DevRegion: "uksouth",
+	}
+}
+
+func BindValidationOptions(opts *RawValidationOptions, cmd *cobra.Command) error {
+	cmd.Flags().StringVar(&opts.ServiceConfigFile, "service-config-file", opts.ServiceConfigFile, "Path to the service configuration file.")
+	cmd.Flags().StringVar(&opts.TopologyFile, "topology-config-file", opts.TopologyFile, "Path to the topology configuration file.")
+	cmd.Flags().BoolVar(&opts.DevMode, "dev-mode", opts.DevMode, "Validate just one region, using public production Ev2 contexts.")
+	cmd.Flags().StringVar(&opts.DevRegion, "dev-region", opts.DevRegion, "Region to use for dev mode validation.")
+
+	for _, flag := range []string{
+		"service-config-file",
+		"topology-config-file",
+	} {
+		if err := cmd.MarkFlagFilename(flag); err != nil {
+			return fmt.Errorf("failed to mark flag %q as a file: %w", flag, err)
+		}
+	}
+	return nil
+}
+
+// RawValidationOptions holds input values.
+type RawValidationOptions struct {
+	ServiceConfigFile string
+	TopologyFile      string
+	DevMode           bool
+	DevRegion         string
+}
+
+// validatedValidationOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
+type validatedValidationOptions struct {
+	*RawValidationOptions
+}
+
+type ValidatedValidationOptions struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*validatedValidationOptions
+}
+
+// completedValidationOptions is a private wrapper that enforces a call of Complete() before config generation can be invoked.
+type completedValidationOptions struct {
+	Topology    *topology.Topology
+	TopologyDir string
+	Config      config.ConfigProvider
+	DevMode     bool
+	DevRegion   string
+}
+
+type ValidationOptions struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*completedValidationOptions
+}
+
+func (o *RawValidationOptions) Validate() (*ValidatedValidationOptions, error) {
+	for _, item := range []struct {
+		flag  string
+		name  string
+		value *string
+	}{
+		{flag: "service-config-file", name: "service configuration file", value: &o.ServiceConfigFile},
+		{flag: "topology-config-file", name: "topology configuration file", value: &o.TopologyFile},
+	} {
+		if item.value == nil || *item.value == "" {
+			return nil, fmt.Errorf("the %s must be provided with --%s", item.name, item.flag)
+		}
+	}
+
+	return &ValidatedValidationOptions{
+		validatedValidationOptions: &validatedValidationOptions{
+			RawValidationOptions: o,
+		},
+	}, nil
+}
+
+func (o *ValidatedValidationOptions) Complete() (*ValidationOptions, error) {
+	t, err := topology.Load(o.TopologyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load topology: %w", err)
+	}
+	if err := t.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate topology: %w", err)
+	}
+
+	c, err := config.NewConfigProvider(o.ServiceConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config file: %w", err)
+	}
+
+	return &ValidationOptions{
+		completedValidationOptions: &completedValidationOptions{
+			Topology:    t,
+			TopologyDir: filepath.Dir(o.TopologyFile),
+			Config:      c,
+			DevMode:     o.DevMode,
+			DevRegion:   o.DevRegion,
+		},
+	}, nil
+}
+
+func (opts *ValidationOptions) ValidatePipelineConfigReferences(ctx context.Context) error {
+	ev2Context, err := ev2config.AllContexts()
+	if err != nil {
+		return fmt.Errorf("failed to load ev2 contexts: %w", err)
+	}
+	group, _ := errgroup.WithContext(ctx)
+	for cloud, environments := range opts.Config.AllContexts() {
+		slog.Info("Validating cloud.", "cloud", cloud)
+		for environment := range environments {
+			slog.Info("Validating environment.", "cloud", cloud, "environment", environment)
+			var regions []string
+			if opts.DevMode {
+				regions = []string{opts.DevRegion}
+			} else {
+				regions = ev2Context[cloud]
+			}
+			for _, region := range regions {
+				slog.Info("Validating region.", "cloud", cloud, "environment", environment, "region", region)
+				prefix := fmt.Sprintf("config[%s][%s][%s]:", cloud, environment, region)
+				ev2Cloud := cloud
+				if opts.DevMode {
+					ev2Cloud = "public"
+				}
+				ev2Cfg, err := ev2config.ResolveConfig(ev2Cloud, region)
+				if err != nil {
+					return fmt.Errorf("%s failed to get ev2 config: %w", prefix, err)
+				}
+				replacements := &config.ConfigReplacements{
+					RegionReplacement:      region,
+					CloudReplacement:       cloud,
+					EnvironmentReplacement: environment,
+					StampReplacement:       "1",
+					Ev2Config:              ev2Cfg,
+				}
+				for key, into := range map[string]*string{
+					"regionShortName": &replacements.RegionShortReplacement,
+				} {
+					value, ok := ev2Cfg.GetByPath(key)
+					if !ok {
+						return fmt.Errorf("%s %q not found in ev2 config", prefix, key)
+					}
+					str, ok := value.(string)
+					if !ok {
+						return fmt.Errorf("%s %q is not a string", prefix, key)
+					}
+					*into = str
+				}
+
+				resolver, err := opts.Config.GetResolver(replacements)
+				if err != nil {
+					return fmt.Errorf("%s failed to get resolver: %w", prefix, err)
+				}
+
+				rawCfg, err := resolver.GetRegionConfiguration(region)
+				if err != nil {
+					return fmt.Errorf("%s failed to get region config: %w", prefix, err)
+				}
+
+				cfg, ok := config.InterfaceToConfiguration(rawCfg)
+				if !ok {
+					return fmt.Errorf("%s: invalid configuration", prefix)
+				}
+
+				if err := resolver.ValidateSchema(cfg); err != nil {
+					return fmt.Errorf("%s resolved region config was invalid: %w", prefix, err)
+				}
+
+				for _, service := range opts.Topology.Services {
+					if err := handleService(prefix, group, opts.TopologyDir, service, cfg); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return group.Wait()
+}
+
+func handleService(context string, group *errgroup.Group, baseDir string, service topology.Service, cfg config.Configuration) error {
+	group.Go(func() error {
+		pipelinePath := service.PipelinePath
+		if pipelinePath == "" {
+			pipelinePath = service.Metadata["pipeline"]
+		}
+		pipeline, err := types.NewPipelineFromFile(filepath.Join(baseDir, pipelinePath), cfg)
+		if err != nil {
+			return fmt.Errorf("%s: %s: failed to parse pipeline %s: %w", context, service.ServiceGroup, pipelinePath, err)
+		}
+
+		type variableRef struct {
+			variable types.Variable
+			ref      string
+		}
+		var variables []variableRef
+		for i, rg := range pipeline.ResourceGroups {
+			for j, step := range rg.Steps {
+				switch step.ActionType() {
+				case "Shell":
+					specificStep, ok := step.(*types.ShellStep)
+					if !ok {
+						return fmt.Errorf("%s: resourceGroups[%d].steps[%d]: have action %q, expected *types.ShellStep, but got %T", service.ServiceGroup, i, j, step.ActionType(), step)
+					}
+					for k, variable := range specificStep.Variables {
+						variables = append(variables, variableRef{
+							variable: variable,
+							ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].variables[%d]", i, j, k),
+						})
+					}
+					variables = append(variables, variableRef{
+						variable: specificStep.ShellIdentity,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].shellIdentity", i, j),
+					})
+				case "ARM":
+					specificStep, ok := step.(*types.ARMStep)
+					if !ok {
+						return fmt.Errorf("%s: resourceGroups[%d].steps[%d]: have action %q, expected *types.ARMStep, but got %T", service.ServiceGroup, i, j, step.ActionType(), step)
+					}
+					for k, variable := range specificStep.Variables {
+						variables = append(variables, variableRef{
+							variable: variable,
+							ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].variables[%d]", i, j, k),
+						})
+					}
+				case "DelegateChildZone":
+					specificStep, ok := step.(*types.DelegateChildZoneStep)
+					if !ok {
+						return fmt.Errorf("%s: resourceGroups[%d].steps[%d]: have action %q, expected *types.DelegateChildZoneStep, but got %T", service.ServiceGroup, i, j, step.ActionType(), step)
+					}
+					variables = append(variables, variableRef{
+						variable: specificStep.ParentZone,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].parentZone", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.ChildZone,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].childZone", i, j),
+					})
+				case "SetCertificateIssuer":
+					specificStep, ok := step.(*types.SetCertificateIssuerStep)
+					if !ok {
+						return fmt.Errorf("%s: resourceGroups[%d].steps[%d]: have action %q, expected *types.SetCertificateIssuerStep, but got %T", service.ServiceGroup, i, j, step.ActionType(), step)
+					}
+					variables = append(variables, variableRef{
+						variable: specificStep.VaultBaseUrl,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].vaultBaseUrl", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.Issuer,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].issuer", i, j),
+					})
+				case "CreateCertificate":
+					specificStep, ok := step.(*types.CreateCertificateStep)
+					if !ok {
+						return fmt.Errorf("%s: resourceGroups[%d].steps[%d]: have action %q, expected *types.CreateCertificateStep, but got %T", service.ServiceGroup, i, j, step.ActionType(), step)
+					}
+					variables = append(variables, variableRef{
+						variable: specificStep.VaultBaseUrl,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].vaultBaseUrl", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.CertificateName,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].certificateName", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.ContentType,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].contentType", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.SAN,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].san", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.Issuer,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].issuer", i, j),
+					})
+				case "ResourceProviderRegistration":
+					specificStep, ok := step.(*types.ResourceProviderRegistrationStep)
+					if !ok {
+						return fmt.Errorf("%s: resourceGroups[%d].steps[%d]: have action %q, expected *types.ResourceProviderRegistrationStep, but got %T", service.ServiceGroup, i, j, step.ActionType(), step)
+					}
+					variables = append(variables, variableRef{
+						variable: specificStep.ResourceProviderNamespaces,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].resourceProviderNamespaces", i, j),
+					})
+				case "ImageMirror":
+					specificStep, ok := step.(*types.ImageMirrorStep)
+					if !ok {
+						return fmt.Errorf("%s: resourceGroups[%d].steps[%d]: have action %q, expected *types.ImageMirrorStep, but got %T", service.ServiceGroup, i, j, step.ActionType(), step)
+					}
+					variables = append(variables, variableRef{
+						variable: specificStep.TargetACR,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].targetACR", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.SourceRegistry,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].sourceRegistry", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.Repository,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].repository", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.Digest,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].digest", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.PullSecretKeyVault,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].pullSecretKeyVault", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.PullSecretName,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].pullSecretName", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.ShellIdentity,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].shellIdentity", i, j),
+					})
+				case "RPLogsAccount", "ClusterLogsAccount":
+					specificStep, ok := step.(*types.LogsStep)
+					if !ok {
+						return fmt.Errorf("%s: resourceGroups[%d].steps[%d]: have action %q, expected *types.LogsStep, but got %T", service.ServiceGroup, i, j, step.ActionType(), step)
+					}
+					variables = append(variables, variableRef{
+						variable: specificStep.SubscriptionId,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].subscriptionId", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.Namespace,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].namespace", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.CertSAN,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].certsan", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.CertDescription,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].certdescription", i, j),
+					})
+					variables = append(variables, variableRef{
+						variable: specificStep.ConfigVersion,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].configVersion", i, j),
+					})
+				}
+			}
+		}
+		for _, variable := range variables {
+			if variable.variable.ConfigRef != "" {
+				if _, ok := cfg.GetByPath(variable.variable.ConfigRef); !ok {
+					return fmt.Errorf("%s: %s: %s: configRef %q not present in configuration", context, service.ServiceGroup, variable.ref, variable.variable.ConfigRef)
+				}
+			}
+		}
+		slog.Info("Validated service.", "service", service.ServiceGroup)
+		return nil
+	})
+	for _, child := range service.Children {
+		if err := handleService(context, group, baseDir, child, cfg); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/tooling/templatize/go.mod
+++ b/tooling/templatize/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250612124615-9e228a1204aa
+	github.com/Azure/ARO-Tools v0.0.0-20250612165309-76d904b6e84c
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.2
@@ -22,6 +22,7 @@ require (
 	github.com/microsoftgraph/msgraph-sdk-go v1.69.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/sync v0.14.0
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
 	sigs.k8s.io/yaml v1.4.0

--- a/tooling/templatize/go.sum
+++ b/tooling/templatize/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250612124615-9e228a1204aa h1:86mKS0Ir15M6xJUpDQtZfZKRIiPY0dSFWM+FJrbwLlI=
-github.com/Azure/ARO-Tools v0.0.0-20250612124615-9e228a1204aa/go.mod h1:yAk9hvxTfwoU4XUyOtLA51kHzI4vvHqNfni6uQXfcVA=
+github.com/Azure/ARO-Tools v0.0.0-20250612165309-76d904b6e84c h1:UPPvSNgQyXcNKX/a0ns2lW53jmjWFhXf9WPb9kQpGCA=
+github.com/Azure/ARO-Tools v0.0.0-20250612165309-76d904b6e84c/go.mod h1:yAk9hvxTfwoU4XUyOtLA51kHzI4vvHqNfni6uQXfcVA=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0 h1:Gt0j3wceWMwPmiazCa8MzMA0MfhmPIz0Qp0FJ6qcM0U=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0/go.mod h1:Ot/6aikWnKWi4l9QB7qVSwa8iMphQNqkWALMoNT3rzM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.0 h1:j8BorDEigD8UFOSZQiSqAMOOleyQOOQPnUAwV+Ls1gA=
@@ -175,6 +175,8 @@ golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKl
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
+golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
The new `templatize pipeline validate` command will render our service configuration into every possible cloud/env/region for prod, and validate that the output passes the schema. It will also, then, pre-process and load every pipeline for all of those regions and validate that the configRefs point to real values.
