### PR TITLE
frontend: Do not convert empty version ID strings 

### DIFF
--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -442,9 +442,6 @@ func (f *Frontend) BuildCSCluster(resourceID *azcorearm.ResourceID, requestHeade
 		return nil, fmt.Errorf("missing " + arm.HeaderNameHomeTenantID + " header")
 	}
 
-	versionCSformat := ocm.NewOpenShiftVersionXYZ(hcpCluster.Properties.Version.ID)
-	hcpCluster.Properties.Version.ID = versionCSformat
-
 	clusterBuilder := arohcpv1alpha1.NewCluster()
 
 	// These attributes cannot be updated after cluster creation.
@@ -500,7 +497,7 @@ func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpC
 			Enabled(csHypershifEnabled)).
 		CCS(arohcpv1alpha1.NewCCS().Enabled(csCCSEnabled)).
 		Version(arohcpv1alpha1.NewVersion().
-			ID(hcpCluster.Properties.Version.ID).
+			ID(ocm.NewOpenShiftVersionXYZ(hcpCluster.Properties.Version.ID)).
 			ChannelGroup(hcpCluster.Properties.Version.ChannelGroup)).
 		Network(arohcpv1alpha1.NewNetwork().
 			Type(string(hcpCluster.Properties.Network.NetworkType)).
@@ -638,14 +635,12 @@ func ConvertCStoNodePool(resourceID *azcorearm.ResourceID, np *arohcpv1alpha1.No
 func (f *Frontend) BuildCSNodePool(ctx context.Context, nodePool *api.HCPOpenShiftClusterNodePool, updating bool) (*arohcpv1alpha1.NodePool, error) {
 	npBuilder := arohcpv1alpha1.NewNodePool()
 
-	nodepoolCSversion := ocm.ConvertOpenShiftVersionAddPrefix(nodePool.Properties.Version.ID)
-
 	// These attributes cannot be updated after node pool creation.
 	if !updating {
 		npBuilder = npBuilder.
 			ID(nodePool.Name).
 			Version(arohcpv1alpha1.NewVersion().
-				ID(nodepoolCSversion).
+				ID(ocm.ConvertOpenShiftVersionAddPrefix(nodePool.Properties.Version.ID)).
 				ChannelGroup(nodePool.Properties.Version.ChannelGroup)).
 			Subnet(nodePool.Properties.Platform.SubnetID).
 			AzureNodePool(arohcpv1alpha1.NewAzureNodePool().

--- a/frontend/pkg/frontend/ocm_test.go
+++ b/frontend/pkg/frontend/ocm_test.go
@@ -334,7 +334,7 @@ func getBaseCSNodePoolBuilder() *arohcpv1alpha1.NodePoolBuilder {
 		).
 		Subnet("").
 		Version(arohcpv1alpha1.NewVersion().
-			ID("openshift-v").
+			ID("").
 			ChannelGroup(""),
 		).
 		Replicas(0).

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -505,14 +505,20 @@ func NewOpenShiftVersionXY(v string) string {
 
 // NewOpenShiftVersionXYZ parses the given version and converts it to CS readable version
 func NewOpenShiftVersionXYZ(v string) string {
-	parts := strings.Split(v, ".")
-	if len(parts) == 1 {
-		parts = append(parts, "0")
+	var csVersion string
+
+	if len(v) > 0 {
+		parts := strings.Split(v, ".")
+		if len(parts) == 1 {
+			parts = append(parts, "0")
+		}
+		// FIXME This assumes X.Y is 4.19. Eventually
+		//       we may need a switch statement here.
+		parts = append(parts[:2], OpenShift419Patch)
+		csVersion = api.OpenShiftVersionPrefix + strings.Join(parts, ".")
 	}
-	// FIXME This assumes X.Y is 4.19. Eventually
-	//       we may need a switch statement here.
-	parts = append(parts[:2], OpenShift419Patch)
-	return api.OpenShiftVersionPrefix + strings.Join(parts, ".")
+
+	return csVersion
 }
 
 // ConvertOpenShiftVersionNoPrefix strips off openshift-v prefix
@@ -522,7 +528,7 @@ func ConvertOpenShiftVersionNoPrefix(v string) string {
 
 // ConvertOpenShiftVersionAddPrefix adds openshift-v prefix
 func ConvertOpenShiftVersionAddPrefix(v string) string {
-	if !strings.HasPrefix(v, api.OpenShiftVersionPrefix) {
+	if len(v) > 0 && !strings.HasPrefix(v, api.OpenShiftVersionPrefix) {
 		return api.OpenShiftVersionPrefix + v
 	}
 	return v


### PR DESCRIPTION
[ARO-20849 - Regression: Omitting version ID sends invalid value to CS](https://issues.redhat.com/browse/ARO-20849)

### What

The version ID fields in the cluster and node pool models are optional. If omitted, we're supposed to send Clusters Service an empty string so it can pick its floating default version.

In the course of recent version ID format changes, we failed to preserve this use case. Omitting the cluster version ID field now results in an error response:

```
{
    "error": {
        "code": "InvalidRequestContent",
        "message": "Version 'openshift-v.0.7' doesn't exist"
    }
}
```

Similarly when omitting a node pool version ID:

```
{
    "error": {
        "code": "InvalidRequestContent",
        "message": "Version 'openshift-v' not found"
    }
}
```