### PR TITLE
Allow controlplaneoperator/dataplaneoperator/service identities to be replaced in the API spec

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -268,19 +268,19 @@ model UserAssignedIdentitiesProfile {
    * operators of the cluster. The set of required managed identities is dependent on the
    * Cluster's OpenShift version. */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "operator name to user assigned identity pairings"
-  @visibility(Lifecycle.Read, Lifecycle.Create)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   controlPlaneOperators: Record<UserAssignedIdentityResourceId>;
 
   /** The set of Azure User-Assigned Managed Identities leveraged for the Data Plane
    * operators of the cluster. The set of required managed identities is dependent on the
    * Cluster's OpenShift version. */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "operator name to user assigned identity pairings"
-  @visibility(Lifecycle.Read, Lifecycle.Create)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   dataPlaneOperators: Record<UserAssignedIdentityResourceId>;
 
   /** Represents the information associated to an Azure User-Assigned Managed Identity whose
    * purpose is to perform service level actions. */
-  @visibility(Lifecycle.Read, Lifecycle.Create)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   serviceManagedIdentity: UserAssignedIdentityResourceId;
 }
 

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1804,6 +1804,7 @@
           },
           "x-ms-mutability": [
             "read",
+            "update",
             "create"
           ]
         },
@@ -1815,6 +1816,7 @@
           },
           "x-ms-mutability": [
             "read",
+            "update",
             "create"
           ]
         },
@@ -1823,6 +1825,7 @@
           "description": "Represents the information associated to an Azure User-Assigned Managed Identity whose\npurpose is to perform service level actions.",
           "x-ms-mutability": [
             "read",
+            "update",
             "create"
           ]
         }


### PR DESCRIPTION
[ARO-17682](https://issues.redhat.com/browse/ARO-17682)

### What

Sets visibility of the `.properties.platform.operatorsAuthentication` fields `controlPlaneOperators`, `dataPlaneOperators`, and `serviceManagedIdentity` to include `Lifecycle.Update`, allowing these properties to be updated on `PUT` and `PATCH` requests. 

### Why

If a customer desires the ability to replace existing identities in-use on the cluster, or add new ones (e.g. OpenShift adds a new identity requirement), they will need to be able to update or add their reference to the cluster resource. 

Note that downstream systems will still need to implement support for this scenario. 

### Special notes for your reviewer

<!-- optional -->
