### PR TITLE
cluster-service: fix dashboards: include cluster variable

### DIFF
--- a/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
+++ b/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
@@ -17,9 +17,9 @@ spec:
     # 28-day rolling SLI
     - record: availability:api_inbound_request_count:sli_ratio_28d
       expr: |
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code!~"5..", service="clusters-service-metrics"}[28d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code!~"5..", service="clusters-service-metrics"}[28d])))
         /
-        sum((max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d]))))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
       labels:
         service: "clusters-service-metrics"
     # Burn rate recording rules for various time windows
@@ -27,9 +27,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[5m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[5m])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -38,9 +38,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[30m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[30m])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -49,9 +49,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[1h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[1h])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -60,9 +60,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[6h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[6h])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -71,9 +71,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[3d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[3d])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -82,9 +82,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[2h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[2h])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -93,9 +93,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[1d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[1d])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -107,17 +107,17 @@ spec:
     # P99 Latency SLI (28-day)
     - record: latency:api_inbound_request_duration:p99_sli_ratio_28d
       expr: |
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[28d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[28d])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
       labels:
         service: "clusters-service-metrics"
     # P90 Latency SLI (28-day)
     - record: latency:api_inbound_request_duration:p90_sli_ratio_28d
       expr: |
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[28d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[28d])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
       labels:
         service: "clusters-service-metrics"
     # P99 Latency Burn Rate Recording Rules
@@ -126,12 +126,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[5m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[5m])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -141,12 +141,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[30m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[30m])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -156,12 +156,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1h])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -171,12 +171,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[6h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[6h])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -186,12 +186,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[3d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[3d])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -201,12 +201,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[2h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[2h])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -216,12 +216,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1d])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -232,12 +232,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[5m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[5m])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
         ) / (1 - 0.90), 0.01
         )
       labels:
@@ -247,12 +247,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[30m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[30m])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
         ) / (1 - 0.90), 0.01
         )
       labels:
@@ -262,12 +262,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1h])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
         ) / (1 - 0.90), 0.01
         )
       labels:
@@ -277,12 +277,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[6h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[6h])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
         ) / (1 - 0.90), 0.01
         )
       labels:
@@ -292,12 +292,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[3d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[3d])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
         ) / (1 - 0.90), 0.01
         )
       labels:
@@ -307,12 +307,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[2h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[2h])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
         ) / (1 - 0.90), 0.01
         )
       labels:
@@ -322,12 +322,12 @@ spec:
         round(
         (
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
         -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1d])))
         )
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
         ) / (1 - 0.90), 0.01
         )
       labels:
@@ -343,15 +343,15 @@ spec:
         summary: 'Cluster Service API availability error budget burn rate is too high'
       expr: |
         (
-        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"})) > 13.44
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"})) > 13.44
         and
-        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{service="clusters-service-metrics"})) > 13.44
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{service="clusters-service-metrics"})) > 13.44
         )
         or
         (
-        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{service="clusters-service-metrics"})) > 5.6
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{service="clusters-service-metrics"})) > 5.6
         and
-        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"})) > 5.6
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"})) > 5.6
         )
       for: 5m
       labels:
@@ -360,9 +360,9 @@ spec:
         short: 30m
     - alert: ClustersServiceAPIAvailability6hto3dErrorBudgetBurn
       expr: |
-        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"})) > 0.934
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"})) > 0.934
         and
-        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{service="clusters-service-metrics"})) > 0.934
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{service="clusters-service-metrics"})) > 0.934
       for: 30m
       labels:
         severity: warning
@@ -379,15 +379,15 @@ spec:
         summary: 'Cluster Service API P99 latency error budget burn rate is too high'
       expr: |
         (
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{service="clusters-service-metrics"})) > 13.44
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{service="clusters-service-metrics"})) > 13.44
         and
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{service="clusters-service-metrics"})) > 13.44
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{service="clusters-service-metrics"})) > 13.44
         )
         or
         (
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{service="clusters-service-metrics"})) > 5.6
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{service="clusters-service-metrics"})) > 5.6
         and
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{service="clusters-service-metrics"})) > 5.6
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{service="clusters-service-metrics"})) > 5.6
         )
       for: 5m
       labels:
@@ -397,9 +397,9 @@ spec:
         slo: api-latency-p99
     - alert: ClustersServiceAPILatency6hto3dP99ErrorBudgetBurn
       expr: |
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{service="clusters-service-metrics"})) > 0.934
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{service="clusters-service-metrics"})) > 0.934
         and
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{service="clusters-service-metrics"})) > 0.934
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{service="clusters-service-metrics"})) > 0.934
       for: 30m
       labels:
         severity: warning
@@ -416,15 +416,15 @@ spec:
         summary: 'Cluster Service API P90 latency error budget burn rate is too high'
       expr: |
         (
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{service="clusters-service-metrics"})) > 13.44
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{service="clusters-service-metrics"})) > 13.44
         and
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{service="clusters-service-metrics"})) > 13.44
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{service="clusters-service-metrics"})) > 13.44
         )
         or
         (
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{service="clusters-service-metrics"})) > 5.6
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{service="clusters-service-metrics"})) > 5.6
         and
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{service="clusters-service-metrics"})) > 5.6
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{service="clusters-service-metrics"})) > 5.6
         )
       for: 5m
       labels:
@@ -434,9 +434,9 @@ spec:
         slo: api-latency-p90
     - alert: ClustersServiceAPILatency6hto3dP90ErrorBudgetBurn
       expr: |
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{service="clusters-service-metrics"})) > 0.934
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{service="clusters-service-metrics"})) > 0.934
         and
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{service="clusters-service-metrics"})) > 0.934
+        sum by (cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{service="clusters-service-metrics"})) > 0.934
       for: 30m
       labels:
         severity: warning


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

The recording rules and metrics do not include the cluster and namespace labels, which are used in the grafana dashboards. This adds the labels to the queries so they are available in the resulting recorded metrics

### Why

### Special notes for your reviewer

<!-- optional -->
