### PR TITLE
ARO-18010: add config for cincinnati version clients

### DIFF
--- a/cluster-service/deploy/templates/aro-hcp-ocp-versions-config.configmap.yaml
+++ b/cluster-service/deploy/templates/aro-hcp-ocp-versions-config.configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aro-hcp-ocp-versions-config
+  namespace: '{{ .Release.Namespace  }}'
+data:
+  aro-hcp-ocp-versions-config.yaml: |
+    defaultVersion:
+      channelGroupName: stable
+      version: 4.18.1
+    channelGroups:
+      # the URL to cincinnati will be the same across all environments, other URLs also need to be whitelisted
+      - url: https://api.openshift.com/api/upgrades_info/graph
+        channelGroupName: stable
+        # the versions must be in sync with what's defined in dev-infrastructure/templates/global-image-sync.bicep
+        # this is to ensure that the enabled release images are synchronized to ACR in lockstep
+        minVersion: 4.18.0
+        # maxVersion is exclusive, contrary to oc-mirror which defines that boundary as inclusive.
+        maxVersion: 4.18.10

--- a/cluster-service/deploy/templates/deployment.yaml
+++ b/cluster-service/deploy/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       annotations:
         checksum/db: '{{ include (print $.Template.BasePath "/database.secret.yaml") . | sha256sum  }}'
         checksum/operatorcfg: '{{ include (print $.Template.BasePath "/azure-operators-managed-identities-config.configmap.yaml") . | sha256sum  }}'
+        checksum/ocpversionscfg: '{{ include (print $.Template.BasePath "/aro-hcp-ocp-versions-config.configmap.yaml") . | sha256sum  }}'
         checksum/cskv: '{{ include (print $.Template.BasePath "/cs-keyvault.secret.yaml") . | sha256sum  }}'
         checksum/provisionshard: '{{ include (print $.Template.BasePath "/provisioning-shards.secret.yaml") . | sha256sum  }}'
         checksum/cs: '{{ include (print $.Template.BasePath "/clusters-service.secret.yaml") . | sha256sum  }}'
@@ -67,6 +68,9 @@ spec:
       - name: azure-operators-managed-identities-config
         configMap:
           name: azure-operators-managed-identities-config
+      - name: aro-hcp-ocp-versions-config
+        configMap:
+          name: aro-hcp-ocp-versions-config
       - name: mixin-pull-secret
         secret:
           secretName: hive-ci-global-pull-secret
@@ -141,6 +145,9 @@ spec:
         - name: azure-operators-managed-identities-config
           mountPath: /configs/azure-operators-managed-identities-config.yaml
           subPath: azure-operators-managed-identities-config.yaml
+        - name: aro-hcp-ocp-versions-config
+          mountPath: /configs/aro-hcp-ocp-versions-config.yaml
+          subPath: aro-hcp-ocp-versions-config.yaml
         command:
         - /usr/local/bin/clusters-service
         - serve
@@ -187,6 +194,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
         - --azure-runtime-config-path=/configs/azure-runtime-config/config.json
         - --azure-operators-managed-identities-config-path=/configs/azure-operators-managed-identities-config.yaml
+        - --aro-hcp-ocp-versions-config-path=/configs/aro-hcp-ocp-versions-config.yaml
         {{- if and .Values.azureMiMockServicePrincipalCertName .Values.azureMiMockServicePrincipalClientId .Values.azureMiMockServicePrincipalPrincipalId }}
         - --azure-mi-mock-service-principal-certificate-bundle-path=/secrets/keyvault/mockMiServicePrincipalCertificateBundle
         - --azure-mi-mock-service-principal-client-id={{ .Values.azureMiMockServicePrincipalClientId }}


### PR DESCRIPTION
(Drafting, as this requires the flag to be introduced in CS first) 

[<!-- Link to Jira issue -->](https://issues.redhat.com/browse/ARO-18010

### What

This adds the configuration required to run the cincinnati version client in clusters service.

### Why

This is needed to have a version controlled and more configurable way of defining what versions should be imported from Cincinnati into the CS database.


