### PR TITLE
add mgmt-output step to resolve azure keyvault secrets provider clientId

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -28,8 +28,6 @@ deploy:
 	ZONE_RESOURCE_ID=$(shell az network dns zone show -n ${ZONE_NAME} -g ${REGIONAL_RESOURCEGROUP} --query id -o tsv) && \
 	CX_SECRETS_KV_URL="https://${CX_SECRETS_KV_NAME}.vault.azure.net/" && \
 	CX_MI_KV_URL="https://${CX_MI_KV_NAME}.vault.azure.net/" && \
-	CX_SECRETS_KV_MI_CLIENT_ID=$(shell az aks show -n ${MGMT_AKS_NAME} -g ${MGMT_RESOURCEGROUP} --query 'addonProfiles.azureKeyvaultSecretsProvider.identity.clientId' -o tsv) && \
-	if [ -z "$${CX_SECRETS_KV_MI_CLIENT_ID}" ]; then echo "Failed to get CX_SECRETS_KV_MI_CLIENT_ID - make sure to provision a MGMT cluster first" >&2; exit 1; fi && \
 	../hack/helm.sh cluster-service deploy ${NAMESPACE} \
 	  -f deploy/$${OVERRIDES} \
 	  --set serviceAccountName=${SERVICE_ACCOUNT_NAME} \
@@ -51,7 +49,7 @@ deploy:
 	  --set shard.zoneResourceId="$${ZONE_RESOURCE_ID}" \
 	  --set shard.cxSecretsKeyVaultUrl="$${CX_SECRETS_KV_URL}" \
 	  --set shard.cxMiKeyVaultUrl="$${CX_MI_KV_URL}" \
-	  --set shard.cxSecretsKeyVaultMiClientId="$${CX_SECRETS_KV_MI_CLIENT_ID}" \
+	  --set shard.cxSecretsKeyVaultMiClientId="${CX_SECRETS_KV_MI_CLIENT_ID}" \
 	  --set shard.maestroRestUrl="http://maestro.maestro.svc.cluster.local:8000" \
 	  --set shard.maestroGrpUrl="maestro-grpc.maestro.svc.cluster.local:8090" \
 	  --set databaseHost=$${DB_HOST} \

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -27,6 +27,15 @@ resourceGroups:
     parameters: ../dev-infrastructure/configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
+- name: '{{ .mgmt.rg }}'
+  subscription: '{{ .mgmt.subscription  }}'
+  steps:
+  - name: mgmt-output
+    action: ARM
+    template: templates/out
+    parameters: ../dev-infrastructure/configurations/output-mgmt.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
 - name: '{{ .svc.rg  }}'
   subscription: '{{ .svc.subscription  }}'
   steps:
@@ -42,6 +51,10 @@ resourceGroups:
     - mirror-image
     - global-output
     variables:
+    - name: CX_SECRETS_KV_MI_CLIENT_ID
+      input:
+        step: mgmt-output
+        name: azureKeyvaultSecretsProviderIdentityClientId
     - name: REGION
       configRef: region
     - name: RESOURCEGROUP

--- a/dev-infrastructure/configurations/output-mgmt.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/output-mgmt.tmpl.bicepparam
@@ -1,0 +1,3 @@
+using '../templates/output-mgmt.bicep'
+
+param mgmtClusterName = '{{ .mgmt.aks.name }}'

--- a/dev-infrastructure/templates/output-mgmt.bicep
+++ b/dev-infrastructure/templates/output-mgmt.bicep
@@ -1,0 +1,7 @@
+@description('Name of the management cluster.')
+param mgmtClusterName string
+
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-10-01' existing = {
+  name: mgmtClusterName
+}
+output azureKeyvaultSecretsProviderIdentityClientId string = aksCluster.properties.addonProfiles.azureKeyvaultSecretsProvider.identity.clientId


### PR DESCRIPTION

Follow up to https://github.com/Azure/ARO-HCP/pull/1956
### What
Fetch the azure keyvaults secrets provider client id from an output stage so that clusters service deployments work in multi subscription environments.

### Why

to fix clusters service deployment to environments with multiple subscriptions.  az commands in shell steps don't work nicely if the resource lives in a separate subscription.

### Special notes for your reviewer

<!-- optional -->
