### PR TITLE
api: Correct visibility decorators

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -47,14 +47,15 @@ model HcpOpenShiftClusterProperties {
   provisioningState?: ProvisioningState;
 
   /** Version of the control plane components */
-  @visibility(Lifecycle.Create, Lifecycle.Read)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   version?: VersionProfile;
 
   /** Cluster DNS configuration */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   dns?: DnsProfile;
 
   /** Cluster network configuration */
-  @visibility(Lifecycle.Create, Lifecycle.Read)
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   network?: NetworkProfile;
 
   /** Shows the cluster web console information */
@@ -62,11 +63,11 @@ model HcpOpenShiftClusterProperties {
   console?: ConsoleProfile;
 
   /** Shows the cluster API server profile */
-  @visibility(Lifecycle.Read)
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   api?: ApiProfile;
 
   /** Azure platform configuration */
-  @visibility(Lifecycle.Read, Lifecycle.Create)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   platform: PlatformProfile;
 
   /** Configure cluter capabilities. */
@@ -211,18 +212,23 @@ union Visibility {
 /** Azure specific configuration */
 model PlatformProfile {
   /** Resource group to put cluster resources */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   managedResourceGroup?: string;
 
   /** The Azure resource ID of the worker subnet */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   subnetId: SubnetResourceId;
 
   /** The core outgoing configuration */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   outboundType?: OutboundType = OutboundType.LoadBalancer;
 
   /** ResourceId for the network security group attached to the cluster subnet */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   networkSecurityGroupId: NetworkSecurityGroupResourceId;
 
   /** The configuration that the operators of the cluster have to authenticate to Azure */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   operatorsAuthentication: OperatorsAuthenticationProfile;
 
   /** URL for the OIDC provider to be used for authentication
@@ -310,7 +316,7 @@ model NodePoolProperties {
   provisioningState?: ProvisioningState;
 
   /** OpenShift version for the nodepool */
-  @visibility(Lifecycle.Read, Lifecycle.Create)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   version?: NodePoolVersionProfile;
 
   /** Azure node pool platform configuration */
@@ -326,6 +332,7 @@ model NodePoolProperties {
   autoRepair?: boolean = true;
 
   /** Representation of a autoscaling in a node pool. */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   autoScaling?: NodePoolAutoScaling;
 
   /** Kubernetes labels to propagate to the NodePool Nodes */
@@ -404,29 +411,35 @@ model NodePoolVersionProfile {
 /** Azure node pool platform configuration */
 model NodePoolPlatformProfile {
   /** The Azure resource ID of the worker subnet */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   subnetId?: string;
 
   /** The VM size according to the documentation:
    * - https://learn.microsoft.com/en-us/azure/virtual-machines/sizes */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   vmSize: string;
 
   /** Whether to enable host based OS and data drive encryption.
    * - https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption#encryption-at-host---end-to-end-encryption-for-your-vm-data
    */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   enableEncryptionAtHost?: boolean = false;
 
   /** The OS disk size in GiB */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   diskSizeGiB?: int32 = 64;
 
   /** The type of the disk storage account
    * - https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types
    */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   diskStorageAccountType?: DiskStorageAccountType = "Premium_LRS";
 
   /** The availability zone for the node pool.
    * Please read the documentation to see which regions support availability zones
    * - https://learn.microsoft.com/en-us/azure/availability-zones/az-overview
    */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   availabilityZone?: string;
 }
 

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1131,12 +1131,17 @@
           "description": "Version of the control plane components",
           "x-ms-mutability": [
             "read",
+            "update",
             "create"
           ]
         },
         "dns": {
           "$ref": "#/definitions/DnsProfile",
-          "description": "Cluster DNS configuration"
+          "description": "Cluster DNS configuration",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "network": {
           "$ref": "#/definitions/NetworkProfile",
@@ -1154,13 +1159,17 @@
         "api": {
           "$ref": "#/definitions/ApiProfile",
           "description": "Shows the cluster API server profile",
-          "readOnly": true
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "platform": {
           "$ref": "#/definitions/PlatformProfile",
           "description": "Azure platform configuration",
           "x-ms-mutability": [
             "read",
+            "update",
             "create"
           ]
         },
@@ -1181,9 +1190,23 @@
       "type": "object",
       "description": "HCP cluster properties",
       "properties": {
-        "dns": {
-          "$ref": "#/definitions/DnsProfile",
-          "description": "Cluster DNS configuration"
+        "version": {
+          "$ref": "#/definitions/VersionProfileUpdate",
+          "description": "Version of the control plane components",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "platform": {
+          "$ref": "#/definitions/PlatformProfileUpdate",
+          "description": "Azure platform configuration",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
         }
       }
     },
@@ -1371,22 +1394,38 @@
       "properties": {
         "subnetId": {
           "type": "string",
-          "description": "The Azure resource ID of the worker subnet"
+          "description": "The Azure resource ID of the worker subnet",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "vmSize": {
           "type": "string",
-          "description": "The VM size according to the documentation:\n- https://learn.microsoft.com/en-us/azure/virtual-machines/sizes"
+          "description": "The VM size according to the documentation:\n- https://learn.microsoft.com/en-us/azure/virtual-machines/sizes",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "enableEncryptionAtHost": {
           "type": "boolean",
           "description": "Whether to enable host based OS and data drive encryption.\n- https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption#encryption-at-host---end-to-end-encryption-for-your-vm-data",
-          "default": false
+          "default": false,
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "diskSizeGiB": {
           "type": "integer",
           "format": "int32",
           "description": "The OS disk size in GiB",
-          "default": 64
+          "default": 64,
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "diskStorageAccountType": {
           "type": "string",
@@ -1417,11 +1456,19 @@
                 "description": "Standard HDD with Locally Redundant Storage (LRS)"
               }
             ]
-          }
+          },
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "availabilityZone": {
           "type": "string",
-          "description": "The availability zone for the node pool.\nPlease read the documentation to see which regions support availability zones\n- https://learn.microsoft.com/en-us/azure/availability-zones/az-overview"
+          "description": "The availability zone for the node pool.\nPlease read the documentation to see which regions support availability zones\n- https://learn.microsoft.com/en-us/azure/availability-zones/az-overview",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         }
       },
       "required": [
@@ -1442,6 +1489,7 @@
           "description": "OpenShift version for the nodepool",
           "x-ms-mutability": [
             "read",
+            "update",
             "create"
           ]
         },
@@ -1474,7 +1522,12 @@
         },
         "autoScaling": {
           "$ref": "#/definitions/NodePoolAutoScaling",
-          "description": "Representation of a autoscaling in a node pool."
+          "description": "Representation of a autoscaling in a node pool.",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
         },
         "labels": {
           "type": "array",
@@ -1518,6 +1571,15 @@
       "type": "object",
       "description": "Represents the node pool properties",
       "properties": {
+        "version": {
+          "$ref": "#/definitions/NodePoolVersionProfileUpdate",
+          "description": "OpenShift version for the nodepool",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
         "replicas": {
           "type": "integer",
           "format": "int32",
@@ -1530,7 +1592,12 @@
         },
         "autoScaling": {
           "$ref": "#/definitions/NodePoolAutoScaling",
-          "description": "Representation of a autoscaling in a node pool."
+          "description": "Representation of a autoscaling in a node pool.",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
         },
         "labels": {
           "type": "array",
@@ -1622,6 +1689,31 @@
         "availableUpgrades"
       ]
     },
+    "NodePoolVersionProfileUpdate": {
+      "type": "object",
+      "description": "Versions represents an OpenShift version.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "ID is the unique identifier of the version.",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "channelGroup": {
+          "type": "string",
+          "description": "ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.",
+          "default": "stable",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      }
+    },
     "OperatorsAuthenticationProfile": {
       "type": "object",
       "description": "The configuration that the operators of the cluster have to authenticate to Azure.",
@@ -1634,6 +1726,16 @@
       "required": [
         "userAssignedIdentities"
       ]
+    },
+    "OperatorsAuthenticationProfileUpdate": {
+      "type": "object",
+      "description": "The configuration that the operators of the cluster have to authenticate to Azure.",
+      "properties": {
+        "userAssignedIdentities": {
+          "$ref": "#/definitions/UserAssignedIdentitiesProfileUpdate",
+          "description": "Represents the information related to Azure User-Assigned managed identities needed\nto perform Operators authentication based on Azure User-Assigned Managed Identities"
+        }
+      }
     },
     "OptionalClusterCapability": {
       "type": "string",
@@ -1659,11 +1761,19 @@
       "properties": {
         "managedResourceGroup": {
           "type": "string",
-          "description": "Resource group to put cluster resources"
+          "description": "Resource group to put cluster resources",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "subnetId": {
           "$ref": "#/definitions/SubnetResourceId",
-          "description": "The Azure resource ID of the worker subnet"
+          "description": "The Azure resource ID of the worker subnet",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "outboundType": {
           "type": "string",
@@ -1682,15 +1792,28 @@
                 "description": "The load balancer configuration"
               }
             ]
-          }
+          },
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "networkSecurityGroupId": {
           "$ref": "#/definitions/NetworkSecurityGroupResourceId",
-          "description": "ResourceId for the network security group attached to the cluster subnet"
+          "description": "ResourceId for the network security group attached to the cluster subnet",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "operatorsAuthentication": {
           "$ref": "#/definitions/OperatorsAuthenticationProfile",
-          "description": "The configuration that the operators of the cluster have to authenticate to Azure"
+          "description": "The configuration that the operators of the cluster have to authenticate to Azure",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
         },
         "issuerUrl": {
           "type": "string",
@@ -1705,6 +1828,21 @@
         "operatorsAuthentication",
         "issuerUrl"
       ]
+    },
+    "PlatformProfileUpdate": {
+      "type": "object",
+      "description": "Azure specific configuration",
+      "properties": {
+        "operatorsAuthentication": {
+          "$ref": "#/definitions/OperatorsAuthenticationProfileUpdate",
+          "description": "The configuration that the operators of the cluster have to authenticate to Azure",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      }
     },
     "ProvisioningState": {
       "type": "string",
@@ -1844,6 +1982,45 @@
         "serviceManagedIdentity"
       ]
     },
+    "UserAssignedIdentitiesProfileUpdate": {
+      "type": "object",
+      "description": "Represents the information related to Azure User-Assigned managed identities needed\nto perform Operators authentication based on Azure User-Assigned Managed Identities",
+      "properties": {
+        "controlPlaneOperators": {
+          "type": "object",
+          "description": "The set of Azure User-Assigned Managed Identities leveraged for the Control Plane\noperators of the cluster. The set of required managed identities is dependent on the\nCluster's OpenShift version.",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserAssignedIdentityResourceId"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "dataPlaneOperators": {
+          "type": "object",
+          "description": "The set of Azure User-Assigned Managed Identities leveraged for the Data Plane\noperators of the cluster. The set of required managed identities is dependent on the\nCluster's OpenShift version.",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserAssignedIdentityResourceId"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "serviceManagedIdentity": {
+          "$ref": "#/definitions/UserAssignedIdentityResourceId",
+          "description": "Represents the information associated to an Azure User-Assigned Managed Identity whose\npurpose is to perform service level actions.",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      }
+    },
     "UserAssignedIdentityResourceId": {
       "type": "string",
       "format": "arm-id",
@@ -1890,6 +2067,22 @@
       "required": [
         "availableUpgrades"
       ]
+    },
+    "VersionProfileUpdate": {
+      "type": "object",
+      "description": "Versions represents an OpenShift version.",
+      "properties": {
+        "channelGroup": {
+          "type": "string",
+          "description": "ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.",
+          "default": "stable",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      }
     }
   },
   "parameters": {}

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -162,6 +162,9 @@ type HcpOpenShiftClusterProperties struct {
 	// REQUIRED; Azure platform configuration
 	Platform *PlatformProfile
 
+	// Shows the cluster API server profile
+	API *APIProfile
+
 	// Configure cluter capabilities.
 	Capabilities *ClusterCapabilitiesProfile
 
@@ -174,9 +177,6 @@ type HcpOpenShiftClusterProperties struct {
 	// Version of the control plane components
 	Version *VersionProfile
 
-	// READ-ONLY; Shows the cluster API server profile
-	API *APIProfile
-
 	// READ-ONLY; Shows the cluster web console information
 	Console *ConsoleProfile
 
@@ -186,8 +186,11 @@ type HcpOpenShiftClusterProperties struct {
 
 // HcpOpenShiftClusterPropertiesUpdate - HCP cluster properties
 type HcpOpenShiftClusterPropertiesUpdate struct {
-	// Cluster DNS configuration
-	DNS *DNSProfile
+	// Azure platform configuration
+	Platform *PlatformProfileUpdate
+
+	// Version of the control plane components
+	Version *VersionProfileUpdate
 }
 
 // HcpOpenShiftClusterUpdate - HCP cluster resource
@@ -371,6 +374,9 @@ type NodePoolPropertiesUpdate struct {
 
 	// Taints for the nodes
 	Taints []*Taint
+
+	// OpenShift version for the nodepool
+	Version *NodePoolVersionProfileUpdate
 }
 
 // NodePoolUpdate - Concrete tracked resource types can be created by aliasing this type using a specific property type.
@@ -407,6 +413,15 @@ type NodePoolVersionProfile struct {
 
 	// READ-ONLY; AvailableUpgrades is a list of version names the current version can be upgraded to.
 	AvailableUpgrades []*string
+}
+
+// NodePoolVersionProfileUpdate - Versions represents an OpenShift version.
+type NodePoolVersionProfileUpdate struct {
+	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
+	ChannelGroup *string
+
+	// ID is the unique identifier of the version.
+	ID *string
 }
 
 // Operation - Details of a REST API operation, returned from the Resource Provider Operations API
@@ -465,6 +480,13 @@ type OperatorsAuthenticationProfile struct {
 	UserAssignedIdentities *UserAssignedIdentitiesProfile
 }
 
+// OperatorsAuthenticationProfileUpdate - The configuration that the operators of the cluster have to authenticate to Azure.
+type OperatorsAuthenticationProfileUpdate struct {
+	// Represents the information related to Azure User-Assigned managed identities needed to perform Operators authentication
+	// based on Azure User-Assigned Managed Identities
+	UserAssignedIdentities *UserAssignedIdentitiesProfileUpdate
+}
+
 // PlatformProfile - Azure specific configuration
 type PlatformProfile struct {
 	// REQUIRED; ResourceId for the network security group attached to the cluster subnet
@@ -484,6 +506,12 @@ type PlatformProfile struct {
 
 	// READ-ONLY; URL for the OIDC provider to be used for authentication to authenticate against user Azure cloud account
 	IssuerURL *string
+}
+
+// PlatformProfileUpdate - Azure specific configuration
+type PlatformProfileUpdate struct {
+	// The configuration that the operators of the cluster have to authenticate to Azure
+	OperatorsAuthentication *OperatorsAuthenticationProfileUpdate
 }
 
 // Resource - Common fields that are returned in the response for all Azure Resource Manager resources
@@ -572,6 +600,22 @@ type UserAssignedIdentitiesProfile struct {
 	ServiceManagedIdentity *string
 }
 
+// UserAssignedIdentitiesProfileUpdate - Represents the information related to Azure User-Assigned managed identities needed
+// to perform Operators authentication based on Azure User-Assigned Managed Identities
+type UserAssignedIdentitiesProfileUpdate struct {
+	// The set of Azure User-Assigned Managed Identities leveraged for the Control Plane operators of the cluster. The set of
+	// required managed identities is dependent on the Cluster's OpenShift version.
+	ControlPlaneOperators map[string]*string
+
+	// The set of Azure User-Assigned Managed Identities leveraged for the Data Plane operators of the cluster. The set of required
+	// managed identities is dependent on the Cluster's OpenShift version.
+	DataPlaneOperators map[string]*string
+
+	// Represents the information associated to an Azure User-Assigned Managed Identity whose purpose is to perform service level
+	// actions.
+	ServiceManagedIdentity *string
+}
+
 // UserAssignedIdentity - User assigned identity properties
 type UserAssignedIdentity struct {
 	// READ-ONLY; The client ID of the assigned identity.
@@ -591,4 +635,10 @@ type VersionProfile struct {
 
 	// READ-ONLY; AvailableUpgrades is a list of version names the current version can be upgraded to.
 	AvailableUpgrades []*string
+}
+
+// VersionProfileUpdate - Versions represents an OpenShift version.
+type VersionProfileUpdate struct {
+	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
+	ChannelGroup *string
 }

--- a/internal/api/v20240610preview/generated/models_serde.go
+++ b/internal/api/v20240610preview/generated/models_serde.go
@@ -540,7 +540,8 @@ func (h *HcpOpenShiftClusterProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HcpOpenShiftClusterPropertiesUpdate.
 func (h HcpOpenShiftClusterPropertiesUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "dns", h.DNS)
+	populate(objectMap, "platform", h.Platform)
+	populate(objectMap, "version", h.Version)
 	return json.Marshal(objectMap)
 }
 
@@ -553,8 +554,11 @@ func (h *HcpOpenShiftClusterPropertiesUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "dns":
-			err = unpopulate(val, "DNS", &h.DNS)
+		case "platform":
+			err = unpopulate(val, "Platform", &h.Platform)
+			delete(rawMsg, key)
+		case "version":
+			err = unpopulate(val, "Version", &h.Version)
 			delete(rawMsg, key)
 		default:
 			err = fmt.Errorf("unmarshalling type %T, unknown field %q", h, key)
@@ -974,6 +978,7 @@ func (n NodePoolPropertiesUpdate) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "labels", n.Labels)
 	populate(objectMap, "replicas", n.Replicas)
 	populate(objectMap, "taints", n.Taints)
+	populate(objectMap, "version", n.Version)
 	return json.Marshal(objectMap)
 }
 
@@ -997,6 +1002,9 @@ func (n *NodePoolPropertiesUpdate) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "taints":
 			err = unpopulate(val, "Taints", &n.Taints)
+			delete(rawMsg, key)
+		case "version":
+			err = unpopulate(val, "Version", &n.Version)
 			delete(rawMsg, key)
 		default:
 			err = fmt.Errorf("unmarshalling type %T, unknown field %q", n, key)
@@ -1082,6 +1090,39 @@ func (n *NodePoolVersionProfile) UnmarshalJSON(data []byte) error {
 		case "availableUpgrades":
 			err = unpopulate(val, "AvailableUpgrades", &n.AvailableUpgrades)
 			delete(rawMsg, key)
+		case "channelGroup":
+			err = unpopulate(val, "ChannelGroup", &n.ChannelGroup)
+			delete(rawMsg, key)
+		case "id":
+			err = unpopulate(val, "ID", &n.ID)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", n, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", n, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NodePoolVersionProfileUpdate.
+func (n NodePoolVersionProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "channelGroup", n.ChannelGroup)
+	populate(objectMap, "id", n.ID)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type NodePoolVersionProfileUpdate.
+func (n *NodePoolVersionProfileUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", n, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
 		case "channelGroup":
 			err = unpopulate(val, "ChannelGroup", &n.ChannelGroup)
 			delete(rawMsg, key)
@@ -1246,6 +1287,35 @@ func (o *OperatorsAuthenticationProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type OperatorsAuthenticationProfileUpdate.
+func (o OperatorsAuthenticationProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "userAssignedIdentities", o.UserAssignedIdentities)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type OperatorsAuthenticationProfileUpdate.
+func (o *OperatorsAuthenticationProfileUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", o, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "userAssignedIdentities":
+			err = unpopulate(val, "UserAssignedIdentities", &o.UserAssignedIdentities)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", o, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", o, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type PlatformProfile.
 func (p PlatformProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -1284,6 +1354,35 @@ func (p *PlatformProfile) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "subnetId":
 			err = unpopulate(val, "SubnetID", &p.SubnetID)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", p, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", p, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PlatformProfileUpdate.
+func (p PlatformProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "operatorsAuthentication", p.OperatorsAuthentication)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type PlatformProfileUpdate.
+func (p *PlatformProfileUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", p, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "operatorsAuthentication":
+			err = unpopulate(val, "OperatorsAuthentication", &p.OperatorsAuthentication)
 			delete(rawMsg, key)
 		default:
 			err = fmt.Errorf("unmarshalling type %T, unknown field %q", p, key)
@@ -1508,6 +1607,43 @@ func (u *UserAssignedIdentitiesProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type UserAssignedIdentitiesProfileUpdate.
+func (u UserAssignedIdentitiesProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "controlPlaneOperators", u.ControlPlaneOperators)
+	populate(objectMap, "dataPlaneOperators", u.DataPlaneOperators)
+	populate(objectMap, "serviceManagedIdentity", u.ServiceManagedIdentity)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type UserAssignedIdentitiesProfileUpdate.
+func (u *UserAssignedIdentitiesProfileUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", u, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "controlPlaneOperators":
+			err = unpopulate(val, "ControlPlaneOperators", &u.ControlPlaneOperators)
+			delete(rawMsg, key)
+		case "dataPlaneOperators":
+			err = unpopulate(val, "DataPlaneOperators", &u.DataPlaneOperators)
+			delete(rawMsg, key)
+		case "serviceManagedIdentity":
+			err = unpopulate(val, "ServiceManagedIdentity", &u.ServiceManagedIdentity)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", u, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", u, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type UserAssignedIdentity.
 func (u UserAssignedIdentity) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -1567,6 +1703,35 @@ func (v *VersionProfile) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "id":
 			err = unpopulate(val, "ID", &v.ID)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", v, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", v, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VersionProfileUpdate.
+func (v VersionProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "channelGroup", v.ChannelGroup)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type VersionProfileUpdate.
+func (v *VersionProfileUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", v, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "channelGroup":
+			err = unpopulate(val, "ChannelGroup", &v.ChannelGroup)
 			delete(rawMsg, key)
 		default:
 			err = fmt.Errorf("unmarshalling type %T, unknown field %q", v, key)


### PR DESCRIPTION
### What

The `@visibility` decorator does not cascade to nested models the way I thought it did. So explicitly declare `@visibility` everywhere.

This exercise actually caught a couple bugs where a nested model had updatable fields but the parent model omitted `Lifecycle.Update` from that field's `@visibility` decorator.