### PR TITLE
tooling/templatize: handle detached HEAD for upstream

### DIFF
--- a/tooling/templatize/cmd/configuration/validate/options.go
+++ b/tooling/templatize/cmd/configuration/validate/options.go
@@ -452,7 +452,9 @@ func renderDiff(
 
 		// check to see if the branch has an upstream set, if so, prefer this
 		upstream, err := command(ctx, dir, "git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
-		if err != nil && !strings.Contains(err.Error(), "fatal: no upstream configured for branch") {
+		if err != nil &&
+			!strings.Contains(err.Error(), "fatal: no upstream configured for branch") &&
+			!strings.Contains(err.Error(), "fatal: HEAD does not point to a branch") {
 			return fmt.Errorf("failed to resolve upstream: %w", err)
 		}
 		upstreamRef = strings.TrimSpace(upstream)


### PR DESCRIPTION
When we're running on a detached HEAD we can still find a merge-base, we just can't determine the upstream for the branch since we're not on a branch.
