### PR TITLE
e2e test of gpu nodepool: disable NC4asT4v3

### DIFF
--- a/test/e2e/gpu_nodepools_create_delete.go
+++ b/test/e2e/gpu_nodepools_create_delete.go
@@ -35,9 +35,9 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 		vmSize  string
 	}
 	gpuSkus := []gpuSKU{
-		{display: "NC4asT4v3", vmSize: "Standard_NC4as_T4_v3"},
 		{display: "NC6sv3", vmSize: "Standard_NC6s_v3"},
-		/*{display: "NC8asT4v3", vmSize: "Standard_NC8as_T4_v3"},
+		/*{display: "NC4asT4v3", vmSize: "Standard_NC4as_T4_v3"},
+		{display: "NC8asT4v3", vmSize: "Standard_NC8as_T4_v3"},
 		{display: "NC12sv3", vmSize: "Standard_NC12s_v3"},
 		{display: "NC16asT4v3", vmSize: "Standard_NC16as_T4_v3"},
 		{display: "NC24sv3", vmSize: "Standard_NC24s_v3"},


### PR DESCRIPTION
### What

Disabling NC4asT4v3 instance for a gpu nodepool E2E test.

### Why

In some testing regions, we don't have NC4asT4v3 available. Let's try a single gpu nodepool configuration for now.

### Special notes for your reviewer

<!-- optional -->
