### PR TITLE
build secret-sync for global-pipeline

### DIFF
--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -10,6 +10,12 @@
 $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Global
 rolloutName: Global Resource Rollout
+buildStep:
+  command: make
+  args:
+  - "-C"
+  - "../tooling/secret-sync"
+  - "secret-sync"
 resourceGroups:
 - name: '{{ .global.rg  }}'
   subscription: '{{ .global.subscription  }}'


### PR DESCRIPTION
adds a buildStep to the global pipeline so we can build the secret-sync tool for use in EV2

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
