### PR TITLE
resource group persist tag handling clarity

### DIFF
--- a/tooling/templatize/pkg/pipeline/arm.go
+++ b/tooling/templatize/pkg/pipeline/arm.go
@@ -111,7 +111,7 @@ func (a *armClient) waitForExistingDeployment(ctx context.Context, timeOutInSeco
 
 func (a *armClient) runArmStep(ctx context.Context, options *PipelineRunOptions, rgName string, step *types.ARMStep, input map[string]Output) (Output, error) {
 	// Ensure resourcegroup exists
-	err := a.ensureResourceGroupExists(ctx, rgName, options.NoPersist)
+	err := a.ensureResourceGroupExists(ctx, rgName, !options.NoPersist)
 	if err != nil {
 		return nil, fmt.Errorf("failed to ensure resource group exists: %w", err)
 	}
@@ -323,17 +323,47 @@ func doWaitForDeployment(ctx context.Context, client *armresources.DeploymentsCl
 	}
 }
 
-func (a *armClient) ensureResourceGroupExists(ctx context.Context, rgName string, rgNoPersist bool) error {
-	// Check if the resource group exists
-	// Once the persist tag is set to true, it should not be removed by automation... tooo dangerous
+// computeResourceGroupTags determines the final tags for a resource group based on existing tags and persist settings.
+//
+// Persist tag rules:
+// 1. If persist tag already exists and is "true", it must be preserved (safety: never remove protection)
+// 2. If persist is true, set persist tag to "true"
+// 3. If persist is false and persist tag doesn't exist or isn't "true", don't add it
+//
+// This function is pure and easily testable - it only depends on its inputs.
+func computeResourceGroupTags(existingTags map[string]*string, persist bool) map[string]*string {
+	// Start with a copy of existing tags to avoid modifying the original
+	resultTags := make(map[string]*string)
+	for k, v := range existingTags {
+		resultTags[k] = v
+	}
+
+	// Check current persist tag value
+	currentPersistValue := ""
+	if existingTags != nil && existingTags["persist"] != nil {
+		currentPersistValue = *existingTags["persist"]
+	}
+
+	// Apply persist tag rules
+	if currentPersistValue == "true" {
+		// Rule 1: Always preserve existing persist=true (critical safety rule)
+		resultTags["persist"] = to.Ptr("true")
+	} else if persist {
+		// Rule 2: Set persist=true when persist is true
+		resultTags["persist"] = to.Ptr("true")
+	} else {
+		// Rule 3: Remove persist tag when persist is false and existing persist != "true"
+		delete(resultTags, "persist")
+	}
+	return resultTags
+}
+
+func (a *armClient) ensureResourceGroupExists(ctx context.Context, rgName string, persist bool) error {
 	rg, err := a.resourceGroupClient.Get(ctx, rgName, nil)
 	if err != nil {
-		// Create the resource group
-		tags := map[string]*string{}
-		if !rgNoPersist {
-			// if no-persist is set, don't set the persist tag, needs double negotiate, cause default should be true
-			tags["persist"] = to.Ptr("true")
-		}
+		// Resource group doesn't exist - create it
+		// We don't have any existing tags, so pass an empty map instead of nil for clarity.
+		tags := computeResourceGroupTags(map[string]*string{}, persist)
 		resourceGroup := armresources.ResourceGroup{
 			Location: to.Ptr(a.Region),
 			Tags:     tags,
@@ -343,14 +373,8 @@ func (a *armClient) ensureResourceGroupExists(ctx context.Context, rgName string
 			return fmt.Errorf("failed to create resource group: %w", err)
 		}
 	} else {
-		tags := rg.Tags
-		if tags == nil {
-			tags = map[string]*string{}
-		}
-		if !rgNoPersist {
-			// if no-persist is set, don't set the persist tag, needs double negotiate, cause default should be true
-			tags["persist"] = to.Ptr("true")
-		}
+		// Resource group exists - update its tags
+		tags := computeResourceGroupTags(rg.Tags, persist)
 		patchResourceGroup := armresources.ResourceGroupPatchable{
 			Tags: tags,
 		}

--- a/tooling/templatize/pkg/pipeline/arm_test.go
+++ b/tooling/templatize/pkg/pipeline/arm_test.go
@@ -188,3 +188,167 @@ func TestGenerateDeploymentNameUniqueness(t *testing.T) {
 		names[name] = true
 	}
 }
+
+func TestComputeResourceGroupTags(t *testing.T) {
+	tests := []struct {
+		name         string
+		existingTags map[string]*string
+		persist      bool
+		expectedTags map[string]*string
+		description  string
+	}{
+		// Empty existing tags
+		{
+			name:         "empty_tags_persist_true",
+			existingTags: map[string]*string{},
+			persist:      true,
+			expectedTags: map[string]*string{
+				"persist": to.Ptr("true"),
+			},
+			description: "Empty tags with persist=true should add persist tag",
+		},
+		{
+			name:         "empty_tags_persist_false",
+			existingTags: map[string]*string{},
+			persist:      false,
+			expectedTags: map[string]*string{},
+			description: "Empty tags with persist=false should remain empty",
+		},
+
+		// Nil existing tags (edge case)
+		{
+			name:         "nil_tags_persist_true",
+			existingTags: nil,
+			persist:      true,
+			expectedTags: map[string]*string{
+				"persist": to.Ptr("true"),
+			},
+			description: "Nil tags with persist=true should add persist tag",
+		},
+		{
+			name:         "nil_tags_persist_false",
+			existingTags: nil,
+			persist:      false,
+			expectedTags: map[string]*string{},
+			description: "Nil tags with persist=false should result in empty map",
+		},
+
+		// Existing tags with persist="true"
+		{
+			name: "existing_persist_true_persist_true",
+			existingTags: map[string]*string{
+				"persist": to.Ptr("true"),
+				"env":     to.Ptr("dev"),
+			},
+			persist: true,
+			expectedTags: map[string]*string{
+				"persist": to.Ptr("true"),
+				"env":     to.Ptr("dev"),
+			},
+			description: "Existing persist=true with persist=true should preserve persist tag",
+		},
+		{
+			name: "existing_persist_true_persist_false",
+			existingTags: map[string]*string{
+				"persist": to.Ptr("true"),
+				"env":     to.Ptr("dev"),
+			},
+			persist: false,
+			expectedTags: map[string]*string{
+				"persist": to.Ptr("true"), // Should be preserved (safety rule)
+				"env":     to.Ptr("dev"),
+			},
+			description: "Existing persist=true with persist=false should preserve persist tag (safety rule)",
+		},
+
+		// Existing tags with persist="false"
+		{
+			name: "existing_persist_false_persist_true",
+			existingTags: map[string]*string{
+				"persist": to.Ptr("false"),
+				"env":     to.Ptr("dev"),
+			},
+			persist: true,
+			expectedTags: map[string]*string{
+				"persist": to.Ptr("true"),
+				"env":     to.Ptr("dev"),
+			},
+			description: "Existing persist=false with persist=true should set persist to true",
+		},
+		{
+			name: "existing_persist_false_persist_false",
+			existingTags: map[string]*string{
+				"persist": to.Ptr("false"),
+				"env":     to.Ptr("dev"),
+			},
+			persist: false,
+			expectedTags: map[string]*string{
+				"env": to.Ptr("dev"),
+			},
+			description: "Existing persist=false with persist=false should not set persist tag",
+		},
+
+		// Existing tags with persist="something_else"
+		{
+			name: "existing_persist_invalid_persist_true",
+			existingTags: map[string]*string{
+				"persist": to.Ptr("maybe"),
+				"env":     to.Ptr("dev"),
+			},
+			persist: true,
+			expectedTags: map[string]*string{
+				"persist": to.Ptr("true"),
+				"env":     to.Ptr("dev"),
+			},
+			description: "Existing persist=invalid with persist=true should set persist to true",
+		},
+		{
+			name: "existing_persist_invalid_persist_false",
+			existingTags: map[string]*string{
+				"persist": to.Ptr("maybe"),
+				"env":     to.Ptr("dev"),
+			},
+			persist: false,
+			expectedTags: map[string]*string{
+				"env": to.Ptr("dev"),
+			},
+			description: "Existing persist=invalid with persist=false should not set persist tag",
+		},
+
+		// Existing tags without persist tag
+		{
+			name: "no_persist_tag_persist_true",
+			existingTags: map[string]*string{
+				"env":     to.Ptr("dev"),
+				"project": to.Ptr("aro-hcp"),
+			},
+			persist: true,
+			expectedTags: map[string]*string{
+				"env":     to.Ptr("dev"),
+				"project": to.Ptr("aro-hcp"),
+				"persist": to.Ptr("true"),
+			},
+			description: "No persist tag with persist=true should add persist tag",
+		},
+		{
+			name: "no_persist_tag_persist_false",
+			existingTags: map[string]*string{
+				"env":     to.Ptr("dev"),
+				"project": to.Ptr("aro-hcp"),
+			},
+			persist: false,
+			expectedTags: map[string]*string{
+				"env":     to.Ptr("dev"),
+				"project": to.Ptr("aro-hcp"),
+			},
+			description: "No persist tag with persist=false should not add persist tag",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computeResourceGroupTags(tt.existingTags, tt.persist)
+			assert.Equal(t, tt.expectedTags, result, tt.description)
+		})
+	}
+}


### PR DESCRIPTION
### What
improve readability on the persist tag handling of resourcegroup 

* extracted tag logic into a dedicated function `computeResourceGroupTags` with explicit rules
* ... and added extensive test cases
* inverted parameter logic: `rgNoPersist`to `persist` throughout the call chain for readability and easier reasonability

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
