### PR TITLE
Force centraluseuap to be non-zonal

### DIFF
--- a/dev-infrastructure/modules/common.bicep
+++ b/dev-infrastructure/modules/common.bicep
@@ -102,6 +102,7 @@ var _locationAvailabilityZones = {
   eastus2euap: {
     availabilityZones: [
       '1'
+      // '2' Not available in EV2
       '3'
       '4'
     ]


### PR DESCRIPTION
### What

Updates our `_locationAvailabilityZones` array used in Bicep modules to define centraluseuap as a non-zonal region. 

### Why

While the centraluseuap region advertises itself as supporting 2 AZs, these zones are not supported by all resources. 

### Special notes for your reviewer

None
