### PR TITLE
Update UID in Grafana dashboard configuration for CS

### DIFF
--- a/cluster-service/grafana-dashboards/cluster-service-slo-compund-metrics.json
+++ b/cluster-service/grafana-dashboards/cluster-service-slo-compund-metrics.json
@@ -2257,8 +2257,8 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "ARO HCP Cluster Service SLOs",
-  "uid": "aro-hcp-cluster-service-slos",
+  "title": "ARO HCP Cluster Service SLOs (Compound Metrics)",
+  "uid": "aro-hcp-cluster-service-slos-compund-metrics",
   "version": 1,
   "weekStart": "",
   "refresh": "5m"

--- a/cluster-service/grafana-dashboards/cluster-service-slo-compund-metrics.json
+++ b/cluster-service/grafana-dashboards/cluster-service-slo-compund-metrics.json
@@ -1104,7 +1104,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_min(latency:api_inbound_request_duration:p90_burnrate5m{cluster=\"$cluster\", service=\"clusters-service-metrics\"} / (1 - 0.90), 0)",
+          "expr": "clamp_min(latency:api_inbound_request_duration:p90_burnrate5m{cluster=\"$cluster\", namespace=\"clusters-service\", service=\"clusters-service-metrics\"} / (1 - 0.90), 0)",
           "hide": false,
           "instant": false,
           "legendFormat": "P90 Burn Rate - 5m",

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1345,7 +1345,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
           summary: 'Cluster Service API availability error budget burn rate is too high'
         }
-        expression: '( sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"})) > 13.44 and sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{service="clusters-service-metrics"})) > 13.44 ) or ( sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{service="clusters-service-metrics"})) > 5.6 and sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"})) > 5.6 )'
+        expression: '( sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44 and sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44 ) or ( sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6 and sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6 )'
         for: 'PT5M'
         severity: 3
       }
@@ -1362,7 +1362,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
           summary: 'API is slowly but steadily burning its 28 day availability error budget (99% SLO)'
         }
-        expression: 'sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"})) > 0.934 and sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{service="clusters-service-metrics"})) > 0.934'
+        expression: 'sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934 and sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934'
         for: 'PT30M'
         severity: 3
       }
@@ -1381,7 +1381,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
           summary: 'Cluster Service API P99 latency error budget burn rate is too high'
         }
-        expression: '( sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{service="clusters-service-metrics"})) > 13.44 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{service="clusters-service-metrics"})) > 13.44 ) or ( sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{service="clusters-service-metrics"})) > 5.6 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{service="clusters-service-metrics"})) > 5.6 )'
+        expression: '( sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44 ) or ( sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6 )'
         for: 'PT5M'
         severity: 3
       }
@@ -1398,7 +1398,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
           summary: 'API is slowly but steadily burning its 28 day 1s latency error budget (99% SLO)'
         }
-        expression: 'sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{service="clusters-service-metrics"})) > 0.934 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{service="clusters-service-metrics"})) > 0.934'
+        expression: 'sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934'
         for: 'PT30M'
         severity: 3
       }
@@ -1417,7 +1417,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
           summary: 'Cluster Service API P90 latency error budget burn rate is too high'
         }
-        expression: '( sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{service="clusters-service-metrics"})) > 13.44 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{service="clusters-service-metrics"})) > 13.44 ) or ( sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{service="clusters-service-metrics"})) > 5.6 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{service="clusters-service-metrics"})) > 5.6 )'
+        expression: '( sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44 ) or ( sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6 )'
         for: 'PT5M'
         severity: 3
       }
@@ -1434,7 +1434,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           runbook_url: 'aka.ms/arohcp-runbook/cs-slo-monitoring'
           summary: 'API is slowly but steadily burning its 28 day 0.1s latency error budget (90% SLO)'
         }
-        expression: 'sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{service="clusters-service-metrics"})) > 0.934 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{service="clusters-service-metrics"})) > 0.934'
+        expression: 'sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934 and sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934'
         for: 'PT30M'
         severity: 3
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -19,49 +19,49 @@ resource arohcpCsApiAvailabilityRecordingRules 'Microsoft.AlertsManagement/prome
       }
       {
         record: 'availability:api_inbound_request_count:burnrate5m'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate30m'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate1h'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate6h'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate3d'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate2h'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[2h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[2h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate1d'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[1d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -12,56 +12,56 @@ resource arohcpCsApiAvailabilityRecordingRules 'Microsoft.AlertsManagement/prome
     rules: [
       {
         record: 'availability:api_inbound_request_count:sli_ratio_28d'
-        expression: 'sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code!~"5..", service="clusters-service-metrics"}[28d]))) / sum((max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d]))))'
+        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code!~"5..", service="clusters-service-metrics"}[28d]))) / sum by(cluster, namespace, service) ((max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d]))))'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate5m'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[5m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[5m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate30m'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[30m]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[30m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate1h'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate6h'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[6h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[6h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate3d'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[3d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[3d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate2h'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[2h]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[2h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'availability:api_inbound_request_count:burnrate1d'
-        expression: 'round( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'round( ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.99), 0.01 )'
         labels: {
           service: 'clusters-service-metrics'
         }
@@ -82,112 +82,112 @@ resource arohcpCsApiLatencyRecordingRules 'Microsoft.AlertsManagement/prometheus
     rules: [
       {
         record: 'latency:api_inbound_request_duration:p99_sli_ratio_28d'
-        expression: 'sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))'
+        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[28d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_sli_ratio_28d'
-        expression: 'sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[28d]))) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))'
+        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[28d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate5m'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[5m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[5m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[5m]))) ) ) / (1 - 0.99), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate30m'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[30m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[30m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[30m]))) ) ) / (1 - 0.99), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate1h'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1h]))) ) ) / (1 - 0.99), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate6h'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[6h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[6h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[6h]))) ) ) / (1 - 0.99), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate3d'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[3d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[3d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[3d]))) ) ) / (1 - 0.99), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate2h'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[2h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[2h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[2h]))) ) ) / (1 - 0.99), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate1d'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.99), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1d]))) ) ) / (1 - 0.99), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate5m'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[5m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[5m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[5m]))) ) ) / (1 - 0.90), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate30m'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[30m]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[30m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[30m]))) ) ) / (1 - 0.90), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate1h'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1h]))) ) ) / (1 - 0.90), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate6h'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[6h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[6h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[6h]))) ) ) / (1 - 0.90), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate3d'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[3d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[3d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[3d]))) ) ) / (1 - 0.90), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate2h'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[2h]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[2h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[2h]))) ) ) / (1 - 0.90), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate1d'
-        expression: 'round( ( ( sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) - sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1d]))) ) / sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d]))) ) / (1 - 0.90), 0.01 )'
+        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1d]))) ) ) / (1 - 0.90), 0.01 ), 0)'
         labels: {
           service: 'clusters-service-metrics'
         }

--- a/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
+++ b/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
@@ -17,9 +17,9 @@ spec:
     # 28-day rolling SLI
     - record: availability:api_inbound_request_count:sli_ratio_28d
       expr: |
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code!~"5..", service="clusters-service-metrics"}[28d])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code!~"5..", service="clusters-service-metrics"}[28d])))
         /
-        sum((max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d]))))
+        sum by(cluster, namespace, service) ((max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d]))))
       labels:
         service: "clusters-service-metrics"
     # Burn rate recording rules for various time windows
@@ -27,9 +27,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[5m])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[5m])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -38,9 +38,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[30m])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[30m])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -49,9 +49,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1h])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1h])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -60,9 +60,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[6h])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[6h])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -71,9 +71,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[3d])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[3d])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -82,9 +82,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[2h])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[2h])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -93,9 +93,9 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1d])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1d])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
         ) / (1 - 0.99), 0.01
         )
       labels:
@@ -107,229 +107,215 @@ spec:
     # P99 Latency SLI (28-day)
     - record: latency:api_inbound_request_duration:p99_sli_ratio_28d
       expr: |
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[28d])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[28d])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
       labels:
         service: "clusters-service-metrics"
     # P90 Latency SLI (28-day)
     - record: latency:api_inbound_request_duration:p90_sli_ratio_28d
       expr: |
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[28d])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[28d])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
       labels:
         service: "clusters-service-metrics"
     # P99 Latency Burn Rate Recording Rules
     - record: latency:api_inbound_request_duration:p99_burnrate5m
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[5m])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[5m])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
-        ) / (1 - 0.99), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[5m])))
         )
+        ) / (1 - 0.99), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p99_burnrate30m
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[30m])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[30m])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
-        ) / (1 - 0.99), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[30m])))
         )
+        ) / (1 - 0.99), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p99_burnrate1h
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1h])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1h])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
-        ) / (1 - 0.99), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1h])))
         )
+        ) / (1 - 0.99), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p99_burnrate6h
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[6h])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[6h])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
-        ) / (1 - 0.99), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[6h])))
         )
+        ) / (1 - 0.99), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p99_burnrate3d
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[3d])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[3d])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
-        ) / (1 - 0.99), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[3d])))
         )
+        ) / (1 - 0.99), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p99_burnrate2h
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[2h])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[2h])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
-        ) / (1 - 0.99), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[2h])))
         )
+        ) / (1 - 0.99), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p99_burnrate1d
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1d])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1d])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
-        ) / (1 - 0.99), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1d])))
         )
+        ) / (1 - 0.99), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
     # P90 Latency Burn Rate Recording Rules
     - record: latency:api_inbound_request_duration:p90_burnrate5m
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[5m])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[5m])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
-        ) / (1 - 0.90), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[5m])))
         )
+        ) / (1 - 0.90), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p90_burnrate30m
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[30m])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[30m])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
-        ) / (1 - 0.90), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[30m])))
         )
+        ) / (1 - 0.90), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p90_burnrate1h
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1h])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1h])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
-        ) / (1 - 0.90), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1h])))
         )
+        ) / (1 - 0.90), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p90_burnrate6h
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[6h])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[6h])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
-        ) / (1 - 0.90), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[6h])))
         )
+        ) / (1 - 0.90), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p90_burnrate3d
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[3d])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[3d])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
-        ) / (1 - 0.90), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[3d])))
         )
+        ) / (1 - 0.90), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p90_burnrate2h
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[2h])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[2h])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
-        ) / (1 - 0.90), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[2h])))
         )
+        ) / (1 - 0.90), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p90_burnrate1d
       expr: |
+        clamp_min(
         round(
         (
-        (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
-        -
-        sum(max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1d])))
-        )
+        1 - (
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1d])))
         /
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
-        ) / (1 - 0.90), 0.01
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1d])))
         )
+        ) / (1 - 0.90), 0.01
+        ), 0)
       labels:
         service: "clusters-service-metrics"
   # Alerts for SLOs
@@ -343,15 +329,15 @@ spec:
         summary: 'Cluster Service API availability error budget burn rate is too high'
       expr: |
         (
-        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"})) > 13.44
+        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44
         and
-        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{service="clusters-service-metrics"})) > 13.44
+        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44
         )
         or
         (
-        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{service="clusters-service-metrics"})) > 5.6
+        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6
         and
-        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"})) > 5.6
+        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6
         )
       for: 5m
       labels:
@@ -360,9 +346,9 @@ spec:
         short: 30m
     - alert: ClustersServiceAPIAvailability6hto3dErrorBudgetBurn
       expr: |
-        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"})) > 0.934
+        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934
         and
-        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{service="clusters-service-metrics"})) > 0.934
+        sum(max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934
       for: 30m
       labels:
         severity: warning
@@ -379,15 +365,15 @@ spec:
         summary: 'Cluster Service API P99 latency error budget burn rate is too high'
       expr: |
         (
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{service="clusters-service-metrics"})) > 13.44
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44
         and
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{service="clusters-service-metrics"})) > 13.44
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44
         )
         or
         (
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{service="clusters-service-metrics"})) > 5.6
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6
         and
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{service="clusters-service-metrics"})) > 5.6
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6
         )
       for: 5m
       labels:
@@ -397,9 +383,9 @@ spec:
         slo: api-latency-p99
     - alert: ClustersServiceAPILatency6hto3dP99ErrorBudgetBurn
       expr: |
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{service="clusters-service-metrics"})) > 0.934
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934
         and
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{service="clusters-service-metrics"})) > 0.934
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934
       for: 30m
       labels:
         severity: warning
@@ -416,15 +402,15 @@ spec:
         summary: 'Cluster Service API P90 latency error budget burn rate is too high'
       expr: |
         (
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{service="clusters-service-metrics"})) > 13.44
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44
         and
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{service="clusters-service-metrics"})) > 13.44
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44
         )
         or
         (
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{service="clusters-service-metrics"})) > 5.6
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6
         and
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{service="clusters-service-metrics"})) > 5.6
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6
         )
       for: 5m
       labels:
@@ -434,9 +420,9 @@ spec:
         slo: api-latency-p90
     - alert: ClustersServiceAPILatency6hto3dP90ErrorBudgetBurn
       expr: |
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{service="clusters-service-metrics"})) > 0.934
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934
         and
-        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{service="clusters-service-metrics"})) > 0.934
+        sum(max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934
       for: 30m
       labels:
         severity: warning

--- a/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
+++ b/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
@@ -27,7 +27,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[5m])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[5m])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[5m])))
         ) / (1 - 0.99), 0.01
@@ -38,7 +38,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[30m])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[30m])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[30m])))
         ) / (1 - 0.99), 0.01
@@ -49,7 +49,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[1h])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1h])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1h])))
         ) / (1 - 0.99), 0.01
@@ -60,7 +60,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[6h])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[6h])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[6h])))
         ) / (1 - 0.99), 0.01
@@ -71,7 +71,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[3d])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[3d])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[3d])))
         ) / (1 - 0.99), 0.01
@@ -82,7 +82,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[2h])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[2h])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[2h])))
         ) / (1 - 0.99), 0.01
@@ -93,7 +93,7 @@ spec:
       expr: |
         round(
         (
-        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..", service="clusters-service-metrics"}[1d])))
+        sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code=~"5..|0", service="clusters-service-metrics"}[1d])))
         /
         sum(max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[1d])))
         ) / (1 - 0.99), 0.01

--- a/observability/alerts/tested-rules/cluster-service-slo-rules_test.yaml
+++ b/observability/alerts/tested-rules/cluster-service-slo-rules_test.yaml
@@ -5,20 +5,20 @@ tests:
 # Test 1: Normal operation - no errors, no alert should fire
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
     # 100 requests per minute, all successful
     values: "100+100x80"
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="201"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="201"}'
     # Additional successful requests
     values: "50+50x80"
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500"}'
     # No 5xx errors
     values: "0+0x80"
   promql_expr_test:
-  - expr: availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}
+  - expr: availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}
     eval_time: 70m
     exp_samples:
-    - labels: 'availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}'
+    - labels: 'availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}'
       value: 0 # No errors = 0 burn rate
   alert_rule_test:
   - eval_time: 70m
@@ -30,17 +30,17 @@ tests:
 # Test 2: Fast burn rate - high error rate triggering critical alert (5m + 1h windows)
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
     # 20% success rate (80% errors) for full test duration
     values: "20+20x80"
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500"}'
     # 80% error rate for full test duration
     values: "80+80x80"
   promql_expr_test:
-  - expr: availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}
+  - expr: availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}
     eval_time: 70m
     exp_samples:
-    - labels: 'availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}'
+    - labels: 'availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}'
       value: 80 # 80% error rate / 1% budget = 80x burn rate
   alert_rule_test:
   - eval_time: 70m
@@ -57,17 +57,17 @@ tests:
 # Test 3: Medium burn rate - triggering critical alert (30m + 6h windows)
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
     # Consistent 90% success rate (10% error rate)
     values: "90+90x400"
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500"}'
     # Consistent 10% error rate
     values: "10+10x400"
   promql_expr_test:
-  - expr: availability:api_inbound_request_count:burnrate30m{service="clusters-service-metrics"}
+  - expr: availability:api_inbound_request_count:burnrate30m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}
     eval_time: 420m # 7 hours
     exp_samples:
-    - labels: 'availability:api_inbound_request_count:burnrate30m{service="clusters-service-metrics"}'
+    - labels: 'availability:api_inbound_request_count:burnrate30m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}'
       value: 10 # 10% error rate / 1% budget = 10x burn rate
   alert_rule_test:
   - eval_time: 420m # 7 hours - after 6h window + buffer
@@ -84,17 +84,17 @@ tests:
 # Test 4: Slow burn rate - triggering warning alert (6h + 3d windows)
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
     # 98.5% success rate (1.5% error rate) - slow burn
     values: "985+985x4320" # 3 days worth of data
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500"}'
     # 1.5% error rate consistently
     values: "15+15x4320"
   promql_expr_test:
-  - expr: availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"}
+  - expr: availability:api_inbound_request_count:burnrate6h{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}
     eval_time: 4400m # After 3 days
     exp_samples:
-    - labels: 'availability:api_inbound_request_count:burnrate6h{service="clusters-service-metrics"}'
+    - labels: 'availability:api_inbound_request_count:burnrate6h{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}'
       value: 1.5 # 1.5% error rate / 1% budget = 1.5x burn rate
   alert_rule_test:
   - eval_time: 4400m # After 3 days + buffer
@@ -110,17 +110,17 @@ tests:
 # Test 5: Edge case - exactly at 99% threshold (should not fire critical alert)
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
     # 99.01% success rate (0.99% error rate) - just below 1% SLO breach
     values: "9901+9901x80"
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500"}'
     # 0.99% error rate - just below threshold
     values: "99+99x80"
   promql_expr_test:
-  - expr: availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}
+  - expr: availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}
     eval_time: 70m
     exp_samples:
-    - labels: 'availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}'
+    - labels: 'availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}'
       value: 0.99 # 0.99% error rate / 1% budget = 0.99x burn rate
   alert_rule_test:
   - eval_time: 70m
@@ -129,23 +129,23 @@ tests:
 # Test 6: Prometheus replica handling (deduplication)
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200", prometheus_replica="prometheus-0"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200", prometheus_replica="prometheus-0"}'
     # 70% success rate from replica 0
     values: "70+70x80"
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200", prometheus_replica="prometheus-1"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200", prometheus_replica="prometheus-1"}'
     # 70% success rate from replica 1 (should be deduplicated by max without)
     values: "70+70x80"
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500", prometheus_replica="prometheus-0"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500", prometheus_replica="prometheus-0"}'
     # 30% error rate from replica 0
     values: "30+30x80"
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500", prometheus_replica="prometheus-1"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500", prometheus_replica="prometheus-1"}'
     # 30% error rate from replica 1 (should be deduplicated by max without)
     values: "30+30x80"
   promql_expr_test:
-  - expr: availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}
+  - expr: availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}
     eval_time: 70m
     exp_samples:
-    - labels: 'availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}'
+    - labels: 'availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}'
       value: 30 # 30% error rate / 1% budget = 30x burn rate
   alert_rule_test:
   - eval_time: 70m
@@ -162,10 +162,10 @@ tests:
 # Test 7: Recovery - alert should stop firing when error rate drops
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
     # High error rate for 65 minutes, then recovery for 20 minutes
     values: "20+20x65 100+100x20"
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500"}'
     # High error rate for 65 minutes, then recovery
     values: "80+80x65 0+0x20"
   alert_rule_test:
@@ -186,20 +186,20 @@ tests:
 # Test 8: Mixed status codes (only 5xx should count as errors)
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
     # 2xx successful
     values: "60+60x80"
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="400"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="400"}'
     # 4xx client errors (should not count as SLO breach)
     values: "20+20x80"
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="500"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500"}'
     # 5xx server errors (should count as SLO breach) - 20% error rate
     values: "20+20x80"
   promql_expr_test:
-  - expr: availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}
+  - expr: availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}
     eval_time: 70m
     exp_samples:
-    - labels: 'availability:api_inbound_request_count:burnrate5m{service="clusters-service-metrics"}'
+    - labels: 'availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}'
       value: 20 # 20% error rate / 1% budget = 20x burn rate
   alert_rule_test:
   - eval_time: 70m
@@ -216,16 +216,16 @@ tests:
 # Test 9: P99 Latency - Normal operation (no latency issues, no alert should fire)
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
     # 1000 successful requests per minute - larger numbers for stability
     values: "1000+1000x80"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
     # 900 requests under 0.1s (90%)
     values: "900+900x80"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
     # 1000 requests under 1s (100% - perfect P99 performance)
     values: "1000+1000x80"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
     # All requests
     values: "1000+1000x80"
   alert_rule_test:
@@ -238,16 +238,16 @@ tests:
 # Test 10: P90 Latency - Normal operation (no latency issues, no alert should fire)
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
     # 1000 successful requests per minute
     values: "1000+1000x80"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
     # 1000 requests under 0.1s (100% - perfect P90 performance)
     values: "1000+1000x80"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
     # All requests under 1s
     values: "1000+1000x80"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
     # All requests
     values: "1000+1000x80"
   alert_rule_test:
@@ -260,16 +260,16 @@ tests:
 # Test 11: P99 Latency - Critical burn rate triggering alert
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
     # 1000 requests per minute
     values: "1000+1000x80"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
     # 500 under 0.1s (50%)
     values: "500+500x80"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
     # 800 under 1s (80% - violating P99 SLO significantly)
     values: "800+800x80"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
     # All requests
     values: "1000+1000x80"
   alert_rule_test:
@@ -288,16 +288,16 @@ tests:
 # Test 12: P90 Latency - Critical burn rate triggering alert
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
     # 1000 requests per minute
     values: "1000+1000x80"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
     # 200 under 0.1s (20% - severely violating P90 SLO)
     values: "200+200x80"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
     # 950 under 1s
     values: "950+950x80"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
     # All requests
     values: "1000+1000x80"
   alert_rule_test:
@@ -316,16 +316,16 @@ tests:
 # Test 13: P99 Latency - Slow burn rate triggering warning alert
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
     # 1000 requests per minute for consistent data over 3 days
     values: "1000+1000x4320" # 3 days worth of data
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
     # 850 under 0.1s (85%)
     values: "850+850x4320"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
     # 980 under 1s (98% - small but persistent P99 violation)
     values: "980+980x4320"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
     # All requests
     values: "1000+1000x4320"
   alert_rule_test:
@@ -342,16 +342,16 @@ tests:
 # Test 14: P90 Latency - Slow burn rate triggering warning alert
 - interval: 1m
   input_series:
-  - series: 'api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code="200"}'
+  - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
     # 1000 requests per minute for consistent data over 3 days
     values: "1000+1000x4320" # 3 days worth of data
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
     # 800 under 0.1s (80% - persistent P90 violation)
     values: "800+800x4320"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
     # 990 under 1s
     values: "990+990x4320"
-  - series: 'api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
+  - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
     # All requests
     values: "1000+1000x4320"
   alert_rule_test:


### PR DESCRIPTION
<!-- Link to Jira issue -->
[ARO-19726](https://issues.redhat.com//browse/ARO-19726)

### What

Updates Grafana dashboard UID for CS SLO compound metrics and fixes Prometheus recording rules to:
- Include HTTP code '0' in API error rate calculations
- Preserve cluster/namespace labels in aggregations for dashboard filtering

### Why

- Recording rules weren't capturing network errors (code=0) in availability SLOs
- Dashboard queries couldn't filter by cluster variable due to missing labels in aggregated metrics
- UID mismatch was preventing proper dashboard linkage

### Special notes for your reviewer

- HTTP code '0' represents network/timeout errors that should count against availability SLO
- All burn rate rules updated to maintain consistency
- Test files updated to match new label structure