### PR TITLE
update demo/bicep scripts to specify 4.19.0 as the OCP version

### DIFF
--- a/demo/bicep/cluster.bicep
+++ b/demo/bicep/cluster.bicep
@@ -80,7 +80,7 @@ resource hcp 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters@2024-06-10-preview'
   location: resourceGroup().location
   properties: {
     version: {
-      id: 'openshift-v4.18.1'
+      id: 'openshift-v4.19.0'
       channelGroup: 'stable'
     }
     dns: {}

--- a/demo/bicep/nodepool.bicep
+++ b/demo/bicep/nodepool.bicep
@@ -14,7 +14,7 @@ resource nodepool 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools@2024
   location: resourceGroup().location
   properties: {
     version: {
-      id: 'openshift-v4.18.1'
+      id: 'openshift-v4.19.0'
       channelGroup: 'stable'
     }
     platform: {


### PR DESCRIPTION
With recent changes we added support for OCP 4.19.0 and stopped supporting 4.18.x.
