### PR TITLE
api: Make networkSecurityGroupId optional again

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -220,7 +220,7 @@ model PlatformProfile {
   outboundType?: OutboundType = OutboundType.loadBalancer;
 
   /** ResourceId for the network security group attached to the cluster subnet */
-  networkSecurityGroupId: NetworkSecurityGroupResourceId;
+  networkSecurityGroupId?: NetworkSecurityGroupResourceId;
 
   /** The configuration that the operators of the cluster have to authenticate to Azure */
   operatorsAuthentication: OperatorsAuthenticationProfile;

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1698,7 +1698,6 @@
       },
       "required": [
         "subnetId",
-        "networkSecurityGroupId",
         "operatorsAuthentication",
         "issuerUrl"
       ]

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -418,12 +418,12 @@ func TestDeploymentPreflight(t *testing.T) {
 						"visibility": "invisible",
 					},
 					"platform": map[string]any{
-						// 2 missing required fields
+						// 1 missing required fields
 					},
 				},
 			},
 			expectStatus: arm.DeploymentPreflightStatusFailed,
-			expectErrors: 4,
+			expectErrors: 3,
 		},
 		{
 			name: "Well-formed node pool resource returns no error",

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -86,7 +86,7 @@ type PlatformProfile struct {
 	ManagedResourceGroup    string                         `json:"managedResourceGroup,omitempty"`
 	SubnetID                string                         `json:"subnetId,omitempty"                                  validate:"required_for_put,resource_id=Microsoft.Network/virtualNetworks/subnets"`
 	OutboundType            OutboundType                   `json:"outboundType,omitempty"                              validate:"omitempty,enum_outboundtype"`
-	NetworkSecurityGroupID  string                         `json:"networkSecurityGroupId,omitempty"                    validate:"required_for_put,resource_id=Microsoft.Network/networkSecurityGroups"`
+	NetworkSecurityGroupID  string                         `json:"networkSecurityGroupId,omitempty"                    validate:"omitempty,resource_id=Microsoft.Network/networkSecurityGroups"`
 	OperatorsAuthentication OperatorsAuthenticationProfile `json:"operatorsAuthentication,omitempty"`
 	IssuerURL               string                         `json:"issuerUrl,omitempty"               visibility:"read"`
 }

--- a/internal/api/hcpopenshiftcluster_test.go
+++ b/internal/api/hcpopenshiftcluster_test.go
@@ -72,10 +72,6 @@ func TestClusterRequiredForPut(t *testing.T) {
 					Message: "Missing required field 'subnetId'",
 					Target:  "properties.platform.subnetId",
 				},
-				{
-					Message: "Missing required field 'networkSecurityGroupId'",
-					Target:  "properties.platform.networkSecurityGroupId",
-				},
 			},
 		},
 		{

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -467,9 +467,6 @@ type OperatorsAuthenticationProfile struct {
 
 // PlatformProfile - Azure specific configuration
 type PlatformProfile struct {
-	// REQUIRED; ResourceId for the network security group attached to the cluster subnet
-	NetworkSecurityGroupID *string
-
 	// REQUIRED; The configuration that the operators of the cluster have to authenticate to Azure
 	OperatorsAuthentication *OperatorsAuthenticationProfile
 
@@ -478,6 +475,9 @@ type PlatformProfile struct {
 
 	// Resource group to put cluster resources
 	ManagedResourceGroup *string
+
+	// ResourceId for the network security group attached to the cluster subnet
+	NetworkSecurityGroupID *string
 
 	// The core outgoing configuration
 	OutboundType *OutboundType


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-17688

### What

Note, this is both an ARM API change and a frontend change.

It basically just reverts https://github.com/Azure/ARO-HCP/commit/2384b7abc841fa9740b55a98c8cf4cbe69edcba5.

### Why

We're charging ahead with ARM APIs before all the features are ready.  YOLO!

### Special notes for your reviewer

<!-- optional -->
