### PR TITLE
api: Replace ClusterCapabilitiesProfile with ClusterImageRegistryProfile

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
@@ -65,7 +65,10 @@
             }
           }
         },
-        "nodeDrainTimeoutMinutes": 20
+        "nodeDrainTimeoutMinutes": 20,
+        "clusterImageRegistry": {
+          "state": "Enabled"
+        }
       },
       "identity": {
         "type": "UserAssigned",
@@ -147,7 +150,10 @@
               }
             }
           },
-          "nodeDrainTimeoutMinutes": 20
+          "nodeDrainTimeoutMinutes": 20,
+          "clusterImageRegistry": {
+            "state": "Enabled"
+          }
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",
@@ -246,7 +252,10 @@
               }
             }
           },
-          "nodeDrainTimeoutMinutes": 20
+          "nodeDrainTimeoutMinutes": 20,
+          "clusterImageRegistry": {
+            "state": "Enabled"
+          }
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
@@ -74,7 +74,10 @@
               }
             }
           },
-          "nodeDrainTimeoutMinutes": 20
+          "nodeDrainTimeoutMinutes": 20,
+          "clusterImageRegistry": {
+            "state": "Enabled"
+          }
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
@@ -75,7 +75,10 @@
                   }
                 }
               },
-              "nodeDrainTimeoutMinutes": 20
+              "nodeDrainTimeoutMinutes": 20,
+              "clusterImageRegistry": {
+                "state": "Enabled"
+              }
             },
             "identity": {
               "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_ListBySubscription_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_ListBySubscription_MaximumSet_Gen.json
@@ -74,7 +74,10 @@
                   }
                 }
               },
-              "nodeDrainTimeoutMinutes": 20
+              "nodeDrainTimeoutMinutes": 20,
+              "clusterImageRegistry": {
+                "state": "Enabled"
+              }
             },
             "identity": {
               "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
@@ -85,7 +85,10 @@
               }
             }
           },
-          "nodeDrainTimeoutMinutes": 20
+          "nodeDrainTimeoutMinutes": 20,
+          "clusterImageRegistry": {
+            "state": "Enabled"
+          }
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -74,10 +74,6 @@ model HcpOpenShiftClusterProperties {
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   autoscaling?: ClusterAutoscalingProfile;
 
-  /** Configure cluster capabilities. */
-  @visibility(Lifecycle.Read, Lifecycle.Create)
-  capabilities?: ClusterCapabilitiesProfile;
-
   /** Configure ETCD. */
   @visibility(Lifecycle.Read, Lifecycle.Create)
   etcd?: EtcdProfile;
@@ -97,24 +93,6 @@ model HcpOpenShiftClusterProperties {
   @maxValue(10080)
   @minValue(0)
   nodeDrainTimeoutMinutes?: int32 = 0;
-}
-/** Cluster capabilities configuration. */
-model ClusterCapabilitiesProfile {
-  /**
-   * Immutable list of disabled capabilities. May only contain "ImageRegistry" at
-   * this time. Additional capabilities may be available in the future. Clients
-   * should expect to handle additional values.
-   */
-  @visibility(Lifecycle.Read, Lifecycle.Create)
-  disabled?: OptionalClusterCapability[];
-}
-
-/** Cluster capabilities that can be disabled. */
-union OptionalClusterCapability {
-  string,
-
-  /** Enables the OpenShift internal image registry. */
-  ImageRegistry: "ImageRegistry",
 }
 
 /** The resource provisioning state. */

--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -93,6 +93,13 @@ model HcpOpenShiftClusterProperties {
   @maxValue(10080)
   @minValue(0)
   nodeDrainTimeoutMinutes?: int32 = 0;
+
+  // Optional features begin here. Each feature has
+  // its own model with at least a "state" property.
+
+  /** OpenShift internal image registry */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  clusterImageRegistry?: ClusterImageRegistryProfile;
 }
 
 /** The resource provisioning state. */
@@ -258,6 +265,17 @@ model ClusterAutoscalingProfile {
    * See the following for more details:
    * https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption */
   podPriorityThreshold?: int32 = -10;
+}
+
+/** OpenShift cluster image registry */
+model ClusterImageRegistryProfile {
+  /** state indicates the desired ImageStream-backed cluster image registry installation mode.
+   * This can only be set during cluster creation and cannot be changed after cluster creation.
+   * Enabled means the ImageStream-backed image registry will be run as pods on worker nodes in
+   * the cluster. Disabled means the ImageStream-backed image registry will not be present in
+   * the cluster. The default is Enabled. */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  state?: "Enabled" | "Disabled" | string = "Enabled";
 }
 
 scalar SubnetResourceId

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
@@ -65,7 +65,10 @@
             }
           }
         },
-        "nodeDrainTimeoutMinutes": 20
+        "nodeDrainTimeoutMinutes": 20,
+        "clusterImageRegistry": {
+          "state": "Enabled"
+        }
       },
       "identity": {
         "type": "UserAssigned",
@@ -147,7 +150,10 @@
               }
             }
           },
-          "nodeDrainTimeoutMinutes": 20
+          "nodeDrainTimeoutMinutes": 20,
+          "clusterImageRegistry": {
+            "state": "Enabled"
+          }
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",
@@ -246,7 +252,10 @@
               }
             }
           },
-          "nodeDrainTimeoutMinutes": 20
+          "nodeDrainTimeoutMinutes": 20,
+          "clusterImageRegistry": {
+            "state": "Enabled"
+          }
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
@@ -74,7 +74,10 @@
               }
             }
           },
-          "nodeDrainTimeoutMinutes": 20
+          "nodeDrainTimeoutMinutes": 20,
+          "clusterImageRegistry": {
+            "state": "Enabled"
+          }
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
@@ -75,7 +75,10 @@
                   }
                 }
               },
-              "nodeDrainTimeoutMinutes": 20
+              "nodeDrainTimeoutMinutes": 20,
+              "clusterImageRegistry": {
+                "state": "Enabled"
+              }
             },
             "identity": {
               "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_ListBySubscription_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_ListBySubscription_MaximumSet_Gen.json
@@ -74,7 +74,10 @@
                   }
                 }
               },
-              "nodeDrainTimeoutMinutes": 20
+              "nodeDrainTimeoutMinutes": 20,
+              "clusterImageRegistry": {
+                "state": "Enabled"
+              }
             },
             "identity": {
               "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
@@ -85,7 +85,10 @@
               }
             }
           },
-          "nodeDrainTimeoutMinutes": 20
+          "nodeDrainTimeoutMinutes": 20,
+          "clusterImageRegistry": {
+            "state": "Enabled"
+          }
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1187,6 +1187,28 @@
         }
       }
     },
+    "ClusterImageRegistryProfile": {
+      "type": "object",
+      "description": "OpenShift cluster image registry",
+      "properties": {
+        "state": {
+          "type": "string",
+          "description": "state indicates the desired ImageStream-backed cluster image registry installation mode.\nThis can only be set during cluster creation and cannot be changed after cluster creation.\nEnabled means the ImageStream-backed image registry will be run as pods on worker nodes in\nthe cluster. Disabled means the ImageStream-backed image registry will not be present in\nthe cluster. The default is Enabled.",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "x-ms-enum": {
+            "modelAsString": true
+          },
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      }
+    },
     "ConsoleProfile": {
       "type": "object",
       "description": "Configuration of the cluster web console",
@@ -1505,6 +1527,14 @@
           "x-ms-mutability": [
             "read",
             "update",
+            "create"
+          ]
+        },
+        "clusterImageRegistry": {
+          "$ref": "#/definitions/ClusterImageRegistryProfile",
+          "description": "OpenShift internal image registry",
+          "x-ms-mutability": [
+            "read",
             "create"
           ]
         }

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1187,23 +1187,6 @@
         }
       }
     },
-    "ClusterCapabilitiesProfile": {
-      "type": "object",
-      "description": "Cluster capabilities configuration.",
-      "properties": {
-        "disabled": {
-          "type": "array",
-          "description": "Immutable list of disabled capabilities. May only contain \"ImageRegistry\" at\nthis time. Additional capabilities may be available in the future. Clients\nshould expect to handle additional values.",
-          "items": {
-            "$ref": "#/definitions/OptionalClusterCapability"
-          },
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ]
-        }
-      }
-    },
     "ConsoleProfile": {
       "type": "object",
       "description": "Configuration of the cluster web console",
@@ -1501,14 +1484,6 @@
           "x-ms-mutability": [
             "read",
             "update",
-            "create"
-          ]
-        },
-        "capabilities": {
-          "$ref": "#/definitions/ClusterCapabilitiesProfile",
-          "description": "Configure cluster capabilities.",
-          "x-ms-mutability": [
-            "read",
             "create"
           ]
         },
@@ -2275,24 +2250,6 @@
           "$ref": "#/definitions/UserAssignedIdentitiesProfileUpdate",
           "description": "Represents the information related to Azure User-Assigned managed identities needed\nto perform Operators authentication based on Azure User-Assigned Managed Identities"
         }
-      }
-    },
-    "OptionalClusterCapability": {
-      "type": "string",
-      "description": "Cluster capabilities that can be disabled.",
-      "enum": [
-        "ImageRegistry"
-      ],
-      "x-ms-enum": {
-        "name": "OptionalClusterCapability",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "ImageRegistry",
-            "value": "ImageRegistry",
-            "description": "Enables the OpenShift internal image registry."
-          }
-        ]
       }
     },
     "OsDiskProfile": {

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -81,38 +81,6 @@ func convertOutboundTypeRPToCS(outboundTypeRP api.OutboundType) (outboundTypeCS 
 	return
 }
 
-func convertDisabledCapabilitiesToCS(in []api.OptionalClusterCapability) []string {
-	var out []string
-	for _, c := range in {
-		out = append(out, string(c))
-	}
-	return out
-}
-
-func convertDisableCapabilitiesToRP(in []string) []api.OptionalClusterCapability {
-	var out []api.OptionalClusterCapability
-	for _, c := range in {
-		out = append(out, api.OptionalClusterCapability(c))
-	}
-	return out
-}
-
-func convertClusterCapabilitiesToRP(in *arohcpv1alpha1.Cluster) api.ClusterCapabilitiesProfile {
-	out := api.ClusterCapabilitiesProfile{}
-	if in == nil {
-		return out
-	}
-	if in.Capabilities() != nil {
-		out.Disabled = convertDisableCapabilitiesToRP(in.Capabilities().Disabled())
-	}
-	return out
-}
-
-func convertClusterCapabilitiesToCSBuilder(in api.ClusterCapabilitiesProfile) *arohcpv1alpha1.ClusterCapabilitiesBuilder {
-	return arohcpv1alpha1.NewClusterCapabilities().
-		Disabled(convertDisabledCapabilitiesToCS(in.Disabled)...)
-}
-
 func convertEnableEncryptionAtHostToCSBuilder(in api.NodePoolPlatformProfile) *arohcpv1alpha1.AzureNodePoolEncryptionAtHostBuilder {
 	var state string
 
@@ -174,7 +142,6 @@ func ConvertCStoHCPOpenShiftCluster(resourceID *azcorearm.ResourceID, cluster *a
 				NetworkSecurityGroupID: cluster.Azure().NetworkSecurityGroupResourceID(),
 				IssuerURL:              "",
 			},
-			Capabilities: convertClusterCapabilitiesToRP(cluster),
 		},
 	}
 
@@ -283,8 +250,7 @@ func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpC
 			MachineCIDR(hcpCluster.Properties.Network.MachineCIDR).
 			HostPrefix(int(hcpCluster.Properties.Network.HostPrefix))).
 		API(arohcpv1alpha1.NewClusterAPI().
-			Listening(convertVisibilityToListening(hcpCluster.Properties.API.Visibility))).
-		Capabilities(convertClusterCapabilitiesToCSBuilder(hcpCluster.Properties.Capabilities))
+			Listening(convertVisibilityToListening(hcpCluster.Properties.API.Visibility)))
 
 	azureBuilder := arohcpv1alpha1.NewAzure().
 		TenantID(tenantID).

--- a/frontend/pkg/frontend/ocm_test.go
+++ b/frontend/pkg/frontend/ocm_test.go
@@ -84,30 +84,6 @@ func TestConvertCStoHCPOpenShiftCluster(t *testing.T) {
 			cluster: arohcpv1alpha1.NewCluster(),
 			want:    clusterResource(),
 		},
-		{
-			name: "disabled capability",
-			cluster: arohcpv1alpha1.NewCluster().
-				Capabilities(
-					arohcpv1alpha1.NewClusterCapabilities().
-						Disabled("red"),
-				),
-			want: clusterResource(withDisabledCapabilities("red")),
-		},
-		{
-			name: "disabled capabilities",
-			cluster: arohcpv1alpha1.NewCluster().
-				Capabilities(
-					arohcpv1alpha1.NewClusterCapabilities().
-						Disabled("red", "green", "blue"),
-				),
-			want: clusterResource(withDisabledCapabilities("red", "green", "blue")),
-		},
-		{
-			name: "disabled capabilities empty",
-			cluster: arohcpv1alpha1.NewCluster().
-				Capabilities(arohcpv1alpha1.NewClusterCapabilities()),
-			want: clusterResource(),
-		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -134,39 +110,6 @@ func TestWithImmutableAttributes(t *testing.T) {
 				},
 			},
 			want: ocmCluster(t, withOCMClusterDefaults()),
-		},
-		{
-			name: "disabled capability",
-			hcpCluster: &api.HCPOpenShiftCluster{
-				Properties: api.HCPOpenShiftClusterProperties{
-					Platform: api.PlatformProfile{
-						ManagedResourceGroup: "test",
-					},
-					Capabilities: api.ClusterCapabilitiesProfile{
-						Disabled: []api.OptionalClusterCapability{
-							api.OptionalClusterCapability("TEST_ONE"),
-						},
-					},
-				},
-			},
-			want: ocmCluster(t, withOCMClusterDefaults(), withOCMDisabledCapabilities("TEST_ONE")),
-		},
-		{
-			name: "disabled capabilities",
-			hcpCluster: &api.HCPOpenShiftCluster{
-				Properties: api.HCPOpenShiftClusterProperties{
-					Platform: api.PlatformProfile{
-						ManagedResourceGroup: "test",
-					},
-					Capabilities: api.ClusterCapabilitiesProfile{
-						Disabled: []api.OptionalClusterCapability{
-							api.OptionalClusterCapability("TEST_ONE"),
-							api.OptionalClusterCapability("TEST_TWO"),
-						},
-					},
-				},
-			},
-			want: ocmCluster(t, withOCMClusterDefaults(), withOCMDisabledCapabilities("TEST_ONE", "TEST_TWO")),
 		},
 	}
 
@@ -208,14 +151,6 @@ func clusterResource(opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCl
 	return c
 }
 
-func withDisabledCapabilities(caps ...string) func(*api.HCPOpenShiftCluster) {
-	return func(c *api.HCPOpenShiftCluster) {
-		for _, capability := range caps {
-			c.Properties.Capabilities.Disabled = append(c.Properties.Capabilities.Disabled, api.OptionalClusterCapability(capability))
-		}
-	}
-}
-
 func ocmCluster(t *testing.T, opts ...func(*arohcpv1alpha1.ClusterBuilder) *arohcpv1alpha1.ClusterBuilder) *arohcpv1alpha1.Cluster {
 	b := arohcpv1alpha1.NewCluster()
 	for _, opt := range opts {
@@ -224,11 +159,6 @@ func ocmCluster(t *testing.T, opts ...func(*arohcpv1alpha1.ClusterBuilder) *aroh
 	c, err := b.Build()
 	assert.NoError(t, err)
 	return c
-}
-func withOCMDisabledCapabilities(values ...string) func(*arohcpv1alpha1.ClusterBuilder) *arohcpv1alpha1.ClusterBuilder {
-	return func(b *arohcpv1alpha1.ClusterBuilder) *arohcpv1alpha1.ClusterBuilder {
-		return b.Capabilities(arohcpv1alpha1.NewClusterCapabilities().Disabled(values...))
-	}
 }
 
 func withOCMClusterDefaults() func(*arohcpv1alpha1.ClusterBuilder) *arohcpv1alpha1.ClusterBuilder {
@@ -248,8 +178,6 @@ func withOCMClusterDefaults() func(*arohcpv1alpha1.ClusterBuilder) *arohcpv1alph
 				SubscriptionID("test").
 				TenantID("test"),
 			).
-			Capabilities(arohcpv1alpha1.NewClusterCapabilities().
-				Disabled()).
 			CCS(arohcpv1alpha1.NewCCS().Enabled(true)).
 			CloudProvider(cmv1.NewCloudProvider().
 				ID("azure")).

--- a/internal/api/enums.go
+++ b/internal/api/enums.go
@@ -56,11 +56,3 @@ const (
 	// EffectPreferNoSchedule - PreferNoSchedule taint effect
 	EffectPreferNoSchedule Effect = "PreferNoSchedule"
 )
-
-// OptionalClusterCapability - Cluster capabilities that can be disabled.
-type OptionalClusterCapability string
-
-const (
-	// OptionalClusterCapabilityImageRegistry - Enables the OpenShift internal image registry.
-	OptionalClusterCapabilityImageRegistry OptionalClusterCapability = "ImageRegistry"
-)

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -35,14 +35,13 @@ type HCPOpenShiftCluster struct {
 
 // HCPOpenShiftClusterProperties represents the property bag of a HCPOpenShiftCluster resource.
 type HCPOpenShiftClusterProperties struct {
-	ProvisioningState arm.ProvisioningState      `json:"provisioningState,omitempty"             visibility:"read"`
-	Version           VersionProfile             `json:"version,omitempty"`
-	DNS               DNSProfile                 `json:"dns,omitempty"`
-	Network           NetworkProfile             `json:"network,omitempty"                       visibility:"read create"`
-	Console           ConsoleProfile             `json:"console,omitempty"                       visibility:"read"`
-	API               APIProfile                 `json:"api,omitempty"`
-	Platform          PlatformProfile            `json:"platform,omitempty"                      visibility:"read create"`
-	Capabilities      ClusterCapabilitiesProfile `json:"capabilities,omitempty"                  visibility:"read create"`
+	ProvisioningState arm.ProvisioningState `json:"provisioningState,omitempty"             visibility:"read"`
+	Version           VersionProfile        `json:"version,omitempty"`
+	DNS               DNSProfile            `json:"dns,omitempty"`
+	Network           NetworkProfile        `json:"network,omitempty"                       visibility:"read create"`
+	Console           ConsoleProfile        `json:"console,omitempty"                       visibility:"read"`
+	API               APIProfile            `json:"api,omitempty"`
+	Platform          PlatformProfile       `json:"platform,omitempty"                      visibility:"read create"`
 }
 
 // VersionProfile represents the cluster control plane version.
@@ -104,13 +103,6 @@ type UserAssignedIdentitiesProfile struct {
 	ControlPlaneOperators  map[string]string `json:"controlPlaneOperators,omitempty"  validate:"dive,keys,required,endkeys,resource_id=Microsoft.ManagedIdentity/userAssignedIdentities"`
 	DataPlaneOperators     map[string]string `json:"dataPlaneOperators,omitempty"     validate:"dive,keys,required,endkeys,resource_id=Microsoft.ManagedIdentity/userAssignedIdentities"`
 	ServiceManagedIdentity string            `json:"serviceManagedIdentity,omitempty" validate:"omitempty,resource_id=Microsoft.ManagedIdentity/userAssignedIdentities"`
-}
-
-// ClusterCapabilitiesProfile - Cluster capabilities configuration.
-// Visibility for the entire struct is "read create".
-type ClusterCapabilitiesProfile struct {
-	// Disabled cluter capabilities.
-	Disabled []OptionalClusterCapability `json:"disabled,omitempty" validate:"dive,enum_optionalclustercapability"`
 }
 
 // Creates an HCPOpenShiftCluster with any non-zero default values.

--- a/internal/api/testhelpers.go
+++ b/internal/api/testhelpers.go
@@ -86,8 +86,6 @@ func NewTestValidator() *validator.Validate {
 		arm.ManagedServiceIdentityTypeSystemAssigned,
 		arm.ManagedServiceIdentityTypeSystemAssignedUserAssigned,
 		arm.ManagedServiceIdentityTypeUserAssigned))
-	validate.RegisterAlias("enum_optionalclustercapability", EnumValidateTag(
-		OptionalClusterCapabilityImageRegistry))
 
 	return validate
 }

--- a/internal/api/v20240610preview/generated/constants.go
+++ b/internal/api/v20240610preview/generated/constants.go
@@ -26,6 +26,25 @@ func PossibleActionTypeValues() []ActionType {
 	}
 }
 
+// ClusterImageRegistryProfileState - state indicates the desired ImageStream-backed cluster image registry installation mode.
+// This can only be set during cluster creation and cannot be changed after cluster creation. Enabled means the
+// ImageStream-backed image registry will be run as pods on worker nodes in the cluster. Disabled means the ImageStream-backed
+// image registry will not be present in the cluster. The default is Enabled.
+type ClusterImageRegistryProfileState string
+
+const (
+	ClusterImageRegistryProfileStateDisabled ClusterImageRegistryProfileState = "Disabled"
+	ClusterImageRegistryProfileStateEnabled  ClusterImageRegistryProfileState = "Enabled"
+)
+
+// PossibleClusterImageRegistryProfileStateValues returns the possible values for the ClusterImageRegistryProfileState const type.
+func PossibleClusterImageRegistryProfileStateValues() []ClusterImageRegistryProfileState {
+	return []ClusterImageRegistryProfileState{
+		ClusterImageRegistryProfileStateDisabled,
+		ClusterImageRegistryProfileStateEnabled,
+	}
+}
+
 // CreatedByType - The type of identity that created the resource.
 type CreatedByType string
 

--- a/internal/api/v20240610preview/generated/constants.go
+++ b/internal/api/v20240610preview/generated/constants.go
@@ -180,21 +180,6 @@ func PossibleOperatorIdentityRequiredValues() []OperatorIdentityRequired {
 	}
 }
 
-// OptionalClusterCapability - Cluster capabilities that can be disabled.
-type OptionalClusterCapability string
-
-const (
-	// OptionalClusterCapabilityImageRegistry - Enables the OpenShift internal image registry.
-	OptionalClusterCapabilityImageRegistry OptionalClusterCapability = "ImageRegistry"
-)
-
-// PossibleOptionalClusterCapabilityValues returns the possible values for the OptionalClusterCapability const type.
-func PossibleOptionalClusterCapabilityValues() []OptionalClusterCapability {
-	return []OptionalClusterCapability{
-		OptionalClusterCapabilityImageRegistry,
-	}
-}
-
 // Origin - The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default
 // value is "user,system"
 type Origin string

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -69,6 +69,15 @@ type ClusterAutoscalingProfile struct {
 	PodPriorityThreshold *int32
 }
 
+// ClusterImageRegistryProfile - OpenShift cluster image registry
+type ClusterImageRegistryProfile struct {
+	// state indicates the desired ImageStream-backed cluster image registry installation mode. This can only be set during cluster
+	// creation and cannot be changed after cluster creation. Enabled means the
+	// ImageStream-backed image registry will be run as pods on worker nodes in the cluster. Disabled means the ImageStream-backed
+	// image registry will not be present in the cluster. The default is Enabled.
+	State *ClusterImageRegistryProfileState
+}
+
 type Components19Kgb1NSchemasAzureResourcemanagerCommontypesManagedserviceidentityupdatePropertiesUserassignedidentitiesAdditionalproperties struct {
 	// READ-ONLY; The client ID of the assigned identity.
 	ClientID *string
@@ -208,6 +217,9 @@ type HcpOpenShiftClusterProperties struct {
 
 	// Configure ClusterAutoscaling .
 	Autoscaling *ClusterAutoscalingProfile
+
+	// OpenShift internal image registry
+	ClusterImageRegistry *ClusterImageRegistryProfile
 
 	// Cluster DNS configuration
 	DNS *DNSProfile

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -69,13 +69,6 @@ type ClusterAutoscalingProfile struct {
 	PodPriorityThreshold *int32
 }
 
-// ClusterCapabilitiesProfile - Cluster capabilities configuration.
-type ClusterCapabilitiesProfile struct {
-	// Immutable list of disabled capabilities. May only contain "ImageRegistry" at this time. Additional capabilities may be
-	// available in the future. Clients should expect to handle additional values.
-	Disabled []*OptionalClusterCapability
-}
-
 type Components19Kgb1NSchemasAzureResourcemanagerCommontypesManagedserviceidentityupdatePropertiesUserassignedidentitiesAdditionalproperties struct {
 	// READ-ONLY; The client ID of the assigned identity.
 	ClientID *string
@@ -215,9 +208,6 @@ type HcpOpenShiftClusterProperties struct {
 
 	// Configure ClusterAutoscaling .
 	Autoscaling *ClusterAutoscalingProfile
-
-	// Configure cluster capabilities.
-	Capabilities *ClusterCapabilitiesProfile
 
 	// Cluster DNS configuration
 	DNS *DNSProfile

--- a/internal/api/v20240610preview/generated/models_serde.go
+++ b/internal/api/v20240610preview/generated/models_serde.go
@@ -167,6 +167,35 @@ func (c *ClusterAutoscalingProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ClusterImageRegistryProfile.
+func (c ClusterImageRegistryProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "state", c.State)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ClusterImageRegistryProfile.
+func (c *ClusterImageRegistryProfile) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", c, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "state":
+			err = unpopulate(val, "State", &c.State)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", c, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", c, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type Components19Kgb1NSchemasAzureResourcemanagerCommontypesManagedserviceidentityupdatePropertiesUserassignedidentitiesAdditionalproperties.
 func (c Components19Kgb1NSchemasAzureResourcemanagerCommontypesManagedserviceidentityupdatePropertiesUserassignedidentitiesAdditionalproperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -592,6 +621,7 @@ func (h HcpOpenShiftClusterProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "api", h.API)
 	populate(objectMap, "autoscaling", h.Autoscaling)
+	populate(objectMap, "clusterImageRegistry", h.ClusterImageRegistry)
 	populate(objectMap, "console", h.Console)
 	populate(objectMap, "dns", h.DNS)
 	populate(objectMap, "etcd", h.Etcd)
@@ -617,6 +647,9 @@ func (h *HcpOpenShiftClusterProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "autoscaling":
 			err = unpopulate(val, "Autoscaling", &h.Autoscaling)
+			delete(rawMsg, key)
+		case "clusterImageRegistry":
+			err = unpopulate(val, "ClusterImageRegistry", &h.ClusterImageRegistry)
 			delete(rawMsg, key)
 		case "console":
 			err = unpopulate(val, "Console", &h.Console)

--- a/internal/api/v20240610preview/generated/models_serde.go
+++ b/internal/api/v20240610preview/generated/models_serde.go
@@ -167,35 +167,6 @@ func (c *ClusterAutoscalingProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type ClusterCapabilitiesProfile.
-func (c ClusterCapabilitiesProfile) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "disabled", c.Disabled)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type ClusterCapabilitiesProfile.
-func (c *ClusterCapabilitiesProfile) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", c, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "disabled":
-			err = unpopulate(val, "Disabled", &c.Disabled)
-			delete(rawMsg, key)
-		default:
-			err = fmt.Errorf("unmarshalling type %T, unknown field %q", c, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", c, err)
-		}
-	}
-	return nil
-}
-
 // MarshalJSON implements the json.Marshaller interface for type Components19Kgb1NSchemasAzureResourcemanagerCommontypesManagedserviceidentityupdatePropertiesUserassignedidentitiesAdditionalproperties.
 func (c Components19Kgb1NSchemasAzureResourcemanagerCommontypesManagedserviceidentityupdatePropertiesUserassignedidentitiesAdditionalproperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -621,7 +592,6 @@ func (h HcpOpenShiftClusterProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "api", h.API)
 	populate(objectMap, "autoscaling", h.Autoscaling)
-	populate(objectMap, "capabilities", h.Capabilities)
 	populate(objectMap, "console", h.Console)
 	populate(objectMap, "dns", h.DNS)
 	populate(objectMap, "etcd", h.Etcd)
@@ -647,9 +617,6 @@ func (h *HcpOpenShiftClusterProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "autoscaling":
 			err = unpopulate(val, "Autoscaling", &h.Autoscaling)
-			delete(rawMsg, key)
-		case "capabilities":
-			err = unpopulate(val, "Capabilities", &h.Capabilities)
 			delete(rawMsg, key)
 		case "console":
 			err = unpopulate(val, "Console", &h.Console)

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -88,18 +88,6 @@ func newUserAssignedIdentitiesProfile(from *api.UserAssignedIdentitiesProfile) *
 	}
 }
 
-func newClusterCapabilitiesProfile(from *api.ClusterCapabilitiesProfile) *generated.ClusterCapabilitiesProfile {
-	out := &generated.ClusterCapabilitiesProfile{
-		Disabled: make([]*generated.OptionalClusterCapability, len(from.Disabled)),
-	}
-
-	for index, item := range from.Disabled {
-		out.Disabled[index] = api.PtrOrNil(generated.OptionalClusterCapability(item))
-	}
-
-	return out
-}
-
 func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.VersionedHCPOpenShiftCluster {
 	if from == nil {
 		from = api.NewDefaultHCPOpenShiftCluster()
@@ -127,7 +115,6 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 				Console:           newConsoleProfile(&from.Properties.Console),
 				API:               newAPIProfile(&from.Properties.API),
 				Platform:          newPlatformProfile(&from.Properties.Platform),
-				Capabilities:      newClusterCapabilitiesProfile(&from.Properties.Capabilities),
 			},
 		},
 	}
@@ -224,9 +211,6 @@ func (c *HcpOpenShiftCluster) Normalize(out *api.HCPOpenShiftCluster) {
 			}
 			if c.Properties.Platform != nil {
 				normalizePlatform(c.Properties.Platform, &out.Properties.Platform)
-			}
-			if c.Properties.Capabilities != nil {
-				normalizeCapabilities(c.Properties.Capabilities, &out.Properties.Capabilities)
 			}
 		}
 	}
@@ -348,17 +332,6 @@ func normalizeIdentityUserAssignedIdentities(p map[string]*generated.UserAssigne
 				ClientID:    value.ClientID,
 				PrincipalID: value.PrincipalID,
 			}
-		}
-	}
-}
-
-func normalizeCapabilities(c *generated.ClusterCapabilitiesProfile, out *api.ClusterCapabilitiesProfile) {
-	if out == nil {
-		out = &api.ClusterCapabilitiesProfile{}
-	}
-	if c.Disabled != nil {
-		for _, v := range api.NonNilSliceValues(c.Disabled) {
-			out.Disabled = append(out.Disabled, api.OptionalClusterCapability(*v))
 		}
 	}
 }

--- a/internal/api/v20240610preview/register.go
+++ b/internal/api/v20240610preview/register.go
@@ -53,7 +53,6 @@ func init() {
 	validate.RegisterAlias("enum_effect", api.EnumValidateTag(generated.PossibleEffectValues()...))
 	validate.RegisterAlias("enum_managedserviceidentitytype", api.EnumValidateTag(generated.PossibleManagedServiceIdentityTypeValues()...))
 	validate.RegisterAlias("enum_networktype", api.EnumValidateTag(generated.PossibleNetworkTypeValues()...))
-	validate.RegisterAlias("enum_optionalclustercapability", api.EnumValidateTag(generated.PossibleOptionalClusterCapabilityValues()...))
 	validate.RegisterAlias("enum_origin", api.EnumValidateTag(generated.PossibleOriginValues()...))
 	validate.RegisterAlias("enum_outboundtype", api.EnumValidateTag(generated.PossibleOutboundTypeValues()...))
 	validate.RegisterAlias("enum_provisioningstate", api.EnumValidateTag(generated.PossibleProvisioningStateValues()...))

--- a/internal/api/v20240610preview/register_test.go
+++ b/internal/api/v20240610preview/register_test.go
@@ -106,8 +106,6 @@ func TestClusterStructTagMap(t *testing.T) {
 		"Properties.Platform.OperatorsAuthentication.UserAssignedIdentities.DataPlaneOperators":     api.VisibilityRead | api.VisibilityCreate,
 		"Properties.Platform.OperatorsAuthentication.UserAssignedIdentities.ServiceManagedIdentity": api.VisibilityRead | api.VisibilityCreate,
 		"Properties.Platform.IssuerURL":               api.VisibilityRead,
-		"Properties.Capabilities":                     skip,
-		"Properties.Capabilities.Disabled":            api.VisibilityRead | api.VisibilityCreate,
 		"Identity":                                    skip,
 		"Identity.PrincipalID":                        api.VisibilityRead,
 		"Identity.TenantID":                           api.VisibilityRead,


### PR DESCRIPTION
[ARO-17706 - REST Specs API: Support HCP Disabled In-Cluster Image Registry](https://issues.redhat.com/browse/ARO-17706)

### What

Replaces the `ClusterCapabilitiesProfile` model with a `ClusterImageRegistryProfile` model.

Here's an illustration in the context of a cluster JSON payload:
```
{
    "properties": {
        "platform": {
            ...
        },
        "clusterImageRegistry": {
            "state": "Enabled" | "Disabled"
        }
    }
}
```

### Why

This pattern was decided on in https://github.com/openshift-online/ocm-api-model/pull/1037.

### Special notes for your reviewer

<!-- optional -->
