### PR TITLE
Support listing external auth resources

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -347,6 +347,22 @@ func (f *Frontend) ArmResourceList(writer http.ResponseWriter, request *http.Req
 		}
 		err = csIterator.GetError()
 
+	case strings.ToLower(api.ExternalAuthResourceTypeName):
+		csIterator := f.clusterServiceClient.ListExternalAuths(clusterInternalID, query)
+
+		for csExternalAuth := range csIterator.Items(ctx) {
+			if doc, ok := documentMap[csExternalAuth.ID()]; ok {
+				value, err := marshalCSExternalAuth(csExternalAuth, doc, versionedInterface)
+				if err != nil {
+					logger.Error(err.Error())
+					arm.WriteInternalServerError(writer)
+					return
+				}
+				pagedResponse.AddValue(value)
+			}
+		}
+		err = csIterator.GetError()
+
 	case strings.ToLower(api.VersionResourceTypeName):
 		csIterator := f.clusterServiceClient.ListVersions()
 

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -320,13 +320,13 @@ func (f *Frontend) ArmResourceList(writer http.ResponseWriter, request *http.Req
 		}
 		err = csIterator.GetError()
 
-	case strings.ToLower(api.ClusterVersionTypeName):
+	case strings.ToLower(api.VersionResourceTypeName):
 		csIterator := f.clusterServiceClient.ListVersions()
 
 		for csVersion := range csIterator.Items(ctx) {
 			versionName := strings.Replace(csVersion.ID(), api.OpenShiftVersionPrefix, "", 1)
 			stringResource := "/subscriptions/" + subscriptionID + "/providers/" + api.ProviderNamespace +
-				"/locations/" + location + "/" + api.ClusterVersionTypeName + "/" + versionName
+				"/locations/" + location + "/" + api.VersionResourceTypeName + "/" + versionName
 			resourceID, err := azcorearm.ParseResourceID(stringResource)
 			if err != nil {
 				logger.Error(err.Error())

--- a/frontend/pkg/frontend/helpers.go
+++ b/frontend/pkg/frontend/helpers.go
@@ -106,7 +106,7 @@ func (f *Frontend) DeleteAllResources(ctx context.Context, subscriptionID string
 
 	transaction := f.dbClient.NewTransaction(database.NewPartitionKey(subscriptionID))
 
-	dbIterator := f.dbClient.ListResourceDocs(prefix, -1, nil)
+	dbIterator := f.dbClient.ListResourceDocs(prefix, nil)
 
 	// Start a deletion operation for all clusters under the subscription.
 	// Cluster Service will delete all node pools belonging to these clusters
@@ -208,7 +208,7 @@ func (f *Frontend) DeleteResource(ctx context.Context, transaction database.DBTr
 	patchOperations.SetProvisioningState(operationDoc.Status)
 	transaction.PatchResourceDoc(resourceItemID, patchOperations, nil)
 
-	iterator := f.dbClient.ListResourceDocs(resourceDoc.ResourceID, -1, nil)
+	iterator := f.dbClient.ListResourceDocs(resourceDoc.ResourceID, nil)
 
 	for childItemID, childResourceDoc := range iterator.Items(ctx) {
 		// This operation is not accessible through any REST endpoint.

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -41,7 +41,7 @@ const (
 	PatternProviders         = "providers/" + api.ProviderNamespace
 	PatternClusters          = api.ClusterResourceTypeName + "/" + WildcardResourceName
 	PatternNodePools         = api.NodePoolResourceTypeName + "/" + WildcardNodePoolName
-	PatternVersions          = api.ClusterVersionTypeName + "/" + WildcardResourceName
+	PatternVersions          = api.VersionResourceTypeName + "/" + WildcardResourceName
 	PatternExternalAuth      = api.ExternalAuthResourceTypeName + "/" + WildcardExternalAuthName
 	PatternDeployments       = "deployments/" + WildcardDeploymentName
 	PatternResourceGroups    = "resourcegroups/" + WildcardResourceGroupName
@@ -104,7 +104,7 @@ func (f *Frontend) routes(r prometheus.Registerer) *MiddlewareMux {
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, api.ExternalAuthResourceTypeName),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceList))
 	mux.Handle(
-		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders, PatternLocations, api.ClusterVersionTypeName),
+		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders, PatternLocations, api.VersionResourceTypeName),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceList))
 
 	// Resource read endpoints

--- a/internal/api/registry.go
+++ b/internal/api/registry.go
@@ -27,12 +27,12 @@ const (
 	ProviderNamespace               = "Microsoft.RedHatOpenShift"
 	ProviderNamespaceDisplay        = "Azure Red Hat OpenShift"
 	ClusterResourceTypeName         = "hcpOpenShiftClusters"
+	VersionResourceTypeName         = "hcpOpenShiftVersions"
 	NodePoolResourceTypeName        = "nodePools"
 	ExternalAuthResourceTypeName    = "externalAuths"
 	OperationResultResourceTypeName = "hcpOperationResults"
 	OperationStatusResourceTypeName = "hcpOperationStatuses"
 	ResourceTypeDisplay             = "Hosted Control Plane (HCP) OpenShift Clusters"
-	ClusterVersionTypeName          = "hcpOpenShiftVersions"
 )
 
 var (
@@ -40,7 +40,7 @@ var (
 	NodePoolResourceType     = azcorearm.NewResourceType(ProviderNamespace, ClusterResourceTypeName+"/"+NodePoolResourceTypeName)
 	ExternalAuthResourceType = azcorearm.NewResourceType(ProviderNamespace, ClusterResourceTypeName+"/"+ExternalAuthResourceTypeName)
 	PreflightResourceType    = azcorearm.NewResourceType(ProviderNamespace, "deployments/preflight")
-	VersionResourceType      = azcorearm.NewResourceType(ProviderNamespace, "locations/"+ClusterVersionTypeName)
+	VersionResourceType      = azcorearm.NewResourceType(ProviderNamespace, "locations/"+VersionResourceTypeName)
 )
 
 type VersionedHCPOpenShiftCluster interface {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -63,7 +63,8 @@ type DBClientIterator[T DocumentProperties] interface {
 
 // DBClientListResourceDocsOptions allows for limiting the results of DBClient.ListResourceDocs.
 type DBClientListResourceDocsOptions struct {
-	// ResourceType matches (case-insensitively) the Azure resource type
+	// ResourceType matches (case-insensitively) the Azure resource type. If unspecified,
+	// DBClient.ListResourceDocs will match resource documents for any resource type.
 	ResourceType *azcorearm.ResourceType
 
 	// PageSizeHint can limit the number of items returned at once. A negative value will cause

--- a/internal/database/util.go
+++ b/internal/database/util.go
@@ -30,19 +30,19 @@ type queryItemsIterator[T DocumentProperties] struct {
 
 // newqueryItemsIterator is a failable push iterator for a paged query response.
 func newQueryItemsIterator[T DocumentProperties](pager *runtime.Pager[azcosmos.QueryItemsResponse]) DBClientIterator[T] {
-	return queryItemsIterator[T]{pager: pager}
+	return &queryItemsIterator[T]{pager: pager}
 }
 
 // newQueryItemsSinglePageIterator is a failable push iterator for a paged
 // query response that stops at the end of the first page and includes a
 // continuation token if additional items are available.
 func newQueryItemsSinglePageIterator[T DocumentProperties](pager *runtime.Pager[azcosmos.QueryItemsResponse]) DBClientIterator[T] {
-	return queryItemsIterator[T]{pager: pager, singlePage: true}
+	return &queryItemsIterator[T]{pager: pager, singlePage: true}
 }
 
 // Items returns a push iterator that can be used directly in for/range loops.
 // If an error occurs during paging, iteration stops and the error is recorded.
-func (iter queryItemsIterator[T]) Items(ctx context.Context) DBClientIteratorItem[T] {
+func (iter *queryItemsIterator[T]) Items(ctx context.Context) DBClientIteratorItem[T] {
 	return func(yield func(string, *T) bool) {
 		for iter.pager.More() {
 			response, err := iter.pager.NextPage(ctx)

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -645,17 +645,17 @@ func (c *MockDBClientListAllSubscriptionDocsCall) DoAndReturn(f func() database.
 }
 
 // ListResourceDocs mocks base method.
-func (m *MockDBClient) ListResourceDocs(prefix *arm0.ResourceID, maxItems int32, continuationToken *string) database.DBClientIterator[database.ResourceDocument] {
+func (m *MockDBClient) ListResourceDocs(prefix *arm0.ResourceID, options *database.DBClientListResourceDocsOptions) database.DBClientIterator[database.ResourceDocument] {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListResourceDocs", prefix, maxItems, continuationToken)
+	ret := m.ctrl.Call(m, "ListResourceDocs", prefix, options)
 	ret0, _ := ret[0].(database.DBClientIterator[database.ResourceDocument])
 	return ret0
 }
 
 // ListResourceDocs indicates an expected call of ListResourceDocs.
-func (mr *MockDBClientMockRecorder) ListResourceDocs(prefix, maxItems, continuationToken any) *MockDBClientListResourceDocsCall {
+func (mr *MockDBClientMockRecorder) ListResourceDocs(prefix, options any) *MockDBClientListResourceDocsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceDocs", reflect.TypeOf((*MockDBClient)(nil).ListResourceDocs), prefix, maxItems, continuationToken)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceDocs", reflect.TypeOf((*MockDBClient)(nil).ListResourceDocs), prefix, options)
 	return &MockDBClientListResourceDocsCall{Call: call}
 }
 
@@ -671,13 +671,13 @@ func (c *MockDBClientListResourceDocsCall) Return(arg0 database.DBClientIterator
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockDBClientListResourceDocsCall) Do(f func(*arm0.ResourceID, int32, *string) database.DBClientIterator[database.ResourceDocument]) *MockDBClientListResourceDocsCall {
+func (c *MockDBClientListResourceDocsCall) Do(f func(*arm0.ResourceID, *database.DBClientListResourceDocsOptions) database.DBClientIterator[database.ResourceDocument]) *MockDBClientListResourceDocsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDBClientListResourceDocsCall) DoAndReturn(f func(*arm0.ResourceID, int32, *string) database.DBClientIterator[database.ResourceDocument]) *MockDBClientListResourceDocsCall {
+func (c *MockDBClientListResourceDocsCall) DoAndReturn(f func(*arm0.ResourceID, *database.DBClientListResourceDocsOptions) database.DBClientIterator[database.ResourceDocument]) *MockDBClientListResourceDocsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/mocks/ocm.go
+++ b/internal/mocks/ocm.go
@@ -622,6 +622,44 @@ func (c *MockClusterServiceClientSpecListClustersCall) DoAndReturn(f func(string
 	return c
 }
 
+// ListExternalAuths mocks base method.
+func (m *MockClusterServiceClientSpec) ListExternalAuths(clusterInternalID ocm.InternalID, searchExpression string) ocm.ExternalAuthListIterator {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListExternalAuths", clusterInternalID, searchExpression)
+	ret0, _ := ret[0].(ocm.ExternalAuthListIterator)
+	return ret0
+}
+
+// ListExternalAuths indicates an expected call of ListExternalAuths.
+func (mr *MockClusterServiceClientSpecMockRecorder) ListExternalAuths(clusterInternalID, searchExpression any) *MockClusterServiceClientSpecListExternalAuthsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExternalAuths", reflect.TypeOf((*MockClusterServiceClientSpec)(nil).ListExternalAuths), clusterInternalID, searchExpression)
+	return &MockClusterServiceClientSpecListExternalAuthsCall{Call: call}
+}
+
+// MockClusterServiceClientSpecListExternalAuthsCall wrap *gomock.Call
+type MockClusterServiceClientSpecListExternalAuthsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockClusterServiceClientSpecListExternalAuthsCall) Return(arg0 ocm.ExternalAuthListIterator) *MockClusterServiceClientSpecListExternalAuthsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockClusterServiceClientSpecListExternalAuthsCall) Do(f func(ocm.InternalID, string) ocm.ExternalAuthListIterator) *MockClusterServiceClientSpecListExternalAuthsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockClusterServiceClientSpecListExternalAuthsCall) DoAndReturn(f func(ocm.InternalID, string) ocm.ExternalAuthListIterator) *MockClusterServiceClientSpecListExternalAuthsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ListNodePools mocks base method.
 func (m *MockClusterServiceClientSpec) ListNodePools(clusterInternalID ocm.InternalID, searchExpression string) ocm.NodePoolListIterator {
 	m.ctrl.T.Helper()

--- a/internal/mocks/ocm.go
+++ b/internal/mocks/ocm.go
@@ -547,10 +547,10 @@ func (c *MockClusterServiceClientSpecGetVersionCall) DoAndReturn(f func(context.
 }
 
 // ListBreakGlassCredentials mocks base method.
-func (m *MockClusterServiceClientSpec) ListBreakGlassCredentials(clusterInternalID ocm.InternalID, searchExpression string) ocm.BreakGlassCredentialListIterator {
+func (m *MockClusterServiceClientSpec) ListBreakGlassCredentials(clusterInternalID ocm.InternalID, searchExpression string) *ocm.BreakGlassCredentialListIterator {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBreakGlassCredentials", clusterInternalID, searchExpression)
-	ret0, _ := ret[0].(ocm.BreakGlassCredentialListIterator)
+	ret0, _ := ret[0].(*ocm.BreakGlassCredentialListIterator)
 	return ret0
 }
 
@@ -567,28 +567,28 @@ type MockClusterServiceClientSpecListBreakGlassCredentialsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClusterServiceClientSpecListBreakGlassCredentialsCall) Return(arg0 ocm.BreakGlassCredentialListIterator) *MockClusterServiceClientSpecListBreakGlassCredentialsCall {
+func (c *MockClusterServiceClientSpecListBreakGlassCredentialsCall) Return(arg0 *ocm.BreakGlassCredentialListIterator) *MockClusterServiceClientSpecListBreakGlassCredentialsCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClusterServiceClientSpecListBreakGlassCredentialsCall) Do(f func(ocm.InternalID, string) ocm.BreakGlassCredentialListIterator) *MockClusterServiceClientSpecListBreakGlassCredentialsCall {
+func (c *MockClusterServiceClientSpecListBreakGlassCredentialsCall) Do(f func(ocm.InternalID, string) *ocm.BreakGlassCredentialListIterator) *MockClusterServiceClientSpecListBreakGlassCredentialsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClusterServiceClientSpecListBreakGlassCredentialsCall) DoAndReturn(f func(ocm.InternalID, string) ocm.BreakGlassCredentialListIterator) *MockClusterServiceClientSpecListBreakGlassCredentialsCall {
+func (c *MockClusterServiceClientSpecListBreakGlassCredentialsCall) DoAndReturn(f func(ocm.InternalID, string) *ocm.BreakGlassCredentialListIterator) *MockClusterServiceClientSpecListBreakGlassCredentialsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ListClusters mocks base method.
-func (m *MockClusterServiceClientSpec) ListClusters(searchExpression string) ocm.ClusterListIterator {
+func (m *MockClusterServiceClientSpec) ListClusters(searchExpression string) *ocm.ClusterListIterator {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListClusters", searchExpression)
-	ret0, _ := ret[0].(ocm.ClusterListIterator)
+	ret0, _ := ret[0].(*ocm.ClusterListIterator)
 	return ret0
 }
 
@@ -605,28 +605,28 @@ type MockClusterServiceClientSpecListClustersCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClusterServiceClientSpecListClustersCall) Return(arg0 ocm.ClusterListIterator) *MockClusterServiceClientSpecListClustersCall {
+func (c *MockClusterServiceClientSpecListClustersCall) Return(arg0 *ocm.ClusterListIterator) *MockClusterServiceClientSpecListClustersCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClusterServiceClientSpecListClustersCall) Do(f func(string) ocm.ClusterListIterator) *MockClusterServiceClientSpecListClustersCall {
+func (c *MockClusterServiceClientSpecListClustersCall) Do(f func(string) *ocm.ClusterListIterator) *MockClusterServiceClientSpecListClustersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClusterServiceClientSpecListClustersCall) DoAndReturn(f func(string) ocm.ClusterListIterator) *MockClusterServiceClientSpecListClustersCall {
+func (c *MockClusterServiceClientSpecListClustersCall) DoAndReturn(f func(string) *ocm.ClusterListIterator) *MockClusterServiceClientSpecListClustersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ListExternalAuths mocks base method.
-func (m *MockClusterServiceClientSpec) ListExternalAuths(clusterInternalID ocm.InternalID, searchExpression string) ocm.ExternalAuthListIterator {
+func (m *MockClusterServiceClientSpec) ListExternalAuths(clusterInternalID ocm.InternalID, searchExpression string) *ocm.ExternalAuthListIterator {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListExternalAuths", clusterInternalID, searchExpression)
-	ret0, _ := ret[0].(ocm.ExternalAuthListIterator)
+	ret0, _ := ret[0].(*ocm.ExternalAuthListIterator)
 	return ret0
 }
 
@@ -643,28 +643,28 @@ type MockClusterServiceClientSpecListExternalAuthsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClusterServiceClientSpecListExternalAuthsCall) Return(arg0 ocm.ExternalAuthListIterator) *MockClusterServiceClientSpecListExternalAuthsCall {
+func (c *MockClusterServiceClientSpecListExternalAuthsCall) Return(arg0 *ocm.ExternalAuthListIterator) *MockClusterServiceClientSpecListExternalAuthsCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClusterServiceClientSpecListExternalAuthsCall) Do(f func(ocm.InternalID, string) ocm.ExternalAuthListIterator) *MockClusterServiceClientSpecListExternalAuthsCall {
+func (c *MockClusterServiceClientSpecListExternalAuthsCall) Do(f func(ocm.InternalID, string) *ocm.ExternalAuthListIterator) *MockClusterServiceClientSpecListExternalAuthsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClusterServiceClientSpecListExternalAuthsCall) DoAndReturn(f func(ocm.InternalID, string) ocm.ExternalAuthListIterator) *MockClusterServiceClientSpecListExternalAuthsCall {
+func (c *MockClusterServiceClientSpecListExternalAuthsCall) DoAndReturn(f func(ocm.InternalID, string) *ocm.ExternalAuthListIterator) *MockClusterServiceClientSpecListExternalAuthsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ListNodePools mocks base method.
-func (m *MockClusterServiceClientSpec) ListNodePools(clusterInternalID ocm.InternalID, searchExpression string) ocm.NodePoolListIterator {
+func (m *MockClusterServiceClientSpec) ListNodePools(clusterInternalID ocm.InternalID, searchExpression string) *ocm.NodePoolListIterator {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListNodePools", clusterInternalID, searchExpression)
-	ret0, _ := ret[0].(ocm.NodePoolListIterator)
+	ret0, _ := ret[0].(*ocm.NodePoolListIterator)
 	return ret0
 }
 
@@ -681,28 +681,28 @@ type MockClusterServiceClientSpecListNodePoolsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClusterServiceClientSpecListNodePoolsCall) Return(arg0 ocm.NodePoolListIterator) *MockClusterServiceClientSpecListNodePoolsCall {
+func (c *MockClusterServiceClientSpecListNodePoolsCall) Return(arg0 *ocm.NodePoolListIterator) *MockClusterServiceClientSpecListNodePoolsCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClusterServiceClientSpecListNodePoolsCall) Do(f func(ocm.InternalID, string) ocm.NodePoolListIterator) *MockClusterServiceClientSpecListNodePoolsCall {
+func (c *MockClusterServiceClientSpecListNodePoolsCall) Do(f func(ocm.InternalID, string) *ocm.NodePoolListIterator) *MockClusterServiceClientSpecListNodePoolsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClusterServiceClientSpecListNodePoolsCall) DoAndReturn(f func(ocm.InternalID, string) ocm.NodePoolListIterator) *MockClusterServiceClientSpecListNodePoolsCall {
+func (c *MockClusterServiceClientSpecListNodePoolsCall) DoAndReturn(f func(ocm.InternalID, string) *ocm.NodePoolListIterator) *MockClusterServiceClientSpecListNodePoolsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ListVersions mocks base method.
-func (m *MockClusterServiceClientSpec) ListVersions() ocm.VersionsListIterator {
+func (m *MockClusterServiceClientSpec) ListVersions() *ocm.VersionsListIterator {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListVersions")
-	ret0, _ := ret[0].(ocm.VersionsListIterator)
+	ret0, _ := ret[0].(*ocm.VersionsListIterator)
 	return ret0
 }
 
@@ -719,19 +719,19 @@ type MockClusterServiceClientSpecListVersionsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClusterServiceClientSpecListVersionsCall) Return(arg0 ocm.VersionsListIterator) *MockClusterServiceClientSpecListVersionsCall {
+func (c *MockClusterServiceClientSpecListVersionsCall) Return(arg0 *ocm.VersionsListIterator) *MockClusterServiceClientSpecListVersionsCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClusterServiceClientSpecListVersionsCall) Do(f func() ocm.VersionsListIterator) *MockClusterServiceClientSpecListVersionsCall {
+func (c *MockClusterServiceClientSpecListVersionsCall) Do(f func() *ocm.VersionsListIterator) *MockClusterServiceClientSpecListVersionsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClusterServiceClientSpecListVersionsCall) DoAndReturn(f func() ocm.VersionsListIterator) *MockClusterServiceClientSpecListVersionsCall {
+func (c *MockClusterServiceClientSpecListVersionsCall) DoAndReturn(f func() *ocm.VersionsListIterator) *MockClusterServiceClientSpecListVersionsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/ocm/iterators.go
+++ b/internal/ocm/iterators.go
@@ -35,7 +35,7 @@ type VersionsListIterator struct {
 
 // Items returns a push iterator that can be used directly in for/range loops.
 // If an error occurs during paging, iteration stops and the error is recorded.
-func (iter ClusterListIterator) Items(ctx context.Context) iter.Seq[*arohcpv1alpha1.Cluster] {
+func (iter *ClusterListIterator) Items(ctx context.Context) iter.Seq[*arohcpv1alpha1.Cluster] {
 	return func(yield func(*arohcpv1alpha1.Cluster) bool) {
 		// Request can be nil to allow for mocking.
 		if iter.request != nil {
@@ -89,7 +89,7 @@ type NodePoolListIterator struct {
 
 // Items returns a push iterator that can be used directly in for/range loops.
 // If an error occurs during paging, iteration stops and the error is recorded.
-func (iter NodePoolListIterator) Items(ctx context.Context) iter.Seq[*arohcpv1alpha1.NodePool] {
+func (iter *NodePoolListIterator) Items(ctx context.Context) iter.Seq[*arohcpv1alpha1.NodePool] {
 	return func(yield func(*arohcpv1alpha1.NodePool) bool) {
 		// Request can be nil to allow for mocking.
 		if iter.request != nil {
@@ -143,7 +143,7 @@ type ExternalAuthListIterator struct {
 
 // Items returns a push iterator that can be used directly in for/range loops.
 // If an error occurs during paging, iteration stops and the error is recorded.
-func (iter ExternalAuthListIterator) Items(ctx context.Context) iter.Seq[*arohcpv1alpha1.ExternalAuth] {
+func (iter *ExternalAuthListIterator) Items(ctx context.Context) iter.Seq[*arohcpv1alpha1.ExternalAuth] {
 	return func(yield func(*arohcpv1alpha1.ExternalAuth) bool) {
 		// Request can be nil to allow for mocking.
 		if iter.request != nil {
@@ -197,7 +197,7 @@ type BreakGlassCredentialListIterator struct {
 
 // Items returns a push iterator that can be used directly in for/range loops.
 // If an error occurs during paging, iteration stops and the error is recorded.
-func (iter BreakGlassCredentialListIterator) Items(ctx context.Context) iter.Seq[*cmv1.BreakGlassCredential] {
+func (iter *BreakGlassCredentialListIterator) Items(ctx context.Context) iter.Seq[*cmv1.BreakGlassCredential] {
 	return func(yield func(*cmv1.BreakGlassCredential) bool) {
 		// Request can be nil to allow for mocking.
 		if iter.request != nil {
@@ -246,7 +246,7 @@ func (iter BreakGlassCredentialListIterator) GetError() error {
 
 // Items returns a push iterator that can be used directly in for/range loops.
 // If an error occurs during paging, iteration stops and the error is recorded.
-func (iter VersionsListIterator) Items(ctx context.Context) iter.Seq[*arohcpv1alpha1.Version] {
+func (iter *VersionsListIterator) Items(ctx context.Context) iter.Seq[*arohcpv1alpha1.Version] {
 	return func(yield func(*arohcpv1alpha1.Version) bool) {
 		// Request can be nil to allow for mocking.
 		if iter.request != nil {

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -55,7 +55,7 @@ type ClusterServiceClientSpec interface {
 	// ListClusters prepares a GET request with the given search expression. Call Items() on
 	// the returned iterator in a for/range loop to execute the request and paginate over results,
 	// then call GetError() to check for an iteration error.
-	ListClusters(searchExpression string) ClusterListIterator
+	ListClusters(searchExpression string) *ClusterListIterator
 
 	// GetNodePool sends a GET request to fetch a node pool from Cluster Service.
 	GetNodePool(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.NodePool, error)
@@ -75,7 +75,7 @@ type ClusterServiceClientSpec interface {
 	// ListNodePools prepares a GET request with the given search expression. Call Items() on
 	// the returned iterator in a for/range loop to execute the request and paginate over results,
 	// then call GetError() to check for an iteration error.
-	ListNodePools(clusterInternalID InternalID, searchExpression string) NodePoolListIterator
+	ListNodePools(clusterInternalID InternalID, searchExpression string) *NodePoolListIterator
 
 	// GetExternalAuth sends a GET request to fetch an external auth config from Cluster Service.
 	GetExternalAuth(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.ExternalAuth, error)
@@ -92,7 +92,7 @@ type ClusterServiceClientSpec interface {
 	// ListExternalAuths prepares a GET request with the given search expression. Call Items() on
 	// the returned iterator in a for/range loop to execute the request and paginate over results,
 	// then call GetError() to check for an iteration error.
-	ListExternalAuths(clusterInternalID InternalID, searchExpression string) ExternalAuthListIterator
+	ListExternalAuths(clusterInternalID InternalID, searchExpression string) *ExternalAuthListIterator
 
 	// GetBreakGlassCredential sends a GET request to fetch a break-glass cluster credential from Cluster Service.
 	GetBreakGlassCredential(ctx context.Context, internalID InternalID) (*cmv1.BreakGlassCredential, error)
@@ -106,7 +106,7 @@ type ClusterServiceClientSpec interface {
 	// ListBreakGlassCredentials prepares a GET request with the given search expression. Call
 	// Items() on the returned iterator in a for/range loop to execute the request and paginate
 	// over results, then call GetError() to check for an iteration error.
-	ListBreakGlassCredentials(clusterInternalID InternalID, searchExpression string) BreakGlassCredentialListIterator
+	ListBreakGlassCredentials(clusterInternalID InternalID, searchExpression string) *BreakGlassCredentialListIterator
 
 	// GetVersion sends a GET request to fetch cluster version
 	GetVersion(ctx context.Context, versionName string) (*arohcpv1alpha1.Version, error)
@@ -114,7 +114,7 @@ type ClusterServiceClientSpec interface {
 	// ListVersions prepares a GET request. Call Items() on
 	// the returned iterator in a for/range loop to execute the request and paginate over results,
 	// then call GetError() to check for an iteration error.
-	ListVersions() VersionsListIterator
+	ListVersions() *VersionsListIterator
 }
 
 type clusterServiceClient struct {
@@ -242,12 +242,12 @@ func (csc *clusterServiceClient) DeleteCluster(ctx context.Context, internalID I
 	return err
 }
 
-func (csc *clusterServiceClient) ListClusters(searchExpression string) ClusterListIterator {
+func (csc *clusterServiceClient) ListClusters(searchExpression string) *ClusterListIterator {
 	clustersListRequest := csc.conn.AroHCP().V1alpha1().Clusters().List()
 	if searchExpression != "" {
 		clustersListRequest.Search(searchExpression)
 	}
-	return ClusterListIterator{request: clustersListRequest}
+	return &ClusterListIterator{request: clustersListRequest}
 }
 
 func (csc *clusterServiceClient) GetNodePool(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.NodePool, error) {
@@ -347,16 +347,16 @@ func (csc *clusterServiceClient) DeleteNodePool(ctx context.Context, internalID 
 	return err
 }
 
-func (csc *clusterServiceClient) ListNodePools(clusterInternalID InternalID, searchExpression string) NodePoolListIterator {
+func (csc *clusterServiceClient) ListNodePools(clusterInternalID InternalID, searchExpression string) *NodePoolListIterator {
 	client, ok := clusterInternalID.GetAroHCPClusterClient(csc.conn)
 	if !ok {
-		return NodePoolListIterator{err: fmt.Errorf("OCM path is not a cluster: %s", clusterInternalID)}
+		return &NodePoolListIterator{err: fmt.Errorf("OCM path is not a cluster: %s", clusterInternalID)}
 	}
 	nodePoolsListRequest := client.NodePools().List()
 	if searchExpression != "" {
 		nodePoolsListRequest.Search(searchExpression)
 	}
-	return NodePoolListIterator{request: nodePoolsListRequest}
+	return &NodePoolListIterator{request: nodePoolsListRequest}
 }
 
 func (csc *clusterServiceClient) GetExternalAuth(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.ExternalAuth, error) {
@@ -417,10 +417,10 @@ func (csc *clusterServiceClient) DeleteExternalAuth(ctx context.Context, interna
 	return err
 }
 
-func (csc *clusterServiceClient) ListExternalAuths(clusterInternalID InternalID, searchExpression string) ExternalAuthListIterator {
+func (csc *clusterServiceClient) ListExternalAuths(clusterInternalID InternalID, searchExpression string) *ExternalAuthListIterator {
 	client, ok := clusterInternalID.GetAroHCPClusterClient(csc.conn)
 	if !ok {
-		return ExternalAuthListIterator{err: fmt.Errorf("OCM path is not a cluster: %s", clusterInternalID)}
+		return &ExternalAuthListIterator{err: fmt.Errorf("OCM path is not a cluster: %s", clusterInternalID)}
 	}
 	externalAuthsListRequest := client.ExternalAuthConfig().ExternalAuths().List()
 	// FIXME ExternalAuthsListRequest is missing a Search method.
@@ -430,7 +430,7 @@ func (csc *clusterServiceClient) ListExternalAuths(clusterInternalID InternalID,
 	//if searchExpression != "" {
 	//	externalAuthsListRequest.Search(searchExpression)
 	//}
-	return ExternalAuthListIterator{request: externalAuthsListRequest}
+	return &ExternalAuthListIterator{request: externalAuthsListRequest}
 }
 
 func (csc *clusterServiceClient) GetBreakGlassCredential(ctx context.Context, internalID InternalID) (*cmv1.BreakGlassCredential, error) {
@@ -478,16 +478,16 @@ func (csc *clusterServiceClient) DeleteBreakGlassCredentials(ctx context.Context
 	return err
 }
 
-func (csc *clusterServiceClient) ListBreakGlassCredentials(clusterInternalID InternalID, searchExpression string) BreakGlassCredentialListIterator {
+func (csc *clusterServiceClient) ListBreakGlassCredentials(clusterInternalID InternalID, searchExpression string) *BreakGlassCredentialListIterator {
 	client, ok := clusterInternalID.GetClusterClient(csc.conn)
 	if !ok {
-		return BreakGlassCredentialListIterator{err: fmt.Errorf("OCM path is not a cluster: %s", clusterInternalID)}
+		return &BreakGlassCredentialListIterator{err: fmt.Errorf("OCM path is not a cluster: %s", clusterInternalID)}
 	}
 	breakGlassCredentialsListRequest := client.BreakGlassCredentials().List()
 	if searchExpression != "" {
 		breakGlassCredentialsListRequest.Search(searchExpression)
 	}
-	return BreakGlassCredentialListIterator{request: breakGlassCredentialsListRequest}
+	return &BreakGlassCredentialListIterator{request: breakGlassCredentialsListRequest}
 }
 
 func (csc *clusterServiceClient) GetVersion(ctx context.Context, versionName string) (*arohcpv1alpha1.Version, error) {
@@ -508,9 +508,9 @@ func (csc *clusterServiceClient) GetVersion(ctx context.Context, versionName str
 	return version, nil
 }
 
-func (csc *clusterServiceClient) ListVersions() VersionsListIterator {
+func (csc *clusterServiceClient) ListVersions() *VersionsListIterator {
 	versionsListRequest := csc.conn.AroHCP().V1alpha1().Versions().List()
-	return VersionsListIterator{request: versionsListRequest}
+	return &VersionsListIterator{request: versionsListRequest}
 }
 
 // NewOpenShiftVersionXY parses the given version, stripping off any

--- a/internal/ocm/tracing.go
+++ b/internal/ocm/tracing.go
@@ -129,7 +129,7 @@ func (csc *clusterServiceClientWithTracing) DeleteCluster(ctx context.Context, i
 	return err
 }
 
-func (csc *clusterServiceClientWithTracing) ListClusters(searchExpression string) ClusterListIterator {
+func (csc *clusterServiceClientWithTracing) ListClusters(searchExpression string) *ClusterListIterator {
 	return csc.csc.ListClusters(searchExpression)
 }
 
@@ -204,7 +204,7 @@ func (csc *clusterServiceClientWithTracing) DeleteNodePool(ctx context.Context, 
 	return err
 }
 
-func (csc *clusterServiceClientWithTracing) ListNodePools(clusterInternalID InternalID, searchExpression string) NodePoolListIterator {
+func (csc *clusterServiceClientWithTracing) ListNodePools(clusterInternalID InternalID, searchExpression string) *NodePoolListIterator {
 	return csc.csc.ListNodePools(clusterInternalID, searchExpression)
 }
 
@@ -279,7 +279,7 @@ func (csc *clusterServiceClientWithTracing) DeleteExternalAuth(ctx context.Conte
 	return err
 }
 
-func (csc *clusterServiceClientWithTracing) ListExternalAuths(clusterInternalID InternalID, searchExpression string) ExternalAuthListIterator {
+func (csc *clusterServiceClientWithTracing) ListExternalAuths(clusterInternalID InternalID, searchExpression string) *ExternalAuthListIterator {
 	return csc.csc.ListExternalAuths(clusterInternalID, searchExpression)
 }
 
@@ -312,7 +312,7 @@ func (csc *clusterServiceClientWithTracing) DeleteBreakGlassCredentials(ctx cont
 	return err
 }
 
-func (csc *clusterServiceClientWithTracing) ListBreakGlassCredentials(clusterInternalID InternalID, searchExpression string) BreakGlassCredentialListIterator {
+func (csc *clusterServiceClientWithTracing) ListBreakGlassCredentials(clusterInternalID InternalID, searchExpression string) *BreakGlassCredentialListIterator {
 	return csc.csc.ListBreakGlassCredentials(clusterInternalID, searchExpression)
 }
 
@@ -320,6 +320,6 @@ func (csc *clusterServiceClientWithTracing) GetVersion(ctx context.Context, vers
 	return csc.csc.GetVersion(ctx, versionName)
 }
 
-func (csc *clusterServiceClientWithTracing) ListVersions() VersionsListIterator {
+func (csc *clusterServiceClientWithTracing) ListVersions() *VersionsListIterator {
 	return csc.csc.ListVersions()
 }

--- a/internal/ocm/tracing.go
+++ b/internal/ocm/tracing.go
@@ -279,6 +279,10 @@ func (csc *clusterServiceClientWithTracing) DeleteExternalAuth(ctx context.Conte
 	return err
 }
 
+func (csc *clusterServiceClientWithTracing) ListExternalAuths(clusterInternalID InternalID, searchExpression string) ExternalAuthListIterator {
+	return csc.csc.ListExternalAuths(clusterInternalID, searchExpression)
+}
+
 func (csc *clusterServiceClientWithTracing) PostBreakGlassCredential(ctx context.Context, clusterInternalID InternalID) (*cmv1.BreakGlassCredential, error) {
 	ctx, span := csc.startChildSpan(ctx, "ClusterServiceClient.PostBreakGlassCredential")
 	defer span.End()


### PR DESCRIPTION
[ARO-20914 - Support listing external auth resources](https://issues.redhat.com/browse/ARO-20914)

### What

This fixes the above Jira bug, along with some list-related scope creep.  Namely:

- Refactor `ArmResourceList` to avoid querying Cosmos DB for resources of type `hcpOpenShiftVersions`, since we don't store those in Cosmos DB.

- Address an old "FIXME" comment in `ArmResourceList` by filtering on resource type in the Cosmos DB query itself, rather than picking through query results.

- Last two commits fix a really bone-headed mistake I made with the "failable iterators" pattern, where errors (and Cosmos DB continuation tokens) were being lost.

### Special notes for your reviewer

As usual, I strongly suggest reviewing one commit at a time.

I've already asked the Clusters Service team to address a new "FIXME" comment I added:

> **FIXME** [ExternalAuthsListRequest](https://pkg.go.dev/github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1#ExternalAuthsListRequest) is missing a `Search` method. Presently it doesn't matter since we only support one ExternalAuth instance per cluster. `Search` will become more important if we ever support multiple.

(the `Search` method helps implement pagination of list results)