### PR TITLE
fix e2e bicep: link a cluster dependency properly

### DIFF
--- a/test/e2e-setup/bicep/demo.bicep
+++ b/test/e2e-setup/bicep/demo.bicep
@@ -32,7 +32,7 @@ module AroHcpCluster 'modules/cluster.bicep' = {
 module AroHcpNodePool 'modules/nodepool.bicep' = {
   name: 'nodepool-1'
   params: {
-    clusterName: clusterName
+    clusterName: AroHcpCluster.outputs.name
     nodePoolName: 'nodepool-1'
   }
 }

--- a/test/e2e-setup/bicep/modules/cluster.bicep
+++ b/test/e2e-setup/bicep/modules/cluster.bicep
@@ -58,3 +58,5 @@ resource hcp 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters@2024-06-10-preview'
   }
   identity: identityValue
 }
+
+output name string = clusterName


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/ARO-20103

### What

Use aro hcp cluster bicep reference in a node pool definition to make the dependency clear so that ARM will start deployment of the node pool after the cluster is present.

### Why

There is no explicit reference between cluster and a node pool in e2e bicep so that ARM is not aware of the dependency.

### Special notes for your reviewer

Minor fix, tested with success via mbuk-0731a deployment today.