### PR TITLE
Add permissions to create/update SALs, remove stale identity json

### DIFF
--- a/dev-infrastructure/scripts/mock-dev-role-definition.json
+++ b/dev-infrastructure/scripts/mock-dev-role-definition.json
@@ -1,9 +1,0 @@
-{
-    "Description": "ARO HCP Dev Role for mock 1p service principal",
-    "Actions": [
-        "Microsoft.Resources/subscriptions/resourceGroups/read",
-        "Microsoft.Resources/subscriptions/resourceGroups/write",
-        "Microsoft.Authorization/*/action",
-        "Microsoft.Authorization/*/read"
-    ]
-}

--- a/dev-infrastructure/templates/mock-identities.bicep
+++ b/dev-infrastructure/templates/mock-identities.bicep
@@ -65,6 +65,11 @@ resource customRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
     permissions: [
       {
         actions: [
+          'Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/delete'
+          'Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/write'
+          'Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/read'
+          'Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/details/read'
+          'Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/validate/action'
           'Microsoft.Resources/subscriptions/resourceGroups/read'
           'Microsoft.Resources/subscriptions/resourceGroups/write'
           'Microsoft.Authorization/*/action'


### PR DESCRIPTION
### What

Update mock 1p app permissions to include those needed for CRUD'ing service association links. 

### Why

Contributor role definition was removed from the mock 1p app breaking SAL operations. Putting them back here. 
