### PR TITLE
e2e test: handle both diabled and invalid versions

### DIFF
--- a/test/e2e/cluster_create_missing_info.go
+++ b/test/e2e/cluster_create_missing_info.go
@@ -114,7 +114,7 @@ var _ = Describe("Customer", func() {
 					45*time.Minute,
 				)
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(MatchRegexp("Version .* doesn't exist")))
+				Expect(err).To(MatchError(MatchRegexp("Version .* (doesn't exist|is disabled)")))
 			},
 		)
 	}


### PR DESCRIPTION
### What

Updates regexp in test/e2e/cluster_create_missing_info.go to match both disabled and invalid versions.

### Why

The test started to fail recently because we are getting error about the version being disabled, while before we got error that it doesn't exist. From the perspective of this negative test, we don't control whether the version has been disabled or is just invalid, but we need to make sure that it's not possible to deploy cluster in such version.

### Special notes for your reviewer

<!-- optional -->
