### PR TITLE
tooling/templatize: manage working directory in-memory

### DIFF
--- a/tooling/templatize/pkg/pipeline/bicep.go
+++ b/tooling/templatize/pkg/pipeline/bicep.go
@@ -39,8 +39,8 @@ func modeFromString(mode string) armresources.DeploymentMode {
 	}
 }
 
-func transformBicepToARMWhatIfDeployment(ctx context.Context, bicepParameterTemplateFile, deploymentMode string, cfg config.Configuration, inputs map[string]any) (*armresources.DeploymentWhatIfProperties, error) {
-	template, params, err := transformParameters(ctx, cfg, inputs, bicepParameterTemplateFile)
+func transformBicepToARMWhatIfDeployment(ctx context.Context, bicepParameterTemplateFile, deploymentMode, pipelineWorkingDir string, cfg config.Configuration, inputs map[string]any) (*armresources.DeploymentWhatIfProperties, error) {
+	template, params, err := transformParameters(ctx, cfg, inputs, bicepParameterTemplateFile, pipelineWorkingDir)
 	if err != nil {
 		return nil, err
 	}
@@ -51,8 +51,8 @@ func transformBicepToARMWhatIfDeployment(ctx context.Context, bicepParameterTemp
 	}, nil
 }
 
-func transformBicepToARMDeployment(ctx context.Context, bicepParameterTemplateFile, deploymentMode string, cfg config.Configuration, inputs map[string]any) (*armresources.DeploymentProperties, error) {
-	template, params, err := transformParameters(ctx, cfg, inputs, bicepParameterTemplateFile)
+func transformBicepToARMDeployment(ctx context.Context, bicepParameterTemplateFile, deploymentMode, pipelineWorkingDir string, cfg config.Configuration, inputs map[string]any) (*armresources.DeploymentProperties, error) {
+	template, params, err := transformParameters(ctx, cfg, inputs, bicepParameterTemplateFile, pipelineWorkingDir)
 	if err != nil {
 		return nil, err
 	}
@@ -63,12 +63,13 @@ func transformBicepToARMDeployment(ctx context.Context, bicepParameterTemplateFi
 	}, nil
 }
 
-func transformParameters(ctx context.Context, cfg config.Configuration, inputs map[string]any, bicepParameterTemplateFile string) (map[string]interface{}, map[string]interface{}, error) {
-	bicepParamContent, err := config.PreprocessFile(bicepParameterTemplateFile, cfg)
+func transformParameters(ctx context.Context, cfg config.Configuration, inputs map[string]any, bicepParameterTemplateFile, pipelineWorkingDir string) (map[string]interface{}, map[string]interface{}, error) {
+	bicepParameterFile := filepath.Join(pipelineWorkingDir, bicepParameterTemplateFile)
+	bicepParamContent, err := config.PreprocessFile(bicepParameterFile, cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to preprocess file: %w", err)
 	}
-	bicepParamBaseDir := filepath.Dir(bicepParameterTemplateFile)
+	bicepParamBaseDir := filepath.Dir(bicepParameterFile)
 	bicepParamFile, err := os.CreateTemp(bicepParamBaseDir, "bicep-params-*.bicepparam")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create temp file: %w", err)

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/go-logr/logr"
 
@@ -76,31 +75,7 @@ func (o ShellOutput) GetValue(_ string) (*OutPutValue, error) {
 }
 
 func RunPipeline(pipeline *types.Pipeline, ctx context.Context, options *PipelineRunOptions) (map[string]Output, error) {
-	logger := logr.FromContextOrDiscard(ctx)
-
 	outPuts := make(map[string]Output)
-
-	// set working directory to the pipeline file directory for the
-	// duration of the execution so that all commands and file references
-	// within the pipeline file are resolved relative to the pipeline file
-	originalDir, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	dir := filepath.Dir(options.PipelineFilePath)
-	logger.V(7).Info("switch current dir to pipeline file directory", "path", dir)
-	err = os.Chdir(dir)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		logger.V(7).Info("switch back dir", "path", originalDir)
-		err = os.Chdir(originalDir)
-		if err != nil {
-			logger.Error(err, "failed to switch back to original directory", "path", originalDir)
-		}
-	}()
-
 	for _, rg := range pipeline.ResourceGroups {
 		// prepare execution context
 		subscriptionID, err := options.SubsciptionLookupFunc(ctx, rg.Subscription)

--- a/tooling/templatize/pkg/pipeline/shell_test.go
+++ b/tooling/templatize/pkg/pipeline/shell_test.go
@@ -119,7 +119,7 @@ func TestCreateCommand(t *testing.T) {
 			assert.NoError(t, err)
 			maps.Copy(tc.envVars, dryRunVars)
 
-			cmd, skipCommand := createCommand(ctx, tc.step.Command, dryRun, tc.envVars)
+			cmd, skipCommand := createCommand(ctx, tc.step.Command, "", dryRun, tc.envVars)
 			assert.Empty(t, cmp.Diff(skipCommand, tc.skipCommand))
 			if !tc.skipCommand {
 				assert.Equal(t, strings.Join(cmd.Args, " "), fmt.Sprintf("/bin/bash -c %s", tc.expectedScript))


### PR DESCRIPTION
Mutating global state (the current directory for the process) is generally a bad idea - not only does this make it impossible to run multiple pipelines in parallel but it does so by creating implicit raciness hidden by the OS interface and not visible to e.g. the `-race` checker in Go tests.