### PR TITLE
fix template path

### DIFF
--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -32,7 +32,7 @@ resourceGroups:
   steps:
   - name: mgmt-output
     action: ARM
-    template: templates/out
+    template: ../dev-infrastructure/templates/output-mgmt.bicep
     parameters: ../dev-infrastructure/configurations/output-mgmt.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What
The template path for mgmt cluster output was incorrect, this PR fixes that. 

<!-- Briefly describe what this PR does -->

### Why 

So we can deploy cluster service.  
<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
