### PR TITLE
e2e: remove skipping tls verification on kubeconfigs now that we have publicly trusted certs

### DIFF
--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -163,11 +163,6 @@ func readStaticRESTConfig(kubeconfigContent *string) (*rest.Config, error) {
 		return nil, err
 	}
 
-	// we are doing this because there's a serious bug.  I haven't got an ETA on a fix, but if we fail to correct it, we definitely need to know.
-	// https://issues.redhat.com/browse/XCMSTRAT-950 for reference when this intentional time bomb explodes.
-	if time.Now().Before(Must(time.Parse(time.RFC3339, "2025-09-02T15:04:05Z"))) {
-		ret.Insecure = true
-	}
 	return ret, nil
 }
 


### PR DESCRIPTION
### What

Remove the tls verification skipping on kubeconfigs.  

### Why

OneCert publicly trusted certs should exist now/soon.  

### Special notes for your reviewer

Green int/stage/prod tests should be our gate here.  
