### PR TITLE
A Monumental One-Letter Namespace Correction That Will Echo Through t…

### DIFF
--- a/docs/ops/hcp-cluster-creation-flow.md
+++ b/docs/ops/hcp-cluster-creation-flow.md
@@ -125,7 +125,7 @@ In order to access Clusters Service for debugging purposes, you can port forward
 Keep in mind that the port-forwarded service does not require authentication and does not enforce authorization!
 
 ```sh
-kubectl port-forward -n cluster-service svc/clusters-service 8001:8000
+kubectl port-forward -n clusters-service svc/clusters-service 8001:8000
 ```
 
 ### Query the State of an HCP


### PR DESCRIPTION
…he Ages

commit [a82774c](https://github.com/Azure/ARO-HCP/commit/a82774c30bbaec4e4765f09cd2cecff2c3b285cc) 

Subject:  A Monumental One-Letter Namespace Correction That Will Echo Through the Ages

Body:
Today marks a historic event in the annals of software development — one that will be spoken of in hushed tones in code review meetings and whispered reverently by future generations of developers: I have changed *one single letter* in a namespace. Yes. Just one. A solitary, lonely, typo-ridden character that dared to defy the conventions of correct spelling, consistency, and human decency.

What was once `cluster-service`  has now been surgically corrected to the vastly more acceptable and societally integrated `clusters-service`. 

This change, though minuscule in scope, was not made lightly. Many seconds of careful deliberation were spent, weighing the impact this would have on the delicate ecosystem of our codebase. Downstream ripple effects were considered. Philosophical debates were held. Stack Overflow was not consulted, but only because it felt too embarrassed to witness such raw power.

Testing:
No electrons were harmed in the process of this change.
The CI pipeline wept softly in gratitude.
Unit tests blinked in confusion, saw nothing had truly changed, and passed anyway.

Reasoning:
- Fixes an egregious typo that has haunted SRE and DEV alike.
- Prevents future generations from writing `cluster-service` and other crimes against semantic correctness.
- Makes us look 0.01% more competent in the eyes of the Open Source Gods.

Implications:
- This is technically a breaking change if anyone was unfortunate enough to use the namespace `cluster-service`.
- May cause legacy code to cry, but hey, they had it coming.

Refactor? ✅
Performance impact? Negligible, but morale is up 12%.
Technical debt reduction? Absolutely.

Thank you for your time, attention, and patience as we navigate this critical improvement. May all our typos be shallow, and all our namespaces be correct.

Signed with a trembling hand and a heart full of purpose,  