### PR TITLE
Fix nil pointer error for Kms.ActiveKey

### DIFF
--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -413,6 +413,9 @@ func normalizeCustomerManaged(p *generated.CustomerManagedEncryptionProfile, out
 		out.EncryptionType = api.CustomerManagedEncryptionType(*p.EncryptionType)
 	}
 	if p.Kms != nil && p.Kms.ActiveKey != nil {
+		if out.Kms == nil {
+			out.Kms = &api.KmsEncryptionProfile{}
+		}
 		normalizeActiveKey(p.Kms.ActiveKey, &out.Kms.ActiveKey)
 	}
 }


### PR DESCRIPTION
### What

We get below error because out.Kms is not initialized. 
```
panic: \"invalid memory address or nil pointer dereference\"\ngoroutine 247 [running]:\nruntime/debug.Stack()\n\t/opt/homebrew/Cellar/go/1.24.5/libexec/src/runtime/debug/stack.go:26 +0x64\ngithub.com/Azure/ARO-HCP/frontend/pkg/frontend.MiddlewarePanic.func1()\n\t/Users/supatil/redhat-projects/uhc-clusters-service/ARO-HCP/frontend/pkg/frontend/middleware_panic.go:32 +0x80\npanic({0x1060167e0?, 0x106eafc00?})\n\t/opt/homebrew/Cellar/go/1.24.5/libexec/src/runtime/panic.go:792 +0x124\ngithub.com/Azure/ARO-HCP/internal/api/v20240610preview.normalizeCustomerManaged(...)\n\t/Users/supatil/redhat-projects/uhc-clusters-service/ARO-HCP/internal/api/v20240610preview/hcpopenshiftclusters_methods.go:416
```
