### PR TITLE
Handle unknown enum values in CS/RP conversions

### DIFF
--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -3,6 +3,7 @@ module github.com/Azure/ARO-HCP/frontend
 go 1.24.3
 
 require (
+	dario.cat/mergo v1.0.1
 	github.com/Azure/ARO-HCP/internal v0.0.0-00010101000000-000000000000
 	github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel v0.4.0
 	github.com/google/go-cmp v0.7.0
@@ -22,7 +23,6 @@ require (
 )
 
 require (
-	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
 	github.com/Azure/retry v0.0.0-20250221010952-92c9290cea0f // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect

--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -98,7 +98,13 @@ func (f *Frontend) CreateOrUpdateExternalAuth(writer http.ResponseWriter, reques
 			return
 		}
 
-		hcpExternalAuth := ConvertCStoExternalAuth(resourceID, csExternalAuth)
+		hcpExternalAuth, err := ConvertCStoExternalAuth(resourceID, csExternalAuth)
+		if err != nil {
+			logger.Error(err.Error())
+			arm.WriteInternalServerError(writer)
+			return
+		}
+
 		operationRequest = database.OperationRequestUpdate
 
 		// This is slightly repetitive for the sake of clarify on PUT vs PATCH.
@@ -255,7 +261,11 @@ func (f *Frontend) CreateOrUpdateExternalAuth(writer http.ResponseWriter, reques
 
 // the necessary conversions for the API version of the request.
 func marshalCSExternalAuth(csEternalAuth *arohcpv1alpha1.ExternalAuth, doc *database.ResourceDocument, versionedInterface api.Version) ([]byte, error) {
-	hcpExternalAuth := ConvertCStoExternalAuth(doc.ResourceID, csEternalAuth)
+	hcpExternalAuth, err := ConvertCStoExternalAuth(doc.ResourceID, csEternalAuth)
+	if err != nil {
+		return nil, err
+	}
+
 	hcpExternalAuth.SystemData = doc.SystemData
 	// TODO: Use the correct state from the document when CS returns ir.
 	hcpExternalAuth.Properties.ProvisioningState = arm.ExternalAuthProvisioningStateSucceeded

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -471,7 +471,12 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 			return
 		}
 
-		hcpCluster := ConvertCStoHCPOpenShiftCluster(resourceID, csCluster)
+		hcpCluster, err := ConvertCStoHCPOpenShiftCluster(resourceID, csCluster)
+		if err != nil {
+			logger.Error(err.Error())
+			arm.WriteInternalServerError(writer)
+			return
+		}
 
 		// Do not set the TrackedResource.Tags field here. We need
 		// the Tags map to remain nil so we can see if the request
@@ -1239,7 +1244,11 @@ func (f *Frontend) OperationStatus(writer http.ResponseWriter, request *http.Req
 // marshalCSCluster renders a CS Cluster object in JSON format, applying
 // the necessary conversions for the API version of the request.
 func marshalCSCluster(csCluster *arohcpv1alpha1.Cluster, doc *database.ResourceDocument, versionedInterface api.Version) ([]byte, error) {
-	hcpCluster := ConvertCStoHCPOpenShiftCluster(doc.ResourceID, csCluster)
+	hcpCluster, err := ConvertCStoHCPOpenShiftCluster(doc.ResourceID, csCluster)
+	if err != nil {
+		return nil, err
+	}
+
 	hcpCluster.SystemData = doc.SystemData
 	hcpCluster.Tags = maps.Clone(doc.Tags)
 	hcpCluster.Properties.ProvisioningState = doc.ProvisioningState

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -165,7 +165,12 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		return
 	}
 
-	hcpCluster := ConvertCStoHCPOpenShiftCluster(resourceID.Parent, csCluster)
+	hcpCluster, err := ConvertCStoHCPOpenShiftCluster(resourceID.Parent, csCluster)
+	if err != nil {
+		logger.Error(err.Error())
+		arm.WriteInternalServerError(writer)
+		return
+	}
 
 	body, err := BodyFromContext(ctx)
 	if err != nil {

--- a/frontend/pkg/frontend/node_pool_test.go
+++ b/frontend/pkg/frontend/node_pool_test.go
@@ -156,7 +156,15 @@ func TestCreateNodePool(t *testing.T) {
 			mockCSClient.EXPECT().
 				GetCluster(gomock.Any(), clusterDoc.InternalID).
 				Return(arohcpv1alpha1.NewCluster().
-					Version(arohcpv1alpha1.NewVersion().ChannelGroup("stable")).
+					API(arohcpv1alpha1.NewClusterAPI().
+						Listening(arohcpv1alpha1.ListeningMethodExternal)).
+					Azure(arohcpv1alpha1.NewAzure().
+						NodesOutboundConnectivity(arohcpv1alpha1.NewAzureNodesOutboundConnectivity().
+							OutboundType(csPlatformOutboundType))).
+					ImageRegistry(arohcpv1alpha1.NewClusterImageRegistry().
+						State(csImageRegistryStateEnabled)).
+					Version(arohcpv1alpha1.NewVersion().
+						ChannelGroup("stable")).
 					Build())
 			// CreateOrUpdateNodePool
 			mockCSClient.EXPECT().

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -289,9 +289,6 @@ func ConvertCStoHCPOpenShiftCluster(resourceID *azcorearm.ResourceID, cluster *a
 				State: convertClusterImageRegistryStateCSToRP(cluster.ImageRegistry().State()),
 			},
 		},
-		Identity: &arm.ManagedServiceIdentity{
-			UserAssignedIdentities: make(map[string]*arm.UserAssignedIdentity),
-		},
 	}
 
 	// Only set etcd encryption settings if they exist in the cluster service response
@@ -314,6 +311,9 @@ func ConvertCStoHCPOpenShiftCluster(resourceID *azcorearm.ResourceID, cluster *a
 	// - The operator-specific maps under OperatorsAuthentication mimics the
 	//   Cluster Service maps but just has operator-to-resourceID pairings.
 	if cluster.Azure().OperatorsAuthentication() != nil {
+		hcpcluster.Identity = &arm.ManagedServiceIdentity{
+			UserAssignedIdentities: make(map[string]*arm.UserAssignedIdentity),
+		}
 		if mi, ok := cluster.Azure().OperatorsAuthentication().GetManagedIdentities(); ok {
 			hcpcluster.Properties.Platform.OperatorsAuthentication.UserAssignedIdentities.ControlPlaneOperators = make(map[string]string)
 			hcpcluster.Properties.Platform.OperatorsAuthentication.UserAssignedIdentities.DataPlaneOperators = make(map[string]string)

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -54,80 +54,96 @@ const (
 	csCustomerManagedEncryptionTypeKms    string = "kms"
 )
 
-func convertListeningToVisibility(listening arohcpv1alpha1.ListeningMethod) (visibility api.Visibility) {
+func convertListeningToVisibility(listening arohcpv1alpha1.ListeningMethod) api.Visibility {
 	switch listening {
 	case arohcpv1alpha1.ListeningMethodExternal:
-		visibility = api.VisibilityPublic
+		return api.VisibilityPublic
 	case arohcpv1alpha1.ListeningMethodInternal:
-		visibility = api.VisibilityPrivate
+		return api.VisibilityPrivate
+	default:
+		// FIXME Return an error instead.
+		return api.Visibility("")
 	}
-	return
 }
 
-func convertVisibilityToListening(visibility api.Visibility) (listening arohcpv1alpha1.ListeningMethod) {
+func convertVisibilityToListening(visibility api.Visibility) arohcpv1alpha1.ListeningMethod {
 	switch visibility {
 	case api.VisibilityPublic:
-		listening = arohcpv1alpha1.ListeningMethodExternal
+		return arohcpv1alpha1.ListeningMethodExternal
 	case api.VisibilityPrivate:
-		listening = arohcpv1alpha1.ListeningMethodInternal
+		return arohcpv1alpha1.ListeningMethodInternal
+	default:
+		// FIXME Return an error instead.
+		return arohcpv1alpha1.ListeningMethod("")
 	}
-	return
 }
 
-func convertOutboundTypeCSToRP(outboundTypeCS string) (outboundTypeRP api.OutboundType) {
+func convertOutboundTypeCSToRP(outboundTypeCS string) api.OutboundType {
 	switch outboundTypeCS {
 	case csPlatformOutboundType:
-		outboundTypeRP = api.OutboundTypeLoadBalancer
+		return api.OutboundTypeLoadBalancer
+	default:
+		// FIXME Return an error instead.
+		return api.OutboundType("")
 	}
-	return
 }
 
-func convertOutboundTypeRPToCS(outboundTypeRP api.OutboundType) (outboundTypeCS string) {
+func convertOutboundTypeRPToCS(outboundTypeRP api.OutboundType) string {
 	switch outboundTypeRP {
 	case api.OutboundTypeLoadBalancer:
-		outboundTypeCS = csPlatformOutboundType
+		return csPlatformOutboundType
+	default:
+		// FIXME Return an error instead.
+		return ""
 	}
-	return
 }
 
-func convertCustomerManagedEncryptionTypeCSToRP(encryptionTypeCS string) (encryptionTypeRP api.CustomerManagedEncryptionType) {
+func convertCustomerManagedEncryptionTypeCSToRP(encryptionTypeCS string) api.CustomerManagedEncryptionType {
 	switch encryptionTypeCS {
 	case csCustomerManagedEncryptionTypeKms:
-		encryptionTypeRP = api.CustomerManagedEncryptionTypeKMS
+		return api.CustomerManagedEncryptionTypeKMS
+	default:
+		// FIXME Return an error instead.
+		return ""
 	}
-	return
 }
 
-func convertCustomerManagedEncryptionTypeRPToCS(encryptionTypeRP api.CustomerManagedEncryptionType) (encryptionTypeCS string) {
+func convertCustomerManagedEncryptionTypeRPToCS(encryptionTypeRP api.CustomerManagedEncryptionType) string {
 	switch encryptionTypeRP {
 	case api.CustomerManagedEncryptionTypeKMS:
-		encryptionTypeCS = csCustomerManagedEncryptionTypeKms
+		return csCustomerManagedEncryptionTypeKms
+	default:
+		// FIXME Return an error instead.
+		return ""
 	}
-	return
 }
 
-func convertUsernameClaimPrefixPolicyCSToRP(prefixPolicyCS string) (prefixPolicyRP api.UsernameClaimPrefixPolicyType) {
+func convertUsernameClaimPrefixPolicyCSToRP(prefixPolicyCS string) api.UsernameClaimPrefixPolicyType {
 	switch prefixPolicyCS {
 	case csUsernameClaimPrefixPolicyPrefix:
-		prefixPolicyRP = api.UsernameClaimPrefixPolicyTypePrefix
+		return api.UsernameClaimPrefixPolicyTypePrefix
 	case csUsernameClaimPrefixPolicyNoPrefix:
-		prefixPolicyRP = api.UsernameClaimPrefixPolicyTypeNoPrefix
+		return api.UsernameClaimPrefixPolicyTypeNoPrefix
 	case "":
-		prefixPolicyRP = api.UsernameClaimPrefixPolicyTypeNone
+		return api.UsernameClaimPrefixPolicyTypeNone
+	default:
+		// FIXME Return an error instead.
+		return api.UsernameClaimPrefixPolicyType("")
 	}
-	return
 }
 
 func convertUsernameClaimPrefixPolicyRPToCS(prefixPolicyRP api.UsernameClaimPrefixPolicyType) (prefixPolicyCS string) {
 	switch prefixPolicyRP {
 	case api.UsernameClaimPrefixPolicyTypePrefix:
-		prefixPolicyCS = csUsernameClaimPrefixPolicyPrefix
+		return csUsernameClaimPrefixPolicyPrefix
 	case api.UsernameClaimPrefixPolicyTypeNoPrefix:
-		prefixPolicyCS = csUsernameClaimPrefixPolicyNoPrefix
+		return csUsernameClaimPrefixPolicyNoPrefix
 	case api.UsernameClaimPrefixPolicyTypeNone:
-		prefixPolicyCS = ""
+		return ""
+	default:
+		// FIXME Return an error instead.
+		return ""
 	}
-	return
 }
 
 func convertEnableEncryptionAtHostToCSBuilder(in api.NodePoolPlatformProfile) *arohcpv1alpha1.AzureNodePoolEncryptionAtHostBuilder {
@@ -174,24 +190,28 @@ func convertNodeDrainTimeoutCSToRP(in *arohcpv1alpha1.Cluster) int32 {
 	return 0
 }
 
-func convertKeyManagementModeTypeCSToRP(keyManagementModeCS string) (keyManagementModeRP api.EtcdDataEncryptionKeyManagementModeType) {
+func convertKeyManagementModeTypeCSToRP(keyManagementModeCS string) api.EtcdDataEncryptionKeyManagementModeType {
 	switch keyManagementModeCS {
 	case csKeyManagementModePlatformManaged:
-		keyManagementModeRP = api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged
+		return api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged
 	case csKeyManagementModeCustomerManaged:
-		keyManagementModeRP = api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+		return api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+	default:
+		// FIXME Return an error instead.
+		return api.EtcdDataEncryptionKeyManagementModeType("")
 	}
-	return
 }
 
-func convertKeyManagementModeTypeRPToCS(keyManagementModeRP api.EtcdDataEncryptionKeyManagementModeType) (keyManagementModeCS string) {
+func convertKeyManagementModeTypeRPToCS(keyManagementModeRP api.EtcdDataEncryptionKeyManagementModeType) string {
 	switch keyManagementModeRP {
 	case api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged:
-		keyManagementModeCS = csKeyManagementModePlatformManaged
+		return csKeyManagementModePlatformManaged
 	case api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged:
-		keyManagementModeCS = csKeyManagementModeCustomerManaged
+		return csKeyManagementModeCustomerManaged
+	default:
+		// FIXME Return an error instead.
+		return ""
 	}
-	return
 }
 
 func convertCustomerManagedEncryptionCSToRP(in *arohcpv1alpha1.AzureEtcdDataEncryption) *api.CustomerManagedEncryptionProfile {

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -49,6 +49,8 @@ const (
 	csPlatformOutboundType                string = "load_balancer"
 	csUsernameClaimPrefixPolicyPrefix     string = "Prefix"
 	csUsernameClaimPrefixPolicyNoPrefix   string = "NoPrefix"
+	csKeyManagementModeCustomerManaged    string = "customer_managed"
+	csKeyManagementModePlatformManaged    string = "platform_managed"
 	csCustomerManagedEncryptionTypeKms    string = "kms"
 )
 
@@ -174,9 +176,9 @@ func convertNodeDrainTimeoutCSToRP(in *arohcpv1alpha1.Cluster) int32 {
 
 func convertKeyManagementModeTypeCSToRP(keyManagementModeCS string) (keyManagementModeRP api.EtcdDataEncryptionKeyManagementModeType) {
 	switch keyManagementModeCS {
-	case "platform_managed":
+	case csKeyManagementModePlatformManaged:
 		keyManagementModeRP = api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged
-	case "customer_managed":
+	case csKeyManagementModeCustomerManaged:
 		keyManagementModeRP = api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
 	}
 	return
@@ -185,9 +187,9 @@ func convertKeyManagementModeTypeCSToRP(keyManagementModeCS string) (keyManageme
 func convertKeyManagementModeTypeRPToCS(keyManagementModeRP api.EtcdDataEncryptionKeyManagementModeType) (keyManagementModeCS string) {
 	switch keyManagementModeRP {
 	case api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged:
-		keyManagementModeCS = "platform_managed"
+		keyManagementModeCS = csKeyManagementModePlatformManaged
 	case api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged:
-		keyManagementModeCS = "customer_managed"
+		keyManagementModeCS = csKeyManagementModeCustomerManaged
 	}
 	return
 }

--- a/frontend/pkg/frontend/ocm_test.go
+++ b/frontend/pkg/frontend/ocm_test.go
@@ -103,7 +103,7 @@ func TestConvertCStoHCPOpenShiftCluster(t *testing.T) {
 				Azure(arohcpv1alpha1.NewAzure().
 					EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
 						DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
-							KeyManagementMode(convertKeyManagementModeTypeRPToCS(api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged))),
+							KeyManagementMode(csKeyManagementModePlatformManaged)),
 					),
 				),
 			want: clusterResource(
@@ -119,7 +119,7 @@ func TestConvertCStoHCPOpenShiftCluster(t *testing.T) {
 				Azure(arohcpv1alpha1.NewAzure().
 					EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
 						DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
-							KeyManagementMode(convertKeyManagementModeTypeRPToCS(api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged)).
+							KeyManagementMode(csKeyManagementModeCustomerManaged).
 							CustomerManaged(arohcpv1alpha1.NewAzureEtcdDataEncryptionCustomerManaged().
 								EncryptionType("kms").
 								Kms(arohcpv1alpha1.NewAzureKmsEncryption().

--- a/frontend/pkg/frontend/ocm_test.go
+++ b/frontend/pkg/frontend/ocm_test.go
@@ -17,11 +17,13 @@ package frontend
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"dario.cat/mergo"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,49 +75,56 @@ func TestRequestIDPropagator(t *testing.T) {
 }
 
 func TestConvertCStoHCPOpenShiftCluster(t *testing.T) {
-	resourceID := testResourceID(t)
+	resourceID, err := azcorearm.ParseResourceID(api.TestClusterResourceID)
+	require.NoError(t, err)
+
 	testCases := []struct {
-		name    string
-		cluster *arohcpv1alpha1.ClusterBuilder
-		want    *api.HCPOpenShiftCluster
+		name             string
+		ocmClusterTweaks *arohcpv1alpha1.ClusterBuilder
+		hcpClusterTweaks *api.HCPOpenShiftCluster
 	}{
 		{
-			name:    "zero",
-			cluster: arohcpv1alpha1.NewCluster(),
-			want:    clusterResource(),
+			name:             "zero",
+			ocmClusterTweaks: arohcpv1alpha1.NewCluster(),
+			hcpClusterTweaks: &api.HCPOpenShiftCluster{},
 		},
 		{
 			name: "converts nodeDrainGracePeriod to nodeDrainTimeoutMinutes",
-			cluster: arohcpv1alpha1.NewCluster().
+			ocmClusterTweaks: arohcpv1alpha1.NewCluster().
 				NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
 					Unit(azureNodePoolNodeDrainGracePeriodUnit).
 					Value(42),
 				),
-			want: clusterResource(
-				func(hsc *api.HCPOpenShiftCluster) {
-					hsc.Properties.NodeDrainTimeoutMinutes = 42
+			hcpClusterTweaks: &api.HCPOpenShiftCluster{
+				Properties: api.HCPOpenShiftClusterProperties{
+					NodeDrainTimeoutMinutes: 42,
 				},
-			),
+			},
 		},
 		{
 			name: "converts EtcdEncryption for only default PlatformManaged",
-			cluster: arohcpv1alpha1.NewCluster().
+			ocmClusterTweaks: arohcpv1alpha1.NewCluster().
 				Azure(arohcpv1alpha1.NewAzure().
 					EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
 						DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
-							KeyManagementMode(csKeyManagementModePlatformManaged)),
+							KeyManagementMode(csKeyManagementModePlatformManaged),
+						),
 					),
 				),
-			want: clusterResource(
-				func(hsc *api.HCPOpenShiftCluster) {
-					hsc.Properties.Etcd.DataEncryption.KeyManagementMode = api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged
-					hsc.Properties.Etcd.DataEncryption.CustomerManaged = nil
+			hcpClusterTweaks: &api.HCPOpenShiftCluster{
+				Properties: api.HCPOpenShiftClusterProperties{
+					Etcd: api.EtcdProfile{
+						DataEncryption: api.EtcdDataEncryptionProfile{
+							KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged,
+							CustomerManaged:   nil,
+						},
+					},
 				},
-			),
+			},
 		},
 		{
 			name: "converts EtcdEncryption for CustomerManaged",
-			cluster: arohcpv1alpha1.NewCluster().
+			ocmClusterTweaks: arohcpv1alpha1.NewCluster().
 				Azure(arohcpv1alpha1.NewAzure().
 					EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
 						DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
@@ -133,44 +142,54 @@ func TestConvertCStoHCPOpenShiftCluster(t *testing.T) {
 						),
 					),
 				),
-			want: clusterResource(
-				func(hsc *api.HCPOpenShiftCluster) {
-					hsc.Properties.Etcd.DataEncryption = api.EtcdDataEncryptionProfile{
-						CustomerManaged: &api.CustomerManagedEncryptionProfile{
-							EncryptionType: "KMS",
-							Kms: &api.KmsEncryptionProfile{
-								ActiveKey: api.KmsKey{
-									Name:      "test",
-									VaultName: "test",
-									Version:   "test-version",
+			hcpClusterTweaks: &api.HCPOpenShiftCluster{
+				Properties: api.HCPOpenShiftClusterProperties{
+					Etcd: api.EtcdProfile{
+						DataEncryption: api.EtcdDataEncryptionProfile{
+							CustomerManaged: &api.CustomerManagedEncryptionProfile{
+								EncryptionType: "KMS",
+								Kms: &api.KmsEncryptionProfile{
+									ActiveKey: api.KmsKey{
+										Name:      "test",
+										VaultName: "test",
+										Version:   "test-version",
+									},
 								},
 							},
+							KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
 						},
-						KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
-					}
+					},
 				},
-			),
+			},
 		},
 		{
 			name: "converts CS ClusterImageRegistry to ClusterImageRegistryProfile",
-			cluster: arohcpv1alpha1.NewCluster().
+			ocmClusterTweaks: arohcpv1alpha1.NewCluster().
 				ImageRegistry(arohcpv1alpha1.NewClusterImageRegistry().
 					State(string(csImageRegistryStateDisabled)),
 				),
-			want: clusterResource(
-				func(hsc *api.HCPOpenShiftCluster) {
-					hsc.Properties.ClusterImageRegistry = api.ClusterImageRegistryProfile{
+			hcpClusterTweaks: &api.HCPOpenShiftCluster{
+				Properties: api.HCPOpenShiftClusterProperties{
+					ClusterImageRegistry: api.ClusterImageRegistryProfile{
 						State: api.ClusterImageRegistryProfileStateDisabled,
-					}
+					},
 				},
-			),
+			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cluster, err := tc.cluster.Build()
-			require.NoError(t, err)
-			assert.Equalf(t, tc.want, ConvertCStoHCPOpenShiftCluster(resourceID, cluster), "ConvertCStoHCPOpenShiftCluster(%v, %v)", resourceID, cluster)
+			csCluster := ocmCluster(t, ocmClusterDefaults(), tc.ocmClusterTweaks)
+			expectHcpCluster := api.ClusterTestCase(t, tc.hcpClusterTweaks)
+
+			// FIXME Temporary hack until we pass cluster autoscaling values to CS.
+			expectHcpCluster.Properties.Autoscaling.MaxPodGracePeriodSeconds = 0
+			expectHcpCluster.Properties.Autoscaling.MaxNodeProvisionTimeSeconds = 0
+			expectHcpCluster.Properties.Autoscaling.PodPriorityThreshold = 0
+
+			actualHcpCluster := ConvertCStoHCPOpenShiftCluster(resourceID, csCluster)
+
+			assert.Equal(t, expectHcpCluster, actualHcpCluster)
 		})
 	}
 }
@@ -182,15 +201,9 @@ func TestWithImmutableAttributes(t *testing.T) {
 		want       *arohcpv1alpha1.Cluster
 	}{
 		{
-			name: "simple default",
-			hcpCluster: &api.HCPOpenShiftCluster{
-				Properties: api.HCPOpenShiftClusterProperties{
-					Platform: api.PlatformProfile{
-						ManagedResourceGroup: "test",
-					},
-				},
-			},
-			want: ocmCluster(t, withOCMClusterDefaults()),
+			name:       "simple default",
+			hcpCluster: &api.HCPOpenShiftCluster{},
+			want:       ocmCluster(t, ocmClusterDefaults()),
 		},
 	}
 
@@ -199,12 +212,19 @@ func TestWithImmutableAttributes(t *testing.T) {
 			var buf bytes.Buffer
 			require.NoError(t, arohcpv1alpha1.MarshalCluster(tc.want, &buf))
 			want := buf.String()
-			result, err := withImmutableAttributes(arohcpv1alpha1.NewCluster(), tc.hcpCluster, "test", "test", "test", "test", "").Build()
+			result, err := withImmutableAttributes(
+				ocmClusterDefaults(),
+				api.ClusterTestCase(t, tc.hcpCluster),
+				api.TestSubscriptionID,
+				api.TestResourceGroupName,
+				api.TestLocation,
+				api.TestTenantID,
+				"").Build()
 			require.NoError(t, err)
 			buf.Reset()
 			require.NoError(t, arohcpv1alpha1.MarshalCluster(result, &buf))
 			got := buf.String()
-			assert.JSONEqf(t, want, got, "withImmutableAttributes(%v, %v, %v, %v, %v, %v, %v)", "NewCluster()", tc.hcpCluster, "test", "test", "test", "test", "test")
+			assert.JSONEq(t, want, got)
 		})
 	}
 }
@@ -215,78 +235,71 @@ func testResourceID(t *testing.T) *azcorearm.ResourceID {
 	return resourceID
 }
 
-func clusterResource(opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
-	c := &api.HCPOpenShiftCluster{
-		TrackedResource: arm.TrackedResource{
-			Resource: arm.Resource{
-				ID:   api.TestClusterResourceID,
-				Name: api.TestClusterName,
-				Type: api.ClusterResourceType.String(),
-			},
-		},
-		Properties: api.HCPOpenShiftClusterProperties{},
-		Identity: &arm.ManagedServiceIdentity{
-			UserAssignedIdentities: make(map[string]*arm.UserAssignedIdentity),
-		},
-	}
-	for _, opt := range opts {
-		opt(c)
+func ocmCluster(t *testing.T, builders ...*arohcpv1alpha1.ClusterBuilder) *arohcpv1alpha1.Cluster {
+	var mergedCluster map[string]interface{}
+
+	for _, builder := range builders {
+		var rawCluster map[string]interface{}
+		var buffer bytes.Buffer
+
+		cluster, err := builder.Build()
+		require.NoError(t, err)
+		require.NoError(t, arohcpv1alpha1.MarshalCluster(cluster, &buffer))
+		require.NoError(t, json.Unmarshal(buffer.Bytes(), &rawCluster))
+		require.NoError(t, mergo.Merge(&mergedCluster, rawCluster, mergo.WithOverride))
 	}
 
-	return c
+	data, err := arm.MarshalJSON(mergedCluster)
+	require.NoError(t, err)
+	cluster, err := arohcpv1alpha1.UnmarshalCluster(data)
+	require.NoError(t, err)
+
+	return cluster
 }
 
-func ocmCluster(t *testing.T, opts ...func(*arohcpv1alpha1.ClusterBuilder) *arohcpv1alpha1.ClusterBuilder) *arohcpv1alpha1.Cluster {
-	b := arohcpv1alpha1.NewCluster()
-	for _, opt := range opts {
-		b = opt(b)
-	}
-	c, err := b.Build()
-	assert.NoError(t, err)
-	return c
-}
-
-func withOCMClusterDefaults() func(*arohcpv1alpha1.ClusterBuilder) *arohcpv1alpha1.ClusterBuilder {
-	return func(b *arohcpv1alpha1.ClusterBuilder) *arohcpv1alpha1.ClusterBuilder {
-		// This reflects how the immutable attributes get set when passed an empty[*] RP
-		// cluster. (well, not exactly empty, need to set Platform.ManagedResourceGroupName
-		// so that we don't get a corresponding random value in the output.)
-		return b.
-			API(arohcpv1alpha1.NewClusterAPI().Listening("")).
-			Azure(arohcpv1alpha1.NewAzure().
-				ManagedResourceGroupName("test").
-				NodesOutboundConnectivity(arohcpv1alpha1.NewAzureNodesOutboundConnectivity().
-					OutboundType("")).
-				ResourceGroupName("test").
-				ResourceName("").
-				SubnetResourceID("").
-				SubscriptionID("test").
-				TenantID("test"),
-			).
-			CCS(arohcpv1alpha1.NewCCS().Enabled(true)).
-			CloudProvider(cmv1.NewCloudProvider().
-				ID("azure")).
-			Flavour(cmv1.NewFlavour().
-				ID("osd-4")).
-			Hypershift(arohcpv1alpha1.NewHypershift().
-				Enabled(true)).
-			Name("").
-			Network(arohcpv1alpha1.NewNetwork().
-				HostPrefix(0).
-				MachineCIDR("").
-				PodCIDR("").
-				ServiceCIDR("").
-				Type("")).
-			Product(cmv1.NewProduct().
-				ID("aro")).
-			Region(cmv1.NewCloudRegion().
-				ID("test")).
-			Version(arohcpv1alpha1.NewVersion().
-				ID("").
-				ChannelGroup("")).
-			ImageRegistry(arohcpv1alpha1.NewClusterImageRegistry().
-				State(""))
-	}
+func ocmClusterDefaults() *arohcpv1alpha1.ClusterBuilder {
+	// This reflects how the immutable attributes get set when passed a minimally
+	// valid RP cluster, using constants from internal/api/testhelpers.go.
+	return arohcpv1alpha1.NewCluster().
+		API(arohcpv1alpha1.NewClusterAPI().
+			Listening(arohcpv1alpha1.ListeningMethodExternal)).
+		Azure(arohcpv1alpha1.NewAzure().
+			EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
+				DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
+					KeyManagementMode(csKeyManagementModePlatformManaged))).
+			ManagedResourceGroupName(api.TestManagedResourceGroupName).
+			NetworkSecurityGroupResourceID(api.TestNetworkSecurityGroupResourceID).
+			NodesOutboundConnectivity(arohcpv1alpha1.NewAzureNodesOutboundConnectivity().
+				OutboundType(csPlatformOutboundType)).
+			ResourceGroupName(api.TestResourceGroupName).
+			ResourceName(api.TestClusterName).
+			SubnetResourceID(api.TestSubnetResourceID).
+			SubscriptionID(api.TestSubscriptionID).
+			TenantID(api.TestTenantID),
+		).
+		CCS(arohcpv1alpha1.NewCCS().Enabled(true)).
+		CloudProvider(cmv1.NewCloudProvider().
+			ID("azure")).
+		Flavour(cmv1.NewFlavour().
+			ID("osd-4")).
+		Hypershift(arohcpv1alpha1.NewHypershift().
+			Enabled(true)).
+		Name(api.TestClusterName).
+		Network(arohcpv1alpha1.NewNetwork().
+			HostPrefix(23).
+			MachineCIDR("10.0.0.0/16").
+			PodCIDR("10.128.0.0/14").
+			ServiceCIDR("172.30.0.0/16").
+			Type("OVNKubernetes")).
+		Product(cmv1.NewProduct().
+			ID("aro")).
+		Region(cmv1.NewCloudRegion().
+			ID(api.TestLocation)).
+		Version(arohcpv1alpha1.NewVersion().
+			ID("").
+			ChannelGroup("stable")).
+		ImageRegistry(arohcpv1alpha1.NewClusterImageRegistry().
+			State(csImageRegistryStateEnabled))
 }
 
 func getHCPNodePoolResource(opts ...func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
@@ -371,9 +384,7 @@ func TestBuildCSNodePool(t *testing.T) {
 }
 
 func externalAuthResource(opts ...func(*api.HCPOpenShiftClusterExternalAuth)) *api.HCPOpenShiftClusterExternalAuth {
-	externalAuth := &api.HCPOpenShiftClusterExternalAuth{
-		Properties: api.HCPOpenShiftClusterExternalAuthProperties{},
-	}
+	externalAuth := api.NewDefaultHCPOpenShiftClusterExternalAuth()
 
 	for _, opt := range opts {
 		opt(externalAuth)

--- a/frontend/pkg/frontend/ocm_test.go
+++ b/frontend/pkg/frontend/ocm_test.go
@@ -187,7 +187,8 @@ func TestConvertCStoHCPOpenShiftCluster(t *testing.T) {
 			expectHcpCluster.Properties.Autoscaling.MaxNodeProvisionTimeSeconds = 0
 			expectHcpCluster.Properties.Autoscaling.PodPriorityThreshold = 0
 
-			actualHcpCluster := ConvertCStoHCPOpenShiftCluster(resourceID, csCluster)
+			actualHcpCluster, err := ConvertCStoHCPOpenShiftCluster(resourceID, csCluster)
+			require.NoError(t, err)
 
 			assert.Equal(t, expectHcpCluster, actualHcpCluster)
 		})
@@ -212,14 +213,16 @@ func TestWithImmutableAttributes(t *testing.T) {
 			var buf bytes.Buffer
 			require.NoError(t, arohcpv1alpha1.MarshalCluster(tc.want, &buf))
 			want := buf.String()
-			result, err := withImmutableAttributes(
+			builder, err := withImmutableAttributes(
 				ocmClusterDefaults(),
 				api.ClusterTestCase(t, tc.hcpCluster),
 				api.TestSubscriptionID,
 				api.TestResourceGroupName,
 				api.TestLocation,
 				api.TestTenantID,
-				"").Build()
+				"")
+			require.NoError(t, err)
+			result, err := builder.Build()
 			require.NoError(t, err)
 			buf.Reset()
 			require.NoError(t, arohcpv1alpha1.MarshalCluster(result, &buf))
@@ -552,7 +555,8 @@ func TestBuildCSExternalAuth(t *testing.T) {
 			ctx := ContextWithLogger(context.Background(), api.NewTestLogger())
 			expected, err := tc.expectedCSExternalAuth.Build()
 			require.NoError(t, err)
-			generatedCSExternalAuth, _ := f.BuildCSExternalAuth(ctx, tc.hcpExternalAuth, false)
+			generatedCSExternalAuth, err := f.BuildCSExternalAuth(ctx, tc.hcpExternalAuth, false)
+			require.NoError(t, err)
 			assert.Equalf(t, expected, generatedCSExternalAuth, "BuildCSExternalAuth(%v, %v)", resourceID, expected)
 		})
 	}

--- a/internal/api/testhelpers.go
+++ b/internal/api/testhelpers.go
@@ -43,6 +43,7 @@ const (
 	TestNodePoolName             = "testNodePool"
 	TestExternalAuthName         = "testExternalAuth"
 	TestDeploymentName           = "testDeployment"
+	TestManagedResourceGroupName = "testManagedResourceGroup"
 	TestNetworkSecurityGroupName = "testNetworkSecurityGroup"
 	TestVirtualNetworkName       = "testVirtualNetwork"
 	TestSubnetName               = "testSubnet"
@@ -137,7 +138,11 @@ func NewTestUserAssignedIdentity(name string) string {
 
 func MinimumValidClusterTestCase() *HCPOpenShiftCluster {
 	resource := NewDefaultHCPOpenShiftCluster()
+	resource.ID = TestClusterResourceID
+	resource.Name = TestClusterName
+	resource.Type = ClusterResourceType.String()
 	resource.Location = TestLocation
+	resource.Properties.Platform.ManagedResourceGroup = TestManagedResourceGroupName
 	resource.Properties.Platform.SubnetID = TestSubnetResourceID
 	resource.Properties.Platform.NetworkSecurityGroupID = TestNetworkSecurityGroupResourceID
 	return resource
@@ -151,6 +156,9 @@ func ClusterTestCase(t *testing.T, tweaks *HCPOpenShiftCluster) *HCPOpenShiftClu
 
 func MinimumValidNodePoolTestCase() *HCPOpenShiftClusterNodePool {
 	resource := NewDefaultHCPOpenShiftClusterNodePool()
+	resource.ID = TestNodePoolResourceID
+	resource.Name = TestNodePoolName
+	resource.Type = NodePoolResourceType.String()
 	resource.Location = TestLocation
 	resource.Properties.Platform.VMSize = "Standard_D8s_v3"
 	return resource
@@ -164,6 +172,9 @@ func NodePoolTestCase(t *testing.T, tweaks *HCPOpenShiftClusterNodePool) *HCPOpe
 
 func MinimumValidExternalAuthTestCase() *HCPOpenShiftClusterExternalAuth {
 	resource := NewDefaultHCPOpenShiftClusterExternalAuth()
+	resource.ID = TestExternalAuthResourceID
+	resource.Name = TestExternalAuthName
+	resource.Type = ExternalAuthResourceType.String()
 	resource.Properties.Issuer.Url = "https://www.redhat.com"
 	resource.Properties.Issuer.Audiences = []string{"audience1"}
 	resource.Properties.Claim.Mappings.Username.Claim = "my-cool-claim"


### PR DESCRIPTION
### What

In the course of converting a CS resource to an RP resource (or vice versa), if the RP encounters an unrecognized enum value it would just leave the destination field empty.  With this change we instead fail the conversion with an error.

### Why

Promised followup to review comments in #2508 (particularly [here](https://github.com/Azure/ARO-HCP/pull/2508#discussion_r2283483841) and [here](https://github.com/Azure/ARO-HCP/pull/2508#discussion_r2283503579)).

### Special notes for your reviewer

Please review one commit at a time.  It will be a lot easier.

This forced me to do some extensive refactoring of `ocm_test.go` because some of the tests were _relying_ on empty enum values.  The 3rd commit ("frontend: Update OCM tests") has all that junk.