### PR TITLE
billing: add workload identity for billing

### DIFF
--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -467,6 +467,11 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
         namespace: 'aro-hcp'
         serviceAccountName: 'backend'
       }
+      billing_wi: {
+        uamiName: 'aro-billing'
+        namespace: 'billing'
+        serviceAccountName: 'aro-billing'
+      }
       backplane_wi: {
         uamiName: 'backplane-api'
         namespace: 'aro-hcp'


### PR DESCRIPTION
### What
add workload identity for billing

### Why
since billing service will be deployed to AKS SVC cluster we need to create WI for billing to access azure resources.

### Special notes for your reviewer

<!-- optional -->
