### PR TITLE
demo: correcting case issues in cluster bicep files

### DIFF
--- a/demo/bicep/cluster.bicep
+++ b/demo/bicep/cluster.bicep
@@ -93,12 +93,12 @@ resource hcp 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters@2024-06-10-preview'
     }
     console: {}
     api: {
-      visibility: 'Public'
+      visibility: 'public'
     }
     platform: {
       managedResourceGroup: managedResourceGroupName
       subnetId: subnetId
-      outboundType: 'LoadBalancer'
+      outboundType: 'loadBalancer'
       networkSecurityGroupId: networkSecurityGroupId
       operatorsAuthentication: {
         userAssignedIdentities: {


### PR DESCRIPTION


### What

Updates case of 'Public' and 'LoadBalancer' in cluster generation bicep file for the demo

### Why

Uppercase 'Public' and 'LoadBalancer' cause an error on provisioning.



