### PR TITLE
e2e: Update bicep modules for customer-managed etcd encryption

### DIFF
--- a/test/e2e-setup/bicep/demo.bicep
+++ b/test/e2e-setup/bicep/demo.bicep
@@ -30,6 +30,8 @@ module AroHcpCluster 'modules/cluster.bicep' = {
     nsgName: customerInfra.outputs.nsgName
     userAssignedIdentitiesValue: managedIdentities.outputs.userAssignedIdentitiesValue
     identityValue: managedIdentities.outputs.identityValue
+    keyVaultName: customerInfra.outputs.keyVaultName
+    etcdEncryptionKeyName: customerInfra.outputs.etcdEncryptionKeyName
   }
 }
 

--- a/test/e2e-setup/bicep/modules/cluster.bicep
+++ b/test/e2e-setup/bicep/modules/cluster.bicep
@@ -22,10 +22,11 @@ param userAssignedIdentitiesValue object
 @description('Cluster Managed Identities')
 param identityValue object
 
-@description('The KeyVault name that contains the encryption key')
+@description('The KeyVault name that contains the etcd encryption key')
 param keyVaultName string
 
-var etcdEncryptionKeyName = 'etcd-data-kms-encryption-key'
+@description('The name of the etcd encryption key in the KeyVault')
+param etcdEncryptionKeyName string
 
 //
 // E X I S T I N G   R E S O U R C E S

--- a/test/e2e-setup/bicep/modules/cluster.bicep
+++ b/test/e2e-setup/bicep/modules/cluster.bicep
@@ -26,7 +26,6 @@ param identityValue object
 param keyVaultName string
 
 var etcdEncryptionKeyName = 'etcd-data-kms-encryption-key'
-var randomSuffix = toLower(uniqueString(resourceGroup().id))
 
 //
 // E X I S T I N G   R E S O U R C E S

--- a/test/e2e-setup/bicep/modules/customer-infra.bicep
+++ b/test/e2e-setup/bicep/modules/customer-infra.bicep
@@ -20,7 +20,7 @@ resource customerNsg 'Microsoft.Network/networkSecurityGroups@2023-05-01' = {
   name: customerNsgName
   location: resourceGroup().location
   tags: {
-    persist: persistTagValue
+    persist: string(persistTagValue)
   }
 }
 
@@ -28,7 +28,7 @@ resource customerVnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
   name: customerVnetName
   location: resourceGroup().location
   tags: {
-    persist: persistTagValue
+    persist: string(persistTagValue)
   }
   properties: {
     addressSpace: {

--- a/test/e2e-setup/bicep/modules/customer-infra.bicep
+++ b/test/e2e-setup/bicep/modules/customer-infra.bicep
@@ -10,6 +10,9 @@ param customerVnetName string = 'customer-vnet'
 @description('Subnet Name')
 param customerVnetSubnetName string = 'customer-subnet-1'
 
+@description('Key Vault Name')
+param customerKeyVaultName string = 'customer-key-vault'
+
 var addressPrefix = '10.0.0.0/16'
 var subnetPrefix = '10.0.0.0/24'
 
@@ -47,9 +50,32 @@ resource customerVnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
   }
 }
 
+resource customerKeyVault 'Microsoft.KeyVault/vaults@2024-12-01-preview' = {
+  name: customerKeyVaultName
+  location: resourceGroup().location
+  properties: {
+    enableRbacAuthorization: true
+    enableSoftDelete: false
+    tenantId: subscription().tenantId
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+  }
+}
+
+resource etcdEncryptionKey 'Microsoft.KeyVault/vaults/keys@2024-12-01-preview' = {
+  parent: customerKeyVault
+  name: 'etcd-data-kms-encryption-key'
+  properties: {
+    kty: 'RSA'
+    keySize: 2048
+  }
+}
+
 //
 // outputs
-// 
+//
 
 @description('Network Security Group Name')
 output nsgName string = customerNsgName
@@ -59,3 +85,6 @@ output vnetName string = customerVnetName
 
 @description('Subnet Name')
 output vnetSubnetName string = customerVnetSubnetName
+
+@description('Key Vault Name')
+output keyVaultName string = customerKeyVaultName

--- a/test/e2e/cluster_create_missing_info.go
+++ b/test/e2e/cluster_create_missing_info.go
@@ -52,7 +52,7 @@ var _ = Describe("Customer", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				By("creating a customer-infra")
-				customerInfraDeploymentResult, err = framework.CreateBicepTemplateAndWait(ctx,
+				customerInfraDeploymentResult, err := framework.CreateBicepTemplateAndWait(ctx,
 					tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
 					*resourceGroup.Name,
 					"customer-infra",

--- a/test/e2e/cluster_create_missing_info.go
+++ b/test/e2e/cluster_create_missing_info.go
@@ -52,7 +52,7 @@ var _ = Describe("Customer", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				By("creating a customer-infra")
-				_, err = framework.CreateBicepTemplateAndWait(ctx,
+				customerInfraDeploymentResult, err = framework.CreateBicepTemplateAndWait(ctx,
 					tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
 					*resourceGroup.Name,
 					"customer-infra",
@@ -88,6 +88,10 @@ var _ = Describe("Customer", func() {
 				Expect(err).NotTo(HaveOccurred())
 				identity, err := framework.GetOutputValue(managedIdentityDeploymentResult, "identityValue")
 				Expect(err).NotTo(HaveOccurred())
+				keyVaultName, err := framework.GetOutputValue(customerInfraDeploymentResult, "keyVaultName")
+				Expect(err).NotTo(HaveOccurred())
+				etcdEncryptionKeyName, err := framework.GetOutputValue(customerInfraDeploymentResult, "etcdEncryptionKeyName")
+				Expect(err).NotTo(HaveOccurred())
 				managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 				_, err = framework.CreateBicepTemplateAndWait(ctx,
 					tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
@@ -103,6 +107,8 @@ var _ = Describe("Customer", func() {
 						"vnetName":                    customerVnetName,
 						"userAssignedIdentitiesValue": userAssignedIdentities,
 						"identityValue":               identity,
+						"keyVaultName":                keyVaultName,
+						"etcdEncryptionKeyName":       etcdEncryptionKeyName,
 					},
 					45*time.Minute,
 				)

--- a/test/e2e/complete_cluster_create.go
+++ b/test/e2e/complete_cluster_create.go
@@ -55,7 +55,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a customer-infra")
-			_, err = framework.CreateBicepTemplateAndWait(ctx,
+			customerInfraDeploymentResult, err = framework.CreateBicepTemplateAndWait(ctx,
 				tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
 				*resourceGroup.Name,
 				"customer-infra",
@@ -91,6 +91,10 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 			identity, err := framework.GetOutputValue(managedIdentityDeploymentResult, "identityValue")
 			Expect(err).NotTo(HaveOccurred())
+			keyVaultName, err := framework.GetOutputValue(customerInfraDeploymentResult, "keyVaultName")
+			Expect(err).NotTo(HaveOccurred())
+			etcdEncryptionKeyName, err := framework.GetOutputValue(customerInfraDeploymentResult, "etcdEncryptionKeyName")
+			Expect(err).NotTo(HaveOccurred())
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			_, err = framework.CreateBicepTemplateAndWait(ctx,
 				tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
@@ -106,6 +110,8 @@ var _ = Describe("Customer", func() {
 					"vnetName":                    customerVnetName,
 					"userAssignedIdentitiesValue": userAssignedIdentities,
 					"identityValue":               identity,
+					"keyVaultName":                keyVaultName,
+					"etcdEncryptionKeyName":       etcdEncryptionKeyName,
 				},
 				45*time.Minute,
 			)

--- a/test/e2e/complete_cluster_create.go
+++ b/test/e2e/complete_cluster_create.go
@@ -55,7 +55,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a customer-infra")
-			customerInfraDeploymentResult, err = framework.CreateBicepTemplateAndWait(ctx,
+			customerInfraDeploymentResult, err := framework.CreateBicepTemplateAndWait(ctx,
 				tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
 				*resourceGroup.Name,
 				"customer-infra",


### PR DESCRIPTION
### What

Similar to #2423 but for the E2E bicep modules.

Adds a customer-managed etcd encryption key to the cluster bicep, along with necessary customer-managed resources.