### PR TITLE
Update SLO definitions and Prometheus expressions in Grafana dashboards

### DIFF
--- a/cluster-service/grafana-dashboards/cluster-service-slo.json
+++ b/cluster-service/grafana-dashboards/cluster-service-slo.json
@@ -33,7 +33,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "Over a 28-day rolling window, 99% of API requests will return with a successful status, where successful is defined as a non-5xx HTTP response code and non timeout error.",
+        "content": "Over a 28-day rolling window, 99% of API requests will return with a successful status, where successful is defined as a non-5xx HTTP response code (which includes timeout errors that return 504).",
         "mode": "markdown"
       },
       "title": "SLO Definition: Availability",
@@ -100,7 +100,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..|0\", service=\"clusters-service-metrics\"}[28d]))) / sum((max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d])))))",
+          "expr": "(sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..\", service=\"clusters-service-metrics\"}[28d]))) / sum((max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d])))))",
           "instant": false,
           "legendFormat": "Availability",
           "range": true,
@@ -203,7 +203,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..|0\", service=\"clusters-service-metrics\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d]))))) / (1 - 0.99)",
+          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..\", service=\"clusters-service-metrics\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d]))))) / (1 - 0.99)",
           "instant": false,
           "legendFormat": "Error budget burn rate",
           "range": true,
@@ -278,7 +278,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..|0\", service=\"clusters-service-metrics\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d]))))) / (1 - 0.99)",
+          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..\", service=\"clusters-service-metrics\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d]))))) / (1 - 0.99)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -377,7 +377,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..|0\", service=\"clusters-service-metrics\"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[5m]))))) / (1 - 0.99), 0)",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[5m]))))) / (1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 5m",
@@ -390,7 +390,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..|0\", service=\"clusters-service-metrics\"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[1h]))))) / (1 - 0.99), 0)",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[1h]))))) / (1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 1h",
@@ -490,7 +490,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..|0\", service=\"clusters-service-metrics\"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[30m]))))) / (1 - 0.99), 0)",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[30m]))))) / (1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 30m",
@@ -503,7 +503,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..|0\", service=\"clusters-service-metrics\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[6h]))))) / (1 - 0.99), 0)",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[6h]))))) / (1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 6h",
@@ -603,7 +603,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", code=~\"5..|0\", service=\"clusters-service-metrics\"}[2h])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[2h])))))/(1 - 0.99), 0)",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", code=~\"5..\", service=\"clusters-service-metrics\"}[2h])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[2h])))))/(1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 2h",
@@ -616,7 +616,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", code=~\"5..|0\", service=\"clusters-service-metrics\"}[1d])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[1d])))))/(1 - 0.99), 0)",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", code=~\"5..\", service=\"clusters-service-metrics\"}[1d])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[1d])))))/(1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 1d",
@@ -716,7 +716,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..|0\", service=\"clusters-service-metrics\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[6h]))))) / (1 - 0.99), 0)",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[6h]))))) / (1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 6h",
@@ -729,7 +729,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..|0\", service=\"clusters-service-metrics\"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[3d]))))) / (1 - 0.99), 0)",
+          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[3d]))))) / (1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 3d",
@@ -826,7 +826,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[28d])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[28d]))))",
+          "expr": "(sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..\"}[28d])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[28d]))))",
           "instant": false,
           "legendFormat": "P90 Latency",
           "range": true,
@@ -929,7 +929,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[28d])))))/(1 - 0.90)",
+          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[28d])))))/(1 - 0.90)",
           "hide": false,
           "instant": false,
           "legendFormat": "P90 Error budget burn rate",
@@ -1005,7 +1005,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[28d])))))/(1 - 0.90)",
+          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[28d])))))/(1 - 0.90)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1104,7 +1104,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[5m]))))) / (1 - 0.90), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..\"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[5m]))))) / (1 - 0.90), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "P90 Burn Rate - 5m",
@@ -1117,7 +1117,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[1h])))))/(1 - 0.90), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..\"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[1h])))))/(1 - 0.90), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "P90 Burn Rate - 1h",
@@ -1217,7 +1217,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[30m])))))/(1 - 0.90), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..\"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[30m])))))/(1 - 0.90), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "P90 Burn Rate - 30m",
@@ -1230,7 +1230,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[6h])))))/(1 - 0.90), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[6h])))))/(1 - 0.90), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "P90 Burn Rate - 6h",
@@ -1330,7 +1330,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[2h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[2h])))))/(1 - 0.90), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..\"}[2h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[2h])))))/(1 - 0.90), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "P90 Burn Rate - 2h",
@@ -1343,7 +1343,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[1d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[1d])))))/(1 - 0.90), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..\"}[1d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[1d])))))/(1 - 0.90), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "P90 Burn Rate - 1d",
@@ -1443,7 +1443,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[6h])))))/(1 - 0.90), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[6h])))))/(1 - 0.90), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "P90 Burn Rate - 6h",
@@ -1456,7 +1456,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..|0\"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[3d])))))/(1 - 0.90), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"0.1\", code!~\"5..\"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[3d])))))/(1 - 0.90), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "P90 Burn Rate - 3d",
@@ -1566,7 +1566,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[28d])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[28d]))))",
+          "expr": "(sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..\"}[28d])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[28d]))))",
           "instant": false,
           "legendFormat": "Latency",
           "range": true,
@@ -1669,7 +1669,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[28d])))))/(1 - 0.99)",
+          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[28d])))))/(1 - 0.99)",
           "hide": false,
           "instant": false,
           "legendFormat": "P99 Error budget burn rate",
@@ -1745,7 +1745,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[28d])))))/(1 - 0.99)",
+          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[28d])))))/(1 - 0.99)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1844,7 +1844,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[5m]))))) / (1 - 0.99), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..\"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[5m]))))) / (1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 5m",
@@ -1857,7 +1857,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[1h])))))/(1 - 0.99), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..\"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[1h])))))/(1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 1h",
@@ -1957,7 +1957,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[30m])))))/(1 - 0.99), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..\"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[30m])))))/(1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 30m",
@@ -1970,7 +1970,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[6h])))))/(1 - 0.99), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[6h])))))/(1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 6h",
@@ -2070,7 +2070,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[2h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[2h])))))/(1 - 0.99), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..\"}[2h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[2h])))))/(1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 2h",
@@ -2083,7 +2083,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[1d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[1d])))))/(1 - 0.99), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..\"}[1d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[1d])))))/(1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 1d",
@@ -2183,7 +2183,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[6h])))))/(1 - 0.99), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[6h])))))/(1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 6h",
@@ -2196,7 +2196,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..|0\"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..|0\"}[3d])))))/(1 - 0.99), 0)",
+          "expr": "clamp_min((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", le=\"1\", code!~\"5..\"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\", code!~\"5..\"}[3d])))))/(1 - 0.99), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 3d",

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -12,56 +12,56 @@ resource arohcpCsApiAvailabilityRecordingRules 'Microsoft.AlertsManagement/prome
     rules: [
       {
         record: 'availability:api_inbound_request_count:sli_ratio_28d'
-        expression: 'sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code!~"5..|0", service="clusters-service-metrics"}[28d]))) / sum((max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d]))))'
+        expression: 'sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code!~"5..", service="clusters-service-metrics"}[28d]))) / sum((max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d]))))'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate5m'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate30m'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate1h'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate6h'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate3d'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate2h'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[2h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[2h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate1d'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[1d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
@@ -82,112 +82,112 @@ resource arohcpCsApiLatencyRecordingRules 'Microsoft.AlertsManagement/prometheus
     rules: [
       {
         record: 'latency:api_inbound_request_duration:p99_sli_ratio_28d'
-        expression: 'sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))'
+        expression: 'sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_sli_ratio_28d'
-        expression: 'sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))'
+        expression: 'sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate5m'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[5m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[5m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate30m'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[30m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[30m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate1h'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[1h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate6h'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[6h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[6h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate3d'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[3d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[3d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate2h'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[2h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[2h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate1d'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[1d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate5m'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[5m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[5m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.90), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate30m'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[30m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[30m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.90), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate1h'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[1h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.90), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate6h'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[6h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[6h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.90), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate3d'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[3d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[3d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.90), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate2h'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[2h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[2h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.90), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate1d'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[1d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.90), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }

--- a/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
+++ b/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
@@ -17,7 +17,7 @@ spec:
     # 28-day rolling SLI
     - record: availability:api_inbound_request_count:sli_ratio_28d
       expr: |
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code!~"5..|0", service="clusters-service-metrics"}[28d])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code!~"5..", service="clusters-service-metrics"}[28d])))
         /
         sum((max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d]))))
       labels:
@@ -27,7 +27,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[5m])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[5m])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
         ) / (1 - 0.99), 0.01
@@ -38,7 +38,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[30m])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[30m])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
         ) / (1 - 0.99), 0.01
@@ -49,7 +49,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1h])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[1h])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
         ) / (1 - 0.99), 0.01
@@ -60,7 +60,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[6h])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[6h])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
         ) / (1 - 0.99), 0.01
@@ -71,7 +71,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[3d])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[3d])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
         ) / (1 - 0.99), 0.01
@@ -82,7 +82,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[2h])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[2h])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
         ) / (1 - 0.99), 0.01
@@ -93,7 +93,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1d])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[1d])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
         ) / (1 - 0.99), 0.01
@@ -107,7 +107,7 @@ spec:
     # P99 Latency SLI (28-day)
     - record: latency:api_inbound_request_duration:p99_sli_ratio_28d
       expr: |
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[28d])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[28d])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
       labels:
@@ -115,7 +115,7 @@ spec:
     # P90 Latency SLI (28-day)
     - record: latency:api_inbound_request_duration:p90_sli_ratio_28d
       expr: |
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[28d])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[28d])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
       labels:
@@ -128,7 +128,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[5m])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[5m])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
@@ -143,7 +143,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[30m])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[30m])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
@@ -158,7 +158,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[1h])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1h])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
@@ -173,7 +173,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[6h])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[6h])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
@@ -188,7 +188,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[3d])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[3d])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
@@ -203,7 +203,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[2h])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[2h])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
@@ -218,7 +218,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5..|0"}[1d])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1d])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
@@ -234,7 +234,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[5m])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[5m])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
@@ -249,7 +249,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[30m])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[30m])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
@@ -264,7 +264,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[1h])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1h])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
@@ -279,7 +279,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[6h])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[6h])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
@@ -294,7 +294,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[3d])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[3d])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
@@ -309,7 +309,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[2h])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[2h])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
@@ -324,7 +324,7 @@ spec:
         (
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5..|0"}[1d])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1d])))
         )
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))


### PR DESCRIPTION
Adjusted API request metrics to exclude only 5xx errors without the '|0' pattern. Refined expressions for better accuracy in SLO calculations as timeout errors already return 504 status code. Updated YAML rules for observability to reflect these changes.

AI assisted code

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
