### PR TITLE
EV2 signal env var fix^2

### DIFF
--- a/hack/deployment-diagnostics.sh
+++ b/hack/deployment-diagnostics.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-if [[ -z "${__zz_injected_EV2__:-}" ]]; then
+if [[ -z "${zz_injected_EV2:-}" ]]; then
    # this script only executes in EV2
    # executing this in other environments with less restricted access to CD logs
    # can lead to leaking sensitive information

--- a/setup-env.mk
+++ b/setup-env.mk
@@ -1,7 +1,7 @@
 SHELL = /bin/bash
 SHELLFLAGS = -eu -o pipefail
 
-ifndef __zz_injected_EV2__
+ifndef zz_injected_EV2
 ifndef RUNS_IN_TEMPLATIZE
 PROJECT_ROOT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 


### PR DESCRIPTION
### What

the actual var name zz_injected_EV2 without the dunder enclosing
follows up on #2134

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
