### PR TITLE
tooling: handle changed schemas during diff generation

### DIFF
--- a/tooling/pipeline-documentation/go.mod
+++ b/tooling/pipeline-documentation/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/pipeline-documentation
 go 1.24.1
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250617115920-94a190e812bc
+	github.com/Azure/ARO-Tools v0.0.0-20250617212610-9d1d61ad2832
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1

--- a/tooling/pipeline-documentation/go.sum
+++ b/tooling/pipeline-documentation/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250617115920-94a190e812bc h1:EodPeB6jm2GjXwQZUc+KVa+Oz/ialw7jOMIOH8tZAJc=
-github.com/Azure/ARO-Tools v0.0.0-20250617115920-94a190e812bc/go.mod h1:yAk9hvxTfwoU4XUyOtLA51kHzI4vvHqNfni6uQXfcVA=
+github.com/Azure/ARO-Tools v0.0.0-20250617212610-9d1d61ad2832 h1:uLsMVSZdoovzlJC0DWGlMlKWlYVWFBC71ORHQ3cUnKU=
+github.com/Azure/ARO-Tools v0.0.0-20250617212610-9d1d61ad2832/go.mod h1:yAk9hvxTfwoU4XUyOtLA51kHzI4vvHqNfni6uQXfcVA=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dusted-go/logging v1.3.0 h1:SL/EH1Rp27oJQIte+LjWvWACSnYDTqNx5gZULin0XRY=

--- a/tooling/templatize/go.mod
+++ b/tooling/templatize/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250617115920-94a190e812bc
+	github.com/Azure/ARO-Tools v0.0.0-20250617212610-9d1d61ad2832
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.2

--- a/tooling/templatize/go.sum
+++ b/tooling/templatize/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250617115920-94a190e812bc h1:EodPeB6jm2GjXwQZUc+KVa+Oz/ialw7jOMIOH8tZAJc=
-github.com/Azure/ARO-Tools v0.0.0-20250617115920-94a190e812bc/go.mod h1:yAk9hvxTfwoU4XUyOtLA51kHzI4vvHqNfni6uQXfcVA=
+github.com/Azure/ARO-Tools v0.0.0-20250617212610-9d1d61ad2832 h1:uLsMVSZdoovzlJC0DWGlMlKWlYVWFBC71ORHQ3cUnKU=
+github.com/Azure/ARO-Tools v0.0.0-20250617212610-9d1d61ad2832/go.mod h1:yAk9hvxTfwoU4XUyOtLA51kHzI4vvHqNfni6uQXfcVA=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0 h1:Gt0j3wceWMwPmiazCa8MzMA0MfhmPIz0Qp0FJ6qcM0U=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0/go.mod h1:Ot/6aikWnKWi4l9QB7qVSwa8iMphQNqkWALMoNT3rzM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1 h1:B+blDbyVIG3WaikNxPnhPiJ1MThR03b3vKGtER95TP4=


### PR DESCRIPTION
The following tooling has an issue when the config *and* the schema have changed - as we will check out the previous version of the config, but not the schema, so we will fail to render the previous region-scoped configuration as the previous RA service config does not pass the current schema. This commit makes sure to check out the JSON schema at the previous commit as well, to make sure we can render a diff.
