### PR TITLE
unconstrain global pipeline step

### DIFF
--- a/acm/pipeline.yaml
+++ b/acm/pipeline.yaml
@@ -5,11 +5,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/backend/pipeline.yaml
+++ b/backend/pipeline.yaml
@@ -5,11 +5,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -5,11 +5,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -14,11 +14,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: infra
     action: ARM

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -13,11 +13,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/dev-infrastructure/mgmt-solo-pipeline.yaml
+++ b/dev-infrastructure/mgmt-solo-pipeline.yaml
@@ -5,11 +5,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -14,11 +14,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   # Query parameters from global deployment, e.g. DNS hzone and ACR resource IDs
   - name: output

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -20,11 +20,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/frontend/pipeline.yaml
+++ b/frontend/pipeline.yaml
@@ -5,11 +5,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/hypershiftoperator/pipeline.yaml
+++ b/hypershiftoperator/pipeline.yaml
@@ -5,11 +5,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/maestro/agent/pipeline.yaml
+++ b/maestro/agent/pipeline.yaml
@@ -5,11 +5,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/maestro/server/pipeline.yaml
+++ b/maestro/server/pipeline.yaml
@@ -5,11 +5,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/observability/prometheus/test-pipeline.yaml
+++ b/observability/prometheus/test-pipeline.yaml
@@ -6,11 +6,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/observability/tracing/pipeline.yaml
+++ b/observability/tracing/pipeline.yaml
@@ -5,11 +5,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/pko/pipeline.yaml
+++ b/pko/pipeline.yaml
@@ -5,11 +5,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/route-monitor-operator/pipeline.yaml
+++ b/route-monitor-operator/pipeline.yaml
@@ -5,11 +5,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM

--- a/secret-sync-controller/pipeline.yaml
+++ b/secret-sync-controller/pipeline.yaml
@@ -5,11 +5,6 @@ resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    regions:
-    - uksouth
   steps:
   - name: output
     action: ARM


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Remove the executionConstraints from the global pipeline steps.  This should allow the global steps to execute when deploying to canary regions.

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
