### PR TITLE
demo: use ARM endpoint to get keyvault version

### DIFF
--- a/demo/03-create-cluster.sh
+++ b/demo/03-create-cluster.sh
@@ -119,7 +119,7 @@ initialize_etcd_encryption_json_map() {
 EOF
 )
 
-  KEY_VAULT_KEY_VERSION=$(az keyvault key show --vault-name ${CUSTOMER_KV_NAME} --name "${ETCD_ENCRYPTION_KEY_NAME}" --output json | jq .key.kid -r | awk -F'/' '{print $NF}')
+  KEY_VAULT_KEY_VERSION=$(az rest --method GET --uri /subscriptions/${SUBSCRIPTION_ID}/resourcegroups/${CUSTOMER_RG_NAME}/providers/Microsoft.KeyVault/vaults/${CUSTOMER_KV_NAME}/keys/${ETCD_ENCRYPTION_KEY_NAME}/versions?api-version=2024-12-01-preview | jq -r '.value[0].name')
   ETCD_ENCRYPTION_JSON_MAP=$(echo -n "${ETCD_ENCRYPTION_JSON_MAP}" | jq \
     --arg vault_name "$CUSTOMER_KV_NAME" \
     --arg key_name "$ETCD_ENCRYPTION_KEY_NAME" \


### PR DESCRIPTION
no Jira

### What

Update demo/03-create-cluster.sh to use ARM Keyvault Get Key Versions endpoint instead of `az keyvault key show`

### Why

`az keyvault key show` requires data plane permissions which we do not grant to the invoking user in the demo scripts


### Special notes for your reviewer

<!-- optional -->
