### PR TITLE
Move alerting resources to separate pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,10 @@ infra.mgmt.aks.kubeconfigfile:
 	@cd dev-infrastructure && DEPLOY_ENV=$(DEPLOY_ENV) make -s mgmt.aks.kubeconfigfile
 .PHONY: infra.mgmt.aks.kubeconfigfile
 
+infra.monitoring:
+	@cd dev-infrastructure && DEPLOY_ENV=$(DEPLOY_ENV) make monitoring
+.PHONY: infra.monitoring
+
 infra.all:
 	@cd dev-infrastructure && DEPLOY_ENV=$(DEPLOY_ENV) make infra
 .PHONY: infra.all

--- a/dev-infrastructure/.gitignore
+++ b/dev-infrastructure/.gitignore
@@ -1,24 +1,3 @@
-configurations/mgmt-cluster.bicepparam
-configurations/mgmt-infra.bicepparam
-configurations/mgmt-nsp.bicepparam
-configurations/svc-cluster.bicepparam
-configurations/svc-infra.bicepparam
-configurations/region.bicepparam
-configurations/metrics.bicepparam
-configurations/acr-svc.bicepparam
-configurations/acr-ocp.bicepparam
-configurations/image-sync.bicepparam
-configurations/dev-role-assignments.bicepparam
-configurations/cs-integ-msi.bicepparam
-configurations/output-region.bicepparam
-configurations/output-global.bicepparam
-configurations/output-svc.bicepparam
-configurations/mock-identities.bicepparam
-configurations/global-acr.bicepparam
-configurations/global-infra.bicepparam
-configurations/global-image-sync.bicepparam
-configurations/output-global.bicepparam
-configurations/output-svc.bicepparam
 config.mk
 
 istio-*

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -287,6 +287,18 @@ mgmt.solo:
 	../templatize.sh $(DEPLOY_ENV) -p mgmt-solo-pipeline.yaml -P run -c $(CLOUD)
 .PHONY: mgmt.solo
 
+#
+# Monitoring
+#
+
+monitoring:
+	../templatize.sh $(DEPLOY_ENV) -p monitoring-pipeline.yaml -P run -c $(CLOUD)
+.PHONY: monitoring
+
+monitoring.what-if:
+	../templatize.sh $(DEPLOY_ENV) -p monitoring-pipeline.yaml -P run -c $(CLOUD) -d
+.PHONY: monitoring.what-if
+
 # ACR DEV customizations
 
 acr: acr-svc-cfg acr-ocp-cfg
@@ -397,10 +409,10 @@ operator-roles.what-if:
 # Common
 #
 
-what-if: global.what-if acr.what-if region.what-if svc.what-if mgmt.what-if operator-roles.what-if automation-account.what-if
+what-if: global.what-if acr.what-if region.what-if svc.what-if mgmt.what-if monitoring.what-if operator-roles.what-if automation-account.what-if
 .PHONY: what-if
 
-infra: region svc.init mgmt.init
+infra: region svc.init mgmt.init monitoring
 .PHONY: infra
 
 clean: svc.clean mgmt.clean region.clean

--- a/dev-infrastructure/configurations/.gitignore
+++ b/dev-infrastructure/configurations/.gitignore
@@ -1,2 +1,2 @@
-mock-identities.bicepparam
-svc-infra.bicepparam
+*.bicepparam
+!*.tmpl.bicepparam

--- a/dev-infrastructure/configurations/monitoring.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/monitoring.tmpl.bicepparam
@@ -1,0 +1,10 @@
+using '../templates/monitoring.bicep'
+
+param azureMonitoringWorkspaceId = '__azureMonitoringWorkspaceId__'
+param hcpAzureMonitoringWorkspaceId = '__hcpAzureMonitoringWorkspaceId__'
+
+param devAlertingEmails = '{{ .monitoring.devAlertingEmails }}'
+param sev1ActionGroupIDs = '{{ .monitoring.sev1ActionGroupIDs }}'
+param sev2ActionGroupIDs = '{{ .monitoring.sev2ActionGroupIDs }}'
+param sev3ActionGroupIDs = '{{ .monitoring.sev3ActionGroupIDs }}'
+param sev4ActionGroupIDs = '{{ .monitoring.sev4ActionGroupIDs }}'

--- a/dev-infrastructure/configurations/region.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/region.tmpl.bicepparam
@@ -25,13 +25,7 @@ param aroDevopsMsiId = '{{ .aroDevopsMsiId }}'
 // Log Analytics
 param enableLogAnalytics = {{ .logs.loganalytics.enable }}
 
-// Metrics
+// Monitoring
 param svcMonitorName = '{{ .monitoring.svcWorkspaceName }}'
 param hcpMonitorName = '{{ .monitoring.hcpWorkspaceName }}'
 param grafanaResourceId = '__grafanaResourceId__'
-
-param devAlertingEmails = '{{ .monitoring.devAlertingEmails }}'
-param sev1ActionGroupIDs = '{{ .monitoring.sev1ActionGroupIDs }}'
-param sev2ActionGroupIDs = '{{ .monitoring.sev2ActionGroupIDs }}'
-param sev3ActionGroupIDs = '{{ .monitoring.sev3ActionGroupIDs }}'
-param sev4ActionGroupIDs = '{{ .monitoring.sev4ActionGroupIDs }}'

--- a/dev-infrastructure/monitoring-pipeline.yaml
+++ b/dev-infrastructure/monitoring-pipeline.yaml
@@ -1,0 +1,36 @@
+#
+# Purpose: Manage monitoring resources for ARO HCP shared by SC and MC
+# Managed Resources:
+# * Azure Monitor Metrics resources for services
+# * Azure Monitor Metrics resources for hosted control planes
+# * Action Groups & Prometheus alerting rules
+#
+$schema: "pipeline.schema.v1"
+serviceGroup: Microsoft.Azure.ARO.HCP.Monitoring
+rolloutName: Monitoring Rollout
+resourceGroups:
+- name: '{{ .regionRG  }}'
+  subscription: '{{ .svc.subscription  }}'
+  steps:
+  - name: region-output
+    action: ARM
+    template: templates/output-region.bicep
+    parameters: configurations/output-region.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
+  - name: monitoring
+    action: ARM
+    template: templates/monitoring.bicep
+    parameters: configurations/monitoring.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    variables:
+    - name: azureMonitoringWorkspaceId
+      input:
+        step: region-output
+        name: azureMonitoringWorkspaceId
+    - name: hcpAzureMonitoringWorkspaceId
+      input:
+        step: region-output
+        name: hcpAzureMonitoringWorkspaceId
+    dependsOn:
+    - region-output

--- a/dev-infrastructure/templates/monitoring.bicep
+++ b/dev-infrastructure/templates/monitoring.bicep
@@ -1,0 +1,53 @@
+@description('ID of the Azure Monitor Workspace for services')
+param azureMonitoringWorkspaceId string
+
+@description('ID of the Azure Monitor Workspace for hosted control planes')
+param hcpAzureMonitoringWorkspaceId string
+
+@description('List of emails for Dev Alerting')
+param devAlertingEmails string
+
+@description('Comma seperated list of action groups for Sev 1 alerts.')
+param sev1ActionGroupIDs string
+
+@description('Comma seperated list of action groups for Sev 2 alerts.')
+param sev2ActionGroupIDs string
+
+@description('Comma seperated list of action groups for Sev 3 alerts.')
+param sev3ActionGroupIDs string
+
+@description('Comma seperated list of action groups for Sev 4 alerts.')
+param sev4ActionGroupIDs string
+
+module actionGroups '../modules/metrics/actiongroups.bicep' = {
+  name: 'actionGroups'
+  params: {
+    devAlertingEmails: devAlertingEmails
+    sev1ActionGroupIDs: sev1ActionGroupIDs
+    sev2ActionGroupIDs: sev2ActionGroupIDs
+    sev3ActionGroupIDs: sev3ActionGroupIDs
+    sev4ActionGroupIDs: sev4ActionGroupIDs
+  }
+}
+
+module serviceAlerts '../modules/metrics/service-rules.bicep' = {
+  name: 'serviceAlerts'
+  params: {
+    azureMonitoringWorkspaceId: azureMonitoringWorkspaceId
+    allSev1ActionGroups: actionGroups.outputs.allSev1ActionGroups
+    allSev2ActionGroups: actionGroups.outputs.allSev2ActionGroups
+    allSev3ActionGroups: actionGroups.outputs.allSev3ActionGroups
+    allSev4ActionGroups: actionGroups.outputs.allSev4ActionGroups
+  }
+}
+
+module hcpAlerts '../modules/metrics/hcp-rules.bicep' = {
+  name: 'hcpAlerts'
+  params: {
+    azureMonitoringWorkspaceId: hcpAzureMonitoringWorkspaceId
+    allSev1ActionGroups: actionGroups.outputs.allSev1ActionGroups
+    allSev2ActionGroups: actionGroups.outputs.allSev2ActionGroups
+    allSev3ActionGroups: actionGroups.outputs.allSev3ActionGroups
+    allSev4ActionGroups: actionGroups.outputs.allSev4ActionGroups
+  }
+}

--- a/dev-infrastructure/templates/region.bicep
+++ b/dev-infrastructure/templates/region.bicep
@@ -54,21 +54,6 @@ param svcMonitorName string
 @description('Name of the Azure Monitor Workspace for hosted control planes')
 param hcpMonitorName string
 
-@description('List of emails for Dev Alerting')
-param devAlertingEmails string
-
-@description('Comma seperated list of action groups for Sev 1 alerts.')
-param sev1ActionGroupIDs string
-
-@description('Comma seperated list of action groups for Sev 2 alerts.')
-param sev2ActionGroupIDs string
-
-@description('Comma seperated list of action groups for Sev 3 alerts.')
-param sev3ActionGroupIDs string
-
-@description('Comma seperated list of action groups for Sev 4 alerts.')
-param sev4ActionGroupIDs string
-
 import * as res from '../modules/resource.bicep'
 
 // Tags the resource group
@@ -200,12 +185,11 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09
     retentionInDays: 90
   }
 }
-
 //
 //   M O N I T O R I N G
 //
 
-module svcMonitoring '../modules/metrics/monitor.bicep' = {
+module svcMonitor '../modules/metrics/monitor.bicep' = {
   name: 'svc-monitor'
   params: {
     grafanaResourceId: grafanaResourceId
@@ -213,43 +197,10 @@ module svcMonitoring '../modules/metrics/monitor.bicep' = {
   }
 }
 
-module hcpMonitoring '../modules/metrics/monitor.bicep' = {
+module hcpMonitor '../modules/metrics/monitor.bicep' = {
   name: 'hcp-monitor'
   params: {
     grafanaResourceId: grafanaResourceId
     monitorName: hcpMonitorName
-  }
-}
-
-module actionGroups '../modules/metrics/actiongroups.bicep' = {
-  name: 'actionGroups'
-  params: {
-    devAlertingEmails: devAlertingEmails
-    sev1ActionGroupIDs: sev1ActionGroupIDs
-    sev2ActionGroupIDs: sev2ActionGroupIDs
-    sev3ActionGroupIDs: sev3ActionGroupIDs
-    sev4ActionGroupIDs: sev4ActionGroupIDs
-  }
-}
-
-module serviceAlerts '../modules/metrics/service-rules.bicep' = {
-  name: 'serviceAlerts'
-  params: {
-    azureMonitoringWorkspaceId: svcMonitoring.outputs.monitorId
-    allSev1ActionGroups: actionGroups.outputs.allSev1ActionGroups
-    allSev2ActionGroups: actionGroups.outputs.allSev2ActionGroups
-    allSev3ActionGroups: actionGroups.outputs.allSev3ActionGroups
-    allSev4ActionGroups: actionGroups.outputs.allSev4ActionGroups
-  }
-}
-
-module hcpAlerts '../modules/metrics/hcp-rules.bicep' = {
-  name: 'hcpAlerts'
-  params: {
-    azureMonitoringWorkspaceId: svcMonitoring.outputs.monitorId
-    allSev1ActionGroups: actionGroups.outputs.allSev1ActionGroups
-    allSev2ActionGroups: actionGroups.outputs.allSev2ActionGroups
-    allSev3ActionGroups: actionGroups.outputs.allSev3ActionGroups
-    allSev4ActionGroups: actionGroups.outputs.allSev4ActionGroups
   }
 }

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -15,3 +15,4 @@ The tree of pipelines making up the ARO HCP service are documented here from the
       - Microsoft.Azure.ARO.HCP.RP.HypershiftOperator ([ref](https://github.com/Azure/ARO-HCP/tree/main/hypershiftoperator/pipeline.yaml)): Deploy the HyperShift operator.
       - Microsoft.Azure.ARO.HCP.PKO ([ref](https://github.com/Azure/ARO-HCP/tree/main/pko/pipeline.yaml)): Deploy the Package Operator.
       - Microsoft.Azure.ARO.HCP.Maestro.Agent ([ref](https://github.com/Azure/ARO-HCP/tree/main/maestro/agent/pipeline.yaml)): Deploy the Maestro Agent and register it with the MQTT stream.
+    - Microsoft.Azure.ARO.HCP.Monitoring ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/monitoring-pipeline.yaml)): Deploy the Monitoring resources

--- a/topology.yaml
+++ b/topology.yaml
@@ -52,6 +52,9 @@ services:
         purpose: Deploy the Maestro Agent and register it with the MQTT stream.
       pipelinePath: dev-infrastructure/mgmt-pipeline.yaml
       purpose: Deploy a management cluster and backing infrastructure.
+    - serviceGroup: Microsoft.Azure.ARO.HCP.Monitoring
+      pipelinePath: dev-infrastructure/monitoring-pipeline.yaml
+      purpose: Deploy the Monitoring resources
     pipelinePath: dev-infrastructure/region-pipeline.yaml
     purpose: Deploy regional shared infrastructure.
   pipelinePath: dev-infrastructure/global-pipeline.yaml


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-18108

### What

- Create pipeline `Microsoft.Azure.ARO.HCP.Monitoring` 
- Move action groups and alerts to Monitoring pipeline
- Small cleanup of gitignore for bicepparam template files

The new pipeline take about 1m30s to complete (local dev) which will greatly improve the iteration time on alerts

### Why

We want to enable quick turnaround time on alerting changes

### Special notes for your reviewer

<!-- optional -->
