### PR TITLE
add automatic collection of all deployment operations in resource groups

### DIFF
--- a/test/e2e/cluster_create_missing_info.go
+++ b/test/e2e/cluster_create_missing_info.go
@@ -80,7 +80,7 @@ var _ = Describe("Customer", func() {
 				_, err = framework.CreateBicepTemplateAndWait(ctx,
 					ic.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
 					*resourceGroup.Name,
-					"infra",
+					"illegal-cluster",
 					clusterTemplate,
 					map[string]string{
 						"networkSecurityGroupId":   networkSecurityGroupID,


### PR DESCRIPTION
This makes it easier to debug test failures.