### PR TITLE
make frontdoor keyvault name optional

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -17,6 +17,13 @@
       "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$",
       "description": "A KV name must be between 3-24 alphanumeric characters. The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens."
     },
+    "optionalKeyVaultName": {
+      "anyOf": [
+      { "$ref": "#/definitions/keyVaultName" },
+      { "type": "string", "pattern": "^$" }
+      ],
+      "description": "A key vault name or an empty string"
+    },
     "operatorConfig": {
       "type": "object",
       "properties": {
@@ -1482,7 +1489,7 @@
               "type": "string"
             },
             "keyVaultName": {
-              "$ref": "#/definitions/keyVaultName"
+              "$ref": "#/definitions/optionalKeyVaultName"
             },
             "msiName": {
               "type": "string"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -422,7 +422,7 @@ defaults:
       subdomain: oic
       name: arohcp{{ .ctx.environment }}
       sku: Premium_AzureFrontDoor
-      keyVaultName: "empty-sentinel" # we don't need one in public cloud, but we need a value to validate the field
+      keyVaultName: "" # we don't need one in public cloud, but we need a value to validate the field
       msiName: arohcp-afd
   # Service Key Vault
   serviceKeyVault:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,16 +3,16 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: e4c83c061d1485d9cb9ceb4c5b6d3838d890bcd8dbbb2a6f069d23d283f73f39
+          westus3: 6dce1db8d5ea4937a61cc1ac691d892cf20a8f3c9da40f6b07dd10b5738e31e0
       dev:
         regions:
-          westus3: b03065b65c641e878384926a1df4fe34aa009ebc842735f3f3ac64d37722ad31
+          westus3: 120850d460f9c38ec8e463ad11cad4ae680a7c1fc5e9b80acef498dc5c445725
       ntly:
         regions:
-          uksouth: 209e9f942d3cbc879299ac0a7db8208bfb8661dc5558b36a4692cb9bc5fdbcb2
+          uksouth: 7e191a815ec906a6143fb2bb3dcbeb137cb5b0b2aef316554f0fcd3d8c7ca2f2
       perf:
         regions:
-          westus3: 13a38ec50dddd571fd7131d640c0dade6e26af8e8c84137ece4af800372e9168
+          westus3: 116f22a08d9ee940330bd3645c05f7dec22dbd811db7f619a13c06a6e4df284d
       pers:
         regions:
-          westus3: ad951c0ceb0948bdd80914cb6a10bc3ea080f6f60a7d362d61bd778ad94ff70f
+          westus3: 92a3ee894db867ba88998171e7acfce5581c51a453e01fb7054622f074a61754

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -339,7 +339,7 @@ msiRp:
   dataPlaneAudienceResource: https://dummy.org
 oidc:
   frontdoor:
-    keyVaultName: empty-sentinel
+    keyVaultName: ""
     msiName: arohcp-afd
     name: arohcpdev
     sku: Premium_AzureFrontDoor

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -339,7 +339,7 @@ msiRp:
   dataPlaneAudienceResource: https://dummy.org
 oidc:
   frontdoor:
-    keyVaultName: empty-sentinel
+    keyVaultName: ""
     msiName: arohcp-afd
     name: arohcpdev
     sku: Premium_AzureFrontDoor

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -339,7 +339,7 @@ msiRp:
   dataPlaneAudienceResource: https://dummy.org
 oidc:
   frontdoor:
-    keyVaultName: empty-sentinel
+    keyVaultName: ""
     msiName: arohcp-afd
     name: arohcpdev
     sku: Premium_AzureFrontDoor

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -339,7 +339,7 @@ msiRp:
   dataPlaneAudienceResource: https://dummy.org
 oidc:
   frontdoor:
-    keyVaultName: empty-sentinel
+    keyVaultName: ""
     msiName: arohcp-afd
     name: arohcpdev
     sku: Premium_AzureFrontDoor

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -341,7 +341,7 @@ msiRp:
   dataPlaneAudienceResource: https://dummy.org
 oidc:
   frontdoor:
-    keyVaultName: empty-sentinel
+    keyVaultName: ""
     msiName: arohcp-afd
     name: arohcpdev
     sku: Premium_AzureFrontDoor


### PR DESCRIPTION
### What

we don't need a keyvault for frontdoor in public cloud as public cloud can use managed certificates. a KV is required in fairfax where managed certificates are not supported

https://issues.redhat.com/browse/ARO-15635

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
