### PR TITLE
hcpctl windows build targets

### DIFF
--- a/tooling/hcpctl/Makefile
+++ b/tooling/hcpctl/Makefile
@@ -2,6 +2,8 @@ SHELL = /bin/bash
 
 # Binary name
 BINARY = hcpctl
+WINDOWS_BINARY = hcpctl.exe
+WINDOWS_BINARY_AMD64 = hcpctl-amd64.exe
 
 # Version information
 CURRENT_COMMIT ?= $(shell git rev-parse --short=7 HEAD)
@@ -39,18 +41,15 @@ test-e2e: build
 .PHONY: test-e2e
 
 # Build for Windows x86_64
-build-windows-amd64:
-	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(BINARY)-amd64.exe .
-.PHONY: build-windows-amd64
+$(WINDOWS_BINARY):
+	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(WINDOWS_BINARY) .
 
 # Build for Windows ARM64
-build-windows-arm64:
-	GOOS=windows GOARCH=arm64 go build $(LDFLAGS) -o $(BINARY)-arm64.exe .
-.PHONY: build-windows-arm64
+$(WINDOWS_BINARY_AMD64):
+	GOOS=windows GOARCH=arm64 go build $(LDFLAGS) -o $(WINDOWS_BINARY_AMD64) .
 
 # Build both Windows binaries
-build-windows: build-windows-amd64 build-windows-arm64
-.PHONY: build-windows
+windows: $(WINDOWS_BINARY) $(WINDOWS_BINARY_AMD64)
 
 # Clean build artifacts
 clean:


### PR DESCRIPTION
### What

use regular (non-phony) build targets for hcpctl. the resulting binaries will be used on SAW devices and windows VMs for AME and MSIT

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
