### PR TITLE
Add Cluster Service SLO dashboard and alerting rules

### DIFF
--- a/cluster-service/grafana-dashboards/cluster-service-slo-compund-metrics.json
+++ b/cluster-service/grafana-dashboards/cluster-service-slo-compund-metrics.json
@@ -1,0 +1,2265 @@
+{
+  "description": "ARO HCP Cluster Service Component",
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Availability SLOs",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 29,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Over a 28-day rolling window, 99% of API requests will return with a successful status, where successful is defined as a non-5xx HTTP response code.",
+        "mode": "markdown"
+      },
+      "title": "SLO Definition: Availability",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Percentage of CS API is available (not returning 5xx Internal Service Errors).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.99
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 4,
+        "y": 1
+      },
+      "id": 1,
+      "maxDataPoints": 1001,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "availability:api_inbound_request_count:sli_ratio_28d{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}",
+          "instant": false,
+          "legendFormat": "Availability",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Availability",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "**Purpose:** This graph displays the Error Budget Burn Rate over the past 28 days to monitor the long-term reliability of Clusters Service Availability.\n\n---\n\n### **Understanding Long-Term Burn Rate Recovery**\n\nThe 28-day Burn Rate is a rolling cumulative metric. After an incident, even if short-term performance looks good, the long-term Burn Rate may remain consistently high and recover slowly. This typically happens because:\n\n1.  **Old Good Data Ages Out:** As time passes, older, well-performing data rolls out of the 28-day window, and new data might not fully compensate for its positive contribution.\n2.  **Traffic Impact:** If traffic (RPS) is high at the time of the incident, problematic requests will constitute a larger proportion of the rolling window.  In such scenarios, error dilution becomes difficult, extending the Burn Rate's recovery period, and this impact is further amplified for services with low sample volume and potentially high incident density.\n3.  **Limited Dilution Capacity:** The weight and volume of newly added healthy requests may be insufficient to quickly dilute historical errors, slowing down the Burn Rate's decrease.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 9,
+        "y": 1
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - availability:api_inbound_request_count:sli_ratio_28d{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}) / (1 - 0.99), 0)",
+          "instant": false,
+          "legendFormat": "Error budget burn rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Availability - Error Budget Burn Rate (28d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "An error budget is the maximum amount of allowable errors a service can incur within its SLO window before it is considered out of compliance with its reliability target. \n\nThe Error budget exhaustion shows how much allowable errors the service has used. \n\nFor example, we have API Availability 99% target value, that means the error budget is 1%. Suppose that actual value is 99.7%, that means the error budget exhaustion is 30%",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 22,
+      "maxDataPoints": 1001,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - availability:api_inbound_request_count:sli_ratio_28d{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}) / (1 - 0.99), 0)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error Budget Exhaustion (99%)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Page if the burn rate over the last 5 minutes and last 1 hour remains at 13.44 or greater.\n\nThis threshold means consuming:\n-  2% of the error budget in 1h \n-  100% in approximately 2 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 13.44
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 4,
+        "y": 7
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(availability:api_inbound_request_count:burnrate5m{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"} / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 5m",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(availability:api_inbound_request_count:burnrate1h{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"} / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 1h",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Critical Burn Rate Alert (5m & 1h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Page if the burn rate over the last 30 minutes and last 6 hours remains at 5.6 or greater.\n\nThis threshold means consuming:\n-  5% of the error budget in 6h \n-  100% in 5 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 5.6
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 9,
+        "y": 7
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "availability:api_inbound_request_count:burnrate30m{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 30m",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "availability:api_inbound_request_count:burnrate6h{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 6h",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Critical Burn Rate Alert (30m & 6h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Send a warning notification if the burn rate over the last 2 hours and last 1 days remains at 2.8 or greater. \n\nThis threshold means consuming:\n-  10% of the error budget in 1 day \n-  100% in approximately 10 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 2.8
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 7
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "availability:api_inbound_request_count:burnrate2h{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 2h",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "availability:api_inbound_request_count:burnrate1d{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 1d",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Warning Burn Rate Alert (2h & 1d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Send a warning notification if the burn rate over the last 6 hours and last 3 days remains at 0.934 or greater.\n\nThis threshold means consuming:\n-  10% of the error budget in 3 days \n-  100% in approximately 26 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.934
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 7
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "availability:api_inbound_request_count:burnrate6h{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 6h",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "availability:api_inbound_request_count:burnrate3d{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 3d",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Warning Burn Rate Alert (6h & 3d)",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 4,
+        "x": 0,
+        "y": 26
+      },
+      "id": 41,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Over a 28-day rolling window, 90% of successful API calls (determined as a non-5xx HTTP response) will complete within 100ms.",
+        "mode": "markdown"
+      },
+      "title": "SLO Definition: P90 Latency",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Percentage of requests to operate cluster are successful with a latency of <100ms",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.90
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 4,
+        "y": 26
+      },
+      "id": 42,
+      "maxDataPoints": 1001,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "latency:api_inbound_request_duration:p90_sli_ratio_28d{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}",
+          "instant": false,
+          "legendFormat": "P90 Latency",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P90 Latency (< 100ms)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "**Purpose:** This graph displays the Error Budget Burn Rate over the past 28 days to monitor the long-term reliability of Clusters Service P90 Latency.\n\n---\n\n### **Understanding Long-Term Burn Rate Recovery**\n\nThe 28-day Burn Rate is a rolling cumulative metric. After an incident, even if short-term performance looks good, the long-term Burn Rate may remain consistently high and recover slowly. This typically happens because:\n\n1.  **Old Good Data Ages Out:** As time passes, older, well-performing data rolls out of the 28-day window, and new data might not fully compensate for its positive contribution.\n2.  **Traffic Impact:** If traffic (RPS) is high at the time of the incident, problematic requests will constitute a larger proportion of the rolling window.  In such scenarios, error dilution becomes difficult, extending the Burn Rate's recovery period, and this impact is further amplified for services with low sample volume and potentially high incident density.\n3.  **Limited Dilution Capacity:** The weight and volume of newly added healthy requests may be insufficient to quickly dilute historical errors, slowing down the Burn Rate's decrease.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 9,
+        "y": 26
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - latency:api_inbound_request_duration:p90_sli_ratio_28d{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}) / (1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Error budget burn rate",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "P90 Latency - Error Budget Burn Rate (28d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "An error budget is the maximum amount of allowable errors a service can incur within its SLO window before it is considered out of compliance with its reliability target. \n\nThe Error budget exhaustion shows how much allowable errors the service has used. \n\nFor example, we have P90 API Latency 90% target value, that means the error budget is 10%. Suppose that actual value is 95%, that means the error budget exhaustion is 50%",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 26
+      },
+      "id": 44,
+      "maxDataPoints": 1001,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - latency:api_inbound_request_duration:p90_sli_ratio_28d{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"})/(1 - 0.90), 0)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error Budget Exhaustion (90%)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Page if the burn rate over the last 5 minutes and last 1 hour remains at 13.44 or greater.\n\nThis threshold means consuming:\n-  2% of the error budget in 1h \n-  100% in approximately 2 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 13.44
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 4,
+        "y": 32
+      },
+      "id": 45,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p90_burnrate5m{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 5m",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:burnrate1h{cluster=\"$cluster\", service=\"clusters-service-metrics\", latency=\"0.1\"} / (1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 1h",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P90 Critical Burn Rate Alert (5m & 1h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Page if the burn rate over the last 30 minutes and last 6 hours remains at 5.6 or greater.\n\nThis threshold means consuming:\n-  5% of the error budget in 6h \n-  100% in 5 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 5.6
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 9,
+        "y": 32
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p90_burnrate30m{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 30m",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p90_burnrate6h{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 6h",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P90 Critical Burn Rate Alert (30m & 6h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Send a warning notification if the burn rate over the last 2 hours and last 1 days remains at 2.8 or greater. \n\n\nThis threshold means consuming:\n-  10% of the error budget in 1 day \n-  100% in approximately 10 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 2.8
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 32
+      },
+      "id": 47,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p90_burnrate2h{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 2h",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p90_burnrate1d{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 1d",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P90 Warning Burn Rate Alert (2h & 1d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Send a warning notification if the burn rate over the last 6 hours and last 3 days remains at 0.934 or greater.\n\nThis threshold means consuming:\n-  10% of the error budget in 3 days \n-  100% in approximately 26 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.934
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 32
+      },
+      "id": 48,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p90_burnrate6h{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 6h",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p90_burnrate3d{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 3d",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P90 Warning Burn Rate Alert (6h & 3d)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 30,
+      "panels": [],
+      "title": "Latency SLOs",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 4,
+        "x": 0,
+        "y": 14
+      },
+      "id": 30,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Over a 28-day rolling window, 99% of successful API calls (determined as a non-5xx HTTP response) will complete within 1s.",
+        "mode": "markdown"
+      },
+      "title": "SLO Definition: P99 Latency",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Percentage of requests to operate cluster are successful with a latency of <1s",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 4,
+        "y": 14
+      },
+      "id": 12,
+      "maxDataPoints": 1001,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "latency:api_inbound_request_duration:p99_sli_ratio_28d{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}",
+          "instant": false,
+          "legendFormat": "Latency",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P99 Latency (< 1s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "**Purpose:** This graph displays the Error Budget Burn Rate over the past 28 days to monitor the long-term reliability of Clusters Service P99 Latency.\n\n---\n\n### **Understanding Long-Term Burn Rate Recovery**\n\nThe 28-day Burn Rate is a rolling cumulative metric. After an incident, even if short-term performance looks good, the long-term Burn Rate may remain consistently high and recover slowly. This typically happens because:\n\n1.  **Old Good Data Ages Out:** As time passes, older, well-performing data rolls out of the 28-day window, and new data might not fully compensate for its positive contribution.\n2.  **Traffic Impact:** If traffic (RPS) is high at the time of the incident, problematic requests will constitute a larger proportion of the rolling window.  In such scenarios, error dilution becomes difficult, extending the Burn Rate's recovery period, and this impact is further amplified for services with low sample volume and potentially high incident density.\n3.  **Limited Dilution Capacity:** The weight and volume of newly added healthy requests may be insufficient to quickly dilute historical errors, slowing down the Burn Rate's decrease.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 9,
+        "y": 14
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - latency:api_inbound_request_duration:p99_sli_ratio_28d{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"})/(1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P99 Error budget burn rate",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Latency - Error Budget Burn Rate (28d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "An error budget is the maximum amount of allowable errors a service can incur within its SLO window before it is considered out of compliance with its reliability target. \n\nThe Error budget exhaustion shows how much allowable errors the service has used. \n\nFor example, we have API Availability 99% target value, that means the error budget is 1%. Suppose that actual value is 99.7%, that means the error budget exhaustion is 30%",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 14
+      },
+      "id": 21,
+      "maxDataPoints": 1001,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - latency:api_inbound_request_duration:p99_sli_ratio_28d{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"})/(1 - 0.99), 0)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error Budget Exhaustion (99%)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Page if the burn rate over the last 5 minutes and last 1 hour remains at 13.44 or greater.\n\nThis threshold means consuming:\n-  2% of the error budget in 1h \n-  100% in approximately 2 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 13.44
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 4,
+        "y": 20
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p99_burnrate5m{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 5m",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p99_burnrate1h{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 1h",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P99 Critical Burn Rate Alert (5m & 1h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Page if the burn rate over the last 30 minutes and last 6 hours remains at 5.6 or greater.\n\nThis threshold means consuming:\n-  5% of the error budget in 6h \n-  100% in 5 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 5.6
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 9,
+        "y": 20
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p99_burnrate30m{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 30m",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p99_burnrate6h{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 6h",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P99 Critical Burn Rate Alert (30m & 6h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Send a warning notification if the burn rate over the last 2 hours and last 1 days remains at 2.8 or greater. \n\n\nThis threshold means consuming:\n-  10% of the error budget in 1 day \n-  100% in approximately 10 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 2.8
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 20
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p99_burnrate2h{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 2h",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p99_burnrate1d{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 1d",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P99 Warning Burn Rate Alert (2h & 1d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Send a warning notification if the burn rate over the last 6 hours and last 3 days remains at 0.934 or greater.\n\nThis threshold means consuming:\n-  10% of the error budget in 3 days \n-  100% in approximately 26 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.934
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 20
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p99_burnrate6h{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 6h",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p99_burnrate3d{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 3d",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P99 Warning Burn Rate Alert (6h & 3d)",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(up,cluster)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up,cluster)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-28d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "ARO HCP Cluster Service SLOs",
+  "uid": "aro-hcp-cluster-service-slos",
+  "version": 1,
+  "weekStart": "",
+  "refresh": "5m"
+}

--- a/cluster-service/grafana-dashboards/cluster-service-slo.json
+++ b/cluster-service/grafana-dashboards/cluster-service-slo.json
@@ -1,0 +1,2264 @@
+{
+  "description": "ARO HCP Cluster Service Component",
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Availability SLOs",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 29,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Over a 28-day rolling window, 99% of API requests will return with a successful status, where successful is defined as a non-5xx HTTP response code and non timeout error.",
+        "mode": "markdown"
+      },
+      "title": "SLO Definition: Availability",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Percentage of CS API is available (not returning 5xx Internal Service Errors).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.99
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 4,
+        "y": 1
+      },
+      "id": 1,
+      "maxDataPoints": 1001,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..|0\", service=\"clusters-service-metrics\"}[28d]))) / sum((max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d])))))",
+          "instant": false,
+          "legendFormat": "Availability",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Availability",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "**Purpose:** This graph displays the Error Budget Burn Rate over the past 28 days to monitor the long-term reliability of Clusters Service Availability.\n\n---\n\n### **Understanding Long-Term Burn Rate Recovery**\n\nThe 28-day Burn Rate is a rolling cumulative metric. After an incident, even if short-term performance looks good, the long-term Burn Rate may remain consistently high and recover slowly. This typically happens because:\n\n1.  **Old Good Data Ages Out:** As time passes, older, well-performing data rolls out of the 28-day window, and new data might not fully compensate for its positive contribution.\n2.  **Traffic Impact:** If traffic (RPS) is high at the time of the incident, problematic requests will constitute a larger proportion of the rolling window.  In such scenarios, error dilution becomes difficult, extending the Burn Rate's recovery period, and this impact is further amplified for services with low sample volume and potentially high incident density.\n3.  **Limited Dilution Capacity:** The weight and volume of newly added healthy requests may be insufficient to quickly dilute historical errors, slowing down the Burn Rate's decrease.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 9,
+        "y": 1
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..|0\", service=\"clusters-service-metrics\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d]))))) / (1 - 0.99)",
+          "instant": false,
+          "legendFormat": "Error budget burn rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Availability - Error Budget Burn Rate (28d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "An error budget is the maximum amount of allowable errors a service can incur within its SLO window before it is considered out of compliance with its reliability target. \n\nThe Error budget exhaustion shows how much allowable errors the service has used. \n\nFor example, we have API Availability 99% target value, that means the error budget is 1%. Suppose that actual value is 99.7%, that means the error budget exhaustion is 30%",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 22,
+      "maxDataPoints": 1001,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..|0\", service=\"clusters-service-metrics\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d]))))) / (1 - 0.99)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error Budget Exhaustion (99%)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Page if the burn rate over the last 5 minutes and last 1 hour remains at 13.44 or greater.\n\nThis threshold means consuming:\n-  2% of the error budget in 1h \n-  100% in approximately 2 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 13.44
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 4,
+        "y": 7
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..|0\", service=\"clusters-service-metrics\"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[5m]))))) / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 5m",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..|0\", service=\"clusters-service-metrics\"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[1h]))))) / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 1h",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Critical Burn Rate Alert (5m & 1h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Page if the burn rate over the last 30 minutes and last 6 hours remains at 5.6 or greater.\n\nThis threshold means consuming:\n-  5% of the error budget in 6h \n-  100% in 5 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 5.6
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 9,
+        "y": 7
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..|0\", service=\"clusters-service-metrics\"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[30m]))))) / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 30m",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..|0\", service=\"clusters-service-metrics\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[6h]))))) / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 6h",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Critical Burn Rate Alert (30m & 6h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Send a warning notification if the burn rate over the last 2 hours and last 1 days remains at 2.8 or greater. \n\nThis threshold means consuming:\n-  10% of the error budget in 1 day \n-  100% in approximately 10 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 2.8
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 7
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", code=~\"5..|0\", service=\"clusters-service-metrics\"}[2h])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[2h])))))/(1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 2h",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", code=~\"5..|0\", service=\"clusters-service-metrics\"}[1d])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[1d])))))/(1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 1d",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Warning Burn Rate Alert (2h & 1d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Send a warning notification if the burn rate over the last 6 hours and last 3 days remains at 0.934 or greater.\n\nThis threshold means consuming:\n-  10% of the error budget in 3 days \n-  100% in approximately 26 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.934
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 7
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..|0\", service=\"clusters-service-metrics\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[6h]))))) / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 6h",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..|0\", service=\"clusters-service-metrics\"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[3d]))))) / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 3d",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Warning Burn Rate Alert (6h & 3d)",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 4,
+        "x": 0,
+        "y": 26
+      },
+      "id": 41,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Over a 28-day rolling window, 90% of successful API calls (determined as a non-5xx HTTP response) will complete within 100ms.",
+        "mode": "markdown"
+      },
+      "title": "SLO Definition: P90 Latency",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Percentage of requests to operate cluster are successful with a latency of <100ms",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.90
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 4,
+        "y": 26
+      },
+      "id": 42,
+      "maxDataPoints": 1001,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[28d])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[28d]))))",
+          "instant": false,
+          "legendFormat": "P90 Latency",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P90 Latency (< 100ms)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "**Purpose:** This graph displays the Error Budget Burn Rate over the past 28 days to monitor the long-term reliability of Clusters Service P90 Latency.\n\n---\n\n### **Understanding Long-Term Burn Rate Recovery**\n\nThe 28-day Burn Rate is a rolling cumulative metric. After an incident, even if short-term performance looks good, the long-term Burn Rate may remain consistently high and recover slowly. This typically happens because:\n\n1.  **Old Good Data Ages Out:** As time passes, older, well-performing data rolls out of the 28-day window, and new data might not fully compensate for its positive contribution.\n2.  **Traffic Impact:** If traffic (RPS) is high at the time of the incident, problematic requests will constitute a larger proportion of the rolling window.  In such scenarios, error dilution becomes difficult, extending the Burn Rate's recovery period, and this impact is further amplified for services with low sample volume and potentially high incident density.\n3.  **Limited Dilution Capacity:** The weight and volume of newly added healthy requests may be insufficient to quickly dilute historical errors, slowing down the Burn Rate's decrease.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 9,
+        "y": 26
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[28d])))))/(1 - 0.90)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Error budget burn rate",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "P90 Latency - Error Budget Burn Rate (28d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "An error budget is the maximum amount of allowable errors a service can incur within its SLO window before it is considered out of compliance with its reliability target. \n\nThe Error budget exhaustion shows how much allowable errors the service has used. \n\nFor example, we have P90 API Latency 90% target value, that means the error budget is 10%. Suppose that actual value is 95%, that means the error budget exhaustion is 50%",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 26
+      },
+      "id": 44,
+      "maxDataPoints": 1001,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[28d])))))/(1 - 0.90)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error Budget Exhaustion (90%)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Page if the burn rate over the last 5 minutes and last 1 hour remains at 13.44 or greater.\n\nThis threshold means consuming:\n-  2% of the error budget in 1h \n-  100% in approximately 2 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 13.44
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 4,
+        "y": 32
+      },
+      "id": 45,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[5m]))))) / (1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 5m",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[1h])))))/(1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 1h",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P90 Critical Burn Rate Alert (5m & 1h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Page if the burn rate over the last 30 minutes and last 6 hours remains at 5.6 or greater.\n\nThis threshold means consuming:\n-  5% of the error budget in 6h \n-  100% in 5 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 5.6
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 9,
+        "y": 32
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[30m])))))/(1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 30m",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[6h])))))/(1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 6h",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P90 Critical Burn Rate Alert (30m & 6h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Send a warning notification if the burn rate over the last 2 hours and last 1 days remains at 2.8 or greater. \n\n\nThis threshold means consuming:\n-  10% of the error budget in 1 day \n-  100% in approximately 10 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 2.8
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 32
+      },
+      "id": 47,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[2h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[2h])))))/(1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 2h",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[1d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[1d])))))/(1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 1d",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P90 Warning Burn Rate Alert (2h & 1d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Send a warning notification if the burn rate over the last 6 hours and last 3 days remains at 0.934 or greater.\n\nThis threshold means consuming:\n-  10% of the error budget in 3 days \n-  100% in approximately 26 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.934
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 32
+      },
+      "id": 48,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[6h])))))/(1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 6h",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[3d])))))/(1 - 0.90), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P90 Burn Rate - 3d",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P90 Warning Burn Rate Alert (6h & 3d)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 30,
+      "panels": [],
+      "title": "Latency SLOs",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 4,
+        "x": 0,
+        "y": 14
+      },
+      "id": 30,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Over a 28-day rolling window, 99% of successful API calls (determined as a non-5xx HTTP response) will complete within 1s.",
+        "mode": "markdown"
+      },
+      "title": "SLO Definition: P99 Latency",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Percentage of requests to operate cluster are successful with a latency of <1s",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 4,
+        "y": 14
+      },
+      "id": 12,
+      "maxDataPoints": 1001,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[28d])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[28d]))))",
+          "instant": false,
+          "legendFormat": "Latency",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P99 Latency (< 1s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "**Purpose:** This graph displays the Error Budget Burn Rate over the past 28 days to monitor the long-term reliability of Clusters Service P99 Latency.\n\n---\n\n### **Understanding Long-Term Burn Rate Recovery**\n\nThe 28-day Burn Rate is a rolling cumulative metric. After an incident, even if short-term performance looks good, the long-term Burn Rate may remain consistently high and recover slowly. This typically happens because:\n\n1.  **Old Good Data Ages Out:** As time passes, older, well-performing data rolls out of the 28-day window, and new data might not fully compensate for its positive contribution.\n2.  **Traffic Impact:** If traffic (RPS) is high at the time of the incident, problematic requests will constitute a larger proportion of the rolling window.  In such scenarios, error dilution becomes difficult, extending the Burn Rate's recovery period, and this impact is further amplified for services with low sample volume and potentially high incident density.\n3.  **Limited Dilution Capacity:** The weight and volume of newly added healthy requests may be insufficient to quickly dilute historical errors, slowing down the Burn Rate's decrease.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 9,
+        "y": 14
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[28d])))))/(1 - 0.99)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "P99 Error budget burn rate",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Latency - Error Budget Burn Rate (28d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "An error budget is the maximum amount of allowable errors a service can incur within its SLO window before it is considered out of compliance with its reliability target. \n\nThe Error budget exhaustion shows how much allowable errors the service has used. \n\nFor example, we have API Availability 99% target value, that means the error budget is 1%. Suppose that actual value is 99.7%, that means the error budget exhaustion is 30%",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 14
+      },
+      "id": 21,
+      "maxDataPoints": 1001,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[28d])))))/(1 - 0.99)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error Budget Exhaustion (99%)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Page if the burn rate over the last 5 minutes and last 1 hour remains at 13.44 or greater.\n\nThis threshold means consuming:\n-  2% of the error budget in 1h \n-  100% in approximately 2 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 13.44
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 4,
+        "y": 20
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[5m]))))) / (1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 5m",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[1h])))))/(1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 1h",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P99 Critical Burn Rate Alert (5m & 1h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Page if the burn rate over the last 30 minutes and last 6 hours remains at 5.6 or greater.\n\nThis threshold means consuming:\n-  5% of the error budget in 6h \n-  100% in 5 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 5.6
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 9,
+        "y": 20
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[30m])))))/(1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 30m",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[6h])))))/(1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 6h",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P99 Critical Burn Rate Alert (30m & 6h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Send a warning notification if the burn rate over the last 2 hours and last 1 days remains at 2.8 or greater. \n\n\nThis threshold means consuming:\n-  10% of the error budget in 1 day \n-  100% in approximately 10 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 2.8
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 20
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[2h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[2h])))))/(1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 2h",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[1d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[1d])))))/(1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 1d",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P99 Warning Burn Rate Alert (2h & 1d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Send a warning notification if the burn rate over the last 6 hours and last 3 days remains at 0.934 or greater.\n\nThis threshold means consuming:\n-  10% of the error budget in 3 days \n-  100% in approximately 26 days",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.934
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 20
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[6h])))))/(1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 6h",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[3d])))))/(1 - 0.99), 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Burn Rate - 3d",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P99 Warning Burn Rate Alert (6h & 3d)",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(up,cluster)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up,cluster)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-28d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "ARO HCP Cluster Service SLOs",
+  "uid": "aro-hcp-cluster-service-slos",
+  "version": 1,
+  "weekStart": ""
+}

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1325,3 +1325,122 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
     ]
   }
 }
+
+resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_cs_slo_availability_alerts'
+  location: resourceGroup().location
+  properties: {
+    rules: [
+      {
+        actions: [for g in actionGroups: { actionGroupId: g }]
+        alert: 'ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn'
+        enabled: true
+        labels: {
+          long: '6h'
+          severity: 'warning'
+          short: '30m'
+        }
+        annotations: {
+          description: 'API is rapidly burning its 28 day availability error budget (99% SLO)'
+          runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
+          summary: 'Cluster Service API availability error budget burn rate is too high'
+        }
+        expression: '( sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"})) > 13.44 and sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{service="clusters-service-metrics"})) > 13.44 ) or ( sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{service="clusters-service-metrics"})) > 5.6 and sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"})) > 5.6 )'
+        for: 'PT5M'
+        severity: 3
+      }
+      {
+        actions: [for g in actionGroups: { actionGroupId: g }]
+        alert: 'ClustersServiceAPIAvailability6hto3dErrorBudgetBurn'
+        enabled: true
+        labels: {
+          severity: 'warning'
+          slo: 'api-availability'
+        }
+        annotations: {
+          description: 'This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days.'
+          runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
+          summary: 'API is slowly but steadily burning its 28 day availability error budget (99% SLO)'
+        }
+        expression: 'sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"})) > 0.934 and sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{service="clusters-service-metrics"})) > 0.934'
+        for: 'PT30M'
+        severity: 3
+      }
+      {
+        actions: [for g in actionGroups: { actionGroupId: g }]
+        alert: 'ClustersServiceAPILatency5mto1hor30mto6hP99ErrorBudgetBurn'
+        enabled: true
+        labels: {
+          long: '6h'
+          severity: 'warning'
+          short: '30m'
+          slo: 'api-latency-p99'
+        }
+        annotations: {
+          description: 'API is rapidly burning its 28 day 1s latency error budget (99% SLO)'
+          runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
+          summary: 'Cluster Service API P99 latency error budget burn rate is too high'
+        }
+        expression: '( sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{service="clusters-service-metrics"})) > 13.44 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{service="clusters-service-metrics"})) > 13.44 ) or ( sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{service="clusters-service-metrics"})) > 5.6 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{service="clusters-service-metrics"})) > 5.6 )'
+        for: 'PT5M'
+        severity: 3
+      }
+      {
+        actions: [for g in actionGroups: { actionGroupId: g }]
+        alert: 'ClustersServiceAPILatency6hto3dP99ErrorBudgetBurn'
+        enabled: true
+        labels: {
+          severity: 'warning'
+          slo: 'api-latency-p99'
+        }
+        annotations: {
+          description: 'This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days.'
+          runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
+          summary: 'API is slowly but steadily burning its 28 day 1s latency error budget (99% SLO)'
+        }
+        expression: 'sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{service="clusters-service-metrics"})) > 0.934 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{service="clusters-service-metrics"})) > 0.934'
+        for: 'PT30M'
+        severity: 3
+      }
+      {
+        actions: [for g in actionGroups: { actionGroupId: g }]
+        alert: 'ClustersServiceAPILatency5mto1hor30mto6hP90ErrorBudgetBurn'
+        enabled: true
+        labels: {
+          long: '6h'
+          severity: 'warning'
+          short: '30m'
+          slo: 'api-latency-p90'
+        }
+        annotations: {
+          description: 'API is rapidly burning its 28 day 0.1s latency error budget (90% SLO)'
+          runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
+          summary: 'Cluster Service API P90 latency error budget burn rate is too high'
+        }
+        expression: '( sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{service="clusters-service-metrics"})) > 13.44 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{service="clusters-service-metrics"})) > 13.44 ) or ( sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{service="clusters-service-metrics"})) > 5.6 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{service="clusters-service-metrics"})) > 5.6 )'
+        for: 'PT5M'
+        severity: 3
+      }
+      {
+        actions: [for g in actionGroups: { actionGroupId: g }]
+        alert: 'ClustersServiceAPILatency6hto3dP90ErrorBudgetBurn'
+        enabled: true
+        labels: {
+          severity: 'warning'
+          slo: 'api-latency-p90'
+        }
+        annotations: {
+          description: 'This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days.'
+          runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
+          summary: 'API is slowly but steadily burning its 28 day 0.1s latency error budget (90% SLO)'
+        }
+        expression: 'sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{service="clusters-service-metrics"})) > 0.934 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{service="clusters-service-metrics"})) > 0.934'
+        for: 'PT30M'
+        severity: 3
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -1,0 +1,197 @@
+param azureMonitoring string
+
+resource arohcpCsApiAvailabilityRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_cs_api_availability_recording_rules'
+  location: resourceGroup().location
+  properties: {
+    scopes: [
+      azureMonitoring
+    ]
+    enabled: true
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'availability:api_inbound_request_count:sli_ratio_28d'
+        expression: 'sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code!~"5..|0", service="clusters-service-metrics"}[28d]))) / sum((max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d]))))'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'availability:api_inbound_request_count:burnrate5m'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'availability:api_inbound_request_count:burnrate30m'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'availability:api_inbound_request_count:burnrate1h'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'availability:api_inbound_request_count:burnrate6h'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'availability:api_inbound_request_count:burnrate3d'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'availability:api_inbound_request_count:burnrate2h'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[2h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'availability:api_inbound_request_count:burnrate1d'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+    ]
+  }
+}
+
+resource arohcpCsApiLatencyRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_cs_api_latency_recording_rules'
+  location: resourceGroup().location
+  properties: {
+    scopes: [
+      azureMonitoring
+    ]
+    enabled: true
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'latency:api_inbound_request_duration:p99_sli_ratio_28d'
+        expression: 'sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p90_sli_ratio_28d'
+        expression: 'sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p99_burnrate5m'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[5m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p99_burnrate30m'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[30m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p99_burnrate1h'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[1h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p99_burnrate6h'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[6h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p99_burnrate3d'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[3d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p99_burnrate2h'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[2h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p99_burnrate1d'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[1d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.99), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p90_burnrate5m'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[5m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.90), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p90_burnrate30m'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[30m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.90), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p90_burnrate1h'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[1h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.90), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p90_burnrate6h'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[6h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.90), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p90_burnrate3d'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[3d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.90), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p90_burnrate2h'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[2h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.90), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+      {
+        record: 'latency:api_inbound_request_duration:p90_burnrate1d'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[1d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.90), 0.01 )'
+        labels: {
+          service: 'clusters-service-metrics'
+        }
+      }
+    ]
+  }
+}

--- a/dev-infrastructure/modules/metrics/service-rules.bicep
+++ b/dev-infrastructure/modules/metrics/service-rules.bicep
@@ -27,3 +27,10 @@ module defaultRuleGroups 'rules/defaultRecordingRuleGroups.bicep' = {
     azureMonitoring: azureMonitoringWorkspaceId
   }
 }
+
+module generatedRecordingRules 'rules/generatedRecordingRules.bicep' = {
+  name: 'generatedRecordingRules'
+  params: {
+    azureMonitoring: azureMonitoringWorkspaceId
+  }
+}

--- a/observability/Makefile
+++ b/observability/Makefile
@@ -16,3 +16,8 @@ alerts: kubernetesControlPlane-prometheusRule
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules run-hcp
 	az bicep format -f $$(yq '.prometheusRules.outputBicep' observability-hcp.yaml)
 .PHONY: alerts
+
+recording-rules:
+	make -C ../tooling/prometheus-rules run-recording-rules
+	az bicep format -f $$(yq '.prometheusRules.outputBicep' observability-recording-rules.yaml)
+.PHONY: recording-rules

--- a/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
+++ b/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
@@ -1,0 +1,447 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster-service
+    app.kubernetes.io/part-of: cluster-service
+    prometheus: k8s
+    role: alert-rules
+  name: cluster-service-slo-rules
+  namespace: monitoring
+spec:
+  groups:
+  # API Availability Recording Rules
+  - name: arohcp_cs_api_availability_recording_rules
+    interval: 1m
+    rules:
+    # 28-day rolling SLI
+    - record: availability:api_inbound_request_count:sli_ratio_28d
+      expr: |
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code!~"5..|0", service="clusters-service-metrics"}[28d])))
+        /
+        sum((max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d]))))
+      labels:
+        service: "clusters-service-metrics"
+    # Burn rate recording rules for various time windows
+    - record: availability:api_inbound_request_count:burnrate5m
+      expr: |
+        round(
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[5m])))
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: availability:api_inbound_request_count:burnrate30m
+      expr: |
+        round(
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[30m])))
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: availability:api_inbound_request_count:burnrate1h
+      expr: |
+        round(
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1h])))
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: availability:api_inbound_request_count:burnrate6h
+      expr: |
+        round(
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[6h])))
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: availability:api_inbound_request_count:burnrate3d
+      expr: |
+        round(
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[3d])))
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: availability:api_inbound_request_count:burnrate2h
+      expr: |
+        round(
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[2h])))
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: availability:api_inbound_request_count:burnrate1d
+      expr: |
+        round(
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1d])))
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+  # API Latency Recording Rules
+  - name: arohcp_cs_api_latency_recording_rules
+    interval: 1m
+    rules:
+    # P99 Latency SLI (28-day)
+    - record: latency:api_inbound_request_duration:p99_sli_ratio_28d
+      expr: |
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[28d])))
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
+      labels:
+        service: "clusters-service-metrics"
+    # P90 Latency SLI (28-day)
+    - record: latency:api_inbound_request_duration:p90_sli_ratio_28d
+      expr: |
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[28d])))
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
+      labels:
+        service: "clusters-service-metrics"
+    # P99 Latency Burn Rate Recording Rules
+    - record: latency:api_inbound_request_duration:p99_burnrate5m
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[5m])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: latency:api_inbound_request_duration:p99_burnrate30m
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[30m])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: latency:api_inbound_request_duration:p99_burnrate1h
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[1h])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: latency:api_inbound_request_duration:p99_burnrate6h
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[6h])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: latency:api_inbound_request_duration:p99_burnrate3d
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[3d])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: latency:api_inbound_request_duration:p99_burnrate2h
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[2h])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: latency:api_inbound_request_duration:p99_burnrate1d
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[1d])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
+        ) / (1 - 0.99), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    # P90 Latency Burn Rate Recording Rules
+    - record: latency:api_inbound_request_duration:p90_burnrate5m
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[5m])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
+        ) / (1 - 0.90), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: latency:api_inbound_request_duration:p90_burnrate30m
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[30m])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
+        ) / (1 - 0.90), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: latency:api_inbound_request_duration:p90_burnrate1h
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[1h])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
+        ) / (1 - 0.90), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: latency:api_inbound_request_duration:p90_burnrate6h
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[6h])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
+        ) / (1 - 0.90), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: latency:api_inbound_request_duration:p90_burnrate3d
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[3d])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
+        ) / (1 - 0.90), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: latency:api_inbound_request_duration:p90_burnrate2h
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[2h])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
+        ) / (1 - 0.90), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+    - record: latency:api_inbound_request_duration:p90_burnrate1d
+      expr: |
+        round(
+        (
+        (
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
+        -
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[1d])))
+        )
+        /
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
+        ) / (1 - 0.90), 0.01
+        )
+      labels:
+        service: "clusters-service-metrics"
+  # Alerts for SLOs
+  - name: arohcp_cs_slo_availability_alerts
+    rules:
+    # API Availability Alerts
+    - alert: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
+      annotations:
+        description: 'API is rapidly burning its 28 day availability error budget (99% SLO)'
+        runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
+        summary: 'Cluster Service API availability error budget burn rate is too high'
+      expr: |
+        (
+        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"})) > 13.44
+        and
+        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{service="clusters-service-metrics"})) > 13.44
+        )
+        or
+        (
+        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{service="clusters-service-metrics"})) > 5.6
+        and
+        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"})) > 5.6
+        )
+      for: 5m
+      labels:
+        long: 6h
+        severity: warning
+        short: 30m
+    - alert: ClustersServiceAPIAvailability6hto3dErrorBudgetBurn
+      expr: |
+        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"})) > 0.934
+        and
+        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{service="clusters-service-metrics"})) > 0.934
+      for: 30m
+      labels:
+        severity: warning
+        slo: api-availability
+      annotations:
+        summary: "API is slowly but steadily burning its 28 day availability error budget (99% SLO)"
+        description: "This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days."
+        runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
+    # API Latency Alerts - P99 (1s threshold)
+    - alert: ClustersServiceAPILatency5mto1hor30mto6hP99ErrorBudgetBurn
+      annotations:
+        description: 'API is rapidly burning its 28 day 1s latency error budget (99% SLO)'
+        runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
+        summary: 'Cluster Service API P99 latency error budget burn rate is too high'
+      expr: |
+        (
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{service="clusters-service-metrics"})) > 13.44
+        and
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{service="clusters-service-metrics"})) > 13.44
+        )
+        or
+        (
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{service="clusters-service-metrics"})) > 5.6
+        and
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{service="clusters-service-metrics"})) > 5.6
+        )
+      for: 5m
+      labels:
+        long: 6h
+        severity: warning
+        short: 30m
+        slo: api-latency-p99
+    - alert: ClustersServiceAPILatency6hto3dP99ErrorBudgetBurn
+      expr: |
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{service="clusters-service-metrics"})) > 0.934
+        and
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{service="clusters-service-metrics"})) > 0.934
+      for: 30m
+      labels:
+        severity: warning
+        slo: api-latency-p99
+      annotations:
+        summary: "API is slowly but steadily burning its 28 day 1s latency error budget (99% SLO)"
+        description: "This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days."
+        runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
+    # API Latency Alerts - P90 (0.1s threshold)
+    - alert: ClustersServiceAPILatency5mto1hor30mto6hP90ErrorBudgetBurn
+      annotations:
+        description: 'API is rapidly burning its 28 day 0.1s latency error budget (90% SLO)'
+        runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
+        summary: 'Cluster Service API P90 latency error budget burn rate is too high'
+      expr: |
+        (
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{service="clusters-service-metrics"})) > 13.44
+        and
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{service="clusters-service-metrics"})) > 13.44
+        )
+        or
+        (
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{service="clusters-service-metrics"})) > 5.6
+        and
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{service="clusters-service-metrics"})) > 5.6
+        )
+      for: 5m
+      labels:
+        long: 6h
+        severity: warning
+        short: 30m
+        slo: api-latency-p90
+    - alert: ClustersServiceAPILatency6hto3dP90ErrorBudgetBurn
+      expr: |
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{service="clusters-service-metrics"})) > 0.934
+        and
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{service="clusters-service-metrics"})) > 0.934
+      for: 30m
+      labels:
+        severity: warning
+        slo: api-latency-p90
+      annotations:
+        summary: "API is slowly but steadily burning its 28 day 0.1s latency error budget (90% SLO)"
+        description: "This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days."
+        runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"

--- a/observability/alerts/tested-rules/cluster-service-slo-rules_test.yaml
+++ b/observability/alerts/tested-rules/cluster-service-slo-rules_test.yaml
@@ -1,0 +1,367 @@
+rule_files:
+- cluster-service-slo-rules.yaml
+evaluation_interval: 1m
+tests:
+# Test 1: Normal operation - no errors, no alert should fire
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+    # 100 requests per minute, all successful
+    values: "100+100x80"
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="201"}'
+    # Additional successful requests
+    values: "50+50x80"
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+    # No 5xx errors
+    values: "0+0x80"
+  promql_expr_test:
+  - expr: availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}
+    eval_time: 70m
+    exp_samples:
+    - labels: 'availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}'
+      value: 0 # No errors = 0 burn rate
+  alert_rule_test:
+  - eval_time: 70m
+    alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
+    # Should not fire - no errors
+  - eval_time: 70m
+    alertname: ClustersServiceAPIAvailability6hto3dErrorBudgetBurn
+    # Should not fire - no errors
+# Test 2: Fast burn rate - high error rate triggering critical alert (5m + 1h windows)
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+    # 20% success rate (80% errors) for full test duration
+    values: "20+20x80"
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+    # 80% error rate for full test duration
+    values: "80+80x80"
+  promql_expr_test:
+  - expr: availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}
+    eval_time: 70m
+    exp_samples:
+    - labels: 'availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}'
+      value: 80 # 80% error rate / 1% budget = 80x burn rate
+  alert_rule_test:
+  - eval_time: 70m
+    alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
+    exp_alerts:
+    - exp_labels:
+        long: "6h"
+        severity: "warning"
+        short: "30m"
+      exp_annotations:
+        description: "API is rapidly burning its 28 day availability error budget (99% SLO)"
+        runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
+        summary: "Cluster Service API availability error budget burn rate is too high"
+# Test 3: Medium burn rate - triggering critical alert (30m + 6h windows)
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+    # Consistent 90% success rate (10% error rate)
+    values: "90+90x400"
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+    # Consistent 10% error rate
+    values: "10+10x400"
+  promql_expr_test:
+  - expr: availability:api_inbound_request_count:burnrate30m{service="clusters-service-metrics"}
+    eval_time: 420m # 7 hours
+    exp_samples:
+    - labels: 'availability:api_inbound_request_count:burnrate30m{service="clusters-service-metrics"}'
+      value: 10 # 10% error rate / 1% budget = 10x burn rate
+  alert_rule_test:
+  - eval_time: 420m # 7 hours - after 6h window + buffer
+    alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
+    exp_alerts:
+    - exp_labels:
+        long: "6h"
+        severity: "warning"
+        short: "30m"
+      exp_annotations:
+        description: "API is rapidly burning its 28 day availability error budget (99% SLO)"
+        runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
+        summary: "Cluster Service API availability error budget burn rate is too high"
+# Test 4: Slow burn rate - triggering warning alert (6h + 3d windows)
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+    # 98.5% success rate (1.5% error rate) - slow burn
+    values: "985+985x4320" # 3 days worth of data
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+    # 1.5% error rate consistently
+    values: "15+15x4320"
+  promql_expr_test:
+  - expr: availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"}
+    eval_time: 4400m # After 3 days
+    exp_samples:
+    - labels: 'availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"}'
+      value: 1.5 # 1.5% error rate / 1% budget = 1.5x burn rate
+  alert_rule_test:
+  - eval_time: 4400m # After 3 days + buffer
+    alertname: ClustersServiceAPIAvailability6hto3dErrorBudgetBurn
+    exp_alerts:
+    - exp_labels:
+        severity: "warning"
+        slo: "api-availability"
+      exp_annotations:
+        summary: "API is slowly but steadily burning its 28 day availability error budget (99% SLO)"
+        description: "This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days."
+        runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
+# Test 5: Edge case - exactly at 99% threshold (should not fire critical alert)
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+    # 99.01% success rate (0.99% error rate) - just below 1% SLO breach
+    values: "9901+9901x80"
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+    # 0.99% error rate - just below threshold
+    values: "99+99x80"
+  promql_expr_test:
+  - expr: availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}
+    eval_time: 70m
+    exp_samples:
+    - labels: 'availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}'
+      value: 0.99 # 0.99% error rate / 1% budget = 0.99x burn rate
+  alert_rule_test:
+  - eval_time: 70m
+    alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
+    # Should not fire - below critical threshold (< 13.44)
+# Test 6: Prometheus replica handling (deduplication)
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200", prometheus_replica="prometheus-0"}'
+    # 70% success rate from replica 0
+    values: "70+70x80"
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200", prometheus_replica="prometheus-1"}'
+    # 70% success rate from replica 1 (should be deduplicated by max without)
+    values: "70+70x80"
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500", prometheus_replica="prometheus-0"}'
+    # 30% error rate from replica 0
+    values: "30+30x80"
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500", prometheus_replica="prometheus-1"}'
+    # 30% error rate from replica 1 (should be deduplicated by max without)
+    values: "30+30x80"
+  promql_expr_test:
+  - expr: availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}
+    eval_time: 70m
+    exp_samples:
+    - labels: 'availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}'
+      value: 30 # 30% error rate / 1% budget = 30x burn rate
+  alert_rule_test:
+  - eval_time: 70m
+    alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
+    exp_alerts:
+    - exp_labels:
+        long: "6h"
+        severity: "warning"
+        short: "30m"
+      exp_annotations:
+        description: "API is rapidly burning its 28 day availability error budget (99% SLO)"
+        runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
+        summary: "Cluster Service API availability error budget burn rate is too high"
+# Test 7: Recovery - alert should stop firing when error rate drops
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+    # High error rate for 65 minutes, then recovery for 20 minutes
+    values: "20+20x65 100+100x20"
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+    # High error rate for 65 minutes, then recovery
+    values: "80+80x65 0+0x20"
+  alert_rule_test:
+  - eval_time: 70m
+    alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
+    exp_alerts:
+    - exp_labels:
+        long: "6h"
+        severity: "warning"
+        short: "30m"
+      exp_annotations:
+        description: "API is rapidly burning its 28 day availability error budget (99% SLO)"
+        runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
+        summary: "Cluster Service API availability error budget burn rate is too high"
+  - eval_time: 135m
+    alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
+    # Should not fire - error rate has been recovered for 70 minutes (1h+ window clear)
+# Test 8: Mixed status codes (only 5xx should count as errors)
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+    # 2xx successful
+    values: "60+60x80"
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="400"}'
+    # 4xx client errors (should not count as SLO breach)
+    values: "20+20x80"
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+    # 5xx server errors (should count as SLO breach) - 20% error rate
+    values: "20+20x80"
+  promql_expr_test:
+  - expr: availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}
+    eval_time: 70m
+    exp_samples:
+    - labels: 'availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}'
+      value: 20 # 20% error rate / 1% budget = 20x burn rate
+  alert_rule_test:
+  - eval_time: 70m
+    alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
+    exp_alerts:
+    - exp_labels:
+        long: "6h"
+        severity: "warning"
+        short: "30m"
+      exp_annotations:
+        description: "API is rapidly burning its 28 day availability error budget (99% SLO)"
+        runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
+        summary: "Cluster Service API availability error budget burn rate is too high"
+# Test 9: P99 Latency - Normal operation (no latency issues, no alert should fire)
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+    # 1000 successful requests per minute - larger numbers for stability
+    values: "1000+1000x80"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
+    # 900 requests under 0.1s (90%)
+    values: "900+900x80"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
+    # 1000 requests under 1s (100% - perfect P99 performance)
+    values: "1000+1000x80"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
+    # All requests
+    values: "1000+1000x80"
+  alert_rule_test:
+  - eval_time: 70m
+    alertname: ClustersServiceAPILatency5mto1hor30mto6hP99ErrorBudgetBurn
+    # Should not fire - no requests are slow
+  - eval_time: 70m
+    alertname: ClustersServiceAPILatency6hto3dP99ErrorBudgetBurn
+    # Should not fire - no requests are slow
+# Test 10: P90 Latency - Normal operation (no latency issues, no alert should fire)
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+    # 1000 successful requests per minute
+    values: "1000+1000x80"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
+    # 1000 requests under 0.1s (100% - perfect P90 performance)
+    values: "1000+1000x80"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
+    # All requests under 1s
+    values: "1000+1000x80"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
+    # All requests
+    values: "1000+1000x80"
+  alert_rule_test:
+  - eval_time: 70m
+    alertname: ClustersServiceAPILatency5mto1hor30mto6hP90ErrorBudgetBurn
+    # Should not fire - no requests are slow
+  - eval_time: 70m
+    alertname: ClustersServiceAPILatency6hto3dP90ErrorBudgetBurn
+    # Should not fire - no requests are slow
+# Test 11: P99 Latency - Critical burn rate triggering alert
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+    # 1000 requests per minute
+    values: "1000+1000x80"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
+    # 500 under 0.1s (50%)
+    values: "500+500x80"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
+    # 800 under 1s (80% - violating P99 SLO significantly)
+    values: "800+800x80"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
+    # All requests
+    values: "1000+1000x80"
+  alert_rule_test:
+  - eval_time: 70m
+    alertname: ClustersServiceAPILatency5mto1hor30mto6hP99ErrorBudgetBurn
+    exp_alerts:
+    - exp_labels:
+        long: "6h"
+        severity: "warning"
+        short: "30m"
+        slo: "api-latency-p99"
+      exp_annotations:
+        description: "API is rapidly burning its 28 day 1s latency error budget (99% SLO)"
+        runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
+        summary: "Cluster Service API P99 latency error budget burn rate is too high"
+# Test 12: P90 Latency - Critical burn rate triggering alert
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+    # 1000 requests per minute
+    values: "1000+1000x80"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
+    # 200 under 0.1s (20% - severely violating P90 SLO)
+    values: "200+200x80"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
+    # 950 under 1s
+    values: "950+950x80"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
+    # All requests
+    values: "1000+1000x80"
+  alert_rule_test:
+  - eval_time: 70m
+    alertname: ClustersServiceAPILatency5mto1hor30mto6hP90ErrorBudgetBurn
+    exp_alerts:
+    - exp_labels:
+        long: "6h"
+        severity: "warning"
+        short: "30m"
+        slo: "api-latency-p90"
+      exp_annotations:
+        description: "API is rapidly burning its 28 day 0.1s latency error budget (90% SLO)"
+        runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
+        summary: "Cluster Service API P90 latency error budget burn rate is too high"
+# Test 13: P99 Latency - Slow burn rate triggering warning alert
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+    # 1000 requests per minute for consistent data over 3 days
+    values: "1000+1000x4320" # 3 days worth of data
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
+    # 850 under 0.1s (85%)
+    values: "850+850x4320"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
+    # 980 under 1s (98% - small but persistent P99 violation)
+    values: "980+980x4320"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
+    # All requests
+    values: "1000+1000x4320"
+  alert_rule_test:
+  - eval_time: 4400m # After 3 days + buffer
+    alertname: ClustersServiceAPILatency6hto3dP99ErrorBudgetBurn
+    exp_alerts:
+    - exp_labels:
+        severity: "warning"
+        slo: "api-latency-p99"
+      exp_annotations:
+        summary: "API is slowly but steadily burning its 28 day 1s latency error budget (99% SLO)"
+        description: "This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days."
+        runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
+# Test 14: P90 Latency - Slow burn rate triggering warning alert
+- interval: 1m
+  input_series:
+  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+    # 1000 requests per minute for consistent data over 3 days
+    values: "1000+1000x4320" # 3 days worth of data
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
+    # 800 under 0.1s (80% - persistent P90 violation)
+    values: "800+800x4320"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
+    # 990 under 1s
+    values: "990+990x4320"
+  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
+    # All requests
+    values: "1000+1000x4320"
+  alert_rule_test:
+  - eval_time: 4400m # After 3 days + buffer
+    alertname: ClustersServiceAPILatency6hto3dP90ErrorBudgetBurn
+    exp_alerts:
+    - exp_labels:
+        severity: "warning"
+        slo: "api-latency-p90"
+      exp_annotations:
+        summary: "API is slowly but steadily burning its 28 day 0.1s latency error budget (90% SLO)"
+        description: "This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days."
+        runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"

--- a/observability/observability-recording-rules.yaml
+++ b/observability/observability-recording-rules.yaml
@@ -1,0 +1,5 @@
+prometheusRules:
+  rulesFolders:
+  - ../observability/alerts/tested-rules
+  untestedRules: []
+  outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep

--- a/observability/observability.yaml
+++ b/observability/observability.yaml
@@ -3,6 +3,7 @@ prometheusRules:
   - ../observability/alerts/prometheus-prometheusRule.yaml
   - ../frontend/alerts/mise-prometheusRule.yaml
   - ../frontend/alerts/frontend-prometheusRule.yaml
+  - ../observability/alerts/tested-rules
   untestedRules:
   - ../observability/alerts/kubernetesControlPlane-prometheusRule.yaml
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -23,3 +24,5 @@ grafana-dashboards:
     path: ../frontend/grafana-dashboards
   - name: Backend
     path: ../backend/grafana-dashboards
+  - name: Clusters Service
+    path: ../cluster-service/grafana-dashboards

--- a/tooling/prometheus-rules/Makefile
+++ b/tooling/prometheus-rules/Makefile
@@ -23,3 +23,7 @@ run:
 run-hcp:
 	go run ./...  --config-file ../../observability/observability-hcp.yaml $(EXTRA_FLAGS)
 .PHONY: run-hcp
+
+run-recording-rules:
+	go run ./...  --config-file ../../observability/observability-recording-rules.yaml
+.PHONY: run-recording-rules

--- a/tooling/prometheus-rules/internal/generator_test.go
+++ b/tooling/prometheus-rules/internal/generator_test.go
@@ -288,7 +288,7 @@ func TestOptionsRunTests(t *testing.T) {
 
 func TestOptionsGenerate(t *testing.T) {
 	tmpDir := t.TempDir()
-	outputFile := filepath.Join(tmpDir, "output.bicep")
+	outputFile := filepath.Join(tmpDir, "AlertingRules_output.bicep")
 
 	opts := &Options{
 		outputBicep: outputFile,
@@ -362,7 +362,7 @@ func TestWriteGroups(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := writeGroups(group, &buf)
+	err := writeAlertGroups(group, &buf)
 	assert.NoError(t, err)
 
 	output := buf.String()


### PR DESCRIPTION
[ARO-6381](https://issues.redhat.com/browse/ARO-6381)

### What
 - Introduces a new Grafana dashboard for monitoring the ARO HCP Cluster Service SLOs, including availability metrics and error budget burn rates. Implements Prometheus alerting rules for detecting critical and warning states based on multi-window burn rate thresholds for API availability.
 - Enhanced the prometheus-rules generator to support both alerting and recording rules generation, allowing proper separation of recording rules from alerts in Bicep files. This enables efficient metric pre-calculation through recording rules for improved query performance.


### Rollout
Post-merge:
- Metrics populate gradually: 5m/30m (immediate), 1h/6h (hours), 3d (days), 28d SLI (weeks)
- Existing alerts continue to function, will automatically switche to optimized recording rules when available

### Special notes for your reviewer
The grafana Dashboard is available:
 - [Raw mterics ](https://arohcp-dev-c9g7a4fjanb0c4gc.wus3.grafana.azure.com/goto/rTsKS2wNR?orgId=1)
 - [Compound metrics](https://arohcp-dev-c9g7a4fjanb0c4gc.wus3.grafana.azure.com/goto/Kru5IhQHg?orgId=1) 

<!-- optional -->
