### PR TITLE
Add role assignment functions for control and data plane identities

### DIFF
--- a/demo/03-create-cluster.sh
+++ b/demo/03-create-cluster.sh
@@ -7,6 +7,8 @@ set -o pipefail
 source env_vars
 source "$(dirname "$0")"/common.sh
 
+CONFIG_FILE="cluster-service/azure-operators-managed-identities-config.yaml"
+
 initialize_control_plane_identities_uamis_names() {
   for operator_name in "${CONTROL_PLANE_OPERATORS_NAMES[@]}"
   do

--- a/demo/03-create-cluster.sh
+++ b/demo/03-create-cluster.sh
@@ -99,6 +99,93 @@ IDENTITY_UAMIS_JSON_MAP=$(echo -n "${IDENTITY_UAMIS_JSON_MAP}" | jq \
 
 }
 
+get_identity_principal_id() {
+  local identity_name="$1"
+  local resource_group="$2"
+  
+  az identity show \
+    --name "${identity_name}" \
+    --resource-group "${resource_group}" \
+    --query principalId \
+    --output tsv
+}
+
+assign_role_to_identity() {
+  local principal_id="$1"
+  local role_name="$2"
+  local scope="$3"
+  
+  echo "Assigning role '${role_name}' to principal ID '${principal_id}' with scope '${scope}'"
+  
+  az role assignment create \
+    --assignee-object-id "${principal_id}" \
+    --assignee-principal-type ServicePrincipal \
+    --role "${role_name}" \
+    --scope "${scope}"
+    
+  echo "Role assignment completed successfully"
+}
+
+create_role_assignments_for_control_plane_identities() {
+  if [[ ! -f "$CONFIG_FILE" ]]; then
+    echo "Warning: CONFIG_FILE not found at ${CONFIG_FILE}. Skipping control plane role assignments."
+    return 0
+  fi
+
+  while read -r operator_name role_definition_resource_id; do
+    if [[ -n "$operator_name" && -n "$role_definition_resource_id" ]]; then
+      # Find the corresponding UAMI name
+      for i in "${!CONTROL_PLANE_OPERATORS_NAMES[@]}"; do
+        if [[ "${CONTROL_PLANE_OPERATORS_NAMES[$i]}" == "$operator_name" ]]; then
+          uami_name="${CONTROL_PLANE_IDENTITIES_UAMIS_NAMES[$i]}"
+          role_definition_id="/subscriptions/${SUBSCRIPTION_ID}${role_definition_resource_id}"
+
+          # Get the principal ID of the managed identity
+          principal_id=$(get_identity_principal_id "${uami_name}" "${CUSTOMER_RG_NAME}")
+          
+          if [[ -n "$principal_id" ]]; then
+            # Assign role at resource group scope
+            assign_role_to_identity "${principal_id}" "${role_definition_id}" "${RESOURCE_GROUP_RESOURCE_ID}"
+          else
+            echo "Error: Could not retrieve principal ID for identity ${uami_name}"
+          fi
+          break
+        fi
+      done
+    fi
+  done < <(yq '.controlPlaneOperatorsIdentities | to_entries[] | .key + " " + .value.roleDefinitions[0].resourceId' "$CONFIG_FILE")
+}
+
+create_role_assignments_for_data_plane_identities() {
+  if [[ ! -f "$CONFIG_FILE" ]]; then
+    echo "Warning: CONFIG_FILE not found at ${CONFIG_FILE}. Skipping data plane role assignments."
+    return 0
+  fi
+
+  while read -r operator_name role_definition_resource_id; do
+    if [[ -n "$operator_name" && -n "$role_definition_resource_id" ]]; then
+      # Find the corresponding UAMI name
+      for i in "${!DATA_PLANE_OPERATORS_NAMES[@]}"; do
+        if [[ "${DATA_PLANE_OPERATORS_NAMES[$i]}" == "$operator_name" ]]; then
+          uami_name="${DATA_PLANE_IDENTITIES_UAMIS_NAMES[$i]}"
+          role_definition_id="/subscriptions/${SUBSCRIPTION_ID}${role_definition_resource_id}"
+
+          # Get the principal ID of the managed identity
+          principal_id=$(get_identity_principal_id "${uami_name}" "${CUSTOMER_RG_NAME}")
+          
+          if [[ -n "$principal_id" ]]; then
+            # Assign role at resource group scope
+            assign_role_to_identity "${principal_id}" "${role_definition_id}" "${RESOURCE_GROUP_RESOURCE_ID}"
+          else
+            echo "Error: Could not retrieve principal ID for identity ${uami_name}"
+          fi
+          break
+        fi
+      done
+    fi
+  done < <(yq '.dataPlaneOperatorsIdentities | to_entries[] | .key + " " + .value.roleDefinitions[0].resourceId' "$CONFIG_FILE")
+}
+
 create_azure_managed_identities_for_cluster() {
   for uami_name in "${CONTROL_PLANE_IDENTITIES_UAMIS_NAMES[@]}"
   do
@@ -117,6 +204,16 @@ create_azure_managed_identities_for_cluster() {
   echo "creating azure user-assigned identity ${service_managed_identity_uami_name} in resource group ${CUSTOMER_RG_NAME}"
   az identity create --name "${service_managed_identity_uami_name}" --resource-group "${CUSTOMER_RG_NAME}"
   echo "user-assigned identity ${uami_name} created"
+}
+
+create_role_assignments_for_cluster() {
+  echo "Creating role assignments for cluster identities..."
+  
+  #TODO : do we Wait for identities to be fully provisioned ?
+  
+  create_role_assignments_for_control_plane_identities
+  create_role_assignments_for_data_plane_identities
+  echo "All role assignments completed"
 }
 
 main() {
@@ -188,6 +285,7 @@ main() {
   CLUSTER_FILE="cluster.json"
 
   create_azure_managed_identities_for_cluster
+  create_role_assignments_for_cluster
 
   jq \
     --arg location "$LOCATION" \


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-18159

### What
This PR adds new functions in demo/create_cluster.sh for the role assignments for the UAMIS (only Data Plane and Control Plane). 


### Why
In CS, we're adding new validations to check data plane and control plane operator permissions. These role assignments are required to ensure the inflight checks pass successfully during ARO-HCP cluster creation once the inflight checks are merged. 


### Testing output 
If azure-operators-managed-identities-config.yaml file not found -

`Creating role assignments for cluster identities...
Warning: CONFIG_FILE not found at cluster-service/azure-operators-managed-identities-config.yaml. Skipping control plane role assignments.
Warning: CONFIG_FILE not found at cluster-service/azure-operators-managed-identities-config.yaml. Skipping data plane role assignments.`


For successful role assignment creation - 

`Assigning role '/subscriptions/1d3378d3-5a3f-4712/providers/Microsoft.Authorization/roleDefinitions/fdc0aaaa-1c3e-548e-ad27-0321e5fab18b' to principal ID '80be8246-2886-4bd3-bcfc-6efbf5567db9' with scope '/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/sjante-test-us'
{
  "condition": null,
  "conditionVersion": null,
  "createdBy": null,
  "createdOn": "2025-06-26T06:39:52.977671+00:00",
  "delegatedManagedIdentityResourceId": null,
  "description": null,
  ...
  "type": "Microsoft.Authorization/roleAssignments",
  "updatedBy": "76cf14a0-2f0c-4327-ac82-47fe030aa4cf",
  "updatedOn": "2025-06-26T06:39:53.439618+00:00"
}
Role assignment completed successfully`