### PR TITLE
optionally generate dedicated CRD chart from OLM bundle

### DIFF
--- a/acm/Makefile
+++ b/acm/Makefile
@@ -63,4 +63,6 @@ helm-chart:
 	rm -rf $$TMP_DIR
 	@echo "Helm chart imported successfully."
 
+	@make -C .. yamlfmt
+
 .PHONY: deploy helm-chart

--- a/route-monitor-operator/Makefile
+++ b/route-monitor-operator/Makefile
@@ -37,7 +37,8 @@ helm-chart:
 		-c olm-bundle-repkg-config.yaml \
 		-s scaffold \
 		-o ${HELM_BASE_DIR}
+	rm -rf ${BUNDLE_TMP_PATH}
 	# TMP Fix: Add runAsUser to route-monitor-operator-controller-manager Deployment
 	yq eval '.spec.template.spec.containers[0].securityContext.runAsUser = 65532' \
 		-i ${RMO_CHART_DIR}/templates/route-monitor-operator-controller-manager.deployment.yaml
-	rm -rf ${BUNDLE_TMP_PATH}
+	make -C .. yamlfmt

--- a/tooling/olm-bundle-repkg/README.md
+++ b/tooling/olm-bundle-repkg/README.md
@@ -70,9 +70,10 @@ Flags:
       --chart-description string   Override chart description
       --chart-name string          Override chart name
   -c, --config string              Path to configuration file (YAML) [REQUIRED]
+      --crd-chart-name string      Name for a separate CRD chart (if not specified, CRDs will be included in the main chart)
   -h, --help                       help for olm-bundle-repkg
   -b, --olm-bundle string          OLM bundle input with protocol prefix: oci:// for bundle images, file:// for manifest directories [REQUIRED]
-  -o, --output-dir string          Output directory for the generated Helm Chart [REQUIRED]
+  -o, --output-dir string          Output directory for the generated Helm Charts [REQUIRED]
   -s, --scaffold-dir string        Directory containing additional templates to be added to the generated Helm Chart
   -l, --source-link string         Link to the Bundle image that is repackaged
 ```


### PR DESCRIPTION
### What

`olm-bundle-repkg` usually places the CRDs of an OLM bundle into the `crd` folders of the chart. but these CRDs are only applied once during first install and are never touched again. this is by design of helm. they want to avoid that people loose their "data" when reinstalling an operator.

proposal: we introduce the option for `olm-bundle-rpkg` to place CRDs into their own chart into the `templates` folder. manifests from the `templates` folder are applied to the cluster even on updates.

with this we gain the ability to update CRDs while also being able to safely reinstall an operator when needed without loosing any CRs.


### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
