### PR TITLE
MSI Refresher - add msiKeyvaultUri to config schema

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1039,6 +1039,10 @@
           "type": "string",
           "description": "The client ID of the first party application that will be used by the refresher"
         },
+        "msiKeyvaultUri": {
+          "type": "string",
+          "description": "The full URI of the MSI keyvault that the refresher will watch"
+        },
         "k8s": {
           "$ref": "#/definitions/k8sServiceAccount"
         },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -388,6 +388,7 @@ defaults:
   msiCredentialsRefresher:
     managedIdentityName: msi-credential-refresher
     firstPartyAppClientId: ""
+    msiKeyvaultUri: ""
     k8s:
       namespace: msi-credential-refresher
       serviceAccountName: msi-credential-refresher

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 9a68cf0bae6779060e5f8a01d9a0c91756661b2b4c2df9c281e4c7a6ea4c8643
+          westus3: 099efa154c6e6f2bfa8b06d3a309f7694bc1ede30761d1162d8b8cfee2c61e06
       dev:
         regions:
-          westus3: 5274c804f944308233be8cd8d2c1065090295e0f09c42cba67f66f6ef3fe2609
+          westus3: 98fb857b22d5574d885408e5653744f22445571cde9af83686883821230cac61
       ntly:
         regions:
-          uksouth: 53411b1037acd7d15466cd1c0a24811ae442366050f8c901da589abf572dce19
+          uksouth: bbfbd72a7775116bc544418ea0cbdc145a6cae069f5677829cef8d445672da76
       perf:
         regions:
-          westus3: bab53df63aed835acb04b52333b80730a39709fe999891ea98f5144075f5c240
+          westus3: 1b017444001ce487c21936ecc6b65bac5f511c86a0c28fc1fb743f4e4b42a8d4
       pers:
         regions:
-          westus3: 92b03ac326a1779634dd79b34eedd67515c28e27151483d8a5d50e548080ac1e
+          westus3: df57124c621924d4c82fbcdb0ae0ab929e1fe177add7d15328cf03c7a19079b4
       swft:
         regions:
-          uksouth: 0518f04ae91ab1511e446d7ff5fff5d7742b35434c6a8d971c2dba10cb16dc3b
+          uksouth: 2f2fef0df95ebfe8cea6b5b511fb16baa0e163c08a3831e1c4235633ffeeffc4

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -399,6 +399,7 @@ msiCredentialsRefresher:
     namespace: msi-credential-refresher
     serviceAccountName: msi-credential-refresher
   managedIdentityName: msi-credential-refresher
+  msiKeyvaultUri: ""
 msiKeyVault:
   name: ah-cspr-mi-usw3-1
   private: false

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -399,6 +399,7 @@ msiCredentialsRefresher:
     namespace: msi-credential-refresher
     serviceAccountName: msi-credential-refresher
   managedIdentityName: msi-credential-refresher
+  msiKeyvaultUri: ""
 msiKeyVault:
   name: ah-dev-mi-usw3-1
   private: false

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -399,6 +399,7 @@ msiCredentialsRefresher:
     namespace: msi-credential-refresher
     serviceAccountName: msi-credential-refresher
   managedIdentityName: msi-credential-refresher
+  msiKeyvaultUri: ""
 msiKeyVault:
   name: ah-ntly-mi-ln-1
   private: false

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -399,6 +399,7 @@ msiCredentialsRefresher:
     namespace: msi-credential-refresher
     serviceAccountName: msi-credential-refresher
   managedIdentityName: msi-credential-refresher
+  msiKeyvaultUri: ""
 msiKeyVault:
   name: ah-perf-mi-usw3ptest-1
   private: false

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -401,6 +401,7 @@ msiCredentialsRefresher:
     namespace: msi-credential-refresher
     serviceAccountName: msi-credential-refresher
   managedIdentityName: msi-credential-refresher
+  msiKeyvaultUri: ""
 msiKeyVault:
   name: ah-pers-mi-usw3test-1
   private: false

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -401,6 +401,7 @@ msiCredentialsRefresher:
     namespace: msi-credential-refresher
     serviceAccountName: msi-credential-refresher
   managedIdentityName: msi-credential-refresher
+  msiKeyvaultUri: ""
 msiKeyVault:
   name: ah-swft-mi-lnstest-1
   private: false


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Adds a new parameter (msiKeyvaultUri) to config schema, and then run make materialize

### Why

The msi credential refresher needs to know what MSI keyvault to watch and subsequently refresh certs from. Long term, there will be an inventory service that it will read, which knows where each MSI keyvault lives. For now, the refresher just takes a --keyvault-uri flag on startup that contains the URI to the keyvault, so we need to pass that to helm via a config.

### Special notes for your reviewer

<!-- optional -->
