### PR TITLE
config: validate that all schema objects have an additionalProperties property set

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -18,7 +18,20 @@ detect-change: materialize
 	fi
 .PHONY: detect-change
 
-validate:
+# This target validates that all object types in the schema have the `additionalProperties` field defined
+validate-additional-properties:
+	@paths=$$(jq -r 'paths(objects | select(has("type") and .type == "object" and (has("additionalProperties") | not))) | "$$." + (map(tostring) | join("."))' ./config.schema.json); \
+	if [ -n "$$paths" ]; then \
+		echo "****************************** Schema error ******************************"; \
+		echo "Object definitions missing an \`additionalProperties\` property found at:"; \
+		echo "$$paths"; \
+		echo "Please add \`\"additionalProperties\": false\` to the object definitions in config.schema.yaml."; \
+		echo "If you are sure that the object should allow additional properties, you can set \`\"additionalProperties\": true\` instead."; \
+		echo "**************************************************************************"; \
+		exit 1; \
+	fi
+
+validate: validate-additional-properties
 	$(MAKE) -C ./../tooling/templatize templatize
 	USER='test' ./../tooling/templatize/templatize configuration validate --service-config-file ./config.yaml \
 	                                                                      --dev-settings-file ./../tooling/templatize/settings.yaml \

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -49,7 +49,6 @@
           "type": "string",
           "description": "ICM routing ID"
         },
-
         "automitigationEnabled": {
           "type": "string",
           "description": "ICM automitigation enabled ID"
@@ -135,6 +134,7 @@
     },
     "certificateRef": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "keyVault": {
           "$ref": "#/definitions/keyVaultName"
@@ -190,6 +190,7 @@
       "patternProperties": {
         "^.+$": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "poll": {
               "type": "boolean"
@@ -261,6 +262,7 @@
         },
         "untaggedImagesRetention": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "enabled": {
               "type": "boolean"
@@ -626,7 +628,7 @@
         "providers": {
           "$ref": "#/definitions/registrationConfig"
         },
-        "usePlannedQuota":{
+        "usePlannedQuota": {
           "type": "boolean"
         },
         "featureFlags": {
@@ -699,6 +701,7 @@
       "properties": {
         "operator": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "version": {
               "type": "string"
@@ -843,7 +846,7 @@
             "kms"
           ]
         },
-        "azureRuntimeConfig" : {
+        "azureRuntimeConfig": {
           "type": "object",
           "properties": {
             "tlsCertificatesIssuer": {
@@ -1009,6 +1012,7 @@
         },
         "aub": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "accountName": {
               "type": "string"
@@ -1024,6 +1028,7 @@
         },
         "pav2": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "cloudName": {
               "type": "string"
@@ -1035,6 +1040,7 @@
         },
         "kusto": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "sku": {
               "type": "string"
@@ -1064,6 +1070,7 @@
         },
         "eventHub": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "namespace": {
               "type": "string"
@@ -1163,7 +1170,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "adminCertName":{
+            "adminCertName": {
               "type": "string"
             },
             "adminCertificateDomain": {
@@ -1490,6 +1497,7 @@
     },
     "arobit": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "forwarder": {
           "type": "object",


### PR DESCRIPTION
[AROSLSRE-233](https://issues.redhat.com/browse/AROSLSRE-233
)
### What

This validation ensures that all schema objects/definitions have an `additionalProperties` defined. 

### Why

json-schema's default behavior is to allow additional properties, which in our case may lead to mistakes when updating the configuration (typos, etc)

### Special notes for your reviewer

<!-- optional -->
