### PR TITLE
tooling: add a command to explain config provenance

### DIFF
--- a/tooling/pipeline-documentation/go.mod
+++ b/tooling/pipeline-documentation/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/pipeline-documentation
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250820014220-4c90dceb795f
+	github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1

--- a/tooling/pipeline-documentation/go.sum
+++ b/tooling/pipeline-documentation/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250820014220-4c90dceb795f h1:2CoV7xN73PfLt1p+hovsCWasKieuJy35Jn/4dQfxYmU=
-github.com/Azure/ARO-Tools v0.0.0-20250820014220-4c90dceb795f/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
+github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0 h1:Rf6WEFopSahIp8Heeu9Y4InS6FesXyT3eOW/Yp75Sfw=
+github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dusted-go/logging v1.3.0 h1:SL/EH1Rp27oJQIte+LjWvWACSnYDTqNx5gZULin0XRY=

--- a/tooling/secret-sync/go.mod
+++ b/tooling/secret-sync/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/secret-sync
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250820014220-4c90dceb795f
+	github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1

--- a/tooling/secret-sync/go.sum
+++ b/tooling/secret-sync/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250820014220-4c90dceb795f h1:2CoV7xN73PfLt1p+hovsCWasKieuJy35Jn/4dQfxYmU=
-github.com/Azure/ARO-Tools v0.0.0-20250820014220-4c90dceb795f/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
+github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0 h1:Rf6WEFopSahIp8Heeu9Y4InS6FesXyT3eOW/Yp75Sfw=
+github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1 h1:Wc1ml6QlJs2BHQ/9Bqu1jiyggbsSjramq2oUmp5WeIo=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1/go.mod h1:Ot/6aikWnKWi4l9QB7qVSwa8iMphQNqkWALMoNT3rzM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1 h1:B+blDbyVIG3WaikNxPnhPiJ1MThR03b3vKGtER95TP4=

--- a/tooling/templatize/cmd/configuration/cmd.go
+++ b/tooling/templatize/cmd/configuration/cmd.go
@@ -17,6 +17,8 @@ package configuration
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/Azure/ARO-HCP/tooling/templatize/cmd/configuration/explain"
+
 	"github.com/Azure/ARO-HCP/tooling/templatize/cmd/configuration/validate"
 
 	"github.com/Azure/ARO-HCP/tooling/templatize/cmd/configuration/render"
@@ -35,6 +37,7 @@ func NewCommand() (*cobra.Command, error) {
 
 	commands := []func() (*cobra.Command, error){
 		render.NewCommand,
+		explain.NewCommand,
 		func() (*cobra.Command, error) {
 			return validate.NewCommand("https://github.com/Azure/ARO-HCP.git")
 		},

--- a/tooling/templatize/cmd/configuration/explain/cmd.go
+++ b/tooling/templatize/cmd/configuration/explain/cmd.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package explain
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCommand() (*cobra.Command, error) {
+	opts := DefaultOptions()
+	cmd := &cobra.Command{
+		Use:           "explain",
+		Short:         "Explain how a value in service configuration is overridden for a given cloud, environment, and region.",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExplain(cmd.Context(), opts)
+		},
+	}
+	if err := BindOptions(opts, cmd); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
+func runExplain(ctx context.Context, opts *RawOptions) error {
+	validated, err := opts.Validate()
+	if err != nil {
+		return err
+	}
+	completed, err := validated.Complete()
+	if err != nil {
+		return err
+	}
+	return completed.ExplainConfiguration(ctx)
+}

--- a/tooling/templatize/cmd/configuration/explain/options.go
+++ b/tooling/templatize/cmd/configuration/explain/options.go
@@ -1,0 +1,200 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package explain
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/Azure/ARO-Tools/pkg/config"
+	"github.com/Azure/ARO-Tools/pkg/config/ev2config"
+	"github.com/spf13/cobra"
+)
+
+func DefaultOptions() *RawOptions {
+	return &RawOptions{
+		Stamp: 1,
+	}
+}
+
+func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
+	cmd.Flags().StringVar(&opts.ServiceConfigFile, "service-config-file", opts.ServiceConfigFile, "Path to the service configuration file.")
+	cmd.Flags().StringVar(&opts.Cloud, "cloud", opts.Cloud, "The name of the cloud to explain in.")
+	cmd.Flags().StringVar(&opts.Environment, "environment", opts.Environment, "The name of the environment to explain in.")
+	cmd.Flags().StringVar(&opts.Region, "region", opts.Region, "The name of the region to explain in.")
+	cmd.Flags().StringVar(&opts.Ev2Cloud, "ev2-cloud", opts.Ev2Cloud, "Cloud to use for Ev2 configuration, useful for dev mode explanations.")
+	cmd.Flags().StringVar(&opts.RegionShortSuffix, "region-short-suffix", opts.RegionShortSuffix, "Suffix to use for region short-name, useful for dev mode explanations.")
+	cmd.Flags().IntVar(&opts.Stamp, "stamp", opts.Stamp, "Stamp value to use, useful for dev mode explanations.")
+
+	cmd.Flags().StringVar(&opts.Path, "path", opts.Path, "Path to the value needing explanation.")
+
+	for _, flag := range []string{
+		"service-config-file",
+	} {
+		if err := cmd.MarkFlagFilename(flag); err != nil {
+			return fmt.Errorf("failed to mark flag %q as a file: %w", flag, err)
+		}
+	}
+	return nil
+}
+
+// RawOptions holds input values.
+type RawOptions struct {
+	ServiceConfigFile string
+	Cloud             string
+	Environment       string
+	Region            string
+	Ev2Cloud          string
+	RegionShortSuffix string
+	Stamp             int
+
+	Path string
+}
+
+// validatedOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
+type validatedOptions struct {
+	*RawOptions
+}
+
+type ValidatedOptions struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*validatedOptions
+}
+
+// completedOptions is a private wrapper that enforces a call of Complete() before config generation can be invoked.
+type completedOptions struct {
+	Config            config.ConfigProvider
+	Cloud             string
+	Environment       string
+	Region            string
+	Ev2Cloud          string
+	RegionShortSuffix string
+	Stamp             int
+	Path              string
+}
+
+type Options struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*completedOptions
+}
+
+func (o *RawOptions) Validate() (*ValidatedOptions, error) {
+	for _, item := range []struct {
+		flag  string
+		name  string
+		value *string
+	}{
+		{flag: "service-config-file", name: "service configuration file", value: &o.ServiceConfigFile},
+		{flag: "cloud", name: "cloud", value: &o.Cloud},
+		{flag: "environment", name: "environment", value: &o.Environment},
+		{flag: "region", name: "region", value: &o.Environment},
+		{flag: "path", name: "path", value: &o.Path},
+	} {
+		if item.value == nil || *item.value == "" {
+			return nil, fmt.Errorf("the %s must be provided with --%s", item.name, item.flag)
+		}
+	}
+
+	return &ValidatedOptions{
+		validatedOptions: &validatedOptions{
+			RawOptions: o,
+		},
+	}, nil
+}
+
+func (o *ValidatedOptions) Complete() (*Options, error) {
+	c, err := config.NewConfigProvider(o.ServiceConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config file: %w", err)
+	}
+
+	return &Options{
+		completedOptions: &completedOptions{
+			Config:            c,
+			Cloud:             o.Cloud,
+			Environment:       o.Environment,
+			Region:            o.Region,
+			Ev2Cloud:          o.Ev2Cloud,
+			RegionShortSuffix: o.RegionShortSuffix,
+			Stamp:             o.Stamp,
+			Path:              o.Path,
+		},
+	}, nil
+}
+
+func (opts *Options) ExplainConfiguration(ctx context.Context) error {
+	ev2Cloud := opts.Cloud
+	if opts.Ev2Cloud != "" {
+		ev2Cloud = opts.Ev2Cloud
+	}
+	ev2Cfg, err := ev2config.ResolveConfig(ev2Cloud, opts.Region)
+	if err != nil {
+		return fmt.Errorf("failed to get ev2 config: %w", err)
+	}
+	replacements := &config.ConfigReplacements{
+		RegionReplacement:      opts.Region,
+		CloudReplacement:       opts.Cloud,
+		EnvironmentReplacement: opts.Environment,
+		StampReplacement:       strconv.Itoa(opts.Stamp),
+		Ev2Config:              ev2Cfg,
+	}
+	for key, into := range map[string]*string{
+		"regionShortName": &replacements.RegionShortReplacement,
+	} {
+		value, err := ev2Cfg.GetByPath(key)
+		if err != nil {
+			return fmt.Errorf("%q not found in ev2 config: %w", key, err)
+		}
+		str, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("%q is not a string", key)
+		}
+		*into = str
+	}
+	if opts.RegionShortSuffix != "" {
+		replacements.RegionShortReplacement += opts.RegionShortSuffix
+	}
+
+	resolver, err := opts.Config.GetResolver(replacements)
+	if err != nil {
+		return fmt.Errorf("failed to get resolver: %w", err)
+	}
+
+	provenance, err := resolver.ValueProvenance(opts.Region, opts.Path)
+	if err != nil {
+		return fmt.Errorf("failed to get value provenance: %w", err)
+	}
+
+	if provenance.ResultSet {
+		fmt.Println("Resulting Value:")
+		fmt.Printf("%s: %#v\n", opts.Path, provenance.Result)
+		fmt.Println()
+	}
+	fmt.Println("Defaults and Overrides:")
+	if provenance.DefaultSet {
+		fmt.Printf("cfg.defaults.%s: %#v\n", opts.Path, provenance.Default)
+	}
+	if provenance.CloudSet {
+		fmt.Printf("cfg.clouds[%s].defaults.%s: %#v\n", opts.Cloud, opts.Path, provenance.Cloud)
+	}
+	if provenance.EnvironmentSet {
+		fmt.Printf("cfg.clouds[%s].environments[%s].defaults.%s: %#v\n", opts.Cloud, opts.Environment, opts.Path, provenance.Environment)
+	}
+	if provenance.RegionSet {
+		fmt.Printf("cfg.clouds[%s].environments[%s].regions[%s].%s: %#v\n", opts.Cloud, opts.Environment, opts.Region, opts.Path, provenance.Region)
+	}
+	return nil
+}

--- a/tooling/templatize/go.mod
+++ b/tooling/templatize/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/templatize
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250820014220-4c90dceb795f
+	github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.2

--- a/tooling/templatize/go.sum
+++ b/tooling/templatize/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250820014220-4c90dceb795f h1:2CoV7xN73PfLt1p+hovsCWasKieuJy35Jn/4dQfxYmU=
-github.com/Azure/ARO-Tools v0.0.0-20250820014220-4c90dceb795f/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
+github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0 h1:Rf6WEFopSahIp8Heeu9Y4InS6FesXyT3eOW/Yp75Sfw=
+github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1 h1:Wc1ml6QlJs2BHQ/9Bqu1jiyggbsSjramq2oUmp5WeIo=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1/go.mod h1:Ot/6aikWnKWi4l9QB7qVSwa8iMphQNqkWALMoNT3rzM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1 h1:B+blDbyVIG3WaikNxPnhPiJ1MThR03b3vKGtER95TP4=

--- a/tooling/yamlwrap/go.mod
+++ b/tooling/yamlwrap/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/yamlwrap
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250820014220-4c90dceb795f
+	github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1

--- a/tooling/yamlwrap/go.sum
+++ b/tooling/yamlwrap/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250820014220-4c90dceb795f h1:2CoV7xN73PfLt1p+hovsCWasKieuJy35Jn/4dQfxYmU=
-github.com/Azure/ARO-Tools v0.0.0-20250820014220-4c90dceb795f/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
+github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0 h1:Rf6WEFopSahIp8Heeu9Y4InS6FesXyT3eOW/Yp75Sfw=
+github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
Often, when we're looking at the end result of rendering config into a region, we would like to know why a certain value looks the way it does, and what defaults and overrides were applied to make it that way.

Examples:

```
$ ./tooling/templatize/templatize configuration explain --service-config-file ./config/config.yaml --ev2-cloud public --cloud dev --environment pers --region switzerlandnorth --path oidc.storageAccount.privateLinkLocation
Resulting Value:
oidc.storageAccount.privateLinkLocation: "germanywestcentral"

Defaults and Overrides:
cfg.defaults.oidc.storageAccount.privateLinkLocation: "switzerlandnorth"
cfg.clouds[dev].environments[pers].regions[switzerlandnorth].oidc.storageAccount.privateLinkLocation: "germanywestcentral"

$ ./tooling/templatize/templatize configuration explain --service-config-file ./config/config.yaml --ev2-cloud public --cloud dev --environment dev --region uksouth --path mgmt.aks.infraAgentPool.poolCount
Resulting Value:
mgmt.aks.infraAgentPool.poolCount: 2

Defaults and Overrides:
cfg.defaults.mgmt.aks.infraAgentPool.poolCount: 2
cfg.clouds[dev].defaults.mgmt.aks.infraAgentPool.poolCount: 2
```