### PR TITLE
Always specify output format when processing az output

### DIFF
--- a/demo/03-create-cluster.sh
+++ b/demo/03-create-cluster.sh
@@ -119,7 +119,7 @@ initialize_etcd_encryption_json_map() {
 EOF
 )
 
-  KEY_VAULT_KEY_VERSION=$(az rest --method GET --uri /subscriptions/${SUBSCRIPTION_ID}/resourcegroups/${CUSTOMER_RG_NAME}/providers/Microsoft.KeyVault/vaults/${CUSTOMER_KV_NAME}/keys/${ETCD_ENCRYPTION_KEY_NAME}/versions?api-version=2024-12-01-preview | jq -r '.value[0].name')
+  KEY_VAULT_KEY_VERSION=$(az rest --method GET --uri /subscriptions/${SUBSCRIPTION_ID}/resourcegroups/${CUSTOMER_RG_NAME}/providers/Microsoft.KeyVault/vaults/${CUSTOMER_KV_NAME}/keys/${ETCD_ENCRYPTION_KEY_NAME}/versions?api-version=2024-12-01-preview --output json | jq -r '.value[0].name')
   ETCD_ENCRYPTION_JSON_MAP=$(echo -n "${ETCD_ENCRYPTION_JSON_MAP}" | jq \
     --arg vault_name "$CUSTOMER_KV_NAME" \
     --arg key_name "$ETCD_ENCRYPTION_KEY_NAME" \

--- a/dev-infrastructure/swift/01_validate_sal.sh
+++ b/dev-infrastructure/swift/01_validate_sal.sh
@@ -10,7 +10,7 @@ if ! is_service_principal; then
     source login_fpa.sh
 fi
 
-parent_guid=$(az network vnet list -g $resource_group | jq -r '.[].resourceGuid')
+parent_guid=$(az network vnet list -g $resource_group -o json | jq -r '.[].resourceGuid')
 api_version=2021-08-01
 body=$( jq -n \
     --arg rn $resource \

--- a/dev-infrastructure/swift/02_create_sal.sh
+++ b/dev-infrastructure/swift/02_create_sal.sh
@@ -7,10 +7,10 @@ set -o pipefail
 source swift_env_vars
 if ! is_redhat_user; then
     az login
-    parent_guid=$(az network vnet list -g $resource_group | jq -r '.[].resourceGuid')
+    parent_guid=$(az network vnet list -g $resource_group -o json | jq -r '.[].resourceGuid')
 fi
 
-parent_guid=$(az network vnet list -g $resource_group | jq -r '.[].resourceGuid')
+parent_guid=$(az network vnet list -g $resource_group -o json | jq -r '.[].resourceGuid')
 
 if ! is_service_principal; then
     source login_fpa.sh

--- a/dev-infrastructure/swift/03_create_podnetwork.sh
+++ b/dev-infrastructure/swift/03_create_podnetwork.sh
@@ -6,9 +6,9 @@ set -o pipefail
 
 source sal_env_vars
 
-subnet_guid=$(az rest --method get --url "/subscriptions/$subscription/resourceGroups/$resource_group/providers/Microsoft.Network/virtualNetworks/$vnet_name/subnets/$subnet_name?api-version=2023-06-01" | jq -r '.properties.serviceAssociationLinks[0].properties.subnetId')
+subnet_guid=$(az rest --method get --url "/subscriptions/$subscription/resourceGroups/$resource_group/providers/Microsoft.Network/virtualNetworks/$vnet_name/subnets/$subnet_name?api-version=2023-06-01" --output json | jq -r '.properties.serviceAssociationLinks[0].properties.subnetId')
 
-vnet_guid=$(az network vnet show -g $resource_group --name $vnet_name | jq -r '.resourceGuid')
+vnet_guid=$(az network vnet show -g $resource_group --name $vnet_name --output json | jq -r '.resourceGuid')
 
 kubectl apply -f - << EOF 
 apiVersion: multitenancy.acn.azure.com/v1alpha1


### PR DESCRIPTION
Don't rely on the user's default output format to be "json"; be explicit.

(My default output format is "table".)

I fixed as many occurrences as I could find.  Most of them were in `/dev-infrastructure/swift`.