### PR TITLE
fix node pool naming failure

### DIFF
--- a/test/e2e/complete_cluster_create.go
+++ b/test/e2e/complete_cluster_create.go
@@ -51,7 +51,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			By("creating a resource group")
-			resourceGroup, err := tc.NewResourceGroup(ctx, "setup-scripts", "uksouth")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "basic-cluster", "uksouth")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a customer-infra")

--- a/test/e2e/gpu_nodepools_create_delete.go
+++ b/test/e2e/gpu_nodepools_create_delete.go
@@ -91,7 +91,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				Expect(framework.VerifyHCPCluster(ctx, adminRESTConfig)).To(Succeed())
 
 				// Use Bicep template to create a nodepool with the specified parameters
-				npName := sku.display
+				npName := "np-1" // node pools have very restrictive naming rules
 				By(fmt.Sprintf("creating GPU nodepool %q with VM size %q using Bicep template", npName, sku.vmSize))
 				_, err = framework.CreateBicepTemplateAndWait(ctx,
 					tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),


### PR DESCRIPTION
fixes 

```
     {
      "status": "Failed",
      "error": {
        "code": "DeploymentFailed",
        "message": "At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.",
        "details": [
          {
            "code": "BadRequest",
            "message": "{\r\n  \"error\": {\r\n    \"code\": \"InvalidResourceName\",\r\n    \"message\": \"The Resource 'Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools/np-gpu-NC4asT4v3' under resource group 'gpu-nodepools-NC4asT4v3-r79j5l' does not conform to the naming restriction.\",\r\n    \"target\": \"/subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54/resourceGroups/gpu-nodepools-NC4asT4v3-r79j5l/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/gpu-nodepool-cluster-z45c42/nodePools/np-gpu-NC4asT4v3\"\r\n  }\r\n}"
          }
        ]
      }
    }

```