### PR TITLE
tracing: fix OpenTelemetry collector config

### DIFF
--- a/observability/tracing/Makefile
+++ b/observability/tracing/Makefile
@@ -1,6 +1,6 @@
 -include ../../setup-env.mk
 
-all: deploy patch-frontend patch-clusterservice
+all: deploy
 	@echo "Observability services are now configured and enabled."
 	@echo "Run the following command to port-forward traffic to the Jaeger service:"
 	@echo ""
@@ -11,25 +11,10 @@ all: deploy patch-frontend patch-clusterservice
 deploy:
 	@if [ "$(DEPLOY)" = "true" ]; then \
 		kubectl apply -k deploy/; \
+		kubectl wait --for=condition=Available deployment -n observability otel-collector --timeout=60s; \
 		kubectl wait --for=condition=Available deployment -n observability jaeger --timeout=60s; \
 		kubectl wait --for=condition=Available deployment -n observability lgtm --timeout=60s; \
 	else \
 		echo "Skipping deployment because DEPLOY is not set to true"; \
 	fi
 .PHONY: deploy
-
-patch-frontend:
-	@kubectl set env -n aro-hcp deployment aro-hcp-frontend --containers aro-hcp-frontend OTEL_EXPORTER_OTLP_ENDPOINT=http://ingest.observability:4318 OTEL_TRACES_EXPORTER=otlp
-	@kubectl wait --for=condition=Available -n aro-hcp deployment aro-hcp-frontend --timeout=30s
-.PHONY: patch-frontend
-
-patch-maestro-server:
-	@kubectl set env -n maestro deployment maestro --containers service OTEL_EXPORTER_OTLP_ENDPOINT=http://ingest.observability:4318 OTEL_TRACES_EXPORTER=otlp
-	@kubectl wait --for=condition=Available -n maestro deployment maestro --timeout=30s
-.PHONY: patch-maestro-server
-
-patch-clusterservice:
-	kubectl patch -n ${CS_NAMESPACE} deployment clusters-service --type json \
-		--patch="[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/command/-\", \"value\": \"--tracing-otlp-url=http://ingest.observability:4318\"}]"
-	@kubectl wait --for=condition=Available -n ${CS_NAMESPACE} deployment clusters-service --timeout=30s
-.PHONY: patch-clusterservice

--- a/observability/tracing/deploy/collector.yaml
+++ b/observability/tracing/deploy/collector.yaml
@@ -17,11 +17,11 @@ data:
 
     exporters:
       otlp/jaeger:
-        endpoint: http://jaeger:4318
+        endpoint: http://jaeger:4317
         tls:
           insecure: true
       otlp/lgtm:
-        endpoint: http://lgtm:4318
+        endpoint: http://lgtm:4317
         tls:
           insecure: true
 


### PR DESCRIPTION
### What

After deploying the new setup with the OTEL collector, I realized that the collector was sending gRPC OTLP to the HTTP ports of Jaeger and lgtm.

It also updates the README.md with the latest changes.

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
