### PR TITLE
Give acm policies its own pipeline

### DIFF
--- a/.github/workflows/services-cd.yml
+++ b/.github/workflows/services-cd.yml
@@ -130,6 +130,9 @@ jobs:
     - name: 'Deploy ACM'
       run: |
         make acm.deploy_pipeline
+    - name: 'Deploy ACM Policies'
+      run: |
+        make acm.policies.deploy_pipeline
     - name: 'Deploy PKO'
       run: |
         make pko.deploy_pipeline

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ services_all = $(join services_svc,services_mgmt)
 # This sections is used to reference pipeline runs and should replace
 # the usage of `svc-deploy.sh` script in the future.
 services_svc_pipelines = backend frontend cluster-service maestro.server observability.tracing
-services_mgmt_pipelines = secret-sync-controller acm hypershiftoperator maestro.agent observability.tracing route-monitor-operator
+services_mgmt_pipelines = secret-sync-controller acm acm.policies hypershiftoperator maestro.agent observability.tracing route-monitor-operator
 %.deploy_pipeline: $(ORAS_LINK)
 	$(eval export dirname=$(subst .,/,$(basename $@)))
 	./templatize.sh $(DEPLOY_ENV) -p ./$(dirname)/pipeline.yaml -P run

--- a/acm/pipeline.yaml
+++ b/acm/pipeline.yaml
@@ -53,25 +53,6 @@ resourceGroups:
         resourceGroup: global
         step: output
         name: globalMSIId
-  - name: deploy-policies
-    aksCluster: '{{ .mgmt.aks.name }}'
-    action: Shell
-    command: make deploy-policies
-    dryRun:
-      variables:
-      - name: DRY_RUN
-        value: "true"
-    variables:
-    - name: ARO_HCP_IMAGE_ACR
-      configRef: acr.svc.name
-    shellIdentity:
-      input:
-        resourceGroup: global
-        step: output
-        name: globalMSIId
-    dependsOn:
-    - resourceGroup: management
-      step: deploy
   - name: scale-down
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell

--- a/acm/policies/pipeline.yaml
+++ b/acm/policies/pipeline.yaml
@@ -1,0 +1,42 @@
+$schema: "pipeline.schema.v1"
+serviceGroup: Microsoft.Azure.ARO.HCP.ACM.Policies
+rolloutName: ACM Policies Rollout
+resourceGroups:
+- name: global
+  resourceGroup: '{{ .global.rg }}'
+  subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
+  steps:
+  - name: output
+    action: ARM
+    template: templates/output-global.bicep
+    parameters: ../../dev-infrastructure/configurations/output-global.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
+- name: management
+  resourceGroup: '{{ .mgmt.rg }}'
+  subscription: '{{ .mgmt.subscription.key }}'
+  steps:
+  - name: deploy-policies
+    aksCluster: '{{ .mgmt.aks.name }}'
+    action: Shell
+    command: cd .. && make deploy-policies
+    dryRun:
+      variables:
+      - name: DRY_RUN
+        value: "true"
+    variables:
+    - name: ARO_HCP_IMAGE_ACR
+      configRef: acr.svc.name
+    shellIdentity:
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: global
+      step: output

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -13,6 +13,7 @@ The tree of pipelines making up the ARO HCP service are documented here from the
     - Microsoft.Azure.ARO.HCP.Management.Infra ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/mgmt-pipeline.yaml)): Deploy a management cluster and backing infrastructure. (Management Cluster)
       - Microsoft.Azure.ARO.HCP.SecretSyncController ([ref](https://github.com/Azure/ARO-HCP/tree/main/secret-sync-controller/pipeline.yaml)): Deploy the Secret Sync Controller.
       - Microsoft.Azure.ARO.HCP.ACM ([ref](https://github.com/Azure/ARO-HCP/tree/main/acm/pipeline.yaml)): Deploy Advanced Cluster Management and Multi-Cluster Engine.
+        - Microsoft.Azure.ARO.HCP.ACM.Policies ([ref](https://github.com/Azure/ARO-HCP/tree/main/acm/policies/pipeline.yaml)): Deploy ACM Policies independently.
       - Microsoft.Azure.ARO.HCP.RP.HypershiftOperator ([ref](https://github.com/Azure/ARO-HCP/tree/main/hypershiftoperator/pipeline.yaml)): Deploy the HyperShift operator.
       - Microsoft.Azure.ARO.HCP.PKO ([ref](https://github.com/Azure/ARO-HCP/tree/main/pko/pipeline.yaml)): Deploy the Package Operator.
       - Microsoft.Azure.ARO.HCP.Maestro.Agent ([ref](https://github.com/Azure/ARO-HCP/tree/main/maestro/agent/pipeline.yaml)): Deploy the Maestro Agent and register it with the MQTT stream.

--- a/topology.yaml
+++ b/topology.yaml
@@ -42,6 +42,10 @@ services:
         pipelinePath: secret-sync-controller/pipeline.yaml
         purpose: Deploy the Secret Sync Controller.
       - serviceGroup: Microsoft.Azure.ARO.HCP.ACM
+        children:
+        - serviceGroup: Microsoft.Azure.ARO.HCP.ACM.Policies
+          pipelinePath: acm/policies/pipeline.yaml
+          purpose: Deploy ACM Policies independently.
         pipelinePath: acm/pipeline.yaml
         purpose: Deploy Advanced Cluster Management and Multi-Cluster Engine.
       - serviceGroup: Microsoft.Azure.ARO.HCP.RP.HypershiftOperator


### PR DESCRIPTION
<!-- Link to Jira issue -->

This is to resolve https://issues.redhat.com/browse/ARO-18011

<!-- Briefly describe what this PR does -->

To make a new pipeline for ACM policy

<!-- Briefly explain why this change is needed -->

As an SRE I want to push policy/day 2 config changes to the fleet separate from any other ARO HCP components.

<!-- optional -->
Tested locally:
```
make acm.policies.deploy_pipeline
./templatize.sh pers -p ./acm/policies/pipeline.yaml -P run

---------------------
Step global-output
  Kind: ARM
  Template: templates/output-global.bicep
  Parameters: ../../dev-infrastructure/configurations/output-global.tmpl.bicepparam

[13:29:39.755] DEBUG+3: Deployment started {
  "deployment": "global-output-3c6b2d4d",
  "resourceGroup": "global",
  "step": "global-output",
  "subscription": "1d3378d3-5a3f-4712-85a1-2485495dfc4b"
}

---------------------
Step deploy-policies
  Kind: Shell
  Command: cd .. && make deploy-policies


[13:29:49.344] DEBUG-1: Executing shell command: cd .. && make deploy-policies
 {
  "command": "cd .. \u0026\u0026 make deploy-policies",
  "resourceGroup": "hcp-underlay-pers-usw3wehe-mgmt-1",
  "step": "deploy-policies",
  "subscription": "1d3378d3-5a3f-4712-85a1-2485495dfc4b"
}
helm upgrade --install --wait --wait-for-jobs \
                policy deploy/helm/policies \
                --namespace open-cluster-management-policies
Release "policy" has been upgraded. Happy Helming!
NAME: policy
LAST DEPLOYED: Tue Aug  5 13:29:52 2025
NAMESPACE: open-cluster-management-policies
STATUS: deployed
REVISION: 2
TEST SUITE: None
```