### PR TITLE
[WIP] Adding MRG Delete Validation

### DIFF
--- a/test/e2e-setup/bicep/modules/cluster.bicep
+++ b/test/e2e-setup/bicep/modules/cluster.bicep
@@ -2,7 +2,7 @@
 param clusterName string
 
 @description('The Hypershift cluster managed resource group name')
-param managedResourceGroupName string = '${clusterName}-rg'
+param managedResourceGroupName string = ''
 
 @description('The Network security group name for the hcp cluster resources')
 param nsgName string

--- a/test/e2e/complete_cluster_create.go
+++ b/test/e2e/complete_cluster_create.go
@@ -96,7 +96,6 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 			etcdEncryptionKeyName, err := framework.GetOutputValue(customerInfraDeploymentResult, "etcdEncryptionKeyName")
 			Expect(err).NotTo(HaveOccurred())
-			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			_, err = framework.CreateBicepTemplateAndWait(ctx,
 				tc.GetARMResourcesClientFactoryOrDie(ctx).NewDeploymentsClient(),
 				*resourceGroup.Name,
@@ -105,7 +104,6 @@ var _ = Describe("Customer", func() {
 				map[string]interface{}{
 					"openshiftVersionId":          openshiftControlPlaneVersionId,
 					"clusterName":                 customerClusterName,
-					"managedResourceGroupName":    managedResourceGroupName,
 					"nsgName":                     customerNetworkSecurityGroupName,
 					"subnetName":                  customerVnetSubnetName,
 					"vnetName":                    customerVnetName,


### PR DESCRIPTION
Adds a test case to verify that in addition to the HCP instance, the Managed Resource Group is also deleted. This ensures that all resources related to the HCP instance are gone from the customer's subscription and that they won't be billed for zombie resources.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

New E2E test case for deletion to verify that all resources related to the HCP instance are gone from the customer subscription.

### Why

<!-- Briefly explain why this change is needed -->
If implementation now or in the future leaves resources in the MRG, customers will continue to be billed for those resources (locked behind a Deny Assignment, so they can't touch them). This would include things like VMs/IPs/LBs that provide the customer-side infra of the HCP instance.

This also happens to protect us as "customers" here - if our CI jobs fail this test - we may have zombie resources in _our_ subs that need manual cleanup.

### Special notes for your reviewer

<!-- optional -->
WIP: This implementation might be incomplete for cases where the MRG is not provided to bicep, and therefore will default to a generated value (requiring a GET before DELETE in the test flow) - I need to run the test suite to confirm this.
