### PR TITLE
Initial ai code assistant context files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ tooling/bin
 **/charts/*.tgz
 /vendor/
 **/*.sha256
+CLAUDE.local.md
+.claude/*.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+This project is the main repo for Red Hat OpenShift on Azure (ARO) in the Hosted Control Planes architecture.
+
+It has a multi-layered build and deploy system because it supports multiple target environments with different deployment solutions:
+- personal dev envs can be set up with `make` and a properly-configured `az` command
+- shared/integrated dev envs use github actions
+- production systems use Microsoft ADO and EV2
+More info:
+- [Tenants and Environments](docs/environments.md)
+- [Deployment via EV2](docs/ev2-deployment.md)
+- [Setting up a Personal DEV Env](docs/personal-dev.md)
+
+Related projects:
+- There's also a helper repo at github.com/Azure/ARO-Tools you can propose changes to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -1,0 +1,10 @@
+Docs on how these configs work:
+- docs/configuration.md
+- docs/bicep.md if you're editing bicep files
+
+When making changes to `configs/config*.yaml` you might need to update the appropriate schema files.
+
+After updating configs, verify and render new config by running:
+- `cd dev-infrastructure; ./create-config.sh dev`
+- `cd config; make materialize`
+These might result in changes to rendered configs which must be attached to any PRs.

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/config/GEMINI.md
+++ b/config/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Add initial ai cli tool hint files for with claude and gemini-specific symlinks.

### Why

When Service Lifecycle team gets asked to assist with some pipeline change, the response should be "please tell claude/gemini to do it" with the expectation that there's a good chance that'll actually work.

And the way to achieving that is by sprinkling well-crafted context files around the project, so that common tasks become obvious to the tools. This is step 1 to doing that.

### Special notes for your reviewer

<!-- optional -->
