### PR TITLE
e2e: Remove "openshift-v" version prefix

### DIFF
--- a/test/e2e/cluster_create_missing_info.go
+++ b/test/e2e/cluster_create_missing_info.go
@@ -32,7 +32,7 @@ var _ = Describe("Customer", func() {
 	})
 
 	for _, version := range []string{
-		"openshift-v4.18.1",
+		"4.18.1",
 		// TODO add other disabled versions here.
 	} {
 		It("should not be able to create a "+version+" HCP cluster",


### PR DESCRIPTION
Followup to https://github.com/Azure/ARO-HCP/pull/2408

The `openshift-v` prefix is no longer accepted by the frontend.