### PR TITLE
update aro-hcp-e2e to accept LOCATION env var

### DIFF
--- a/test/e2e/cluster_create_missing_info.go
+++ b/test/e2e/cluster_create_missing_info.go
@@ -49,7 +49,7 @@ var _ = Describe("Customer", func() {
 				ic := framework.InvocationContext()
 
 				By("creating a resource group")
-				resourceGroup, cleanupResourceGroup, err := ic.NewResourceGroup(ctx, "basic-create", "uksouth")
+				resourceGroup, cleanupResourceGroup, err := ic.NewResourceGroup(ctx, "basic-create", ic.Location())
 				DeferCleanup(func(ctx SpecContext) {
 					err := cleanupResourceGroup(ctx)
 					Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/complete_cluster_create.go
+++ b/test/e2e/complete_cluster_create.go
@@ -50,7 +50,7 @@ var _ = Describe("Customer", func() {
 			ic := framework.InvocationContext()
 
 			By("creating a resource group")
-			resourceGroup, cleanupResourceGroup, err := ic.NewResourceGroup(ctx, "basic-create", "uksouth")
+			resourceGroup, cleanupResourceGroup, err := ic.NewResourceGroup(ctx, "basic-create", ic.Location())
 			DeferCleanup(func(ctx SpecContext) {
 				err := cleanupResourceGroup(ctx)
 				Expect(err).NotTo(HaveOccurred())

--- a/test/util/framework/zero_dep.go
+++ b/test/util/framework/zero_dep.go
@@ -36,6 +36,7 @@ type TestContext struct {
 	subscriptionName string
 	tenantID         string
 	testUserClientID string
+	location         string
 
 	contextLock                   sync.RWMutex
 	subscriptionID                string
@@ -67,6 +68,7 @@ func InvocationContext() *TestContext {
 			subscriptionName: subscriptionName(),
 			tenantID:         tenantID(),
 			testUserClientID: testUserClientID(),
+			location:         location(),
 		}
 	})
 	return invocationContext
@@ -265,10 +267,20 @@ func (tc *TestContext) getSubscriptionIDUnlocked(ctx context.Context) (string, e
 	return tc.subscriptionID, nil
 }
 
+func (tc *TestContext) Location() string {
+	return tc.location
+}
+
 // subscriptionName returns the value of CUSTOMER_SUBSCRIPTION environment variable
 func subscriptionName() string {
 	// can't use gomega in this method since it is used outside of It()
 	return os.Getenv("CUSTOMER_SUBSCRIPTION")
+}
+
+// location returns the Azure location to use, like "uksouth"
+func location() string {
+	// can't use gomega in this method since it is used outside of It()
+	return os.Getenv("LOCATION")
 }
 
 // testUserClientID returns the value of AZURE_CLIENT_ID environment variable


### PR DESCRIPTION
This allows different test invocations to select where to create stuff. This does prevent us from installing to multiple different locations for cross location tests.  We'll cross that bridge later.

https://github.com/Azure/ARO-HCP/pull/2212 only from the correct branch