### PR TITLE
trim cert CN to 64 chars to align with rfc 5280

### DIFF
--- a/dev-infrastructure/modules/keyvault/key-vault-cert-with-access.bicep
+++ b/dev-infrastructure/modules/keyvault/key-vault-cert-with-access.bicep
@@ -36,12 +36,14 @@ param certificateAccessManagedIdentityPrincipalId string
 //
 
 var fqdn = '${hostName}.${certDomain}'
+// // RFC 5280 requires that the common name be <= 64 characters.
+var cn = length(fqdn) > 64 ? substring(fqdn, max(0, length(fqdn) - 64), 64) : fqdn
 
 module clientCertificate 'key-vault-cert.bicep' = {
   name: '${hostName}-cert'
   params: {
     keyVaultName: keyVaultName
-    subjectName: 'CN=${fqdn}'
+    subjectName: 'CN=${cn}'
     certName: keyVaultCertificateName
     keyVaultManagedIdentityId: kvCertOfficerManagedIdentityResourceId
     dnsNames: [

--- a/dev-infrastructure/scripts/key-vault-cert.ps1
+++ b/dev-infrastructure/scripts/key-vault-cert.ps1
@@ -38,6 +38,14 @@ try
 
         Write-Output $DNSNamesArray
 
+        # RFC 5280 requires that the common name be <= 64 characters
+        if ($SubjectName -match '^CN=(.+)$') {
+            $cn = $matches[1]
+            if ($cn.Length -gt 64) {
+                throw "CN length violates RFC 5280, it must be less than or equal to 64 characters."
+            }
+        }
+
         $PolicyParams = @{
             RenewAtPercentageLifetime = $RenewAtPercentageLifetime
             SecretContentType         = $SecretContentType


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/ARO-20399

### What

trim certificate CN to 64 characters to align with RFC 5280 

### Why

OneCert will not issue certificates with CN greater than 64 characters.

### Special notes for your reviewer

<!-- optional -->
