### PR TITLE
Add a "cluster_id" attribute to backend logs

### DIFF
--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -439,6 +439,7 @@ func (s *OperationsScanner) processOperations(ctx context.Context, subscriptionI
 					"operation_id", operationID,
 					"resource_id", operationDoc.ExternalID.String(),
 					"internal_id", operationDoc.InternalID.String(),
+					"cluster_id", operationDoc.InternalID.ClusterID(),
 				),
 			})
 	}

--- a/internal/ocm/internalid.go
+++ b/internal/ocm/internalid.go
@@ -121,6 +121,21 @@ func (id *InternalID) ID() string {
 	return path.Base(id.path)
 }
 
+// ClusterID returns the path element following "clusters", if present.
+func (id *InternalID) ClusterID() string {
+	var returnNextElement bool
+
+	for _, element := range strings.Split(id.path, "/") {
+		if returnNextElement {
+			return element
+		} else if element == "clusters" {
+			returnNextElement = true
+		}
+	}
+
+	return ""
+}
+
 // Kind returns the kind of resource described by InternalID, currently
 // limited to "Cluster" and "NodePool".
 func (id *InternalID) Kind() string {

--- a/internal/ocm/internalid_test.go
+++ b/internal/ocm/internalid_test.go
@@ -34,8 +34,9 @@ func TestInternalID(t *testing.T) {
 	tests := []struct {
 		name      string
 		path      string
-		id        string
 		kind      string
+		id        string
+		clusterID string
 		expectErr bool
 	}{
 		{
@@ -47,29 +48,33 @@ func TestInternalID(t *testing.T) {
 		{
 			name:      "parse v1 cluster",
 			path:      "/api/clusters_mgmt/v1/clusters/abc",
-			id:        "abc",
 			kind:      cmv1.ClusterKind,
+			id:        "abc",
+			clusterID: "abc",
 			expectErr: false,
 		},
 		{
 			name:      "parse aro_hcp v1alpha1 cluster",
 			path:      "/api/aro_hcp/v1alpha1/clusters/abc",
-			id:        "abc",
 			kind:      arohcpv1alpha1.ClusterKind,
+			id:        "abc",
+			clusterID: "abc",
 			expectErr: false,
 		},
 		{
 			name:      "parse v1 node pool",
 			path:      "/api/clusters_mgmt/v1/clusters/abc/node_pools/def",
-			id:        "def",
 			kind:      cmv1.NodePoolKind,
+			id:        "def",
+			clusterID: "abc",
 			expectErr: false,
 		},
 		{
 			name:      "parse aro_hcp v1alpha1 node pool",
 			path:      "/api/aro_hcp/v1alpha1/clusters/abc/node_pools/def",
-			id:        "def",
 			kind:      arohcpv1alpha1.NodePoolKind,
+			id:        "def",
+			clusterID: "abc",
 			expectErr: false,
 		},
 	}
@@ -94,11 +99,14 @@ func TestInternalID(t *testing.T) {
 				return
 			}
 
+			kind := internalID.Kind()
+			assert.Equal(t, tt.kind, kind)
+
 			id := internalID.ID()
 			assert.Equal(t, tt.id, id)
 
-			kind := internalID.Kind()
-			assert.Equal(t, tt.kind, kind)
+			clusterID := internalID.ClusterID()
+			assert.Equal(t, tt.clusterID, clusterID)
 
 			str := internalID.String()
 			assert.Equal(t, tt.path, str)


### PR DESCRIPTION
### What

Adds a "cluster_id" attribute to backend logs.  This will be the OCM cluster ID.

### Why

For easier correlation with logs from other namespaces.