### PR TITLE
Update VMSize of nodepool

### DIFF
--- a/cluster-service/cluster-creation.md
+++ b/cluster-service/cluster-creation.md
@@ -263,7 +263,7 @@ cat <<EOF > nodepool-test.json
     "auto_repair": false,
     "azure_node_pool": {
         "resource_name": "$NAME",
-        "vm_size": "Standard_D8s_v3",
+        "vm_size": "Standard_D2s_v3",
         "os_disk": {
             "size_gibibytes": 64,
             "storage_account_type": "StandardSSD_LRS",

--- a/cluster-service/deploy/templates/cloud-resource-constraints-config.configmap.yaml
+++ b/cluster-service/deploy/templates/cloud-resource-constraints-config.configmap.yaml
@@ -10,6 +10,12 @@ data:
     instance_types:
     # hand-crafted list to the ones mentioned in https://issues.redhat.com/browse/XCMSTRAT-1002
     # those are the instance types that are also enabled in ARO Classic
+    - id: Standard_D2s_v3
+      ccs_only: true
+      enabled: true
+    - id: Standard_D2ps_v6
+      ccs_only: true
+      enabled: true
     - id: Standard_D8s_v3
       ccs_only: true
       enabled: true

--- a/cluster-service/deploy/templates/cloud-resources-config.configmap.yaml
+++ b/cluster-service/deploy/templates/cloud-resources-config.configmap.yaml
@@ -9,6 +9,23 @@ data:
   instance-types.yaml: |
     instance_types:
     # DEMO INSTANCE TYPES
+    - id: Standard_D2s_v3
+      name: Standard_D2s_v3 - General purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      memory: 8589934592
+      category: general_purpose
+      size: d2s_v3
+      generic_name: standard-d2s_v3
+    - id: Standard_D2ps_v6
+      name: D2ps_v6 - General purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      memory: 8589934592
+      category: general_purpose
+      size: d2ps_v6
+      generic_name: standard-d2ps_v6
+      architecture: arm64
     - id: Standard_D8s_v3
       name: Standard_D8s_v3 - General purpose
       cloud_provider_id: azure

--- a/demo/bicep/nodepool.bicep
+++ b/demo/bicep/nodepool.bicep
@@ -19,7 +19,7 @@ resource nodepool 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools@2024
     }
     platform: {
       subnetId: hcp.properties.platform.subnetId
-      vmSize: 'Standard_D8s_v3'
+      vmSize: 'Standard_D2s_v3'
       osDisk: {
         sizeGiB: 64
         diskStorageAccountType: 'StandardSSD_LRS'

--- a/demo/node_pool.tmpl.json
+++ b/demo/node_pool.tmpl.json
@@ -7,7 +7,7 @@
     },
     "platform": {
       "subnetId": "/subscriptions/$sub/resourceGroups/$customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet/subnets/customer-subnet-1",
-      "vmSize": "Standard_D8s_v3",
+      "vmSize": "Standard_D2s_v3",
       "osDisk": {
         "sizeGiB": 64,
         "diskStorageAccountType": "StandardSSD_LRS"

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -440,7 +440,7 @@ func TestDeploymentPreflight(t *testing.T) {
 						"channelGroup": "stable",
 					},
 					"platform": map[string]any{
-						"vmSize": "Standard_D8s_v3",
+						"vmSize": "Standard_D2s_v3",
 					},
 				},
 			},

--- a/frontend/utils/create.go
+++ b/frontend/utils/create.go
@@ -115,7 +115,7 @@ func CreateNodePool() error {
 				// VMSize should match configs/cloud-resources/instance-types.yaml
 				// and configs/cloud-resource-constraints/instance-type-constraints.yaml
 				// in CS config files.
-				VMSize: "Standard_D8s_v3",
+				VMSize: "Standard_D2s_v3",
 			},
 			Replicas: 2,
 		},

--- a/internal/api/testhelpers.go
+++ b/internal/api/testhelpers.go
@@ -133,7 +133,7 @@ func ClusterTestCase(t *testing.T, tweaks *HCPOpenShiftCluster) *HCPOpenShiftClu
 func MinimumValidNodePoolTestCase() *HCPOpenShiftClusterNodePool {
 	resource := NewDefaultHCPOpenShiftClusterNodePool()
 	resource.Location = TestLocation
-	resource.Properties.Platform.VMSize = "Standard_D8s_v3"
+	resource.Properties.Platform.VMSize = "Standard_D2s_v3"
 	return resource
 }
 


### PR DESCRIPTION
[ARO-17958](https://issues.redhat.com/browse/ARO-17958)

### What

Reducing VM Size for ARO-HCP NodePools this would save costs and allow us to provision more of those resources hitting quota limits later.

Both `Standard_D2s_v3` (amd64) and `Standard_D2ps_v6` (arm64) have been tested and verified to ensure that all cluster operators run successfully on node pools created with these VM sizes.
