### PR TITLE
Update CS ARO HCP OCP maxVersion to 4.19.6

### DIFF
--- a/cluster-service/deploy/templates/aro-hcp-ocp-versions-config.configmap.yaml
+++ b/cluster-service/deploy/templates/aro-hcp-ocp-versions-config.configmap.yaml
@@ -16,4 +16,4 @@ data:
         # this is to ensure that the enabled release images are synchronized to ACR in lockstep
         minVersion: 4.19.0
         # maxVersion is exclusive, contrary to oc-mirror which defines that boundary as inclusive.
-        maxVersion: 4.19.1
+        maxVersion: 4.19.7


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Update max supported version of OCP to the latest version available in the stable channel which is currently 4.19.6.

### Why

To allow clusters to be created using OCP 4.19.6.

