### PR TITLE
feat: bump cs image to 5a131d6

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -570,7 +570,7 @@ clouds:
       clustersService:
         environment: "arohcpdev"
         image:
-          digest: sha256:0dee01f6620847b53030ae716547953931769c362364e5de6e4e05991aac1168
+          digest: sha256:41c6ff66219ca049036bcfb98e0c134a9315fc8a7b21d20e598f494f94a54649
         # NOTE: The role names must not include commas(,) in the name as the roleNames field
         # here is a comma separated list of role definition names.
         azureOperatorsManagedIdentities:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 8018d5581db6368fb95417f4c49a9c37b99a0d340bbd0e6ac382054e4552ae0a
+          westus3: b022a505cbea7cfe3da6f44cf7b941969b57a9b84804cc22b58467f909d47a25
       dev:
         regions:
-          westus3: a065aef54f254353b391f5eae9521331f36067d73834c1462570044954b934dc
+          westus3: f65c01c3f5ed2973d7dcd51fa7ca2e95a923f0e0f720e61014653f548a02c095
       ntly:
         regions:
-          uksouth: db82ebe372f3739975629c35fd8d4a336f4be16d5e09d678d281248ef88606ad
+          uksouth: b8d40c2ae6831f8ba408e7caae74870d92c9a81da154f053afb1ef3574ecbb50
       perf:
         regions:
-          westus3: 9d74f92c95b89295d6303fa6c32b1073a154735322456d8b62905c4cb73b0d35
+          westus3: 2a38fc5674b335206b0aba790f8c56ae487bc4fe2ec39d8e99749632469b3a4a
       pers:
         regions:
-          westus3: f1e78e643ac983927ac9954cf3988b229b8e1eb5067a8f10ae7fcab29618b217
+          westus3: d1c8b4178abbe64ea209741518681b9f1f67447a7c37da1a26308d34b78e9829
       swft:
         regions:
-          uksouth: 39f6f2cda3b07391240bf5adc3fd9ce6d33b48d27618daa82022fec627499b34
+          uksouth: b5ca8ae3aa3b3b71716479f28bbd692cabb163a310c00fe6ba81918452c0b9fa

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -66,7 +66,7 @@ clustersService:
       roleNames: Azure Red Hat OpenShift KMS Plugin - Dev
   environment: arohcpdev
   image:
-    digest: sha256:0dee01f6620847b53030ae716547953931769c362364e5de6e4e05991aac1168
+    digest: sha256:41c6ff66219ca049036bcfb98e0c134a9315fc8a7b21d20e598f494f94a54649
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -66,7 +66,7 @@ clustersService:
       roleNames: Azure Red Hat OpenShift KMS Plugin - Dev
   environment: arohcpdev
   image:
-    digest: sha256:0dee01f6620847b53030ae716547953931769c362364e5de6e4e05991aac1168
+    digest: sha256:41c6ff66219ca049036bcfb98e0c134a9315fc8a7b21d20e598f494f94a54649
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -66,7 +66,7 @@ clustersService:
       roleNames: Azure Red Hat OpenShift KMS Plugin - Dev
   environment: arohcpdev
   image:
-    digest: sha256:0dee01f6620847b53030ae716547953931769c362364e5de6e4e05991aac1168
+    digest: sha256:41c6ff66219ca049036bcfb98e0c134a9315fc8a7b21d20e598f494f94a54649
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -66,7 +66,7 @@ clustersService:
       roleNames: Azure Red Hat OpenShift KMS Plugin - Dev
   environment: arohcpdev
   image:
-    digest: sha256:0dee01f6620847b53030ae716547953931769c362364e5de6e4e05991aac1168
+    digest: sha256:41c6ff66219ca049036bcfb98e0c134a9315fc8a7b21d20e598f494f94a54649
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -66,7 +66,7 @@ clustersService:
       roleNames: Azure Red Hat OpenShift KMS Plugin - Dev
   environment: arohcpdev
   image:
-    digest: sha256:0dee01f6620847b53030ae716547953931769c362364e5de6e4e05991aac1168
+    digest: sha256:41c6ff66219ca049036bcfb98e0c134a9315fc8a7b21d20e598f494f94a54649
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -66,7 +66,7 @@ clustersService:
       roleNames: Azure Red Hat OpenShift KMS Plugin - Dev
   environment: arohcpdev
   image:
-    digest: sha256:0dee01f6620847b53030ae716547953931769c362364e5de6e4e05991aac1168
+    digest: sha256:41c6ff66219ca049036bcfb98e0c134a9315fc8a7b21d20e598f494f94a54649
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:


### PR DESCRIPTION
### What
Update CS release to [5a131d62](https://gitlab.cee.redhat.com/service/uhc-clusters-service/tree/5a131d62c7af9d3d346ed403e5a81e8cd670fc8a)

changes from last release can be seen [here](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/compare/aebf0e3ec7eea098143f7627611b6d0c9ac3ccec...5a131d62c7af9d3d346ed403e5a81e8cd670fc8a)

### Why
Contains changes to enable external auth for ARO HCP clusters

### Special notes for your reviewer
N/A