### PR TITLE
add missing secretsync CRD role

### DIFF
--- a/secret-sync-controller/deploy/templates/secret-sync-admin.clusterrole.yaml
+++ b/secret-sync-controller/deploy/templates/secret-sync-admin.clusterrole.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secret-sync-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - secret-sync.x-k8s.io
+    resources:
+      - secretsyncs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - secret-sync.x-k8s.io
+    resources:
+      - secretsyncs/status
+    verbs:
+      - get


### PR DESCRIPTION
### What

this one aggreates into admin and grants permissions to process `SecretSync` CRDs via ManifestWork.

https://redhat-internal.slack.com/archives/C07A2CVUV44/p1749072011093899

https://issues.redhat.com/browse/ARO-17118

follows up on #2042

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
