### PR TITLE
monitoring workspace int/stg/prod rename

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -179,8 +179,8 @@ defaults:
     # Our yaml formatter does not allow >- when there is no value, so remember
     # to chage "" to >- when you add a value.
     grafanaRoles: ""
-    svcWorkspaceName: 'services-{{ .ctx.regionShort }}'
-    hcpWorkspaceName: 'hcps-{{ .ctx.regionShort }}'
+    svcWorkspaceName: 'services-{{ .ctx.region }}'
+    hcpWorkspaceName: 'hcps-{{ .ctx.region }}'
     icm:
       manageConnection: true
       connectionName: ""
@@ -808,6 +808,8 @@ clouds:
         grafanaZoneRedundantMode: Disabled
         grafanaRoles: >-
           6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
+        svcWorkspaceName: 'services-{{ .ctx.regionShort }}'
+        hcpWorkspaceName: 'hcps-{{ .ctx.regionShort }}'
       kvCertOfficerPrincipalId: 'c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb'
     environments:
       dev:


### PR DESCRIPTION
### What

Instead of the region short name (e.g. ln) we will use the region name (e.g. uksouth) to name both regional monitoring workspaces.

https://issues.redhat.com/browse/ARO-20316

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
