### PR TITLE
bump hcp, cs, backend, frontend and ocp version

### DIFF
--- a/cluster-service/deploy/templates/aro-hcp-ocp-versions-config.configmap.yaml
+++ b/cluster-service/deploy/templates/aro-hcp-ocp-versions-config.configmap.yaml
@@ -7,7 +7,7 @@ data:
   aro-hcp-ocp-versions-config.yaml: |
     defaultVersion:
       channelGroupName: stable
-      version: 4.19.0
+      version: 4.19.7
     channelGroups:
       # the URL to cincinnati will be the same across all environments, other URLs also need to be whitelisted
       - url: https://api.openshift.com/api/upgrades_info/graph
@@ -16,4 +16,4 @@ data:
         # this is to ensure that the enabled release images are synchronized to ACR in lockstep
         minVersion: 4.19.0
         # maxVersion is exclusive, contrary to oc-mirror which defines that boundary as inclusive.
-        maxVersion: 4.19.1
+        maxVersion: 4.19.8

--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -59,7 +59,7 @@ clouds:
           # Hypershift
           hypershift:
             image:
-              digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
+              digest: sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a
           # Maestro
           maestro:
             image:
@@ -126,7 +126,7 @@ clouds:
           # Hypershift
           hypershift:
             image:
-              digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
+              digest: sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a
           # Maestro
           maestro:
             image:
@@ -193,7 +193,7 @@ clouds:
           # Hypershift
           hypershift:
             image:
-              digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
+              digest: sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a
           # Maestro
           maestro:
             image:

--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -8,7 +8,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:1f69d9707f4f36e64fe280b32686899bdd1541f7dba935a7d66b03c4e2e13883
+              digest: sha256:9c0915fed0341dcc7939133413dad4c506a11103d818fbf9e744d81405ec1221
           # ACR Pull
           acrPull:
             image:
@@ -75,7 +75,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:1f69d9707f4f36e64fe280b32686899bdd1541f7dba935a7d66b03c4e2e13883
+              digest: sha256:9c0915fed0341dcc7939133413dad4c506a11103d818fbf9e744d81405ec1221
           # ACR Pull
           acrPull:
             image:
@@ -142,7 +142,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:1f69d9707f4f36e64fe280b32686899bdd1541f7dba935a7d66b03c4e2e13883
+              digest: sha256:9c0915fed0341dcc7939133413dad4c506a11103d818fbf9e744d81405ec1221
           # ACR Pull
           acrPull:
             image:

--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -51,11 +51,11 @@ clouds:
           # RP Frontend
           frontend:
             image:
-              digest: sha256:df7506c4b69be5f0a06dfc925fd23d55746431f36b59ad42bfd728d85edc7e44
+              digest: sha256:7ea750064350fa81a70d2623e3c68aeb440ad244cb3c49e83edc4a23a5b53ee0
           # RP Backend
           backend:
             image:
-              digest: sha256:817ba4fb3a276e9029b7e1a9a82aaa7a55e49a11789ac09458346eb88254a7e0
+              digest: sha256:65dd2c36952fc8a3cb6f3835773c55b98ea7f9d7d96edb01f73bd038c11a9ee7
           # Hypershift
           hypershift:
             image:
@@ -118,11 +118,11 @@ clouds:
           # RP Frontend
           frontend:
             image:
-              digest: sha256:df7506c4b69be5f0a06dfc925fd23d55746431f36b59ad42bfd728d85edc7e44
+              digest: sha256:7ea750064350fa81a70d2623e3c68aeb440ad244cb3c49e83edc4a23a5b53ee0
           # RP Backend
           backend:
             image:
-              digest: sha256:817ba4fb3a276e9029b7e1a9a82aaa7a55e49a11789ac09458346eb88254a7e0
+              digest: sha256:65dd2c36952fc8a3cb6f3835773c55b98ea7f9d7d96edb01f73bd038c11a9ee7
           # Hypershift
           hypershift:
             image:
@@ -185,11 +185,11 @@ clouds:
           # RP Frontend
           frontend:
             image:
-              digest: sha256:df7506c4b69be5f0a06dfc925fd23d55746431f36b59ad42bfd728d85edc7e44
+              digest: sha256:7ea750064350fa81a70d2623e3c68aeb440ad244cb3c49e83edc4a23a5b53ee0
           # RP Backend
           backend:
             image:
-              digest: sha256:817ba4fb3a276e9029b7e1a9a82aaa7a55e49a11789ac09458346eb88254a7e0
+              digest: sha256:65dd2c36952fc8a3cb6f3835773c55b98ea7f9d7d96edb01f73bd038c11a9ee7
           # Hypershift
           hypershift:
             image:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -163,7 +163,7 @@ defaults:
       registry: quay.io
       repository: acm-d/rhtap-hypershift-operator
     namespace: hypershift
-    additionalInstallArg: ''
+    additionalInstallArg: '--enable-cpo-overrides'
   # Log settings
   logs:
     mdsd:
@@ -748,7 +748,7 @@ clouds:
         image:
           registry: quay.io
           repository: acm-d/rhtap-hypershift-operator
-          digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
+          digest: sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a
       # Backplane API
       backplaneAPI:
         image:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -719,7 +719,7 @@ clouds:
       clustersService:
         environment: "arohcpdev"
         image:
-          digest: sha256:86dbb522948be740908865a6eed8564101ef400b3fa2a8a0da9ac46159971fa8
+          digest: sha256:9c0915fed0341dcc7939133413dad4c506a11103d818fbf9e744d81405ec1221
         # NOTE: The role names must not include commas(,) in the name as the roleNames field
         # here is a comma separated list of role definition names.
         azureOperatorsManagedIdentities:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -6,16 +6,16 @@ clouds:
           westus3: 076e8b67e4abbe9db63f52ef1b69abdb6b72fb41492db7efaf95b878b104ebd3
       dev:
         regions:
-          westus3: 7247ceebdeb361562dbdf892ff41f5e374a1e5d2af4354b3d9e69cf554dc6427
+          westus3: 0dc5cbe8ac4d9f018cd2165826fed03b8feabaa15e01268aa76e8556c5c0cfca
       ntly:
         regions:
-          uksouth: dee97d7bf76bdf7832a0d1e8ec12deae603446e4b3278b1e01b26915dc4f26fa
+          uksouth: 561fb24906b22441d78fb73f1ef2d8280dc3da56265c2e6bbbf50480dc6e241d
       perf:
         regions:
-          westus3: d783ffb66b60238f82fd684da998fd195186ef8e6aae5f9abf3743f3602a56f7
+          westus3: cfe859fd084c1322cc49c0186b1e159189ec8131d93489bc5bb2cf70185f32ba
       pers:
         regions:
           westus3: 90fb7bd201ad8b29e095820ce630b72ba2dbe28a5ecd2731020775c64d1ee208
       swft:
         regions:
-          uksouth: a23e35990a041cd21f83a4cd5c0e7ae2bce9e65eed35e35eb674abb960db2843
+          uksouth: 6c6341891964ced92a524a2a19bd0e9efc25062f76cf29163cc332cc05d63c2b

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:86dbb522948be740908865a6eed8564101ef400b3fa2a8a0da9ac46159971fa8
+    digest: sha256:9c0915fed0341dcc7939133413dad4c506a11103d818fbf9e744d81405ec1221
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:86dbb522948be740908865a6eed8564101ef400b3fa2a8a0da9ac46159971fa8
+    digest: sha256:9c0915fed0341dcc7939133413dad4c506a11103d818fbf9e744d81405ec1221
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -248,9 +248,9 @@ global:
           poll: true
         poll: true
 hypershift:
-  additionalInstallArg: ""
+  additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
+    digest: sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:86dbb522948be740908865a6eed8564101ef400b3fa2a8a0da9ac46159971fa8
+    digest: sha256:9c0915fed0341dcc7939133413dad4c506a11103d818fbf9e744d81405ec1221
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -248,9 +248,9 @@ global:
           poll: true
         poll: true
 hypershift:
-  additionalInstallArg: ""
+  additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
+    digest: sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:86dbb522948be740908865a6eed8564101ef400b3fa2a8a0da9ac46159971fa8
+    digest: sha256:9c0915fed0341dcc7939133413dad4c506a11103d818fbf9e744d81405ec1221
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -248,9 +248,9 @@ global:
           poll: true
         poll: true
 hypershift:
-  additionalInstallArg: ""
+  additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
+    digest: sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:86dbb522948be740908865a6eed8564101ef400b3fa2a8a0da9ac46159971fa8
+    digest: sha256:9c0915fed0341dcc7939133413dad4c506a11103d818fbf9e744d81405ec1221
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:86dbb522948be740908865a6eed8564101ef400b3fa2a8a0da9ac46159971fa8
+    digest: sha256:9c0915fed0341dcc7939133413dad4c506a11103d818fbf9e744d81405ec1221
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -248,9 +248,9 @@ global:
           poll: true
         poll: true
 hypershift:
-  additionalInstallArg: ""
+  additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
+    digest: sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Bumps hcp, cs, backend, frontend, and ocp version
adds the --enable-cpo-overrides installation argument to installer config

### Why

see [slack thread](https://redhat-external.slack.com/archives/C075PHEFZKQ/p1755267359181299)

### Special notes for your reviewer

<!-- optional -->
