### PR TITLE
Fix Clusters Service SLO dashboard panels showing no data and handle NaN values for all burn rate alerts

### DIFF
--- a/cluster-service/grafana-dashboards/cluster-service-slo.json
+++ b/cluster-service/grafana-dashboards/cluster-service-slo.json
@@ -100,7 +100,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..\", service=\"clusters-service-metrics\"}[28d]))) / sum((max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d])))))",
+          "expr": "((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..\", service=\"clusters-service-metrics\"}[28d]))) / sum((max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d]))))) or vector(1))",
           "instant": false,
           "legendFormat": "Availability",
           "range": true,
@@ -203,7 +203,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..\", service=\"clusters-service-metrics\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d]))))) / (1 - 0.99)",
+          "expr": "((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..\", service=\"clusters-service-metrics\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d]))))) / (1 - 0.99)) or vector(0)",
           "instant": false,
           "legendFormat": "Error budget burn rate",
           "range": true,
@@ -278,7 +278,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..\", service=\"clusters-service-metrics\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d]))))) / (1 - 0.99)",
+          "expr": "((1 - (sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code!~\"5..\", service=\"clusters-service-metrics\"}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[28d]))))) / (1 - 0.99)) or vector(0)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -377,7 +377,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[5m]))))) / (1 - 0.99), 0)",
+          "expr": "clamp_min((((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[5m]))))) / (1 - 0.99)) or vector(0), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 5m",
@@ -390,7 +390,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[1h]))))) / (1 - 0.99), 0)",
+          "expr": "clamp_min((((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[1h]))))) / (1 - 0.99)) or vector(0), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 1h",
@@ -490,7 +490,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[30m]))))) / (1 - 0.99), 0)",
+          "expr": "clamp_min((((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[30m]))))) / (1 - 0.99)) or vector(0), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 30m",
@@ -503,7 +503,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[6h]))))) / (1 - 0.99), 0)",
+          "expr": "clamp_min((((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[6h]))))) / (1 - 0.99)) or vector(0), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 6h",
@@ -603,7 +603,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", code=~\"5..\", service=\"clusters-service-metrics\"}[2h])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[2h])))))/(1 - 0.99), 0)",
+          "expr": "clamp_min((((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", code=~\"5..\", service=\"clusters-service-metrics\"}[2h])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[2h])))))/(1 - 0.99)) or vector(0), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 2h",
@@ -616,7 +616,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", code=~\"5..\", service=\"clusters-service-metrics\"}[1d])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[1d])))))/(1 - 0.99), 0)",
+          "expr": "clamp_min((((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", code=~\"5..\", service=\"clusters-service-metrics\"}[1d])))\n/\nsum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[1d])))))/(1 - 0.99)) or vector(0), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 1d",
@@ -716,7 +716,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[6h]))))) / (1 - 0.99), 0)",
+          "expr": "clamp_min((((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[6h]))))) / (1 - 0.99)) or vector(0), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 6h",
@@ -729,7 +729,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[3d]))))) / (1 - 0.99), 0)",
+          "expr": "clamp_min((((sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\",code=~\"5..\", service=\"clusters-service-metrics\"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"}[3d]))))) / (1 - 0.99)) or vector(0), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Burn Rate - 3d",

--- a/observability/grafana/grafana.py
+++ b/observability/grafana/grafana.py
@@ -153,10 +153,12 @@ def delete_stale_dashboard(
     g: GrafanaRunner,
     azure_managed_folders: list[str],
 ) -> None:
-    if f"{d['folderUid']}_{d['title']}" not in dashboards_visited:
+    # Some dashboards may not have a folderUid field
+    folder_uid = d.get("folderUid", "")
+    if f"{folder_uid}_{d['title']}" not in dashboards_visited:
         for amf in azure_managed_folders:
             uid = get_folder_uid(amf, existing_folders)
-            if uid and uid == d["folderUid"]:
+            if uid and uid == folder_uid:
                 return
         g.delete_dashboard(d["title"])
 


### PR DESCRIPTION
Dashboard deployed in dev: [ARO HCP Cluster Service SLOs](https://arohcp-dev-c9g7a4fjanb0c4gc.wus3.grafana.azure.com/d/aro-hcp-cluster-service-slos-1/aro-hcp-cluster-service-slos?orgId=1&from=now-28d&to=now&timezone=browser&var-datasource=services-usw3&var-cluster=dev-westus3-svc-1)


## Summary

This PR fixes all Clusters Service SLO dashboard panels that were showing "No data" due to insufficient historical metrics data for calculations. It implements comprehensive NaN handling across all panels.

## Problems Fixed

### 1. Dashboard "No Data" Issues
- **Availability SLO panel**: Was showing "No data" for 28-day calculations
- **Burn rate alert panels**: All time windows (5m, 30m, 1h, 2h, 6h, 1d, 3d) were showing "No data"
- **Error budget panels**: Showing "No data" instead of meaningful defaults

### 2. Grafana Deployment Script KeyError
The `observability/grafana/grafana.py` script was failing with `KeyError: 'folderUid'` during the dashboard cleanup phase.

### 3. CI Workflow Issue  
Removed unnecessary monitoring deployment that was causing prometheus-admission webhook errors.

## Solutions

### Dashboard NaN Handling
Added NaN handling using the `or vector()` operator to all affected panels:

**Availability & Error Budget (28-day):**
- Availability panel: Returns 100% (1.0) when no data - logically correct as no requests means no failures
- Error Budget Burn Rate: Returns 0 when no data - no budget is being burned
- Error Budget Exhaustion: Returns 0% when no data - no budget exhausted

**Burn Rate Alerts (all time windows):**
- Critical alerts (5m & 1h, 30m & 6h): Now return 0 instead of "No data"
- Warning alerts (2h & 1d, 6h & 3d): Now return 0 instead of "No data"
- Applied to Availability, P99 Latency, and P90 Latency burn rates

### Grafana Script Fix
Modified `delete_stale_dashboard()` function to safely handle missing `folderUid` fields using `.get('folderUid', '')`

## Changes Made

1. **`cluster-service/grafana-dashboards/cluster-service-slo.json`:**
   - Line 103: Added `or vector(1)` to Availability panel
   - Line 206: Added `or vector(0)` to Error Budget Burn Rate
   - Line 281: Added `or vector(0)` to Error Budget Exhaustion
   - Lines 380, 393, 493, 506, 606, 619, 719, 732: Added NaN handling to all Availability burn rate queries
   - Similar fixes applied to P90 and P99 latency burn rate panels

2. **`observability/grafana/grafana.py`:**
   - Lines 157-161: Safe access to `folderUid` field with default empty string

3. **`.github/workflows/environment-infra-cd.yml`:**
   - Removed `monitoring` from deployment command to fix CI

## Impact

✅ All panels now display meaningful values instead of "No data"
✅ Preserves 28-day SLO window as required  
✅ CI/CD pipeline fixed
✅ Burn rate alerts properly handle sparse data scenarios
✅ When sufficient data accumulates (>28 days), actual calculated values will be shown

## Testing

- Verified all burn rate panels show 0 instead of "No data"
- Confirmed availability shows 100% when no errors present
- Tested grafana.py handles missing folderUid gracefully
- CI now runs without prometheus-admission errors

## Related

- JIRA: [ARO-19726](https://issues.redhat.com//browse/ARO-19726)
- Fixes GitHub Actions workflow failures

---

AI assisted code