### PR TITLE
fix namespace for kubelet ds

### DIFF
--- a/mgmt-fixes/Makefile
+++ b/mgmt-fixes/Makefile
@@ -4,7 +4,7 @@ PIPELINE_STEP = "mgmt-fixes"
 
 deploy:
 	@if [ "$(APPLY_KUBELET_FIXES)" = "true" ]; then \
-		../hack/helm.sh mgmt-fixes deploy/kubelet-ds kube-system; \
+		../hack/helm.sh mgmt-fixes deploy/kubelet-ds default; \
 	else \
 		echo "Skipping kubelet patching"; \
 	fi


### PR DESCRIPTION
### What

the helm deployemt of the kubelet ds lives in default, not kube-system

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
