### PR TITLE
Add missing diskEncryptionSets permission to HCP CAPZ dev role

### DIFF
--- a/dev-infrastructure/configurations/dev-operator-roles.bicepparam
+++ b/dev-infrastructure/configurations/dev-operator-roles.bicepparam
@@ -163,6 +163,7 @@ param roles = [
       'Microsoft.Network/networkInterfaces/read'
       'Microsoft.Network/networkInterfaces/write'
       'Microsoft.Network/virtualNetworks/subnets/join/action'
+      'Microsoft.Compute/diskEncryptionSets/read'
     ]
     notActions: []
     dataActions: []


### PR DESCRIPTION
<!-- Link to Jira issue -->

This is part 1 of https://issues.redhat.com/browse/ARO-19915

### What

<!-- Briefly describe what this PR does -->

During testing, QE discovered the Azure Red Hat OpenShift Cluster API Role was missing a permission needed to use DiskEncryptionSet. After adding this permission via a custom role, the functionality worked as intended.

### Why

Before we update the built-in role, we want to ensure that the source of truth for the permissions is also updated (be it upstream documentation, or a credentialsrequest). In this case, these permissions are special for HCP and so this is the source of truth for them.
<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

Adding the permission here won't update the built-in role in Azure - that is a separate process that typically takes at least a few weeks.

<!-- optional -->
