### PR TITLE
feat: add support for asynchronous cluster updates

### DIFF
--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -976,6 +976,8 @@ func (s *OperationsScanner) convertClusterStatus(ctx context.Context, op operati
 		}
 	case arohcpv1alpha1.ClusterStateInstalling:
 		opStatus = arm.ProvisioningStateProvisioning
+	case arohcpv1alpha1.ClusterStateUpdating:
+		opStatus = arm.ProvisioningStateUpdating
 	case arohcpv1alpha1.ClusterStateReady:
 		// Resource deletion is successful when fetching its state
 		// from Cluster Service returns a "404 Not Found" error. If

--- a/backend/operations_scanner_test.go
+++ b/backend/operations_scanner_test.go
@@ -422,6 +422,14 @@ func TestConvertClusterStatus(t *testing.T) {
 			expectConversionError:    false,
 		},
 		{
+			name:                     "Convert ClusterStateUpdating",
+			clusterState:             arohcpv1alpha1.ClusterStateUpdating,
+			currentProvisioningState: arm.ProvisioningStateAccepted,
+			updatedProvisioningState: arm.ProvisioningStateUpdating,
+			expectCloudError:         false,
+			expectConversionError:    false,
+		},
+		{
 			name:                     "Convert ClusterStateResuming",
 			clusterState:             arohcpv1alpha1.ClusterStateResuming,
 			currentProvisioningState: arm.ProvisioningStateAccepted,


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-19963

### What
Introduce a new arm provisions state "updating" non-terminal state when CS returns the state of the cluster resource as "updating".

### Why

This change is needed to support the async updates behaviour in the CS update clusters endpoint. 

### Special notes for your reviewer

<!-- optional -->
