### PR TITLE
CODEOWNERS: Add @mociarain to /config

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,7 +22,7 @@ go.work* @bennerv @geoberle @janboll @weinong @whober0521 @jonathan34c @tony-sch
 /backend/ @bennerv @mbarnes @SudoBrendan @mociarain @venkateshsredhat @nanyte25 @kostola @DennisJWheeler @hbhushan3 @oriAdler @sclarkso @tsatam @katherinelc321
 /internal/ @bennerv @mbarnes @SudoBrendan @mociarain @venkateshsredhat @nanyte25 @kostola @DennisJWheeler @hbhushan3 @oriAdler @sclarkso @tsatam @katherinelc321
 /tooling/ @bennerv @geoberle @janboll @weinong @whober0521 @jonathan34c @tony-schndr @jfchevrette @mmazur @roivaz @stevekuznetsov
-/config/ @bennerv @geoberle @janboll @weinong @whober0521 @jonathan34c @tony-schndr @jfchevrette @mmazur @roivaz @stevekuznetsov @mbarnes @SudoBrendan @JameelB @miguelsorianod @katherinelc321 @tsatam
+/config/ @bennerv @geoberle @janboll @weinong @whober0521 @jonathan34c @tony-schndr @jfchevrette @mmazur @roivaz @stevekuznetsov @mbarnes @SudoBrendan @JameelB @miguelsorianod @katherinelc321 @tsatam @mociarain
 /metrics/ @bennerv @geoberle @janboll @weinong @whober0521 @jonathan34c @tony-schndr @jfchevrette @mmazur @roivaz @stevekuznetsov
 /cluster-service/ @machi1990 @miguelsorianod @JameelB
 /observability/tracing/ @frzifus @simonpasquier @dinhxuanvu @mbarnes


### PR DESCRIPTION
[Maitiu](https://github.com/mociarain) is already on the 1P team but he somehow got omitted from owning the `/config` directory for image digest updates.