### PR TITLE
RP Frontend - Support HCP Disabled In-Cluster Image Registry

### DIFF
--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -43,6 +43,8 @@ const (
 	azureNodePoolEncryptionAtHostDisabled string = "disabled"
 	azureNodePoolEncryptionAtHostEnabled  string = "enabled"
 	azureNodePoolNodeDrainGracePeriodUnit string = "minutes"
+	csImageRegistryStateDisabled          string = "disabled"
+	csImageRegistryStateEnabled           string = "enabled"
 )
 
 func convertListeningToVisibility(listening arohcpv1alpha1.ListeningMethod) (visibility api.Visibility) {
@@ -91,6 +93,19 @@ func convertEnableEncryptionAtHostToCSBuilder(in api.NodePoolPlatformProfile) *a
 	}
 
 	return arohcpv1alpha1.NewAzureNodePoolEncryptionAtHost().State(state)
+}
+
+func convertClusterImageRegistryToCSBuilder(in api.ClusterImageRegistryProfile) *arohcpv1alpha1.ClusterImageRegistryBuilder {
+	var state string
+	if in.State != nil {
+		switch *in.State {
+		case api.ClusterImageRegistryProfileStateDisabled:
+			state = csImageRegistryStateDisabled
+		case api.ClusterImageRegistryProfileStateEnabled:
+			state = csImageRegistryStateEnabled
+		}
+	}
+	return arohcpv1alpha1.NewClusterImageRegistry().State(state)
 }
 
 func convertNodeDrainTimeoutCSToRP(in *arohcpv1alpha1.Cluster) int32 {
@@ -150,7 +165,6 @@ func convertNodeDrainTimeoutCSToRP(in *arohcpv1alpha1.Cluster) int32 {
 
 // func convertEtcdRPToCS(in api.EtcdProfile) *arohcpv1alpha1.AzureEtcdEncryptionBuilder {
 // 	azureEtcdDataEncryptionBuilder := arohcpv1alpha1.NewAzureEtcdDataEncryption().KeyManagementMode(convertKeyManagementModeTypeRPToCS(in.DataEncryption.KeyManagementMode))
-// ConvertCStoHCPOpenShiftCluster converts a CS Cluster object into HCPOpenShiftCluster object
 // 	if in.DataEncryption.CustomerManaged.Kms != nil || in.DataEncryption.CustomerManaged.EncryptionType != "" {
 // 		azureEtcdDataEncryptionCustomerManagedBuilder := arohcpv1alpha1.NewAzureEtcdDataEncryptionCustomerManaged().EncryptionType(string(in.DataEncryption.CustomerManaged.EncryptionType))
 // 		azureKmsKeyBuilder := arohcpv1alpha1.NewAzureKmsKey().KeyName(in.DataEncryption.CustomerManaged.Kms.ActiveKey.Name).KeyVaultName(in.DataEncryption.CustomerManaged.Kms.ActiveKey.VaultName).KeyVersion(in.DataEncryption.CustomerManaged.Kms.ActiveKey.Version)
@@ -162,6 +176,22 @@ func convertNodeDrainTimeoutCSToRP(in *arohcpv1alpha1.Cluster) int32 {
 
 // }
 
+func convertClusterImageRegistryStateCSToRP(in *arohcpv1alpha1.Cluster) *api.ClusterImageRegistryProfileState {
+	var registryState *api.ClusterImageRegistryProfileState
+	if clusterImageRegistry, ok := in.GetImageRegistry(); ok {
+		if state, ok := clusterImageRegistry.GetState(); ok {
+			switch state {
+			case csImageRegistryStateDisabled:
+				registryState = api.Ptr(api.ClusterImageRegistryProfileStateDisabled)
+			case csImageRegistryStateEnabled:
+				registryState = api.Ptr(api.ClusterImageRegistryProfileStateEnabled)
+			}
+		}
+	}
+	return registryState
+}
+
+// ConvertCStoHCPOpenShiftCluster converts a CS Cluster object into HCPOpenShiftCluster object
 func ConvertCStoHCPOpenShiftCluster(resourceID *azcorearm.ResourceID, cluster *arohcpv1alpha1.Cluster) *api.HCPOpenShiftCluster {
 	// A word about ProvisioningState:
 	// ProvisioningState is stored in Cosmos and is applied to the
@@ -211,6 +241,9 @@ func ConvertCStoHCPOpenShiftCluster(resourceID *azcorearm.ResourceID, cluster *a
 				IssuerURL:              "",
 			},
 			NodeDrainTimeoutMinutes: convertNodeDrainTimeoutCSToRP(cluster),
+			ClusterImageRegistry: api.ClusterImageRegistryProfile{
+				State: convertClusterImageRegistryStateCSToRP(cluster),
+			},
 		},
 	}
 
@@ -340,8 +373,8 @@ func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpC
 			MachineCIDR(hcpCluster.Properties.Network.MachineCIDR).
 			HostPrefix(int(hcpCluster.Properties.Network.HostPrefix))).
 		API(arohcpv1alpha1.NewClusterAPI().
-			Listening(convertVisibilityToListening(hcpCluster.Properties.API.Visibility)))
-
+			Listening(convertVisibilityToListening(hcpCluster.Properties.API.Visibility))).
+		ImageRegistry(convertClusterImageRegistryToCSBuilder(hcpCluster.Properties.ClusterImageRegistry))
 	azureBuilder := arohcpv1alpha1.NewAzure().
 		TenantID(tenantID).
 		SubscriptionID(subscriptionID).

--- a/frontend/pkg/frontend/ocm_test.go
+++ b/frontend/pkg/frontend/ocm_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
@@ -114,6 +115,20 @@ func TestConvertCStoHCPOpenShiftCluster(t *testing.T) {
 		// 		},
 		// 	),
 		// },
+		{
+			name: "converts CS ClusterImageRegistry to ClusterImageRegistryProfile",
+			cluster: arohcpv1alpha1.NewCluster().
+				ImageRegistry(arohcpv1alpha1.NewClusterImageRegistry().
+					State(string(csImageRegistryStateDisabled)),
+				),
+			want: clusterResource(
+				func(hsc *api.HCPOpenShiftCluster) {
+					hsc.Properties.ClusterImageRegistry = api.ClusterImageRegistryProfile{
+						State: to.Ptr(api.ClusterImageRegistryProfileStateDisabled),
+					}
+				},
+			),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -234,6 +249,8 @@ func withOCMClusterDefaults() func(*arohcpv1alpha1.ClusterBuilder) *arohcpv1alph
 				ID("test")).
 			Version(arohcpv1alpha1.NewVersion().
 				ID("").
-				ChannelGroup(""))
+				ChannelGroup("")).
+			ImageRegistry(arohcpv1alpha1.NewClusterImageRegistry().
+				State(""))
 	}
 }

--- a/internal/api/enums.go
+++ b/internal/api/enums.go
@@ -72,3 +72,14 @@ const (
 	// EtcdDataEncryptionKeyManagementModeTypePlatformManaged - Platform managed encryption key management mode type.
 	EtcdDataEncryptionKeyManagementModeTypePlatformManaged EtcdDataEncryptionKeyManagementModeType = "PlatformManaged"
 )
+
+// ClusterImageRegistryProfileState - state indicates the desired ImageStream-backed cluster image registry installation mode.
+// This can only be set during cluster creation and cannot be changed after cluster creation. Enabled means the
+// ImageStream-backed image registry will be run as pods on worker nodes in the cluster. Disabled means the ImageStream-backed
+// image registry will not be present in the cluster. The default is Enabled.
+type ClusterImageRegistryProfileState string
+
+const (
+	ClusterImageRegistryProfileStateDisabled ClusterImageRegistryProfileState = "Disabled"
+	ClusterImageRegistryProfileStateEnabled  ClusterImageRegistryProfileState = "Enabled"
+)

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -35,16 +35,17 @@ type HCPOpenShiftCluster struct {
 
 // HCPOpenShiftClusterProperties represents the property bag of a HCPOpenShiftCluster resource.
 type HCPOpenShiftClusterProperties struct {
-	ProvisioningState       arm.ProvisioningState     `json:"provisioningState,omitempty"       visibility:"read"`
-	Version                 VersionProfile            `json:"version,omitempty"`
-	DNS                     DNSProfile                `json:"dns,omitempty"`
-	Network                 NetworkProfile            `json:"network,omitempty"                 visibility:"read create"`
-	Console                 ConsoleProfile            `json:"console,omitempty"                 visibility:"read"`
-	API                     APIProfile                `json:"api,omitempty"`
-	Platform                PlatformProfile           `json:"platform,omitempty"                visibility:"read create"`
-	Autoscaling             ClusterAutoscalingProfile `json:"autoscaling,omitempty"             visibility:"read create update"`
-	NodeDrainTimeoutMinutes int32                     `json:"nodeDrainTimeoutMinutes,omitempty" visibility:"read create update" validate:"omitempty,min=0,max=10080"`
-	Etcd                    EtcdProfile               `json:"etcd,omitempty"                   visibility:"read create"`
+	ProvisioningState       arm.ProvisioningState       `json:"provisioningState,omitempty"       visibility:"read"`
+	Version                 VersionProfile              `json:"version,omitempty"`
+	DNS                     DNSProfile                  `json:"dns,omitempty"`
+	Network                 NetworkProfile              `json:"network,omitempty"                 visibility:"read create"`
+	Console                 ConsoleProfile              `json:"console,omitempty"                 visibility:"read"`
+	API                     APIProfile                  `json:"api,omitempty"`
+	Platform                PlatformProfile             `json:"platform,omitempty"                visibility:"read create"`
+	Autoscaling             ClusterAutoscalingProfile   `json:"autoscaling,omitempty"             visibility:"read create update"`
+	NodeDrainTimeoutMinutes int32                       `json:"nodeDrainTimeoutMinutes,omitempty" visibility:"read create update" validate:"omitempty,min=0,max=10080"`
+	Etcd                    EtcdProfile                 `json:"etcd,omitempty"                    visibility:"read create"`
+	ClusterImageRegistry    ClusterImageRegistryProfile `json:"clusterImageRegistry,omitempty"    visibility:"read create"`
 }
 
 // VersionProfile represents the cluster control plane version.
@@ -146,6 +147,15 @@ type UserAssignedIdentitiesProfile struct {
 	ControlPlaneOperators  map[string]string `json:"controlPlaneOperators,omitempty"  validate:"dive,keys,required,endkeys,resource_id=Microsoft.ManagedIdentity/userAssignedIdentities"`
 	DataPlaneOperators     map[string]string `json:"dataPlaneOperators,omitempty"     validate:"dive,keys,required,endkeys,resource_id=Microsoft.ManagedIdentity/userAssignedIdentities"`
 	ServiceManagedIdentity string            `json:"serviceManagedIdentity,omitempty" validate:"omitempty,resource_id=Microsoft.ManagedIdentity/userAssignedIdentities"`
+}
+
+// ClusterImageRegistryProfile - OpenShift cluster image registry
+type ClusterImageRegistryProfile struct {
+	// state indicates the desired ImageStream-backed cluster image registry installation mode. This can only be set during cluster
+	// creation and cannot be changed after cluster creation. Enabled means the
+	// ImageStream-backed image registry will be run as pods on worker nodes in the cluster. Disabled means the ImageStream-backed
+	// image registry will not be present in the cluster. The default is Enabled.
+	State *ClusterImageRegistryProfileState `json:"state,omitempty" validate:"omitempty,enum_clusterimageregistryprofilestate"`
 }
 
 // Creates an HCPOpenShiftCluster with any non-zero default values.

--- a/internal/api/hcpopenshiftcluster_test.go
+++ b/internal/api/hcpopenshiftcluster_test.go
@@ -266,6 +266,22 @@ func TestClusterValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "Bad enum_clusterimageregistryprofilestate",
+			tweaks: &HCPOpenShiftCluster{
+				Properties: HCPOpenShiftClusterProperties{
+					ClusterImageRegistry: ClusterImageRegistryProfile{
+						State: Ptr(ClusterImageRegistryProfileState("not enabled")),
+					},
+				},
+			},
+			expectErrors: []arm.CloudErrorBody{
+				{
+					Message: "Invalid value 'not enabled' for field 'state' (must be one of: Enabled Disabled)",
+					Target:  "properties.clusterImageRegistry.state",
+				},
+			},
+		},
+		{
 			name: "Base domain prefix is too long",
 			tweaks: &HCPOpenShiftCluster{
 				Properties: HCPOpenShiftClusterProperties{

--- a/internal/api/testhelpers.go
+++ b/internal/api/testhelpers.go
@@ -86,6 +86,9 @@ func NewTestValidator() *validator.Validate {
 		arm.ManagedServiceIdentityTypeSystemAssigned,
 		arm.ManagedServiceIdentityTypeSystemAssignedUserAssigned,
 		arm.ManagedServiceIdentityTypeUserAssigned))
+	validate.RegisterAlias("enum_clusterimageregistryprofilestate", EnumValidateTag(
+		ClusterImageRegistryProfileStateEnabled,
+		ClusterImageRegistryProfileStateDisabled))
 
 	return validate
 }

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -117,6 +117,17 @@ func newKmsKey(from *api.KmsKey) *generated.KmsKey {
 		Version:   api.PtrOrNil(from.Version),
 	}
 }
+
+func newClusterImageRegistryProfile(from *api.ClusterImageRegistryProfile) *generated.ClusterImageRegistryProfile {
+	profile := &generated.ClusterImageRegistryProfile{
+		State: nil,
+	}
+	if from.State != nil {
+		profile.State = api.Ptr(generated.ClusterImageRegistryProfileState(*from.State))
+	}
+	return profile
+}
+
 func newOperatorsAuthenticationProfile(from *api.OperatorsAuthenticationProfile) *generated.OperatorsAuthenticationProfile {
 	return &generated.OperatorsAuthenticationProfile{
 		UserAssignedIdentities: newUserAssignedIdentitiesProfile(&from.UserAssignedIdentities),
@@ -160,6 +171,7 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 				Platform:                newPlatformProfile(&from.Properties.Platform),
 				Autoscaling:             newClusterAutoscalingProfile(&from.Properties.Autoscaling),
 				NodeDrainTimeoutMinutes: api.PtrOrNil(from.Properties.NodeDrainTimeoutMinutes),
+				ClusterImageRegistry:    newClusterImageRegistryProfile(&from.Properties.ClusterImageRegistry),
 				Etcd:                    newEtcdProfile(&from.Properties.Etcd),
 			},
 		},
@@ -263,6 +275,9 @@ func (c *HcpOpenShiftCluster) Normalize(out *api.HCPOpenShiftCluster) {
 			}
 			if c.Properties.NodeDrainTimeoutMinutes != nil {
 				out.Properties.NodeDrainTimeoutMinutes = *c.Properties.NodeDrainTimeoutMinutes
+			}
+			if c.Properties.ClusterImageRegistry != nil {
+				normalizeClusterImageRegistry(c.Properties.ClusterImageRegistry, &out.Properties.ClusterImageRegistry)
 			}
 			if c.Properties.Etcd != nil {
 				normalizeEtcd(c.Properties.Etcd, &out.Properties.Etcd)
@@ -411,6 +426,12 @@ func normalizeActiveKey(p *generated.KmsKey, out *api.KmsKey) {
 	}
 	if p.Version != nil {
 		out.Version = *p.Version
+	}
+}
+
+func normalizeClusterImageRegistry(p *generated.ClusterImageRegistryProfile, out *api.ClusterImageRegistryProfile) {
+	if p.State != nil {
+		out.State = api.PtrOrNil(api.ClusterImageRegistryProfileState(*p.State))
 	}
 }
 

--- a/internal/api/v20240610preview/register.go
+++ b/internal/api/v20240610preview/register.go
@@ -57,4 +57,5 @@ func init() {
 	validate.RegisterAlias("enum_outboundtype", api.EnumValidateTag(generated.PossibleOutboundTypeValues()...))
 	validate.RegisterAlias("enum_provisioningstate", api.EnumValidateTag(generated.PossibleProvisioningStateValues()...))
 	validate.RegisterAlias("enum_visibility", api.EnumValidateTag(generated.PossibleVisibilityValues()...))
+	validate.RegisterAlias("enum_clusterimageregistryprofilestate", api.EnumValidateTag(generated.PossibleClusterImageRegistryProfileStateValues()...))
 }

--- a/internal/api/v20240610preview/register_test.go
+++ b/internal/api/v20240610preview/register_test.go
@@ -112,6 +112,8 @@ func TestClusterStructTagMap(t *testing.T) {
 		"Properties.Autoscaling.MaxNodeProvisionTimeSeconds":                     api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
 		"Properties.Autoscaling.PodPriorityThreshold":                            api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
 		"Properties.NodeDrainTimeoutMinutes":                                     api.VisibilityRead | api.VisibilityCreate | api.VisibilityUpdate,
+		"Properties.ClusterImageRegistry":                                        api.VisibilityRead | api.VisibilityCreate,
+		"Properties.ClusterImageRegistry.State":                                  api.VisibilityRead | api.VisibilityCreate,
 		"Properties.Etcd":                                                        skip,
 		"Properties.Etcd.DataEncryption":                                         skip,
 		"Properties.Etcd.DataEncryption.CustomerManaged":                         skip,


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://issues.redhat.com/browse/ARO-17707
### What

- Accepts ClusterImageRegistryProfile with state as Enabled/Disabled and pass it to CS cluster creation API

<!-- Briefly describe what this PR does -->

### Why

- Changes needed to enable/disable Image Registry capabilities during the cluster creation

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

- Cluster Creattion:

```
// Added disabling of clusterImageRegistry state to disabled in template
./03-create-cluster.sh

// OUTPUT FROM the Frontend

"clusterImageRegistry": {
            "state": "Disabled"
 },
```

- Cluster Patch with state change

```
OUTPUT:
{
    "error": {
        "code": "InvalidRequestContent",
        "message": "Field 'state' cannot be updated",
        "target": "properties.clusterImageRegistry.state"
    }
}
```
<!-- optional -->
