### PR TITLE
bump the HO image in personal dev environment

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1050,6 +1050,12 @@ clouds:
             tracing:
               address: "http://ingest.observability:4318"
               exporter: "otlp"
+          hypershift:
+            additionalInstallArg: '--enable-cpo-overrides=true'
+            image:
+              registry: quay.io
+              repository: acm-d/rhtap-hypershift-operator
+              digest: sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a
           # MC
           mgmt:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -15,7 +15,7 @@ clouds:
           westus3: ca0d25a6cc4793300ec9f5a0974988f202539bdeee3cf24ee70387a205757b8a
       pers:
         regions:
-          westus3: f85491445796d12aa4ea8af10c077a6354e63de3b326e00a05cccf71e871458a
+          westus3: e82b4495d972b8cb3c77bf15a157f002a3dc91c2731273352dae1689b8ae337c
       swft:
         regions:
           uksouth: c370aad1d2a4af5ca5b4df88b1b21c2e1b68cbc07da43262c63937c2974beabf

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -248,9 +248,9 @@ global:
           poll: true
         poll: true
 hypershift:
-  additionalInstallArg: ""
+  additionalInstallArg: --enable-cpo-overrides=true
   image:
-    digest: sha256:e470a4ad44f23684d36e1352a36892cffa8cbc604bac76b17a7e9b5d9dff5ed1
+    digest: sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift


### PR DESCRIPTION

<!-- Link to Jira issue -->

### What

- Add hypershift configuration to pers environment with updated image digest
- Enable CPO overrides via additionalInstallArg flag
- Update hypershift operator to quay.io/acm-d/rhtap-hypershift-operator@sha256:8ad6f8249dcef32d60ffbe39e6bf3f6db32dd32af63a7302e93e1b1667468b9a

This applies the same hypershift operator configuration from the cspr environment to the pers environment, ensuring consistency between development environments.

Related to: https://github.com/Azure/ARO-HCP/pull/2514

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
