### PR TITLE
Add location details for all internal errors.

### DIFF
--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -997,7 +997,7 @@ func convertNodePoolStatus(op operation, nodePoolStatus *arohcpv1alpha1.NodePool
 		//     operations so "Internal Server Error" is all we can do for now.
 		//     https://issues.redhat.com/browse/ARO-14969
 		opStatus = arm.ProvisioningStateFailed
-		opError = arm.NewInternalServerError().CloudErrorBody
+		opError = arm.NewInternalServerError("converting node pool status").CloudErrorBody
 	default:
 		err = fmt.Errorf("unhandled NodePoolState '%s'", state)
 	}

--- a/frontend/pkg/frontend/middleware_locksubscription.go
+++ b/frontend/pkg/frontend/middleware_locksubscription.go
@@ -34,7 +34,7 @@ func MiddlewareLockSubscription(w http.ResponseWriter, r *http.Request, next htt
 	dbClient, err := DBClientFromContext(ctx)
 	if err != nil {
 		logger.Error(err.Error())
-		arm.WriteInternalServerError(w)
+		arm.WriteInternalServerError(w, "failed getting database client")
 		return
 	}
 
@@ -63,7 +63,7 @@ func MiddlewareLockSubscription(w http.ResponseWriter, r *http.Request, next htt
 					"/subscriptions/"+subscriptionID, "%s", message)
 			} else {
 				message += err.Error()
-				arm.WriteInternalServerError(w)
+				arm.WriteInternalServerError(w, "failed to acquire lock")
 			}
 			logger.Error(message)
 			return

--- a/frontend/pkg/frontend/middleware_panic.go
+++ b/frontend/pkg/frontend/middleware_panic.go
@@ -30,7 +30,7 @@ func MiddlewarePanic(w http.ResponseWriter, r *http.Request, next http.HandlerFu
 			if e := recover(); e != nil {
 				logger := LoggerFromContext(r.Context())
 				logger.Error(fmt.Sprintf("panic: %#v\n%s\n", e, string(debug.Stack())))
-				arm.WriteInternalServerError(w)
+				arm.WriteInternalServerError(w, "panicked")
 			}
 		}()
 	}

--- a/frontend/pkg/frontend/middleware_validatesubscription.go
+++ b/frontend/pkg/frontend/middleware_validatesubscription.go
@@ -39,7 +39,7 @@ func MiddlewareValidateSubscriptionState(w http.ResponseWriter, r *http.Request,
 	dbClient, err := DBClientFromContext(ctx)
 	if err != nil {
 		logger.Error(err.Error())
-		arm.WriteInternalServerError(w)
+		arm.WriteInternalServerError(w, "failed getting database client")
 		return
 	}
 
@@ -109,6 +109,6 @@ func MiddlewareValidateSubscriptionState(w http.ResponseWriter, r *http.Request,
 			subscription.State)
 	default:
 		logger.Error(fmt.Sprintf("unsupported subscription state %q", subscription.State))
-		arm.WriteInternalServerError(w)
+		arm.WriteInternalServerError(w, "unhandled subscription state")
 	}
 }

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -50,21 +50,21 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 	versionedInterface, err := VersionFromContext(ctx)
 	if err != nil {
 		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
+		arm.WriteInternalServerError(writer, "failed getting versioned interface")
 		return
 	}
 
 	resourceID, err := ResourceIDFromContext(ctx)
 	if err != nil {
 		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
+		arm.WriteInternalServerError(writer, "failed getting resource ID")
 		return
 	}
 
 	systemData, err := SystemDataFromContext(ctx)
 	if err != nil {
 		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
+		arm.WriteInternalServerError(writer, "failed getting system data")
 		return
 	}
 
@@ -73,7 +73,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 	resourceItemID, resourceDoc, err := f.dbClient.GetResourceDoc(ctx, resourceID)
 	if err != nil && !database.IsResponseError(err, http.StatusNotFound) {
 		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
+		arm.WriteInternalServerError(writer, "failed reading resource document for node pool")
 		return
 	}
 
@@ -146,7 +146,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		if database.IsResponseError(err, http.StatusNotFound) {
 			arm.WriteResourceNotFoundError(writer, resourceID.Parent)
 		} else {
-			arm.WriteInternalServerError(writer)
+			arm.WriteInternalServerError(writer, "failed getting resource document for cluster")
 		}
 		return
 	}
@@ -163,7 +163,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 	body, err := BodyFromContext(ctx)
 	if err != nil {
 		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
+		arm.WriteInternalServerError(writer, "failed reading body")
 		return
 	}
 	if err = json.Unmarshal(body, versionedRequestNodePool); err != nil {
@@ -186,7 +186,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 	csNodePool, err := f.BuildCSNodePool(ctx, hcpNodePool, updating)
 	if err != nil {
 		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
+		arm.WriteInternalServerError(writer, "failed building cluster-service node pool")
 		return
 	}
 
@@ -203,7 +203,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		_, clusterDoc, err := f.dbClient.GetResourceDoc(ctx, resourceID.Parent)
 		if err != nil {
 			logger.Error(err.Error())
-			arm.WriteInternalServerError(writer)
+			arm.WriteInternalServerError(writer, "failed getting resource document for cluster the second time")
 			return
 		}
 
@@ -217,7 +217,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		resourceDoc.InternalID, err = ocm.NewInternalID(csNodePool.HREF())
 		if err != nil {
 			logger.Error(err.Error())
-			arm.WriteInternalServerError(writer)
+			arm.WriteInternalServerError(writer, "failed creating internal ID")
 			return
 		}
 	}
@@ -259,7 +259,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 	})
 	if err != nil {
 		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
+		arm.WriteInternalServerError(writer, "failed executing transaction")
 		return
 	}
 
@@ -267,14 +267,14 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 	resourceDoc, err = transactionResult.GetResourceDoc(resourceItemID)
 	if err != nil {
 		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
+		arm.WriteInternalServerError(writer, "failed reading the transaction result")
 		return
 	}
 
 	responseBody, err := marshalCSNodePool(csNodePool, resourceDoc, versionedInterface)
 	if err != nil {
 		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
+		arm.WriteInternalServerError(writer, "failed to marshal to node pool")
 		return
 	}
 

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -458,7 +458,7 @@ func CSErrorToCloudError(err error, resourceID *azcorearm.ResourceID) *arm.Cloud
 		}
 	}
 
-	return arm.NewInternalServerError()
+	return arm.NewInternalServerError("unknown cluster-service error type")
 }
 
 // transportFunc implements the http.RoundTripper interface.

--- a/internal/api/arm/error.go
+++ b/internal/api/arm/error.go
@@ -141,17 +141,23 @@ func WriteCloudError(w http.ResponseWriter, err *CloudError) {
 	_, _ = WriteJSONResponse(w, err.StatusCode, err)
 }
 
-// NewInternalServerError creates a CloudError for an internal server error
-func NewInternalServerError() *CloudError {
+// NewInternalServerError creates a CloudError for an internal server error.
+// locationHint is a means to find which internal error was encountered.  It must be a constant or known pattern string.
+// This is critical for us to avoid accidentally reporting things like internal IP addresses, internal user identities, or
+// other internal service knowledge via the API.
+func NewInternalServerError(locationHint string) *CloudError {
 	return NewCloudError(
 		http.StatusInternalServerError,
 		CloudErrorCodeInternalServerError, "",
-		"Internal server error.")
+		"Internal server error.  Origin: %q", locationHint)
 }
 
 // WriteInternalServerError writes an internal server error to the given ResponseWriter
-func WriteInternalServerError(w http.ResponseWriter) {
-	WriteCloudError(w, NewInternalServerError())
+// locationHint is a means to find which internal error was encountered.  It must be a constant or known pattern string.
+// This is critical for us to avoid accidentally reporting things like internal IP addresses, internal user identities, or
+// other internal service knowledge via the API.
+func WriteInternalServerError(w http.ResponseWriter, locationHint string) {
+	WriteCloudError(w, NewInternalServerError(locationHint))
 }
 
 // NewConflictError creates a CloudError for a conflict error


### PR DESCRIPTION


<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

This allows us to determine which particular area had an internal are without risking internal details of the service like IPs, service identities, etc being leaked via unvetted library error messages.

### Why

<!-- Briefly explain why this change is needed -->

We need to be able to debug  our service when something fails.  Without this there are numerous different spots to have internal errors for individual actions and we have no way to track which is causing an issue.

### Special notes for your reviewer

<!-- optional -->


/assign @mbarnes 