### PR TITLE
make RP image digests explicit in dev config

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -38,8 +38,11 @@ push: image
 	docker push ${ARO_HCP_BACKEND_IMAGE}:${CURRENT_COMMIT}
 .PHONY: push
 
+deploy.current: push
+	@$(MAKE) deploy IMAGE_DIGEST=$(shell ../get-digest.sh ${ARO_HCP_IMAGE_ACR} ${ARO_HCP_IMAGE_REPOSITORY} ${CURRENT_COMMIT})
+.PHONY: deploy.current
+
 deploy:
-	DIGEST=$$(../get-digest.sh ${ARO_HCP_IMAGE_ACR} arohcpbackend) \
 	BACKEND_MI_CLIENT_ID=$$(az identity show \
 			-g ${RESOURCEGROUP} \
 			-n backend \
@@ -53,11 +56,11 @@ deploy:
 		--set configMap.databaseUrl="$${DB_URL}" \
 		--set configMap.backendMiClientId="$${BACKEND_MI_CLIENT_ID}" \
 		--set serviceAccount.workloadIdentityClientId="$${BACKEND_MI_CLIENT_ID}" \
-		--set configMap.currentVersion=${ARO_HCP_BACKEND_IMAGE}@$${DIGEST} \
+		--set configMap.currentVersion=${ARO_HCP_BACKEND_IMAGE}@${IMAGE_DIGEST} \
 		--set configMap.location=${LOCATION} \
 		--set clustersService.namespace=${CS_NAMESPACE} \
 		--set clustersService.serviceAccount=${CS_SERVICE_ACCOUNT_NAME} \
-		--set deployment.imageName=${ARO_HCP_BACKEND_IMAGE}@$${DIGEST} \
+		--set deployment.imageName=${ARO_HCP_BACKEND_IMAGE}@${IMAGE_DIGEST} \
 		--set tracing.address=${TRACING_ADDRESS} \
 		--set tracing.exporter=${TRACING_EXPORTER} \
 		--namespace aro-hcp

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -476,11 +476,11 @@ clouds:
         cert:
           issuer: Self
         image:
-          digest: '' # if empty uses commit sha of repo
+          digest: sha256:c17e8ad764e73a56812097c0dd70ed5a6f1b60fa28251dbfb5203ae08dc61228
       # Backend
       backend:
         image:
-          digest: '' # if empty uses commit sha of repo
+          digest: sha256:1faed23b9b2234ca6081f21aec3cdee374542a096996a143f85efb5b21eae925
       # Image Sync
       imageSync:
         ocMirror:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,16 +3,16 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 79255bfc1c3310cfabcef3fb18507f885b97f05f11d7edc5b2b7ddacfdf500c7
+          westus3: 0037ac8e27290b9af526bb527a55b3f81112e982f055dbc26fd530f0264d9af4
       dev:
         regions:
-          westus3: 147334f15efddc0474344511c2861ebd67a71e5fa31bb8aa5aa8f4b054103997
+          westus3: ddbf6d6bfcc39e7e9de8395e0135a05f3eb019ad2d5e0faac4b01bee3ef33a5c
       ntly:
         regions:
-          uksouth: bf949553557cca9ae80a41c1b7a6d7df1929c8111752d4f06b4ae061b6b66242
+          uksouth: f2a8708990bec43ee8107ed49d2bd677f0690fc833a44542b38f050330e72b6d
       perf:
         regions:
-          westus3: e579595a931fa507f5285365827ebc8d42aa02d77a1d170201580c6c9bda9079
+          westus3: 1c003d04b0befa0923a048827364174270c32f52faf4a321da05696d71b3da64
       pers:
         regions:
-          westus3: dfcfe17ff667de6efd4cc014522ee70601a829200e7876d975b3f88c81ba2d65
+          westus3: c6c7b046da336fa441a19d4f8f38cff2f13e91a0c9f00b7472e90cf1c9454700

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -16,7 +16,7 @@ armHelperFPAPrincipalId: 47f69502-0065-4d9a-b19b-d403e183d2f4
 aroDevopsMsiId: /subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-rollout-identity
 backend:
   image:
-    digest: ""
+    digest: sha256:1faed23b9b2234ca6081f21aec3cdee374542a096996a143f85efb5b21eae925
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpbackend
   tracing:
@@ -97,7 +97,7 @@ frontend:
     private: false
     zoneRedundantMode: Disabled
   image:
-    digest: ""
+    digest: sha256:c17e8ad764e73a56812097c0dd70ed5a6f1b60fa28251dbfb5203ae08dc61228
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   tracing:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -16,7 +16,7 @@ armHelperFPAPrincipalId: 47f69502-0065-4d9a-b19b-d403e183d2f4
 aroDevopsMsiId: /subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-rollout-identity
 backend:
   image:
-    digest: ""
+    digest: sha256:1faed23b9b2234ca6081f21aec3cdee374542a096996a143f85efb5b21eae925
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpbackend
   tracing:
@@ -97,7 +97,7 @@ frontend:
     private: false
     zoneRedundantMode: Disabled
   image:
-    digest: ""
+    digest: sha256:c17e8ad764e73a56812097c0dd70ed5a6f1b60fa28251dbfb5203ae08dc61228
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   tracing:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -16,7 +16,7 @@ armHelperFPAPrincipalId: 47f69502-0065-4d9a-b19b-d403e183d2f4
 aroDevopsMsiId: /subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-rollout-identity
 backend:
   image:
-    digest: ""
+    digest: sha256:1faed23b9b2234ca6081f21aec3cdee374542a096996a143f85efb5b21eae925
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpbackend
   tracing:
@@ -97,7 +97,7 @@ frontend:
     private: false
     zoneRedundantMode: Disabled
   image:
-    digest: ""
+    digest: sha256:c17e8ad764e73a56812097c0dd70ed5a6f1b60fa28251dbfb5203ae08dc61228
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   tracing:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -16,7 +16,7 @@ armHelperFPAPrincipalId: 47f69502-0065-4d9a-b19b-d403e183d2f4
 aroDevopsMsiId: /subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-rollout-identity
 backend:
   image:
-    digest: ""
+    digest: sha256:1faed23b9b2234ca6081f21aec3cdee374542a096996a143f85efb5b21eae925
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpbackend
   tracing:
@@ -97,7 +97,7 @@ frontend:
     private: true
     zoneRedundantMode: Auto
   image:
-    digest: ""
+    digest: sha256:c17e8ad764e73a56812097c0dd70ed5a6f1b60fa28251dbfb5203ae08dc61228
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   tracing:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -16,7 +16,7 @@ armHelperFPAPrincipalId: 47f69502-0065-4d9a-b19b-d403e183d2f4
 aroDevopsMsiId: /subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-rollout-identity
 backend:
   image:
-    digest: ""
+    digest: sha256:1faed23b9b2234ca6081f21aec3cdee374542a096996a143f85efb5b21eae925
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpbackend
   tracing:
@@ -97,7 +97,7 @@ frontend:
     private: false
     zoneRedundantMode: Disabled
   image:
-    digest: ""
+    digest: sha256:c17e8ad764e73a56812097c0dd70ed5a6f1b60fa28251dbfb5203ae08dc61228
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   tracing:

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -41,8 +41,11 @@ push: image
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
 	docker push ${ARO_HCP_FRONTEND_IMAGE}:${CURRENT_COMMIT}
 
+deploy.current: push
+	@$(MAKE) deploy IMAGE_DIGEST=$(shell ../get-digest.sh ${ARO_HCP_IMAGE_ACR} ${ARO_HCP_IMAGE_REPOSITORY} ${CURRENT_COMMIT})
+.PHONY: deploy.current
+
 deploy:
-	DIGEST=$$(../get-digest.sh ${ARO_HCP_IMAGE_ACR} arohcpfrontend) \
 	FRONTEND_MI_CLIENT_ID=$$(az identity show \
 			-g ${RESOURCEGROUP} \
 			-n frontend \
@@ -81,9 +84,9 @@ deploy:
 		--set serviceAccount.workloadIdentityTenantId="$${FRONTEND_MI_TENANT_ID}" \
 		--set pullBinding.workloadIdentityClientId="$${IMAGE_PULLER_MI_CLIENT_ID}" \
 		--set pullBinding.workloadIdentityTenantId="$${IMAGE_PULLER_MI_TENANT_ID}" \
-		--set configMap.currentVersion=${ARO_HCP_FRONTEND_IMAGE}@$${DIGEST} \
+		--set configMap.currentVersion=${ARO_HCP_FRONTEND_IMAGE}@${IMAGE_DIGEST} \
 		--set configMap.location=${LOCATION}  \
-		--set deployment.imageName=${ARO_HCP_FRONTEND_IMAGE}@$${DIGEST} \
+		--set deployment.imageName=${ARO_HCP_FRONTEND_IMAGE}@${IMAGE_DIGEST} \
 		--set pullBinding.registry=${ARO_HCP_IMAGE_REGISTRY} \
 		--set pullBinding.scope=repository:${ARO_HCP_IMAGE_REPOSITORY}:pull \
 		--set clustersService.namespace=${CS_NAMESPACE} \

--- a/get-digest.sh
+++ b/get-digest.sh
@@ -1,38 +1,25 @@
 #!/bin/bash
 
-if [ "$#" -ne 2 ]
+if [ "$#" -ne 3 ]
 then
-    echo "Need ARO_HCP_IMAGE_ACR and REPOSITORY parameters"
+    echo "Usage: $0 <ARO_HCP_IMAGE_ACR> <REPOSITORY> <TAG>"
     exit 1
 fi
 
 aro_hcp_image_acr=${1}
 repository=${2}
+tag=${3}
 
-if [ -n "${IMAGE_DIGEST_OVERRIDE}" ];
+tags=$(az acr repository show-tags --orderby time_desc --n "${aro_hcp_image_acr}" --repository "${repository}" --detail)
+
+# find the digest for the specified tag
+suggested_digest=$(jq -r --arg TAG "${tag}" \
+    'first(.[] | select(.name==$TAG) | .digest)' <<< "${tags}")
+if [ -n "${suggested_digest}" ] && [ "${suggested_digest}" != "null" ];
 then
-    echo ${IMAGE_DIGEST_OVERRIDE}
+    echo "${suggested_digest}"
     exit 0
 fi
 
-if [ -n "${IMAGE_DIGEST}" ];
-then
-    echo ${IMAGE_DIGEST}
-    exit 0
-fi
-
-
-tags=$(mktemp)
-trap "rm ${tags}" EXIT
-
-az acr repository show-tags --orderby time_desc --n ${aro_hcp_image_acr} --repository ${repository} --detail > $tags
-
-suggested_digest=$(jq -r --arg TAG $(git rev-parse --short=7 HEAD) \
-    'first(.[] | select(.name==$TAG) | .digest)' $tags)
-if [ -n "${suggested_digest}" ];
-then
-    echo ${suggested_digest}
-    exit 0
-fi
-
-jq -r 'first(.[] | .digest)' $tags
+# if there is no digest for the specified tag, return the first digest from the list of non-dirty tags
+jq -r 'first(.[] | select(.name | endswith("-dirty") | not) | .digest)' <<< "${tags}"


### PR DESCRIPTION
### What

in dev environments, the rp image digests were undefined and we had a deployment mechanism in place to lookup digests at deploytime. this was supposed to bring some dev-ease-of-life. but it also makes reasoning about the config harder and is problematic for processes that require proper configuration.

this PR proposed the following changes:
* RH config needs to mention the image digests and the `make deploy` targets as well as the GH action based delivery will rely on that
* there will be an additional target `make deploy.current` that will provide the current behaviour and can be used in personal dev environments

this implies that 1P needs to bump the digests in config at relevant points in time to make sure the changes that should go to integrated dev are actually promoted.

<!-- Link to Jira issue -->

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
