### PR TITLE
tooling: add a command to only validate changed pipelines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,8 +207,11 @@ list:
 
 validate-config-pipelines:
 	$(MAKE) -C tooling/templatize templatize
-	tooling/templatize/templatize pipeline validate --topology-config-file topology.yaml --service-config-file config/config.yaml --dev-mode --dev-region $(shell yq '.environments[] | select(.name == "dev") | .defaults.region' <tooling/templatize/settings.yaml)
-	tooling/templatize/templatize pipeline validate --topology-config-file topology.yaml --service-config-file config/config.msft.yaml
+	tooling/templatize/templatize pipeline validate --topology-config-file topology.yaml --service-config-file config/config.yaml --dev-mode --dev-region $(shell yq '.environments[] | select(.name == "dev") | .defaults.region' <tooling/templatize/settings.yaml) $(ONLY_CHANGED)
+	tooling/templatize/templatize pipeline validate --topology-config-file topology.yaml --service-config-file config/config.msft.yaml $(DEV_MODE) $(ONLY_CHANGED)
+
+validate-changed-config-pipelines:
+	$(MAKE) validate-config-pipelines DEV_MODE="--dev-mode --dev-region uksouth" ONLY_CHANGED="--only-changed"
 
 validate-config:
 	$(MAKE) -C config/ validate


### PR DESCRIPTION
Instead of running the (kind of long) validation on every single pipline in every single possible region, we can do some git magic to try to deliver the minimal "did I break something?" button.
