### PR TITLE
avoid conflicts with multiple concurrent deployments

### DIFF
--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -763,7 +763,7 @@ module fpaCertificate '../modules/keyvault/key-vault-cert.bicep' = if (manageFpa
 //
 
 module genevaRPCertificate '../modules/keyvault/key-vault-cert-with-access.bicep' = {
-  name: 'geneva-rp-certificate'
+  name: 'geneva-rp-certificate-${uniqueString(resourceGroup().name)}'
   scope: resourceGroup(serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName


### PR DESCRIPTION
### What

since the geneva cert is stored in the svc kv, which is shared in DEV, the deployment name needs to have some unquieness to it to prevent name conflict when multiple people run the deployment

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
