### PR TITLE
add policy deployment as dedicated step to the ACM pipeline

### DIFF
--- a/acm/deploy.sh
+++ b/acm/deploy.sh
@@ -56,5 +56,3 @@ ${HELM_CMD} \
 if [ "${DRY_RUN}" != "true" ]; then
     kubectl annotate mce multiclusterengine installer.multicluster.openshift.io/pause=${MCE_PAUSE_RECONCILIATION} --overwrite
 fi
-
-make deploy-policies

--- a/acm/pipeline.yaml
+++ b/acm/pipeline.yaml
@@ -33,6 +33,24 @@ resourceGroups:
         name: globalMSIId
     dependsOn:
     - global-output
+  - name: deploy-policies
+    aksCluster: '{{ .mgmt.aks.name }}'
+    action: Shell
+    command: make deploy-policies
+    dryRun:
+      variables:
+      - name: DRY_RUN
+        value: "true"
+    variables:
+    - name: ARO_HCP_IMAGE_ACR
+      configRef: acr.svc.name
+    shellIdentity:
+      input:
+        step: global-output
+        name: globalMSIId
+    dependsOn:
+    - deploy
+    - global-output
   - name: scale-down
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell
@@ -49,4 +67,5 @@ resourceGroups:
         step: global-output
         name: globalMSIId
     dependsOn:
+    - deploy
     - global-output


### PR DESCRIPTION
### What

the policy deployment step was skipped when MCE is paused.
added the policy as dedicated step so that it is not affected by a paused MCE

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
