### PR TITLE
bump CS tmp fix image in STAGE

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -75,7 +75,8 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:0dee01f6620847b53030ae716547953931769c362364e5de6e4e05991aac1168
+              registry: arohcpsvcdev.azurecr.io
+              digest: sha256:64b4fd5d657f17a13a960f37fde59b25310e9d336e5c727ac121ac7ff98788f8
           # ACR Pull
           acrPull:
             image:

--- a/observability/prometheus/deploy/templates/ama-metrics-settings-configmap.yaml
+++ b/observability/prometheus/deploy/templates/ama-metrics-settings-configmap.yaml
@@ -1,12 +1,10 @@
 kind: ConfigMap
 apiVersion: v1
 data:
-  schema-version:
-    #string.used by agent to parse config. supported versions are {v1}. Configs with other schema versions will be rejected by the agent.
-    v1
-  config-version:
-    #string.used by customer to keep track of this config file's version in their source control/repository (max allowed 10 chars, other chars will be truncated)
-    ver1
+  schema-version: v1
+  #string.used by agent to parse config. supported versions are {v1}. Configs with other schema versions will be rejected by the agent.
+  config-version: ver1
+  #string.used by customer to keep track of this config file's version in their source control/repository (max allowed 10 chars, other chars will be truncated)
   prometheus-collector-settings: |-
     cluster_alias = ""
   default-scrape-settings-enabled: |-

--- a/observability/prometheus/test-pipeline.yaml
+++ b/observability/prometheus/test-pipeline.yaml
@@ -62,7 +62,6 @@ resourceGroups:
         name: globalMSIId
     dependsOn:
     - global-output
-
 - name: '{{ .svc.rg  }}'
   subscription: '{{ .svc.subscription  }}'
   steps:


### PR DESCRIPTION
### What

registry: arohcpsvcdev.azurecr.io
digest: sha256:64b4fd5d657f17a13a960f37fde59b25310e9d336e5c727ac121ac7ff98788f8

piggyback yamllint fixes for unrelated files to make linters happy again

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
