### PR TITLE
BREAKING CHANGE: Demos Auto-Detect Env

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -8,6 +8,22 @@
 * (optional but useful) port-forward Maestro running on SC: `kubectl port-forward -n maestro svc/maestro 8002:8000`
 * ensure that the environment variable `$LOCATION` is either unset or set to the integrated dev environment's region
 
+## Environment Detection
+
+The demo scripts automatically detect the target environment (in [env_vars](./env_vars)) using the following logic:
+
+### Development Mode (`RP_MODE=development`)
+When `RP_MODE=development` is set, the demo scripts will:
+- Use `http://localhost:8443` as the frontend host rather than routing to ARM
+- Set `DEMO_ENV_NAME` to the value of `DEPLOY_ENV` (defaults to `pers`)
+
+### Other Environments
+When `RP_MODE` is NOT set to `development`, all requests will route to ARM, and the scripts will check Azure Feature Exposure Control (AFEC) flags on the current subscription to determine the environment:
+
+- **INT Environment**: Detected by registered `Microsoft.RedHatOpenShift/INT-APPROVED` AFEC flag on the subscription
+- **STG Environment**: Detected by registered `Microsoft.RedHatOpenShift/STAGING-APPROVED` AFEC flag on the subscription
+- **PROD Environment**: Default (if the other AFEC flags are not present)
+
 ## Register the subscription with the RP
 
 The RP needs to know the subscription in order to be able to create clusters in it.

--- a/demo/env_vars
+++ b/demo/env_vars
@@ -1,23 +1,33 @@
 #!/bin/bash
 
-# Defined here because it's used here.
-is_int_testing_subscription() {
-    return $(test "$(az account show --query name --output tsv)" = "ARO SRE Team - INT (EA Subscription 3)")
+# Check if subscription has AFEC feature flags for environment detection
+check_afec_environment() {
+    # INT
+    if az feature list --namespace "Microsoft.RedHatOpenShift" --query "[?contains(name, 'INT-APPROVED') && properties.state=='Registered'].name" --output tsv | grep -qi "INT-APPROVED"; then
+        echo "int"
+        return 0
+    fi
+
+    # STG
+    if az feature list --namespace "Microsoft.RedHatOpenShift" --query "[?contains(name, 'STAGING-APPROVED') && properties.state=='Registered'].name" --output tsv | grep -qi "STAGING-APPROVED"; then
+        echo "stg"
+        return 0
+    fi
+
+    # Assume prod otherwise
+    echo "prod"
+    return 0
 }
 
-is_stg_testing_subscription() {
-    return $(test "$(az account show --query name --output tsv)" = "ARO HCP - STAGE testing (EA Subscription)")
-}
-
-if is_int_testing_subscription; then
-    export FRONTEND_HOST=$(az cloud show --query endpoints.resourceManager --output tsv)
-    DEMO_ENV_NAME=int
-elif is_stg_testing_subscription; then
-    export FRONTEND_HOST=$(az cloud show --query endpoints.resourceManager --output tsv)
-    DEMO_ENV_NAME=stg
-else
+# Environment detection logic based on RP_MODE and AFEC flags
+if [ "${RP_MODE:-}" = "development" ]; then
+    # Force localhost frontend
     export FRONTEND_HOST="http://localhost:8443"
     DEMO_ENV_NAME=${DEPLOY_ENV:-pers}
+else
+    # Not in dev mode, use ARM routing
+    export FRONTEND_HOST=$(az cloud show --query endpoints.resourceManager --output tsv)
+    DEMO_ENV_NAME=$(check_afec_environment)
 fi
 
 if [ -z "${CUSTOMER_RG_NAME:-}" ]; then


### PR DESCRIPTION
JIRA: N/A - this arose from convos with consulting teams.

### What

<!-- Briefly describe what this PR does -->

TL;DR - **the BREAKING CHANGE: to hit `localhost` Frontend instances when using demos, use `RP_MODE=development`**. All other requests route via ARM, and your resource extensions (e.g. `-int`) are automatically determined based on the Subscription you are logged into (and its registered AFECs).

### Why

<!-- Briefly explain why this change is needed -->

Today, we ask our consultants to manually edit `env_vars` in our demos to test our RP. This change gives them a clear path to test without modifying code, but also simplifies our demo naming conventions to auto-detect what environment you are connecting to rather than keying off of hard-coded values.

### Special notes for your reviewer

<!-- optional -->
