### PR TITLE
use the shared_dir for backup cleanup from e2e

### DIFF
--- a/test/e2e/cluster_create_missing_info.go
+++ b/test/e2e/cluster_create_missing_info.go
@@ -46,7 +46,7 @@ var _ = Describe("Customer", func() {
 					customerVnetSubnetName           = "customer-vnet-subnet1"
 					customerClusterName              = "illegal-hcp-cluster"
 				)
-				ic := framework.NewInvocationContext()
+				ic := framework.NewTestContext()
 
 				By("creating a resource group")
 				resourceGroup, err := ic.NewResourceGroup(ctx, "illegal-ocp-version", ic.Location())

--- a/test/e2e/complete_cluster_create.go
+++ b/test/e2e/complete_cluster_create.go
@@ -46,7 +46,7 @@ var _ = Describe("Customer", func() {
 				customerClusterName              = "basic-hcp-cluster"
 				customerNodePoolName             = "np-1"
 			)
-			ic := framework.NewInvocationContext()
+			ic := framework.NewTestContext()
 
 			By("creating a resource group")
 			resourceGroup, err := ic.NewResourceGroup(ctx, "basic-create", "uksouth")

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -31,6 +31,7 @@ import (
 
 type perBinaryInvocationTestContext struct {
 	artifactDir      string
+	sharedDir        string
 	subscriptionName string
 	tenantID         string
 	testUserClientID string
@@ -61,6 +62,7 @@ func invocationContext() *perBinaryInvocationTestContext {
 	initializeOnce.Do(func() {
 		invocationContextInstance = &perBinaryInvocationTestContext{
 			artifactDir:      artifactDir(),
+			sharedDir:        sharedDir(),
 			subscriptionName: subscriptionName(),
 			tenantID:         tenantID(),
 			testUserClientID: testUserClientID(),
@@ -128,6 +130,14 @@ func (tc *perBinaryInvocationTestContext) Location() string {
 func artifactDir() string {
 	// can't use gomega in this method since it is used outside of It()
 	return os.Getenv("ARTIFACT_DIR")
+}
+
+// sharedDir is SHARED_DIR.  It is a spot to store *files only* that can be shared between ci-operator steps.
+// We can use this for anything, but currently we have a backup cleanup and collection scripts that use files
+// here to cleanup and debug testing resources.
+func sharedDir() string {
+	// can't use gomega in this method since it is used outside of It()
+	return os.Getenv("SHARED_DIR")
 }
 
 // subscriptionName returns the value of CUSTOMER_SUBSCRIPTION environment variable

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -45,7 +45,7 @@ type perItOrDescribeTestContext struct {
 	armSubscriptionsClientFactory *armsubscriptions.ClientFactory
 }
 
-func NewInvocationContext() *perItOrDescribeTestContext {
+func NewTestContext() *perItOrDescribeTestContext {
 	tc := &perItOrDescribeTestContext{
 		perBinaryInvocationTestContext: invocationContext(),
 	}
@@ -132,6 +132,13 @@ func (tc *perItOrDescribeTestContext) NewResourceGroup(ctx context.Context, reso
 		tc.knownResourceGroups = append(tc.knownResourceGroups, resourceGroupName)
 	}()
 	ginkgo.GinkgoLogr.Info("creating resource group", "resourceGroup", resourceGroupName)
+
+	if len(tc.perBinaryInvocationTestContext.sharedDir) > 0 {
+		resourceGroupCleanupFilename := filepath.Join(tc.perBinaryInvocationTestContext.sharedDir, "tracked-resource-group_"+resourceGroupName)
+		if err := os.WriteFile(resourceGroupCleanupFilename, []byte{}, 0644); err != nil {
+			ginkgo.GinkgoLogr.Error(err, "failed writing resource group cleanup file", "resourceGroup", resourceGroupName)
+		}
+	}
 
 	resourceGroup, err := CreateResourceGroup(ctx, tc.GetARMResourcesClientFactoryOrDie(ctx).NewResourceGroupsClient(), resourceGroupName, location, 20*time.Minute)
 	if err != nil {


### PR DESCRIPTION
requires https://github.com/openshift/release/pull/67796 .

This should cleanup on cancellation once it works.