### PR TITLE
grant permissions for KV issuer registration on global KV

### DIFF
--- a/dev-infrastructure/configurations/global-infra.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-infra.tmpl.bicepparam
@@ -31,3 +31,6 @@ param azureFrontDoorKeyVaultTagValue = '{{ .oidc.frontdoor.keyVault.tagValue }}'
 param azureFrontDoorUseManagedCertificates = {{ .oidc.frontdoor.useManagedCertificates }}
 param keyVaultAdminPrincipalId = '{{ .kvCertOfficerPrincipalId }}'
 param oidcMsiName = '{{ .oidc.frontdoor.msiName }}'
+
+// SP for KV certificate issuer registration
+param kvCertOfficerPrincipalId = '{{ .kvCertOfficerPrincipalId }}'

--- a/dev-infrastructure/templates/global-infra.bicep
+++ b/dev-infrastructure/templates/global-infra.bicep
@@ -62,6 +62,10 @@ param azureFrontDoorSkuName string
 param keyVaultAdminPrincipalId string
 param oidcMsiName string
 
+@description('KV certificate officer principal ID')
+param kvCertOfficerPrincipalId string
+
+
 //
 //  G L O B A L   M S I
 //
@@ -70,6 +74,8 @@ resource globalMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31'
   name: globalMSIName
   location: location
 }
+
+
 
 //   G L O B A L    K V
 
@@ -100,6 +106,24 @@ module globalMSIKVCryptoUser '../modules/keyvault/keyvault-secret-access.bicep' 
     keyVaultName: keyVaultName
     roleName: 'Key Vault Crypto Officer'
     managedIdentityPrincipalId: globalMSI.properties.principalId
+  }
+}
+
+module kvCertOfficer '../modules/keyvault/keyvault-secret-access.bicep' = {
+  name: guid(kvCertOfficerPrincipalId, globalKV.name, 'cert-officer')
+  params: {
+    keyVaultName: keyVaultName
+    roleName: 'Key Vault Certificates Officer'
+    managedIdentityPrincipalId: kvCertOfficerPrincipalId
+  }
+}
+
+module kvSecretsOfficer '../modules/keyvault/keyvault-secret-access.bicep' = {
+  name: guid(kvCertOfficerPrincipalId, globalKV.name, 'secrets-officer')
+  params: {
+    keyVaultName: keyVaultName
+    roleName: 'Key Vault Secrets Officer'
+    managedIdentityPrincipalId: kvCertOfficerPrincipalId
   }
 }
 

--- a/dev-infrastructure/templates/global-infra.bicep
+++ b/dev-infrastructure/templates/global-infra.bicep
@@ -65,7 +65,6 @@ param oidcMsiName string
 @description('KV certificate officer principal ID')
 param kvCertOfficerPrincipalId string
 
-
 //
 //  G L O B A L   M S I
 //
@@ -74,8 +73,6 @@ resource globalMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31'
   name: globalMSIName
   location: location
 }
-
-
 
 //   G L O B A L    K V
 


### PR DESCRIPTION
### What

grant permissions for KV issuer registration on global KV
without these permissions, registering a onecert issuer on the global KV will fail.
this will unblock the creation of the geneva admin certificate in the global KV

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
