### PR TITLE
dev-infrastructure: shorten some step names

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -51,7 +51,7 @@ resourceGroups:
       resourceGroup: global
       step: output
       name: globalMSIId
-  - name: mgmt-infra
+  - name: infra
     action: ARM
     template: templates/mgmt-infra.bicep
     parameters: configurations/mgmt-infra.tmpl.bicepparam
@@ -92,11 +92,11 @@ resourceGroups:
     vaultBaseUrl:
       input:
         resourceGroup: management
-        step: mgmt-infra
+        step: infra
         name: cxKeyVaultUrl
     issuer:
       value: OneCertV2-PublicCA
-  - name: mgmt-oncert-private-kv-issuer
+  - name: oncert-private-kv-issuer
     action: SetCertificateIssuer
     secretKeyVault:
       configRef: ev2.assistedId.certificate.keyVault
@@ -107,11 +107,11 @@ resourceGroups:
     vaultBaseUrl:
       input:
         resourceGroup: management
-        step: mgmt-infra
+        step: infra
         name: mgmtKeyVaultUrl
     issuer:
       value: OneCertV2-PrivateCA
-  - name: mgmt-oncert-public-kv-issuer
+  - name: oncert-public-kv-issuer
     action: SetCertificateIssuer
     secretKeyVault:
       configRef: ev2.assistedId.certificate.keyVault
@@ -122,12 +122,12 @@ resourceGroups:
     vaultBaseUrl:
       input:
         resourceGroup: management
-        step: mgmt-infra
+        step: infra
         name: mgmtKeyVaultUrl
     issuer:
       value: OneCertV2-PublicCA
   # Build the MC
-  - name: mgmt-cluster
+  - name: cluster
     action: ARM
     template: templates/mgmt-cluster.bicep
     parameters: configurations/mgmt-cluster.tmpl.bicepparam
@@ -172,10 +172,10 @@ resourceGroups:
     - resourceGroup: management
       step: cx-oncert-public-kv-issuer
     - resourceGroup: management
-      step: mgmt-oncert-private-kv-issuer
+      step: oncert-private-kv-issuer
     - resourceGroup: management
-      step: mgmt-oncert-public-kv-issuer
-  - name: mgmt-nsp
+      step: oncert-public-kv-issuer
+  - name: nsp
     action: ARM
     template: templates/mgmt-nsp.bicep
     parameters: configurations/mgmt-nsp.tmpl.bicepparam
@@ -188,10 +188,10 @@ resourceGroups:
         name: subscriptionId
     dependsOn:
     - resourceGroup: management
-      step: mgmt-cluster
+      step: cluster
     - resourceGroup: management
-      step: mgmt-infra
-  - name: mgmt-cluster-output
+      step: infra
+  - name: cluster-output
     action: ARM
     template: templates/output-mgmt-cluster.bicep
     parameters: configurations/output-mgmt-cluster.tmpl.bicepparam
@@ -201,7 +201,7 @@ resourceGroups:
     - resourceGroup: regional
       step: output
     - resourceGroup: management
-      step: mgmt-cluster
+      step: cluster
   - name: prometheus
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell
@@ -246,21 +246,21 @@ resourceGroups:
     - name: DCR_REMOTE_WRITE_URL
       input:
         resourceGroup: management
-        step: mgmt-cluster-output
+        step: cluster-output
         name: dcrRemoteWriteUrl
     - name: HCP_DCR_REMOTE_WRITE_URL
       input:
         resourceGroup: management
-        step: mgmt-cluster-output
+        step: cluster-output
         name: hcpDcrRemoteWriteUrl
     - name: PROMETHEUS_UAMI_CLIENT_ID
       input:
         resourceGroup: management
-        step: mgmt-cluster-output
+        step: cluster-output
         name: prometheusUAMIClientId
     dependsOn:
     - resourceGroup: management
-      step: mgmt-cluster
+      step: cluster
     shellIdentity:
       input:
         resourceGroup: global
@@ -291,7 +291,7 @@ resourceGroups:
         step: output
         name: globalMSIId
         # Install cluster patches
-  - name: mgmt-fixes
+  - name: fixes
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell
     command: make -C ../mgmt-fixes deploy
@@ -304,7 +304,7 @@ resourceGroups:
       configRef: mgmt.applyKubeletFixes
     dependsOn:
     - resourceGroup: management
-      step: mgmt-cluster
+      step: cluster
     shellIdentity:
       input:
         resourceGroup: global
@@ -365,7 +365,7 @@ resourceGroups:
       configRef: geneva.logs.environment
     dependsOn:
     - resourceGroup: management
-      step: mgmt-cluster
+      step: cluster
     shellIdentity:
       input:
         resourceGroup: global

--- a/dev-infrastructure/mgmt-solo-pipeline.yaml
+++ b/dev-infrastructure/mgmt-solo-pipeline.yaml
@@ -41,7 +41,7 @@ resourceGroups:
         step: output
         name: logAnalyticsWorkspaceId
   # Build the MC
-  - name: mgmt-cluster
+  - name: cluster
     action: ARM
     template: templates/mgmt-cluster.bicep
     parameters: configurations/mgmt-cluster.tmpl.bicepparam
@@ -93,9 +93,9 @@ resourceGroups:
       configRef: acrPull.image.registry
     dependsOn:
     - resourceGroup: management
-      step: mgmt-cluster
+      step: cluster
   # Install cluster patches
-  - name: mgmt-fixes
+  - name: fixes
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell
     command: make -C ../mgmt-fixes deploy
@@ -108,4 +108,4 @@ resourceGroups:
       configRef: mgmt.applyKubeletFixes
     dependsOn:
     - resourceGroup: management
-      step: mgmt-cluster
+      step: cluster

--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -123,7 +123,7 @@ resourceGroups:
       step: svc-acr-replication
     - resourceGroup: global
       step: ocp-acr-replication
-  - name: region
+  - name: infra
     action: ARM
     template: templates/region.bicep
     parameters: configurations/region.tmpl.bicepparam
@@ -160,4 +160,4 @@ resourceGroups:
     outputOnly: true
     dependsOn:
     - resourceGroup: regional
-      step: region
+      step: infra

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -60,7 +60,7 @@ resourceGroups:
         step: output
         name: logAnalyticsWorkspaceId
   # Configure certificate issuers for the SVC KV
-  - name: svc-oncert-private-kv-issuer
+  - name: oncert-private-kv-issuer
     action: SetCertificateIssuer
     secretKeyVault:
       configRef: ev2.assistedId.certificate.keyVault
@@ -75,7 +75,7 @@ resourceGroups:
         name: svcKeyVaultUrl
     issuer:
       value: OneCertV2-PrivateCA
-  - name: svc-oncert-public-kv-issuer
+  - name: oncert-public-kv-issuer
     action: SetCertificateIssuer
     secretKeyVault:
       configRef: ev2.assistedId.certificate.keyVault
@@ -91,7 +91,7 @@ resourceGroups:
     issuer:
       value: OneCertV2-PublicCA
   # Create SVC cluster
-  - name: svc-cluster
+  - name: cluster
     action: ARM
     template: templates/svc-cluster.bicep
     parameters: configurations/svc-cluster.tmpl.bicepparam
@@ -129,10 +129,10 @@ resourceGroups:
         name: azureFrontDoorResourceId
     dependsOn:
     - resourceGroup: service
-      step: svc-oncert-private-kv-issuer
+      step: oncert-private-kv-issuer
     - resourceGroup: service
-      step: svc-oncert-public-kv-issuer
-  - name: svc-cluster-output
+      step: oncert-public-kv-issuer
+  - name: cluster-output
     action: ARM
     template: templates/output-svc-cluster.bicep
     parameters: configurations/output-svc-cluster.tmpl.bicepparam
@@ -142,7 +142,7 @@ resourceGroups:
     - resourceGroup: regional
       step: output
     - resourceGroup: service
-      step: svc-cluster
+      step: cluster
   # Deploy prometheus first since istio depends on it's CRDs
   - name: prometheus
     aksCluster: '{{ .svc.aks.name }}'
@@ -186,16 +186,16 @@ resourceGroups:
     - name: DCR_REMOTE_WRITE_URL
       input:
         resourceGroup: service
-        step: svc-cluster-output
+        step: cluster-output
         name: dcrRemoteWriteUrl
     - name: PROMETHEUS_UAMI_CLIENT_ID
       input:
         resourceGroup: service
-        step: svc-cluster-output
+        step: cluster-output
         name: prometheusUAMIClientId
     dependsOn:
     - resourceGroup: service
-      step: svc-cluster
+      step: cluster
     shellIdentity:
       input:
         resourceGroup: global
@@ -317,7 +317,7 @@ resourceGroups:
       configRef: geneva.logs.environment
     dependsOn:
     - resourceGroup: service
-      step: svc-cluster
+      step: cluster
     shellIdentity:
       input:
         resourceGroup: global


### PR DESCRIPTION
We always refer to the step in the context of its resource group now, so there is no need to have a prefix that mimics this.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
