### PR TITLE
Allow RP to use versions from fast channel

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -148,7 +148,7 @@ model VersionProfile {
 
   /** ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set. */
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
-  channelGroup?: string = "stable";
+  channelGroup?: string = "fast";
 }
 
 /** DNS contains the DNS settings of the cluster */
@@ -574,7 +574,7 @@ model NodePoolVersionProfile {
 
   /** ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set. */
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
-  channelGroup?: string = "stable";
+  channelGroup?: string = "fast";
 }
 
 /** Azure node pool platform configuration */

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -2951,7 +2951,7 @@
         "channelGroup": {
           "type": "string",
           "description": "ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.",
-          "default": "stable",
+          "default": "fast",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3624,7 +3624,7 @@
         "channelGroup": {
           "type": "string",
           "description": "ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.",
-          "default": "stable",
+          "default": "fast",
           "x-ms-mutability": [
             "read",
             "update",

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,6 +14,8 @@ make push
 make deploy
 ```
 
+Note: KUBECONFIG should use the svc environment.
+
 > To create a cluster, follow the instructions in [development-setup.md](../dev-infrastructure/docs/development-setup.md)
 
 ## Available endpoints

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -388,7 +388,7 @@ func TestDeploymentPreflight(t *testing.T) {
 				"properties": map[string]any{
 					"version": map[string]any{
 						"id":           "4.0",
-						"channelGroup": "stable",
+						"channelGroup": "fast",
 					},
 					"api": map[string]any{
 						"visibility": "Public",
@@ -410,7 +410,7 @@ func TestDeploymentPreflight(t *testing.T) {
 				"apiVersion": api.TestAPIVersion,
 				"properties": map[string]any{
 					"version": map[string]any{
-						"channelGroup": "stable",
+						"channelGroup": "fast",
 					},
 					"network": map[string]any{
 						// 1 invalid fields
@@ -437,7 +437,7 @@ func TestDeploymentPreflight(t *testing.T) {
 				"apiVersion": api.TestAPIVersion,
 				"properties": map[string]any{
 					"version": map[string]any{
-						"channelGroup": "stable",
+						"channelGroup": "fast",
 					},
 					"platform": map[string]any{
 						"vmSize": "Standard_D8s_v3",
@@ -455,7 +455,7 @@ func TestDeploymentPreflight(t *testing.T) {
 				"apiVersion": api.TestAPIVersion,
 				"properties": map[string]any{
 					"version": map[string]any{
-						"channelGroup": "stable",
+						"channelGroup": "fast",
 					},
 					"platform": map[string]any{
 						// 1 missing required field

--- a/frontend/pkg/frontend/node_pool_test.go
+++ b/frontend/pkg/frontend/node_pool_test.go
@@ -51,7 +51,7 @@ var dummyNodePoolHREF = ocm.GenerateNodePoolHREF(dummyClusterHREF, api.TestNodeP
 
 var dummyLocation = "Spain"
 var dummyVMSize = "Big"
-var dummyVersionID = "4.18.0"
+var dummyVersionID = "4.19.7"
 
 func TestCreateNodePool(t *testing.T) {
 	clusterResourceID, _ := azcorearm.ParseResourceID(api.TestClusterResourceID)
@@ -67,7 +67,7 @@ func TestCreateNodePool(t *testing.T) {
 		Properties: &generated.NodePoolProperties{
 			Version: &generated.NodePoolVersionProfile{
 				ID:           &dummyVersionID,
-				ChannelGroup: api.Ptr("stable"),
+				ChannelGroup: api.Ptr("fast"),
 			},
 			Platform: &generated.NodePoolPlatformProfile{
 				VMSize: &dummyVMSize,
@@ -91,8 +91,8 @@ func TestCreateNodePool(t *testing.T) {
 		Labels(make(map[string]string)).
 		Subnet("").
 		Version(arohcpv1alpha1.NewVersion().
-			ID("openshift-v" + dummyVersionID).
-			ChannelGroup("stable"),
+			ID("openshift-v" + dummyVersionID + "-fast").
+			ChannelGroup("fast"),
 		).
 		Replicas(0).
 		AutoRepair(true).Build()
@@ -164,7 +164,7 @@ func TestCreateNodePool(t *testing.T) {
 					ImageRegistry(arohcpv1alpha1.NewClusterImageRegistry().
 						State(csImageRegistryStateEnabled)).
 					Version(arohcpv1alpha1.NewVersion().
-						ChannelGroup("stable")).
+						ChannelGroup("fast")).
 					Build())
 			// CreateOrUpdateNodePool
 			mockCSClient.EXPECT().

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -583,7 +583,7 @@ func ConvertCStoNodePool(resourceID *azcorearm.ResourceID, np *arohcpv1alpha1.No
 		},
 		Properties: api.HCPOpenShiftClusterNodePoolProperties{
 			Version: api.NodePoolVersionProfile{
-				ID:           ocm.ConvertOpenShiftVersionNoPrefix(np.Version().ID()),
+				ID:           ocm.ConvertCSVersionToOpenShiftVersion(np.Version().ID()),
 				ChannelGroup: np.Version().ChannelGroup(),
 			},
 			Platform: api.NodePoolPlatformProfile{
@@ -640,7 +640,7 @@ func (f *Frontend) BuildCSNodePool(ctx context.Context, nodePool *api.HCPOpenShi
 		npBuilder = npBuilder.
 			ID(nodePool.Name).
 			Version(arohcpv1alpha1.NewVersion().
-				ID(ocm.ConvertOpenShiftVersionAddPrefix(nodePool.Properties.Version.ID)).
+				ID(ocm.ConvertOpenShiftVersionToCS(nodePool.Properties.Version.ID, nodePool.Properties.Version.ChannelGroup)).
 				ChannelGroup(nodePool.Properties.Version.ChannelGroup)).
 			Subnet(nodePool.Properties.Platform.SubnetID).
 			AzureNodePool(arohcpv1alpha1.NewAzureNodePool().

--- a/frontend/pkg/frontend/ocm_test.go
+++ b/frontend/pkg/frontend/ocm_test.go
@@ -300,7 +300,7 @@ func ocmClusterDefaults() *arohcpv1alpha1.ClusterBuilder {
 			ID(api.TestLocation)).
 		Version(arohcpv1alpha1.NewVersion().
 			ID("").
-			ChannelGroup("stable")).
+			ChannelGroup("fast")).
 		ImageRegistry(arohcpv1alpha1.NewClusterImageRegistry().
 			State(csImageRegistryStateEnabled))
 }

--- a/frontend/utils/create.go
+++ b/frontend/utils/create.go
@@ -61,7 +61,7 @@ func CreateJSONFile() error {
 	cluster := api.HCPOpenShiftCluster{
 		Properties: api.HCPOpenShiftClusterProperties{
 			Version: api.VersionProfile{
-				ChannelGroup: "stable",
+				ChannelGroup: "fast",
 			},
 			DNS: api.DNSProfile{},
 			Network: api.NetworkProfile{
@@ -103,7 +103,7 @@ func CreateNodePool() error {
 		Properties: api.HCPOpenShiftClusterNodePoolProperties{
 			ProvisioningState: arm.ProvisioningState(""),
 			Version: api.NodePoolVersionProfile{
-				ChannelGroup: "stable",
+				ChannelGroup: "fast",
 			},
 			Platform: api.NodePoolPlatformProfile{
 				SubnetID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dev-test-rg/providers/Microsoft.Network/virtualNetworks/xyz/subnets/xyz",

--- a/internal/api/arm/preflight_test.go
+++ b/internal/api/arm/preflight_test.go
@@ -26,7 +26,7 @@ func TestDetectTLE(t *testing.T) {
 				"properties": map[string]any{
 					"version": map[string]any{
 						"id":           "4.18",
-						"channelGroup": "stable",
+						"channelGroup": "fast",
 					},
 					"dns": map[string]any{},
 					"network": map[string]any{

--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -50,7 +50,7 @@ type HCPOpenShiftClusterProperties struct {
 
 // VersionProfile represents the cluster control plane version.
 type VersionProfile struct {
-	ID           string `json:"id,omitempty"                visibility:"read create"        validate:"required_unless=ChannelGroup stable,omitempty,openshift_version"`
+	ID           string `json:"id,omitempty"                visibility:"read create"        validate:"required_unless=ChannelGroup fast,omitempty,openshift_version"`
 	ChannelGroup string `json:"channelGroup,omitempty"      visibility:"read create update"`
 }
 
@@ -169,7 +169,7 @@ func NewDefaultHCPOpenShiftCluster() *HCPOpenShiftCluster {
 	return &HCPOpenShiftCluster{
 		Properties: HCPOpenShiftClusterProperties{
 			Version: VersionProfile{
-				ChannelGroup: "stable",
+				ChannelGroup: "fast",
 			},
 			Network: NetworkProfile{
 				NetworkType: NetworkTypeOVNKubernetes,
@@ -217,13 +217,14 @@ func (cluster *HCPOpenShiftCluster) validateVersion() []arm.CloudErrorBody {
 		}
 	}
 
-	// XXX For now, "stable" is the only accepted value. In the future, we may
+	// XXX For now, "fast" is the only accepted value. In the future, we may
 	//     allow unlocking other channel groups through Azure Feature Exposure
 	//     Control (AFEC) flags or some other mechanism.
-	if cluster.Properties.Version.ChannelGroup != "stable" {
+	// TODO: support other channel groups through AFEC for devs
+	if cluster.Properties.Version.ChannelGroup != "fast" {
 		errorDetails = append(errorDetails, arm.CloudErrorBody{
 			Code:    arm.CloudErrorCodeInvalidRequestContent,
-			Message: "Channel group must be 'stable'",
+			Message: "Channel group must be 'fast'",
 			Target:  "properties.version.channelGroup",
 		})
 	}

--- a/internal/api/hcpopenshiftcluster_test.go
+++ b/internal/api/hcpopenshiftcluster_test.go
@@ -352,13 +352,13 @@ func TestClusterValidate(t *testing.T) {
 			tweaks: &HCPOpenShiftCluster{
 				Properties: HCPOpenShiftClusterProperties{
 					Version: VersionProfile{
-						ChannelGroup: "fast",
+						ChannelGroup: "stable",
 					},
 				},
 			},
 			expectErrors: []arm.CloudErrorBody{
 				{
-					Message: "Field 'id' is required when 'channelGroup' is not 'stable'",
+					Message: "Field 'id' is required when 'channelGroup' is not 'fast'",
 					Target:  "properties.version.id",
 				},
 			},
@@ -510,7 +510,7 @@ func TestClusterValidate(t *testing.T) {
 			},
 			expectErrors: []arm.CloudErrorBody{
 				{
-					Message: "Channel group must be 'stable'",
+					Message: "Channel group must be 'fast'",
 					Target:  "properties.version.channelGroup",
 				},
 			},

--- a/internal/api/hcpopenshiftclusternodepool.go
+++ b/internal/api/hcpopenshiftclusternodepool.go
@@ -49,7 +49,7 @@ type HCPOpenShiftClusterNodePoolProperties struct {
 // NodePoolVersionProfile represents the worker node pool version.
 // Visbility for the entire struct is "read create update".
 type NodePoolVersionProfile struct {
-	ID           string `json:"id,omitempty"           validate:"required_unless=ChannelGroup stable,omitempty,openshift_version"`
+	ID           string `json:"id,omitempty"           validate:"required_unless=ChannelGroup fast,omitempty,openshift_version"`
 	ChannelGroup string `json:"channelGroup,omitempty"`
 }
 
@@ -90,7 +90,7 @@ func NewDefaultHCPOpenShiftClusterNodePool() *HCPOpenShiftClusterNodePool {
 	return &HCPOpenShiftClusterNodePool{
 		Properties: HCPOpenShiftClusterNodePoolProperties{
 			Version: NodePoolVersionProfile{
-				ChannelGroup: "stable",
+				ChannelGroup: "fast",
 			},
 			Platform: NodePoolPlatformProfile{
 				OSDisk: OSDiskProfile{

--- a/internal/api/hcpopenshiftclusternodepool_test.go
+++ b/internal/api/hcpopenshiftclusternodepool_test.go
@@ -295,7 +295,7 @@ func TestNodePoolValidate(t *testing.T) {
 			},
 			expectErrors: []arm.CloudErrorBody{
 				{
-					Message: "Node pool channel group 'freshmeat' must be the same as control plane channel group 'stable'",
+					Message: "Node pool channel group 'freshmeat' must be the same as control plane channel group 'fast'",
 					Target:  "properties.version.channelGroup",
 				},
 			},

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -533,3 +533,28 @@ func ConvertOpenShiftVersionAddPrefix(v string) string {
 	}
 	return v
 }
+
+// ConvertOpenShiftVersionToCS parses the given version an channel group and converts it in a
+// CS readable version "openshift-v<X.Y.Z>" or "openshift-v<X.Y.Z>-channel_group"
+func ConvertOpenShiftVersionToCS(v, cg string) string {
+	var csVersion string
+	if len(v) > 0 {
+		csVersion = NewOpenShiftVersionXYZ(v)
+		if cg == "stable" {
+			return csVersion
+		}
+		csVersion = fmt.Sprintf("%v-%v", csVersion, cg)
+	}
+	return csVersion
+}
+
+// Convert a CS version openshift-v<X.Y.Z>-<channel_group> to
+// an OpenShift version <X.Y.Z>
+func ConvertCSVersionToOpenShiftVersion(v string) string {
+	// Remove the openshift-v prefix
+	withoutPrefix := ConvertOpenShiftVersionNoPrefix(v)
+	// Split on dash to get version and channel group parts
+	parts := strings.Split(withoutPrefix, "-")
+	// Return the first part which is the version
+	return parts[0]
+}


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://issues.redhat.com/browse/ARO-20740

### What

<!-- Briefly describe what this PR does -->
With this change the RP will allow to create clusters and node pool with fast channel.

### Why

<!-- Briefly explain why this change is needed -->
We want to add fast channel support, so OCP versions can be delivered sooner. For that the RP and CS needs to support the use of versions from this channel. 
Additionally 'fast' channel will be the default channel. This will be in a follow-up MR.

**Requirements**:
- CS need the support of creation of node pools https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/10414
- CS needs to support multiple channel configuration https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/10401
- ARO-HCP configuration is spitted for envs (different confs for different envs) 
- Update CS image in aro-hcp, configure fast channel in `cluster-service/deploy/templates/aro-hcp-ocp-versions-config.configmap.yaml`


**Future steps:**
- Make `fast`  the default channel in CS API
- Make `fast` the default channel in the ARM API

### Special notes for your reviewer
For manual test this I have:

1. Configure CS to support fast channels
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: aro-hcp-ocp-versions-config
  namespace: '{{ .Release.Namespace }}'
data:
  aro-hcp-ocp-versions-config.yaml: |
    defaultVersion:
      channelGroupName: fast
      version: 4.19.0
    channelGroups:
      # the URL to cincinnati will be the same across all environments, other URLs also need to be whitelisted
      - url: https://api.openshift.com/api/upgrades_info/graph
        channelGroupName: fast
        # the versions must be in sync with what's defined in dev-infrastructure/templates/global-image-sync.bicep
        # this is to ensure that the enabled release images are synchronized to ACR in lockstep
        minVersion: 4.19.0
        # maxVersion is exclusive, contrary to oc-mirror which defines that boundary as inclusive.
        maxVersion: 4.19.8
```
2. Deploy CS with the change in https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/10414
3. Deploy the frontend with the change in this PR
4. Change the demo templates for cluster and node pool to use `fast` channel
