### PR TITLE
tooling/templatize: honor dependencies during step execution

### DIFF
--- a/tooling/templatize/cmd/pipeline/run/options.go
+++ b/tooling/templatize/cmd/pipeline/run/options.go
@@ -113,6 +113,6 @@ func (o *RunOptions) RunPipeline(ctx context.Context) error {
 		NoPersist:                o.NoPersist,
 		DeploymentTimeoutSeconds: o.DeploymentTimeoutSeconds,
 		PipelineFilePath:         o.PipelineOptions.PipelineFilePath,
-	})
+	}, pipeline.RunStep)
 	return err
 }

--- a/tooling/templatize/internal/end2end/e2e_test.go
+++ b/tooling/templatize/internal/end2end/e2e_test.go
@@ -23,6 +23,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+	"github.com/spf13/cobra"
 
 	"github.com/stretchr/testify/assert"
 
@@ -37,6 +40,11 @@ func persistAndRun(t *testing.T, e2eImpl E2E) {
 
 	cmd, err := run.NewCommand()
 	assert.NoError(t, err)
+
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		cmd.SetContext(logr.NewContext(cmd.Context(), testr.New(t)))
+		return nil
+	}
 
 	err = cmd.Execute()
 	assert.NoError(t, err)

--- a/tooling/templatize/pkg/pipeline/inspect.go
+++ b/tooling/templatize/pkg/pipeline/inspect.go
@@ -110,7 +110,7 @@ func aquireOutputChainingInputs(ctx context.Context, steps []string, pipeline *t
 			NoPersist:                true,
 			DeploymentTimeoutSeconds: 60,
 		}
-		outputs, err := RunPipeline(pipeline, ctx, runOptions)
+		outputs, err := RunPipeline(pipeline, ctx, runOptions, RunStep)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Previously, we were doing a naive in-order traversal of the resource groups and steps, which led some piplines to be written in very convoluted ways so as to make sure that this implementation detail did not interfere with execution and input/output chaining.

We now build a graph of steps that need to execute, and traverse them in a depth-first manner. We will be able to add parallelism to this as well, but I did not have time to make that happen right now.
