### PR TITLE
Revert "tooling: bump ARO-Tools to latest revision"

### DIFF
--- a/acm/pipeline.yaml
+++ b/acm/pipeline.yaml
@@ -2,18 +2,16 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.ACM
 rolloutName: ACM Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../dev-infrastructure/configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: management
-  resourceGroup: '{{ .mgmt.rg }}'
+- name: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
   - name: deploy
@@ -37,9 +35,10 @@ resourceGroups:
       configRef: acm.mce.bundle.digest
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
+    dependsOn:
+    - global-output
   - name: deploy-policies
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell
@@ -53,12 +52,11 @@ resourceGroups:
       configRef: acr.svc.name
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
     dependsOn:
-    - resourceGroup: management
-      step: deploy
+    - deploy
+    - global-output
   - name: scale-down
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell
@@ -72,9 +70,8 @@ resourceGroups:
       configRef: acm.mce.pauseReconciliation
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
     dependsOn:
-    - resourceGroup: management
-      step: deploy
+    - deploy
+    - global-output

--- a/backend/pipeline.yaml
+++ b/backend/pipeline.yaml
@@ -2,11 +2,10 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.RP.Backend
 rolloutName: RP Backend Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../dev-infrastructure/configurations/output-global.tmpl.bicepparam
@@ -28,11 +27,11 @@ resourceGroups:
       configRef: imageSync.ondemandSync.pullSecretName
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-- name: service
-  resourceGroup: '{{ .svc.rg }}'
+    dependsOn:
+    - global-output
+- name: '{{ .svc.rg }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
   - name: deploy
@@ -44,8 +43,8 @@ resourceGroups:
       - name: DRY_RUN
         value: "true"
     dependsOn:
-    - resourceGroup: global
-      step: mirror-image
+    - mirror-image
+    - global-output
     variables:
     - name: ARO_HCP_IMAGE_ACR
       configRef: acr.svc.name
@@ -75,6 +74,5 @@ resourceGroups:
       configRef: backend.tracing.exporter
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -2,11 +2,10 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.ClusterService
 rolloutName: Cluster Service Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../dev-infrastructure/configurations/output-global.tmpl.bicepparam
@@ -28,21 +27,20 @@ resourceGroups:
       configRef: imageSync.ondemandSync.pullSecretName
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-- name: management
-  resourceGroup: '{{ .mgmt.rg }}'
+    dependsOn:
+    - global-output
+- name: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
-  - name: output
+  - name: mgmt-output
     action: ARM
     template: ../dev-infrastructure/templates/output-mgmt.bicep
     parameters: ../dev-infrastructure/configurations/output-mgmt.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: service
-  resourceGroup: '{{ .svc.rg }}'
+- name: '{{ .svc.rg }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
   - name: deploy
@@ -54,13 +52,12 @@ resourceGroups:
       - name: DRY_RUN
         value: "true"
     dependsOn:
-    - resourceGroup: global
-      step: mirror-image
+    - mirror-image
+    - global-output
     variables:
     - name: CX_SECRETS_KV_MI_CLIENT_ID
       input:
-        resourceGroup: management
-        step: output
+        step: mgmt-output
         name: azureKeyvaultSecretsProviderIdentityClientId
     - name: REGION
       configRef: region
@@ -142,13 +139,11 @@ resourceGroups:
       configRef: msiRp.dataPlaneAudienceResource
     - name: OCP_ACR_RESOURCE_ID
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: ocpAcrResourceId
     - name: OCP_ACR_URL
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: ocpAcrLoginServer
     # this is maestro consumer registration stuff
     # this goes away when we have a real registration process
@@ -170,6 +165,5 @@ resourceGroups:
       configRef: clustersService.azureRuntimeConfig.tlsCertificatesIssuer
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId

--- a/dev-infrastructure/cleanup/delete.mgmt.pipeline.yaml
+++ b/dev-infrastructure/cleanup/delete.mgmt.pipeline.yaml
@@ -2,18 +2,16 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Management.Delete
 rolloutName: Delete Management Resource Group
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: management
-  resourceGroup: '{{ .mgmt.rg }}'
+- name: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
   - name: rg-ownership
@@ -24,9 +22,10 @@ resourceGroups:
     variables:
     - name: globalMSIId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
+    dependsOn:
+    - global-output
   - name: delete-mgmt
     action: Shell
     command: ./delete.sh
@@ -39,9 +38,8 @@ resourceGroups:
       configRef: mgmt.rg
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
     dependsOn:
-    - resourceGroup: management
-      step: rg-ownership
+    - global-output
+    - rg-ownership

--- a/dev-infrastructure/cleanup/delete.region.pipeline.yaml
+++ b/dev-infrastructure/cleanup/delete.region.pipeline.yaml
@@ -2,17 +2,16 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Region.Delete
 rolloutName: Delete Regional Resource Group
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-  - name: rg-ownership
+  - name: global-rg-ownership
     action: ARM
     template: ../templates/rg-ownership.bicep
     parameters: ../configurations/rg-ownership.tmpl.bicepparam
@@ -20,11 +19,11 @@ resourceGroups:
     variables:
     - name: globalMSIId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-- name: regional
-  resourceGroup: '{{ .regionRG }}'
+    dependsOn:
+    - global-output
+- name: '{{ .regionRG }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
   - name: rg-ownership
@@ -35,9 +34,10 @@ resourceGroups:
     variables:
     - name: globalMSIId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
+    dependsOn:
+    - global-output
   - name: delete-region
     action: Shell
     command: ./delete.sh
@@ -50,11 +50,9 @@ resourceGroups:
       configRef: regionRG
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
     dependsOn:
-    - resourceGroup: global
-      step: rg-ownership
-    - resourceGroup: regional
-      step: rg-ownership
+    - global-output
+    - global-rg-ownership
+    - rg-ownership

--- a/dev-infrastructure/cleanup/delete.svc.pipeline.yaml
+++ b/dev-infrastructure/cleanup/delete.svc.pipeline.yaml
@@ -2,18 +2,16 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Service.Delete
 rolloutName: Delete Service Resource Group
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: service
-  resourceGroup: '{{ .svc.rg }}'
+- name: '{{ .svc.rg }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
   - name: rg-ownership
@@ -24,9 +22,10 @@ resourceGroups:
     variables:
     - name: globalMSIId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
+    dependsOn:
+    - global-output
   - name: delete-svc
     action: Shell
     command: ./delete.sh
@@ -39,9 +38,8 @@ resourceGroups:
       configRef: svc.rg
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
     dependsOn:
-    - resourceGroup: service
-      step: rg-ownership
+    - global-output
+    - rg-ownership

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -10,18 +10,25 @@
 $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Global
 rolloutName: Global Resource Rollout
+buildStep:
+  command: make
+  args:
+  - "-C"
+  - "../tooling/secret-sync"
+  - "secret-sync"
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: infra
+  - name: global-infra
     action: ARM
     template: templates/global-infra.bicep
     parameters: configurations/global-infra.tmpl.bicepparam
     deploymentLevel: ResourceGroup
-  - name: onecert-private-kv-issuer
+  - name: global-onecert-private-kv-issuer
     action: SetCertificateIssuer
+    dependsOn:
+    - global-infra
     secretKeyVault:
       configRef: ev2.assistedId.certificate.keyVault
     secretName:
@@ -30,29 +37,26 @@ resourceGroups:
       configRef: ev2.assistedId.applicationId
     vaultBaseUrl:
       input:
-        resourceGroup: global
-        step: infra
         name: globalKeyVaultUrl
+        step: global-infra
     issuer:
       value: OneCertV2-PrivateCA
-  - name: certificates
+  - name: global-certificates
     action: ARM
     template: templates/global-certificates.bicep
     parameters: configurations/global-certificates.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     dependsOn:
-    - resourceGroup: global
-      step: onecert-private-kv-issuer
-  - name: output
+    - global-onecert-private-kv-issuer
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
     dependsOn:
-    - resourceGroup: global
-      step: infra
-  - name: housekeeping
+    - global-infra
+  - name: global-housekeeping
     action: Shell
     command: scripts/global-housekeeping.sh
     dryRun:
@@ -62,19 +66,19 @@ resourceGroups:
     variables:
     - name: GLOBAL_RESOURCE_GROUP
       configRef: global.rg
+    dependsOn:
+    - global-output
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
   - name: grafana-dashboards
     action: Shell
     command: cd ../observability/grafana && ./deploy.sh
     dependsOn:
-    - resourceGroup: global
-      step: housekeeping
-    - resourceGroup: global
-      step: infra
+    - global-housekeeping
+    - global-infra
+    - global-output
     dryRun:
       variables:
       - name: DRY_RUN
@@ -86,8 +90,7 @@ resourceGroups:
       configRef: global.rg
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
   # creates DNS delegation for the ARO HCP global SVC zone
   - name: svcChildZone
@@ -97,8 +100,7 @@ resourceGroups:
     childZone:
       configRef: dns.svcParentZoneName
     dependsOn:
-    - resourceGroup: global
-      step: infra
+    - global-infra
   # creates DNS delegation for the ARO HCP global CX zone
   - name: cxChildZone
     action: DelegateChildZone
@@ -107,17 +109,15 @@ resourceGroups:
     childZone:
       configRef: dns.cxParentZoneName
     dependsOn:
-    - resourceGroup: global
-      step: infra
+    - global-infra
   # create global ARO HCP ACRs for OCP and SVC images
-  - name: acrs
+  - name: global-acrs
     action: ARM
     template: templates/global-acr.bicep
     parameters: configurations/global-acr.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     dependsOn:
-    - resourceGroup: global
-      step: infra
+    - global-infra
   # ingests secrets into the global KV
   - name: decrypt-and-ingest-secrets
     action: SecretSync
@@ -125,11 +125,10 @@ resourceGroups:
     configurationFile: 'data/encryptedsecrets.yaml'
     encryptionKey: 'secretSyncKey'
     dependsOn:
-    - resourceGroup: global
-      step: infra
+    - global-infra
+    - global-output
     identityFrom:
-      resourceGroup: global
-      step: output
+      step: global-output
       name: globalMSIId
   # mirror oc-mirror image
   - name: mirror-oc-mirror-image
@@ -147,14 +146,12 @@ resourceGroups:
     pullSecretName:
       configRef: imageSync.ondemandSync.pullSecretName
     dependsOn:
-    - resourceGroup: global
-      step: acrs
-    - resourceGroup: global
-      step: decrypt-and-ingest-secrets
+    - global-output
+    - global-acrs
+    - decrypt-and-ingest-secrets
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
   # deploys the image mirror for the ACRs
   - name: imagemirror
@@ -163,5 +160,4 @@ resourceGroups:
     parameters: configurations/global-image-sync.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     dependsOn:
-    - resourceGroup: global
-      step: mirror-oc-mirror-image
+    - mirror-oc-mirror-image

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -10,47 +10,44 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Management.Infra
 rolloutName: Management Cluster Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: service
-  resourceGroup: '{{ .svc.rg }}'
+- name: '{{ .svc.rg }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
-  - name: output
+  - name: svc-output
     action: ARM
     template: templates/output-svc.bicep
     parameters: configurations/output-svc.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: regional
-  resourceGroup: '{{ .regionRG }}'
+- name: '{{ .regionRG }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
-  - name: output
+  - name: region-output
     action: ARM
     template: templates/output-region.bicep
     parameters: configurations/output-region.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: management
-  resourceGroup: '{{ .mgmt.rg }}'
+- name: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
   - name: rpRegistration
     action: ProviderFeatureRegistration
     providerConfigRef: mgmt.subscription.providers
     identityFrom:
-      resourceGroup: global
-      step: output
+      step: global-output
       name: globalMSIId
+    dependsOn:
+    - global-output
   - name: mgmt-infra
     action: ARM
     template: templates/mgmt-infra.bicep
@@ -59,30 +56,30 @@ resourceGroups:
     variables:
     - name: clusterServiceMIResourceId
       input:
-        resourceGroup: service
-        step: output
+        step: svc-output
         name: cs
     - name: msiRefresherMIResourceId
       input:
-        resourceGroup: service
-        step: output
+        step: svc-output
         name: msiRefresher
     - name: logAnalyticsWorkspaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: logAnalyticsWorkspaceId
     - name: globalMSIId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
     dependsOn:
-    - resourceGroup: management
-      step: rpRegistration
+    - global-output
+    - region-output
+    - svc-output
+    - rpRegistration
   # Configure certificate issuers for the MC KVs
   - name: cx-oncert-public-kv-issuer
     action: SetCertificateIssuer
+    dependsOn:
+    - mgmt-infra
     secretKeyVault:
       configRef: ev2.assistedId.certificate.keyVault
     secretName:
@@ -91,13 +88,14 @@ resourceGroups:
       configRef: ev2.assistedId.applicationId
     vaultBaseUrl:
       input:
-        resourceGroup: management
-        step: mgmt-infra
         name: cxKeyVaultUrl
+        step: mgmt-infra
     issuer:
       value: OneCertV2-PublicCA
   - name: mgmt-oncert-private-kv-issuer
     action: SetCertificateIssuer
+    dependsOn:
+    - mgmt-infra
     secretKeyVault:
       configRef: ev2.assistedId.certificate.keyVault
     secretName:
@@ -106,13 +104,14 @@ resourceGroups:
       configRef: ev2.assistedId.applicationId
     vaultBaseUrl:
       input:
-        resourceGroup: management
-        step: mgmt-infra
         name: mgmtKeyVaultUrl
+        step: mgmt-infra
     issuer:
       value: OneCertV2-PrivateCA
   - name: mgmt-oncert-public-kv-issuer
     action: SetCertificateIssuer
+    dependsOn:
+    - mgmt-infra
     secretKeyVault:
       configRef: ev2.assistedId.certificate.keyVault
     secretName:
@@ -121,9 +120,8 @@ resourceGroups:
       configRef: ev2.assistedId.applicationId
     vaultBaseUrl:
       input:
-        resourceGroup: management
-        step: mgmt-infra
         name: mgmtKeyVaultUrl
+        step: mgmt-infra
     issuer:
       value: OneCertV2-PublicCA
   # Build the MC
@@ -135,46 +133,38 @@ resourceGroups:
     variables:
     - name: ocpAcrResourceId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: ocpAcrResourceId
     - name: svcAcrResourceId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: svcAcrResourceId
     - name: globalMSIId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
     - name: azureMonitoringWorkspaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: azureMonitoringWorkspaceId
     - name: hcpAzureMonitoringWorkspaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: hcpAzureMonitoringWorkspaceId
     - name: maestroEventGridNamespaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: maestroEventGridNamespaceId
     - name: logAnalyticsWorkspaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: logAnalyticsWorkspaceId
     dependsOn:
-    - resourceGroup: management
-      step: cx-oncert-public-kv-issuer
-    - resourceGroup: management
-      step: mgmt-oncert-private-kv-issuer
-    - resourceGroup: management
-      step: mgmt-oncert-public-kv-issuer
+    - cx-oncert-public-kv-issuer
+    - mgmt-oncert-private-kv-issuer
+    - mgmt-oncert-public-kv-issuer
+    - global-output
+    - region-output
   - name: mgmt-nsp
     action: ARM
     template: templates/mgmt-nsp.bicep
@@ -183,14 +173,11 @@ resourceGroups:
     variables:
     - name: serviceClusterSubscriptionId
       input:
-        resourceGroup: service
-        step: output
+        step: svc-output
         name: subscriptionId
     dependsOn:
-    - resourceGroup: management
-      step: mgmt-cluster
-    - resourceGroup: management
-      step: mgmt-infra
+    - mgmt-cluster
+    - mgmt-infra
   - name: prometheus
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell
@@ -233,12 +220,10 @@ resourceGroups:
     - name: CS_ENVIRONMENT
       configRef: clustersService.environment
     dependsOn:
-    - resourceGroup: management
-      step: mgmt-cluster
+    - mgmt-cluster
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
         # Install ACRpull
   - name: acrpull
@@ -257,12 +242,10 @@ resourceGroups:
     - name: ACRPULL_REGISTRY
       configRef: acrPull.image.registry
     dependsOn:
-    - resourceGroup: management
-      step: prometheus
+    - prometheus
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
         # Install cluster patches
   - name: mgmt-fixes
@@ -277,12 +260,10 @@ resourceGroups:
     - name: APPLY_KUBELET_FIXES
       configRef: mgmt.applyKubeletFixes
     dependsOn:
-    - resourceGroup: management
-      step: mgmt-cluster
+    - mgmt-cluster
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
   - name: arobit
     aksCluster: '{{ .mgmt.aks.name }}'
@@ -338,10 +319,8 @@ resourceGroups:
     - name: GENEVA_ENVIRONMENT
       configRef: geneva.logs.environment
     dependsOn:
-    - resourceGroup: management
-      step: mgmt-cluster
+    - mgmt-cluster
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId

--- a/dev-infrastructure/mgmt-solo-pipeline.yaml
+++ b/dev-infrastructure/mgmt-solo-pipeline.yaml
@@ -2,31 +2,28 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Management.Infra.Solo
 rolloutName: Management Cluster Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: regional
-  resourceGroup: '{{ .regionRG }}'
+- name: '{{ .regionRG }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
-  - name: output
+  - name: region-output
     action: ARM
     template: templates/output-region.bicep
     parameters: configurations/output-region.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: management
-  resourceGroup: '{{ .mgmt.rg }}'
+- name: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
-  - name: infra
+  - name: mgmt-infra
     action: ARM
     template: templates/mgmt-infra.bicep
     parameters: configurations/mgmt-infra.tmpl.bicepparam
@@ -37,8 +34,7 @@ resourceGroups:
       value: "-"
     - name: logAnalyticsWorkspaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: logAnalyticsWorkspaceId
   # Build the MC
   - name: mgmt-cluster
@@ -49,32 +45,28 @@ resourceGroups:
     variables:
     - name: ocpAcrResourceId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: ocpAcrResourceId
     - name: svcAcrResourceId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: svcAcrResourceId
     - name: azureMonitoringWorkspaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: azureMonitoringWorkspaceId
     - name: maestroEventGridNamespaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: maestroEventGridNamespaceId
     - name: logAnalyticsWorkspaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: logAnalyticsWorkspaceId
     dependsOn:
-    - resourceGroup: management
-      step: infra
+    - mgmt-infra
+    - region-output
+    - global-output
   # Install ACRpull
   - name: acrpull
     aksCluster: '{{ .mgmt.aks.name }}'
@@ -92,8 +84,7 @@ resourceGroups:
     - name: ACRPULL_REGISTRY
       configRef: acrPull.image.registry
     dependsOn:
-    - resourceGroup: management
-      step: mgmt-cluster
+    - mgmt-cluster
   # Install cluster patches
   - name: mgmt-fixes
     aksCluster: '{{ .mgmt.aks.name }}'
@@ -107,5 +98,4 @@ resourceGroups:
     - name: APPLY_KUBELET_FIXES
       configRef: mgmt.applyKubeletFixes
     dependsOn:
-    - resourceGroup: management
-      step: mgmt-cluster
+    - mgmt-cluster

--- a/dev-infrastructure/monitoring-pipeline.yaml
+++ b/dev-infrastructure/monitoring-pipeline.yaml
@@ -9,11 +9,10 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Monitoring
 rolloutName: Monitoring Rollout
 resourceGroups:
-- name: regional
-  resourceGroup: '{{ .regionRG }}'
+- name: '{{ .regionRG }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
-  - name: output
+  - name: region-output
     action: ARM
     template: templates/output-region.bicep
     parameters: configurations/output-region.tmpl.bicepparam
@@ -27,11 +26,11 @@ resourceGroups:
     variables:
     - name: azureMonitoringWorkspaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: azureMonitoringWorkspaceId
     - name: hcpAzureMonitoringWorkspaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: hcpAzureMonitoringWorkspaceId
+    dependsOn:
+    - region-output

--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -11,12 +11,11 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Region
 rolloutName: Region Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
   # Query parameters from global deployment, e.g. DNS hzone and ACR resource IDs
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: configurations/output-global.tmpl.bicepparam
@@ -36,9 +35,10 @@ resourceGroups:
       configRef: region
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
+    dependsOn:
+    - global-output
   - name: svc-acr-replication
     action: Shell
     command: scripts/manage-acr-replication.sh
@@ -53,76 +53,23 @@ resourceGroups:
         value: "true"
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-  - name: add-svc-grafana-datasource
-    action: Shell
-    command: scripts/add-grafana-datasource.sh
-    variables:
-    - name: GRAFANA_RESOURCE_ID
-      input:
-        resourceGroup: global
-        step: output
-        name: grafanaResourceId
-    - name: PROM_QUERY_URL
-      input:
-        resourceGroup: regional
-        step: output
-        name: monitorPrometheusQueryEndpoint
-    - name: MONITOR_ID
-      input:
-        resourceGroup: regional
-        step: output
-        name: azureMonitoringWorkspaceId
-    shellIdentity:
-      input:
-        resourceGroup: global
-        step: output
-        name: globalMSIId
-  - name: add-hcp-grafana-datasource
-    action: Shell
-    command: scripts/add-grafana-datasource.sh
-    variables:
-    - name: GRAFANA_RESOURCE_ID
-      input:
-        resourceGroup: global
-        step: output
-        name: grafanaResourceId
-    - name: PROM_QUERY_URL
-      input:
-        resourceGroup: regional
-        step: output
-        name: hcpMonitorPrometheusQueryEndpoint
-    - name: MONITOR_ID
-      input:
-        resourceGroup: regional
-        step: output
-        name: hcpAzureMonitoringWorkspaceId
     dependsOn:
-    - resourceGroup: global
-      step: add-svc-grafana-datasource
-    shellIdentity:
-      input:
-        resourceGroup: global
-        step: output
-        name: globalMSIId
-- name: regional
-  resourceGroup: '{{ .regionRG }}'
+    - global-output
+- name: '{{ .regionRG }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
   - name: rpRegistration
     action: ProviderFeatureRegistration
     providerConfigRef: svc.subscription.providers
     identityFrom:
-      resourceGroup: global
-      step: output
+      step: global-output
       name: globalMSIId
     dependsOn:
-    - resourceGroup: global
-      step: svc-acr-replication
-    - resourceGroup: global
-      step: ocp-acr-replication
+    - global-output
+    - svc-acr-replication
+    - ocp-acr-replication
   - name: region
     action: ARM
     template: templates/region.bicep
@@ -131,33 +78,80 @@ resourceGroups:
     variables:
     - name: globalMSIId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
     - name: cxParentZoneResourceId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: cxParentZoneResourceId
     - name: svcParentZoneResourceId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: svcParentZoneResourceId
     - name: grafanaResourceId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: grafanaResourceId
     dependsOn:
-    - resourceGroup: regional
-      step: rpRegistration
-  - name: output
+    - global-output
+    - rpRegistration
+  - name: region-output
     action: ARM
     template: templates/output-region.bicep
     parameters: configurations/output-region.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
     dependsOn:
-    - resourceGroup: regional
-      step: region
+    - region
+- name: '{{ .global.rg }}'
+  subscription: '{{ .global.subscription.key }}'
+  steps:
+  - name: add-svc-grafana-datasource
+    action: Shell
+    command: scripts/add-grafana-datasource.sh
+    variables:
+    - name: GRAFANA_RESOURCE_ID
+      input:
+        step: global-output
+        name: grafanaResourceId
+    - name: PROM_QUERY_URL
+      input:
+        step: region-output
+        name: monitorPrometheusQueryEndpoint
+    - name: MONITOR_ID
+      input:
+        step: region-output
+        name: azureMonitoringWorkspaceId
+    dependsOn:
+    - region-output
+    - global-output
+    shellIdentity:
+      input:
+        step: global-output
+        name: globalMSIId
+- name: '{{ .global.rg }}'
+  subscription: '{{ .global.subscription.key }}'
+  steps:
+  - name: add-hcp-grafana-datasource
+    action: Shell
+    command: scripts/add-grafana-datasource.sh
+    variables:
+    - name: GRAFANA_RESOURCE_ID
+      input:
+        step: global-output
+        name: grafanaResourceId
+    - name: PROM_QUERY_URL
+      input:
+        step: region-output
+        name: hcpMonitorPrometheusQueryEndpoint
+    - name: MONITOR_ID
+      input:
+        step: region-output
+        name: hcpAzureMonitoringWorkspaceId
+    dependsOn:
+    - add-svc-grafana-datasource
+    - global-output
+    shellIdentity:
+      input:
+        step: global-output
+        name: globalMSIId

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -17,33 +17,30 @@ serviceGroup: Microsoft.Azure.ARO.HCP.Service.Infra
 rolloutName: Service Cluster Rollout
 resourceGroups:
 # Query parameters from global deployment, e.g. ACR resource IDs
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
 # Query parameters from regional deployment, e.g. Azure Monitor workspace ID
-- name: regional
-  resourceGroup: '{{ .regionRG }}'
+- name: '{{ .regionRG }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
-  - name: output
+  - name: region-output
     action: ARM
     template: templates/output-region.bicep
     parameters: configurations/output-region.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: service
-  resourceGroup: '{{ .svc.rg }}'
+- name: '{{ .svc.rg }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
   # Create SVC KV
-  - name: infra
+  - name: svc-infra
     action: ARM
     template: templates/svc-infra.bicep
     parameters: configurations/svc-infra.tmpl.bicepparam
@@ -51,17 +48,20 @@ resourceGroups:
     variables:
     - name: globalMSIId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
     - name: logAnalyticsWorkspaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: logAnalyticsWorkspaceId
+    dependsOn:
+    - global-output
+    - region-output
   # Configure certificate issuers for the SVC KV
   - name: svc-oncert-private-kv-issuer
     action: SetCertificateIssuer
+    dependsOn:
+    - svc-infra
     secretKeyVault:
       configRef: ev2.assistedId.certificate.keyVault
     secretName:
@@ -70,13 +70,14 @@ resourceGroups:
       configRef: ev2.assistedId.applicationId
     vaultBaseUrl:
       input:
-        resourceGroup: service
-        step: infra
         name: svcKeyVaultUrl
+        step: svc-infra
     issuer:
       value: OneCertV2-PrivateCA
   - name: svc-oncert-public-kv-issuer
     action: SetCertificateIssuer
+    dependsOn:
+    - svc-infra
     secretKeyVault:
       configRef: ev2.assistedId.certificate.keyVault
     secretName:
@@ -85,9 +86,8 @@ resourceGroups:
       configRef: ev2.assistedId.applicationId
     vaultBaseUrl:
       input:
-        resourceGroup: service
-        step: infra
         name: svcKeyVaultUrl
+        step: svc-infra
     issuer:
       value: OneCertV2-PublicCA
   # Create SVC cluster
@@ -99,39 +99,33 @@ resourceGroups:
     variables:
     - name: globalMSIId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
     - name: ocpAcrResourceId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: ocpAcrResourceId
     - name: svcAcrResourceId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: svcAcrResourceId
     - name: azureMonitoringWorkspaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: azureMonitoringWorkspaceId
     - name: logAnalyticsWorkspaceId
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: logAnalyticsWorkspaceId
     - name: azureFrontDoorResourceId
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: azureFrontDoorResourceId
     dependsOn:
-    - resourceGroup: service
-      step: svc-oncert-private-kv-issuer
-    - resourceGroup: service
-      step: svc-oncert-public-kv-issuer
+    - svc-oncert-private-kv-issuer
+    - svc-oncert-public-kv-issuer
+    - global-output
+    - region-output
   # Deploy prometheus first since istio depends on it's CRDs
   - name: prometheus
     aksCluster: '{{ .svc.aks.name }}'
@@ -173,12 +167,11 @@ resourceGroups:
     - name: CLUSTER_NAME
       configRef: svc.aks.name
     dependsOn:
-    - resourceGroup: service
-      step: svc
+    - svc
+    - global-output
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
         # configure istio
   - name: istio-config
@@ -193,12 +186,11 @@ resourceGroups:
     - name: ISTIO_VERSIONS
       configRef: svc.istio.versions
     dependsOn:
-    - resourceGroup: service
-      step: prometheus
+    - prometheus
+    - global-output
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
         # - updates workload to use istio on version svc.istio.targetVersion
         # - configures istio IP tag usage
@@ -218,12 +210,11 @@ resourceGroups:
     - name: REGION_RESOURCEGROUP
       configRef: regionRG
     dependsOn:
-    - resourceGroup: service
-      step: istio-config
+    - istio-config
+    - global-output
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
         # Install ACRpull
   - name: acrpull
@@ -242,12 +233,12 @@ resourceGroups:
     - name: ACRPULL_REGISTRY
       configRef: acrPull.image.registry
     dependsOn:
-    - resourceGroup: service
-      step: prometheus
+    - prometheus
+    - svc
+    - global-output
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
   - name: arobit
     aksCluster: '{{ .svc.aks.name }}'
@@ -295,10 +286,9 @@ resourceGroups:
     - name: GENEVA_ENVIRONMENT
       configRef: geneva.logs.environment
     dependsOn:
-    - resourceGroup: service
-      step: svc
+    - svc
+    - global-output
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId

--- a/docs/acrs-and-images.md
+++ b/docs/acrs-and-images.md
@@ -67,8 +67,7 @@ clustersService:
       configRef: imageSync.ondemandSync.pullSecretName
     shellIdentity:
       input:
-          resourceGroup: global
-          step: output
+          step: global-output
           name: globalMSIId
 ```
 

--- a/docs/bicep.md
+++ b/docs/bicep.md
@@ -58,30 +58,28 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Region
 rolloutName: Region Rollout
 resourceGroups:
-- name: regional                                               (1)
-  resourceGroup: {{ .regionRG }}                               (2)
-  subscription: {{ .svc.subscription.key }}                    (3)
+- name: {{ .regionRG }}                                        (1)
+  subscription: {{ .svc.subscription.key }}                        (2)
   steps:
-  - name: region                                               (4)
-    action: ARM                                                (5)
-    template: templates/my-template.bicep                      (6)
-    parameters: configurations/my-template.tmpl.bicepparam     (7)
-    deploymentLevel: ResourceGroup/Subscription                (8)
-    variables:                                                 (9)
+  - name: region                                               (3)
+    action: ARM                                                (4)
+    template: templates/my-template.bicep                      (5)
+    parameters: configurations/my-template.tmpl.bicepparam     (6)
+    deploymentLevel: ResourceGroup/Subscription                (7)
+    variables:                                                 (8)
       ...
-    [outputOnly: true/false]                                   (10)
+    [outputOnly: true/false]                                   (9)
 ```
 
-1. The name of the group, within the pipeline
-2. The name of Azure resourcegroup targeted by this deployment
-3. The name of the Azue Subscription targeted by this deployment. When deploying via EV2, this needs to reference an [EV2 subscription key](https://ev2docs.azure.net/features/service-artifacts/actions/subscriptionProvisioningParameters.html#subscription-key)
-4. The name of the Azure deployment
-5. The action type `ARM` marks this step as ARM/Bicep deployment action
-6. File reference to the Bicep template, relative to the location of the pipeline file
-7. File reference to the Bicep parameter file, relative to the location of the pipeline file. This is a Go template file that will be processed to generate the final parameter file
-8. The deployment level for the Bicep template.
-9. covered in detail in the [Output templates and output chaining](#output-templates-and-output-chaining) section
-10. If `true`, a Bicep step is not allowed to declare any resources and can only provide output by inspecting `existing` resources. See details in the [output templates and output chaining](#output-templates-and-output-chaining) and [dry runs](#dry-runs) sections.
+1. The name of Azure resourcegroup targeted by this deployment
+2. The name of the Azue Subscription targeted by this deployment. When deploying via EV2, this needs to reference an [EV2 subscription key](https://ev2docs.azure.net/features/service-artifacts/actions/subscriptionProvisioningParameters.html#subscription-key)
+3. The name of the Azure deployment
+4. The action type `ARM` marks this step as ARM/Bicep deployment action
+5. File reference to the Bicep template, relative to the location of the pipeline file
+6. File reference to the Bicep parameter file, relative to the location of the pipeline file. This is a Go template file that will be processed to generate the final parameter file
+7. The deployment level for the Bicep template.
+8. covered in detail in the [Output templates and output chaining](#output-templates-and-output-chaining) section
+9. If `true`, a Bicep step is not allowed to declare any resources and can only provide output by inspecting `existing` resources. See details in the [output templates and output chaining](#output-templates-and-output-chaining) and [dry runs](#dry-runs) sections.
 
 ## Cross-Subscription deployments
 
@@ -125,17 +123,15 @@ With this in place we can hook up both bicep templates in a pipeline file.
 ```yaml
 ...
 resourceGroups:
-- name: global
-  resourceGroup: {{ .global.rg }}                                (3)
+- name: {{ .global.rg }}                                         (3)
   subscription: {{ .global.subscription.key }}
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: configurations/output-global.tmpl.bicepparam
     outputOnly: true                                             (4)
-- name: regional
-  resourceGroup: {{ .regionRG }}                                 (5)
+- name: {{ .regionRG }}                                          (5)
   subscription: {{ .svc.subscription.key }}
   steps:
   - name: region
@@ -146,8 +142,7 @@ resourceGroups:
       ...
       - name: svcParentZoneResourceId                            (6)
         input:                                                   (7)
-          resourceGroup: global
-          step: output
+          step: global-output
           name: svcParentZoneResourceId
 ```
 

--- a/frontend/pipeline.yaml
+++ b/frontend/pipeline.yaml
@@ -2,11 +2,10 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.RP.Frontend
 rolloutName: RP Frontend Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../dev-infrastructure/configurations/output-global.tmpl.bicepparam
@@ -28,11 +27,11 @@ resourceGroups:
       configRef: imageSync.ondemandSync.pullSecretName
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-- name: service
-  resourceGroup: '{{ .svc.rg }}'
+    dependsOn:
+    - global-output
+- name: '{{ .svc.rg }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
   - name: deploy
@@ -44,8 +43,8 @@ resourceGroups:
       - name: DRY_RUN
         value: "true"
     dependsOn:
-    - resourceGroup: global
-      step: mirror-image
+    - mirror-image
+    - global-output
     variables:
     - name: ARO_HCP_IMAGE_ACR
       configRef: acr.svc.name
@@ -97,6 +96,5 @@ resourceGroups:
       configRef: frontend.audit.tcpAddress
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId

--- a/hypershiftoperator/pipeline.yaml
+++ b/hypershiftoperator/pipeline.yaml
@@ -2,11 +2,10 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.RP.HypershiftOperator
 rolloutName: RP HypershiftOperator Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../dev-infrastructure/configurations/output-global.tmpl.bicepparam
@@ -28,11 +27,11 @@ resourceGroups:
       configRef: imageSync.ondemandSync.pullSecretName
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-- name: management
-  resourceGroup: '{{ .mgmt.rg }}'
+    dependsOn:
+    - global-output
+- name: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
   - name: deploy
@@ -44,8 +43,8 @@ resourceGroups:
       - name: DRY_RUN
         value: "true"
     dependsOn:
-    - resourceGroup: global
-      step: mirror-image
+    - mirror-image
+    - global-output
     variables:
     - name: ARO_HCP_SVC_ACR
       configRef: acr.svc.name
@@ -65,6 +64,5 @@ resourceGroups:
       configRef: hypershift.additionalInstallArg
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId

--- a/maestro/agent/pipeline.yaml
+++ b/maestro/agent/pipeline.yaml
@@ -2,11 +2,10 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Maestro.Agent
 rolloutName: Maestro Agent Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../../dev-infrastructure/configurations/output-global.tmpl.bicepparam
@@ -28,21 +27,20 @@ resourceGroups:
       configRef: imageSync.ondemandSync.pullSecretName
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-- name: regional
-  resourceGroup: '{{ .regionRG }}'
+    dependsOn:
+    - global-output
+- name: '{{ .regionRG }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
-  - name: output
+  - name: region-output
     action: ARM
     template: ../../dev-infrastructure/templates/output-region.bicep
     parameters: ../../dev-infrastructure/configurations/output-region.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: management
-  resourceGroup: '{{ .mgmt.rg }}'
+- name: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
   - name: deploy
@@ -80,19 +78,16 @@ resourceGroups:
       configRef: acr.svc.name
     - name: EVENTGRID_HOSTNAME
       input:
-        resourceGroup: regional
-        step: output
+        step: region-output
         name: maestroEventGridNamespacesHostname
     dependsOn:
-    - resourceGroup: global
-      step: mirror-image
+    - mirror-image
+    - region-output
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-- name: service
-  resourceGroup: '{{ .svc.rg }}'
+- name: '{{ .svc.rg }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
   - name: register-agent-with-server
@@ -109,10 +104,8 @@ resourceGroups:
     - name: NAMESPACE
       configRef: maestro.server.k8s.namespace
     dependsOn:
-    - resourceGroup: management
-      step: deploy
+    - deploy
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId

--- a/maestro/server/pipeline.yaml
+++ b/maestro/server/pipeline.yaml
@@ -2,11 +2,10 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Maestro.Server
 rolloutName: Maestro Server Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../../dev-infrastructure/configurations/output-global.tmpl.bicepparam
@@ -28,11 +27,11 @@ resourceGroups:
       configRef: imageSync.ondemandSync.pullSecretName
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-- name: regional
-  resourceGroup: '{{ .svc.rg }}'
+    dependsOn:
+    - global-output
+- name: '{{ .svc.rg }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
   - name: deploy
@@ -44,8 +43,7 @@ resourceGroups:
       - name: DRY_RUN
         value: "true"
     dependsOn:
-    - resourceGroup: global
-      step: mirror-image
+    - mirror-image
     variables:
     - name: EVENTGRID_NAME
       configRef: maestro.eventGrid.name
@@ -93,6 +91,5 @@ resourceGroups:
       configRef: maestro.server.tracing.exporter
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId

--- a/observability/prometheus/test-pipeline.yaml
+++ b/observability/prometheus/test-pipeline.yaml
@@ -3,21 +3,19 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Management.Prometheus
 rolloutName: Management Cluster Prometheus Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../../dev-infrastructure/configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: management
-  resourceGroup: '{{ .mgmt.rg }}'
+- name: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
-  - name: deploy
+  - name: deploy mgmt
     action: Shell
     aksCluster: '{{ .mgmt.aks.name }}'
     command: make deploy
@@ -60,14 +58,14 @@ resourceGroups:
       configRef: clustersService.environment
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-- name: service
-  resourceGroup: '{{ .svc.rg  }}'
+    dependsOn:
+    - global-output
+- name: '{{ .svc.rg  }}'
   subscription: '{{ .svc.subscription  }}'
   steps:
-  - name: deploy
+  - name: deploy svc
     action: Shell
     aksCluster: '{{ .svc.aks.name  }}'
     command: make deploy
@@ -110,6 +108,7 @@ resourceGroups:
       configRef: clustersService.environment
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
+    dependsOn:
+    - global-output

--- a/observability/tracing/pipeline.yaml
+++ b/observability/tracing/pipeline.yaml
@@ -2,21 +2,19 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Observability
 rolloutName: Observability Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../../dev-infrastructure/configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: service
-  resourceGroup: '{{ .svc.rg }}'
+- name: '{{ .svc.rg }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
-  - name: deploy
+  - name: deploy svc
     aksCluster: '{{ .svc.aks.name }}'
     action: Shell
     command: make deploy
@@ -26,14 +24,14 @@ resourceGroups:
         value: "true"
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-- name: management
-  resourceGroup: '{{ .mgmt.rg }}'
+    dependsOn:
+    - global-output
+- name: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
-  - name: deploy
+  - name: deploy mgmt
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell
     command: make deploy
@@ -43,6 +41,7 @@ resourceGroups:
         value: "true"
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
+    dependsOn:
+    - global-output

--- a/pko/pipeline.yaml
+++ b/pko/pipeline.yaml
@@ -2,11 +2,10 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.PKO
 rolloutName: RP PKO Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../dev-infrastructure/configurations/output-global.tmpl.bicepparam
@@ -28,9 +27,10 @@ resourceGroups:
       configRef: imageSync.ondemandSync.pullSecretName
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
+    dependsOn:
+    - global-output
   - name: mirror-image-manager
     action: ImageMirror
     targetACR:
@@ -47,9 +47,10 @@ resourceGroups:
       configRef: imageSync.ondemandSync.pullSecretName
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
+    dependsOn:
+    - global-output
   - name: mirror-image-remotephase-manager
     action: ImageMirror
     targetACR:
@@ -66,11 +67,11 @@ resourceGroups:
       configRef: imageSync.ondemandSync.pullSecretName
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-- name: management
-  resourceGroup: '{{ .mgmt.rg }}'
+    dependsOn:
+    - global-output
+- name: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
   - name: deploy
@@ -82,12 +83,9 @@ resourceGroups:
       - name: DRY_RUN
         value: "true"
     dependsOn:
-    - resourceGroup: global
-      step: mirror-image-package
-    - resourceGroup: global
-      step: mirror-image-manager
-    - resourceGroup: global
-      step: mirror-image-remotephase-manager
+    - mirror-image-package
+    - mirror-image-manager
+    - mirror-image-remotephase-manager
     variables:
     - name: ARO_HCP_IMAGE_ACR
       configRef: acr.svc.name
@@ -107,6 +105,5 @@ resourceGroups:
       configRef: mgmt.rg
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId

--- a/route-monitor-operator/pipeline.yaml
+++ b/route-monitor-operator/pipeline.yaml
@@ -2,11 +2,10 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.RouteMonitorOperator
 rolloutName: Route Monitor Operator Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../dev-infrastructure/configurations/output-global.tmpl.bicepparam
@@ -28,9 +27,10 @@ resourceGroups:
       configRef: imageSync.ondemandSync.pullSecretName
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
+    dependsOn:
+    - global-output
   - name: mirror-blackbox-image
     action: ImageMirror
     targetACR:
@@ -47,11 +47,11 @@ resourceGroups:
       configRef: imageSync.ondemandSync.pullSecretName
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-- name: management
-  resourceGroup: '{{ .mgmt.rg }}'
+    dependsOn:
+    - global-output
+- name: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
   - name: deploy
@@ -80,12 +80,10 @@ resourceGroups:
     - name: BLACKBOX_IMAGE_DIGEST
       configRef: routeMonitorOperator.blackboxExporterImage.digest
     dependsOn:
-    - resourceGroup: global
-      step: mirror-operator-image
-    - resourceGroup: global
-      step: mirror-blackbox-image
+    - mirror-operator-image
+    - mirror-blackbox-image
+    - global-output
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId

--- a/secret-sync-controller/pipeline.yaml
+++ b/secret-sync-controller/pipeline.yaml
@@ -2,11 +2,10 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.SecretSyncController
 rolloutName: Secret Sync Controller Rollout
 resourceGroups:
-- name: global
-  resourceGroup: '{{ .global.rg }}'
+- name: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
-  - name: output
+  - name: global-output
     action: ARM
     template: templates/output-global.bicep
     parameters: ./../dev-infrastructure/configurations/output-global.tmpl.bicepparam
@@ -28,11 +27,11 @@ resourceGroups:
       configRef: imageSync.ondemandSync.pullSecretName
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId
-- name: management
-  resourceGroup: '{{ .mgmt.rg }}'
+    dependsOn:
+    - global-output
+- name: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
   - name: deploy
@@ -44,8 +43,8 @@ resourceGroups:
       - name: DRY_RUN
         value: "true"
     dependsOn:
-    - resourceGroup: global
-      step: mirror-image
+    - mirror-image
+    - global-output
     variables:
     - name: ACR_NAME
       configRef: acr.svc.name
@@ -57,6 +56,5 @@ resourceGroups:
       configRef: secretSyncController.providerImage
     shellIdentity:
       input:
-        resourceGroup: global
-        step: output
+        step: global-output
         name: globalMSIId

--- a/tooling/pipeline-documentation/go.mod
+++ b/tooling/pipeline-documentation/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/pipeline-documentation
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b
+	github.com/Azure/ARO-Tools v0.0.0-20250730233107-5c676fd28b18
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1

--- a/tooling/pipeline-documentation/go.sum
+++ b/tooling/pipeline-documentation/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b h1:fGm215++CttdUu6IO9TYY/0wUpfsxcY9u8xze2rJeRo=
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
+github.com/Azure/ARO-Tools v0.0.0-20250730233107-5c676fd28b18 h1:4toZi9R0HucJsJfDa/gZzxx/vomytJR/KqoTFfdaIeA=
+github.com/Azure/ARO-Tools v0.0.0-20250730233107-5c676fd28b18/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dusted-go/logging v1.3.0 h1:SL/EH1Rp27oJQIte+LjWvWACSnYDTqNx5gZULin0XRY=

--- a/tooling/secret-sync/go.mod
+++ b/tooling/secret-sync/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/secret-sync
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b
+	github.com/Azure/ARO-Tools v0.0.0-20250730233107-5c676fd28b18
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1

--- a/tooling/secret-sync/go.sum
+++ b/tooling/secret-sync/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b h1:fGm215++CttdUu6IO9TYY/0wUpfsxcY9u8xze2rJeRo=
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
+github.com/Azure/ARO-Tools v0.0.0-20250730233107-5c676fd28b18 h1:4toZi9R0HucJsJfDa/gZzxx/vomytJR/KqoTFfdaIeA=
+github.com/Azure/ARO-Tools v0.0.0-20250730233107-5c676fd28b18/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1 h1:Wc1ml6QlJs2BHQ/9Bqu1jiyggbsSjramq2oUmp5WeIo=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1/go.mod h1:Ot/6aikWnKWi4l9QB7qVSwa8iMphQNqkWALMoNT3rzM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1 h1:B+blDbyVIG3WaikNxPnhPiJ1MThR03b3vKGtER95TP4=

--- a/tooling/templatize/cmd/pipeline/validate/cmd.go
+++ b/tooling/templatize/cmd/pipeline/validate/cmd.go
@@ -16,9 +16,6 @@ package validate
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -31,17 +28,7 @@ func NewCommand() (*cobra.Command, error) {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := runValidate(cmd.Context(), opts); err != nil {
-				lines := strings.Split(err.Error(), "\n")
-				if len(lines) == 1 {
-					return err
-				}
-				for _, line := range lines {
-					fmt.Println(strings.TrimSpace(line))
-				}
-				return errors.New(lines[0])
-			}
-			return nil
+			return runInspect(cmd.Context(), opts)
 		},
 	}
 	if err := BindValidationOptions(opts, cmd); err != nil {
@@ -50,7 +37,7 @@ func NewCommand() (*cobra.Command, error) {
 	return cmd, nil
 }
 
-func runValidate(ctx context.Context, opts *RawValidationOptions) error {
+func runInspect(ctx context.Context, opts *RawValidationOptions) error {
 	validated, err := opts.Validate()
 	if err != nil {
 		return err

--- a/tooling/templatize/go.mod
+++ b/tooling/templatize/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/templatize
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b
+	github.com/Azure/ARO-Tools v0.0.0-20250730233107-5c676fd28b18
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.2

--- a/tooling/templatize/go.sum
+++ b/tooling/templatize/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b h1:fGm215++CttdUu6IO9TYY/0wUpfsxcY9u8xze2rJeRo=
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
+github.com/Azure/ARO-Tools v0.0.0-20250730233107-5c676fd28b18 h1:4toZi9R0HucJsJfDa/gZzxx/vomytJR/KqoTFfdaIeA=
+github.com/Azure/ARO-Tools v0.0.0-20250730233107-5c676fd28b18/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1 h1:Wc1ml6QlJs2BHQ/9Bqu1jiyggbsSjramq2oUmp5WeIo=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1/go.mod h1:Ot/6aikWnKWi4l9QB7qVSwa8iMphQNqkWALMoNT3rzM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1 h1:B+blDbyVIG3WaikNxPnhPiJ1MThR03b3vKGtER95TP4=

--- a/tooling/templatize/pkg/pipeline/arm.go
+++ b/tooling/templatize/pkg/pipeline/arm.go
@@ -110,7 +110,7 @@ func (a *armClient) waitForExistingDeployment(ctx context.Context, timeOutInSeco
 	return fmt.Errorf("timeout exeeded waiting for deployment %s in rg %s", deploymentName, rgName)
 }
 
-func (a *armClient) runArmStep(ctx context.Context, options *PipelineRunOptions, rgName string, step *types.ARMStep, input Outputs) (Output, error) {
+func (a *armClient) runArmStep(ctx context.Context, options *PipelineRunOptions, rgName string, step *types.ARMStep, input map[string]Output) (Output, error) {
 	// Ensure resourcegroup exists
 	err := a.ensureResourceGroupExists(ctx, rgName, !options.NoPersist)
 	if err != nil {
@@ -207,7 +207,7 @@ func pollAndPrint[T any](ctx context.Context, p *runtime.Poller[T]) error {
 	return nil
 }
 
-func doDryRun(ctx context.Context, client *armresources.DeploymentsClient, rgName string, deploymentName string, step *types.ARMStep, pipelineWorkingDir string, cfg config.Configuration, input Outputs) (Output, error) {
+func doDryRun(ctx context.Context, client *armresources.DeploymentsClient, rgName string, deploymentName string, step *types.ARMStep, pipelineWorkingDir string, cfg config.Configuration, input map[string]Output) (Output, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	inputValues, err := getInputValues(step.Variables, cfg, input)
@@ -281,7 +281,7 @@ func pollAndGetOutput[T any](ctx context.Context, p *runtime.Poller[T]) (ArmOutp
 	return nil, nil
 }
 
-func doWaitForDeployment(ctx context.Context, client *armresources.DeploymentsClient, rgName string, deploymentName string, step *types.ARMStep, pipelineWorkingDir string, cfg config.Configuration, input Outputs) (Output, error) {
+func doWaitForDeployment(ctx context.Context, client *armresources.DeploymentsClient, rgName string, deploymentName string, step *types.ARMStep, pipelineWorkingDir string, cfg config.Configuration, input map[string]Output) (Output, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	inputValues, err := getInputValues(step.Variables, cfg, input)

--- a/tooling/templatize/pkg/pipeline/image_mirror.go
+++ b/tooling/templatize/pkg/pipeline/image_mirror.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-logr/logr"
 )
 
-func runImageMirrorStep(ctx context.Context, step *types.ImageMirrorStep, options *PipelineRunOptions, inputs Outputs, outputWriter io.Writer) error {
+func runImageMirrorStep(ctx context.Context, step *types.ImageMirrorStep, options *PipelineRunOptions, inputs map[string]Output, outputWriter io.Writer) error {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	tmpFile, err := os.CreateTemp("", "")

--- a/tooling/templatize/pkg/pipeline/inspect.go
+++ b/tooling/templatize/pkg/pipeline/inspect.go
@@ -98,8 +98,8 @@ func inspectVars(ctx context.Context, pipeline *types.Pipeline, s types.Step, op
 	return nil
 }
 
-func aquireOutputChainingInputs(ctx context.Context, steps []string, pipeline *types.Pipeline, options *InspectOptions) (Outputs, error) {
-	inputs := make(Outputs)
+func aquireOutputChainingInputs(ctx context.Context, steps []string, pipeline *types.Pipeline, options *InspectOptions) (map[string]Output, error) {
+	inputs := make(map[string]Output)
 	for _, depStep := range steps {
 		runOptions := &PipelineRunOptions{
 			DryRun:                   true,
@@ -114,11 +114,8 @@ func aquireOutputChainingInputs(ctx context.Context, steps []string, pipeline *t
 		if err != nil {
 			return nil, err
 		}
-		for group, values := range outputs {
-			inputs[group] = map[string]Output{}
-			for key, value := range values {
-				inputs[group][key] = value
-			}
+		for key, value := range outputs {
+			inputs[key] = value
 		}
 	}
 	return inputs, nil

--- a/tooling/templatize/pkg/pipeline/shell.go
+++ b/tooling/templatize/pkg/pipeline/shell.go
@@ -54,7 +54,7 @@ func buildBashScript(command string) string {
 	return fmt.Sprintf("set -o errexit -o nounset  -o pipefail\n%s", command)
 }
 
-func runShellStep(s *types.ShellStep, ctx context.Context, kubeconfigFile string, options *PipelineRunOptions, inputs Outputs, outputWriter io.Writer) error {
+func runShellStep(s *types.ShellStep, ctx context.Context, kubeconfigFile string, options *PipelineRunOptions, inputs map[string]Output, outputWriter io.Writer) error {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	// set dryRun config if needed
@@ -162,7 +162,7 @@ func runRegistrationStep(s *types.ProviderFeatureRegistrationStep, ctx context.C
 	return completed.Register(ctx)
 }
 
-func mapStepVariables(vars []types.Variable, cfg config.Configuration, inputs Outputs) (map[string]string, error) {
+func mapStepVariables(vars []types.Variable, cfg config.Configuration, inputs map[string]Output) (map[string]string, error) {
 	values, err := getInputValues(vars, cfg, inputs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get input values: %w", err)

--- a/tooling/templatize/pkg/pipeline/shell_test.go
+++ b/tooling/templatize/pkg/pipeline/shell_test.go
@@ -115,7 +115,7 @@ func TestCreateCommand(t *testing.T) {
 			if tc.dryRun {
 				dryRun = &tc.step.DryRun
 			}
-			dryRunVars, err := mapStepVariables(tc.step.DryRun.Variables, tc.configuration, Outputs{})
+			dryRunVars, err := mapStepVariables(tc.step.DryRun.Variables, tc.configuration, map[string]Output{})
 			assert.NoError(t, err)
 			maps.Copy(tc.envVars, dryRunVars)
 
@@ -136,7 +136,7 @@ func TestMapStepVariables(t *testing.T) {
 	testCases := []struct {
 		name     string
 		cfg      config.Configuration
-		input    Outputs
+		input    map[string]Output
 		step     *types.ShellStep
 		expected map[string]string
 		err      string
@@ -220,22 +220,17 @@ func TestMapStepVariables(t *testing.T) {
 						Value: types.Value{
 							Input: &types.Input{
 								Name: "output1",
-								StepDependency: types.StepDependency{
-									ResourceGroup: "rg",
-									Step:          "step1",
-								},
+								Step: "step1",
 							},
 						},
 					},
 				},
 			},
-			input: Outputs{
-				"rg": map[string]Output{
-					"step1": ArmOutput{
-						"output1": map[string]any{
-							"type":  "String",
-							"value": "bar",
-						},
+			input: map[string]Output{
+				"step1": ArmOutput{
+					"output1": map[string]any{
+						"type":  "String",
+						"value": "bar",
 					},
 				},
 			},
@@ -253,10 +248,7 @@ func TestMapStepVariables(t *testing.T) {
 						Value: types.Value{
 							Input: &types.Input{
 								Name: "output1",
-								StepDependency: types.StepDependency{
-									ResourceGroup: "rg",
-									Step:          "step1",
-								},
+								Step: "step1",
 							},
 						},
 					},
@@ -274,22 +266,17 @@ func TestMapStepVariables(t *testing.T) {
 						Value: types.Value{
 							Input: &types.Input{
 								Name: "output1",
-								StepDependency: types.StepDependency{
-									ResourceGroup: "rg",
-									Step:          "step1",
-								},
+								Step: "step1",
 							},
 						},
 					},
 				},
 			},
-			input: Outputs{
-				"rg": map[string]Output{
-					"step1": ArmOutput{
-						"anotheroutput": map[string]any{
-							"type":  "String",
-							"value": "bar",
-						},
+			input: map[string]Output{
+				"step1": ArmOutput{
+					"anotheroutput": map[string]any{
+						"type":  "String",
+						"value": "bar",
 					},
 				},
 			},
@@ -352,7 +339,7 @@ func TestRunShellStep(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := runShellStep(tc.step, context.Background(), "", &PipelineRunOptions{}, Outputs{}, &buf)
+			err := runShellStep(tc.step, context.Background(), "", &PipelineRunOptions{}, map[string]Output{}, &buf)
 			if tc.err != "" {
 				assert.ErrorContains(t, err, tc.err)
 			} else {
@@ -368,7 +355,7 @@ func TestRunShellStepCaptureOutput(t *testing.T) {
 	}
 	var buf bytes.Buffer
 
-	err := runShellStep(step, context.Background(), "", &PipelineRunOptions{}, Outputs{}, &buf)
+	err := runShellStep(step, context.Background(), "", &PipelineRunOptions{}, map[string]Output{}, &buf)
 	assert.NoError(t, err)
 	assert.Equal(t, buf.String(), "hallo\n")
 }

--- a/tooling/templatize/testdata/e2eArmDeploy.yaml
+++ b/tooling/templatize/testdata/e2eArmDeploy.yaml
@@ -1,8 +1,7 @@
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-- name: rg
-  resourceGroup: '{{ .rg }}'
+- name: '{{ .rg }}'
   subscription: '{{ .subscription }}'
   steps:
   - name: test

--- a/tooling/templatize/testdata/e2eArmDeploySubscriptionScope.yaml
+++ b/tooling/templatize/testdata/e2eArmDeploySubscriptionScope.yaml
@@ -1,8 +1,7 @@
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-- name: rg
-  resourceGroup: '{{ .rg }}'
+- name: '{{ .rg }}'
   subscription: '{{ .subscription }}'
   steps:
   - name: parameterA

--- a/tooling/templatize/testdata/e2eArmDeployWithOutput.yaml
+++ b/tooling/templatize/testdata/e2eArmDeployWithOutput.yaml
@@ -1,8 +1,7 @@
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-- name: rg
-  resourceGroup: '{{ .rg }}'
+- name: '{{ .rg }}'
   subscription: '{{ .subscription }}'
   steps:
   - name: createZone
@@ -18,6 +17,5 @@ resourceGroups:
     variables:
     - name: zoneName
       input:
-        resourceGroup: rg
         name: zoneName
         step: createZone

--- a/tooling/templatize/testdata/e2eArmDeployWithOutputRGOverlap.yaml
+++ b/tooling/templatize/testdata/e2eArmDeployWithOutputRGOverlap.yaml
@@ -1,8 +1,7 @@
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-- name: rg
-  resourceGroup: '{{ .rg }}'
+- name: '{{ .rg }}'
   subscription: '{{ .subscription }}'
   steps:
   - name: parameterA
@@ -10,8 +9,7 @@ resourceGroups:
     template: testa.bicep
     parameters: testa.bicepparm
     deploymentLevel: ResourceGroup
-- name: rg-2
-  resourceGroup: '{{ .rg }}-2'
+- name: '{{ .rg }}-2'
   subscription: '{{ .subscription }}'
   steps:
   - name: readInput
@@ -22,6 +20,5 @@ resourceGroups:
     variables:
     - name: end
       input:
-        resourceGroup: rg
         name: parameterA
         step: parameterA

--- a/tooling/templatize/testdata/e2eArmDeployWithOutputToArm.yaml
+++ b/tooling/templatize/testdata/e2eArmDeployWithOutputToArm.yaml
@@ -1,8 +1,7 @@
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-- name: rg
-  resourceGroup: '{{ .rg }}'
+- name: '{{ .rg }}'
   subscription: '{{ .subscription }}'
   steps:
   - name: stepA
@@ -15,7 +14,6 @@ resourceGroups:
     variables:
     - name: parameterB
       input:
-        resourceGroup: rg
         name: parameterA
         step: stepA
     template: testb.bicep
@@ -29,6 +27,5 @@ resourceGroups:
     variables:
     - name: end
       input:
-        resourceGroup: rg
         name: parameterC
         step: stepB

--- a/tooling/templatize/testdata/e2eArmDeployWithStaticVariable.yaml
+++ b/tooling/templatize/testdata/e2eArmDeployWithStaticVariable.yaml
@@ -1,8 +1,7 @@
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-- name: rg
-  resourceGroup: '{{ .rg }}'
+- name: '{{ .rg }}'
   subscription: '{{ .subscription }}'
   steps:
   - name: createZone
@@ -21,6 +20,5 @@ resourceGroups:
     variables:
     - name: zoneName
       input:
-        resourceGroup: rg
         name: zoneName
         step: createZone

--- a/tooling/templatize/testdata/e2eDryRun.yaml
+++ b/tooling/templatize/testdata/e2eDryRun.yaml
@@ -1,8 +1,7 @@
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-- name: rg
-  resourceGroup: '{{ .rg }}'
+- name: '{{ .rg }}'
   subscription: '{{ .subscription }}'
   steps:
   - name: output

--- a/tooling/templatize/testdata/e2eKubernetes.yaml
+++ b/tooling/templatize/testdata/e2eKubernetes.yaml
@@ -1,8 +1,7 @@
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-- name: rg
-  resourceGroup: '{{ .rg }}'
+- name: '{{ .rg }}'
   subscription: '{{ .subscription }}'
   steps:
   - name: test
@@ -10,4 +9,4 @@ resourceGroups:
     aksCluster: dev-westus3-svc-1
     command: kubectl get namespaces
     shellIdentity:
-      value: "test"
+      Value: "test"

--- a/tooling/templatize/testdata/e2eMake.yaml
+++ b/tooling/templatize/testdata/e2eMake.yaml
@@ -2,15 +2,14 @@ $schema: pipeline.schema.v1
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-- name: rg
-  resourceGroup: '{{ .rg }}'
+- name: '{{ .rg }}'
   subscription: '{{ .subscription }}'
   steps:
   - name: test
     action: Shell
     command: make test
     shellIdentity:
-      value: "test"
+      Value: "test"
     variables:
     - name: TEST_ENV
       configRef: test_env

--- a/tooling/templatize/testdata/e2eOutputOnly.yaml
+++ b/tooling/templatize/testdata/e2eOutputOnly.yaml
@@ -1,8 +1,7 @@
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-- name: rg
-  resourceGroup: '{{ .rg }}'
+- name: '{{ .rg }}'
   subscription: '{{ .subscription }}'
   steps:
   - name: parameterA
@@ -15,11 +14,10 @@ resourceGroups:
     action: Shell
     command: echo ${end} > env.txt
     shellIdentity:
-      value: "test"
+      Value: "test"
     variables:
     - name: end
       input:
-        resourceGroup: rg
         name: parameterA
         step: parameterA
     dryRun:

--- a/tooling/templatize/testdata/e2eShell.yaml
+++ b/tooling/templatize/testdata/e2eShell.yaml
@@ -1,12 +1,11 @@
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-- name: rg
-  resourceGroup: '{{ .rg }}'
+- name: '{{ .rg }}'
   subscription: '{{ .subscription }}'
   steps:
   - name: readInput
     action: Shell
     command: /bin/echo ${PWD} > env.txt
     shellIdentity:
-      value: "test"
+      Value: "test"

--- a/tooling/templatize/testdata/pipeline.yaml
+++ b/tooling/templatize/testdata/pipeline.yaml
@@ -2,8 +2,7 @@ $schema: pipeline.schema.v1
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-- name: regional
-  resourceGroup: '{{ .regionRG }}'
+- name: '{{ .regionRG }}'
   subscription: '{{ .serviceClusterSubscription }}'
   steps:
   - name: deploy
@@ -46,8 +45,7 @@ resourceGroups:
     childZone:
       configRef: childZone
     dependsOn:
-    - resourceGroup: regional
-      step: deploy
+    - deploy
   - name: issuerTest
     action: SetCertificateIssuer
     vaultBaseUrl:
@@ -55,17 +53,17 @@ resourceGroups:
     issuer:
       configRef: provider
     dependsOn:
-    - resourceGroup: regional
-      step: deploy
+    - deploy
   - name: issuerTestOutputChaining
     action: SetCertificateIssuer
     vaultBaseUrl:
       input:
-        resourceGroup: regional
         name: kvUrl
         step: deploy
     issuer:
       value: provider
+    dependsOn:
+    - deploy
   - name: cert
     action: CreateCertificate
     vaultBaseUrl:

--- a/tooling/templatize/testdata/zz_fixture_TestRawOptions.yaml
+++ b/tooling/templatize/testdata/zz_fixture_TestRawOptions.yaml
@@ -2,8 +2,7 @@ $schema: pipeline.schema.v1
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-- name: regional
-  resourceGroup: 'hcp-underlay-uksouth-dev'
+- name: 'hcp-underlay-uksouth-dev'
   subscription: 'hcp-uksouth'
   steps:
   - name: deploy
@@ -41,8 +40,7 @@ resourceGroups:
     childZone:
       configRef: childZone
     dependsOn:
-    - resourceGroup: regional
-      step: deploy
+    - deploy
   - name: issuerTest
     action: SetCertificateIssuer
     vaultBaseUrl:
@@ -50,17 +48,17 @@ resourceGroups:
     issuer:
       configRef: provider
     dependsOn:
-    - resourceGroup: regional
-      step: deploy
+    - deploy
   - name: issuerTestOutputChaining
     action: SetCertificateIssuer
     vaultBaseUrl:
       input:
-        resourceGroup: regional
         name: kvUrl
         step: deploy
     issuer:
       value: provider
+    dependsOn:
+    - deploy
   - name: cert
     action: CreateCertificate
     vaultBaseUrl:

--- a/tooling/yamlwrap/go.mod
+++ b/tooling/yamlwrap/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/yamlwrap
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b
+	github.com/Azure/ARO-Tools v0.0.0-20250730233107-5c676fd28b18
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1

--- a/tooling/yamlwrap/go.sum
+++ b/tooling/yamlwrap/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b h1:fGm215++CttdUu6IO9TYY/0wUpfsxcY9u8xze2rJeRo=
-github.com/Azure/ARO-Tools v0.0.0-20250806205506-91ac55d5960b/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
+github.com/Azure/ARO-Tools v0.0.0-20250730233107-5c676fd28b18 h1:4toZi9R0HucJsJfDa/gZzxx/vomytJR/KqoTFfdaIeA=
+github.com/Azure/ARO-Tools v0.0.0-20250730233107-5c676fd28b18/go.mod h1:6H7dEAGxb1c/tJqGl8JI32whg/rtLmV1wHoBNAfhv70=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
Reverts Azure/ARO-HCP#2398

@stevekuznetsov need to revert this as sdp-pipelines is not ready for this yet

```
make -C hcp/ update
echo "ARO_HCP_REPO_REVISION=0944f1532c3a" > Revision.mk
cd ../tooling/ && go build -o aro ./cmd
# go.goms.io/aro/sdp-pipelines/tooling/pkg/types/pipeline
pkg/types/pipeline/feature_registration.go:177:15: cannot use f.DependsOn (variable of type []"github.com/Azure/ARO-Tools/pkg/types".StepDependency) as []string value in struct literal
pkg/types/pipeline/step.go:61:15: cannot use step.DependsOn (variable of type []"github.com/Azure/ARO-Tools/pkg/types".StepDependency) as []string value in struct literal
make: *** [../tooling/aro] Error 1
```