### PR TITLE
EV2 signaling env var name change

### DIFF
--- a/hack/deployment-diagnostics.sh
+++ b/hack/deployment-diagnostics.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-if [[ -z "${EV2:-}" ]]; then
+if [[ -z "${__zz_injected_EV2__:-}" ]]; then
    # this script only executes in EV2
    # executing this in other environments with less restricted access to CD logs
    # can lead to leaking sensitive information

--- a/setup-env.mk
+++ b/setup-env.mk
@@ -1,7 +1,7 @@
 SHELL = /bin/bash
 SHELLFLAGS = -eu -o pipefail
 
-ifndef EV2
+ifndef __zz_injected_EV2__
 ifndef RUNS_IN_TEMPLATIZE
 PROJECT_ROOT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 


### PR DESCRIPTION
### What

SDP-pipelines recently introduced env var conflict avoidance and because of that, the env var to signal an EV2 run changed from `EV2` to `__zz_injected_EV2__`.

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
