### PR TITLE
fix oidc read endpoint for CS

### DIFF
--- a/cluster-service/oidc-base-endpoint.sh
+++ b/cluster-service/oidc-base-endpoint.sh
@@ -7,7 +7,7 @@ AFD_ENDPOINT="$3"
 
 PUBLIC_ACCESS_ENABLED=$(az storage account show -n "${STORAGE_ACCOUNT}" -g "${RESOURCEGROUP}" --query allowBlobPublicAccess -o tsv)
 if [ "$PUBLIC_ACCESS_ENABLED" == "true" ]; then
-    BLOB_ENDPOINT=$(az storage account show -n "${STORAGE_ACCOUNT}" -g "${RESOURCEGROUP}" --query primaryEndpoints.blob -o tsv)
+    BLOB_ENDPOINT=$(az storage account show -n "${STORAGE_ACCOUNT}" -g "${RESOURCEGROUP}" --query primaryEndpoints.web -o tsv)
     echo "$BLOB_ENDPOINT"
 else
     echo "$AFD_ENDPOINT"


### PR DESCRIPTION
### What

we accidentally used the blob endpoint for read instead the web endpoint

follows up on #2130

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
