### PR TITLE
Revert "patch for region count in westus3"

### DIFF
--- a/dev-infrastructure/modules/common.bicep
+++ b/dev-infrastructure/modules/common.bicep
@@ -403,7 +403,6 @@ var _locationAvailabilityZones = {
       '1'
       '2'
       '3'
-      '4'
     ]
   }
   westusstage: {


### PR DESCRIPTION
Reverts Azure/ARO-HCP#2291

fixing this properly is not going to be easy

[23:40:07.672] ERROR: command failed {
  "err": "failed to run ARM step: failed to wait for deployment completion: GET [https://management.azure.com/subscriptions/***/resourcegroups/global/providers/Microsoft.Resources/deployments/imagemirror/operationStatuses/08584477745099789333\n--------------------------------------------------------------------------------\nRESPONSE](https://management.azure.com/subscriptions/***/resourcegroups/global/providers/Microsoft.Resources/deployments/imagemirror/operationStatuses/08584477745099789333/n--------------------------------------------------------------------------------/nRESPONSE) 200: 200 OK\nERROR CODE: DeploymentFailed\n--------------------------------------------------------------------------------\n{\n  \"status\": \"Failed\",\n  \"error\": {\n    \"code\": \"DeploymentFailed\",\n    \"message\": \"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.\",\n    \"details\": [\n      {\n        \"code\": \"Conflict\",\n        \"message\": \"{\\r\\n  \\\"status\\\": \\\"Failed\\\",\\r\\n  \\\"error\\\": {\\r\\n    \\\"code\\\": \\\"ResourceDeploymentFailure\\\",\\r\\n    \\\"message\\\": \\\"The resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'.\\\",\\r\\n    \\\"details\\\": [\\r\\n      {\\r\\n        \\\"code\\\": \\\"DeploymentFailed\\\",\\r\\n        \\\"target\\\": \\\"/subscriptions/***/resourceGroups/global/providers/Microsoft.Resources/deployments/containerapp-nat-gateway-ip\\\",\\r\\n        \\\"message\\\": \\\"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.\\\",\\r\\n        \\\"details\\\": [\\r\\n          {\\r\\n            \\\"code\\\": \\\"InvalidAvailabilityZone\\\",\\r\\n            \\\"message\\\": \\\"The zone(s) '4' for resource 'Microsoft.Network/publicIPAddresses/containerapp-nat-gateway-ip' is not supported. The supported zones for location 'westus3' are '1,2,3'\\\"\\r\\n          }\\r\\n        ]\\r\\n      }\\r\\n    ]\\r\\n  }\\r\\n}\"\n      }\n    ]\n  }\n}\n--------------------------------------------------------------------------------\n"