### PR TITLE
patch for region count in westus3

### DIFF
--- a/dev-infrastructure/modules/common.bicep
+++ b/dev-infrastructure/modules/common.bicep
@@ -403,6 +403,7 @@ var _locationAvailabilityZones = {
       '1'
       '2'
       '3'
+      '4'
     ]
   }
   westusstage: {


### PR DESCRIPTION
### What

we have two sources for region count
* common.bicep
* ARO-tools (which is supposed to replace common.bicep in that regard)

this PR just makes sure that common.bicep lists the same amount of regions as ARO-tools does, but we need to fix this

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
