### PR TITLE
fix global-pipeline dependencies

### DIFF
--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -35,6 +35,8 @@ resourceGroups:
     parameters: configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
+    dependsOn:
+    - global-infra
   - name: grafana-dashboards
     action: Shell
     command: cd ../observability/grafana && ./deploy.sh


### PR DESCRIPTION
### What

add a dependency to the `global-output` step of the `global-pipeline` to wait for base infastructure creation.
otherwise it will fail on missing infra references

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
