### PR TITLE
tooling: update parsing logic for remote names

### DIFF
--- a/tooling/templatize/cmd/configuration/validate/options.go
+++ b/tooling/templatize/cmd/configuration/validate/options.go
@@ -574,12 +574,16 @@ func DetermineMergeBase(ctx context.Context, dir, centralRemoteUrl string) (stri
 				return "", fmt.Errorf("failed to get git remotes: %w", err)
 			}
 			for _, remoteName := range strings.Split(remotes, "\n") {
-				remoteUrl, err := command(ctx, dir, "git", "remote", "get-url", strings.TrimSpace(remoteName))
+				remote := strings.TrimSpace(remoteName)
+				if remote == "" {
+					continue
+				}
+				remoteUrl, err := command(ctx, dir, "git", "remote", "get-url", remote)
 				if err != nil {
 					return "", fmt.Errorf("failed to get git remote URL: %w", err)
 				}
 				if strings.TrimSpace(remoteUrl) == centralRemoteUrl {
-					upstreamRef = strings.TrimSpace(remoteName) + "/main"
+					upstreamRef = remote + "/main"
 					break
 				}
 			}

--- a/tooling/templatize/cmd/configuration/validate/options.go
+++ b/tooling/templatize/cmd/configuration/validate/options.go
@@ -567,7 +567,15 @@ func DetermineMergeBase(ctx context.Context, dir, centralRemoteUrl string) (stri
 		}
 		upstreamRef = strings.TrimSpace(upstream)
 
-		if upstreamRef == "" {
+		// unless it's just a version of this branch on the upstream repo
+		branch, err := command(ctx, dir, "git", "rev-parse", "--abbrev-ref", "HEAD")
+		if err != nil &&
+			!strings.Contains(err.Error(), "fatal: HEAD does not point to a branch") {
+			return "", fmt.Errorf("failed to resolve upstream: %w", err)
+		}
+		branchName := strings.TrimSpace(branch)
+
+		if upstreamRef == "" || strings.HasSuffix(upstreamRef, branchName) {
 			// if no upstream set, make a guess based on the remotes and where 99% of merges go
 			remotes, err := command(ctx, dir, "git", "remote")
 			if err != nil {


### PR DESCRIPTION
There is a newline at the end of the output, which causes one of the remotes to be `''` after stripping white-space.
