### PR TITLE
e2e: test keyvault certs

### DIFF
--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -132,8 +132,8 @@ var _ = Describe("Customer", func() {
 
 		fmt.Fprintf(GinkgoWriter, "Issuer: %v\n", actualAPICert.Issuer)
 		Expect(actualAPICert.Issuer).To(SatisfyAll(
-			HaveField("CommonName", ContainElements("Microsoft Azure RSA TLS Issuing CA")),
-			HaveField("Organization", ContainElements("Microsoft Corporation")),
+			HaveField("CommonName", MatchRegexp(`Microsoft\sAzure\sRSA\sTLS\sIssuing\sCA\s[0-9]+`)),
+			HaveField("Organization", ContainElement("Microsoft Corporation")),
 		), "expect certificate to be issued by Microsoft")
 
 		By("creating the node pool")
@@ -181,8 +181,8 @@ var _ = Describe("Customer", func() {
 			fmt.Fprintf(GinkgoWriter, "Issuer OU: %v", actualCert.Issuer.OrganizationalUnit)
 			return actualCert, nil
 		}).WithTimeout(2*time.Minute).WithPolling(10*time.Second).To(SatisfyAll(
-			HaveField("CommonName", ContainElements("Microsoft Azure RSA TLS Issuing CA")),
-			HaveField("Organization", ContainElements("Microsoft Corporation")),
+			HaveField("Issuer.CommonName", MatchRegexp(`Microsoft\sAzure\sRSA\sTLS\sIssuing\sCA\s[0-9]+`)),
+			HaveField("Issuer.Organization", ContainElement("Microsoft Corporation")),
 		), "expect certificate to be issued by Microsoft")
 	})
 })


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-18498

### What

Add e2e test to verify that Kube API Server and default Ingress endpoints are using certificates from key vault.

### Why

Feature completion

### Special notes for your reviewer

The tests simply try to verify that the certs are not signed by the internal OpenShift CA. More explicit validation would be great (e.g. actually lookup and compare with cert in keyvalut) but I think this is a good start.
