### PR TITLE
Support kube-API IP Access Control

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -43,6 +43,7 @@ CLUSTER_NAME=abc ./03-create-cluster.sh
 
 Observe the cluster creation with `./query-cluster-rp.sh` until `properties.provisioningState` is (hopefully) `Succeeded`.
 `properties.api.url` holds the URL to the API server of the HCP.
+`properties.api.authorizedCidrs` (optional) can be used to restrict access to the API server to specific IPv4 CIDR blocks.
 
 See [Get the kubeconfig for an HCP](#get-the-kubeconfig-for-an-hcp) on how to get the kubeconfig for the HCP.
 

--- a/demo/cluster.tmpl.json
+++ b/demo/cluster.tmpl.json
@@ -15,7 +15,11 @@
     },
     "console": {},
     "api": {
-      "visibility": "Public"
+      "visibility": "Public",
+      "authorizedCidrs": [
+        "192.168.1.0/24",
+        "10.0.0.0/16"
+      ]
     },
     "platform": {
       "managedResourceGroup": "$managed-resource-group",

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -81,6 +81,14 @@ func convertOutboundTypeRPToCS(outboundTypeRP api.OutboundType) (outboundTypeCS 
 	return
 }
 
+// convertAuthorizedCidrs extracts authorized CIDRs from CS cluster API object
+func convertAuthorizedCidrs(clusterAPI *arohcpv1alpha1.ClusterAPI) []string {
+	if cidrs := clusterAPI.AllowedCIDRBlocks(); cidrs != nil {
+		return cidrs
+	}
+	return nil
+}
+
 func convertEnableEncryptionAtHostToCSBuilder(in api.NodePoolPlatformProfile) *arohcpv1alpha1.AzureNodePoolEncryptionAtHostBuilder {
 	var state string
 
@@ -132,8 +140,9 @@ func ConvertCStoHCPOpenShiftCluster(resourceID *azcorearm.ResourceID, cluster *a
 				URL: cluster.Console().URL(),
 			},
 			API: api.APIProfile{
-				URL:        cluster.API().URL(),
-				Visibility: convertListeningToVisibility(cluster.API().Listening()),
+				URL:             cluster.API().URL(),
+				Visibility:      convertListeningToVisibility(cluster.API().Listening()),
+				AuthorizedCidrs: convertAuthorizedCidrs(cluster.API()),
 			},
 			Platform: api.PlatformProfile{
 				ManagedResourceGroup:   cluster.Azure().ManagedResourceGroupName(),
@@ -250,7 +259,8 @@ func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpC
 			MachineCIDR(hcpCluster.Properties.Network.MachineCIDR).
 			HostPrefix(int(hcpCluster.Properties.Network.HostPrefix))).
 		API(arohcpv1alpha1.NewClusterAPI().
-			Listening(convertVisibilityToListening(hcpCluster.Properties.API.Visibility)))
+			Listening(convertVisibilityToListening(hcpCluster.Properties.API.Visibility)).
+			AllowedCIDRBlocks(hcpCluster.Properties.API.AuthorizedCidrs))
 
 	azureBuilder := arohcpv1alpha1.NewAzure().
 		TenantID(tenantID).

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -75,8 +75,9 @@ type ConsoleProfile struct {
 
 // APIProfile represents a cluster API server configuration.
 type APIProfile struct {
-	URL        string     `json:"url,omitempty"        visibility:"read"`
-	Visibility Visibility `json:"visibility,omitempty" visibility:"read create" validate:"omitempty,enum_visibility"`
+	URL             string     `json:"url,omitempty"             visibility:"read"`
+	Visibility      Visibility `json:"visibility,omitempty"    visibility:"read create" validate:"omitempty,enum_visibility"`
+	AuthorizedCidrs []string   `json:"authorizedCidrs,omitempty" visibility:"read create update" validate:"max=500,dive,cidrv4"`
 }
 
 // PlatformProfile represents the Azure platform configuration.

--- a/internal/api/v20240610preview/register_test.go
+++ b/internal/api/v20240610preview/register_test.go
@@ -95,6 +95,7 @@ func TestClusterStructTagMap(t *testing.T) {
 		"Properties.API":                                                     skip,
 		"Properties.API.URL":                                                 skip,
 		"Properties.API.Visibility":                                          api.VisibilityRead | api.VisibilityCreate,
+		"Properties.API.AuthorizedCidrs":                                     api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
 		"Properties.Platform":                                                skip,
 		"Properties.Platform.ManagedResourceGroup":                           api.VisibilityRead | api.VisibilityCreate,
 		"Properties.Platform.SubnetID":                                       api.VisibilityRead | api.VisibilityCreate,


### PR DESCRIPTION
Support for kube-API IP Access Control has been successfully implemented in the ARO-HCP project through the addition of an `authorizedCidrs` field. This field allows users to specify a list of authorized IPv4 CIDR blocks that can access the API server.

Waiting for merge of https://github.com/openshift-online/ocm-api-model/pull/1059/files#diff-364d063fef766917b654a76528b2154563eed08f9d346c352e6fd1eba8f5fd34

Ticket - https://issues.redhat.com/browse/ARO-15672