### PR TITLE
adds geneva logs admin certificates to global keyvault

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1010,9 +1010,6 @@
             "adminCertName":{
               "type": "string"
             },
-            "adminCertDomain":{
-              "type": "string"
-            },
             "administrators": {
               "type": "object",
               "additionalProperties": false,

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1007,6 +1007,12 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "adminCertName":{
+              "type": "string"
+            },
+            "adminCertDomain":{
+              "type": "string"
+            },
             "administrators": {
               "type": "object",
               "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -133,10 +133,9 @@ defaults:
         - AME\WEINONGW
         securityGroup: AME\TM-AzureRedHatOpenShift-Leads
       adminCertName: "geneva-logs-admin-{{ .ctx.environment }}"
-      adminCertDomain: ""
       manageCertificates: true
       certificateIssuer: Self
-      certificateDomain: "aro-hcp-{{ .ctx.environment }}.azure.com"
+      certificateDomain: "geneva.keyvault.aro-hcp-{{ .ctx.environment }}.azure.com"
       typeName: ""
       environment: "Test"
       cluster:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -132,6 +132,8 @@ defaults:
         alias:
         - AME\WEINONGW
         securityGroup: AME\TM-AzureRedHatOpenShift-Leads
+      adminCertName: "geneva-logs-admin-{{ .ctx.environment }}"
+      adminCertDomain: ""
       manageCertificates: true
       certificateIssuer: Self
       certificateDomain: "aro-hcp-{{ .ctx.environment }}.azure.com"

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 150654a24a4482231050e50a146c1d4b3523a45b174704f26a61183a0b2948d5
+          westus3: 407e670254f55eeede420a3afc6337e7aa883ac086d63a3c88f353c223b169c9
       dev:
         regions:
-          westus3: 0cbf15ac8ab38e31a58af7f40cf600648f02052c618193287dfd02406b309789
+          westus3: af486e8ed243492f99ae6ef803487e46dbb90379c1093674b7447538058963b4
       ntly:
         regions:
-          uksouth: 56da1daa0e7d6906bc4af04cde3ea1e9c53890b71a3bad3259f9f6cd76e0e74e
+          uksouth: 275ba56f04af4dd4e05d2be91b399c3b9be22f5dbc09e23b12fa98efd5b28008
       perf:
         regions:
-          westus3: 131dff23bc7f145fd4f60294277b1cb5582483a4f0b5b1238dd9461c7adea77b
+          westus3: cc8b21c306cbeba09eaac2e4f54648371b5b122ec703ee2086969f9d884408a4
       pers:
         regions:
-          westus3: 4aae16f86e05e6578a9cfddf40ca13e2e1925c15c0d5d586aca90e0d60b3e25d
+          westus3: eeeb8ae742499ba25e990b636142a5a3f7d2fb21ea7fb8eaca6de6442d8776a0
       swft:
         regions:
-          uksouth: 316692e3bc59f9beae983ac6fea5c5326ccd492ed85cd671d8e183e2463d2913
+          uksouth: 30b9820d7f60b3486e7af1a0fd4f646175f55ff7e75230b7b9502f424ea30876

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 407e670254f55eeede420a3afc6337e7aa883ac086d63a3c88f353c223b169c9
+          westus3: e2dc3a082fd000cabc4a8303a2302fb7f3f5ec90380e52e63e6f40c560c38dcb
       dev:
         regions:
-          westus3: af486e8ed243492f99ae6ef803487e46dbb90379c1093674b7447538058963b4
+          westus3: ab3f49476e9c26aa0aa90e1fbf8d0335088337d9a47058f14eb9a87000607530
       ntly:
         regions:
-          uksouth: 275ba56f04af4dd4e05d2be91b399c3b9be22f5dbc09e23b12fa98efd5b28008
+          uksouth: 1ae364189e0b11f2131fdf61eb3e0b386c4ad6a4bcfd8aa762c79141ebf8190b
       perf:
         regions:
-          westus3: cc8b21c306cbeba09eaac2e4f54648371b5b122ec703ee2086969f9d884408a4
+          westus3: c0a6e91e2e640072d4b582e607a0bf0a7075944878b5f46a6872538a469ecb04
       pers:
         regions:
-          westus3: eeeb8ae742499ba25e990b636142a5a3f7d2fb21ea7fb8eaca6de6442d8776a0
+          westus3: 7ce5feef14cd246f66265df2791ea3b5129f142f50bf5274183a061e1e26b358
       swft:
         regions:
-          uksouth: 30b9820d7f60b3486e7af1a0fd4f646175f55ff7e75230b7b9502f424ea30876
+          uksouth: 4e95ee39d185e78405d27027f59c7ef33f1f5ab8411cc870bedb22e1e10c8d69

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -156,13 +156,12 @@ frontend:
     exporter: ""
 geneva:
   logs:
-    adminCertDomain: ""
     adminCertName: geneva-logs-admin-cspr
     administrators:
       alias:
       - AME\WEINONGW
       securityGroup: AME\TM-AzureRedHatOpenShift-Leads
-    certificateDomain: aro-hcp-cspr.azure.com
+    certificateDomain: geneva.keyvault.aro-hcp-cspr.azure.com
     certificateIssuer: Self
     cluster:
       accountName: placeholder

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -156,6 +156,8 @@ frontend:
     exporter: ""
 geneva:
   logs:
+    adminCertDomain: ""
+    adminCertName: geneva-logs-admin-cspr
     administrators:
       alias:
       - AME\WEINONGW

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -156,6 +156,8 @@ frontend:
     exporter: ""
 geneva:
   logs:
+    adminCertDomain: ""
+    adminCertName: geneva-logs-admin-dev
     administrators:
       alias:
       - AME\WEINONGW

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -156,13 +156,12 @@ frontend:
     exporter: ""
 geneva:
   logs:
-    adminCertDomain: ""
     adminCertName: geneva-logs-admin-dev
     administrators:
       alias:
       - AME\WEINONGW
       securityGroup: AME\TM-AzureRedHatOpenShift-Leads
-    certificateDomain: aro-hcp-dev.azure.com
+    certificateDomain: geneva.keyvault.aro-hcp-dev.azure.com
     certificateIssuer: Self
     cluster:
       accountName: placeholder

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -156,6 +156,8 @@ frontend:
     exporter: ""
 geneva:
   logs:
+    adminCertDomain: ""
+    adminCertName: geneva-logs-admin-ntly
     administrators:
       alias:
       - AME\WEINONGW

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -156,13 +156,12 @@ frontend:
     exporter: ""
 geneva:
   logs:
-    adminCertDomain: ""
     adminCertName: geneva-logs-admin-ntly
     administrators:
       alias:
       - AME\WEINONGW
       securityGroup: AME\TM-AzureRedHatOpenShift-Leads
-    certificateDomain: aro-hcp-ntly.azure.com
+    certificateDomain: geneva.keyvault.aro-hcp-ntly.azure.com
     certificateIssuer: Self
     cluster:
       accountName: placeholder

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -156,6 +156,8 @@ frontend:
     exporter: ""
 geneva:
   logs:
+    adminCertDomain: ""
+    adminCertName: geneva-logs-admin-perf
     administrators:
       alias:
       - AME\WEINONGW

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -156,13 +156,12 @@ frontend:
     exporter: ""
 geneva:
   logs:
-    adminCertDomain: ""
     adminCertName: geneva-logs-admin-perf
     administrators:
       alias:
       - AME\WEINONGW
       securityGroup: AME\TM-AzureRedHatOpenShift-Leads
-    certificateDomain: aro-hcp-perf.azure.com
+    certificateDomain: geneva.keyvault.aro-hcp-perf.azure.com
     certificateIssuer: Self
     cluster:
       accountName: placeholder

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -156,13 +156,12 @@ frontend:
     exporter: otlp
 geneva:
   logs:
-    adminCertDomain: ""
     adminCertName: geneva-logs-admin-pers
     administrators:
       alias:
       - AME\WEINONGW
       securityGroup: AME\TM-AzureRedHatOpenShift-Leads
-    certificateDomain: aro-hcp-pers.azure.com
+    certificateDomain: geneva.keyvault.aro-hcp-pers.azure.com
     certificateIssuer: Self
     cluster:
       accountName: placeholder

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -156,6 +156,8 @@ frontend:
     exporter: otlp
 geneva:
   logs:
+    adminCertDomain: ""
+    adminCertName: geneva-logs-admin-pers
     administrators:
       alias:
       - AME\WEINONGW

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -156,13 +156,12 @@ frontend:
     exporter: ""
 geneva:
   logs:
-    adminCertDomain: ""
     adminCertName: geneva-logs-admin-swft
     administrators:
       alias:
       - AME\WEINONGW
       securityGroup: AME\TM-AzureRedHatOpenShift-Leads
-    certificateDomain: aro-hcp-swft.azure.com
+    certificateDomain: geneva.keyvault.aro-hcp-swft.azure.com
     certificateIssuer: Self
     cluster:
       accountName: placeholder

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -156,6 +156,8 @@ frontend:
     exporter: ""
 geneva:
   logs:
+    adminCertDomain: ""
+    adminCertName: geneva-logs-admin-swft
     administrators:
       alias:
       - AME\WEINONGW

--- a/dev-infrastructure/configurations/global-certificates.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-certificates.tmpl.bicepparam
@@ -1,9 +1,9 @@
 using '../templates/global-certificates.bicep'
 
 param globalKeyVaultName = '{{ .global.keyVault.name }}'
-param genevaCertificateDomain = '{{ .logs.certificateDomain }}'
-param genevaCertificateHostName = '{{ .logs.adminCertDomain }}'
-param genevaCertificateIssuer = '{{ .logs.certificateIssuer }}'
-param genevaLogsAccountAdmin = '{{ .logs.adminCertName }}'
-param genevaManageCertificates = {{ .logs.manageCertificates }}
+param genevaCertificateDomain = '{{ .geneva.logs.certificateDomain }}'
+param genevaCertificateHostName = '{{ .geneva.logs.adminCertName }}'
+param genevaCertificateIssuer = '{{ .geneva.logs.certificateIssuer }}'
+param genevaLogsAccountAdmin = '{{ .geneva.logs.adminCertName }}'
+param genevaManageCertificates = {{ .geneva.logs.manageCertificates }}
 param ev2MsiName = '{{ .global.globalMSIName }}'

--- a/dev-infrastructure/configurations/global-certificates.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-certificates.tmpl.bicepparam
@@ -1,0 +1,9 @@
+using '../templates/global-certificates.bicep'
+
+param globalKeyVaultName = '{{ .global.keyVault.name }}'
+param genevaCertificateDomain = '{{ .logs.certificateDomain }}'
+param genevaCertificateHostName = '{{ .logs.adminCertDomain }}'
+param genevaCertificateIssuer = '{{ .logs.certificateIssuer }}'
+param genevaLogsAccountAdmin = '{{ .logs.adminCertName }}'
+param genevaManageCertificates = {{ .logs.manageCertificates }}
+param ev2MsiName = '{{ .global.globalMSIName }}'

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -29,6 +29,29 @@ resourceGroups:
     template: templates/global-infra.bicep
     parameters: configurations/global-infra.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+  - name: global-onecert-private-kv-issuer
+    action: SetCertificateIssuer
+    dependsOn:
+    - global-infra
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
+    applicationId:
+      configRef: ev2.assistedId.applicationId
+    vaultBaseUrl:
+      input:
+        name: globalKeyVaultUrl
+        step: global-infra
+    issuer:
+      value: OneCertV2-PrivateCA
+  - name: global-certificates
+    action: ARM
+    template: templates/global-certificates.bicep
+    parameters: configurations/global-certificates.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    dependsOn:
+    - global-onecert-private-kv-issuer
   - name: global-output
     action: ARM
     template: templates/output-global.bicep

--- a/dev-infrastructure/templates/global-certificates.bicep
+++ b/dev-infrastructure/templates/global-certificates.bicep
@@ -1,0 +1,24 @@
+param globalKeyVaultName string
+param genevaCertificateDomain string
+param genevaCertificateHostName string
+param genevaCertificateIssuer string
+param genevaLogsAccountAdmin string
+param genevaManageCertificates bool
+param ev2MsiName string
+
+resource ev2MSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: ev2MsiName 
+}
+
+module genevaRPCertificate '../modules/keyvault/key-vault-cert-with-access.bicep' = if (genevaManageCertificates) {
+  name: 'geveva-logs-account-admin-certificate'
+  params: {
+    keyVaultName: globalKeyVaultName
+    kvCertOfficerManagedIdentityResourceId: ev2MSI.id
+    certDomain: genevaCertificateDomain
+    certificateIssuer: genevaCertificateIssuer
+    hostName: genevaCertificateHostName 
+    keyVaultCertificateName: genevaLogsAccountAdmin
+    certificateAccessManagedIdentityPrincipalId: ev2MSI.properties.principalId 
+  }
+}

--- a/dev-infrastructure/templates/global-certificates.bicep
+++ b/dev-infrastructure/templates/global-certificates.bicep
@@ -7,7 +7,7 @@ param genevaManageCertificates bool
 param ev2MsiName string
 
 resource ev2MSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
-  name: ev2MsiName 
+  name: ev2MsiName
 }
 
 module genevaRPCertificate '../modules/keyvault/key-vault-cert-with-access.bicep' = if (genevaManageCertificates) {
@@ -17,8 +17,8 @@ module genevaRPCertificate '../modules/keyvault/key-vault-cert-with-access.bicep
     kvCertOfficerManagedIdentityResourceId: ev2MSI.id
     certDomain: genevaCertificateDomain
     certificateIssuer: genevaCertificateIssuer
-    hostName: genevaCertificateHostName 
+    hostName: genevaCertificateHostName
     keyVaultCertificateName: genevaLogsAccountAdmin
-    certificateAccessManagedIdentityPrincipalId: ev2MSI.properties.principalId 
+    certificateAccessManagedIdentityPrincipalId: ev2MSI.properties.principalId
   }
 }

--- a/dev-infrastructure/templates/global-infra.bicep
+++ b/dev-infrastructure/templates/global-infra.bicep
@@ -329,3 +329,5 @@ module azureFrontDoor '../modules/oidc/global/main.bicep' = {
     oidcMsiName: oidcMsiName
   }
 }
+
+output globalKeyVaultUrl string = globalKV.outputs.kvUrl


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Adds onecert private issuer to the global keyvault and adds a certificate provisioning step to the global-pipeline.yaml.  The certificate will be retrieved via ev2 identity and will perform geneva logs account administration.


### Why
to manage geneva logs account

### Special notes for your reviewer

<!-- optional -->
