### PR TITLE
Add etcd encryptionKey REST Spec

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -72,6 +72,14 @@ model HcpOpenShiftClusterProperties {
   /** Configure cluter capabilities. */
   @visibility(Lifecycle.Read, Lifecycle.Create)
   capabilities?: ClusterCapabilitiesProfile;
+
+  /** Configure etcd encryption KMS key.
+   * Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault,
+   * e.g using the AzureCLI: `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
+   *
+   */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  etcdEncryptionKey: KmsKey;
 }
 
 /** Cluster capabilities configuration. */
@@ -290,6 +298,27 @@ scalar UserAssignedIdentityResourceId
       type: "Microsoft.ManagedIdentity/userAssignedIdentities",
     }
   ]>;
+
+/** A represention of a KeyVault Secret. */
+model KmsKey {
+  /** vaultName is the name of the keyvault that contains the secret */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  @maxLength(255)
+  @minLength(1)
+  vaultName: string;
+
+  /** name is the name of the keyvault key used for encrypt/decrypt */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  @maxLength(255)
+  @minLength(1)
+  name: string;
+
+  /** version contains the version of the key to use */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  @maxLength(255)
+  @minLength(1)
+  version: string;
+}
 
 /*
  * =======================================

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1171,10 +1171,19 @@
             "read",
             "create"
           ]
+        },
+        "etcdEncryptionKey": {
+          "$ref": "#/definitions/KmsKey",
+          "description": "Configure etcd encryption KMS key.\nYour Microsoft Entra application used to create the cluster must be authorized to access this keyvault,\ne.g using the AzureCLI: `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         }
       },
       "required": [
-        "platform"
+        "platform",
+        "etcdEncryptionKey"
       ]
     },
     "HcpOpenShiftClusterPropertiesUpdate": {
@@ -1204,6 +1213,47 @@
         {
           "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
         }
+      ]
+    },
+    "KmsKey": {
+      "type": "object",
+      "description": "A represention of a KeyVault Secret.",
+      "properties": {
+        "vaultName": {
+          "type": "string",
+          "description": "vaultName is the name of the keyvault that contains the secret",
+          "minLength": 1,
+          "maxLength": 255,
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "name is the name of the keyvault key used for encrypt/decrypt",
+          "minLength": 1,
+          "maxLength": 255,
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "description": "version contains the version of the key to use",
+          "minLength": 1,
+          "maxLength": 255,
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      },
+      "required": [
+        "vaultName",
+        "name",
+        "version"
       ]
     },
     "Label": {

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -159,6 +159,11 @@ type HcpOpenShiftClusterListResult struct {
 
 // HcpOpenShiftClusterProperties - HCP cluster properties
 type HcpOpenShiftClusterProperties struct {
+	// REQUIRED; Configure etcd encryption KMS key. Your Microsoft Entra application used to create the cluster must be authorized
+	// to access this keyvault, e.g using the AzureCLI: az keyvault set-policy -n
+	// $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>
+	EtcdEncryptionKey *KmsKey
+
 	// REQUIRED; Azure platform configuration
 	Platform *PlatformProfile
 
@@ -212,6 +217,18 @@ type HcpOpenShiftClusterUpdate struct {
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
 	Type *string
+}
+
+// KmsKey - A represention of a KeyVault Secret.
+type KmsKey struct {
+	// REQUIRED; name is the name of the keyvault key used for encrypt/decrypt
+	Name *string
+
+	// REQUIRED; vaultName is the name of the keyvault that contains the secret
+	VaultName *string
+
+	// REQUIRED; version contains the version of the key to use
+	Version *string
 }
 
 // Label represents the Kubernetes label

--- a/internal/api/v20240610preview/generated/models_serde.go
+++ b/internal/api/v20240610preview/generated/models_serde.go
@@ -487,6 +487,7 @@ func (h HcpOpenShiftClusterProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "capabilities", h.Capabilities)
 	populate(objectMap, "console", h.Console)
 	populate(objectMap, "dns", h.DNS)
+	populate(objectMap, "etcdEncryptionKey", h.EtcdEncryptionKey)
 	populate(objectMap, "network", h.Network)
 	populate(objectMap, "platform", h.Platform)
 	populate(objectMap, "provisioningState", h.ProvisioningState)
@@ -514,6 +515,9 @@ func (h *HcpOpenShiftClusterProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "dns":
 			err = unpopulate(val, "DNS", &h.DNS)
+			delete(rawMsg, key)
+		case "etcdEncryptionKey":
+			err = unpopulate(val, "EtcdEncryptionKey", &h.EtcdEncryptionKey)
 			delete(rawMsg, key)
 		case "network":
 			err = unpopulate(val, "Network", &h.Network)
@@ -614,6 +618,43 @@ func (h *HcpOpenShiftClusterUpdate) UnmarshalJSON(data []byte) error {
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", h, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type KmsKey.
+func (k KmsKey) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "name", k.Name)
+	populate(objectMap, "vaultName", k.VaultName)
+	populate(objectMap, "version", k.Version)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type KmsKey.
+func (k *KmsKey) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", k, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "name":
+			err = unpopulate(val, "Name", &k.Name)
+			delete(rawMsg, key)
+		case "vaultName":
+			err = unpopulate(val, "VaultName", &k.VaultName)
+			delete(rawMsg, key)
+		case "version":
+			err = unpopulate(val, "Version", &k.Version)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", k, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", k, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
https://issues.redhat.com/browse/XCMSTRAT-981

### What

This implements a basic structure for the ETCD encryption but a user. It is designed to allow a user to specific version of a customer managed key to use for encryption.

Note:
The key is not rotatable or patchable. 

Some context is in here: https://docs.google.com/document/d/1MD6KPGDRAgiuok93ut9lSG8QS5RmM-F_buWomj-5MaU/edit?tab=t.0
