### PR TITLE
fix: do not set CS MultiAZ attribute during cluster creation

### DIFF
--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -36,7 +36,6 @@ const (
 	csCloudProvider    string = "azure"
 	csProductId        string = "aro"
 	csHypershifEnabled bool   = true
-	csMultiAzEnabled   bool   = true
 	csCCSEnabled       bool   = true
 
 	// The OCM SDK does not provide these constants.
@@ -254,7 +253,6 @@ func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpC
 			ID(csProductId)).
 		Hypershift(arohcpv1alpha1.NewHypershift().
 			Enabled(csHypershifEnabled)).
-		MultiAZ(csMultiAzEnabled).
 		CCS(arohcpv1alpha1.NewCCS().Enabled(csCCSEnabled)).
 		Version(arohcpv1alpha1.NewVersion().
 			ID(hcpCluster.Properties.Version.ID).

--- a/frontend/pkg/frontend/ocm_test.go
+++ b/frontend/pkg/frontend/ocm_test.go
@@ -198,7 +198,6 @@ func withOCMClusterDefaults() func(*arohcpv1alpha1.ClusterBuilder) *arohcpv1alph
 				ID("osd-4")).
 			Hypershift(arohcpv1alpha1.NewHypershift().
 				Enabled(true)).
-			MultiAZ(true).
 			Name("").
 			Network(arohcpv1alpha1.NewNetwork().
 				HostPrefix(0).


### PR DESCRIPTION
With recent changes, the Multi AZ attribute in CS is readonly for the ARO-HCP offering and it cannot be provided during cluster creation anymore. The Control Plane Multi AZness is determined depending on whether the region where it is deployed supports multiple AZs or not.

This decision was reflected in https://issues.redhat.com/browse/ARO-17289, which was approved by api domain owners in CS too.
