### PR TITLE
msi-acrpull: bump to v0.1.18 for poams report

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -12,7 +12,7 @@ clouds:
           # ACR Pull
           acrPull:
             image:
-              digest: sha256:c802a91b3b0fe4a3875a03904140a14eb54c8b94db1d510946c9c438d28689c0 #v0.1.14
+              digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664 #v0.1.18
           # Secret Sync Controller
           secretSyncController:
             image:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -689,7 +689,7 @@ clouds:
       # ACR Pull
       acrPull:
         image:
-          digest: sha256:c802a91b3b0fe4a3875a03904140a14eb54c8b94db1d510946c9c438d28689c0 #v0.1.14
+          digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664 #v0.1.18
       # Secret Sync Controller
       secretSyncController:
         image:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 77967f93feaa4bee2c33627f06e2e48e56a235398307eecad55c88e54d19b5c4
+          westus3: 6eca5883bdac7a43b5c001a595ec248f8a1286c89bda62fa79df583b5f72e61e
       dev:
         regions:
-          westus3: 00b9bda7b0caf877b8957f22aaef263da5ee378866a7d3fca800759db5439632
+          westus3: a42fb6980c5daf1cd969e89c4a56c3c320e636ebec7c71100393dfc5d1df2546
       ntly:
         regions:
-          uksouth: 7f8322e81217ffc3dda9e328655f1094dbc03ad2ebfd9287598bc3218359b797
+          uksouth: b594b955341551154433bc61315390b0930fe2d1cd20c84dbc65d2f89595f8fb
       perf:
         regions:
-          westus3: a66579f1e92df5774577605e32a7233e2a1723b663a3ca371f290fa012d9401a
+          westus3: 0477f14b98f170d1beee5eb7a0bdd4312b2c9f266f1c898bf26c9a20a2ee3775
       pers:
         regions:
-          westus3: 5fd9d9fe9ac56e4b90ba15caa9eb9ad3c8f26e771dc0d67c075a4fa1284202a5
+          westus3: 15763faf78ae955da6a4f4e5054ffdf8c689216591aa74043ed6f045ed8e2e2a
       swft:
         regions:
-          uksouth: 40b133b4edf131b756244d07696eeda2e9ad451f48b4c9cf9ce85ac7aade1a4d
+          uksouth: 041695dc79e0e4320e54126acd29c42714c431b03fe44d44d455cfb6470bca42

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -29,7 +29,7 @@ acr:
     zoneRedundantMode: Disabled
 acrPull:
   image:
-    digest: sha256:c802a91b3b0fe4a3875a03904140a14eb54c8b94db1d510946c9c438d28689c0
+    digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664
     registry: mcr.microsoft.com
     repository: aks/msi-acrpull
 administration:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -29,7 +29,7 @@ acr:
     zoneRedundantMode: Disabled
 acrPull:
   image:
-    digest: sha256:c802a91b3b0fe4a3875a03904140a14eb54c8b94db1d510946c9c438d28689c0
+    digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664
     registry: mcr.microsoft.com
     repository: aks/msi-acrpull
 administration:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -29,7 +29,7 @@ acr:
     zoneRedundantMode: Disabled
 acrPull:
   image:
-    digest: sha256:c802a91b3b0fe4a3875a03904140a14eb54c8b94db1d510946c9c438d28689c0
+    digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664
     registry: mcr.microsoft.com
     repository: aks/msi-acrpull
 administration:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -29,7 +29,7 @@ acr:
     zoneRedundantMode: Disabled
 acrPull:
   image:
-    digest: sha256:c802a91b3b0fe4a3875a03904140a14eb54c8b94db1d510946c9c438d28689c0
+    digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664
     registry: mcr.microsoft.com
     repository: aks/msi-acrpull
 administration:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -29,7 +29,7 @@ acr:
     zoneRedundantMode: Disabled
 acrPull:
   image:
-    digest: sha256:c802a91b3b0fe4a3875a03904140a14eb54c8b94db1d510946c9c438d28689c0
+    digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664
     registry: mcr.microsoft.com
     repository: aks/msi-acrpull
 administration:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -29,7 +29,7 @@ acr:
     zoneRedundantMode: Disabled
 acrPull:
   image:
-    digest: sha256:c802a91b3b0fe4a3875a03904140a14eb54c8b94db1d510946c9c438d28689c0
+    digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664
     registry: mcr.microsoft.com
     repository: aks/msi-acrpull
 administration:


### PR DESCRIPTION
### What

no-jira, but we're getting asked to bump this for vulns showing in poams report.  

### Why

Vulnerabilities

### Special notes for your reviewer

Nothing, going to validate ACR pulls still work for images in shared dev once this deploys.  Then will SDP-piplines pr it into INT+staging.  


```
$ podman pull mcr.microsoft.com/aks/msi-acrpull:v0.1.18
Trying to pull mcr.microsoft.com/aks/msi-acrpull:v0.1.18...
Getting image source signatures
Copying blob 1561ba252238 done   | 
Copying blob 13a126dcad87 done   | 
Copying config 55eb2a7cdf done   | 
Writing manifest to image destination
55eb2a7cdfb8c2bdc974a81f67f12ebac6b9b886d7dd72e5d08f0e075b0428d2
$ podman inspect mcr.microsoft.com/aks/msi-acrpull:v0.1.18 | jq '.[0].Digest'
"sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664"
