### PR TITLE
prefix mirror job names and cleanup oc-mirror jobs

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1346,6 +1346,9 @@
             "enabled": {
               "type": "boolean"
             },
+            "jobNamePrefix": {
+              "type": "string"
+            },
             "image": {
               "$ref": "#/definitions/containerImage"
             },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -554,6 +554,7 @@ defaults:
       pullSecretName: component-sync-pull-secret
     ocMirror:
       enabled: true
+      jobNamePrefix: '{{ .ctx.environment }}-'
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: image-sync/oc-mirror

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 32796c63c45ecb1cd19a94ec20960f417230280b9d26c43ae69840290e631abf
+          westus3: 327e62e66e8fcef13913296b155fab6405a3c0748f9e86db807e8cb87ac5da19
       dev:
         regions:
-          westus3: ff723edd3200a99b38ba70e039d78fe8f3a9b0df89ec2aa2ae8071b6dc932295
+          westus3: 94cda4e82071603ffcbd87758e72e8a4664680cb884ebe38238b9645a9302c6b
       ntly:
         regions:
-          uksouth: c571c0b6bfdf69c6becf8aa703d2f98357c4b93c5cf9fb43b64f009e52b8dadc
+          uksouth: 36b51b34526ef8d18f20e35fa67f863508cb4420c13f031167be490b432a7f68
       perf:
         regions:
-          westus3: 8d26989a5744b4a7c9ba1e61d6e5de6255759ae4218a39d20babb7a173d3f1d1
+          westus3: d41ec03ec7a19055a3413a646f35fb10734483822622d177d2dc674bb189847e
       pers:
         regions:
-          westus3: 911b2cc1ceaf254917878c09e7c7f5e6fc0d15ce7f7c563c3f01542f30b7b0dd
+          westus3: e0b460e0f352c0f2db9f0525115bedeee19ae76a4337fd2c6a56c20f266fbc86
       swft:
         regions:
-          uksouth: 88f14185454b43f2e9ae621c37318411bb451fb50c002f5a50446d29ec63327f
+          uksouth: 5ed58ad20cb2f361db911816229a2c3c9446af3dae8b9a59abb566d55ac028b4

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -248,6 +248,7 @@ imageSync:
       digest: sha256:92dc2b18de0126caa2212f62c54023f6e8ecf12e2025c37a5f4151d0253ae14e
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
+    jobNamePrefix: cspr-
     pullSecretName: ocmirror-pull-secret
   ondemandSync:
     pullSecretName: component-sync-pull-secret

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -248,6 +248,7 @@ imageSync:
       digest: sha256:92dc2b18de0126caa2212f62c54023f6e8ecf12e2025c37a5f4151d0253ae14e
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
+    jobNamePrefix: dev-
     pullSecretName: ocmirror-pull-secret
   ondemandSync:
     pullSecretName: component-sync-pull-secret

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -248,6 +248,7 @@ imageSync:
       digest: sha256:92dc2b18de0126caa2212f62c54023f6e8ecf12e2025c37a5f4151d0253ae14e
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
+    jobNamePrefix: ntly-
     pullSecretName: ocmirror-pull-secret
   ondemandSync:
     pullSecretName: component-sync-pull-secret

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -248,6 +248,7 @@ imageSync:
       digest: sha256:92dc2b18de0126caa2212f62c54023f6e8ecf12e2025c37a5f4151d0253ae14e
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
+    jobNamePrefix: perf-
     pullSecretName: ocmirror-pull-secret
   ondemandSync:
     pullSecretName: component-sync-pull-secret

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -248,6 +248,7 @@ imageSync:
       digest: sha256:92dc2b18de0126caa2212f62c54023f6e8ecf12e2025c37a5f4151d0253ae14e
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
+    jobNamePrefix: pers-
     pullSecretName: ocmirror-pull-secret
   ondemandSync:
     pullSecretName: component-sync-pull-secret

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -248,6 +248,7 @@ imageSync:
       digest: sha256:92dc2b18de0126caa2212f62c54023f6e8ecf12e2025c37a5f4151d0253ae14e
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
+    jobNamePrefix: swft-
     pullSecretName: ocmirror-pull-secret
   ondemandSync:
     pullSecretName: component-sync-pull-secret

--- a/dev-infrastructure/configurations/global-image-sync.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-image-sync.tmpl.bicepparam
@@ -1,6 +1,7 @@
 using '../templates/global-image-sync.bicep'
 
 param containerAppEnvName = '{{ .imageSync.environmentName }}'
+param jobNamePrefix = '{{ .imageSync.ocMirror.jobNamePrefix }}'
 param containerAppOutboundServiceTags = '{{ .imageSync.outboundServiceTags }}'
 param location = '{{ .global.region }}'
 

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -27,7 +27,7 @@ resourceGroups:
     deploymentLevel: ResourceGroup
   - name: global-housekeeping
     action: Shell
-    command: scripts/global-tidying.sh
+    command: scripts/global-housekeeping.sh
     dryRun:
       variables:
       - name: DRY_RUN

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -20,15 +20,23 @@ resourceGroups:
 - name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  # creates global infra
-  # * the parent DNS zones for the ARO HCP services
-  # * the global KV
-  # * the global Grafana instance
   - name: global-infra
     action: ARM
     template: templates/global-infra.bicep
     parameters: configurations/global-infra.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+  - name: global-housekeeping
+    action: Shell
+    command: scripts/global-tidying.sh
+    dryRun:
+      variables:
+      - name: DRY_RUN
+        value: "true"
+    variables:
+    - name: GLOBAL_RESOURCE_GROUP
+      configRef: global.rg
+    dependsOn:
+    - global-infra
   - name: global-onecert-private-kv-issuer
     action: SetCertificateIssuer
     dependsOn:

--- a/dev-infrastructure/scripts/global-housekeeping.sh
+++ b/dev-infrastructure/scripts/global-housekeeping.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Function to display usage
+usage() {
+    echo "Usage: Set environment variables and run the script"
+    echo ""
+    echo "Required environment variables:"
+    echo "  GLOBAL_RESOURCE_GROUP: Azure resource group containing resources to clean up"
+    echo ""
+    echo "Optional environment variables:"
+    echo "  DRY_RUN: Set to any value to simulate deletions without actually deleting"
+    echo ""
+    echo "Examples:"
+    echo "  # Normal cleanup"
+    echo "  export GLOBAL_RESOURCE_GROUP=my-cleanup-rg"
+    echo "  $0"
+    echo ""
+    echo "  # Dry run to see what would be deleted"
+    echo "  export GLOBAL_RESOURCE_GROUP=my-cleanup-rg"
+    echo "  export DRY_RUN=1"
+    echo "  $0"
+    exit 1
+}
+
+# Check if required environment variables are set
+if [ -z "${GLOBAL_RESOURCE_GROUP:-}" ]; then
+    echo "Error: GLOBAL_RESOURCE_GROUP environment variable is not set"
+    usage
+fi
+
+# Check if DRY_RUN mode is enabled
+if [ -n "${DRY_RUN:-}" ]; then
+    echo "DRY_RUN mode enabled - will only show what would be deleted, not actually delete anything"
+    DRY_RUN_MODE=true
+else
+    DRY_RUN_MODE=false
+fi
+
+# Function to execute or just log a command based on DRY_RUN mode
+execute() {
+    if [ "$DRY_RUN_MODE" = true ]; then
+        echo "[DRY_RUN] Command: $*"
+    else
+        "$@"
+    fi
+}
+
+#
+#   C O N T A I N E R   A P P   J O B S
+#
+
+CONTAINER_APP_JOBS_TO_DELETE=("acm-mirror" "component-sync" "oc-mirror-4-18" "oc-mirror-4-19" "oc-mirror")
+for job in "${CONTAINER_APP_JOBS_TO_DELETE[@]}"; do
+    if az containerapp job show --name "$job" --resource-group "$GLOBAL_RESOURCE_GROUP" &>/dev/null; then
+        execute az containerapp job delete --name "$job" --resource-group "$GLOBAL_RESOURCE_GROUP" --yes
+    else
+        echo "Container app job '$job' does not exist in resource group '$GLOBAL_RESOURCE_GROUP', skipping."
+    fi
+done


### PR DESCRIPTION
### What

* prefixing job names allows us to distinguish for what environment they do their job, e.g. in STAGE and PROD
* remove oc-mirror jobs
* cleanup old jobs via a script

supports dry-run

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
