### PR TITLE
bump aro-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,3 +218,7 @@ validate-changed-config-pipelines:
 
 validate-config:
 	$(MAKE) -C config/ validate
+
+ARO-Tools:
+	pushd tooling/templatize/; GOPROXY=direct go get github.com/Azure/ARO-Tools@main; popd; go work sync && make all-tidy
+.PHONY: ARO-Tools

--- a/tooling/pipeline-documentation/go.mod
+++ b/tooling/pipeline-documentation/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/pipeline-documentation
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0
+	github.com/Azure/ARO-Tools v0.0.0-20250822174637-c5323676be35
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1

--- a/tooling/pipeline-documentation/go.sum
+++ b/tooling/pipeline-documentation/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0 h1:Rf6WEFopSahIp8Heeu9Y4InS6FesXyT3eOW/Yp75Sfw=
-github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
+github.com/Azure/ARO-Tools v0.0.0-20250822174637-c5323676be35 h1:XPz/iuW0NHHlIMcV7jtg8ECvUGr9037SRieajiAdOPs=
+github.com/Azure/ARO-Tools v0.0.0-20250822174637-c5323676be35/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dusted-go/logging v1.3.0 h1:SL/EH1Rp27oJQIte+LjWvWACSnYDTqNx5gZULin0XRY=

--- a/tooling/secret-sync/go.mod
+++ b/tooling/secret-sync/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/secret-sync
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0
+	github.com/Azure/ARO-Tools v0.0.0-20250822174637-c5323676be35
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1

--- a/tooling/secret-sync/go.sum
+++ b/tooling/secret-sync/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0 h1:Rf6WEFopSahIp8Heeu9Y4InS6FesXyT3eOW/Yp75Sfw=
-github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
+github.com/Azure/ARO-Tools v0.0.0-20250822174637-c5323676be35 h1:XPz/iuW0NHHlIMcV7jtg8ECvUGr9037SRieajiAdOPs=
+github.com/Azure/ARO-Tools v0.0.0-20250822174637-c5323676be35/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1 h1:Wc1ml6QlJs2BHQ/9Bqu1jiyggbsSjramq2oUmp5WeIo=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1/go.mod h1:Ot/6aikWnKWi4l9QB7qVSwa8iMphQNqkWALMoNT3rzM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1 h1:B+blDbyVIG3WaikNxPnhPiJ1MThR03b3vKGtER95TP4=

--- a/tooling/templatize/go.mod
+++ b/tooling/templatize/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/templatize
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0
+	github.com/Azure/ARO-Tools v0.0.0-20250822174637-c5323676be35
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.2

--- a/tooling/templatize/go.sum
+++ b/tooling/templatize/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0 h1:Rf6WEFopSahIp8Heeu9Y4InS6FesXyT3eOW/Yp75Sfw=
-github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
+github.com/Azure/ARO-Tools v0.0.0-20250822174637-c5323676be35 h1:XPz/iuW0NHHlIMcV7jtg8ECvUGr9037SRieajiAdOPs=
+github.com/Azure/ARO-Tools v0.0.0-20250822174637-c5323676be35/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1 h1:Wc1ml6QlJs2BHQ/9Bqu1jiyggbsSjramq2oUmp5WeIo=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1/go.mod h1:Ot/6aikWnKWi4l9QB7qVSwa8iMphQNqkWALMoNT3rzM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1 h1:B+blDbyVIG3WaikNxPnhPiJ1MThR03b3vKGtER95TP4=

--- a/tooling/yamlwrap/go.mod
+++ b/tooling/yamlwrap/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/yamlwrap
 go 1.24.3
 
 require (
-	github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0
+	github.com/Azure/ARO-Tools v0.0.0-20250822174637-c5323676be35
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1

--- a/tooling/yamlwrap/go.sum
+++ b/tooling/yamlwrap/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0 h1:Rf6WEFopSahIp8Heeu9Y4InS6FesXyT3eOW/Yp75Sfw=
-github.com/Azure/ARO-Tools v0.0.0-20250820220354-ba2c2a0a30a0/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
+github.com/Azure/ARO-Tools v0.0.0-20250822174637-c5323676be35 h1:XPz/iuW0NHHlIMcV7jtg8ECvUGr9037SRieajiAdOPs=
+github.com/Azure/ARO-Tools v0.0.0-20250822174637-c5323676be35/go.mod h1:CNFSZBQhsSjLul0BwHX2+TlCRW/b/NJPjKyJwjMq8l0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

bumping aro-tools to allow geneva log refactoring needed for both classic and hcp

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
