### PR TITLE
make e2e cleanup possible after exit

### DIFF
--- a/test/cmd/aro-hcp-tests/cleanup.go
+++ b/test/cmd/aro-hcp-tests/cleanup.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Azure/ARO-HCP/test/util/framework"
+)
+
+func NewDeleteExpiredResourceGroupsCommand() *cobra.Command {
+	nowString := time.Now().Format(time.RFC3339)
+
+	cmd := &cobra.Command{
+		Use:          "delete-expired-resource-groups",
+		Short:        "Look for all resource groups from e2e runs that need to be deleted.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancelCause := context.WithCancelCause(context.Background())
+			defer cancelCause(errors.New("exiting"))
+
+			abortCh := make(chan os.Signal, 2)
+			go func() {
+				<-abortCh
+				fmt.Fprintf(os.Stderr, "Interrupted, terminating tests")
+				cancelCause(errors.New("interrupt received"))
+
+				select {
+				case sig := <-abortCh:
+					fmt.Fprintf(os.Stderr, "Interrupted twice, exiting (%s)", sig)
+					switch sig {
+					case syscall.SIGINT:
+						os.Exit(130)
+					default:
+						os.Exit(130) // if we were interrupted, never return zero.
+					}
+
+				case <-time.After(30 * time.Minute): // allow time for cleanup.  If we finish before this, we'll exit
+					fmt.Fprintf(os.Stderr, "Timed out during cleanup, exiting")
+					os.Exit(130) // if we were interrupted, never return zero.
+				}
+			}()
+			signal.Notify(abortCh, syscall.SIGINT, syscall.SIGTERM)
+
+			now, err := time.Parse(time.RFC3339, nowString)
+			if err != nil {
+				return err
+			}
+
+			// convenient way to get clients
+			tc := framework.NewTestContext()
+			expiredResourceGroups, err := framework.ListAllExpiredResourceGroups(
+				ctx,
+				tc.GetARMResourcesClientFactoryOrDie(ctx).NewResourceGroupsClient(),
+				now,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to list expired resource groups: %w", err)
+			}
+
+			expiredResourceGroupsNames := []string{}
+			for _, resourceGroup := range expiredResourceGroups {
+				fmt.Printf("Deleting resource group %s\n", *resourceGroup.Name)
+				expiredResourceGroupsNames = append(expiredResourceGroupsNames, *resourceGroup.Name)
+			}
+			err = framework.CleanupResourceGroups(ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				tc.GetARMResourcesClientFactoryOrDie(ctx).NewResourceGroupsClient(),
+				expiredResourceGroupsNames)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error during cleanup: %v", err)
+			}
+
+			return err
+		},
+	}
+
+	cmd.Flags().StringVar(&nowString, "now", nowString, "The current time")
+
+	return cmd
+}

--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -134,6 +134,7 @@ func main() {
 	}
 
 	root.AddCommand(cmd.DefaultExtensionCommands(registry)...)
+	root.AddCommand(NewDeleteExpiredResourceGroupsCommand())
 
 	if err := func() error {
 		return root.Execute()

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -54,7 +54,8 @@ var (
 )
 
 const (
-	StandardPollInterval = 10 * time.Second
+	StandardPollInterval            = 10 * time.Second
+	StandardResourceGroupExpiration = 4 * time.Hour
 )
 
 // InvocationContext requires the following env vars

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -81,27 +81,53 @@ func (tc *perItOrDescribeTestContext) BeforeEach(ctx context.Context) {
 
 // deleteCreatedResources deletes what was created that we know of.
 func (tc *perItOrDescribeTestContext) deleteCreatedResources(ctx context.Context) {
+	hcpClientFactory, err := tc.Get20240610ClientFactory(ctx)
+	if err != nil {
+		ginkgo.GinkgoLogr.Error(err, "failed to get HCP client")
+		return
+	}
+	resourceGroupsClientFactory, err := tc.GetARMResourcesClientFactory(ctx)
+	if err != nil {
+		ginkgo.GinkgoLogr.Error(err, "failed to get ARM client")
+		return
+	}
 	tc.contextLock.RLock()
+	resourceGroupNames := tc.knownResourceGroups
 	defer tc.contextLock.RUnlock()
 	ginkgo.GinkgoLogr.Info("deleting created resources")
 
-	// deletion takes a while, it's worth it to do this in parallel
-	waitGroup, ctx := errgroup.WithContext(ctx)
-	for _, resourceGroupName := range tc.knownResourceGroups {
-		currResourceGroupName := resourceGroupName
-		waitGroup.Go(func() error {
-			// prevent a stray panic from exiting the process. Don't do this generally because ginkgo/gomega rely on panics to function.
-			utilruntime.HandleCrashWithContext(ctx)
-
-			return tc.cleanupResourceGroup(ctx, currResourceGroupName)
-		})
-	}
-	if err := waitGroup.Wait(); err != nil {
-		// remember that Wait only shows the first error, not all the errors.
+	err = CleanupResourceGroups(ctx, hcpClientFactory.NewHcpOpenShiftClustersClient(), resourceGroupsClientFactory.NewResourceGroupsClient(), resourceGroupNames)
+	if err != nil {
 		ginkgo.GinkgoLogr.Error(err, "at least one resource group failed to delete: %w", err)
 	}
 
 	ginkgo.GinkgoLogr.Info("finished deleting created resources")
+}
+
+func CleanupResourceGroups(ctx context.Context, hcpClient *hcpapi20240610.HcpOpenShiftClustersClient, resourceGroupsClient *armresources.ResourceGroupsClient, resourceGroupNames []string) error {
+	// deletion takes a while, it's worth it to do this in parallel
+	wg := sync.WaitGroup{}
+	errCh := make(chan error, len(resourceGroupNames))
+	for _, currResourceGroupName := range resourceGroupNames {
+		wg.Add(1)
+		go func(ctx context.Context) {
+			defer wg.Done()
+			// prevent a stray panic from exiting the process. Don't do this generally because ginkgo/gomega rely on panics to function.
+			utilruntime.HandleCrashWithContext(ctx)
+
+			if err := cleanupResourceGroup(ctx, hcpClient, resourceGroupsClient, currResourceGroupName); err != nil {
+				errCh <- err
+			}
+		}(ctx)
+	}
+	wg.Wait()
+	close(errCh)
+
+	errs := []error{}
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }
 
 // collectDebugInfo collects information and saves it in artifact dir
@@ -146,7 +172,7 @@ func (tc *perItOrDescribeTestContext) NewResourceGroup(ctx context.Context, reso
 		}
 	}
 
-	resourceGroup, err := CreateResourceGroup(ctx, tc.GetARMResourcesClientFactoryOrDie(ctx).NewResourceGroupsClient(), resourceGroupName, location, 20*time.Minute)
+	resourceGroup, err := CreateResourceGroup(ctx, tc.GetARMResourcesClientFactoryOrDie(ctx).NewResourceGroupsClient(), resourceGroupName, location, StandardResourceGroupExpiration, 20*time.Minute)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resource group: %w", err)
 	}
@@ -157,27 +183,17 @@ func (tc *perItOrDescribeTestContext) NewResourceGroup(ctx context.Context, reso
 // cleanupResourceGroup is the standard resourcegroup cleanup.  It attempts to
 // 1. delete all HCP clusters and wait for success
 // 2. delete the resource group and wait for success
-func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, resourceGroupName string) error {
+func cleanupResourceGroup(ctx context.Context, hcpClient *hcpapi20240610.HcpOpenShiftClustersClient, resourceGroupsClient *armresources.ResourceGroupsClient, resourceGroupName string) error {
 	errs := []error{}
 
 	ginkgo.GinkgoLogr.Info("deleting all hcp clusters in resource group", "resourceGroup", resourceGroupName)
-	if hcpClientFactory, err := tc.get20240610ClientFactoryUnlocked(ctx); err == nil {
-		err := DeleteAllHCPClusters(ctx, hcpClientFactory.NewHcpOpenShiftClustersClient(), resourceGroupName, 60*time.Minute)
-		if err != nil {
-			return fmt.Errorf("failed to cleanup resource group: %w", err)
-		}
-	} else {
-		errs = append(errs, fmt.Errorf("failed creating client factory for cleanup: %w", err))
+	if err := DeleteAllHCPClusters(ctx, hcpClient, resourceGroupName, 60*time.Minute); err != nil {
+		return fmt.Errorf("failed to cleanup resource group: %w", err)
 	}
 
 	ginkgo.GinkgoLogr.Info("deleting resource group", "resourceGroup", resourceGroupName)
-	if armClientFactory, err := tc.getARMResourcesClientFactoryUnlocked(ctx); err == nil {
-		err := DeleteResourceGroup(ctx, armClientFactory.NewResourceGroupsClient(), resourceGroupName, 60*time.Minute)
-		if err != nil {
-			return fmt.Errorf("failed to cleanup resource group: %w", err)
-		}
-	} else {
-		errs = append(errs, fmt.Errorf("failed creating client factory for cleanup: %w", err))
+	if err := DeleteResourceGroup(ctx, resourceGroupsClient, resourceGroupName, 60*time.Minute); err != nil {
+		return fmt.Errorf("failed to cleanup resource group: %w", err)
 	}
 
 	return errors.Join(errs...)


### PR DESCRIPTION
This adds tags to our resource groups created by e2e with expiry times and adds a command we can wire up in prow to periodically sweep all e2e resource groups and clean up expired ones.

/assign @jharrington22 