### PR TITLE
[Do Not Merge] ARO-19726: Add monitoring to environment-infra-cd workflow

### DIFF
--- a/.github/workflows/environment-infra-cd.yml
+++ b/.github/workflows/environment-infra-cd.yml
@@ -60,7 +60,7 @@ jobs:
         az config set bicep.use_binary_from_path=false
         az bicep install
         cd dev-infrastructure/
-        make region
+        make region monitoring
   deploy_service_cluster_rg:
     needs:
     - deploy_region_rg


### PR DESCRIPTION
## Description
This PR updates the environment-infra-cd.yml workflow to include 'monitoring' in the make region command.

## Related Issue
[ARO-19726](https://issues.redhat.com//browse/ARO-19726): Clusters Service SLO Alert

## Changes
- Updated .github/workflows/environment-infra-cd.yml to include 'monitoring' in the make region command

## Testing
- [ ] Workflow tested successfully
- [ ] Monitoring resources deployed correctly