### PR TITLE
bump hypershift operator in CSPR env 

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -936,6 +936,12 @@ clouds:
             cosmosDB:
               private: false
               zoneRedundantMode: 'Disabled'
+          hypershift:
+            additionalInstallArg: '--enable-cpo-overrides=true'
+            image:
+              registry: quay.io
+              repository: acm-d/rhtap-hypershift-operator
+              digest: sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a
       ntly:
         # this is an environment to test the deployability of infra nightly
         defaults:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,7 +3,7 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 08890f4111672a5fd61fadb8db01735484fd38a81dc72c82e8bd93d0b5076f40
+          westus3: e5b591cf887edb50a7fadb409b4c0ef31bc64f998d2048cded0108c448490d8f
       dev:
         regions:
           westus3: 6cb8c77cb73c340eb1921dabf3290e608ff3ea8df65be0cb082ea77eb9ff86fd

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -248,9 +248,9 @@ global:
           poll: true
         poll: true
 hypershift:
-  additionalInstallArg: ""
+  additionalInstallArg: --enable-cpo-overrides=true
   image:
-    digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
+    digest: sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift


### PR DESCRIPTION


<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

bump hypershift operator in CSPR env to quay.io/acm-d/rhtap-hypershift-operator@sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a
Also enables CPO overrides via the environment flag.


### Why

<!-- Briefly explain why this change is needed -->

Bump HO in CSPR env in attempt to mitigate the "too many files open" issue observed in that env. 
The HO build also contains the CPO override with the mitigation for the fix

### Special notes for your reviewer

<!-- optional -->
