### PR TITLE
ARO-20009: update HO and CS images to sync breaking changes

### DIFF
--- a/cluster-service/cluster-creation.md
+++ b/cluster-service/cluster-creation.md
@@ -265,9 +265,11 @@ cat <<EOF > nodepool-test.json
     "azure_node_pool": {
         "resource_name": "$NAME",
         "vm_size": "Standard_D8s_v3",
-        "os_disk_size_gibibytes": 30,
-        "os_disk_storage_account_type": "StandardSSD_LRS",
-        "ephemeral_os_disk_enabled": false
+        "os_disk": {
+            "size_gibibytes": 64,
+            "storage_account_type": "StandardSSD_LRS",
+            "persistence": "persistent"
+        }
     }
 }
 EOF

--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -8,7 +8,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:8b2e9af554ad3422f5c30830e383eddffdeac37f64677359d6913f53a4a2abfb
+              digest: sha256:1bb9f13def38ff771df1afb7c47496c2aab89915328f8c3066b966f744b2e26d
           # ACR Pull
           acrPull:
             image:
@@ -59,7 +59,7 @@ clouds:
           # Hypershift
           hypershift:
             image:
-              digest: sha256:caa1da4abd381492c07951575b8e64c6cce499252b697e3f6fade575803b2bcf
+              digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
           # Maestro
           maestro:
             image:
@@ -75,7 +75,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:8b2e9af554ad3422f5c30830e383eddffdeac37f64677359d6913f53a4a2abfb
+              digest: sha256:1bb9f13def38ff771df1afb7c47496c2aab89915328f8c3066b966f744b2e26d
           # ACR Pull
           acrPull:
             image:
@@ -142,7 +142,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:8b2e9af554ad3422f5c30830e383eddffdeac37f64677359d6913f53a4a2abfb
+              digest: sha256:1bb9f13def38ff771df1afb7c47496c2aab89915328f8c3066b966f744b2e26d
           # ACR Pull
           acrPull:
             image:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -671,7 +671,7 @@ clouds:
       clustersService:
         environment: "arohcpdev"
         image:
-          digest: sha256:8b2e9af554ad3422f5c30830e383eddffdeac37f64677359d6913f53a4a2abfb
+          digest: sha256:1bb9f13def38ff771df1afb7c47496c2aab89915328f8c3066b966f744b2e26d
         # NOTE: The role names must not include commas(,) in the name as the roleNames field
         # here is a comma separated list of role definition names.
         azureOperatorsManagedIdentities:
@@ -698,7 +698,7 @@ clouds:
         image:
           registry: quay.io
           repository: acm-d/rhtap-hypershift-operator
-          digest: sha256:caa1da4abd381492c07951575b8e64c6cce499252b697e3f6fade575803b2bcf
+          digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
       # Backplane API
       backplaneAPI:
         image:
@@ -887,9 +887,6 @@ clouds:
             cosmosDB:
               private: false
               zoneRedundantMode: 'Disabled'
-          hypershift:
-            image:
-              digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
       ntly:
         # this is an environment to test the deployability of infra nightly
         defaults:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 971b7b58a756b72db5bd9dbe02064e9838241973ba44ee6ef649b8ce44c3392a
+          westus3: 69cf553c308327dff2ca537be8d2b1bc10dbc403492028a103621ac663ff7666
       dev:
         regions:
-          westus3: dba8942e0c59c76118b2d246b428694f2c4790657f244f2aa1cf5b1272086af8
+          westus3: a6967e3a9d56511b375675887ad779f18e9f952303e7ac182e1fb3fc1f102e28
       ntly:
         regions:
-          uksouth: a11efb811d6f3b9c2360bf9e141d37ed6d178b0f1113727311f1fc5ae4ff0147
+          uksouth: 7c62b2a43d199f4fade7ffd6abcfd1c3f565b62ea639cd77a8a67d5b24d09959
       perf:
         regions:
-          westus3: 5b5007c224feb81196d0481007c0cd368badc1f8fe7da0e70985d45d860ae3d5
+          westus3: 157191a0e251f909e560169094bdf8b9d8c244ae3bbfcf6b6c5f30fba803937d
       pers:
         regions:
-          westus3: bf667db3bfc85e69a18c96c3e6d1dd142429cec53d5844d31f49eebe4883c910
+          westus3: 4ace7eb40f26b7cc7a11d82e1e0ef10218dfa92dda1584824555b901ba9278da
       swft:
         regions:
-          uksouth: 1c43bcf07f565c238030cdb43817afbccce5a6fad9780b04685e01ab3e70e838
+          uksouth: b5e96918cf24fedd60d8250d68629a6127419de5b00de57cf48cbbde3a0d2cb2

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -101,7 +101,7 @@ clustersService:
       roleNames: Azure Red Hat OpenShift KMS Plugin - Dev
   environment: arohcpdev
   image:
-    digest: sha256:8b2e9af554ad3422f5c30830e383eddffdeac37f64677359d6913f53a4a2abfb
+    digest: sha256:1bb9f13def38ff771df1afb7c47496c2aab89915328f8c3066b966f744b2e26d
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -101,7 +101,7 @@ clustersService:
       roleNames: Azure Red Hat OpenShift KMS Plugin - Dev
   environment: arohcpdev
   image:
-    digest: sha256:8b2e9af554ad3422f5c30830e383eddffdeac37f64677359d6913f53a4a2abfb
+    digest: sha256:1bb9f13def38ff771df1afb7c47496c2aab89915328f8c3066b966f744b2e26d
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:
@@ -235,7 +235,7 @@ global:
 hypershift:
   additionalInstallArg: ""
   image:
-    digest: sha256:caa1da4abd381492c07951575b8e64c6cce499252b697e3f6fade575803b2bcf
+    digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -101,7 +101,7 @@ clustersService:
       roleNames: Azure Red Hat OpenShift KMS Plugin - Dev
   environment: arohcpdev
   image:
-    digest: sha256:8b2e9af554ad3422f5c30830e383eddffdeac37f64677359d6913f53a4a2abfb
+    digest: sha256:1bb9f13def38ff771df1afb7c47496c2aab89915328f8c3066b966f744b2e26d
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:
@@ -235,7 +235,7 @@ global:
 hypershift:
   additionalInstallArg: ""
   image:
-    digest: sha256:caa1da4abd381492c07951575b8e64c6cce499252b697e3f6fade575803b2bcf
+    digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -101,7 +101,7 @@ clustersService:
       roleNames: Azure Red Hat OpenShift KMS Plugin - Dev
   environment: arohcpdev
   image:
-    digest: sha256:8b2e9af554ad3422f5c30830e383eddffdeac37f64677359d6913f53a4a2abfb
+    digest: sha256:1bb9f13def38ff771df1afb7c47496c2aab89915328f8c3066b966f744b2e26d
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:
@@ -235,7 +235,7 @@ global:
 hypershift:
   additionalInstallArg: ""
   image:
-    digest: sha256:caa1da4abd381492c07951575b8e64c6cce499252b697e3f6fade575803b2bcf
+    digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -101,7 +101,7 @@ clustersService:
       roleNames: Azure Red Hat OpenShift KMS Plugin - Dev
   environment: arohcpdev
   image:
-    digest: sha256:8b2e9af554ad3422f5c30830e383eddffdeac37f64677359d6913f53a4a2abfb
+    digest: sha256:1bb9f13def38ff771df1afb7c47496c2aab89915328f8c3066b966f744b2e26d
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:
@@ -235,7 +235,7 @@ global:
 hypershift:
   additionalInstallArg: ""
   image:
-    digest: sha256:caa1da4abd381492c07951575b8e64c6cce499252b697e3f6fade575803b2bcf
+    digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -101,7 +101,7 @@ clustersService:
       roleNames: Azure Red Hat OpenShift KMS Plugin - Dev
   environment: arohcpdev
   image:
-    digest: sha256:8b2e9af554ad3422f5c30830e383eddffdeac37f64677359d6913f53a4a2abfb
+    digest: sha256:1bb9f13def38ff771df1afb7c47496c2aab89915328f8c3066b966f744b2e26d
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:
@@ -235,7 +235,7 @@ global:
 hypershift:
   additionalInstallArg: ""
   image:
-    digest: sha256:caa1da4abd381492c07951575b8e64c6cce499252b697e3f6fade575803b2bcf
+    digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift


### PR DESCRIPTION
Update Hypershift Operator image and Clusters Service image in the configuration of ARO-HCP environments

Hypershift Operator has introduced API breaking changes that require updating both CS and Hypershift operator to have matching client and server side changes.
This commit updates the Hypershift Operator version in the non MSFT environments to contain those new changes that are breaking changes.

The commit also introduces most recent CS changes.

CS image SHA 1bb9f13def38ff771df1afb7c47496c2aab89915328f8c3066b966f744b2e26d corresponds to CS commit id a0d0ee1.
Hypershift image SHA e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1 corresponds to Hypershift commit a94db93