### PR TITLE
Always set ExternalAuthDocs to Succeeded

### DIFF
--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -598,7 +598,7 @@ func (s *OperationsScanner) pollExternalAuthOperation(ctx context.Context, op op
 
 	err := s.updateOperationStatus(ctx, op, arm.ProvisioningStateSucceeded, nil)
 	if err != nil {
-		s.recordOperationError(ctx, pollNodePoolOperationLabel, err)
+		s.recordOperationError(ctx, pollExternalAuthOperationLabel, err)
 		op.logger.Error(fmt.Sprintf("Failed to update operation status: %v", err))
 	}
 }


### PR DESCRIPTION
A small PR to initially force all externalAuthOperations to be set as Succeeded. This is a temporary workaround until CS and Hypershift support state changes.

