### PR TITLE
oidc storage account PLS location  config

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1822,6 +1822,10 @@
             "public": {
               "type": "boolean",
               "description": "Whether the storage account is public or private. If private, it can only be accessed via Azure Front Door"
+            },
+            "privateLinkLocation": {
+              "type": "string",
+              "description": "The location of the storage account private link. Not every region supports private links so we need to be able to override the default location."
             }
           },
           "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -579,6 +579,7 @@ defaults:
       name: "arohcp{{ .ctx.environment }}oidc{{ .ctx.regionShort }}" # [globally-unique]
       zoneRedundantMode: Auto
       public: false
+      privateLinkLocation: "{{ .ctx.region }}"
     frontdoor:
       subdomain: oic
       name: arohcp{{ .ctx.environment }}

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 9c7de4f0203bd25d38d805b25caca10ab443c94ee6939875def41216543c7d43
+          westus3: 780018c29ad3d411ee2b6b87e88589a28f37e9b79b734d104134606471ea3921
       dev:
         regions:
-          westus3: 0f9170283b1c87b0379430ccb362dc1c7892bbde2e61bb64e5fc79dbe4530b3d
+          westus3: f7776ff06d85904a694632be7d2f00435721043c8a8f525ddb052831791057ff
       ntly:
         regions:
-          uksouth: d89e7c153e92dcb2722acf88762eb5a4a56f5058516e94d7b4ea5d2634a27ca2
+          uksouth: e7a511f4efa562a0e1966a5ba7993713d8284911723b25c97b6f46839384a3b7
       perf:
         regions:
-          westus3: 73da2c6286daa06c953befaceec00c4c4ff3fe210dae4dedb09763fbd0c0092a
+          westus3: 7e04065e9eb5528a627baaa690036a8a5f702b7b6bdf20a091318ff82b22ede1
       pers:
         regions:
-          westus3: 16615792370785e35af6b4bfa37a01961f1e7254822e185711649b3106c648a6
+          westus3: 2c02d7ebcc621a4dd4f61ed8b311f7236a14b1572b5f6e4275b0835cce7ab1af
       swft:
         regions:
-          uksouth: bf31b18c20dc0c5968046a3f94fa8860bf5963c605bf5c885efe28ef152ca370
+          uksouth: 11668f63ba04793d7216f25f1f69c0767dab4599e42cff5e880aec81c2b9405c

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -484,6 +484,7 @@ oidc:
     useManagedCertificates: true
   storageAccount:
     name: arohcpcsproidcusw3
+    privateLinkLocation: westus3
     public: true
     zoneRedundantMode: Auto
 pko:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -484,6 +484,7 @@ oidc:
     useManagedCertificates: true
   storageAccount:
     name: arohcpdevoidcusw3
+    privateLinkLocation: westus3
     public: true
     zoneRedundantMode: Auto
 pko:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -484,6 +484,7 @@ oidc:
     useManagedCertificates: true
   storageAccount:
     name: arohcpntlyoidcln
+    privateLinkLocation: uksouth
     public: true
     zoneRedundantMode: Auto
 pko:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -484,6 +484,7 @@ oidc:
     useManagedCertificates: true
   storageAccount:
     name: arohcpperfoidcusw3ptest
+    privateLinkLocation: westus3
     public: true
     zoneRedundantMode: Auto
 pko:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -486,6 +486,7 @@ oidc:
     useManagedCertificates: true
   storageAccount:
     name: arohcppersoidcusw3test
+    privateLinkLocation: westus3
     public: true
     zoneRedundantMode: Auto
 pko:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -486,6 +486,7 @@ oidc:
     useManagedCertificates: true
   storageAccount:
     name: arohcpswftoidclnstest
+    privateLinkLocation: uksouth
     public: true
     zoneRedundantMode: Auto
 pko:

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -83,6 +83,7 @@ param svcAcrResourceId = '__svcAcrResourceId__'
 
 // OIDC
 param oidcStorageAccountName = '{{ .oidc.storageAccount.name }}'
+param oidcStoragePrivateLinkLocation = '{{ .oidc.storageAccount.privateLinkLocation }}'
 param oidcZoneRedundantMode = '{{ .oidc.storageAccount.zoneRedundantMode }}'
 param oidcStorageAccountPublic = {{ .oidc.storageAccount.public }}
 param azureFrontDoorResourceId = '__azureFrontDoorResourceId__'

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -221,6 +221,9 @@ param serviceKeyVaultResourceGroup string = resourceGroup().name
 @description('OIDC Storage Account name')
 param oidcStorageAccountName string
 
+@description('The location of the OIDC storage account private link')
+param oidcStoragePrivateLinkLocation string
+
 @description('Whether the OIDC storage account is public or private. If private, it can only be accessed via Azure Front Door')
 param oidcStorageAccountPublic bool
 
@@ -656,7 +659,7 @@ module oidc '../modules/oidc/region/main.bicep' = {
     routeName: azureFrontDoorRegionalSubdomain
     originGroupName: azureFrontDoorRegionalSubdomain
     originName: azureFrontDoorRegionalSubdomain
-    privateLinkLocation: location
+    privateLinkLocation: oidcStoragePrivateLinkLocation
     storageAccountAccessPrincipalId: csManagedIdentityPrincipalId
     skuName: determineZoneRedundancy(locationAvailabilityZoneList, oidcZoneRedundantMode)
       ? 'Standard_ZRS'


### PR DESCRIPTION
### What

for AFD the oidc storage accounts creates a PLS in the same region as the storage account. but not every region supports this so we need a way to override.

the global defaults will still default to the same region

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
