### PR TITLE
shorten deployment names + introduce geneva admin cert domain

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1050,6 +1050,9 @@
             "adminCertName":{
               "type": "string"
             },
+            "adminCertificateDomain": {
+              "type": "string"
+            },
             "administrators": {
               "type": "object",
               "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -128,10 +128,11 @@ defaults:
         alias:
         - AME\WEINONGW
         securityGroup: AME\TM-AzureRedHatOpenShift-Leads
+      adminCertificateDomain: "geneva.keyvault.aro-hcp-global.azure.com"
       adminCertName: "geneva-logs-admin-{{ .ctx.environment }}"
       manageCertificates: true
       certificateIssuer: Self
-      certificateDomain: "geneva.keyvault.aro-hcp-{{ .ctx.environment }}.azure.com"
+      certificateDomain: "geneva.keyvault.aro-hcp.azure.com"
       typeName: ""
       environment: "Test"
       cluster:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 69cf553c308327dff2ca537be8d2b1bc10dbc403492028a103621ac663ff7666
+          westus3: 1c18a0cfab264b35cee7c8087cf5aa646e8cea35e27aa00bab0c1880676546d1
       dev:
         regions:
-          westus3: a6967e3a9d56511b375675887ad779f18e9f952303e7ac182e1fb3fc1f102e28
+          westus3: 42e0d0e98a88b5ed770baab1b3f511cdf9101187d95a0775ea58ef87aaefed62
       ntly:
         regions:
-          uksouth: 7c62b2a43d199f4fade7ffd6abcfd1c3f565b62ea639cd77a8a67d5b24d09959
+          uksouth: b254859bfd911fad9543593b464081ad358cca6b6fb027b8d11054c525e012fd
       perf:
         regions:
-          westus3: 157191a0e251f909e560169094bdf8b9d8c244ae3bbfcf6b6c5f30fba803937d
+          westus3: 6485ccdc4fbc9026b983f339c8d2aae458e441ed5a56f3e1ac949bfdaa662799
       pers:
         regions:
-          westus3: 4ace7eb40f26b7cc7a11d82e1e0ef10218dfa92dda1584824555b901ba9278da
+          westus3: 875f0128bbd72bba6681bf0f112389941b88c087f73b5087ba8ae3ff91aefc2c
       swft:
         regions:
-          uksouth: b5e96918cf24fedd60d8250d68629a6127419de5b00de57cf48cbbde3a0d2cb2
+          uksouth: a0629442a35c80336531d4006809d6a941e9d062b70df42b591e5a79fec88f7e

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -165,11 +165,12 @@ frontend:
 geneva:
   logs:
     adminCertName: geneva-logs-admin-cspr
+    adminCertificateDomain: geneva.keyvault.aro-hcp-global.azure.com
     administrators:
       alias:
       - AME\WEINONGW
       securityGroup: AME\TM-AzureRedHatOpenShift-Leads
-    certificateDomain: geneva.keyvault.aro-hcp-cspr.azure.com
+    certificateDomain: geneva.keyvault.aro-hcp.azure.com
     certificateIssuer: Self
     cluster:
       accountName: placeholder

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -165,11 +165,12 @@ frontend:
 geneva:
   logs:
     adminCertName: geneva-logs-admin-dev
+    adminCertificateDomain: geneva.keyvault.aro-hcp-global.azure.com
     administrators:
       alias:
       - AME\WEINONGW
       securityGroup: AME\TM-AzureRedHatOpenShift-Leads
-    certificateDomain: geneva.keyvault.aro-hcp-dev.azure.com
+    certificateDomain: geneva.keyvault.aro-hcp.azure.com
     certificateIssuer: Self
     cluster:
       accountName: placeholder

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -165,11 +165,12 @@ frontend:
 geneva:
   logs:
     adminCertName: geneva-logs-admin-ntly
+    adminCertificateDomain: geneva.keyvault.aro-hcp-global.azure.com
     administrators:
       alias:
       - AME\WEINONGW
       securityGroup: AME\TM-AzureRedHatOpenShift-Leads
-    certificateDomain: geneva.keyvault.aro-hcp-ntly.azure.com
+    certificateDomain: geneva.keyvault.aro-hcp.azure.com
     certificateIssuer: Self
     cluster:
       accountName: placeholder

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -165,11 +165,12 @@ frontend:
 geneva:
   logs:
     adminCertName: geneva-logs-admin-perf
+    adminCertificateDomain: geneva.keyvault.aro-hcp-global.azure.com
     administrators:
       alias:
       - AME\WEINONGW
       securityGroup: AME\TM-AzureRedHatOpenShift-Leads
-    certificateDomain: geneva.keyvault.aro-hcp-perf.azure.com
+    certificateDomain: geneva.keyvault.aro-hcp.azure.com
     certificateIssuer: Self
     cluster:
       accountName: placeholder

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -165,11 +165,12 @@ frontend:
 geneva:
   logs:
     adminCertName: geneva-logs-admin-pers
+    adminCertificateDomain: geneva.keyvault.aro-hcp-global.azure.com
     administrators:
       alias:
       - AME\WEINONGW
       securityGroup: AME\TM-AzureRedHatOpenShift-Leads
-    certificateDomain: geneva.keyvault.aro-hcp-pers.azure.com
+    certificateDomain: geneva.keyvault.aro-hcp.azure.com
     certificateIssuer: Self
     cluster:
       accountName: placeholder

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -165,11 +165,12 @@ frontend:
 geneva:
   logs:
     adminCertName: geneva-logs-admin-swft
+    adminCertificateDomain: geneva.keyvault.aro-hcp-global.azure.com
     administrators:
       alias:
       - AME\WEINONGW
       securityGroup: AME\TM-AzureRedHatOpenShift-Leads
-    certificateDomain: geneva.keyvault.aro-hcp-swft.azure.com
+    certificateDomain: geneva.keyvault.aro-hcp.azure.com
     certificateIssuer: Self
     cluster:
       accountName: placeholder

--- a/dev-infrastructure/configurations/global-certificates.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-certificates.tmpl.bicepparam
@@ -1,7 +1,7 @@
 using '../templates/global-certificates.bicep'
 
 param globalKeyVaultName = '{{ .global.keyVault.name }}'
-param genevaCertificateDomain = '{{ .geneva.logs.certificateDomain }}'
+param genevaCertificateDomain = '{{ .geneva.logs.adminCertificateDomain }}'
 param genevaCertificateHostName = '{{ .geneva.logs.adminCertName }}'
 param genevaCertificateIssuer = '{{ .geneva.logs.certificateIssuer }}'
 param genevaLogsAccountAdmin = '{{ .geneva.logs.adminCertName }}'

--- a/dev-infrastructure/modules/cluster-service.bicep
+++ b/dev-infrastructure/modules/cluster-service.bicep
@@ -77,7 +77,7 @@ param postgresZoneRedundantMode string
 import * as res from 'resource.bicep'
 
 module csPostgres 'postgres/postgres.bicep' = if (deployPostgres) {
-  name: '${deployment().name}-postgres'
+  name: 'cs-postgres-deployment'
   scope: resourceGroup(regionalResourceGroup)
   params: {
     name: postgresServerName
@@ -130,7 +130,7 @@ module csPostgres 'postgres/postgres.bicep' = if (deployPostgres) {
 //
 
 module csManagedIdentityDatabaseAccess 'postgres/postgres-access.bicep' = if (deployPostgres) {
-  name: '${deployment().name}-cs-db-access'
+  name: 'cs-db-access'
   scope: resourceGroup(regionalResourceGroup)
   params: {
     postgresServerName: postgresServerName

--- a/dev-infrastructure/modules/maestro/maestro-consumer.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-consumer.bicep
@@ -17,7 +17,7 @@ param maestroCertificateDomain string
 param maestroCertificateIssuer string
 
 module eventGridClientCert '../keyvault/key-vault-cert-with-access.bicep' = {
-  name: 'maesro-eg-crt-${uniqueString(maestroConsumerName)}'
+  name: 'maestro-eg-crt-${uniqueString(maestroConsumerName)}'
   params: {
     keyVaultName: certKeyVaultName
     kvCertOfficerManagedIdentityResourceId: keyVaultOfficerManagedIdentityName

--- a/dev-infrastructure/modules/maestro/maestro-consumer.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-consumer.bicep
@@ -17,7 +17,7 @@ param maestroCertificateDomain string
 param maestroCertificateIssuer string
 
 module eventGridClientCert '../keyvault/key-vault-cert-with-access.bicep' = {
-  name: '${deployment().name}-eg-crt-${uniqueString(maestroConsumerName)}'
+  name: 'maesro-eg-crt-${uniqueString(maestroConsumerName)}'
   params: {
     keyVaultName: certKeyVaultName
     kvCertOfficerManagedIdentityResourceId: keyVaultOfficerManagedIdentityName
@@ -34,7 +34,7 @@ import * as res from '../resource.bicep'
 var eventGridNamespaceRef = res.eventgridNamespaceRefFromId(maestroEventGridNamespaceId)
 
 module evengGridAccess 'maestro-eventgrid-access.bicep' = {
-  name: '${deployment().name}-eg-access'
+  name: 'eg-access-${uniqueString(maestroConsumerName)}'
   scope: resourceGroup(eventGridNamespaceRef.resourceGroup.subscriptionId, eventGridNamespaceRef.resourceGroup.name)
   params: {
     eventGridNamespaceName: eventGridNamespaceRef.name

--- a/dev-infrastructure/modules/maestro/maestro-server.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-server.bicep
@@ -81,7 +81,7 @@ param regionalResourceGroup string
 import * as res from '../resource.bicep'
 
 module maestroPostgres '../postgres/postgres.bicep' = if (deployPostgres) {
-  name: '${deployment().name}-postgres'
+  name: 'maestro-postgres-deployment'
   scope: resourceGroup(regionalResourceGroup)
   params: {
     name: postgresServerName
@@ -131,7 +131,7 @@ module maestroPostgres '../postgres/postgres.bicep' = if (deployPostgres) {
 }
 
 module maestroManagedIdentityDatabaseAccess '../postgres/postgres-access.bicep' = if (deployPostgres) {
-  name: '${deployment().name}-maestro-db-access'
+  name: 'maestro-db-access'
   scope: resourceGroup(regionalResourceGroup)
   params: {
     postgresServerName: postgresServerName
@@ -150,7 +150,7 @@ module maestroManagedIdentityDatabaseAccess '../postgres/postgres-access.bicep' 
 //
 
 module eventGridClientCert '../keyvault/key-vault-cert-with-access.bicep' = {
-  name: '${deployment().name}-eg-crt-${uniqueString(mqttClientName)}'
+  name: 'maestro-eg-crt-${uniqueString(mqttClientName)}'
   scope: resourceGroup(certKeyVaultResourceGroup)
   params: {
     keyVaultName: certKeyVaultName
@@ -164,7 +164,7 @@ module eventGridClientCert '../keyvault/key-vault-cert-with-access.bicep' = {
 }
 
 module evengGridAccess 'maestro-eventgrid-access.bicep' = {
-  name: '${deployment().name}-eg-access'
+  name: 'maestro-eg-access-${uniqueString(mqttClientName)}'
   scope: resourceGroup(maestroInfraResourceGroup)
   params: {
     eventGridNamespaceName: maestroEventGridNamespaceName

--- a/dev-infrastructure/modules/postgres/postgres-access.bicep
+++ b/dev-infrastructure/modules/postgres/postgres-access.bicep
@@ -44,7 +44,7 @@ var sqlScriptLines = [
 ]
 
 module managedIdentityDatabaseAccess 'postgres-sql.bicep' = {
-  name: '${deployment().name}-db-access'
+  name: 'db-mi-access-${uniqueString(databaseName)}'
   params: {
     postgresServerName: postgres.properties.fullyQualifiedDomainName
     databaseName: 'postgres' // access configuration is managed in the postgres DB

--- a/dev-infrastructure/modules/postgres/postgres-sql.bicep
+++ b/dev-infrastructure/modules/postgres/postgres-sql.bicep
@@ -19,7 +19,7 @@ param forceUpdateTag string = guid('${sqlScript}/${postgresServerName}/${databas
 import * as res from '../resource.bicep'
 
 resource deploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
-  name: deployment().name
+  name: 'postgres-sql-${uniqueString(postgresServerName, databaseName, deployment().name)}'
   location: resourceGroup().location
   kind: 'AzureCLI'
   identity: {

--- a/dev-infrastructure/modules/postgres/postgres.bicep
+++ b/dev-infrastructure/modules/postgres/postgres.bicep
@@ -198,7 +198,7 @@ output port int = 5432
 //
 
 module servicePostgresPrivateEndpoint '../private-endpoint.bicep' = if (managedPrivateEndpoint) {
-  name: '${deployment().name}-svcs-kv-pe'
+  name: 'svcs-kv-pe-${uniqueString(deployment().name)}'
   scope: resourceGroup(managedPrivateEndpointResourceGroup)
   params: {
     location: location

--- a/dev-infrastructure/templates/mgmt-infra.bicep
+++ b/dev-infrastructure/templates/mgmt-infra.bicep
@@ -78,7 +78,7 @@ resource aroDevopsMSIReader 'Microsoft.Authorization/roleAssignments@2022-04-01'
 //
 
 module cxKeyVault '../modules/keyvault/keyvault.bicep' = {
-  name: '${deployment().name}-cx-kv'
+  name: 'cx-kv-${uniqueString(cxKeyVaultName)}'
   params: {
     location: location
     keyVaultName: cxKeyVaultName
@@ -110,7 +110,7 @@ module cxKeyVaultAccess '../modules/keyvault/keyvault-secret-access.bicep' = [
 output cxKeyVaultUrl string = cxKeyVault.outputs.kvUrl
 
 module msiKeyVault '../modules/keyvault/keyvault.bicep' = {
-  name: '${deployment().name}-msi-kv'
+  name: 'msi-kv-${uniqueString(msiKeyVaultName)}'
   params: {
     location: location
     keyVaultName: msiKeyVaultName
@@ -125,7 +125,7 @@ module msiKeyVault '../modules/keyvault/keyvault.bicep' = {
 output msiKeyVaultUrl string = msiKeyVault.outputs.kvUrl
 
 module mgmtKeyVault '../modules/keyvault/keyvault.bicep' = {
-  name: '${deployment().name}-mgmt-kv'
+  name: 'mgmt-kv-${uniqueString(mgmtKeyVaultName)}'
   params: {
     location: location
     keyVaultName: mgmtKeyVaultName

--- a/dev-infrastructure/templates/region.bicep
+++ b/dev-infrastructure/templates/region.bicep
@@ -146,7 +146,7 @@ module svcAcrReplication '../modules/acr/acr-replication.bicep' = if (globalRegi
 //
 
 module maestroInfra '../modules/maestro/maestro-infra.bicep' = {
-  name: '${deployment().name}-maestro'
+  name: 'maestro-infra-deployment'
   params: {
     eventGridNamespaceName: maestroEventGridNamespacesName
     location: location

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -511,7 +511,7 @@ module rpCosmosDb '../modules/rp-cosmos.bicep' = if (deployFrontendCosmos) {
 }
 
 module rpCosmosdbPrivateEndpoint '../modules/private-endpoint.bicep' = {
-  name: '${deployment().name}-rp-pe'
+  name: 'rp-pe-${uniqueString(deployment().name)}'
   params: {
     location: location
     subnetIds: [svcCluster.outputs.aksNodeSubnetId]


### PR DESCRIPTION
### What

EV2 prepends a random identifier in front of deployment names so we need to make sure our deployment names are short enough to still have room for that

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
