### PR TITLE
Bump cluster-service image digest

### DIFF
--- a/config/config.msft.public-cloud-overlay.yaml
+++ b/config/config.msft.public-cloud-overlay.yaml
@@ -95,7 +95,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:5830e8c95beba213e3f2aa885fd55171fdf601993966f1ac0a36784ba6eb5ba2
+              digest: sha256:aac9226ea3c3712918a04b125e4ef765c8bc8e6968c0e3db05c6e662aa497282
           # ACR Pull
           acrPull:
             image:
@@ -221,7 +221,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:5830e8c95beba213e3f2aa885fd55171fdf601993966f1ac0a36784ba6eb5ba2
+              digest: sha256:aac9226ea3c3712918a04b125e4ef765c8bc8e6968c0e3db05c6e662aa497282
           # ACR Pull
           acrPull:
             image:

--- a/config/config.msft.yaml
+++ b/config/config.msft.yaml
@@ -453,7 +453,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:5830e8c95beba213e3f2aa885fd55171fdf601993966f1ac0a36784ba6eb5ba2
+              digest: sha256:aac9226ea3c3712918a04b125e4ef765c8bc8e6968c0e3db05c6e662aa497282
           # ACR Pull
           acrPull:
             image:
@@ -579,7 +579,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:5830e8c95beba213e3f2aa885fd55171fdf601993966f1ac0a36784ba6eb5ba2
+              digest: sha256:aac9226ea3c3712918a04b125e4ef765c8bc8e6968c0e3db05c6e662aa497282
           # ACR Pull
           acrPull:
             image:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -408,7 +408,7 @@ clouds:
       clustersService:
         environment: "arohcpdev"
         image:
-          digest: sha256:5830e8c95beba213e3f2aa885fd55171fdf601993966f1ac0a36784ba6eb5ba2
+          digest: sha256:aac9226ea3c3712918a04b125e4ef765c8bc8e6968c0e3db05c6e662aa497282
         # NOTE: The role names must not include commas(,) in the name as the roleNames field
         # here is a comma separated list of role definition names.
         azureOperatorsManagedIdentities:

--- a/config/public-cloud-cspr.json
+++ b/config/public-cloud-cspr.json
@@ -70,7 +70,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:5830e8c95beba213e3f2aa885fd55171fdf601993966f1ac0a36784ba6eb5ba2",
+      "digest": "sha256:aac9226ea3c3712918a04b125e4ef765c8bc8e6968c0e3db05c6e662aa497282",
       "registry": "quay.io",
       "repository": "app-sre/uhc-clusters-service"
     },

--- a/config/public-cloud-dev.json
+++ b/config/public-cloud-dev.json
@@ -70,7 +70,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:5830e8c95beba213e3f2aa885fd55171fdf601993966f1ac0a36784ba6eb5ba2",
+      "digest": "sha256:aac9226ea3c3712918a04b125e4ef765c8bc8e6968c0e3db05c6e662aa497282",
       "registry": "quay.io",
       "repository": "app-sre/uhc-clusters-service"
     },

--- a/config/public-cloud-msft-int.json
+++ b/config/public-cloud-msft-int.json
@@ -70,7 +70,7 @@
     },
     "environment": "arohcpint",
     "image": {
-      "digest": "sha256:5830e8c95beba213e3f2aa885fd55171fdf601993966f1ac0a36784ba6eb5ba2",
+      "digest": "sha256:aac9226ea3c3712918a04b125e4ef765c8bc8e6968c0e3db05c6e662aa497282",
       "registry": "quay.io",
       "repository": "app-sre/uhc-clusters-service"
     },

--- a/config/public-cloud-msft-stg.json
+++ b/config/public-cloud-msft-stg.json
@@ -70,7 +70,7 @@
     },
     "environment": "arohcpstg",
     "image": {
-      "digest": "sha256:5830e8c95beba213e3f2aa885fd55171fdf601993966f1ac0a36784ba6eb5ba2",
+      "digest": "sha256:aac9226ea3c3712918a04b125e4ef765c8bc8e6968c0e3db05c6e662aa497282",
       "registry": "quay.io",
       "repository": "app-sre/uhc-clusters-service"
     },

--- a/config/public-cloud-ntly.json
+++ b/config/public-cloud-ntly.json
@@ -70,7 +70,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:5830e8c95beba213e3f2aa885fd55171fdf601993966f1ac0a36784ba6eb5ba2",
+      "digest": "sha256:aac9226ea3c3712918a04b125e4ef765c8bc8e6968c0e3db05c6e662aa497282",
       "registry": "quay.io",
       "repository": "app-sre/uhc-clusters-service"
     },

--- a/config/public-cloud-pers.json
+++ b/config/public-cloud-pers.json
@@ -70,7 +70,7 @@
     },
     "environment": "arohcpdev",
     "image": {
-      "digest": "sha256:5830e8c95beba213e3f2aa885fd55171fdf601993966f1ac0a36784ba6eb5ba2",
+      "digest": "sha256:aac9226ea3c3712918a04b125e4ef765c8bc8e6968c0e3db05c6e662aa497282",
       "registry": "quay.io",
       "repository": "app-sre/uhc-clusters-service"
     },


### PR DESCRIPTION
This PR rollout new image of cluster-service.

The image of Cluster Service support multiple roles for the managed identities.

The sha aac9226ea3c3712918a04b125e4ef765c8bc8e6968c0e3db05c6e662aa497282 corresponds to the image tag e8bb1a5 