### PR TITLE
enhance grafana bicep IAM configuration

### DIFF
--- a/config/config.msft.public-cloud-overlay.yaml
+++ b/config/config.msft.public-cloud-overlay.yaml
@@ -205,7 +205,8 @@ clouds:
           armHelperCertName: intArmHelperCert
           # Grafana
           monitoring:
-            grafanaAdminGroupPrincipalId: "2fdb57d4-3fd3-415d-b604-1d0e37a188fe" # Azure Red Hat OpenShift MSFT Engineering.
+            grafanaRoles: >-
+              2fdb57d4-3fd3-415d-b604-1d0e37a188fe/Group/Admin
           # Global MSI
           aroDevopsMsiId: "/subscriptions/5299e6b7-b23b-46c8-8277-dc1147807117/resourcegroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity"
           # Cert Officer used for KV signer registration
@@ -323,7 +324,8 @@ clouds:
             manage: true
           # Grafana
           monitoring:
-            grafanaAdminGroupPrincipalId: '' # EV2 currently only allows service principal role assignment, so leave it empty for now
+            # EV2 currently only allows service principal role assignment, so leave it empty for now
+            grafanaRoles: >-
           # Global MSI
           aroDevopsMsiId: '/subscriptions/9a53d80e-dae0-4c8a-af90-30575d253127/resourceGroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity'
           # Cert Officer used for KV signer registration

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -83,6 +83,9 @@ defaults:
   # Monitoring
   monitoring:
     grafanaName: "arohcp-{{ .ctx.environment }}"
+    # Format: Multiline string using '>-' YAML block scalar
+    #   One item per line, formatted as: UUID/PrincipalType/RoleName
+    grafanaRoles: ""
     svcWorkspaceName: 'arohcp-{{ .ctx.environment }}-{{ .ctx.regionShort }}'
     hcpWorkspaceName: 'arohcp-hcp-{{ .ctx.environment }}-{{ .ctx.regionShort }}'
     devAlertingEmails: ""
@@ -563,7 +566,8 @@ clouds:
           armHelperCertName: intArmHelperCert
           # Grafana
           monitoring:
-            grafanaAdminGroupPrincipalId: "2fdb57d4-3fd3-415d-b604-1d0e37a188fe" # Azure Red Hat OpenShift MSFT Engineering.
+            grafanaRoles: >-
+              2fdb57d4-3fd3-415d-b604-1d0e37a188fe/Group/Admin
           # Global MSI
           aroDevopsMsiId: "/subscriptions/5299e6b7-b23b-46c8-8277-dc1147807117/resourcegroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity"
           # Cert Officer used for KV signer registration
@@ -681,7 +685,8 @@ clouds:
             manage: true
           # Grafana
           monitoring:
-            grafanaAdminGroupPrincipalId: '' # EV2 currently only allows service principal role assignment, so leave it empty for now
+            # EV2 currently only allows service principal role assignment, so leave it empty for now
+            grafanaRoles: ""
           # Global MSI
           aroDevopsMsiId: '/subscriptions/9a53d80e-dae0-4c8a-af90-30575d253127/resourceGroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity'
           # Cert Officer used for KV signer registration

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1048,9 +1048,6 @@
     "monitoring": {
       "type": "object",
       "properties": {
-        "grafanaAdminGroupPrincipalId": {
-          "type": "string"
-        },
         "grafanaName": {
           "type": "string"
         },
@@ -1059,6 +1056,11 @@
         },
         "grafanaZoneRedundantMode": {
           "$ref": "#/definitions/zoneRedundantMode"
+        },
+        "grafanaRoles": {
+          "type": "string",
+          "description": "A space-separated list of Service Principals IDs, Types and their desired grafana roles The format is: <principalId>/<principalType>/<role>, e.g. 12345678-1234-1234-1234-123456789012/Group/Admin",
+          "pattern": "^$|^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\/(Group|ServicePrincipal|User)\\/(Contributor|Admin|Viewer)\\s*)+$"
         },
         "svcWorkspaceName": {
           "type": "string",
@@ -1092,8 +1094,8 @@
       },
       "additionalProperties": false,
       "required": [
-        "grafanaAdminGroupPrincipalId",
         "grafanaName",
+        "grafanaRoles",
         "grafanaZoneRedundantMode",
         "svcWorkspaceName",
         "hcpWorkspaceName"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -80,6 +80,9 @@ defaults:
   # Monitoring
   monitoring:
     grafanaName: "arohcp-{{ .ctx.environment }}"
+    # Format: Multiline string using '>-' YAML block scalar
+    #   One item per line, formatted as: UUID/PrincipalType/RoleName
+    grafanaRoles: >-
     svcWorkspaceName: 'arohcp-{{ .ctx.environment }}-{{ .ctx.regionShort }}'
     hcpWorkspaceName: 'arohcp-hcp-{{ .ctx.environment }}-{{ .ctx.regionShort }}'
     devAlertingEmails: ""
@@ -530,7 +533,8 @@ clouds:
         devAlertingEmails: "aro-hcp-service-lifecycle-team@redhat.com"
         grafanaMajorVersion: '11'
         grafanaZoneRedundantMode: Disabled
-        grafanaAdminGroupPrincipalId: 6b6d3adf-8476-4727-9812-20ffdef2b85c
+        grafanaRoles: >-
+          6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
       # DEVOPS MSI
       aroDevopsMsiId: '/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-rollout-identity'
       kvCertOfficerPrincipalId: 'c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb'

--- a/config/public-cloud-cspr.json
+++ b/config/public-cloud-cspr.json
@@ -345,9 +345,9 @@
   },
   "monitoring": {
     "devAlertingEmails": "aro-hcp-service-lifecycle-team@redhat.com",
-    "grafanaAdminGroupPrincipalId": "6b6d3adf-8476-4727-9812-20ffdef2b85c",
     "grafanaMajorVersion": "11",
     "grafanaName": "arohcp-dev",
+    "grafanaRoles": "6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin",
     "grafanaZoneRedundantMode": "Disabled",
     "hcpWorkspaceName": "arohcp-hcp-cspr-ussw1",
     "sev1ActionGroupIDs": "",

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -345,9 +345,9 @@
   },
   "monitoring": {
     "devAlertingEmails": "aro-hcp-service-lifecycle-team@redhat.com",
-    "grafanaAdminGroupPrincipalId": "6b6d3adf-8476-4727-9812-20ffdef2b85c",
     "grafanaMajorVersion": "11",
     "grafanaName": "arohcp-dev",
+    "grafanaRoles": "6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin",
     "grafanaZoneRedundantMode": "Disabled",
     "hcpWorkspaceName": "arohcp-hcp-dev-ussw1",
     "sev1ActionGroupIDs": "",

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -348,9 +348,9 @@
   },
   "monitoring": {
     "devAlertingEmails": "",
-    "grafanaAdminGroupPrincipalId": "2fdb57d4-3fd3-415d-b604-1d0e37a188fe",
     "grafanaMajorVersion": "11",
     "grafanaName": "arohcp-int",
+    "grafanaRoles": "2fdb57d4-3fd3-415d-b604-1d0e37a188fe/Group/Admin",
     "grafanaZoneRedundantMode": "Disabled",
     "hcpWorkspaceName": "arohcp-hcp-int-ussw1",
     "sev1ActionGroupIDs": "",

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -344,9 +344,9 @@
   },
   "monitoring": {
     "devAlertingEmails": "",
-    "grafanaAdminGroupPrincipalId": "",
     "grafanaMajorVersion": "11",
     "grafanaName": "arohcp-stg",
+    "grafanaRoles": "",
     "grafanaZoneRedundantMode": "Disabled",
     "hcpWorkspaceName": "arohcp-hcp-stg-ussw1",
     "sev1ActionGroupIDs": "",

--- a/config/public-cloud-ntly.json
+++ b/config/public-cloud-ntly.json
@@ -345,9 +345,9 @@
   },
   "monitoring": {
     "devAlertingEmails": "aro-hcp-service-lifecycle-team@redhat.com",
-    "grafanaAdminGroupPrincipalId": "6b6d3adf-8476-4727-9812-20ffdef2b85c",
     "grafanaMajorVersion": "11",
     "grafanaName": "arohcp-dev",
+    "grafanaRoles": "6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin",
     "grafanaZoneRedundantMode": "Disabled",
     "hcpWorkspaceName": "arohcp-hcp-ntly-ussw1",
     "sev1ActionGroupIDs": "",

--- a/config/public-cloud-pers.json
+++ b/config/public-cloud-pers.json
@@ -348,9 +348,9 @@
   },
   "monitoring": {
     "devAlertingEmails": "aro-hcp-service-lifecycle-team@redhat.com",
-    "grafanaAdminGroupPrincipalId": "6b6d3adf-8476-4727-9812-20ffdef2b85c",
     "grafanaMajorVersion": "11",
     "grafanaName": "arohcp-dev",
+    "grafanaRoles": "6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin",
     "grafanaZoneRedundantMode": "Disabled",
     "hcpWorkspaceName": "arohcp-hcp-pers-ussw1test",
     "sev1ActionGroupIDs": "",

--- a/dev-infrastructure/configurations/global-infra.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-infra.tmpl.bicepparam
@@ -13,8 +13,8 @@ param keyVaultSoftDelete = {{ .global.keyVault.softDelete }}
 
 param grafanaName = '{{ .monitoring.grafanaName }}'
 param grafanaMajorVersion = '{{ .monitoring.grafanaMajorVersion }}'
-param grafanaAdminGroupPrincipalId = '{{ .monitoring.grafanaAdminGroupPrincipalId }}'
 param grafanaZoneRedundantMode = '{{ .monitoring.grafanaZoneRedundantMode }}'
+param grafanaRoles = '{{ .monitoring.grafanaRoles }}'
 
 param globalNSPName = '{{ .global.nsp.name }}'
 param globalNSPAccessMode = '{{ .global.nsp.accessMode }}'

--- a/dev-infrastructure/modules/common.bicep
+++ b/dev-infrastructure/modules/common.bicep
@@ -411,7 +411,11 @@ var _locationAvailabilityZones = {
 }
 
 @export()
-func csvToArray(inputString string) array => inputString == '' ? [] : split(inputString, ',')
+func splitOrEmptyArray(inputString string, delimiter string) array =>
+  inputString == '' ? [] : split(inputString, delimiter)
+
+@export()
+func csvToArray(inputString string) array => splitOrEmptyArray(inputString, ',')
 
 @export()
 func arrayToCSV(inputArray array) string => join(inputArray, ',')

--- a/dev-infrastructure/modules/grafana/instance.bicep
+++ b/dev-infrastructure/modules/grafana/instance.bicep
@@ -1,3 +1,7 @@
+import {
+  splitOrEmptyArray
+} from '../common.bicep'
+
 param location string
 
 @description('Metrics global Grafana name')
@@ -5,9 +9,6 @@ param grafanaName string
 
 @description('The Grafana major version')
 param grafanaMajorVersion string
-
-@description('The admin group principal ID to manage Grafana')
-param grafanaAdminGroupPrincipalId string
 
 @description('The identity that will manage Grafana')
 param grafanaManagerPrincipalId string
@@ -18,13 +19,15 @@ param zoneRedundancy bool
 @description('The azure monitor workspace IDs to integrate with Grafana')
 param azureMonitorWorkspaceIds array
 
-// Azure Managed Grafana Workspace Contributor: Can manage Azure Managed Grafana resources, without providing access to the workspaces themselves.
-// https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/monitor#azure-managed-grafana-workspace-contributor
-var grafanaContributor = '5c2d7e57-b7c2-4d8a-be4f-82afa42c6e95'
-
-// Grafana Admin: Perform all Grafana operations, including the ability to manage data sources, create dashboards, and manage role assignments within Grafana.
-// https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/monitor#grafana-admin
-var grafanaAdminRole = '22926164-76b3-42b3-bc55-97df8dab3e41'
+@description('List of grafana role assignments as a space-separated list of items in the format of "principalId/principalType/role"')
+param grafanaRoles string
+var grafanaRolesArray = [
+  for gr in splitOrEmptyArray(grafanaRoles, ' '): {
+    principalId: split(gr, '/')[0]
+    principalType: split(gr, '/')[1]
+    role: split(gr, '/')[2]
+  }
+]
 
 resource grafana 'Microsoft.Dashboard/grafana@2024-10-01' = {
   name: grafanaName
@@ -48,34 +51,33 @@ resource grafana 'Microsoft.Dashboard/grafana@2024-10-01' = {
   }
 }
 
-resource grafanaManagerContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(grafana.id, grafanaManagerPrincipalId, grafanaContributor)
-  scope: grafana
-  properties: {
-    principalId: grafanaManagerPrincipalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', grafanaContributor)
-  }
+// Built-in roles for Azure Monitor Grafana
+var grafanaBuiltInRoles = {
+  Contributor: '5c2d7e57-b7c2-4d8a-be4f-82afa42c6e95'
+  Admin: '22926164-76b3-42b3-bc55-97df8dab3e41'
+  Viewer: '60921a7e-fef1-4a43-9b16-a26c52ad4769'
 }
 
 resource grafanaManagerAdmin 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(grafana.id, grafanaManagerPrincipalId, grafanaAdminRole)
+  name: guid(grafana.id, grafanaManagerPrincipalId, grafanaBuiltInRoles.Admin)
   scope: grafana
   properties: {
     principalId: grafanaManagerPrincipalId
     principalType: 'ServicePrincipal'
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', grafanaAdminRole)
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', grafanaBuiltInRoles.Admin)
   }
 }
 
-resource adminRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(grafanaAdminGroupPrincipalId)) {
-  name: guid(grafana.id, grafanaAdminGroupPrincipalId, grafanaAdminRole)
-  scope: grafana
-  properties: {
-    principalId: grafanaAdminGroupPrincipalId
-    principalType: 'group'
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', grafanaAdminRole)
+resource grafanaRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for gra in grafanaRolesArray: {
+    name: guid(grafana.id, gra.principalId, gra.role)
+    scope: grafana
+    properties: {
+      principalId: gra.principalId
+      principalType: gra.principalType
+      roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', grafanaBuiltInRoles[gra.role])
+    }
   }
-}
+]
 
 output grafanaId string = grafana.id

--- a/dev-infrastructure/templates/global-infra.bicep
+++ b/dev-infrastructure/templates/global-infra.bicep
@@ -30,8 +30,8 @@ param grafanaName string
 @description('The Grafana major version')
 param grafanaMajorVersion string
 
-@description('The admin group principal ID to use Grafana')
-param grafanaAdminGroupPrincipalId string
+@description('List of grafana role assignments as a space-separated list of items in the format of "principalId/principalType/role"')
+param grafanaRoles string
 
 @description('The zone redundant mode of Grafana')
 param grafanaZoneRedundantMode string
@@ -180,8 +180,8 @@ module grafana '../modules/grafana/instance.bicep' = {
     location: location
     grafanaName: grafanaName
     grafanaMajorVersion: grafanaMajorVersion
-    grafanaAdminGroupPrincipalId: grafanaAdminGroupPrincipalId
     grafanaManagerPrincipalId: globalMSI.properties.principalId
+    grafanaRoles: grafanaRoles
     zoneRedundancy: determineZoneRedundancy(locationAvailabilityZoneList, grafanaZoneRedundantMode)
     azureMonitorWorkspaceIds: grafanaWorkspaceIdLookup.outputs.azureMonitorWorkspaceIds
   }


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-17964

### What

Improves the grafana role assignment configuration such that
- We can have more than one Principal per role
- We can assign Principals to the grafana Viewer role in addition to Admin
- We can assign roles to User Principals (though that will probably be a rare case)

The `grafanaRoles` value was implemented as a space-separated value of `UUID/PrincipalType/Role` because we do not have support for array in our tooling. This is similar to CSV values we use in place of arrays. Here since the values are longer strings, I opted for a spare-separated list which allows using the `>-` YAML block scalar to make the `grafanaRoles` value more manageable. A standard quoted string would also work.

Motivating example for using space-separated values and `>-` versus CSV
```yaml
# not using block scalar
grafanaRoles: "3e9a6d3c-8e0b-48a5-a29c-2c8c4b8f1f01/ServicePrincipal/Contributor,67729671-1fa6-4e25-895c-29135761a2ae/Group/Admin,658b9f61-c2ca-4a02-854d-0872339e1718/Group/Viewer"
# using block scalar is _almost_ as if we had an array
grafanaRoles: >-
  3e9a6d3c-8e0b-48a5-a29c-2c8c4b8f1f01/ServicePrincipal/Contributor
  67729671-1fa6-4e25-895c-29135761a2ae/Group/Admin
  658b9f61-c2ca-4a02-854d-0872339e1718/Group/Viewer
```

This is all enforced at the schema level through an exhaustive pattern which will trip whenever the string (using block scalar or not) is not in the right format. The pattern also includes enforcement of the Principal Types and grafana role names we support

### Why

### Special notes for your reviewer

<!-- optional -->
