### PR TITLE
database: Add correlation data to OperationDocument

### DIFF
--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -440,6 +440,8 @@ func (s *OperationsScanner) processOperations(ctx context.Context, subscriptionI
 					"resource_id", operationDoc.ExternalID.String(),
 					"internal_id", operationDoc.InternalID.String(),
 					"cluster_id", operationDoc.InternalID.ClusterID(),
+					"client_request_id", operationDoc.ClientRequestID,
+					"correlation_request_id", operationDoc.CorrelationRequestID,
 				),
 			})
 	}

--- a/backend/operations_scanner_test.go
+++ b/backend/operations_scanner_test.go
@@ -99,7 +99,7 @@ func TestSetDeleteOperationAsCompleted(t *testing.T) {
 				newTimestamp:       func() time.Time { return time.Now().UTC() },
 			}
 
-			operationDoc := database.NewOperationDocument(database.OperationRequestDelete, resourceID, internalID)
+			operationDoc := database.NewOperationDocument(database.OperationRequestDelete, resourceID, internalID, nil)
 			operationDoc.OperationID = operationID
 			operationDoc.NotificationURI = server.URL
 			operationDoc.Status = tt.operationStatus
@@ -261,7 +261,7 @@ func TestUpdateOperationStatus(t *testing.T) {
 				newTimestamp:       func() time.Time { return time.Now().UTC() },
 			}
 
-			operationDoc := database.NewOperationDocument(database.OperationRequestCreate, resourceID, internalID)
+			operationDoc := database.NewOperationDocument(database.OperationRequestCreate, resourceID, internalID, nil)
 			operationDoc.OperationID = operationID
 			operationDoc.NotificationURI = server.URL
 			operationDoc.Status = tt.currentOperationStatus

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -68,6 +68,13 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		return
 	}
 
+	correlationData, err := CorrelationDataFromContext(ctx)
+	if err != nil {
+		logger.Error(err.Error())
+		arm.WriteInternalServerError(writer)
+		return
+	}
+
 	pk := database.NewPartitionKey(resourceID.SubscriptionID)
 
 	resourceItemID, resourceDoc, err := f.dbClient.GetResourceDoc(ctx, resourceID)
@@ -224,7 +231,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 
 	transaction := f.dbClient.NewTransaction(pk)
 
-	operationDoc := database.NewOperationDocument(operationRequest, resourceDoc.ResourceID, resourceDoc.InternalID)
+	operationDoc := database.NewOperationDocument(operationRequest, resourceDoc.ResourceID, resourceDoc.InternalID, correlationData)
 	operationID := transaction.CreateOperationDoc(operationDoc, nil)
 
 	f.ExposeOperation(writer, request, operationID, transaction)

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -227,6 +227,10 @@ type OperationDocument struct {
 	// OperationID is the Azure resource ID of the operation status (may be nil if the
 	// operation was implicit, such as deleting a child resource along with the parent)
 	OperationID *azcorearm.ResourceID `json:"operationId,omitempty"`
+	// ClientRequestID is provided by the "x-ms-client-request-id" request header
+	ClientRequestID string `json:"clientRequestId,omitempty"`
+	// CorrelationRequstID is provided by the "x-ms-correlation-request-id" request header
+	CorrelationRequestID string `json:"correlationRequestId,omitempty"`
 	// NotificationURI is provided by the Azure-AsyncNotificationUri header if the
 	// Async Operation Callbacks ARM feature is enabled
 	NotificationURI string `json:"notificationUri,omitempty"`
@@ -242,7 +246,7 @@ type OperationDocument struct {
 	Error *arm.CloudErrorBody `json:"error,omitempty"`
 }
 
-func NewOperationDocument(request OperationRequest, externalID *azcorearm.ResourceID, internalID ocm.InternalID) *OperationDocument {
+func NewOperationDocument(request OperationRequest, externalID *azcorearm.ResourceID, internalID ocm.InternalID, correlationData *arm.CorrelationData) *OperationDocument {
 	now := time.Now().UTC()
 
 	doc := &OperationDocument{
@@ -252,6 +256,11 @@ func NewOperationDocument(request OperationRequest, externalID *azcorearm.Resour
 		StartTime:          now,
 		LastTransitionTime: now,
 		Status:             arm.ProvisioningStateAccepted,
+	}
+
+	if correlationData != nil {
+		doc.ClientRequestID = correlationData.ClientRequestID
+		doc.CorrelationRequestID = correlationData.CorrelationRequestID
 	}
 
 	// When deleting, set Status directly to ProvisioningStateDeleting


### PR DESCRIPTION
[ARO-19986 - Log correlation_request_id to the backend](https://issues.redhat.com/browse/ARO-19986)

### What

The frontend will record the client request ID and correlation request ID in operation documents for the backend to include in its log messages.

### Why

Improved correlation of log messages amongst various ARO-HCP components related to a particular asynchronous operation.