### PR TITLE
feat: bump cs to eced2ef (extends to msft envs)

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -8,7 +8,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:9c0915fed0341dcc7939133413dad4c506a11103d818fbf9e744d81405ec1221
+              digest: sha256:79a123ce924031cef6c3a0a8bec251351800beffc3b98abdb931a6684ae8fb43
           # ACR Pull
           acrPull:
             image:
@@ -75,7 +75,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:9c0915fed0341dcc7939133413dad4c506a11103d818fbf9e744d81405ec1221
+              digest: sha256:79a123ce924031cef6c3a0a8bec251351800beffc3b98abdb931a6684ae8fb43
           # ACR Pull
           acrPull:
             image:
@@ -142,7 +142,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:9c0915fed0341dcc7939133413dad4c506a11103d818fbf9e744d81405ec1221
+              digest: sha256:79a123ce924031cef6c3a0a8bec251351800beffc3b98abdb931a6684ae8fb43
           # ACR Pull
           acrPull:
             image:


### PR DESCRIPTION
### What

Follows @https://github.com/Azure/ARO-HCP/pull/2544 and extends cluster service bump to Microsoft environments.

The dev environments were already updated in PR #2544. This commit adds the same digest update to Microsoft environments:

Steps taken to update Microsoft environments:

1. Used podman to pull and inspect the image: podman pull quay.io/app-sre/uhc-clusters-service:eced2ef podman inspect quay.io/app-sre/uhc-clusters-service:eced2ef --format "{{.Digest}}"

2. Extracted image digest: sha256:79a123ce924031cef6c3a0a8bec251351800beffc3b98abdb931a6684ae8fb43

3. Updated clustersService.image.digest in config/config.msft.clouds-overlay.yaml:
   - int environment
   - stg environment
   - prod environment

This ensures cluster service is bumped from commit 3b84a01 to eced2ef across both dev and Microsoft environments.


### Why

Fixes [ARO-20737](https://issues.redhat.com//browse/ARO-20737)


### Special notes for your reviewer

<!-- optional -->
