### PR TITLE
add az managed prom config map

### DIFF
--- a/observability/prometheus/deploy/templates/ama-metrics-settings-configmap.yaml
+++ b/observability/prometheus/deploy/templates/ama-metrics-settings-configmap.yaml
@@ -1,0 +1,77 @@
+kind: ConfigMap
+apiVersion: v1
+data:
+  schema-version:
+    #string.used by agent to parse config. supported versions are {v1}. Configs with other schema versions will be rejected by the agent.
+    v1
+  config-version:
+    #string.used by customer to keep track of this config file's version in their source control/repository (max allowed 10 chars, other chars will be truncated)
+    ver1
+  prometheus-collector-settings: |-
+    cluster_alias = ""
+  default-scrape-settings-enabled: |-
+    kubelet = true
+    coredns = true
+    cadvisor = true
+    kubeproxy = true
+    apiserver = true
+    kubestate = false # OSS prometheus scrapes kube-state-metrics so the HCP ksm are routed to the hcp Azure Monitor Workspace
+    nodeexporter = true
+    windowsexporter = false
+    windowskubeproxy = false
+    kappiebasic = true
+    networkobservabilityRetina = true
+    networkobservabilityHubble = true
+    networkobservabilityCilium = true
+    prometheuscollectorhealth = true
+    controlplane-apiserver = true
+    controlplane-cluster-autoscaler = true
+    controlplane-kube-scheduler = true
+    controlplane-kube-controller-manager = true
+    controlplane-etcd = true
+  # Regex for which namespaces to scrape through pod annotation based scraping.
+  # This is none by default. Use '.*' to scrape all namespaces of annotated pods.
+  pod-annotation-based-scraping: |-
+    podannotationnamespaceregex = ""
+  default-targets-metrics-keep-list: |-
+    kubelet = ""
+    coredns = ""
+    cadvisor = ""
+    kubeproxy = ""
+    apiserver = ""
+    kubestate = ""
+    nodeexporter = ""
+    windowsexporter = ""
+    windowskubeproxy = ""
+    podannotations = ""
+    kappiebasic = ""
+    networkobservabilityRetina = ""
+    networkobservabilityHubble = ""
+    networkobservabilityCilium = ""
+    controlplane-apiserver = ""
+    controlplane-cluster-autoscaler = ""
+    controlplane-kube-scheduler = ""
+    controlplane-kube-controller-manager = ""
+    controlplane-etcd = ""
+    minimalingestionprofile = false
+  default-targets-scrape-interval-settings: |-
+    kubelet = "30s"
+    coredns = "30s"
+    cadvisor = "30s"
+    kubeproxy = "30s"
+    apiserver = "30s"
+    kubestate = "30s"
+    nodeexporter = "30s"
+    windowsexporter = "30s"
+    windowskubeproxy = "30s"
+    kappiebasic = "30s"
+    networkobservabilityRetina = "30s"
+    networkobservabilityHubble = "30s"
+    networkobservabilityCilium = "30s"
+    prometheuscollectorhealth = "30s"
+    podannotations = "30s"
+  debug-mode: |-
+    enabled = false
+metadata:
+  name: ama-metrics-settings-configmap
+  namespace: kube-system

--- a/observability/prometheus/deploy/values.yaml
+++ b/observability/prometheus/deploy/values.yaml
@@ -57,7 +57,7 @@ kube-prometheus-stack:
   kubeApiServer:
     enabled: false
   kubeStateMetrics:
-    enabled: false
+    enabled: true # OSS prometheus scrapes kube-state-metrics so the HCP ksm are routed to the hcp Azure Monitor Workspace
   prometheusOperator:
     enabled: true
     ## Use '{{ template "kube-prometheus-stack.fullname" . }}-operator' by default

--- a/observability/prometheus/test-pipeline.yaml
+++ b/observability/prometheus/test-pipeline.yaml
@@ -1,3 +1,4 @@
+# The real pipelines are in dev-infrastructure/mgmt-pipeline.yaml dev-infrastructure/svc-pipeline.yaml
 $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Management.Prometheus
 rolloutName: Management Cluster Prometheus Rollout
@@ -5,7 +6,7 @@ resourceGroups:
 - name: '{{ .mgmt.rg  }}'
   subscription: '{{ .mgmt.subscription  }}'
   steps:
-  - name: deploy
+  - name: deploy mgmt
     action: Shell
     aksCluster: '{{ .mgmt.aks.name  }}'
     command: make deploy
@@ -44,6 +45,53 @@ resourceGroups:
       configRef: mgmt.rg
     - name: CLUSTER_NAME
       configRef: mgmt.aks.name
+    - name: CS_ENVIRONMENT
+      configRef: clustersService.environment
+    shellIdentity:
+      configRef: aroDevopsMsiId
+
+- name: '{{ .svc.rg  }}'
+  subscription: '{{ .svc.subscription  }}'
+  steps:
+  - name: deploy svc
+    action: Shell
+    aksCluster: '{{ .svc.aks.name  }}'
+    command: make deploy
+    dryRun:
+      variables:
+      - name: DRY_RUN
+        value: "true"
+    variables:
+    - name: PROMETHEUS_OPERATOR_REGISTRY
+      configRef: svc.prometheus.prometheusOperator.image.registry
+    - name: PROMETHEUS_OPERATOR_REPOSITORY
+      configRef: svc.prometheus.prometheusOperator.image.repository
+    - name: PROMETHEUS_OPERATOR_DIGEST
+      configRef: svc.prometheus.prometheusOperator.image.digest
+    - name: PROMETHEUS_CONFIG_RELOADER_REGISTRY
+      configRef: svc.prometheus.prometheusConfigReloader.image.registry
+    - name: PROMETHEUS_CONFIG_RELOADER_REPOSITORY
+      configRef: svc.prometheus.prometheusConfigReloader.image.repository
+    - name: PROMETHEUS_CONFIG_RELOADER_DIGEST
+      configRef: svc.prometheus.prometheusConfigReloader.image.digest
+    - name: PROMETHEUS_SPEC_REGISTRY
+      configRef: svc.prometheus.prometheusSpec.image.registry
+    - name: PROMETHEUS_SPEC_REPOSITORY
+      configRef: svc.prometheus.prometheusSpec.image.repository
+    - name: PROMETHEUS_SPEC_DIGEST
+      configRef: svc.prometheus.prometheusSpec.image.digest
+    - name: PROMETHEUS_SPEC_REPLICAS
+      configRef: svc.prometheus.prometheusSpec.replicas
+    - name: PROMETHEUS_SPEC_SHARDS
+      configRef: svc.prometheus.prometheusSpec.shards
+    - name: PROMETHEUS_SPEC_VERSION
+      configRef: svc.prometheus.prometheusSpec.version
+    - name: PROMETHEUS_NAMESPACE_LABEL
+      configRef: svc.prometheus.namespaceLabel
+    - name: RESOURCE_GROUP
+      configRef: svc.rg
+    - name: CLUSTER_NAME
+      configRef: svc.aks.name
     - name: CS_ENVIRONMENT
       configRef: clustersService.environment
     shellIdentity:


### PR DESCRIPTION
- observability/prometheus/deploy/templates/ama-metrics-settings-configmap.yaml
  - This confimap turns on some default scrape settings.
  - kubestate is disabled
- adds kube state metrics to OSS Prometheus
  - So that service and hcp related kube state metrics are forwarded to the proper Azure Monitor Workspace

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
