### PR TITLE
denyassignment env variable for CS

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -39,6 +39,7 @@ deploy:
 	  --set oidcIssuerBaseUrl=$${OIDC_ISSUER_BASE_ENDPOINT} \
 	  --set tlsCertificatesIssuer=$${TLS_CERTIFICATES_ISSUER} \
 	  --set tlsCertificatesEnabled=$(TLS_CERTIFICATES_ENABLED) \
+	  --set denyAssignments=$(DENYASSIGNMENTS) \
 	  --set tenantId=$${TENANT_ID} \
 	  --set region=${REGION} \
 	  --set serviceKeyvaultName=${SERVICE_KV} \

--- a/cluster-service/deploy/templates/deployment.yaml
+++ b/cluster-service/deploy/templates/deployment.yaml
@@ -110,6 +110,9 @@ spec:
       - name: service
         image: '{{ .Values.imageRegistry }}/{{ .Values.imageRepository }}@{{ .Values.imageDigest }}'
         imagePullPolicy: IfNotPresent
+        env:
+        - name: DENYASSIGNMENTS
+          value: {{ .Values.denyAssignments }}
         volumeMounts:
         - name: service
           mountPath: /secrets/service

--- a/cluster-service/deploy/values.yaml
+++ b/cluster-service/deploy/values.yaml
@@ -170,6 +170,8 @@ oidcIssuerBaseUrl: ""
 tlsCertificatesIssuer: ""
 # tls certificates enabled  indicates whether TLS certificates are enabled or disabled for Ingress and Kube API Server.
 tlsCertificatesEnabled: true
+# Temporary deny assignment feature flag
+denyAssignments: "disabled"
 # The client id of the service principal that represents the ARM Helper Identity.
 azureArmHelperIdentityClientId: ""
 # The name of the secret that contains the ARM Helper Indentity certificate bundle.

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -133,6 +133,8 @@ resourceGroups:
       configRef: clustersService.k8s.serviceAccountName
     - name: ENVIRONMENT
       configRef: clustersService.environment
+    - name: DENYASSIGNMENTS
+      configRef: clustersService.denyAssignments
     - name: MI_DATAPLANE_AUDIENCE_RESOURCE
       configRef: msiRp.dataPlaneAudienceResource
     - name: OCP_ACR_RESOURCE_ID

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -691,6 +691,13 @@
           "minLength": 1,
           "maxLength": 10
         },
+        "denyAssignments": {
+          "type": "string",
+          "enum": [
+            "enabled",
+            "disabled"
+          ]
+        },
         "image": {
           "$ref": "#/definitions/containerImage"
         },
@@ -767,6 +774,7 @@
       "additionalProperties": false,
       "required": [
         "environment",
+        "denyAssignments",
         "image",
         "managedIdentityName",
         "k8s",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -533,6 +533,7 @@ defaults:
       address: ""
       exporter: ""
     environment: "arohcp{{ .ctx.environment }}"
+    denyAssignments: "disabled"
     postgres:
       name: "arohcp-{{ .ctx.environment }}-dbcs-{{ .ctx.regionShort }}" # [globally-unique]
       deploy: true


### PR DESCRIPTION
### What

this PR introduces a new config options `clustersService.denyassignments` which controls if the denyassignment feature is enabled in a specific environment. we will enable this for the time being in STAGE while the feature is still under development. for any other environment this feature will remain disabled.

the override to enable denyassignments can be found in the sdp-pipelines repo the the MSFT sensitive configuration overrides

[ARO-5982](https://issues.redhat.com//browse/ARO-5982)

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
