### PR TITLE
strip out prefix from resource name

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -64,7 +64,7 @@ curl -X GET "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/p
 Get HcpOpenshiftVersion Resource
 
 ```bash
-curl -X GET "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift/locations/westus3/hcpOpenShiftVersions/openshift-v4.19.0?api-version=2024-06-10-preview"
+curl -X GET "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift/locations/westus3/hcpOpenShiftVersions/4.19.0?api-version=2024-06-10-preview"
 ```
 
 List HcpOpenShiftClusterResource Resources by Subscription ID

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -324,7 +324,9 @@ func (f *Frontend) ArmResourceList(writer http.ResponseWriter, request *http.Req
 		csIterator := f.clusterServiceClient.ListVersions()
 
 		for csVersion := range csIterator.Items(ctx) {
-			stringResource := "/subscriptions/" + subscriptionID + "/providers/" + api.ProviderNamespace + "/locations/" + location + "/" + api.ClusterVersionTypeName + "/" + csVersion.ID()
+			versionName := strings.Replace(csVersion.ID(), api.OpenShiftVersionPrefix, "", 1)
+			stringResource := "/subscriptions/" + subscriptionID + "/providers/" + api.ProviderNamespace +
+				"/locations/" + location + "/" + api.ClusterVersionTypeName + "/" + versionName
 			resourceID, err := azcorearm.ParseResourceID(stringResource)
 			if err != nil {
 				logger.Error(err.Error())

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -20,10 +20,11 @@ import (
 
 	"strings"
 
-	"github.com/Azure/ARO-HCP/internal/api"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
 )
 
 type ClusterServiceClientSpec interface {

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"fmt"
 
+	"strings"
+
+	"github.com/Azure/ARO-HCP/internal/api"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -393,6 +396,10 @@ func (csc *clusterServiceClient) ListBreakGlassCredentials(clusterInternalID Int
 }
 
 func (csc *clusterServiceClient) GetVersion(ctx context.Context, versionName string) (*arohcpv1alpha1.Version, error) {
+
+	if !strings.Contains(versionName, api.OpenShiftVersionPrefix) {
+		versionName = api.OpenShiftVersionPrefix + versionName
+	}
 	client := csc.conn.AroHCP().V1alpha1().Versions().Version(versionName)
 
 	resp, err := client.Get().SendContext(ctx)

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -398,7 +398,7 @@ func (csc *clusterServiceClient) ListBreakGlassCredentials(clusterInternalID Int
 
 func (csc *clusterServiceClient) GetVersion(ctx context.Context, versionName string) (*arohcpv1alpha1.Version, error) {
 
-	if !strings.Contains(versionName, api.OpenShiftVersionPrefix) {
+	if !strings.HasPrefix(versionName, api.OpenShiftVersionPrefix) {
 		versionName = api.OpenShiftVersionPrefix + versionName
 	}
 	client := csc.conn.AroHCP().V1alpha1().Versions().Version(versionName)


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Formats version resource name to strip out prefix openshift-v

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
