### PR TITLE
fix: make sure nodepool name length <= 15

### DIFF
--- a/test/e2e/gpu_nodepools_create_delete.go
+++ b/test/e2e/gpu_nodepools_create_delete.go
@@ -91,7 +91,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				Expect(framework.VerifyHCPCluster(ctx, adminRESTConfig)).To(Succeed())
 
 				// Use Bicep template to create a nodepool with the specified parameters
-				npName := "np-gpu-" + sku.display
+				npName := sku.display
 				By(fmt.Sprintf("creating GPU nodepool %q with VM size %q using Bicep template", npName, sku.vmSize))
 				_, err = framework.CreateBicepTemplateAndWait(ctx,
 					tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),


### PR DESCRIPTION
### What

Drops "np-gpu" prefix from a node pool name in e2e gpu node pool test.

### Why

Max length of a node pool name is 15 characters, which we are breaching with the current prefix.

### Special notes for your reviewer
