### PR TITLE
Update CS image in dev envs and INT preparation. CS commit id 5c0cfa5

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -8,7 +8,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:79a123ce924031cef6c3a0a8bec251351800beffc3b98abdb931a6684ae8fb43
+              digest: sha256:2e1eb2baf9995aca7f59a9e85fc5f0d12e464848d823abfa712f9731b6da93b2
           # ACR Pull
           acrPull:
             image:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -727,7 +727,7 @@ clouds:
       clustersService:
         environment: "arohcpdev"
         image:
-          digest: sha256:79a123ce924031cef6c3a0a8bec251351800beffc3b98abdb931a6684ae8fb43
+          digest: sha256:2e1eb2baf9995aca7f59a9e85fc5f0d12e464848d823abfa712f9731b6da93b2
         # NOTE: The role names must not include commas(,) in the name as the roleNames field
         # here is a comma separated list of role definition names.
         azureOperatorsManagedIdentities:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 8da7f713a95e1214b456bf50501fcb701f3fe91d2b218d6bdefa1882fb27414f
+          westus3: 7f7b2ceae43c8b63f18c76d456cb299e0a262a3b5053f15fd4ef340a46ad3aa8
       dev:
         regions:
-          westus3: 2a7602d43b71e108af3ea33caa9cbd79329a70fea36a9e6ecc215416bff213b6
+          westus3: e7f7b930071d1165b18047b4116446d8df6c13124c0573879bf09ddf9d1fe850
       ntly:
         regions:
-          uksouth: 517142a279beffcaa64b5ab0c7f6b4d07242d3fe80a58ed94f5ab83dccfa6d01
+          uksouth: 4cf7d6e9836b4551519af90e4d960ea5ce04ee4991cab45bebda42a7165f020b
       perf:
         regions:
-          westus3: cf85faf3a7d10ab909887b6173b6d365eb923a8f8e45daaa917acca80c6e3e0a
+          westus3: 026689b4a371bbc6c09fd9624de00fbeea986288922ec31a1669703144cf5664
       pers:
         regions:
-          westus3: 4e6b27da7f7add8d8b56b50cdbf92b59fa055133125513018da615794d548833
+          westus3: 9d852dcfefa847ad040c61e4f629ee93a1d6275991ca12e752496b894deb377b
       swft:
         regions:
-          uksouth: 1067a0fd01a93d1b73ba73c4d6fc8748ed3d5b471580982ae5ca6bdbada69d8a
+          uksouth: 6362c624922e2f511a13b90a179a0b1739e670f8f562e22f67ddf6967dbd16e3

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:79a123ce924031cef6c3a0a8bec251351800beffc3b98abdb931a6684ae8fb43
+    digest: sha256:2e1eb2baf9995aca7f59a9e85fc5f0d12e464848d823abfa712f9731b6da93b2
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:79a123ce924031cef6c3a0a8bec251351800beffc3b98abdb931a6684ae8fb43
+    digest: sha256:2e1eb2baf9995aca7f59a9e85fc5f0d12e464848d823abfa712f9731b6da93b2
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:79a123ce924031cef6c3a0a8bec251351800beffc3b98abdb931a6684ae8fb43
+    digest: sha256:2e1eb2baf9995aca7f59a9e85fc5f0d12e464848d823abfa712f9731b6da93b2
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:79a123ce924031cef6c3a0a8bec251351800beffc3b98abdb931a6684ae8fb43
+    digest: sha256:2e1eb2baf9995aca7f59a9e85fc5f0d12e464848d823abfa712f9731b6da93b2
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:79a123ce924031cef6c3a0a8bec251351800beffc3b98abdb931a6684ae8fb43
+    digest: sha256:2e1eb2baf9995aca7f59a9e85fc5f0d12e464848d823abfa712f9731b6da93b2
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:79a123ce924031cef6c3a0a8bec251351800beffc3b98abdb931a6684ae8fb43
+    digest: sha256:2e1eb2baf9995aca7f59a9e85fc5f0d12e464848d823abfa712f9731b6da93b2
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:


### PR DESCRIPTION
Updates CS image corresponding to CS git commit 5c0cfa5.

Includes the changes to attempt to include cert full chain for K8s APIServer and Default Ingress TLS certs, as well as other non ARO-HCP changes of CS in general.