### PR TITLE
Keyvault is associated with NSP

### DIFF
--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -582,18 +582,6 @@ module logsServiceKeyVaultAccess '../modules/keyvault/keyvault-secret-access.bic
   }
 }
 
-module serviceKeyVaultPrivateEndpoint '../modules/private-endpoint.bicep' = {
-  name: '${deployment().name}-svcs-kv-pe'
-  params: {
-    location: location
-    subnetIds: [svcCluster.outputs.aksNodeSubnetId]
-    vnetId: svcCluster.outputs.aksVnetId
-    privateLinkServiceId: serviceKeyVault.id
-    serviceType: 'keyvault'
-    groupId: 'vault'
-  }
-}
-
 //
 //   C L U S T E R   S E R V I C E
 //


### PR DESCRIPTION

<!-- Link to Jira issue -->

### What

No more need for private endpoint as well.
Remove it to allow EV2 access


### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
