### PR TITLE
pipelines: constrain global resource groups to uksouth

### DIFF
--- a/acm/pipeline.yaml
+++ b/acm/pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/backend/pipeline.yaml
+++ b/backend/pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/dev-infrastructure/cleanup/delete.mgmt.pipeline.yaml
+++ b/dev-infrastructure/cleanup/delete.mgmt.pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/dev-infrastructure/cleanup/delete.region.pipeline.yaml
+++ b/dev-infrastructure/cleanup/delete.region.pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/dev-infrastructure/cleanup/delete.svc.pipeline.yaml
+++ b/dev-infrastructure/cleanup/delete.svc.pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -14,6 +14,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: infra
     action: ARM

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -13,6 +13,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/dev-infrastructure/mgmt-solo-pipeline.yaml
+++ b/dev-infrastructure/mgmt-solo-pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -14,6 +14,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   # Query parameters from global deployment, e.g. DNS hzone and ACR resource IDs
   - name: output

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -20,6 +20,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/frontend/pipeline.yaml
+++ b/frontend/pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/hypershiftoperator/pipeline.yaml
+++ b/hypershiftoperator/pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/maestro/agent/pipeline.yaml
+++ b/maestro/agent/pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/maestro/server/pipeline.yaml
+++ b/maestro/server/pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/observability/prometheus/test-pipeline.yaml
+++ b/observability/prometheus/test-pipeline.yaml
@@ -6,6 +6,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/observability/tracing/pipeline.yaml
+++ b/observability/tracing/pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/pko/pipeline.yaml
+++ b/pko/pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/route-monitor-operator/pipeline.yaml
+++ b/route-monitor-operator/pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/secret-sync-controller/pipeline.yaml
+++ b/secret-sync-controller/pipeline.yaml
@@ -5,6 +5,11 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
+  executionConstraints:
+  - clouds:
+    - public
+    regions:
+    - uksouth
   steps:
   - name: output
     action: ARM

--- a/tooling/pipeline-documentation/go.mod
+++ b/tooling/pipeline-documentation/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/pipeline-documentation
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b
+	github.com/Azure/ARO-Tools v0.0.0-20250806221148-3eb2b46661ed
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1

--- a/tooling/pipeline-documentation/go.sum
+++ b/tooling/pipeline-documentation/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b h1:fGm215++CttdUu6IO9TYY/0wUpfsxcY9u8xze2rJeRo=
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
+github.com/Azure/ARO-Tools v0.0.0-20250806221148-3eb2b46661ed h1:4AfAT7oMxgosNJ1xxZz6UFGjsSEDKdyyCyKXmfAYmaA=
+github.com/Azure/ARO-Tools v0.0.0-20250806221148-3eb2b46661ed/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dusted-go/logging v1.3.0 h1:SL/EH1Rp27oJQIte+LjWvWACSnYDTqNx5gZULin0XRY=

--- a/tooling/secret-sync/go.mod
+++ b/tooling/secret-sync/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/secret-sync
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b
+	github.com/Azure/ARO-Tools v0.0.0-20250806221148-3eb2b46661ed
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1

--- a/tooling/secret-sync/go.sum
+++ b/tooling/secret-sync/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b h1:fGm215++CttdUu6IO9TYY/0wUpfsxcY9u8xze2rJeRo=
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
+github.com/Azure/ARO-Tools v0.0.0-20250806221148-3eb2b46661ed h1:4AfAT7oMxgosNJ1xxZz6UFGjsSEDKdyyCyKXmfAYmaA=
+github.com/Azure/ARO-Tools v0.0.0-20250806221148-3eb2b46661ed/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1 h1:Wc1ml6QlJs2BHQ/9Bqu1jiyggbsSjramq2oUmp5WeIo=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1/go.mod h1:Ot/6aikWnKWi4l9QB7qVSwa8iMphQNqkWALMoNT3rzM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1 h1:B+blDbyVIG3WaikNxPnhPiJ1MThR03b3vKGtER95TP4=

--- a/tooling/templatize/go.mod
+++ b/tooling/templatize/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/templatize
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b
+	github.com/Azure/ARO-Tools v0.0.0-20250806221148-3eb2b46661ed
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.2

--- a/tooling/templatize/go.sum
+++ b/tooling/templatize/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b h1:fGm215++CttdUu6IO9TYY/0wUpfsxcY9u8xze2rJeRo=
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
+github.com/Azure/ARO-Tools v0.0.0-20250806221148-3eb2b46661ed h1:4AfAT7oMxgosNJ1xxZz6UFGjsSEDKdyyCyKXmfAYmaA=
+github.com/Azure/ARO-Tools v0.0.0-20250806221148-3eb2b46661ed/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1 h1:Wc1ml6QlJs2BHQ/9Bqu1jiyggbsSjramq2oUmp5WeIo=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1/go.mod h1:Ot/6aikWnKWi4l9QB7qVSwa8iMphQNqkWALMoNT3rzM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1 h1:B+blDbyVIG3WaikNxPnhPiJ1MThR03b3vKGtER95TP4=

--- a/tooling/yamlwrap/go.mod
+++ b/tooling/yamlwrap/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/yamlwrap
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b
+	github.com/Azure/ARO-Tools v0.0.0-20250806221148-3eb2b46661ed
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1

--- a/tooling/yamlwrap/go.sum
+++ b/tooling/yamlwrap/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b h1:fGm215++CttdUu6IO9TYY/0wUpfsxcY9u8xze2rJeRo=
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
+github.com/Azure/ARO-Tools v0.0.0-20250806221148-3eb2b46661ed h1:4AfAT7oMxgosNJ1xxZz6UFGjsSEDKdyyCyKXmfAYmaA=
+github.com/Azure/ARO-Tools v0.0.0-20250806221148-3eb2b46661ed/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
tooling: bump ARO-Tools to get execution constraints

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

pipelines: constrain global resource groups to uksouth

Using the new execution constraint functionality, we can declare that
global resource groups only execute against `uksouth`. Regional resource
groups remain able to refer to the chained outputs from these groups. We
will need to add additional constraints to other clouds as we roll out
to them by adding more entries to the constraint list.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

