### PR TITLE
symlink bingo binary basenames

### DIFF
--- a/.bingo/Symlinks.mk
+++ b/.bingo/Symlinks.mk
@@ -1,0 +1,11 @@
+YAMLFMT_LINK := $(GOBIN)/yamlfmt
+$(YAMLFMT_LINK): $(YAMLFMT)
+	@echo "creating symlink for $(YAMLFMT) at $(YAMLFMT_LINK)"
+	@rm -f $(YAMLFMT_LINK)
+	@ln -s $(YAMLFMT) $(YAMLFMT_LINK)
+
+ORAS_LINK := $(GOBIN)/oras
+$(ORAS_LINK): $(ORAS)
+	@echo "creating symlink for $(ORAS) at $(ORAS_LINK)"
+	@rm -f $(ORAS_LINK)
+	@ln -s $(ORAS) $(ORAS_LINK)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 include ./.bingo/Variables.mk
+include ./.bingo/Symlinks.mk
 SHELL = /bin/bash
 PATH := $(GOBIN):$(PATH)
 
@@ -185,17 +186,17 @@ services_all = $(join services_svc,services_mgmt)
 # the usage of `svc-deploy.sh` script in the future.
 services_svc_pipelines = backend frontend cluster-service maestro.server observability.tracing
 services_mgmt_pipelines = secret-sync-controller acm hypershiftoperator maestro.agent observability.tracing
-%.deploy_pipeline: $(ORAS)
+%.deploy_pipeline: $(ORAS_LINK)
 	$(eval export dirname=$(subst .,/,$(basename $@)))
 	./templatize.sh $(DEPLOY_ENV) -p ./$(dirname)/pipeline.yaml -P run
 
-%.dry_run: $(ORAS)
+%.dry_run: $(ORAS_LINK)
 	$(eval export dirname=$(subst .,/,$(basename $@)))
 	./templatize.sh $(DEPLOY_ENV) -p ./$(dirname)/pipeline.yaml -P run -d
 
-svc.deployall: $(ORAS) $(addsuffix .deploy_pipeline, $(services_svc_pipelines)) $(addsuffix .deploy, $(services_svc))
-mgmt.deployall: $(ORAS) $(addsuffix .deploy, $(services_mgmt)) $(addsuffix .deploy_pipeline, $(services_mgmt_pipelines))
-deployall: $(ORAS) svc.deployall mgmt.deployall
+svc.deployall: $(ORAS_LINK) $(addsuffix .deploy_pipeline, $(services_svc_pipelines)) $(addsuffix .deploy, $(services_svc))
+mgmt.deployall: $(ORAS_LINK) $(addsuffix .deploy, $(services_mgmt)) $(addsuffix .deploy_pipeline, $(services_mgmt_pipelines))
+deployall: $(ORAS_LINK) svc.deployall mgmt.deployall
 
 listall:
 	@echo svc: ${services_svc}

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -48,10 +48,10 @@ resourceGroups:
       - name: DRY_RUN
         value: "true"
     variables:
-      - name: GRAFANA_NAME
-        configRef: monitoring.grafanaName
-      - name: GLOBAL_RESOURCEGROUP
-        configRef: global.rg
+    - name: GRAFANA_NAME
+      configRef: monitoring.grafanaName
+    - name: GLOBAL_RESOURCEGROUP
+      configRef: global.rg
     shellIdentity:
       input:
         step: global-output


### PR DESCRIPTION
### What

bingo provides tools like oras and yamlfmt as versioned binary names in the gobin directory. but certain pipelines of ours expect them with their basename, e.g. `oras` instead of `oras-$version`

this PR makes sure we have up to date shortname symlinks for oras and yamlfmt

this PR also contains an unrelated yaml format lint fix

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
