### PR TITLE
chore: update global image sync related to 4.19 to be stable channel

### DIFF
--- a/dev-infrastructure/templates/global-image-sync.bicep
+++ b/dev-infrastructure/templates/global-image-sync.bicep
@@ -302,10 +302,10 @@ var ocpMirrorDefinitions = [
     major: '4.19'
     channels: [
       {
-        name: 'candidate-4.19'
+        name: 'stable-4.19'
         type: 'ocp'
         full: true
-        minVersion: '4.19.0-rc.2'
+        minVersion: '4.19.0'
       }
     ]
   }


### PR DESCRIPTION
Now 4.19 GA images are released.

This MR:
* Renames candidate-4.19 channel to stable-4.19
* changes minVersion 4.19.0-rc.2 to 4.19.0