### PR TITLE
add azure context environme variables to shell steps

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -41,7 +41,7 @@ push: image
 deploy:
 	DIGEST=$$(../get-digest.sh ${ARO_HCP_IMAGE_ACR} arohcpbackend) \
 	BACKEND_MI_CLIENT_ID=$$(az identity show \
-			-g ${RESOURCEGROUP} \
+			-g ${ResourceGroup} \
 			-n backend \
 			--query clientId -o tsv) && \
 	DB_URL=$$(az cosmosdb show -n ${DB_NAME} -g ${REGION_RG} --query documentEndpoint -o tsv) && \

--- a/backend/pipeline.yaml
+++ b/backend/pipeline.yaml
@@ -41,10 +41,6 @@ resourceGroups:
       configRef: region
     - name: REGION_RG
       configRef: regionRG
-    - name: RESOURCEGROUP
-      configRef: svc.rg
-    - name: AKS_NAME
-      configRef: svc.aks.name
     - name: DB_NAME
       configRef: frontend.cosmosDB.name
     - name: IMAGE_DIGEST

--- a/backplane-api/Makefile
+++ b/backplane-api/Makefile
@@ -4,11 +4,11 @@
 deploy:
 	@kubectl create namespace aro-hcp --dry-run=client -o json | kubectl apply -f - && \
 	AZURE_TENANT_ID=$(shell az account show --query tenantId --output tsv) && \
-	BACKPLANE_MI_CLIENT_ID=$$(az identity show -g ${RESOURCEGROUP} -n backplane --query clientId -o tsv) && \
-	BACKPLANE_MI_TENANT_ID=$$(az identity show -g ${RESOURCEGROUP} -n backplane --query tenantId -o tsv) && \
-	IMAGE_PULLER_MI_CLIENT_ID=$$(az identity show -g ${RESOURCEGROUP} -n image-puller --query clientId -o tsv) && \
-	IMAGE_PULLER_MI_TENANT_ID=$$(az identity show -g ${RESOURCEGROUP} -n image-puller --query tenantId -o tsv) && \
-	CSI_SECRET_STORE_CLIENT_ID=$(shell az aks show -g ${RESOURCEGROUP} -n ${AKS_NAME} --query addonProfiles.azureKeyvaultSecretsProvider.identity.clientId -o tsv) && \
+	BACKPLANE_MI_CLIENT_ID=$$(az identity show -g ${ResourceGroup} -n backplane --query clientId -o tsv) && \
+	BACKPLANE_MI_TENANT_ID=$$(az identity show -g ${ResourceGroup} -n backplane --query tenantId -o tsv) && \
+	IMAGE_PULLER_MI_CLIENT_ID=$$(az identity show -g ${ResourceGroup} -n image-puller --query clientId -o tsv) && \
+	IMAGE_PULLER_MI_TENANT_ID=$$(az identity show -g ${ResourceGroup} -n image-puller --query tenantId -o tsv) && \
+	CSI_SECRET_STORE_CLIENT_ID=$(shell az aks show -g ${ResourceGroup} -n ${AKSCluster} --query addonProfiles.azureKeyvaultSecretsProvider.identity.clientId -o tsv) && \
 	IMAGE_TAG=$$(../get-tag.sh ${ARO_HCP_IMAGE_ACR} backplane-api) && \
 	${HELM_CMD} aro-hcp-backplane-api-dev deploy/helm/backplane-api/ \
 		--namespace aro-hcp \

--- a/backplane-api/pipeline.yaml
+++ b/backplane-api/pipeline.yaml
@@ -18,10 +18,6 @@ resourceGroups:
       configRef: acr.svc.name
     - name: LOCATION
       configRef: region
-    - name: RESOURCEGROUP
-      configRef: svc.rg
-    - name: AKS_NAME
-      configRef: svc.aks.name
     - name: COMMIT
       configRef: backplaneAPI.image.digest
     - name: SERVICE_KEY_VAULT

--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -16,10 +16,10 @@ ZONE_NAME ?= "${REGIONAL_DNS_SUBDOMAIN}.${CX_PARENT_DNS_ZONE_NAME}"
 deploy:
 	@source ./generate_helm_set_flags.sh && \
 	kubectl create namespace ${NAMESPACE} --dry-run=client -o json | kubectl apply -f - && \
-	IMAGE_PULLER_MI_CLIENT_ID=$(shell az identity show -g ${RESOURCEGROUP} -n image-puller --query clientId -o tsv) && \
-	IMAGE_PULLER_MI_TENANT_ID=$(shell az identity show -g ${RESOURCEGROUP} -n image-puller --query tenantId -o tsv) && \
+	IMAGE_PULLER_MI_CLIENT_ID=$(shell az identity show -g ${ResourceGroup} -n image-puller --query clientId -o tsv) && \
+	IMAGE_PULLER_MI_TENANT_ID=$(shell az identity show -g ${ResourceGroup} -n image-puller --query tenantId -o tsv) && \
 	kubectl label namespace ${NAMESPACE} "istio.io/rev=${ISTO_TAG}" --overwrite=true && \
-	AZURE_CS_MI_CLIENT_ID=$(shell az identity show -g ${RESOURCEGROUP} -n ${MI_NAME} --query clientId -o tsv) && \
+	AZURE_CS_MI_CLIENT_ID=$(shell az identity show -g ${ResourceGroup} -n ${MI_NAME} --query clientId -o tsv) && \
 	TENANT_ID=$(shell az account show --query tenantId --output tsv) && \
 	OIDC_BLOB_SERVICE_ENDPOINT=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${REGIONAL_RESOURCEGROUP} --query primaryEndpoints.blob -o tsv) && \
 	OIDC_ISSUER_BASE_ENDPOINT=$(shell az storage account show -n ${OIDC_STORAGE_ACCOUNT} -g ${REGIONAL_RESOURCEGROUP} --query primaryEndpoints.web -o tsv) && \
@@ -69,7 +69,7 @@ deploy:
 	  "$${OP_HELM_SET_FLAGS[@]}"
 
 deploy-pr-env-deps:
-	AZURE_CS_MI_CLIENT_ID=$(shell az identity show -g ${RESOURCEGROUP} -n clusters-service --query clientId -o tsv) && \
+	AZURE_CS_MI_CLIENT_ID=$(shell az identity show -g ${ResourceGroup} -n clusters-service --query clientId -o tsv) && \
 	oc process --local -f cspr/cluster-service-namespace.yaml \
 		-p CLIENT_ID=$${AZURE_CS_MI_CLIENT_ID} \
 		-p KEY_VAULT_NAME=${SERVICE_KV} \
@@ -84,7 +84,7 @@ deploy-pr-env-deps:
 	oc process --local -f cspr/orphaned-namespace-cleaner.yaml | oc apply -f -
 
 create-pr-env-sp:
-	CLUSTER_ID=$(shell az aks show -g ${RESOURCEGROUP} -n ${AKS_NAME} --query id -o tsv) && \
+	CLUSTER_ID=$(shell az aks show -g ${ResourceGroup} -n ${AKSCluster} --query id -o tsv) && \
 	az ad sp create-for-rbac \
 	--display-name "cs-pr-authentication" \
 	--role 'Contributor' \

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -44,10 +44,6 @@ resourceGroups:
     variables:
     - name: REGION
       configRef: region
-    - name: RESOURCEGROUP
-      configRef: svc.rg
-    - name: AKS_NAME
-      configRef: svc.aks.name
     - name: SERVICE_KV
       configRef: serviceKeyVault.name
     - name: OIDC_STORAGE_ACCOUNT

--- a/docs/pipeline-concept.md
+++ b/docs/pipeline-concept.md
@@ -157,6 +157,17 @@ The resourcegroup (`resourceGroups.name`) is pre-created before step execution s
 
 If an `resourceGroups.aksCluster` is specified, the `KUBECONFIG` environment variable is set and allows cluster admin interaction withe the AKS cluster. This is mostly relevant for `Shell` steps.
 
+#### Environment Variables
+
+The following environment variables are set for each step execution:
+
+- `ResourceGroup`: The name of the resource group being targeted by the step.
+- `Subscription`: The Azure subscription ID (not the Azure subscription resource ID) being targeted by the step.
+- `AKSCluster`: The name of the AKS cluster being targeted by the step, if applicable.
+- `KUBECONFIG`: The path to the kubeconfig file for the AKS cluster, if applicable.
+- `DRY_RUN`: Set to `true` if the step is executed in dry-run mode, allowing scripts to adapt their behavior accordingly.
+- `EV2`: Set to `1` if the step is executed within EV2. Undefined otherwise
+
 ## Pipeline Deployment Scope
 
 A pipeline is the smallest unit of deployment in ARO HCP. This means that all steps within a pipeline are executed from start to finish—there is no concept of executing a single step in only.

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -44,23 +44,23 @@ push: image
 deploy:
 	DIGEST=$$(../get-digest.sh ${ARO_HCP_IMAGE_ACR} arohcpfrontend) \
 	FRONTEND_MI_CLIENT_ID=$$(az identity show \
-			-g ${RESOURCEGROUP} \
+			-g ${ResourceGroup} \
 			-n frontend \
 			--query clientId -o tsv) && \
 	FRONTEND_MI_TENANT_ID=$$(az identity show \
-			-g ${RESOURCEGROUP} \
+			-g ${ResourceGroup} \
 			-n frontend \
 			--query tenantId -o tsv) &&\
 	IMAGE_PULLER_MI_CLIENT_ID=$$(az identity show \
-			-g ${RESOURCEGROUP} \
+			-g ${ResourceGroup} \
 			-n image-puller \
 			--query clientId -o tsv) && \
 	IMAGE_PULLER_MI_TENANT_ID=$$(az identity show \
-			-g ${RESOURCEGROUP} \
+			-g ${ResourceGroup} \
 			-n image-puller \
 			--query tenantId -o tsv) && \
-	SECRET_STORE_MI_CLIENT_ID=$$(az aks show --resource-group ${RESOURCEGROUP} \
-			--name ${AKS_NAME} \
+	SECRET_STORE_MI_CLIENT_ID=$$(az aks show --resource-group ${ResourceGroup} \
+			--name ${AKSCluster} \
 			--query addonProfiles.azureKeyvaultSecretsProvider.identity.clientId \
 			--output tsv) && \
 	TENANT_ID=$(shell az account show --query tenantId --output tsv) && \

--- a/frontend/pipeline.yaml
+++ b/frontend/pipeline.yaml
@@ -41,10 +41,6 @@ resourceGroups:
       configRef: region
     - name: REGION_RG
       configRef: regionRG
-    - name: RESOURCEGROUP
-      configRef: svc.rg
-    - name: AKS_NAME
-      configRef: svc.aks.name
     - name: DB_NAME
       configRef: frontend.cosmosDB.name
     - name: IMAGE_DIGEST

--- a/hypershiftoperator/Makefile
+++ b/hypershiftoperator/Makefile
@@ -5,7 +5,7 @@ deploy:
 	@kubectl create namespace ${HYPERSHIFT_NAMESPACE} --dry-run=client -o json | kubectl apply -f - && \
 	AZURE_TENANT_ID=$(shell az account show --query tenantId --output tsv) && \
 	AZURE_SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) && \
-	CSI_SECRET_STORE_CLIENT_ID=$(shell az aks show -n ${AKS_NAME} -g ${RESOURCEGROUP} --query 'addonProfiles.azureKeyvaultSecretsProvider.identity.clientId' -o tsv) && \
+	CSI_SECRET_STORE_CLIENT_ID=$(shell az aks show -n ${AKSCluster} -g ${ResourceGroup} --query 'addonProfiles.azureKeyvaultSecretsProvider.identity.clientId' -o tsv) && \
 	${HELM_CMD} hypershift deploy \
 		--namespace ${HYPERSHIFT_NAMESPACE} \
 		--set image=${ARO_HCP_SVC_ACR}.azurecr.io/${HO_IMAGE_REPOSITORY} \

--- a/hypershiftoperator/pipeline.yaml
+++ b/hypershiftoperator/pipeline.yaml
@@ -43,10 +43,6 @@ resourceGroups:
       configRef: hypershift.image.digest
     - name: HO_IMAGE_REPOSITORY
       configRef: hypershift.image.repository
-    - name: RESOURCEGROUP
-      configRef: mgmt.rg
-    - name: AKS_NAME
-      configRef: mgmt.aks.name
     - name: HYPERSHIFT_NAMESPACE
       configRef: hypershift.namespace
     - name: HO_ADDITIONAL_INSTALL_ARG

--- a/maestro/agent/Makefile
+++ b/maestro/agent/Makefile
@@ -3,7 +3,7 @@
 deploy:
 	@kubectl create namespace maestro --dry-run=client -o json | kubectl apply -f -
 	@TENANT_ID=$(shell az account show --query tenantId --output tsv) && \
-	MAESTRO_MI_CLIENT_ID=$(shell az identity show -g "${MGMT_RG}" -n maestro-consumer --query clientId -o tsv) && \
+	MAESTRO_MI_CLIENT_ID=$(shell az identity show -g "${ResourceGroup}" -n maestro-consumer --query clientId -o tsv) && \
 	../../hack/helm.sh maestro-agent deploy maestro \
 		--set consumerName=${CONSUMER_NAME} \
 		--set glog_v=${MAESTRO_LOG_LEVEL} \

--- a/maestro/agent/pipeline.yaml
+++ b/maestro/agent/pipeline.yaml
@@ -46,8 +46,6 @@ resourceGroups:
       configRef: maestro.eventGrid.name
     - name: REGION_RG
       configRef: regionRG
-    - name: MGMT_RG
-      configRef: mgmt.rg
     - name: CONSUMER_NAME
       configRef: maestro.agent.consumerName
     - name: MAESTRO_LOG_LEVEL

--- a/maestro/server/Makefile
+++ b/maestro/server/Makefile
@@ -5,10 +5,10 @@ deploy:
 	@kubectl label ${KUBECTL_DRY_RUN} namespace ${NAMESPACE} "istio.io/rev=${ISTO_TAG}" --overwrite=true
 	@EVENTGRID_HOSTNAME=$(shell az resource show -n ${EVENTGRID_NAME} -g ${REGION_RG} --resource-type "Microsoft.EventGrid/namespaces" --query properties.topicSpacesConfiguration.hostname -o tsv) && \
 	TENANT_ID=$(shell az account show --query tenantId --output tsv) && \
-	MAESTRO_MI_CLIENT_ID=$(shell az identity show -g "${SVC_RG}" -n ${MANAGED_IDENTITY_NAME} --query clientId -o tsv) && \
+	MAESTRO_MI_CLIENT_ID=$(shell az identity show -g "${ResourceGroup}" -n ${MANAGED_IDENTITY_NAME} --query clientId -o tsv) && \
 	DATABASE_HOST=$$(if [ "${USE_AZURE_DB}" = "true" ]; then az postgres flexible-server show -g ${REGION_RG} -n ${DATABASE_SERVER_NAME} --query fullyQualifiedDomainName -o tsv; else echo "maestro-db"; fi) && \
 	OVERRIDES=$$(if [ "${USE_AZURE_DB}" = "true" ]; then echo "azuredb.values.yaml"; else echo "containerdb.values.yaml"; fi) && \
-	IMAGE_PULLER_MI_CLIENT_ID=$(shell az identity show -g ${SVC_RG} -n image-puller --query clientId -o tsv) && \
+	IMAGE_PULLER_MI_CLIENT_ID=$(shell az identity show -g ${ResourceGroup} -n image-puller --query clientId -o tsv) && \
 	../../hack/helm.sh maestro-server deploy ${NAMESPACE} \
 		-f deploy/$${OVERRIDES} \
 		--set maestro.serviceAccount=${SERVICE_ACCOUNT_NAME} \

--- a/maestro/server/pipeline.yaml
+++ b/maestro/server/pipeline.yaml
@@ -39,10 +39,6 @@ resourceGroups:
       configRef: maestro.eventGrid.name
     - name: REGION_RG
       configRef: regionRG
-    - name: SVC_RG
-      configRef: svc.rg
-    - name: AKS_NAME
-      configRef: svc.aks.name
     - name: IMAGE_REPO
       configRef: maestro.image.repository
     - name: IMAGE_DIGEST

--- a/pko/Makefile
+++ b/pko/Makefile
@@ -8,11 +8,11 @@ ARO_HCP_IMAGE_REPOSITORY ?= package-operator/package-operator-package
 deploy:
 	@kubectl create namespace ${NAMESPACE} --dry-run=client -o json | kubectl apply -f -
 	IMAGE_PULLER_MI_CLIENT_ID=$$(az identity show \
-			-g ${RESOURCEGROUP} \
+			-g ${ResourceGroup} \
 			-n image-puller \
 			--query clientId -o tsv) && \
 	IMAGE_PULLER_MI_TENANT_ID=$$(az identity show \
-			-g ${RESOURCEGROUP} \
+			-g ${ResourceGroup} \
 			-n image-puller \
 			--query tenantId -o tsv) && \
 	${HELM_CMD} package-operator ./deploy \

--- a/pko/pipeline.yaml
+++ b/pko/pipeline.yaml
@@ -83,7 +83,5 @@ resourceGroups:
       configRef: pko.imageManager.repository
     - name: PKO_IMAGEMANAGER_DIGEST
       configRef: pko.imageManager.digest
-    - name: RESOURCEGROUP
-      configRef: mgmt.rg
     shellIdentity:
       configRef: aroDevopsMsiId

--- a/tooling/templatize/cmd/pipeline/inspect/cmd.go
+++ b/tooling/templatize/cmd/pipeline/inspect/cmd.go
@@ -17,6 +17,7 @@ package inspect
 import (
 	"context"
 
+	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/azauth"
 	"github.com/spf13/cobra"
 )
 
@@ -43,6 +44,10 @@ func runInspect(ctx context.Context, opts *RawInspectOptions) error {
 		return err
 	}
 	completed, err := validated.Complete()
+	if err != nil {
+		return err
+	}
+	err = azauth.SetupAzureAuth(ctx)
 	if err != nil {
 		return err
 	}

--- a/tooling/templatize/cmd/pipeline/inspect/cmd.go
+++ b/tooling/templatize/cmd/pipeline/inspect/cmd.go
@@ -17,8 +17,9 @@ package inspect
 import (
 	"context"
 
-	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/azauth"
 	"github.com/spf13/cobra"
+
+	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/azauth"
 )
 
 func NewCommand() (*cobra.Command, error) {

--- a/tooling/templatize/pkg/pipeline/image_mirror.go
+++ b/tooling/templatize/pkg/pipeline/image_mirror.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-logr/logr"
 )
 
-func runImageMirrorStep(ctx context.Context, step *types.ImageMirrorStep, options *PipelineRunOptions, inputs map[string]Output, outputWriter io.Writer) error {
+func runImageMirrorStep(ctx context.Context, step *types.ImageMirrorStep, executionTarget ExecutionTarget, options *PipelineRunOptions, inputs map[string]Output, outputWriter io.Writer) error {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	tmpFile, err := os.CreateTemp("", "")
@@ -61,5 +61,5 @@ func runImageMirrorStep(ctx context.Context, step *types.ImageMirrorStep, option
 		return fmt.Errorf("error resolving image mirror step %w", err)
 	}
 
-	return runShellStep(tmpShellStep, ctx, "", options, inputs, outputWriter)
+	return runShellStep(tmpShellStep, ctx, "", executionTarget, options, inputs, outputWriter)
 }

--- a/tooling/templatize/pkg/pipeline/inspect.go
+++ b/tooling/templatize/pkg/pipeline/inspect.go
@@ -33,13 +33,13 @@ func NewStepInspectScopes() map[string]StepInspectScope {
 
 // InspectOptions contains the options for the Inspect method
 type InspectOptions struct {
-	Scope                 string
-	Format                string
-	Step                  string
-	Region                string
-	Configuration         config.Configuration
-	ScopeFunctions        map[string]StepInspectScope
-	OutputFile            io.Writer
+	Scope                  string
+	Format                 string
+	Step                   string
+	Region                 string
+	Configuration          config.Configuration
+	ScopeFunctions         map[string]StepInspectScope
+	OutputFile             io.Writer
 	SubscriptionLookupFunc func(context.Context, string) (string, error)
 }
 
@@ -120,14 +120,8 @@ func inspectVars(ctx context.Context, pipeline *types.Pipeline, s types.Step, op
 			region:           options.Region,
 		}
 
-		// Determine kubeconfig file (mock path if AKS cluster is defined)
-		kubeconfigFile := ""
-		if step.AKSCluster != "" {
-			kubeconfigFile = "/tmp/kubeconfig-" + step.AKSCluster // Mock kubeconfig path
-		}
-
 		// Build complete environment including Azure context variables
-		envVars = buildStepShellEnvironment(step, kubeconfigFile, executionTarget, stepVars, nil, false)
+		envVars = buildStepShellEnvironment(step, "", executionTarget, stepVars, nil, false)
 	default:
 		return fmt.Errorf("inspecting step variables not implemented for action type %s", s.ActionType())
 	}

--- a/tooling/templatize/pkg/pipeline/inspect_test.go
+++ b/tooling/templatize/pkg/pipeline/inspect_test.go
@@ -80,12 +80,12 @@ func TestInspectVars(t *testing.T) {
 				Configuration: config.Configuration{
 					"foo": "bar",
 				},
-				Format: "shell",
-				Region: "westus3",
+				Format:                 "shell",
+				Region:                 "westus3",
 				SubscriptionLookupFunc: mockSubscriptionLookup,
 			},
 			expectedVariables: map[string]string{
-				"FOO":          "bar",
+				"FOO":           "bar",
 				"ResourceGroup": "test-rg",
 				"Subscription":  "mock-sub-test-subscription",
 			},
@@ -130,18 +130,18 @@ func TestInspectVars(t *testing.T) {
 				Configuration: config.Configuration{
 					"foo": "bar",
 				},
-				Format: "makefile",
-				Region: "westus3",
+				Format:                 "makefile",
+				Region:                 "westus3",
 				SubscriptionLookupFunc: mockSubscriptionLookup,
 			},
 			expectedVariables: map[string]string{
-				"FOO":          "bar",
+				"FOO":           "bar",
 				"ResourceGroup": "test-rg",
 				"Subscription":  "mock-sub-test-subscription",
 			},
 		},
 		{
-			name: "failed action",
+			name:     "failed action",
 			pipeline: &types.Pipeline{},
 			caseStep: &types.ARMStep{
 				StepMeta: types.StepMeta{
@@ -180,10 +180,10 @@ func TestInspectVars(t *testing.T) {
 				Command: "echo hello",
 			},
 			options: &InspectOptions{
-				Format: "unknown",
+				Format:                 "unknown",
 				SubscriptionLookupFunc: mockSubscriptionLookup,
 			},
-			err:     "unknown output format \"unknown\"",
+			err: "unknown output format \"unknown\"",
 		},
 		{
 			name: "with AKS cluster",
@@ -212,15 +212,14 @@ func TestInspectVars(t *testing.T) {
 				AKSCluster: "my-aks-cluster",
 			},
 			options: &InspectOptions{
-				Format: "shell",
-				Region: "westus3",
+				Format:                 "shell",
+				Region:                 "westus3",
 				SubscriptionLookupFunc: mockSubscriptionLookup,
 			},
 			expectedVariables: map[string]string{
 				"ResourceGroup": "aks-rg",
 				"Subscription":  "mock-sub-aks-subscription",
 				"AKSCluster":    "my-aks-cluster",
-				"KUBECONFIG":    "/tmp/kubeconfig-my-aks-cluster",
 			},
 		},
 	}
@@ -235,9 +234,10 @@ func TestInspectVars(t *testing.T) {
 				output := buf.String()
 				// Check for presence of expected variables based on format
 				for varName, varValue := range tc.expectedVariables {
-					if tc.options.Format == "makefile" {
+					switch tc.options.Format {
+					case "makefile":
 						assert.Contains(t, output, fmt.Sprintf("%s ?= %s", varName, varValue))
-					} else if tc.options.Format == "shell" {
+					case "shell":
 						assert.Contains(t, output, fmt.Sprintf("export %s=\"%s\"", varName, varValue))
 					}
 				}

--- a/tooling/templatize/pkg/pipeline/inspect_test.go
+++ b/tooling/templatize/pkg/pipeline/inspect_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestInspectVars(t *testing.T) {
-	// Define reusable subscription lookup function
 	mockSubscriptionLookup := func(ctx context.Context, name string) (string, error) {
 		return "mock-sub-" + name, nil
 	}

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -143,7 +143,7 @@ func RunStep(s types.Step, ctx context.Context, executionTarget ExecutionTarget,
 	case *types.ImageMirrorStep:
 		var buf bytes.Buffer
 
-		err := runImageMirrorStep(ctx, step, options, outPuts, &buf)
+		err := runImageMirrorStep(ctx, step, executionTarget, options, outPuts, &buf)
 		if err != nil {
 			return nil, fmt.Errorf("error running Image Mirror Step, %v", err)
 		}
@@ -164,7 +164,7 @@ func RunStep(s types.Step, ctx context.Context, executionTarget ExecutionTarget,
 			return nil, fmt.Errorf("failed to prepare kubeconfig: %w", err)
 		}
 
-		err = runShellStep(step, ctx, kubeconfigFile, options, outPuts, &buf)
+		err = runShellStep(step, ctx, kubeconfigFile, executionTarget, options, outPuts, &buf)
 		if err != nil {
 			return nil, fmt.Errorf("error running Shell Step, %v", err)
 		}


### PR DESCRIPTION
### What

add `ResourceGroup`, `Subscription` and `AKSCluster` environment variables to shell step execution and inspection

### Why

this way we get parity with EV2 and reduce the amount of custom defined env vars

### Special notes for your reviewer

<!-- optional -->
