### PR TITLE
Add KeyVault permission to msi mock identity

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -138,6 +138,13 @@ create-mock-identities:
 	SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
 	./scripts/create-sp-for-rbac.sh
 
+	APPLICATION_NAME=aro-dev-msi-mock2 \
+	KEY_VAULT_NAME=aro-hcp-dev-svc-kv \
+	CERTIFICATE_NAME=msiMockCert2 \
+	ROLE_DEFINITION_NAME='Azure Red Hat OpenShift KMS Plugin - Dev' \
+	SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
+	./scripts/create-sp-for-rbac.sh
+
 .PHONY: create-mock-identities
 
 #


### PR DESCRIPTION
### What

We need to assign `Azure Red Hat OpenShift KMS Plugin - Dev` role to the MSI mock identity. This is required to enable HyperShift to interact with the Key Vault during the etcd encryption process. The permission is necessary because the MSI Data Plane service is not available in dev or personal environments.
