### PR TITLE
Add "vcs-ref" label during image builds

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,4 +18,6 @@ RUN make --directory backend ARO_HCP_IMAGE_TAG=${TAG} ENV_VARS_FILE=/app/image-e
 FROM --platform=${PLATFORM} mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot
 WORKDIR /
 COPY --from=builder /app/backend/aro-hcp-backend .
+ARG REVISION
+LABEL vcs-ref="${REVISION}"
 ENTRYPOINT ["/aro-hcp-backend"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,15 +3,15 @@ ARG PLATFORM
 # Builder image installs tools needed to build aro-hcp-backend
 FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0 AS builder
 RUN yum install --assumeyes jq
-ARG CURRENT_COMMIT
 COPY internal/go.mod internal/go.sum internal/
 COPY backend/go.mod backend/go.sum backend/
 RUN cd backend && go mod download
 WORKDIR /app
 COPY . .
+ARG TAG
 # https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips#build-option-to-require-fips-mode
-ENV CGO_ENABLED=1 GOFLAGS='-tags=requirefips' CURRENT_COMMIT=${CURRENT_COMMIT}
-RUN make --directory backend CURRENT_COMMIT=${CURRENT_COMMIT} ENV_VARS_FILE=/app/image-environment
+ENV CGO_ENABLED=1 GOFLAGS='-tags=requirefips'
+RUN make --directory backend ARO_HCP_IMAGE_TAG=${TAG} ENV_VARS_FILE=/app/image-environment
 
 
 # Deployment image copies aro-hcp-backend from builder image

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,6 +1,7 @@
 -include ../setup-env.mk
 -include ../helm-cmd.mk
 
+ARO_HCP_REVISION = $(shell git rev-parse HEAD)
 ARO_HCP_IMAGE_TAG ?= $(shell git rev-parse --short=7 HEAD)$(shell git status --porcelain --untracked-files=no | grep --quiet . && echo -dirty)
 ARO_HCP_IMAGE_REGISTRY ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
 ARO_HCP_BACKEND_IMAGE ?= ${ARO_HCP_IMAGE_REGISTRY}/${ARO_HCP_IMAGE_REPOSITORY}:${ARO_HCP_IMAGE_TAG}
@@ -29,6 +30,7 @@ image:
 	          cp ${ENV_VARS_FILE} image-environment; \
 	          docker build . --file backend/Dockerfile \
 	                         --build-arg PLATFORM=linux/amd64 \
+	                         --build-arg REVISION=${ARO_HCP_REVISION} \
 	                         --build-arg TAG=${ARO_HCP_IMAGE_TAG} \
 	                         --tag ${ARO_HCP_BACKEND_IMAGE}"
 .PHONY: image

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,14 +1,14 @@
 -include ../setup-env.mk
 -include ../helm-cmd.mk
 
-CURRENT_COMMIT ?= $(shell COMMIT_SHA=$$(git rev-parse --short=7 HEAD); if [ -z "$$(git status --porcelain 2>/dev/null)" ]; then echo "$$COMMIT_SHA"; else echo "$$COMMIT_SHA"-dirty; fi )
+ARO_HCP_IMAGE_TAG ?= $(shell git rev-parse --short=7 HEAD)$(shell git status --porcelain --untracked-files=no | grep --quiet . && echo -dirty)
 ARO_HCP_IMAGE_REGISTRY ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
-ARO_HCP_BACKEND_IMAGE ?= $(ARO_HCP_IMAGE_REGISTRY)/$(ARO_HCP_IMAGE_REPOSITORY)
+ARO_HCP_BACKEND_IMAGE ?= ${ARO_HCP_IMAGE_REGISTRY}/${ARO_HCP_IMAGE_REPOSITORY}:${ARO_HCP_IMAGE_TAG}
 
 .DEFAULT_GOAL := backend
 
 backend:
-	go build -ldflags="-X github.com/Azure/ARO-HCP/internal/version.CommitSHA=${CURRENT_COMMIT}" -o aro-hcp-backend .
+	go build -ldflags="-X github.com/Azure/ARO-HCP/internal/version.CommitSHA=${ARO_HCP_IMAGE_TAG}" -o aro-hcp-backend .
 .PHONY: backend
 
 run:
@@ -28,14 +28,14 @@ image:
 	          trap 'rm --force image-environment && popd > /dev/null' EXIT; \
 	          cp ${ENV_VARS_FILE} image-environment; \
 	          docker build . --file backend/Dockerfile \
-	                         --build-arg CURRENT_COMMIT=${CURRENT_COMMIT} \
 	                         --build-arg PLATFORM=linux/amd64 \
-	                         --tag ${ARO_HCP_BACKEND_IMAGE}:${CURRENT_COMMIT}"
+	                         --build-arg TAG=${ARO_HCP_IMAGE_TAG} \
+	                         --tag ${ARO_HCP_BACKEND_IMAGE}"
 .PHONY: image
 
 push: image
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
-	docker push ${ARO_HCP_BACKEND_IMAGE}:${CURRENT_COMMIT}
+	docker push ${ARO_HCP_BACKEND_IMAGE}
 .PHONY: push
 
 deploy:
@@ -53,11 +53,11 @@ deploy:
 		--set configMap.databaseUrl="$${DB_URL}" \
 		--set configMap.backendMiClientId="$${BACKEND_MI_CLIENT_ID}" \
 		--set serviceAccount.workloadIdentityClientId="$${BACKEND_MI_CLIENT_ID}" \
-		--set configMap.currentVersion=${ARO_HCP_BACKEND_IMAGE}@$${DIGEST} \
+		--set configMap.currentVersion=${ARO_HCP_IMAGE_REGISTRY}/${ARO_HCP_IMAGE_REPOSITORY}@$${DIGEST} \
 		--set configMap.location=${LOCATION} \
 		--set clustersService.namespace=${CS_NAMESPACE} \
 		--set clustersService.serviceAccount=${CS_SERVICE_ACCOUNT_NAME} \
-		--set deployment.imageName=${ARO_HCP_BACKEND_IMAGE}@$${DIGEST} \
+		--set deployment.imageName=${ARO_HCP_IMAGE_REGISTRY}/${ARO_HCP_IMAGE_REPOSITORY}@$${DIGEST} \
 		--set tracing.address=${TRACING_ADDRESS} \
 		--set tracing.exporter=${TRACING_EXPORTER} \
 		--namespace aro-hcp

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,15 +3,15 @@ ARG PLATFORM
 # Base and builder image will need to be replaced by Fips compliant one
 FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0 AS builder
 RUN yum install --assumeyes jq
-ARG CURRENT_COMMIT
 COPY internal/go.mod internal/go.sum internal/
 COPY frontend/go.mod frontend/go.sum frontend/
 RUN cd frontend && go mod download
 WORKDIR /app
 COPY . .
+ARG TAG
 # https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips#build-option-to-require-fips-mode
-ENV CGO_ENABLED=1 GOFLAGS='-tags=requirefips' CURRENT_COMMIT=${CURRENT_COMMIT}
-RUN make --directory frontend CURRENT_COMMIT=${CURRENT_COMMIT} ENV_VARS_FILE=/app/image-environment
+ENV CGO_ENABLED=1 GOFLAGS='-tags=requirefips'
+RUN make --directory frontend ARO_HCP_IMAGE_TAG=${TAG} ENV_VARS_FILE=/app/image-environment
 
 FROM --platform=${PLATFORM} mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot
 WORKDIR /

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,4 +16,6 @@ RUN make --directory frontend ARO_HCP_IMAGE_TAG=${TAG} ENV_VARS_FILE=/app/image-
 FROM --platform=${PLATFORM} mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot
 WORKDIR /
 COPY --from=builder /app/frontend/aro-hcp-frontend .
+ARG REVISION
+LABEL vcs-ref="${REVISION}"
 ENTRYPOINT ["/aro-hcp-frontend"]

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,5 +1,6 @@
 -include ../setup-env.mk
 
+ARO_HCP_REVISION = $(shell git rev-parse HEAD)
 ARO_HCP_IMAGE_TAG ?= $(shell git rev-parse --short=7 HEAD)$(shell git status --porcelain --untracked-files=no | grep --quiet . && echo -dirty)
 ARO_HCP_IMAGE_REGISTRY ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
 ARO_HCP_FRONTEND_IMAGE ?= ${ARO_HCP_IMAGE_REGISTRY}/${ARO_HCP_IMAGE_REPOSITORY}:${ARO_HCP_IMAGE_TAG}
@@ -29,6 +30,7 @@ image:
 	          cp ${ENV_VARS_FILE} image-environment; \
 	          docker build . --file frontend/Dockerfile \
 	                         --build-arg PLATFORM=linux/amd64 \
+	                         --build-arg REVISION=${ARO_HCP_REVISION} \
 	                         --build-arg TAG=${ARO_HCP_IMAGE_TAG} \
 	                         --tag ${ARO_HCP_FRONTEND_IMAGE}"
 .PHONY: image

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -9,10 +9,6 @@ ARO_HCP_FRONTEND_IMAGE ?= $(ARO_HCP_IMAGE_REGISTRY)/$(ARO_HCP_IMAGE_REPOSITORY)
 frontend:
 	go build -ldflags="-X github.com/Azure/ARO-HCP/internal/version.CommitSHA=${CURRENT_COMMIT}" -o aro-hcp-frontend .
 
-info:
-	@echo "ARO_HCP_FRONTEND_IMAGE: ${ARO_HCP_FRONTEND_IMAGE}"
-	@echo "COMMIT: ${CURRENT_COMMIT}"
-
 run:
 	DB_URL=$$(az cosmosdb show -n ${DB_NAME} -g ${REGION_RG} --query documentEndpoint -o tsv) && \
 	./aro-hcp-frontend --location ${LOCATION} \

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,13 +1,13 @@
 -include ../setup-env.mk
 
-CURRENT_COMMIT ?= $(shell COMMIT_SHA=$$(git rev-parse --short=7 HEAD); if [ -z "$$(git status --porcelain 2>/dev/null)" ]; then echo "$$COMMIT_SHA"; else echo "$$COMMIT_SHA"-dirty; fi )
+ARO_HCP_IMAGE_TAG ?= $(shell git rev-parse --short=7 HEAD)$(shell git status --porcelain --untracked-files=no | grep --quiet . && echo -dirty)
 ARO_HCP_IMAGE_REGISTRY ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
-ARO_HCP_FRONTEND_IMAGE ?= $(ARO_HCP_IMAGE_REGISTRY)/$(ARO_HCP_IMAGE_REPOSITORY)
+ARO_HCP_FRONTEND_IMAGE ?= ${ARO_HCP_IMAGE_REGISTRY}/${ARO_HCP_IMAGE_REPOSITORY}:${ARO_HCP_IMAGE_TAG}
 
 .DEFAULT_GOAL := frontend
 
 frontend:
-	go build -ldflags="-X github.com/Azure/ARO-HCP/internal/version.CommitSHA=${CURRENT_COMMIT}" -o aro-hcp-frontend .
+	go build -ldflags="-X github.com/Azure/ARO-HCP/internal/version.CommitSHA=${ARO_HCP_IMAGE_TAG}" -o aro-hcp-frontend .
 
 run:
 	DB_URL=$$(az cosmosdb show -n ${DB_NAME} -g ${REGION_RG} --query documentEndpoint -o tsv) && \
@@ -28,14 +28,14 @@ image:
 	          trap 'rm --force image-environment && popd > /dev/null' EXIT; \
 	          cp ${ENV_VARS_FILE} image-environment; \
 	          docker build . --file frontend/Dockerfile \
-	                         --build-arg CURRENT_COMMIT=${CURRENT_COMMIT} \
 	                         --build-arg PLATFORM=linux/amd64 \
-	                         --tag ${ARO_HCP_FRONTEND_IMAGE}:${CURRENT_COMMIT}"
+	                         --build-arg TAG=${ARO_HCP_IMAGE_TAG} \
+	                         --tag ${ARO_HCP_FRONTEND_IMAGE}"
 .PHONY: image
 
 push: image
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
-	docker push ${ARO_HCP_FRONTEND_IMAGE}:${CURRENT_COMMIT}
+	docker push ${ARO_HCP_FRONTEND_IMAGE}
 
 deploy:
 	DIGEST=$$(../get-digest.sh ${ARO_HCP_IMAGE_ACR} arohcpfrontend) \
@@ -77,9 +77,9 @@ deploy:
 		--set serviceAccount.workloadIdentityTenantId="$${FRONTEND_MI_TENANT_ID}" \
 		--set pullBinding.workloadIdentityClientId="$${IMAGE_PULLER_MI_CLIENT_ID}" \
 		--set pullBinding.workloadIdentityTenantId="$${IMAGE_PULLER_MI_TENANT_ID}" \
-		--set configMap.currentVersion=${ARO_HCP_FRONTEND_IMAGE}@$${DIGEST} \
+		--set configMap.currentVersion=${ARO_HCP_IMAGE_REGISTRY}/${ARO_HCP_IMAGE_REPOSITORY}@$${DIGEST} \
 		--set configMap.location=${LOCATION}  \
-		--set deployment.imageName=${ARO_HCP_FRONTEND_IMAGE}@$${DIGEST} \
+		--set deployment.imageName=${ARO_HCP_IMAGE_REGISTRY}/${ARO_HCP_IMAGE_REPOSITORY}@$${DIGEST} \
 		--set pullBinding.registry=${ARO_HCP_IMAGE_REGISTRY} \
 		--set pullBinding.scope=repository:${ARO_HCP_IMAGE_REPOSITORY}:pull \
 		--set clustersService.namespace=${CS_NAMESPACE} \


### PR DESCRIPTION
### What

By request from @geoberle, this adds a `vcs-ref` label to the frontend and backend images with the value of the git revision the image was built from.

There's also some Makefile refactoring here to try to clarify some of the variable names.  This is split into separate commits for easier review.

### Why

I'm told this is for a tool that reports the current state of our various environments by inspecting images and extracting this label.