### PR TITLE
add featureFlags field to config schema.

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -581,6 +581,12 @@
         },
         "providers": {
           "$ref": "#/definitions/registrationConfig"
+        },
+        "featureFlags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
### What
add `featureFlags` field to config schema. We don't mark it required as of today we do this only for billing under svc subscription. Making it required field will unnecessary as we will need to introduce this under all sub Id fields , that is global, svc, mgmt.

### Why
add `featureFlags` field to config schema. We don't mark it required as of today we do this only for billing under svc subscription. Making it required field will unnecessary as we will need to introduce this under all sub Id fields , that is global, svc, mgmt.

### Special notes for your reviewer

<!-- optional -->
