### PR TITLE
Add cluster & nodepool test with custom osDisk size.

### DIFF
--- a/test/e2e-setup/bicep/modules/nodepool.bicep
+++ b/test/e2e-setup/bicep/modules/nodepool.bicep
@@ -10,6 +10,9 @@ param replicas int = 2
 @description('OpenShift Version ID to use')
 param openshiftVersionId string = '4.19.0'
 
+@description('Size of the osDisk for the node pool in GiB')
+param osDiskSizeGiB int = 64
+
 resource hcp 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters@2024-06-10-preview' existing = {
   name: clusterName
 }
@@ -27,7 +30,7 @@ resource nodepool 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools@2024
       subnetId: hcp.properties.platform.subnetId
       vmSize: 'Standard_D8s_v3'
       osDisk: {
-        sizeGiB: 64
+        sizeGiB: osDiskSizeGiB
         diskStorageAccountType: 'StandardSSD_LRS'
       }
     }

--- a/test/e2e/cluster_create_nodepool_osdisk_test.go
+++ b/test/e2e/cluster_create_nodepool_osdisk_test.go
@@ -1,0 +1,146 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+)
+
+var _ = Describe("Customer", func() {
+	BeforeEach(func() {
+		// do nothing.  per test initialization usually ages better than shared.
+	})
+
+	It("should be able to create an HCP cluster using bicep templates",
+		labels.RequireNothing,
+		labels.Critical,
+		labels.Positive,
+		func(ctx context.Context) {
+			const (
+				customerNetworkSecurityGroupName       = "customer-nsg-name"
+				customerVnetName                       = "customer-vnet-name"
+				customerVnetSubnetName                 = "customer-vnet-subnet1"
+				customerClusterName                    = "basic-hcp-cluster"
+				customerNodePoolName                   = "np-128"
+				openshiftControlPlaneVersionId         = "4.19"
+				openshiftNodeVersionId                 = "4.19.0"
+				openshiftNodeOsDiskSizeGiB       int32 = 128
+			)
+			tc := framework.NewTestContext()
+
+			By("creating a resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "clusternp128", tc.Location())
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating a customer-infra")
+			_, err = framework.CreateBicepTemplateAndWait(ctx,
+				tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
+				*resourceGroup.Name,
+				"customer-infra",
+				framework.Must(TestArtifactsFS.ReadFile("test-artifacts/generated-test-artifacts/modules/customer-infra.json")),
+				map[string]interface{}{
+					"persistTagValue":        false,
+					"customerNsgName":        customerNetworkSecurityGroupName,
+					"customerVnetName":       customerVnetName,
+					"customerVnetSubnetName": customerVnetSubnetName,
+				},
+				45*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating managed identities")
+			managedIdentityDeploymentResult, err := framework.CreateBicepTemplateAndWait(ctx,
+				tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
+				*resourceGroup.Name,
+				"managed-identities",
+				framework.Must(TestArtifactsFS.ReadFile("test-artifacts/generated-test-artifacts/modules/managed-identities.json")),
+				map[string]interface{}{
+					"clusterName": customerClusterName,
+					"nsgName":     customerNetworkSecurityGroupName,
+					"vnetName":    customerVnetName,
+					"subnetName":  customerVnetSubnetName,
+				},
+				45*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating the cluster")
+			userAssignedIdentities, err := framework.GetOutputValue(managedIdentityDeploymentResult, "userAssignedIdentitiesValue")
+			Expect(err).NotTo(HaveOccurred())
+			identity, err := framework.GetOutputValue(managedIdentityDeploymentResult, "identityValue")
+			Expect(err).NotTo(HaveOccurred())
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			_, err = framework.CreateBicepTemplateAndWait(ctx,
+				tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
+				*resourceGroup.Name,
+				"cluster",
+				framework.Must(TestArtifactsFS.ReadFile("test-artifacts/generated-test-artifacts/modules/cluster.json")),
+				map[string]interface{}{
+					"openshiftVersionId":          openshiftControlPlaneVersionId,
+					"clusterName":                 customerClusterName,
+					"managedResourceGroupName":    managedResourceGroupName,
+					"nsgName":                     customerNetworkSecurityGroupName,
+					"subnetName":                  customerVnetSubnetName,
+					"vnetName":                    customerVnetName,
+					"userAssignedIdentitiesValue": userAssignedIdentities,
+					"identityValue":               identity,
+				},
+				45*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("getting credentials")
+			adminRESTConfig, err := framework.GetAdminRESTConfigForHCPCluster(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				customerClusterName,
+				10*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("ensuring the cluster is viable")
+			err = framework.VerifyHCPCluster(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating the node pool with osDisk size 128GiB")
+			_, err = framework.CreateBicepTemplateAndWait(ctx,
+				tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
+				*resourceGroup.Name,
+				"node-pool",
+				framework.Must(TestArtifactsFS.ReadFile("test-artifacts/generated-test-artifacts/modules/nodepool.json")),
+				map[string]interface{}{
+					"openshiftVersionId": openshiftNodeVersionId,
+					"clusterName":        customerClusterName,
+					"nodePoolName":       customerNodePoolName,
+					"replicas":           2,
+					"osDiskSizeGiB":      openshiftNodeOsDiskSizeGiB,
+				},
+				45*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying nodepool configuration")
+			err = framework.VerifyNodePoolConfiguration(ctx, adminRESTConfig, customerClusterName, customerNodePoolName, 2, openshiftNodeOsDiskSizeGiB)
+			Expect(err).NotTo(HaveOccurred())
+		})
+})


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-20544

### What

Create cluster, verify cluster created, create nodepool with 128GiB osDisk size, verify nodepool replicas and osDisk size match spec.

### Why
Confirm we can create a nodepool with a non-default osDisk size
### Special notes for your reviewer

Changes to nodepool bicep template should not affect existing tests, nodepool verification in hcp_helper.go so that future tests can use it. 
