### PR TITLE
add target in CS Makefile to generate aro-hcp versions config file for dev

### DIFF
--- a/cluster-service/.gitignore
+++ b/cluster-service/.gitignore
@@ -4,3 +4,4 @@ local/local-provisioning-shards.yml
 local/azure-runtime-config.yaml
 local/azure-runtime-config.json
 azure-operators-managed-identities-config.yaml
+aro-hcp-ocp-versions-config.yaml

--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -113,7 +113,7 @@ local-azure-operators-managed-identities-config:
 	@source ./generate_helm_set_flags.sh && \
 	helm template deploy -s templates/azure-operators-managed-identities-config.configmap.yaml \
 	  "$${OP_HELM_SET_FLAGS[@]}" \
-	  | yq '.data."azure-operators-managed-identities-config.yaml"' > ./azure-operators-managed-identities-config.yaml
+	  | yq '.data["azure-operators-managed-identities-config.yaml"]' > ./azure-operators-managed-identities-config.yaml
 .PHONY: local-azure-operators-managed-identities-config
 
 local-aro-hcp-ocp-versions-config:

--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -116,6 +116,10 @@ local-azure-operators-managed-identities-config:
 	  | yq '.data."azure-operators-managed-identities-config.yaml"' > ./azure-operators-managed-identities-config.yaml
 .PHONY: local-azure-operators-managed-identities-config
 
+local-aro-hcp-ocp-versions-config:
+	helm template deploy -s templates/aro-hcp-ocp-versions-config.configmap.yaml | yq '.data["aro-hcp-ocp-versions-config.yaml"]' > ./aro-hcp-ocp-versions-config.yaml
+.PHONY: local-aro-hcp-ocp-versions-config
+
 #
 # Shared OIDC Storage
 #


### PR DESCRIPTION
With the source being the helm file. Useful for local development of CS.
