### PR TITLE
Add Authorized IP to Api Server

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
@@ -23,7 +23,11 @@
           "hostPrefix": 21
         },
         "api": {
-          "visibility": "Public"
+          "visibility": "Public",
+          "authorizedCidrs": [
+            "192.168.1.0/24",
+            "10.0.0.0/16"
+          ]
         },
         "platform": {
           "managedResourceGroup": "nhyhywrxupo",

--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
@@ -28,7 +28,11 @@
           },
           "api": {
             "visibility": "Public",
-            "url": "https://api.test.shrd.usw3test.hcp.osadev.cloud:443"
+            "url": "https://api.test.shrd.usw3test.hcp.osadev.cloud:443",
+            "authorizedCidrs": [
+              "192.168.1.0/24",
+              "203.0.113.0/24"
+            ]
           },
           "platform": {
             "managedResourceGroup": "nhyhywrxupo",

--- a/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2024-06-10-preview/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
@@ -39,7 +39,11 @@
           },
           "api": {
             "visibility": "Public",
-            "url": "https://api.test.shrd.usw3test.hcp.osadev.cloud:443"
+            "url": "https://api.test.shrd.usw3test.hcp.osadev.cloud:443",
+            "authorizedCidrs": [
+              "172.16.0.0/12",
+              "203.0.113.0/24"
+            ]
           },
           "platform": {
             "managedResourceGroup": "nhyhywrxupo",

--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -200,6 +200,11 @@ model ApiProfile {
   /** The internet visibility of the OpenShift API server */
   @visibility(Lifecycle.Read, Lifecycle.Create)
   visibility?: Visibility = Visibility.Public;
+
+  /** The list of authorized IPv4 CIDR blocks allowed to access the API server. Maximum 5000 entries. */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  @maxItems(5000)
+  authorizedCidrs?: string[];
 }
 
 /** The internet visibility of the OpenShift API server */

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
@@ -23,7 +23,11 @@
           "hostPrefix": 21
         },
         "api": {
-          "visibility": "Public"
+          "visibility": "Public",
+          "authorizedCidrs": [
+            "192.168.1.0/24",
+            "10.0.0.0/16"
+          ]
         },
         "platform": {
           "managedResourceGroup": "nhyhywrxupo",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
@@ -28,7 +28,11 @@
           },
           "api": {
             "visibility": "Public",
-            "url": "https://api.test.shrd.usw3test.hcp.osadev.cloud:443"
+            "url": "https://api.test.shrd.usw3test.hcp.osadev.cloud:443",
+            "authorizedCidrs": [
+              "192.168.1.0/24",
+              "203.0.113.0/24"
+            ]
           },
           "platform": {
             "managedResourceGroup": "nhyhywrxupo",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/examples/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
@@ -39,7 +39,11 @@
           },
           "api": {
             "visibility": "Public",
-            "url": "https://api.test.shrd.usw3test.hcp.osadev.cloud:443"
+            "url": "https://api.test.shrd.usw3test.hcp.osadev.cloud:443",
+            "authorizedCidrs": [
+              "172.16.0.0/12",
+              "203.0.113.0/24"
+            ]
           },
           "platform": {
             "managedResourceGroup": "nhyhywrxupo",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -1108,6 +1108,19 @@
             "read",
             "create"
           ]
+        },
+        "authorizedCidrs": {
+          "type": "array",
+          "description": "The list of authorized IPv4 CIDR blocks allowed to access the API server. Maximum 5000 entries.",
+          "maxItems": 5000,
+          "items": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
         }
       },
       "required": [

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -16,6 +16,9 @@ type APIProfile struct {
 
 	// READ-ONLY; URL endpoint for the API server
 	URL *string
+
+	// The list of authorized IPv4 CIDR blocks allowed to access the API server. Maximum 5000 entries.
+	AuthorizedCidrs []*string
 }
 
 // AzureResourceManagerCommonTypesManagedServiceIdentityUpdate - Managed service identity (system assigned and/or user assigned

--- a/internal/api/v20240610preview/generated/models_serde.go
+++ b/internal/api/v20240610preview/generated/models_serde.go
@@ -18,6 +18,7 @@ import (
 // MarshalJSON implements the json.Marshaller interface for type APIProfile.
 func (a APIProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "authorizedCidrs", a.AuthorizedCidrs)
 	populate(objectMap, "url", a.URL)
 	populate(objectMap, "visibility", a.Visibility)
 	return json.Marshal(objectMap)
@@ -32,6 +33,9 @@ func (a *APIProfile) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "authorizedCidrs":
+			err = unpopulate(val, "AuthorizedCidrs", &a.AuthorizedCidrs)
+			delete(rawMsg, key)
 		case "url":
 			err = unpopulate(val, "URL", &a.URL)
 			delete(rawMsg, key)


### PR DESCRIPTION
Replaces https://github.com/Azure/ARO-HCP/pull/1932

Ticket -
https://issues.redhat.com/browse/ARO-15671

What
Spec for adding authorizedIpRanges to api server

Support for up to 5000 authorized IP ranges (IPv4 CIDR)
Configurable at cluster creation time and updatable post-deployment
Feature can be disabled by providing an empty array (reverts to default access)
Added co-pilot generated examples
