### PR TITLE
feat: update CS image to include etcd data encryption with cmk in dev…

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -697,7 +697,7 @@ clouds:
       clustersService:
         environment: "arohcpdev"
         image:
-          digest: sha256:9e42358ccc59e25eec67f893961183e6b77f70ff3ec0bddb1b2b80411b7944d3
+          digest: sha256:551377f1f37f26e92ef0d4b1228fa42650f78b2cd3194b52ffaf480cd0796dda
         # NOTE: The role names must not include commas(,) in the name as the roleNames field
         # here is a comma separated list of role definition names.
         azureOperatorsManagedIdentities:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: db8a59ad1e5ba7252bd1aedca0606fc842b276fe995e97ba19efe5f05b6655ae
+          westus3: 22fbe4f5d4c4f4117a790a2dc633a32b58ef103e8cce582b3873da03c9087203
       dev:
         regions:
-          westus3: 60877ff5490734c8fb9ef278856a891fe248e77c9cf72c012c52e3d5fe6bd758
+          westus3: 8702c217fd0013f0736264e9a3a4b928bb1025bf669f612814a21bc829732937
       ntly:
         regions:
-          uksouth: 1a7535ad61d5d73e82bdfa02fe1146ec936abda5bec4b009a219313fad8e80ae
+          uksouth: 80b1895b4a565919eb709a8228e53f99275f4fbf6c51b0821663c4bd734feff6
       perf:
         regions:
-          westus3: 3de41cd540c50e070071609a24fe2288a241ad323d19c39cd7c111e04f8eb473
+          westus3: f09d2e4b40ea4843b1835fa7dc502ec98dc7703cc6519c68459589b52a1ca7f8
       pers:
         regions:
-          westus3: b0278b1cdd4f41fb15f7e9fb2ad333812edf10a60868019c47cfcd289d604f7f
+          westus3: 47784d3a6b4b03300420d412585731dc2b03b7a02e5d7c5ceff4601c58b904b3
       swft:
         regions:
-          uksouth: 951a7c1199a228b47deaf0721cdb1d8818abd1f760179263514b2f1c193ecfcb
+          uksouth: 2c205fe6dfff150e5174330fdafb90e7a4693ce3c21bb40800245b64f5020b8f

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -104,7 +104,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:9e42358ccc59e25eec67f893961183e6b77f70ff3ec0bddb1b2b80411b7944d3
+    digest: sha256:551377f1f37f26e92ef0d4b1228fa42650f78b2cd3194b52ffaf480cd0796dda
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -104,7 +104,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:9e42358ccc59e25eec67f893961183e6b77f70ff3ec0bddb1b2b80411b7944d3
+    digest: sha256:551377f1f37f26e92ef0d4b1228fa42650f78b2cd3194b52ffaf480cd0796dda
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -104,7 +104,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:9e42358ccc59e25eec67f893961183e6b77f70ff3ec0bddb1b2b80411b7944d3
+    digest: sha256:551377f1f37f26e92ef0d4b1228fa42650f78b2cd3194b52ffaf480cd0796dda
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -104,7 +104,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:9e42358ccc59e25eec67f893961183e6b77f70ff3ec0bddb1b2b80411b7944d3
+    digest: sha256:551377f1f37f26e92ef0d4b1228fa42650f78b2cd3194b52ffaf480cd0796dda
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -104,7 +104,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:9e42358ccc59e25eec67f893961183e6b77f70ff3ec0bddb1b2b80411b7944d3
+    digest: sha256:551377f1f37f26e92ef0d4b1228fa42650f78b2cd3194b52ffaf480cd0796dda
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -104,7 +104,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:9e42358ccc59e25eec67f893961183e6b77f70ff3ec0bddb1b2b80411b7944d3
+    digest: sha256:551377f1f37f26e92ef0d4b1228fa42650f78b2cd3194b52ffaf480cd0796dda
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:


### PR DESCRIPTION
We update the CS image to introduce the functionality that now requires creating ARO-HCP Clusters with etcd data encryption enabled with customer managed keys.

The sha 551377f1f37f26e92ef0d4b1228fa42650f78b2cd3194b52ffaf480cd0796dda corresponds to the CS git commit a196446