### PR TITLE
add missing KMS Mi to e2e setup and tests

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -107,6 +107,11 @@ create-int-mock-identities:
 	ROLE_DEFINITION_NAME=$${MSI_MOCK_ROLE_NAME} \
 	SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
 	./scripts/create-sp-for-rbac.sh
+	az role assignment create \
+		--role "Key Vault Crypto User" \
+		--assignee "$(shell az ad app list --display-name aro-hcp-int-msi-mock --query '[*]'.appId -o tsv)" \
+		--scope "/subscriptions/$(shell az account show --query id --output tsv)" \
+		--only-show-errors
 
 .PHONY: create-mock-identities
 

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -106,7 +106,7 @@ create-int-mock-identities:
 	CERTIFICATE_NAME=$${MSI_MOCK_CERT_NAME} \
 	ROLE_DEFINITION_NAME=$${MSI_MOCK_ROLE_NAME} \
 	SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
-	./scripts/create-sp-for-rbac.sh
+	./scripts/create-sp-for-rbac.sh && \
 	az role assignment create \
 		--role "Key Vault Crypto User" \
 		--assignee "$(shell az ad app list --display-name aro-hcp-int-msi-mock --query '[*]'.appId -o tsv)" \

--- a/test/e2e-setup/bicep/demo.bicep
+++ b/test/e2e-setup/bicep/demo.bicep
@@ -18,6 +18,7 @@ module managedIdentities 'modules/managed-identities.bicep' = {
     vnetName: customerInfra.outputs.vnetName
     subnetName: customerInfra.outputs.vnetSubnetName
     nsgName: customerInfra.outputs.nsgName
+    keyVaultName: customerInfra.outputs.keyVaultName
   }
 }
 

--- a/test/e2e-setup/bicep/image-registry/disabled-image-registry-cluster.bicep
+++ b/test/e2e-setup/bicep/image-registry/disabled-image-registry-cluster.bicep
@@ -22,7 +22,11 @@ param userAssignedIdentitiesValue object
 @description('Cluster Managed Identities')
 param identityValue object
 
-var randomSuffix = toLower(uniqueString(resourceGroup().id))
+@description('The KeyVault name that contains the etcd encryption key')
+param keyVaultName string
+
+@description('The name of the etcd encryption key in the KeyVault')
+param etcdEncryptionKeyName string
 
 //
 // E X I S T I N G   R E S O U R C E S
@@ -39,6 +43,15 @@ resource subnet 'Microsoft.Network/virtualNetworks/subnets@2022-07-01' existing 
 
 resource nsg 'Microsoft.Network/networkSecurityGroups@2022-07-01' existing = {
   name: nsgName
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2024-12-01-preview' existing = {
+  name: keyVaultName
+}
+
+resource etcdEncryptionKey 'Microsoft.KeyVault/vaults/keys@2024-12-01-preview' existing = {
+  parent: keyVault
+  name: etcdEncryptionKeyName
 }
 
 //
@@ -64,7 +77,17 @@ resource hcp 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters@2024-06-10-preview'
     console: {}
     etcd: {
       dataEncryption: {
-        keyManagementMode: 'PlatformManaged'
+        keyManagementMode: 'CustomerManaged'
+        customerManaged: {
+          encryptionType: 'kms'
+          kms: {
+            activeKey: {
+              vaultName: keyVaultName
+              name: etcdEncryptionKeyName
+              version: last(split(etcdEncryptionKey.properties.keyUriWithVersion, '/'))
+            }
+          }
+        }
       }
     }
     api: {

--- a/test/e2e-setup/bicep/infra-only.bicep
+++ b/test/e2e-setup/bicep/infra-only.bicep
@@ -18,6 +18,7 @@ module managedIdentities 'modules/managed-identities.bicep' = {
     vnetName: customerInfra.outputs.vnetName
     subnetName: customerInfra.outputs.vnetSubnetName
     nsgName: customerInfra.outputs.nsgName
+    keyVaultName: customerInfra.outputs.keyVaultName
   }
 }
 

--- a/test/e2e-setup/bicep/modules/cluster.bicep
+++ b/test/e2e-setup/bicep/modules/cluster.bicep
@@ -100,7 +100,7 @@ resource hcp 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters@2024-06-10-preview'
       managedResourceGroup: managedResourceGroupName
       subnetId: subnet.id
       outboundType: 'LoadBalancer'
-      networkSecurityGroupId: nsg.id 
+      networkSecurityGroupId: nsg.id
       operatorsAuthentication: {
         userAssignedIdentities: userAssignedIdentitiesValue
       }

--- a/test/e2e-setup/bicep/modules/managed-identities.bicep
+++ b/test/e2e-setup/bicep/modules/managed-identities.bicep
@@ -463,7 +463,7 @@ resource serviceManagedIdentityRoleAssignmentNSG 'Microsoft.Authorization/roleAs
 // KMS identity
 //
 
-resource kmsAzureMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+resource kmsMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: '${clusterName}-cp-kms-${randomSuffix}'
   location: resourceGroup().location
 }
@@ -473,19 +473,19 @@ var keyVaultCryptoUserRoleId = subscriptionResourceId(
   '12338af0-0e69-4776-bea7-57ae8d297424'
 )
 
-resource kmsRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, kmsAzureMi.id, keyVaultCryptoUserRoleId, keyVault.id)
+resource keyVaultCryptoUserToKeyVaultRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, kmsMi.id, keyVaultCryptoUserRoleId, keyVault.id)
   scope: keyVault
   properties: {
-    principalId: kmsAzureMi.properties.principalId
+    principalId: kmsMi.properties.principalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: keyVaultCryptoUserRoleId
   }
 }
 
 resource serviceManagedIdentityReaderOnKMSAzureMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, kmsAzureMi.id)
-  scope: kmsAzureMi
+  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, kmsMi.id)
+  scope: kmsMi
   properties: {
     principalId: serviceManagedIdentity.properties.principalId
     principalType: 'ServicePrincipal'
@@ -507,7 +507,7 @@ output userAssignedIdentitiesValue object = {
     'file-csi-driver': fileCsiDriverMi.id
     'image-registry': imageRegistryMi.id
     'cloud-network-config': cloudNetworkConfigMi.id
-    'kms': kmsAzureMi.id
+    'kms': kmsMi.id
   }
   dataPlaneOperators: {
     'disk-csi-driver': dpDiskCsiDriverMi.id
@@ -529,6 +529,6 @@ output identityValue object = {
     '${fileCsiDriverMi.id}': {}
     '${imageRegistryMi.id}': {}
     '${cloudNetworkConfigMi.id}': {}
-    '${kmsAzureMi.id}': {}
+    '${kmsMi.id}': {}
   }
 }

--- a/test/e2e/cluster_create_missing_info.go
+++ b/test/e2e/cluster_create_missing_info.go
@@ -68,16 +68,19 @@ var _ = Describe("Customer", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				By("creating a managed identities")
+				keyVaultName, err := framework.GetOutputValue(customerInfraDeploymentResult, "keyVaultName")
+				Expect(err).NotTo(HaveOccurred())
 				managedIdentityDeploymentResult, err := framework.CreateBicepTemplateAndWait(ctx,
 					tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
 					*resourceGroup.Name,
 					"managed-identities",
 					framework.Must(TestArtifactsFS.ReadFile("test-artifacts/generated-test-artifacts/modules/managed-identities.json")),
 					map[string]interface{}{
-						"clusterName": customerClusterName,
-						"nsgName":     customerNetworkSecurityGroupName,
-						"vnetName":    customerVnetName,
-						"subnetName":  customerVnetSubnetName,
+						"clusterName":  customerClusterName,
+						"nsgName":      customerNetworkSecurityGroupName,
+						"vnetName":     customerVnetName,
+						"subnetName":   customerVnetSubnetName,
+						"keyVaultName": keyVaultName,
 					},
 					45*time.Minute,
 				)
@@ -87,8 +90,6 @@ var _ = Describe("Customer", func() {
 				userAssignedIdentities, err := framework.GetOutputValue(managedIdentityDeploymentResult, "userAssignedIdentitiesValue")
 				Expect(err).NotTo(HaveOccurred())
 				identity, err := framework.GetOutputValue(managedIdentityDeploymentResult, "identityValue")
-				Expect(err).NotTo(HaveOccurred())
-				keyVaultName, err := framework.GetOutputValue(customerInfraDeploymentResult, "keyVaultName")
 				Expect(err).NotTo(HaveOccurred())
 				etcdEncryptionKeyName, err := framework.GetOutputValue(customerInfraDeploymentResult, "etcdEncryptionKeyName")
 				Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/complete_cluster_create.go
+++ b/test/e2e/complete_cluster_create.go
@@ -71,16 +71,19 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a managed identities")
+			keyVaultName, err := framework.GetOutputValue(customerInfraDeploymentResult, "keyVaultName")
+			Expect(err).NotTo(HaveOccurred())
 			managedIdentityDeploymentResult, err := framework.CreateBicepTemplateAndWait(ctx,
 				tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
 				*resourceGroup.Name,
 				"managed-identities",
 				framework.Must(TestArtifactsFS.ReadFile("test-artifacts/generated-test-artifacts/modules/managed-identities.json")),
 				map[string]interface{}{
-					"clusterName": customerClusterName,
-					"nsgName":     customerNetworkSecurityGroupName,
-					"vnetName":    customerVnetName,
-					"subnetName":  customerVnetSubnetName,
+					"clusterName":  customerClusterName,
+					"nsgName":      customerNetworkSecurityGroupName,
+					"vnetName":     customerVnetName,
+					"subnetName":   customerVnetSubnetName,
+					"keyVaultName": keyVaultName,
 				},
 				45*time.Minute,
 			)
@@ -90,8 +93,6 @@ var _ = Describe("Customer", func() {
 			userAssignedIdentities, err := framework.GetOutputValue(managedIdentityDeploymentResult, "userAssignedIdentitiesValue")
 			Expect(err).NotTo(HaveOccurred())
 			identity, err := framework.GetOutputValue(managedIdentityDeploymentResult, "identityValue")
-			Expect(err).NotTo(HaveOccurred())
-			keyVaultName, err := framework.GetOutputValue(customerInfraDeploymentResult, "keyVaultName")
 			Expect(err).NotTo(HaveOccurred())
 			etcdEncryptionKeyName, err := framework.GetOutputValue(customerInfraDeploymentResult, "etcdEncryptionKeyName")
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/image_registry_cluster_create.go
+++ b/test/e2e/image_registry_cluster_create.go
@@ -51,7 +51,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a customer-infra")
-			_, err = framework.CreateBicepTemplateAndWait(ctx,
+			customerInfraDeploymentResult, err := framework.CreateBicepTemplateAndWait(ctx,
 				tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
 				*resourceGroup.Name,
 				"customer-infra",
@@ -67,16 +67,19 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a managed identities")
+			keyVaultName, err := framework.GetOutputValue(customerInfraDeploymentResult, "keyVaultName")
+			Expect(err).NotTo(HaveOccurred())
 			managedIdentityDeploymentResult, err := framework.CreateBicepTemplateAndWait(ctx,
 				tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
 				*resourceGroup.Name,
 				"managed-identities",
 				framework.Must(TestArtifactsFS.ReadFile("test-artifacts/generated-test-artifacts/modules/managed-identities.json")),
 				map[string]interface{}{
-					"clusterName": customerClusterName,
-					"nsgName":     customerNetworkSecurityGroupName,
-					"vnetName":    customerVnetName,
-					"subnetName":  customerVnetSubnetName,
+					"clusterName":  customerClusterName,
+					"nsgName":      customerNetworkSecurityGroupName,
+					"vnetName":     customerVnetName,
+					"subnetName":   customerVnetSubnetName,
+					"keyVaultName": keyVaultName,
 				},
 				45*time.Minute,
 			)
@@ -86,6 +89,8 @@ var _ = Describe("Customer", func() {
 			userAssignedIdentities, err := framework.GetOutputValue(managedIdentityDeploymentResult, "userAssignedIdentitiesValue")
 			Expect(err).NotTo(HaveOccurred())
 			identity, err := framework.GetOutputValue(managedIdentityDeploymentResult, "identityValue")
+			Expect(err).NotTo(HaveOccurred())
+			etcdEncryptionKeyName, err := framework.GetOutputValue(customerInfraDeploymentResult, "etcdEncryptionKeyName")
 			Expect(err).NotTo(HaveOccurred())
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			_, err = framework.CreateBicepTemplateAndWait(ctx,
@@ -102,6 +107,8 @@ var _ = Describe("Customer", func() {
 					"vnetName":                    customerVnetName,
 					"userAssignedIdentitiesValue": userAssignedIdentities,
 					"identityValue":               identity,
+					"keyVaultName":                keyVaultName,
+					"etcdEncryptionKeyName":       etcdEncryptionKeyName,
 				},
 				45*time.Minute,
 			)


### PR DESCRIPTION
### What

Add missing KMS managed identity to e2e-setup and tests

### Why

This is now required and was missed in https://github.com/Azure/ARO-HCP/pull/2464

### Special notes for your reviewer
