### PR TITLE
generated prometheus rules bicep files should ignore unused params

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -1,9 +1,14 @@
+#disable-next-line no-unused-params
 param azureMonitoring string
 
+#disable-next-line no-unused-params
 param allSev1ActionGroups array
 
+#disable-next-line no-unused-params
 param allSev2ActionGroups array
 
+#disable-next-line no-unused-params
 param allSev3ActionGroups array
 
+#disable-next-line no-unused-params
 param allSev4ActionGroups array

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1,11 +1,16 @@
+#disable-next-line no-unused-params
 param azureMonitoring string
 
+#disable-next-line no-unused-params
 param allSev1ActionGroups array
 
+#disable-next-line no-unused-params
 param allSev2ActionGroups array
 
+#disable-next-line no-unused-params
 param allSev3ActionGroups array
 
+#disable-next-line no-unused-params
 param allSev4ActionGroups array
 
 resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -216,14 +216,19 @@ func (o *Options) Generate() error {
 		}
 	}()
 
-	if _, err := output.Write([]byte(`param azureMonitoring string
+	if _, err := output.Write([]byte(`#disable-next-line no-unused-params
+param azureMonitoring string
 
+#disable-next-line no-unused-params
 param allSev1ActionGroups array
 
+#disable-next-line no-unused-params
 param allSev2ActionGroups array
 
+#disable-next-line no-unused-params
 param allSev3ActionGroups array
 
+#disable-next-line no-unused-params
 param allSev4ActionGroups array
 `)); err != nil {
 		return err

--- a/tooling/prometheus-rules/testdata/generated.bicep
+++ b/tooling/prometheus-rules/testdata/generated.bicep
@@ -1,11 +1,16 @@
+#disable-next-line no-unused-params
 param azureMonitoring string
 
+#disable-next-line no-unused-params
 param allSev1ActionGroups array
 
+#disable-next-line no-unused-params
 param allSev2ActionGroups array
 
+#disable-next-line no-unused-params
 param allSev3ActionGroups array
 
+#disable-next-line no-unused-params
 param allSev4ActionGroups array
 
 resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {


### PR DESCRIPTION
### What

At present the generated bicep files contain parameters that sometimes are unused. This causes warnings in the bicep linter checks which we want to eliminate.

Another approach would be to only write the param to the file if a given severity is present, but in my estimation the extra code and complexity is not worth it and disabling the linter checks is a very valid option for generated files

### Why

We want to get rid of bicep linter warnings

### Special notes for your reviewer

<!-- optional -->
