### PR TITLE
Update RG for svc.dev-role-assignments

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -224,7 +224,7 @@ svc.what-if:
 svc.dev-role-assignments:
 	az deployment group create \
 		--name ${ROLE_ASSIGNMENTS_DEPLOYMENT_NAME} \
-		--resource-group "${SVC_RESOURCEGROUP}" \
+		--resource-group "${REGIONAL_RESOURCEGROUP}" \
 		--template-file templates/dev-roleassignments.bicep \
 		--parameters configurations/dev-role-assignments.bicepparam \
 		--parameters principalID=${PRINCIPAL_ID}


### PR DESCRIPTION
[ARO-16089 - Rescope service cluster resource group resources](https://issues.redhat.com/browse/ARO-16089)

### What

Updates the `svc.dev-role-assignments` make target to use `REGIONAL_RESOURCEGROUP`.

### Why

Followup to https://github.com/Azure/ARO-HCP/pull/1613