### PR TITLE
update the actual error message we get for no version

### DIFF
--- a/test/e2e/cluster_create_missing_info.go
+++ b/test/e2e/cluster_create_missing_info.go
@@ -88,7 +88,7 @@ var _ = Describe("Customer", func() {
 					45*time.Minute,
 				)
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(MatchRegexp("Version .* is disabled")))
+				Expect(err).To(MatchError(MatchRegexp("Version .* doesn't exist")))
 			},
 		)
 	}


### PR DESCRIPTION
Fixes the 

>            "message": "{\r\n  \"error\": {\r\n    \"code\": \"InvalidRequestContent\",\r\n    \"message\": \"Version 'openshift-v4.18.0' doesn't exist\"\r\n  }\r\n}"

error from CI in this run https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel/1954815110463623168