### PR TITLE
[WIP] : POC - ACM policies required for consuming ingress TLS certificate on hosted cluster data plane

### DIFF
--- a/acm/deploy/helm/policies/templates/ingress-tls-secret.policy.yaml
+++ b/acm/deploy/helm/policies/templates/ingress-tls-secret.policy.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: ingress-tls-secret
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  disabled: false
+  remediationAction: enforce
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: ingress-tls-secret
+        spec:
+          evaluationInterval:
+            compliant: 10m
+            noncompliant: 10s
+          pruneObjectBehavior: DeleteIfCreated
+          remediationAction: enforce
+          object-templates:
+          - complianceType: MustHave
+            objectDefinition:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: '{{`{{hub .ManagedClusterName hub}}`}}'
+                namespace: openshift-ingress
+              data: '{{`{{hub copySecretData "open-cluster-management-policies" .ManagedClusterName hub}}`}}'
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: ingress-tls-secret
+  namespace: '{{ .Release.Namespace }}'
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+  name: all-hosted-clusters
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: ingress-tls-secret


### PR DESCRIPTION


<!-- Link to Jira issue -->
https://issues.redhat.com/browse/ARO-16545

### What
This PR showcases how acm policies can be utilised for consuming ingress TLS certificate on hosted cluster data plane.
This PR has two parts:

- ACM policy to mirror ingress TLS cert from acm policy namespace on management cluster to openshift-ingress namespace on data plane
- ACM policies to apply the needed Ingress Controller configuration to consume the ingress TLS certificate

### Special notes for your reviewer

<!-- optional -->
