### PR TITLE
Fix casing of "encryptionType" value ("KMS" not "kms")

### DIFF
--- a/demo/03-create-cluster.sh
+++ b/demo/03-create-cluster.sh
@@ -105,7 +105,7 @@ initialize_etcd_encryption_json_map() {
       "dataEncryption": {
         "keyManagementMode": "CustomerManaged",
         "customerManaged": {
-          "encryptionType": "kms",
+          "encryptionType": "KMS",
           "kms": {
             "activeKey": {
               "vaultName": "",

--- a/demo/bicep/cluster.bicep
+++ b/demo/bicep/cluster.bicep
@@ -525,7 +525,7 @@ resource hcp 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters@2024-06-10-preview'
       dataEncryption: {
         keyManagementMode: 'CustomerManaged'
         customerManaged: {
-          encryptionType: 'kms'
+          encryptionType: 'KMS'
           kms: {
              activeKey: {
               vaultName: keyVaultName

--- a/demo/cluster.tmpl.json
+++ b/demo/cluster.tmpl.json
@@ -18,7 +18,7 @@
       "dataEncryption": {
         "keyManagementMode": "CustomerManaged",
         "customerManaged": {
-          "encryptionType": "kms",
+          "encryptionType": "KMS",
           "kms": {
             "activeKey": {
               "vaultName": "customer-kv",

--- a/test/e2e-setup/bicep/image-registry/disabled-image-registry-cluster.bicep
+++ b/test/e2e-setup/bicep/image-registry/disabled-image-registry-cluster.bicep
@@ -79,7 +79,7 @@ resource hcp 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters@2024-06-10-preview'
       dataEncryption: {
         keyManagementMode: 'CustomerManaged'
         customerManaged: {
-          encryptionType: 'kms'
+          encryptionType: 'KMS'
           kms: {
             activeKey: {
               vaultName: keyVaultName

--- a/test/e2e-setup/bicep/modules/cluster.bicep
+++ b/test/e2e-setup/bicep/modules/cluster.bicep
@@ -79,7 +79,7 @@ resource hcp 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters@2024-06-10-preview'
       dataEncryption: {
         keyManagementMode: 'CustomerManaged'
         customerManaged: {
-          encryptionType: 'kms'
+          encryptionType: 'KMS'
           kms: {
             activeKey: {
               vaultName: keyVaultName


### PR DESCRIPTION
### What

The ARO-HCP RP temporarily accepts both `"kms"` and `"KMS"`. Once these corrections are deployed to all environments, the RP will be made to only accept `"KMS"`.

### Why

The OpenAPI specification for ARM only defines the enum value `"KMS"`, and enum values are case-sensitive.
