### PR TITLE
nest disk settings under "osDisk" in node_pool.tmpl.json

### DIFF
--- a/demo/node_pool.tmpl.json
+++ b/demo/node_pool.tmpl.json
@@ -8,8 +8,10 @@
     "platform": {
       "subnetId": "/subscriptions/$sub/resourceGroups/$customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet/subnets/customer-subnet-1",
       "vmSize": "Standard_D8s_v3",
-      "sizeGiB": 64,
-      "diskStorageAccountType": "StandardSSD_LRS"
+      "osDisk": {
+        "sizeGiB": 64,
+        "diskStorageAccountType": "StandardSSD_LRS"
+      }
     },
     "replicas": 2
   }


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Mirror the layout of `NodePoolPlatformProfile.OSDisk` by placing "sizeGiB" and "diskStorageAccountType" fields under "osDisk".

### Why
Upon executing `04-create-nodepool.sh`, the script reports about failing to unmarshal values because "sizeGiB" field is nested inside "osDisk"
```
./04-create-nodepool.sh
HTTP/1.1 400 Bad Request
Content-Type: application/json
X-Ms-Client-Request-Id: b73526cb-4dca-429f-bff3-fa1a90f9b89f
X-Ms-Error-Code: InvalidRequestContent
X-Ms-Request-Id: c766161e-58ad-4c85-9f96-282e7bc2fc10
Date: Tue, 08 Jul 2025 05:08:04 GMT
Content-Length: 431

{
    "error": {
        "code": "InvalidRequestContent",
        "message": "The request content was invalid and could not be deserialized: \"unmarshalling type *generated.NodePool: struct field Properties: unmarshalling type *generated.NodePoolProperties: struct field
Platform: unmarshalling type *generated.NodePoolPlatformProfile: unmarshalling type *generated.NodePoolPlatformProfile, unknown field \\\"sizeGiB\\\"\""
    }
}
```

### Special notes for your reviewer

The JSON structure has been changed to align with `OSDiskProfile` https://github.com/Azure/ARO-HCP/blob/main/internal/api/hcpopenshiftclusternodepool.go#L56-L70