### PR TITLE
fine grained swift settings for vnet and nodepools

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -228,7 +228,10 @@
         "clusterOutboundIPAddressIPTags": {
           "$ref": "#/definitions/keyColonValueCSV"
         },
-        "enableSwiftV2": {
+        "enableSwiftV2Vnet": {
+          "type": "boolean"
+        },
+        "enableSwiftV2Nodepools": {
           "type": "boolean"
         }
       },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -229,7 +229,8 @@ defaults:
         osDiskSizeGB: 32
         azCount: {{ .ev2.availabilityZoneCount }}
       clusterOutboundIPAddressIPTags: ""
-      enableSwiftV2: true
+      enableSwiftV2Vnet: true
+      enableSwiftV2Nodepools: true
     logs:
       namespace: HCPCustomerLogs
       san: ""
@@ -562,7 +563,8 @@ clouds:
             azCount: 1
           etcd:
             kvSoftDelete: false
-          enableSwiftV2: false
+          enableSwiftV2Vnet: false
+          enableSwiftV2Nodepools: false
         nsp:
           accessMode: 'Learning'
         prometheus:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,16 +3,16 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 7fe46e5f3655e0e0efb7e368527a707d897b82030492a25ce9d19a59d0826073
+          westus3: 8ff2721972ef1bff432c4d693ef1688b1d7c891d0bdb4db6c989f1f305a9515b
       dev:
         regions:
-          westus3: 10881b2a70648f080a5508e0f4b7b7da7e8bd2d9b43e5122f51816156eeafd16
+          westus3: 067b9de4acb42a8604eed48f1a35cddabeb88297872d5c11bf57b3cdeaed1775
       ntly:
         regions:
-          uksouth: 02e55a8aafbc8fe3d79bd8378257bbc63960a713145e03c81184e17e8a30a420
+          uksouth: e995f6524ae390d91a64c8cfb97669f8a7b4c354731cb887705d926ecf569cb2
       perf:
         regions:
-          westus3: 86e60475e5a1e3145fb1c045a8c054d0739feec9aa4a44e6b5d504a9714b189c
+          westus3: c24335732ae9f81ff0bc1aebf2b90bac9b061c3fcbce7dd7a6fe691a47c77ee2
       pers:
         regions:
-          westus3: c0dff1fcffb7b4189488272e60597dfe45ed0adbb6c078066e37981efa0270e9
+          westus3: 5947d2294a034d2a7a16296852d17695866be0999e2776e90a16da7e800692a2

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -219,7 +219,8 @@ maestro:
 mgmt:
   aks:
     clusterOutboundIPAddressIPTags: ""
-    enableSwiftV2: false
+    enableSwiftV2Nodepools: false
+    enableSwiftV2Vnet: false
     etcd:
       kvName: ah-cspr-me-usw3-1
       kvSoftDelete: false

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -219,7 +219,8 @@ maestro:
 mgmt:
   aks:
     clusterOutboundIPAddressIPTags: ""
-    enableSwiftV2: false
+    enableSwiftV2Nodepools: false
+    enableSwiftV2Vnet: false
     etcd:
       kvName: ah-dev-me-usw3-1
       kvSoftDelete: false

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -219,7 +219,8 @@ maestro:
 mgmt:
   aks:
     clusterOutboundIPAddressIPTags: ""
-    enableSwiftV2: false
+    enableSwiftV2Nodepools: false
+    enableSwiftV2Vnet: false
     etcd:
       kvName: ah-ntly-me-ln-1
       kvSoftDelete: false

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -219,7 +219,8 @@ maestro:
 mgmt:
   aks:
     clusterOutboundIPAddressIPTags: ""
-    enableSwiftV2: false
+    enableSwiftV2Nodepools: false
+    enableSwiftV2Vnet: false
     etcd:
       kvName: ah-perf-me-usw3ptest-1
       kvSoftDelete: false

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -219,7 +219,8 @@ maestro:
 mgmt:
   aks:
     clusterOutboundIPAddressIPTags: ""
-    enableSwiftV2: false
+    enableSwiftV2Nodepools: false
+    enableSwiftV2Vnet: false
     etcd:
       kvName: ah-pers-me-usw3test-1
       kvSoftDelete: false

--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -27,7 +27,8 @@ param aksUserOsDiskSizeGB = {{ .mgmt.aks.userAgentPool.osDiskSizeGB }}
 param aksClusterOutboundIPAddressIPTags = '{{ .mgmt.aks.clusterOutboundIPAddressIPTags }}'
 param aksNetworkDataplane = '{{ .mgmt.aks.networkDataplane }}'
 param aksNetworkPolicy = '{{ .mgmt.aks.networkDataplane }}'
-param aksEnableSwift = {{ .mgmt.aks.enableSwiftV2 }}
+param aksEnableSwiftVnet = {{ .mgmt.aks.enableSwiftV2Vnet }}
+param aksEnableSwiftNodepools = {{ .mgmt.aks.enableSwiftV2Nodepools }}
 
 // Maestro
 param maestroConsumerName = '{{ .maestro.agent.consumerName }}'
@@ -65,4 +66,3 @@ param logsServiceAccount = '{{ .logs.mdsd.serviceAccountName }}'
 
 // Log Analytics Workspace ID will be passed from region pipeline if enabled in config
 param logAnalyticsWorkspaceId = '__logAnalyticsWorkspaceId__'
-

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -53,7 +53,8 @@ param workloadIdentities array
 param nodeSubnetNSGId string
 param networkDataplane string
 param networkPolicy string
-param enableSwiftV2 bool
+param enableSwiftV2Vnet bool
+param enableSwiftV2Nodepools bool
 
 @description('Istio Ingress Gateway Public IP Address resource name')
 param istioIngressGatewayIPAddressName string = ''
@@ -208,7 +209,7 @@ module vnetCreation '../modules/network/vnet.bicep' = {
     location: location
     vnetName: vnetName
     vnetAddressPrefix: vnetAddressPrefix
-    enableSwift: enableSwiftV2
+    enableSwift: enableSwiftV2Vnet
     deploymentMsiId: deploymentMsiId
   }
   dependsOn: [
@@ -575,7 +576,7 @@ resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2
       nodeLabels: {
         'aro-hcp.azure.com/role': 'worker'
       }
-      tags: enableSwiftV2
+      tags: enableSwiftV2Nodepools
         ? {
             'aks-nic-enable-multi-tenancy': 'true'
           }

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -92,8 +92,11 @@ param aksEtcdKVEnableSoftDelete bool = true
 @description('IPTags to be set on the cluster outbound IP address in the format of ipTagType:tag,ipTagType:tag')
 param aksClusterOutboundIPAddressIPTags string = ''
 
-@description('Enable Swift V2 for the AKS cluster and VNET')
-param aksEnableSwift bool
+@description('Enable Swift V2 for the AKS cluster VNET')
+param aksEnableSwiftVnet bool
+
+@description('Enable Swift V2 for the AKS cluster nodepools')
+param aksEnableSwiftNodepools bool
 
 @description('The name of the maestro consumer.')
 param maestroConsumerName string
@@ -236,7 +239,8 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     networkPolicy: aksNetworkPolicy
     userOsDiskSizeGB: aksUserOsDiskSizeGB
     deploymentMsiId: aroDevopsMsiId
-    enableSwiftV2: aksEnableSwift
+    enableSwiftV2Vnet: aksEnableSwiftVnet
+    enableSwiftV2Nodepools: aksEnableSwiftNodepools
   }
 }
 

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -386,7 +386,8 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
     pullAcrResourceIds: [svcAcrResourceId]
     deploymentMsiId: aroDevopsMsiId
-    enableSwiftV2: false
+    enableSwiftV2Vnet: false
+    enableSwiftV2Nodepools: false
   }
 }
 


### PR DESCRIPTION
### What

with the new settings we can enable swift on the vnet but keep it disabled on the nodepools for the time being until we can use it. this means though that we need to recreate the nodepools when we do so (which is still less effort than a complete MC rebuild)

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
