### PR TITLE
feat: only create the federated credentials if missing

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -29,7 +29,7 @@ INT_TESTING_SUBSCRIPTION_ID = 64f0619f-ebc2-4156-9d91-c4c781de7e54
 STAGE_TESTING_SUBSCRIPTION_ID = b23756f7-4594-40a3-980f-10bb6168fc20
 
 # Environments where automation accounts are deployed
-AUTOMATION_ACCOUNT_ENVS = dev stage #int pending some permission updates
+AUTOMATION_ACCOUNT_ENVS = dev stage int
 
 list:
 	@grep '^[^#[:space:]].*:' Makefile

--- a/dev-infrastructure/templates/automation-account.bicep
+++ b/dev-infrastructure/templates/automation-account.bicep
@@ -19,7 +19,7 @@ param scriptVersion string = '0de69144a537d9e5a032605a5fa82e863fc45a9e'
 module automationAccount '../modules/automation-account/account.bicep' = {
   name: 'hcp-${environment}-automation'
   params: {
-    dryRun: false
+    dryRun: true
     automationAccountName: automationAccountName
     automationAccountManagedIdentity: 'hcp-${environment}-automation'
     location: location

--- a/tooling/azure-automation/github-actions/hack/create-application.sh
+++ b/tooling/azure-automation/github-actions/hack/create-application.sh
@@ -84,27 +84,37 @@ for env in "${AUTOMATION_ACCOUNT_ENVS[@]}"; do
     done
 done
 
-az ad app federated-credential create --id "${APP_ID}" --parameters \
-'{
-    "audiences": [
-        "api://AzureADTokenExchange"
-    ],
-    "description": "https://github.com/Azure/ARO-HCP runner",
-    "issuer": "https://token.actions.githubusercontent.com",
-    "name": "aro-hcp-pr-runner",
-    "subject": "repo:Azure/ARO-HCP:pull_request"
-}'
+# Create federated credential for PRs only if it doesn't already exist
+if ! az ad app federated-credential list --id "${APP_ID}" --query "[?name=='aro-hcp-pr-runner']" | grep -q 'aro-hcp-pr-runner'; then
+    az ad app federated-credential create --id "${APP_ID}" --parameters \
+    '{
+      "audiences": [
+          "api://AzureADTokenExchange"
+      ],
+      "description": "https://github.com/Azure/ARO-HCP runner",
+      "issuer": "https://token.actions.githubusercontent.com",
+      "name": "aro-hcp-pr-runner",
+      "subject": "repo:Azure/ARO-HCP:pull_request"
+    }'
+else
+    echo "Federated credential 'aro-hcp-pr-runner' already exists for app ${APP_ID}"
+fi
 
-az ad app federated-credential create --id "${APP_ID}" --parameters \
-'{
-    "audiences": [
-        "api://AzureADTokenExchange"
-    ],
-    "description": "https://github.com/Azure/ARO-HCP runner",
-    "issuer": "https://token.actions.githubusercontent.com",
-    "name": "aro-hcp-main",
-    "subject": "repo:Azure/ARO-HCP:ref:refs/heads/main"
-}'
+# Create federated credential for main branch only if it doesn't already exist
+if ! az ad app federated-credential list --id "${APP_ID}" --query "[?name=='aro-hcp-main']" | grep -q 'aro-hcp-main'; then
+    az ad app federated-credential create --id "${APP_ID}" --parameters \
+    '{
+        "audiences": [
+            "api://AzureADTokenExchange"
+        ],
+        "description": "https://github.com/Azure/ARO-HCP runner",
+        "issuer": "https://token.actions.githubusercontent.com",
+        "name": "aro-hcp-main",
+        "subject": "repo:Azure/ARO-HCP:ref:refs/heads/main"
+    }'
+else
+    echo "Federated credential 'aro-hcp-main' already exists for app ${APP_ID}"
+fi
 
 echo "----------- Configure GitHub with the below secrets -----------"
 echo "AZURE_CLIENT_ID: ${APP_ID}"


### PR DESCRIPTION
Related to https://github.com/Azure/ARO-HCP/pull/2190

https://issues.redhat.com/browse/ARO-20032

### What

Skips federation credentials when are present, so the script is idempotent. Also enables `INT` automation account targets after adding the required permissions (thanks to @tony-schndr ).

### Why

It will raise an error if the credentials already exists.

### Special notes for your reviewer

