### PR TITLE
ARO-15324 | Add required permission to MSI mock

### DIFF
--- a/dev-infrastructure/templates/mock-identities.bicep
+++ b/dev-infrastructure/templates/mock-identities.bicep
@@ -121,6 +121,7 @@ resource msiCustomRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
       {
         actions: [
           'Microsoft.Network/virtualNetworks/read'
+          'Microsoft.Network/virtualNetworks/join/action'
           'Microsoft.Network/virtualNetworks/subnets/read'
           'Microsoft.Network/virtualNetworks/subnets/write'
           'Microsoft.Network/virtualNetworks/subnets/join/action'


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-15324

### What

The MSI mock is used for control plane identities. Add a required permission which is expected for the image registry operator.

### Why

Pass the new inflight for control plane identities permissions.

### Special notes for your reviewer

<!-- optional -->
