### PR TITLE
MSI refresher workload identity

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -3,21 +3,28 @@
   "title": "Generated schema for Root",
   "type": "object",
   "definitions": {
-    "rfc1123String": {
+    "namespaceName": {
       "type": "string",
       "minLength": 1,
       "maxLength": 63,
       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
       "description": "A valid RFC1123 DNS label. Must start and end with a lowercase letter or number, and can contain hyphens in between."
     },
+    "serviceAccountName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 243,
+      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+      "description": "A valid RFC1123 DNS subdomain. Multiple RFC1123 DNS label devided by a dot."
+    },
     "k8sServiceAccount": {
       "type": "object",
       "properties": {
         "namespace": {
-          "$ref": "#/definitions/rfc1123String"
+          "$ref": "#/definitions/namespaceName"
         },
         "serviceAccountName": {
-          "$ref": "#/definitions/rfc1123String"
+          "$ref": "#/definitions/serviceAccountName"
         }
       },
       "additionalProperties": false,

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1027,6 +1027,40 @@
         "dataPlaneAudienceResource"
       ]
     },
+    "msiCredentialsRefresher": {
+      "type": "object",
+      "properties": {
+        "managedIdentityName": {
+          "type": "string",
+          "description": "The name of the MSI that will be used by the refresher"
+        },
+        "k8s": {
+          "type": "object",
+          "properties": {
+            "namespace": {
+              "type": "string"
+            },
+            "serviceAccountName": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "namespace",
+            "serviceAccountName"
+          ]
+        },
+        "image": {
+          "$ref": "#/definitions/containerImage"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "managedIdentityName",
+        "k8s",
+        "image"
+      ]
+    },
     "global": {
       "type": "object",
       "additionalProperties": false,
@@ -1761,6 +1795,8 @@
     "region",
     "regionRG",
     "serviceKeyVault",
-    "svc"
+    "svc",
+    "msiRp",
+    "msiCredentialsRefresher"
   ]
 }

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -3,6 +3,29 @@
   "title": "Generated schema for Root",
   "type": "object",
   "definitions": {
+    "rfc1123String": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 63,
+      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+      "description": "A valid RFC1123 DNS label. Must start and end with a lowercase letter or number, and can contain hyphens in between."
+    },
+    "k8sServiceAccount": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "$ref": "#/definitions/rfc1123String"
+        },
+        "serviceAccountName": {
+          "$ref": "#/definitions/rfc1123String"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "namespace",
+        "serviceAccountName"
+      ]
+    },
     "postgresName": {
       "type": "string",
       "minLength": 3,
@@ -587,20 +610,7 @@
           "description": "The name of the MSI that will be used by CS to interact with Azure"
         },
         "k8s": {
-          "type": "object",
-          "properties": {
-            "namespace": {
-              "type": "string"
-            },
-            "serviceAccountName": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "namespace",
-            "serviceAccountName"
-          ]
+          "$ref": "#/definitions/k8sServiceAccount"
         },
         "postgres": {
           "$ref": "#/definitions/postgres"
@@ -1035,20 +1045,7 @@
           "description": "The name of the MSI that will be used by the refresher"
         },
         "k8s": {
-          "type": "object",
-          "properties": {
-            "namespace": {
-              "type": "string"
-            },
-            "serviceAccountName": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "namespace",
-            "serviceAccountName"
-          ]
+          "$ref": "#/definitions/k8sServiceAccount"
         },
         "image": {
           "$ref": "#/definitions/containerImage"
@@ -1271,20 +1268,7 @@
               "$ref": "#/definitions/tracing"
             },
             "k8s": {
-              "type": "object",
-              "properties": {
-                "namespace": {
-                  "type": "string"
-                },
-                "serviceAccountName": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "namespace",
-                "serviceAccountName"
-              ]
+              "$ref": "#/definitions/k8sServiceAccount"
             }
           },
           "additionalProperties": false,

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1056,13 +1056,34 @@
         },
         "image": {
           "$ref": "#/definitions/containerImage"
+        },
+        "certificate": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "issuer": {
+              "$ref": "#/definitions/certificateIssuer"
+            },
+            "manage": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "issuer",
+            "manage"
+          ]
         }
       },
       "additionalProperties": false,
       "required": [
         "managedIdentityName",
         "k8s",
-        "image"
+        "image",
+        "certificate"
       ]
     },
     "global": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -375,6 +375,16 @@ defaults:
   # MSI RP
   msiRp:
     dataPlaneAudienceResource: https://dummy.org
+  # MSI Credentials Refresher
+  msiCredentialsRefresher:
+    managedIdentityName: msi-credential-refresher
+    k8s:
+      namespace: msi-credential-refresher
+      serviceAccountName: msi-credential-refresher
+    image:
+      registry: "empty-sentinel"
+      repository: "empty-sentinel"
+      digest: ""
   # Maestro
   maestro:
     server:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -385,6 +385,10 @@ defaults:
       registry: "empty-sentinel"
       repository: "empty-sentinel"
       digest: ""
+    certificate:
+      name: "msi-refresher"
+      manage: true
+      issuer: OneCertV2-PrivateCA
   # Maestro
   maestro:
     server:
@@ -633,7 +637,10 @@ clouds:
         rg: 'global'
         region: 'westus3'
         softDelete: true
-      # disable soft delete on etcd KVs in DEV
+      # MSI Credentials Refresher
+      msiCredentialsRefresher:
+        certificate:
+          manage: false
       svc:
         subscription:
           key: ARO Hosted Control Planes (EA Subscription 1)

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 81cd71ff86565b2a6a2c5f571f04dcb353051c7d9f192ed9f008019c2ca09e23
+          westus3: b0468cee07bdaf6adf9a968495b450264c71b6a02815d144c69973ef14a613d4
       dev:
         regions:
-          westus3: c04c09064adf7bd57375e6486130930ce3906fb705cdc3ee7f50084b00e57af7
+          westus3: cb1fbbc68f0b12c24dec56ec441c0f3e8a47e420bc614d0637ddffe7761ee719
       ntly:
         regions:
-          uksouth: dc62a6b15ae6d73b69c8bcd56ca757b9ed78861742f72d2f6a251988958d355e
+          uksouth: 422078ce8f012c1862945c5c7fd89b97b717f52c6da96ec2d6f04fa043bdddde
       perf:
         regions:
-          westus3: 714651752cbc1cf21ee40eebf34e1fc5cc5558d108bd3491541f9765ed0c4584
+          westus3: 18e4c609394c22f2a457575d038bb2f45815bcd37feae7c86940fa57e6fcf815
       pers:
         regions:
-          westus3: 1e2915d18ab19e35dfa9ac5b688d301846737650cc525804774b2e827e957a97
+          westus3: 7e8c19b781c4fa49d6939a16793560b947664f5703cb5f049bf5fca2927a54d2
       swft:
         regions:
-          uksouth: d4b5d60ea20cdd2806788da42f7cfe9c550fe417fadb9dc61266994bb84578e0
+          uksouth: 4b2d7d49cb3842e4b683cc9ba432e1ef275a4517ba33d202c85c57f5908bb394

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: b022a505cbea7cfe3da6f44cf7b941969b57a9b84804cc22b58467f909d47a25
+          westus3: 81cd71ff86565b2a6a2c5f571f04dcb353051c7d9f192ed9f008019c2ca09e23
       dev:
         regions:
-          westus3: f65c01c3f5ed2973d7dcd51fa7ca2e95a923f0e0f720e61014653f548a02c095
+          westus3: c04c09064adf7bd57375e6486130930ce3906fb705cdc3ee7f50084b00e57af7
       ntly:
         regions:
-          uksouth: b8d40c2ae6831f8ba408e7caae74870d92c9a81da154f053afb1ef3574ecbb50
+          uksouth: dc62a6b15ae6d73b69c8bcd56ca757b9ed78861742f72d2f6a251988958d355e
       perf:
         regions:
-          westus3: 2a38fc5674b335206b0aba790f8c56ae487bc4fe2ec39d8e99749632469b3a4a
+          westus3: 714651752cbc1cf21ee40eebf34e1fc5cc5558d108bd3491541f9765ed0c4584
       pers:
         regions:
-          westus3: d1c8b4178abbe64ea209741518681b9f1f67447a7c37da1a26308d34b78e9829
+          westus3: 1e2915d18ab19e35dfa9ac5b688d301846737650cc525804774b2e827e957a97
       swft:
         regions:
-          uksouth: b5ca8ae3aa3b3b71716479f28bbd692cabb163a310c00fe6ba81918452c0b9fa
+          uksouth: d4b5d60ea20cdd2806788da42f7cfe9c550fe417fadb9dc61266994bb84578e0

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -377,6 +377,10 @@ monitoring:
   sev4ActionGroupIDs: ""
   svcWorkspaceName: services-cspr-usw3
 msiCredentialsRefresher:
+  certificate:
+    issuer: OneCertV2-PrivateCA
+    manage: false
+    name: msi-refresher
   image:
     digest: ""
     registry: empty-sentinel

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -376,6 +376,15 @@ monitoring:
   sev3ActionGroupIDs: ""
   sev4ActionGroupIDs: ""
   svcWorkspaceName: services-cspr-usw3
+msiCredentialsRefresher:
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  k8s:
+    namespace: msi-credential-refresher
+    serviceAccountName: msi-credential-refresher
+  managedIdentityName: msi-credential-refresher
 msiKeyVault:
   name: ah-cspr-mi-usw3-1
   private: false

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -376,6 +376,15 @@ monitoring:
   sev3ActionGroupIDs: ""
   sev4ActionGroupIDs: ""
   svcWorkspaceName: services-usw3
+msiCredentialsRefresher:
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  k8s:
+    namespace: msi-credential-refresher
+    serviceAccountName: msi-credential-refresher
+  managedIdentityName: msi-credential-refresher
 msiKeyVault:
   name: ah-dev-mi-usw3-1
   private: false

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -377,6 +377,10 @@ monitoring:
   sev4ActionGroupIDs: ""
   svcWorkspaceName: services-usw3
 msiCredentialsRefresher:
+  certificate:
+    issuer: OneCertV2-PrivateCA
+    manage: false
+    name: msi-refresher
   image:
     digest: ""
     registry: empty-sentinel

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -377,6 +377,10 @@ monitoring:
   sev4ActionGroupIDs: ""
   svcWorkspaceName: aro-hcp-ntly-svc-ln
 msiCredentialsRefresher:
+  certificate:
+    issuer: OneCertV2-PrivateCA
+    manage: false
+    name: msi-refresher
   image:
     digest: ""
     registry: empty-sentinel

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -376,6 +376,15 @@ monitoring:
   sev3ActionGroupIDs: ""
   sev4ActionGroupIDs: ""
   svcWorkspaceName: aro-hcp-ntly-svc-ln
+msiCredentialsRefresher:
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  k8s:
+    namespace: msi-credential-refresher
+    serviceAccountName: msi-credential-refresher
+  managedIdentityName: msi-credential-refresher
 msiKeyVault:
   name: ah-ntly-mi-ln-1
   private: false

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -376,6 +376,15 @@ monitoring:
   sev3ActionGroupIDs: ""
   sev4ActionGroupIDs: ""
   svcWorkspaceName: services-usw3ptest
+msiCredentialsRefresher:
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  k8s:
+    namespace: msi-credential-refresher
+    serviceAccountName: msi-credential-refresher
+  managedIdentityName: msi-credential-refresher
 msiKeyVault:
   name: ah-perf-mi-usw3ptest-1
   private: false

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -377,6 +377,10 @@ monitoring:
   sev4ActionGroupIDs: ""
   svcWorkspaceName: services-usw3ptest
 msiCredentialsRefresher:
+  certificate:
+    issuer: OneCertV2-PrivateCA
+    manage: false
+    name: msi-refresher
   image:
     digest: ""
     registry: empty-sentinel

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -378,6 +378,15 @@ monitoring:
   sev3ActionGroupIDs: ""
   sev4ActionGroupIDs: ""
   svcWorkspaceName: services-usw3test
+msiCredentialsRefresher:
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  k8s:
+    namespace: msi-credential-refresher
+    serviceAccountName: msi-credential-refresher
+  managedIdentityName: msi-credential-refresher
 msiKeyVault:
   name: ah-pers-mi-usw3test-1
   private: false

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -379,6 +379,10 @@ monitoring:
   sev4ActionGroupIDs: ""
   svcWorkspaceName: services-usw3test
 msiCredentialsRefresher:
+  certificate:
+    issuer: OneCertV2-PrivateCA
+    manage: false
+    name: msi-refresher
   image:
     digest: ""
     registry: empty-sentinel

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -379,6 +379,10 @@ monitoring:
   sev4ActionGroupIDs: ""
   svcWorkspaceName: services-lnstest
 msiCredentialsRefresher:
+  certificate:
+    issuer: OneCertV2-PrivateCA
+    manage: false
+    name: msi-refresher
   image:
     digest: ""
     registry: empty-sentinel

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -378,6 +378,15 @@ monitoring:
   sev3ActionGroupIDs: ""
   sev4ActionGroupIDs: ""
   svcWorkspaceName: services-lnstest
+msiCredentialsRefresher:
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  k8s:
+    namespace: msi-credential-refresher
+    serviceAccountName: msi-credential-refresher
+  managedIdentityName: msi-credential-refresher
 msiKeyVault:
   name: ah-swft-mi-lnstest-1
   private: false

--- a/dev-infrastructure/configurations/mgmt-infra.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-infra.tmpl.bicepparam
@@ -25,6 +25,9 @@ param globalMSIId = '__globalMSIId__'
 // used for Key Vault access
 param clusterServiceMIResourceId = '__clusterServiceMIResourceId__'
 
+// MSI Refresher identity
+// used for Key Vault access
+param msiRefresherMIResourceId = '__msiRefresherMIResourceId__'
+
 // Log Analytics Workspace ID will be passed from region pipeline if enabled in config
 param logAnalyticsWorkspaceId = '__logAnalyticsWorkspaceId__'
-

--- a/dev-infrastructure/configurations/output-svc.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/output-svc.tmpl.bicepparam
@@ -1,3 +1,4 @@
 using '../templates/output-svc.bicep'
 
 param csMIName = '{{ .clustersService.managedIdentityName }}'
+param msiRefresherMIName = '{{ .msiCredentialsRefresher.managedIdentityName }}'

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -64,6 +64,10 @@ param csMIName = '{{ .clustersService.managedIdentityName }}'
 param csNamespace = '{{ .clustersService.k8s.namespace }}'
 param csServiceAccountName = '{{ .clustersService.k8s.serviceAccountName }}'
 
+param msiRefresherMIName = '{{ .msiCredentialsRefresher.managedIdentityName }}'
+param msiRefresherNamespace = '{{ .msiCredentialsRefresher.k8s.namespace }}'
+param msiRefresherServiceAccountName = '{{ .msiCredentialsRefresher.k8s.serviceAccountName }}'
+
 param serviceKeyVaultName = '{{ .serviceKeyVault.name }}'
 param serviceKeyVaultResourceGroup = '{{ .serviceKeyVault.rg }}'
 

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -64,10 +64,6 @@ param csMIName = '{{ .clustersService.managedIdentityName }}'
 param csNamespace = '{{ .clustersService.k8s.namespace }}'
 param csServiceAccountName = '{{ .clustersService.k8s.serviceAccountName }}'
 
-param msiRefresherMIName = '{{ .msiCredentialsRefresher.managedIdentityName }}'
-param msiRefresherNamespace = '{{ .msiCredentialsRefresher.k8s.namespace }}'
-param msiRefresherServiceAccountName = '{{ .msiCredentialsRefresher.k8s.serviceAccountName }}'
-
 param serviceKeyVaultName = '{{ .serviceKeyVault.name }}'
 param serviceKeyVaultResourceGroup = '{{ .serviceKeyVault.rg }}'
 
@@ -99,6 +95,10 @@ param genevaActionsServiceTag = '{{ .genevaActions.serviceTag }}'
 param fpaCertificateName = '{{ .firstPartyAppCertificate.name }}'
 param fpaCertificateIssuer = '{{ .firstPartyAppCertificate.issuer }}'
 param manageFpaCertificate = {{ .firstPartyAppCertificate.manage }}
+
+param manageMsiRefresherCertificate = {{ .msiCredentialsRefresher.certificate.manage }}
+param msiRefresherCertificateName = '{{ .msiCredentialsRefresher.certificate.name }}'
+param msiRefresherCertificateIssuer = '{{ .msiCredentialsRefresher.certificate.issuer }}'
 
 // Azure Monitor Workspace
 param azureMonitoringWorkspaceId = '__azureMonitoringWorkspaceId__'

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -58,6 +58,10 @@ resourceGroups:
       input:
         step: svc-output
         name: cs
+    - name: msiRefresherMIResourceId
+      input:
+        step: svc-output
+        name: msiRefresher
     - name: logAnalyticsWorkspaceId
       input:
         step: region-output

--- a/dev-infrastructure/templates/mgmt-infra.bicep
+++ b/dev-infrastructure/templates/mgmt-infra.bicep
@@ -28,8 +28,11 @@ param mgmtKeyVaultPrivate bool
 @description('Defines if the MGMT KeyVault has soft delete enabled')
 param mgmtKeyVaultSoftDelete bool
 
-@description('Cluster user assigned identity resource id, used to grant KeyVault access')
+@description('CS MI resource ID, used to grant KeyVault access')
 param clusterServiceMIResourceId string
+
+@description('MSI credentials refresher MI resource ID, used to grant KeyVault access')
+param msiRefresherMIResourceId string
 
 @description('KV certificate officer principal ID')
 param kvCertOfficerPrincipalId string
@@ -144,11 +147,28 @@ output mgmtKeyVaultUrl string = mgmtKeyVault.outputs.kvUrl
 
 import * as res from '../modules/resource.bicep'
 
-module csKeyVaultAccess '../modules/cluster-service-mc-kv-access.bicep' = if (res.isMsiResourceId(clusterServiceMIResourceId)) {
+module csKeyVaultAccess '../modules/mgmt-kv-access.bicep' = if (res.isMsiResourceId(clusterServiceMIResourceId)) {
   name: 'cs-msi-kv-access'
   params: {
-    clusterServiceMIResourceId: clusterServiceMIResourceId
+    managedIdentityResourceId: clusterServiceMIResourceId
     cxKeyVaultName: cxKeyVaultName
+    msiKeyVaultName: msiKeyVaultName
+  }
+  dependsOn: [
+    cxKeyVault
+    msiKeyVault
+  ]
+}
+
+//
+//   M S I   C R E D E N T I A L S   R E F R E S H E R   K V   A C C E S S
+//
+
+module msiRefresherKeyVaultAccess '../modules/mgmt-kv-access.bicep' = if (res.isMsiResourceId(msiRefresherMIResourceId)) {
+  name: 'msi-refresher-msi-kv-access'
+  params: {
+    managedIdentityResourceId: msiRefresherMIResourceId
+    cxKeyVaultName: ''
     msiKeyVaultName: msiKeyVaultName
   }
   dependsOn: [

--- a/dev-infrastructure/templates/mgmt-infra.bicep
+++ b/dev-infrastructure/templates/mgmt-infra.bicep
@@ -151,13 +151,9 @@ module csKeyVaultAccess '../modules/mgmt-kv-access.bicep' = if (res.isMsiResourc
   name: 'cs-msi-kv-access'
   params: {
     managedIdentityResourceId: clusterServiceMIResourceId
-    cxKeyVaultName: cxKeyVaultName
-    msiKeyVaultName: msiKeyVaultName
+    cxKeyVaultName: cxKeyVault.outputs.kvName
+    msiKeyVaultName: msiKeyVault.outputs.kvName
   }
-  dependsOn: [
-    cxKeyVault
-    msiKeyVault
-  ]
 }
 
 //
@@ -169,10 +165,6 @@ module msiRefresherKeyVaultAccess '../modules/mgmt-kv-access.bicep' = if (res.is
   params: {
     managedIdentityResourceId: msiRefresherMIResourceId
     cxKeyVaultName: ''
-    msiKeyVaultName: msiKeyVaultName
+    msiKeyVaultName: msiKeyVault.outputs.kvName
   }
-  dependsOn: [
-    cxKeyVault
-    msiKeyVault
-  ]
 }

--- a/dev-infrastructure/templates/output-svc.bicep
+++ b/dev-infrastructure/templates/output-svc.bicep
@@ -1,10 +1,18 @@
 @description('The name of the CS managed identity')
 param csMIName string
+@description('The name of the MSI refresher managed identity')
+param msiRefresherMIName string
 
+// CS MI resource ID
 resource csMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
   name: csMIName
 }
-
 output cs string = csMSI.id
+
+// MSI refresher MI resource ID
+resource msiRefresherMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: msiRefresherMIName
+}
+output msiRefresher string = msiRefresherMSI.id
 
 output subscriptionId string = subscription().id

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -157,6 +157,15 @@ param csPostgresServerStorageSizeGB int
 @description('If true, make the CS Postgres instance private')
 param clusterServicePostgresPrivate bool = true
 
+@description('The name of the managed identity for the MSI Credentials Refresher')
+param msiRefresherMIName string
+
+@description('The namespace of the MSI Credentials Refresher managed identity')
+param msiRefresherNamespace string
+
+@description('The service account name of the MSI Credentials Refresher managed identity')
+param msiRefresherServiceAccountName string
+
 @description('Deploy ARO HCP Maestro Postgres if true')
 param deployMaestroPostgres bool = true
 
@@ -402,6 +411,11 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
         uamiName: 'prometheus'
         namespace: 'prometheus'
         serviceAccountName: 'prometheus'
+      }
+      msi_credential_refresher_wi: {
+        uamiName: msiRefresherMIName
+        namespace: msiRefresherNamespace
+        serviceAccountName: msiRefresherServiceAccountName
       }
     })
     aksKeyVaultName: aksKeyVaultName


### PR DESCRIPTION
### What

introduce a new MI + workload identity settings for the MSI refresher deployment.
it also gets granted permissions on the MSI KV of a MGMT cluster on MGMT cluster provisioning

this PR also introduces the config structures for MSI refresher image references

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
