### PR TITLE
enable size tagging to define ClusterSizingConfiguration

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -92,7 +92,7 @@ defaults:
       registry: quay.io
       repository: acm-d/rhtap-hypershift-operator
     namespace: hypershift
-    additionalInstallArg: ''
+    additionalInstallArg: '--enable-size-tagging=true'
   # Log settings
   logs:
     mdsd:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -92,7 +92,7 @@ defaults:
       registry: quay.io
       repository: acm-d/rhtap-hypershift-operator
     namespace: hypershift
-    additionalInstallArg: '--enable-size-tagging=true'
+    additionalInstallArg: ''
   # Log settings
   logs:
     mdsd:

--- a/hypershiftoperator/deploy/templates/installer.job.yaml
+++ b/hypershiftoperator/deploy/templates/installer.job.yaml
@@ -27,6 +27,7 @@ spec:
             --registry-overrides "{{ .Values.registryOverrides }}" \
             --hypershift-image {{ .Values.image }}@{{ .Values.imageDigest }} \
             --platform-monitoring=None \
+            --enable-size-tagging=true \
             {{ .Values.additionalArgs }}
       restartPolicy: Never
       serviceAccountName: hypershift-installer


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Hypershift `ClusterSizingConfiguration` is required to size control plane components for workloads.
This is disabled by default and can be enabled by adding `--enable-size-tagging` at install.  
Details of CSC [here](https://hypershift-docs.netlify.app/how-to/azure/scheduler/#clustersizingconfiguration)

```
--enable-size-tagging                            If true, HyperShift will tag the HostedCluster with a size label corresponding to the number of worker nodes
```

### Why

This is needed to configure HCP size for large scale clusters.

### Special notes for your reviewer
The default CSC config looks like this,
```
apiVersion: scheduling.hypershift.openshift.io/v1alpha1
kind: ClusterSizingConfiguration
metadata:
  name: cluster
spec:
  concurrency:
    limit: 5
    slidingWindow: 0s
  sizes:
  - criteria:
      from: 0
      to: 10
    name: small
  - criteria:
      from: 11
      to: 100
    name: medium
  - criteria:
      from: 101
    name: large
  transitionDelay:
    decrease: 0s
    increase: 0s
```
<!-- optional -->
