### PR TITLE
ARO-17798: Set minimal permissions to call the Check Access API

### DIFF
--- a/dev-infrastructure/.gitignore
+++ b/dev-infrastructure/.gitignore
@@ -2,5 +2,5 @@ config.mk
 
 istio-*
 
-# Azure CLI config directory
-azure-config/
+# Azure CLI config directory for mock FPA
+mock-fpa-azure-config/

--- a/dev-infrastructure/.gitignore
+++ b/dev-infrastructure/.gitignore
@@ -1,3 +1,6 @@
 config.mk
 
 istio-*
+
+# Azure CLI config directory
+azure-config/

--- a/dev-infrastructure/modules/policy/mock-fpa-restrictions.bicep
+++ b/dev-infrastructure/modules/policy/mock-fpa-restrictions.bicep
@@ -1,0 +1,250 @@
+targetScope = 'subscription'
+
+@description('Application ID of the mock FPA service principal to restrict')
+param mockFpaAppId string
+
+@description('Environment name for resource naming')
+param environment string
+
+@description('Enable enforcement of the policy (set to false for testing)')
+param enforcementEnabled bool = true
+
+var enforcementMode = enforcementEnabled ? 'Default' : 'DoNotEnforce'
+
+// Policy to deny dangerous resource operations by the mock FPA
+resource denyDangerousOperationsPolicy 'Microsoft.Authorization/policyDefinitions@2021-06-01' = {
+  name: 'deny-mock-fpa-dangerous-ops-${environment}'
+  properties: {
+    displayName: 'Deny Mock FPA Dangerous Operations'
+    description: 'Prevents mock FPA from dangerous operations while allowing checkAccess API calls'
+    policyType: 'Custom'
+    mode: 'All'
+    metadata: {
+      category: 'Security'
+      description: 'Restricts Contributor permissions for mock FPA to prevent dangerous operations'
+    }
+    parameters: {
+      effect: {
+        type: 'String'
+        metadata: {
+          displayName: 'Effect'
+          description: 'Enable or disable the execution of the policy'
+        }
+        allowedValues: [
+          'Deny'
+          'Disabled'
+        ]
+        defaultValue: 'Deny'
+      }
+      mockFpaAppId: {
+        type: 'String'
+        metadata: {
+          displayName: 'Mock FPA Application ID'
+          description: 'The application ID of the mock FPA service principal to restrict'
+        }
+      }
+    }
+    policyRule: {
+      if: {
+        allOf: [
+          // Check if the request is coming from the mock FPA
+          {
+            // Match on the app ID in the request context
+            value: '[requestContext().identity.appid]'
+            equals: '[parameters(\'mockFpaAppId\')]'
+          }
+          {
+            // Block dangerous resource types and operations
+            anyOf: [
+              // Block role assignments and definitions (privilege escalation)
+              {
+                allOf: [
+                  {
+                    field: 'type'
+                    in: [
+                      'Microsoft.Authorization/roleAssignments'
+                      'Microsoft.Authorization/roleDefinitions'
+                      'Microsoft.Authorization/policyAssignments'
+                      'Microsoft.Authorization/policyDefinitions'
+                    ]
+                  }
+                ]
+              }
+              // Block critical infrastructure deletion
+              {
+                allOf: [
+                  {
+                    field: 'type'
+                    in: [
+                      'Microsoft.Resources/resourceGroups'
+                      'Microsoft.KeyVault/vaults'
+                      'Microsoft.Storage/storageAccounts'
+                      'Microsoft.Network/virtualNetworks'
+                      'Microsoft.Compute/virtualMachines'
+                      'Microsoft.ContainerService/managedClusters'
+                    ]
+                  }
+                  {
+                    // Only block delete operations for these resources
+                    source: 'action'
+                    like: 'Microsoft.*/delete'
+                  }
+                ]
+              }
+              // Block creation of high-privilege resources
+              {
+                allOf: [
+                  {
+                    field: 'type'
+                    equals: 'Microsoft.Compute/virtualMachines'
+                  }
+                  {
+                    source: 'action'
+                    like: 'Microsoft.Compute/virtualMachines/write'
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+      then: {
+        effect: '[parameters(\'effect\')]'
+      }
+    }
+  }
+}
+
+// Policy assignment for dangerous operations
+resource denyDangerousOperationsAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
+  name: 'deny-mock-fpa-dangerous-ops-${environment}'
+  location: deployment().location
+  properties: {
+    displayName: 'Deny Mock FPA Dangerous Operations - ${environment}'
+    description: 'Restricts mock FPA Contributor permissions to prevent dangerous operations'
+    policyDefinitionId: denyDangerousOperationsPolicy.id
+    enforcementMode: enforcementMode
+    parameters: {
+      effect: {
+        value: 'Deny'
+      }
+      mockFpaAppId: {
+        value: mockFpaAppId
+      }
+    }
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+}
+
+// Policy to allow only required network operations
+resource allowRequiredNetworkOpsPolicy 'Microsoft.Authorization/policyDefinitions@2021-06-01' = {
+  name: 'allow-mock-fpa-required-network-ops-${environment}'
+  properties: {
+    displayName: 'Allow Mock FPA Required Network Operations'
+    description: 'Permits only the specific network operations required by mock FPA for service association links'
+    policyType: 'Custom'
+    mode: 'All'
+    metadata: {
+      category: 'Network'
+      description: 'Allows mock FPA to perform only necessary subnet service association link operations'
+    }
+    parameters: {
+      effect: {
+        type: 'String'
+        metadata: {
+          displayName: 'Effect'
+          description: 'Enable or disable the execution of the policy'
+        }
+        allowedValues: [
+          'Audit'
+          'Deny'
+          'Disabled'
+        ]
+        defaultValue: 'Audit'
+      }
+      mockFpaAppId: {
+        type: 'String'
+        metadata: {
+          displayName: 'Mock FPA Principal ID'
+          description: 'The principal ID of the mock FPA service principal'
+        }
+      }
+    }
+    policyRule: {
+      if: {
+        allOf: [
+          // Match requests from mock FPA
+          {
+            value: '[requestContext().identity.appid]'
+            equals: '[parameters(\'mockFpaAppId\')]'
+          }
+          // Target subnet operations that are NOT service association links
+          {
+            field: 'type'
+            equals: 'Microsoft.Network/virtualNetworks/subnets'
+          }
+          {
+            not: {
+              anyOf: [
+                {
+                  source: 'action'
+                  contains: 'serviceAssociationLinks'
+                }
+                {
+                  field: 'name'
+                  contains: 'serviceAssociationLinks'
+                }
+              ]
+            }
+          }
+        ]
+      }
+      then: {
+        effect: '[parameters(\'effect\')]'
+      }
+    }
+  }
+}
+
+// Assignment for network operations policy (audit mode to monitor)
+resource allowRequiredNetworkOpsAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
+  name: 'allow-mock-fpa-network-ops-${environment}'
+  location: deployment().location
+  properties: {
+    displayName: 'Allow Mock FPA Required Network Operations - ${environment}'
+    description: 'Monitors mock FPA network operations to ensure only required operations are performed'
+    policyDefinitionId: allowRequiredNetworkOpsPolicy.id
+    enforcementMode: enforcementMode
+    parameters: {
+      effect: {
+        value: 'Audit'
+      }
+      mockFpaAppId: {
+        value: mockFpaAppId
+      }
+    }
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+}
+
+@description('Policy definition IDs for reference')
+output policyDefinitionIds array = [
+  denyDangerousOperationsPolicy.id
+  allowRequiredNetworkOpsPolicy.id
+]
+
+@description('Policy assignment IDs for reference')
+output policyAssignmentIds array = [
+  denyDangerousOperationsAssignment.id
+  allowRequiredNetworkOpsAssignment.id
+]
+
+@description('Policy assignment names for easier management')
+output policyAssignmentNames array = [
+  denyDangerousOperationsAssignment.name
+  allowRequiredNetworkOpsAssignment.name
+]

--- a/dev-infrastructure/scripts/dev-application.sh
+++ b/dev-infrastructure/scripts/dev-application.sh
@@ -2,6 +2,9 @@
 
 # This script can be used to spin up a standalone dev application which will be used as a 'mock first party application'.
 # This is required due to the lack of the ability to have a first party app be used in the dev tenant
+#
+# This script uses a dedicated Azure CLI config directory (azure-config) to avoid interfering
+# with the user's existing Azure CLI configuration.
 
 LOCATION=${LOCATION:-"westus3"}
 UNIQUE_PREFIX=${UNIQUE_PREFIX:-"HCP-$USER-$LOCATION"}
@@ -32,6 +35,14 @@ AH_CERTIFICATE_NAME=${ARO_HCP_DEV_AH_CERTIFICATE_NAME:-"$UNIQUE_PREFIX-ah-cert"}
 AZURE_BUILTIN_ROLE_OWNER="8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
 AZURE_BUILTIN_ROLE_CONTRIBUTOR="b24988ac-6180-42a0-ab88-20f7382dd24c"
 
+# Set up dedicated Azure CLI config directory to avoid interfering with user's existing setup
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AZURE_CONFIG_DIR="$SCRIPT_DIR/../azure-config"
+export AZURE_CONFIG_DIR
+
+# Create Azure config directory if it doesn't exist
+mkdir -p "$AZURE_CONFIG_DIR"
+
 printEnv() {
     echo "LOCATION: $LOCATION"
     echo "RESOURCE_GROUP: $RESOURCE_GROUP"
@@ -53,6 +64,7 @@ shellEnv() {
     echo "ARO_HCP_DEV_FP_CERTIFICATE_NAME=\"$FP_CERTIFICATE_NAME\"; export ARO_HCP_DEV_FP_CERTIFICATE_NAME"
     echo "ARO_HCP_DEV_AH_APPLICATION_NAME=\"$AH_APPLICATION_NAME\"; export ARO_HCP_DEV_AH_APPLICATION_NAME"
     echo "ARO_HCP_DEV_AH_CERTIFICATE_NAME=\"$FP_CERTIFICATE_NAME\"; export ARO_HCP_DEV_AH_CERTIFICATE_NAME"
+    echo "AZURE_CONFIG_DIR=\"$AZURE_CONFIG_DIR\"; export AZURE_CONFIG_DIR"
 }
 
 createServicePrincipal() {

--- a/dev-infrastructure/scripts/dev-application.sh
+++ b/dev-infrastructure/scripts/dev-application.sh
@@ -40,7 +40,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/mock-fpa-common.sh"
 
 # Set up Azure config directory and file paths
-setup_azure_config "$SCRIPT_DIR"
+setupAzureConfig "$SCRIPT_DIR"
 
 printEnv() {
     printMockFpaEnv "$LOCATION" "$RESOURCE_GROUP" "$SUBSCRIPTION_ID" "$KEY_VAULT_NAME" \

--- a/dev-infrastructure/scripts/dev-application.sh
+++ b/dev-infrastructure/scripts/dev-application.sh
@@ -289,7 +289,21 @@ loginWithMockServicePrincipal() {
     echo "Logging in as mock FPA service principal (App ID: $appId)"
     az login --service-principal -u "$appId" --certificate app.pem --tenant "$tenantId"
 
-    rm app.pfx app.pem
+    # Note: Not deleting app.pem as Azure CLI needs to reference it for subsequent operations
+    # The certificate file will be cleaned up when the session ends
+    rm app.pfx
+    echo "Certificate file app.pem kept for Azure CLI session"
+}
+
+cleanupCertificateFiles() {
+    # Clean up certificate files when done with service principal session
+    if [ -f "app.pem" ]; then
+        echo "Cleaning up certificate file"
+        rm app.pem
+    fi
+    if [ -f "app.pfx" ]; then
+        rm app.pfx
+    fi
 }
 
 case "$1" in
@@ -311,8 +325,11 @@ case "$1" in
     "delete-policies")
         deleteMockFpaPolicies
     ;;
+    "cleanup")
+        cleanupCertificateFiles
+    ;;
     *)
-        echo "Usage: $0 {create|delete|login|shell|deploy-policies|delete-policies}"
+        echo "Usage: $0 {create|delete|login|shell|deploy-policies|delete-policies|cleanup}"
         exit 1
     ;;
 esac

--- a/dev-infrastructure/scripts/dev-application.sh
+++ b/dev-infrastructure/scripts/dev-application.sh
@@ -39,8 +39,8 @@ AZURE_BUILTIN_ROLE_CONTRIBUTOR="b24988ac-6180-42a0-ab88-20f7382dd24c"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/mock-fpa-common.sh"
 
-# Set up Azure config directory and file paths
-setupAzureConfig "$SCRIPT_DIR"
+# Set up Azure config directory and file paths for mock FPA operations
+initialAzureConfigSetup "$SCRIPT_DIR"
 
 printEnv() {
     printMockFpaEnv "$LOCATION" "$RESOURCE_GROUP" "$SUBSCRIPTION_ID" "$KEY_VAULT_NAME" \
@@ -51,6 +51,9 @@ shellEnv() {
     # Calling shell can "eval" this output.
     exportMockFpaShellEnv "$LOCATION" "$RESOURCE_GROUP" "$SUBSCRIPTION_ID" "$KEY_VAULT_NAME" \
         "$FP_APPLICATION_NAME" "$FP_CERTIFICATE_NAME" "$AH_APPLICATION_NAME" "$AH_CERTIFICATE_NAME"
+
+    # Export the original Azure config directory for test scripts
+    echo "ORIGINAL_AZURE_CONFIG_DIR=\"$ORIGINAL_AZURE_CONFIG_DIR\"; export ORIGINAL_AZURE_CONFIG_DIR"
 }
 
 createServicePrincipal() {
@@ -272,24 +275,35 @@ deleteApps() {
 
 case "$1" in
     "create")
+        # Ensure we're using developer config for administrative operations
+        useDeveloperConfig
         createApps
     ;;
     "delete")
+        # Ensure we're using developer config for administrative operations
+        useDeveloperConfig
         deleteApps
     ;;
     "login")
+        # Login function handles its own context switching
         loginWithMockServicePrincipal "$FP_CERTIFICATE_NAME" "$KEY_VAULT_NAME" "$FP_APPLICATION_NAME"
     ;;
     "shell")
         shellEnv
     ;;
     "deploy-policies")
+        # Ensure we're using developer config for policy operations
+        useDeveloperConfig
         deployMockFpaPolicies
     ;;
     "delete-policies")
+        # Ensure we're using developer config for policy operations
+        useDeveloperConfig
         deleteMockFpaPolicies
     ;;
     "cleanup")
+        # Cleanup operates on mock FPA certificate files
+        useMockFpaConfig
         cleanupMockFpaCertificateFiles
     ;;
     *)

--- a/dev-infrastructure/scripts/dev-application.sh
+++ b/dev-infrastructure/scripts/dev-application.sh
@@ -3,7 +3,7 @@
 # This script can be used to spin up a standalone dev application which will be used as a 'mock first party application'.
 # This is required due to the lack of the ability to have a first party app be used in the dev tenant
 #
-# This script uses a dedicated Azure CLI config directory (azure-config) to avoid interfering
+# This script uses a dedicated Azure CLI config directory (mock-fpa-azure-config) to avoid interfering
 # with the user's existing Azure CLI configuration.
 
 LOCATION=${LOCATION:-"westus3"}

--- a/dev-infrastructure/scripts/dev-application.sh
+++ b/dev-infrastructure/scripts/dev-application.sh
@@ -286,7 +286,8 @@ loginWithMockServicePrincipal() {
     appId=$(az ad app list --display-name "$FP_APPLICATION_NAME" --query "[0].appId" -o tsv)
     tenantId=$(az account show --query tenantId -o tsv)
 
-    az login --service-principal -u "$appId" -p app.pem --tenant "$tenantId"
+    echo "Logging in as mock FPA service principal (App ID: $appId)"
+    az login --service-principal -u "$appId" --certificate app.pem --tenant "$tenantId"
 
     rm app.pfx app.pem
 }

--- a/dev-infrastructure/scripts/mock-fpa-common.sh
+++ b/dev-infrastructure/scripts/mock-fpa-common.sh
@@ -7,13 +7,13 @@
 setupAzureConfig() {
     local script_dir="$1"
 
-    AZURE_CONFIG_DIR="$script_dir/../azure-config"
+    AZURE_CONFIG_DIR="$script_dir/../mock-fpa-azure-config"
     export AZURE_CONFIG_DIR
 
     # Create Azure config directory if it doesn't exist
     mkdir -p "$AZURE_CONFIG_DIR"
 
-    # Define certificate file paths with mock-fpa- prefix in azure-config directory
+    # Define certificate file paths with mock-fpa- prefix in mock-fpa-azure-config directory
     MOCK_FPA_PFX_FILE="$AZURE_CONFIG_DIR/mock-fpa-app.pfx"
     MOCK_FPA_PEM_FILE="$AZURE_CONFIG_DIR/mock-fpa-app.pem"
 
@@ -21,7 +21,7 @@ setupAzureConfig() {
     export MOCK_FPA_PEM_FILE
 }
 
-# Login with mock service principal using certificates from azure-config directory
+# Login with mock service principal using certificates from mock-fpa-azure-config directory
 loginWithMockServicePrincipal() {
     local fp_certificate_name="$1"
     local key_vault_name="$2"

--- a/dev-infrastructure/scripts/mock-fpa-common.sh
+++ b/dev-infrastructure/scripts/mock-fpa-common.sh
@@ -4,7 +4,7 @@
 # This file contains shared logic for dev-application.sh and test-mock-fpa-policies.sh
 
 # Set up dedicated Azure CLI config directory and file paths
-setup_azure_config() {
+setupAzureConfig() {
     local script_dir="$1"
 
     AZURE_CONFIG_DIR="$script_dir/../azure-config"
@@ -35,7 +35,7 @@ loginWithMockServicePrincipal() {
 
     # Ensure azure config directory and file paths are set up
     if [[ -z "$MOCK_FPA_PFX_FILE" || -z "$MOCK_FPA_PEM_FILE" ]]; then
-        echo "Error: Mock FPA file paths not initialized. Call setup_azure_config first."
+        echo "Error: Mock FPA file paths not initialized. Call setupAzureConfig first."
         return 1
     fi
 
@@ -103,11 +103,11 @@ cleanupMockFpaCertificateFiles() {
 }
 
 # Check if we're already logged in as the expected mock FPA service principal
-is_logged_in_as_mock_fpa() {
+isLoggedInAsMockFpa() {
     local fp_application_name="$1"
 
     if [[ -z "$fp_application_name" ]]; then
-        echo "Error: Missing application name for is_logged_in_as_mock_fpa"
+        echo "Error: Missing application name for isLoggedInAsMockFpa"
         return 1
     fi
 

--- a/dev-infrastructure/scripts/mock-fpa-common.sh
+++ b/dev-infrastructure/scripts/mock-fpa-common.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+# Common functions for mock FPA scripts
+# This file contains shared logic for dev-application.sh and test-mock-fpa-policies.sh
+
+# Set up dedicated Azure CLI config directory and file paths
+setup_azure_config() {
+    local script_dir="$1"
+
+    AZURE_CONFIG_DIR="$script_dir/../azure-config"
+    export AZURE_CONFIG_DIR
+
+    # Create Azure config directory if it doesn't exist
+    mkdir -p "$AZURE_CONFIG_DIR"
+
+    # Define certificate file paths with mock-fpa- prefix in azure-config directory
+    MOCK_FPA_PFX_FILE="$AZURE_CONFIG_DIR/mock-fpa-app.pfx"
+    MOCK_FPA_PEM_FILE="$AZURE_CONFIG_DIR/mock-fpa-app.pem"
+
+    export MOCK_FPA_PFX_FILE
+    export MOCK_FPA_PEM_FILE
+}
+
+# Login with mock service principal using certificates from azure-config directory
+loginWithMockServicePrincipal() {
+    local fp_certificate_name="$1"
+    local key_vault_name="$2"
+    local fp_application_name="$3"
+
+    if [[ -z "$fp_certificate_name" || -z "$key_vault_name" || -z "$fp_application_name" ]]; then
+        echo "Error: Missing required parameters for loginWithMockServicePrincipal"
+        echo "Usage: loginWithMockServicePrincipal <certificate_name> <key_vault_name> <application_name>"
+        return 1
+    fi
+
+    # Ensure azure config directory and file paths are set up
+    if [[ -z "$MOCK_FPA_PFX_FILE" || -z "$MOCK_FPA_PEM_FILE" ]]; then
+        echo "Error: Mock FPA file paths not initialized. Call setup_azure_config first."
+        return 1
+    fi
+
+    echo "Downloading certificate from Key Vault to: $MOCK_FPA_PFX_FILE"
+    az keyvault secret download \
+        --name "$fp_certificate_name" \
+        --vault-name "$key_vault_name" \
+        --encoding base64 \
+        --file "$MOCK_FPA_PFX_FILE"
+
+    echo "Converting certificate to PEM format: $MOCK_FPA_PEM_FILE"
+    openssl pkcs12 \
+        -in "$MOCK_FPA_PFX_FILE" \
+        -passin pass: \
+        -out "$MOCK_FPA_PEM_FILE" \
+        -nodes
+
+    local appId=$(az ad app list --display-name "$fp_application_name" --query "[0].appId" -o tsv)
+    local tenantId=$(az account show --query tenantId -o tsv)
+
+    echo "Logging in as mock FPA service principal (App ID: $appId)"
+    az login --service-principal -u "$appId" --certificate "$MOCK_FPA_PEM_FILE" --tenant "$tenantId"
+
+    # Note: Not deleting PEM file as Azure CLI needs to reference it for subsequent operations
+    # The certificate file will be cleaned up when the session ends
+    rm "$MOCK_FPA_PFX_FILE"
+    echo "Certificate file $MOCK_FPA_PEM_FILE kept for Azure CLI session"
+    echo "Temporary PFX file $MOCK_FPA_PFX_FILE removed"
+}
+
+# Clean up certificate files when done with service principal session
+cleanupMockFpaCertificateFiles() {
+    local files_cleaned=0
+
+    if [[ -f "$MOCK_FPA_PEM_FILE" ]]; then
+        echo "Cleaning up certificate file: $MOCK_FPA_PEM_FILE"
+        rm "$MOCK_FPA_PEM_FILE"
+        ((files_cleaned++))
+    fi
+
+    if [[ -f "$MOCK_FPA_PFX_FILE" ]]; then
+        echo "Cleaning up certificate file: $MOCK_FPA_PFX_FILE"
+        rm "$MOCK_FPA_PFX_FILE"
+        ((files_cleaned++))
+    fi
+
+    # Also clean up legacy files from current directory (backward compatibility)
+    if [[ -f "app.pem" ]]; then
+        echo "Cleaning up legacy certificate file: app.pem"
+        rm "app.pem"
+        ((files_cleaned++))
+    fi
+
+    if [[ -f "app.pfx" ]]; then
+        echo "Cleaning up legacy certificate file: app.pfx"
+        rm "app.pfx"
+        ((files_cleaned++))
+    fi
+
+    if [[ $files_cleaned -eq 0 ]]; then
+        echo "No certificate files found to clean up"
+    else
+        echo "Cleaned up $files_cleaned certificate file(s)"
+    fi
+}
+
+# Check if we're already logged in as the expected mock FPA service principal
+is_logged_in_as_mock_fpa() {
+    local fp_application_name="$1"
+
+    if [[ -z "$fp_application_name" ]]; then
+        echo "Error: Missing application name for is_logged_in_as_mock_fpa"
+        return 1
+    fi
+
+    local current_user=$(az account show --query user.name -o tsv 2>/dev/null || echo "")
+    local current_type=$(az account show --query user.type -o tsv 2>/dev/null || echo "")
+
+    # Check if we're logged in as a service principal
+    if [[ "$current_type" != "servicePrincipal" || -z "$current_user" ]]; then
+        return 1
+    fi
+
+    # Try to get the expected app ID
+    local expected_app_id=""
+    if expected_app_id=$(az ad app list --display-name "$fp_application_name" --query "[0].appId" -o tsv 2>/dev/null) && [[ -n "$expected_app_id" ]]; then
+        if [[ "$current_user" == "$expected_app_id" ]]; then
+            echo "Already logged in as mock FPA service principal: $current_user"
+            return 0
+        fi
+    else
+        # Can't verify the exact app ID, but if we're a service principal and the name looks right,
+        # we'll assume it's correct to avoid authentication loops
+        echo "Already logged in as service principal: $current_user (assuming this is the mock FPA)"
+        return 0
+    fi
+
+    return 1
+}
+
+# Print environment information with azure config directory
+printMockFpaEnv() {
+    local location="$1"
+    local resource_group="$2"
+    local subscription_id="$3"
+    local key_vault_name="$4"
+    local fp_application_name="$5"
+    local fp_certificate_name="$6"
+    local ah_application_name="$7"
+    local ah_certificate_name="$8"
+
+    echo "LOCATION: $location"
+    echo "RESOURCE_GROUP: $resource_group"
+    echo "SUBSCRIPTION_ID: $subscription_id"
+    echo "KEY_VAULT_NAME: $key_vault_name"
+    echo "FP_APPLICATION_NAME: $fp_application_name"
+    echo "FP_CERTIFICATE_NAME: $fp_certificate_name"
+    echo "AH_APPLICATION_NAME: $ah_application_name"
+    echo "AH_CERTIFICATE_NAME: $ah_certificate_name"
+    echo "AZURE_CONFIG_DIR: $AZURE_CONFIG_DIR"
+    echo "MOCK_FPA_CERT_FILES: $MOCK_FPA_PEM_FILE, $MOCK_FPA_PFX_FILE"
+}
+
+# Export environment variables for shell usage
+exportMockFpaShellEnv() {
+    local location="$1"
+    local resource_group="$2"
+    local subscription_id="$3"
+    local key_vault_name="$4"
+    local fp_application_name="$5"
+    local fp_certificate_name="$6"
+    local ah_application_name="$7"
+    local ah_certificate_name="$8"
+
+    echo "LOCATION=\"$location\"; export LOCATION"
+    echo "RESOURCE_GROUP=\"$resource_group\"; export RESOURCE_GROUP"
+    echo "SUBSCRIPTION_ID=\"$subscription_id\"; export SUBSCRIPTION_ID"
+    echo "ARO_HCP_DEV_KEY_VAULT_NAME=\"$key_vault_name\"; export ARO_HCP_DEV_KEY_VAULT_NAME"
+    echo "ARO_HCP_DEV_FP_APPLICATION_NAME=\"$fp_application_name\"; export ARO_HCP_DEV_FP_APPLICATION_NAME"
+    echo "ARO_HCP_DEV_FP_CERTIFICATE_NAME=\"$fp_certificate_name\"; export ARO_HCP_DEV_FP_CERTIFICATE_NAME"
+    echo "ARO_HCP_DEV_AH_APPLICATION_NAME=\"$ah_application_name\"; export ARO_HCP_DEV_AH_APPLICATION_NAME"
+    echo "ARO_HCP_DEV_AH_CERTIFICATE_NAME=\"$ah_certificate_name\"; export ARO_HCP_DEV_AH_CERTIFICATE_NAME"
+    echo "AZURE_CONFIG_DIR=\"$AZURE_CONFIG_DIR\"; export AZURE_CONFIG_DIR"
+    echo "MOCK_FPA_PFX_FILE=\"$MOCK_FPA_PFX_FILE\"; export MOCK_FPA_PFX_FILE"
+    echo "MOCK_FPA_PEM_FILE=\"$MOCK_FPA_PEM_FILE\"; export MOCK_FPA_PEM_FILE"
+}

--- a/dev-infrastructure/scripts/test-mock-fpa-policies.sh
+++ b/dev-infrastructure/scripts/test-mock-fpa-policies.sh
@@ -234,6 +234,13 @@ save_current_user() {
 # Restore original user context
 restore_original_user() {
     print_info "Restoring original user context..."
+
+    # Clean up certificate files from service principal session
+    if [ -f "app.pem" ]; then
+        print_info "Cleaning up certificate files"
+        rm -f app.pem app.pfx
+    fi
+
     if [[ "$ORIGINAL_USER_TYPE" == "user" ]]; then
         az login >/dev/null 2>&1 || {
             echo -e "${YELLOW}⚠️  Please run 'az login' to restore your session${NC}"
@@ -493,6 +500,11 @@ main() {
 
 # Handle script interruption
 cleanup_on_interrupt() {
+    print_info "Script interrupted, cleaning up..."
+
+    # Clean up certificate files
+    rm -f app.pem app.pfx
+
     # Only restore if we were originally a user (not service principal)
     if [[ -n "$ORIGINAL_USER_TYPE" && "$ORIGINAL_USER_TYPE" != "servicePrincipal" ]]; then
         restore_original_user

--- a/dev-infrastructure/scripts/test-mock-fpa-policies.sh
+++ b/dev-infrastructure/scripts/test-mock-fpa-policies.sh
@@ -15,7 +15,7 @@
 #   VERBOSE_OUTPUT: Set to false to hide detailed error output (default: true)
 #   FAIL_FAST: Set to true to stop at first failure (default: false)
 
-set -euo pipefail
+set -uo pipefail
 
 # Colors for output
 RED='\033[0;31m'
@@ -105,6 +105,15 @@ done
 VERBOSE_OUTPUT=${VERBOSE_OUTPUT:-true}
 FAIL_FAST=${FAIL_FAST:-false}
 
+# Helper function to exit cleanly in fail-fast mode
+fail_fast_exit() {
+    echo -e "${RED}💥 FAIL-FAST: Stopping execution due to test failure${NC}"
+    # Flush output buffers before exiting to ensure all messages are displayed
+    exec 1>&1 2>&2
+    sleep 1
+    exit 1
+}
+
 # Helper function to run tests with optional continue-on-failure
 run_test() {
     local test_function="$1"
@@ -173,8 +182,7 @@ test_should_succeed() {
 
         # Exit immediately if fail-fast is enabled
         if [[ "$FAIL_FAST" == "true" ]]; then
-            echo -e "${RED}💥 FAIL-FAST: Stopping execution due to test failure${NC}"
-            exit 1
+            fail_fast_exit
         fi
 
         return 1
@@ -206,8 +214,7 @@ test_should_fail() {
 
         # Exit immediately if fail-fast is enabled
         if [[ "$FAIL_FAST" == "true" ]]; then
-            echo -e "${RED}💥 FAIL-FAST: Stopping execution due to test failure${NC}"
-            exit 1
+            fail_fast_exit
         fi
 
         return 1

--- a/dev-infrastructure/scripts/test-mock-fpa-policies.sh
+++ b/dev-infrastructure/scripts/test-mock-fpa-policies.sh
@@ -12,7 +12,7 @@
 # Options:
 #   --quiet: Disable verbose output (same as VERBOSE_OUTPUT=false)
 #   --fail-fast: Stop execution at the first test failure (default: continue all tests)
-#   VERBOSE_OUTPUT: Set to false to hide detailed error output (default: true)
+#   VERBOSE_OUTPUT: Set to false to hide detailed command output for all tests (default: true)
 #   FAIL_FAST: Set to true to stop at first failure (default: false)
 
 set -uo pipefail
@@ -84,12 +84,12 @@ while [[ $# -gt 0 ]]; do
             echo "Test mock FPA restriction policies"
             echo ""
             echo "Options:"
-            echo "  --quiet, -q      Disable verbose error output"
+            echo "  --quiet, -q      Disable verbose test output"
             echo "  --fail-fast, -f  Stop execution at the first test failure"
             echo "  --help, -h       Show this help message"
             echo ""
             echo "Environment variables:"
-            echo "  VERBOSE_OUTPUT   Set to false to disable verbose output (default: true)"
+            echo "  VERBOSE_OUTPUT   Set to false to hide detailed command output for all tests (default: true)"
             echo "  FAIL_FAST        Set to true to stop at first failure (default: false)"
             exit 0
             ;;
@@ -169,6 +169,13 @@ test_should_succeed() {
 
     if [[ $exit_code -eq 0 ]]; then
         print_success "$test_name"
+        if [[ "$VERBOSE_OUTPUT" == "true" ]]; then
+            echo -e "${GREEN}Command: $command${NC}"
+            echo -e "${GREEN}Exit code: $exit_code${NC}"
+            echo -e "${GREEN}Output:${NC}"
+            echo "$output" | sed 's/^/  /'  # Indent output for readability
+            echo ""
+        fi
         return 0
     else
         print_failure "$test_name - Operation was blocked but should have succeeded"
@@ -220,6 +227,13 @@ test_should_fail() {
         return 1
     else
         print_success "$test_name - Correctly blocked"
+        if [[ "$VERBOSE_OUTPUT" == "true" ]]; then
+            echo -e "${GREEN}Command: $command${NC}"
+            echo -e "${GREEN}Exit code: $exit_code${NC}"
+            echo -e "${GREEN}Output:${NC}"
+            echo "$output" | sed 's/^/  /'  # Indent output for readability
+            echo ""
+        fi
         return 0
     fi
 }

--- a/dev-infrastructure/scripts/test-mock-fpa-policies.sh
+++ b/dev-infrastructure/scripts/test-mock-fpa-policies.sh
@@ -34,20 +34,20 @@ AH_APPLICATION_NAME="${ARO_HCP_DEV_AH_APPLICATION_NAME:-}"
 # Validate required variables are set
 validate_environment() {
     local missing_vars=()
-    
+
     [[ -z "$SUBSCRIPTION_ID" ]] && missing_vars+=("SUBSCRIPTION_ID")
-    [[ -z "$RESOURCE_GROUP" ]] && missing_vars+=("RESOURCE_GROUP") 
+    [[ -z "$RESOURCE_GROUP" ]] && missing_vars+=("RESOURCE_GROUP")
     [[ -z "$KEY_VAULT_NAME" ]] && missing_vars+=("KEY_VAULT_NAME")
     [[ -z "$FP_APPLICATION_NAME" ]] && missing_vars+=("FP_APPLICATION_NAME")
     [[ -z "$FP_CERTIFICATE_NAME" ]] && missing_vars+=("FP_CERTIFICATE_NAME")
-    
+
     if [[ ${#missing_vars[@]} -gt 0 ]]; then
         echo -e "${RED}Error: Missing required environment variables: ${missing_vars[*]}${NC}"
         echo "Make sure the dev applications are created first by running:"
         echo "  $SCRIPT_DIR/dev-application.sh create"
         exit 1
     fi
-    
+
     print_info "Environment validated successfully"
 }
 
@@ -86,9 +86,9 @@ print_info() {
 test_should_succeed() {
     local test_name="$1"
     local command="$2"
-    
+
     print_test "$test_name (should succeed)"
-    
+
     if eval "$command" >/dev/null 2>&1; then
         print_success "$test_name"
         return 0
@@ -102,9 +102,9 @@ test_should_succeed() {
 test_should_fail() {
     local test_name="$1"
     local command="$2"
-    
+
     print_test "$test_name (should be blocked)"
-    
+
     if eval "$command" >/dev/null 2>&1; then
         print_failure "$test_name - Operation succeeded but should have been blocked"
         return 1
@@ -147,19 +147,19 @@ get_test_resource_group() {
 # Test basic read operations (should work with Contributor role)
 test_read_operations() {
     print_header "Testing Read Operations (Should Succeed)"
-    
+
     test_should_succeed "List resource groups" \
         "az group list --query '[].name' -o tsv"
-    
+
     test_should_succeed "List storage accounts" \
         "az storage account list --query '[].name' -o tsv"
-    
+
     test_should_succeed "List virtual networks" \
         "az network vnet list --query '[].name' -o tsv"
-    
+
     test_should_succeed "List key vaults" \
         "az keyvault list --query '[].name' -o tsv"
-    
+
     test_should_succeed "Show subscription details" \
         "az account show --query id -o tsv"
 }
@@ -167,17 +167,17 @@ test_read_operations() {
 # Test check access operations (requires built-in role)
 test_check_access_operations() {
     print_header "Testing Check Access Operations (Should Succeed)"
-    
+
     # Get current user's object ID for check access tests
     local current_user_id=$(az ad signed-in-user show --query id -o tsv 2>/dev/null || echo "")
-    
+
     if [[ -n "$current_user_id" ]]; then
         test_should_succeed "Check access for current user" \
             "az role assignment list --assignee '$current_user_id' --query '[].roleDefinitionName' -o tsv"
     else
         print_info "Skipping check access test - cannot get current user ID"
     fi
-    
+
     test_should_succeed "List role definitions" \
         "az role definition list --query '[0].roleName' -o tsv"
 }
@@ -185,23 +185,23 @@ test_check_access_operations() {
 # Test policy-restricted operations (should be blocked)
 test_restricted_operations() {
     print_header "Testing Restricted Operations (Should Be Blocked)"
-    
+
     # Test role assignment creation (should be blocked)
     test_should_fail "Create role assignment" \
         "az role assignment create --assignee '$FP_APPLICATION_NAME' --role 'Reader' --scope '/subscriptions/$SUBSCRIPTION_ID' --dry-run"
-    
+
     # Test role definition creation (should be blocked)
     test_should_fail "Create custom role definition" \
         "az role definition create --role-definition '{\"Name\":\"TestRole-$USER\",\"Description\":\"Test\",\"Actions\":[\"Microsoft.Storage/*/read\"],\"AssignableScopes\":[\"/subscriptions/$SUBSCRIPTION_ID\"]}'"
-    
+
     # Test policy assignment creation (should be blocked)
     test_should_fail "Create policy assignment" \
         "az policy assignment create --name 'test-policy-$USER' --policy '/providers/Microsoft.Authorization/policyDefinitions/56a914f7-8874-476c-8bbc-d748663e4d06' --scope '/subscriptions/$SUBSCRIPTION_ID'"
-    
+
     # Test critical resource deletion (should be blocked)
     test_should_fail "Delete resource group (dry run)" \
         "az group delete --name '$TEST_RG' --yes --dry-run"
-    
+
     test_should_fail "Delete key vault (dry run)" \
         "az keyvault delete --name '$KEY_VAULT_NAME' --dry-run"
 }
@@ -209,7 +209,7 @@ test_restricted_operations() {
 # Test VM creation (should be blocked by policy)
 test_vm_operations() {
     print_header "Testing VM Operations (Should Be Blocked)"
-    
+
     # Test VM creation (should be blocked)
     test_should_fail "Create virtual machine" \
         "az vm create --resource-group '$TEST_RG' --name 'test-vm-$USER' --image 'UbuntuLTS' --admin-username 'testuser' --generate-ssh-keys --dry-run"
@@ -218,18 +218,18 @@ test_vm_operations() {
 # Test network operations (service association links should be allowed)
 test_network_operations() {
     print_header "Testing Network Operations"
-    
+
     # Find a VNet/subnet for testing
     local test_vnet=$(az network vnet list --resource-group "$TEST_RG" --query "[0].name" -o tsv 2>/dev/null || echo "")
     local test_subnet=$(az network vnet subnet list --resource-group "$TEST_RG" --vnet-name "$test_vnet" --query "[0].name" -o tsv 2>/dev/null || echo "")
-    
+
     if [[ -n "$test_vnet" && -n "$test_subnet" ]]; then
         print_info "Testing with VNet: $test_vnet, Subnet: $test_subnet"
-        
+
         # Reading subnet should work
         test_should_succeed "Read subnet configuration" \
             "az network vnet subnet show --resource-group '$TEST_RG' --vnet-name '$test_vnet' --name '$test_subnet' --query 'name' -o tsv"
-        
+
         # Service association links should be allowed (but we'll just test read access)
         test_should_succeed "List service association links" \
             "az network vnet subnet show --resource-group '$TEST_RG' --vnet-name '$test_vnet' --name '$test_subnet' --query 'serviceAssociationLinks' -o tsv"
@@ -241,54 +241,84 @@ test_network_operations() {
 # Main test execution
 main() {
     print_header "Mock FPA Policy Restriction Tests"
-    
+
     # Validate environment variables
     validate_environment
-    
+
     print_info "Testing environment: $SUBSCRIPTION_ID"
     print_info "Mock FPA Application: $FP_APPLICATION_NAME"
-    
+
     # Save current context
     save_current_user
-    
+
     # Get test resources
     get_test_resource_group
-    
-    # Login as mock FPA
-    print_info "Switching to mock FPA identity..."
-    if ! $SCRIPT_DIR/dev-application.sh login >/dev/null 2>&1; then
-        print_failure "Failed to login as mock FPA"
-        exit 1
+
+    # Check if already logged in as the correct service principal
+    local current_user=$(az account show --query user.name -o tsv 2>/dev/null || echo "")
+    local current_type=$(az account show --query user.type -o tsv 2>/dev/null || echo "")
+
+    # Check if we're logged in as a service principal and if it looks like our FPA
+    local skip_login=false
+    if [[ "$current_type" == "servicePrincipal" && -n "$current_user" ]]; then
+        # If we can't get the expected app ID due to authentication issues,
+        # we'll assume we're already logged in correctly if the user is a service principal
+        # and the application name contains our expected pattern
+        local expected_app_id=""
+        if expected_app_id=$(az ad app list --display-name "$FP_APPLICATION_NAME" --query "[0].appId" -o tsv 2>/dev/null) && [[ -n "$expected_app_id" ]]; then
+            if [[ "$current_user" == "$expected_app_id" ]]; then
+                skip_login=true
+                print_info "Already logged in as mock FPA service principal: $current_user"
+            fi
+        else
+            # Can't verify the exact app ID, but if we're a service principal and the name looks right,
+            # we'll assume it's correct to avoid authentication loops
+            print_info "Already logged in as service principal: $current_user (assuming this is the mock FPA)"
+            skip_login=true
+        fi
     fi
-    
-    # Verify we're logged in as the service principal
-    local current_user=$(az account show --query user.name -o tsv)
-    local current_type=$(az account show --query user.type -o tsv)
-    
-    if [[ "$current_type" != "servicePrincipal" ]]; then
-        print_failure "Not logged in as service principal (type: $current_type)"
-        restore_original_user
-        exit 1
+
+    if [[ "$skip_login" == "false" ]]; then
+        # Login as mock FPA
+        print_info "Switching to mock FPA identity..."
+        if ! $SCRIPT_DIR/dev-application.sh login >/dev/null 2>&1; then
+            print_failure "Failed to login as mock FPA"
+            exit 1
+        fi
+
+        # Verify we're logged in as the service principal
+        current_user=$(az account show --query user.name -o tsv)
+        current_type=$(az account show --query user.type -o tsv)
+
+        if [[ "$current_type" != "servicePrincipal" ]]; then
+            print_failure "Not logged in as service principal (type: $current_type)"
+            restore_original_user
+            exit 1
+        fi
+
+        print_info "Successfully logged in as: $current_user ($current_type)"
     fi
-    
-    print_info "Successfully logged in as: $current_user ($current_type)"
-    
+
     # Run test suites
     test_read_operations
     test_check_access_operations
     test_restricted_operations
     test_vm_operations
     test_network_operations
-    
-    # Restore original context
-    restore_original_user
-    
+
+    # Restore original context only if we changed it
+    if [[ "$skip_login" == "false" && "$ORIGINAL_USER_TYPE" != "servicePrincipal" ]]; then
+        restore_original_user
+    else
+        print_info "Keeping current service principal session"
+    fi
+
     # Print summary
     print_header "Test Results Summary"
     echo -e "${GREEN}Tests Passed: $TESTS_PASSED${NC}"
     echo -e "${RED}Tests Failed: $TESTS_FAILED${NC}"
     echo -e "${BLUE}Total Tests: $TESTS_TOTAL${NC}"
-    
+
     if [[ $TESTS_FAILED -eq 0 ]]; then
         echo -e "${GREEN}🎉 All tests passed! Mock FPA policies are working correctly.${NC}"
         exit 0
@@ -299,7 +329,14 @@ main() {
 }
 
 # Handle script interruption
-trap 'restore_original_user; exit 1' INT TERM
+cleanup_on_interrupt() {
+    # Only restore if we were originally a user (not service principal)
+    if [[ -n "$ORIGINAL_USER_TYPE" && "$ORIGINAL_USER_TYPE" != "servicePrincipal" ]]; then
+        restore_original_user
+    fi
+    exit 1
+}
+trap 'cleanup_on_interrupt' INT TERM
 
 # Check if required tools are available
 if ! command -v az >/dev/null 2>&1; then

--- a/dev-infrastructure/scripts/test-mock-fpa-policies.sh
+++ b/dev-infrastructure/scripts/test-mock-fpa-policies.sh
@@ -4,6 +4,9 @@
 # This script tests that the mock FPA has minimum required permissions and dangerous operations are blocked
 # The script continues running all tests even if some fail, providing a comprehensive report at the end
 #
+# This script uses a dedicated Azure CLI config directory (../azure-config) to avoid interfering
+# with the user's existing Azure CLI configuration.
+#
 # Usage:
 #   ./test-mock-fpa-policies.sh [--quiet] [--fail-fast]
 #   VERBOSE_OUTPUT=false ./test-mock-fpa-policies.sh
@@ -34,6 +37,16 @@ if ! eval "$($SCRIPT_DIR/dev-application.sh shell)"; then
     echo "  $SCRIPT_DIR/dev-application.sh create"
     exit 1
 fi
+
+# Ensure Azure config directory is set up (should be sourced from dev-application.sh)
+if [[ -z "$AZURE_CONFIG_DIR" ]]; then
+    # Fallback if not set by dev-application.sh
+    AZURE_CONFIG_DIR="$SCRIPT_DIR/../azure-config"
+    export AZURE_CONFIG_DIR
+fi
+
+# Create Azure config directory if it doesn't exist
+mkdir -p "$AZURE_CONFIG_DIR"
 
 # Map exported variables to expected names
 SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-}"

--- a/dev-infrastructure/scripts/test-mock-fpa-policies.sh
+++ b/dev-infrastructure/scripts/test-mock-fpa-policies.sh
@@ -1,0 +1,313 @@
+#!/bin/bash
+
+# Test script to verify mock FPA restriction policies are working correctly
+# This script tests that the mock FPA has minimum required permissions and dangerous operations are blocked
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Get script directory for relative paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source environment variables from dev-application.sh
+if ! eval "$($SCRIPT_DIR/dev-application.sh shell)"; then
+    echo -e "${RED}Error: Could not source environment from dev-application.sh${NC}"
+    echo "Make sure the dev applications are created first by running:"
+    echo "  $SCRIPT_DIR/dev-application.sh create"
+    exit 1
+fi
+
+# Map exported variables to expected names
+SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-}"
+RESOURCE_GROUP="${RESOURCE_GROUP:-}"
+KEY_VAULT_NAME="${ARO_HCP_DEV_KEY_VAULT_NAME:-}"
+FP_APPLICATION_NAME="${ARO_HCP_DEV_FP_APPLICATION_NAME:-}"
+FP_CERTIFICATE_NAME="${ARO_HCP_DEV_FP_CERTIFICATE_NAME:-}"
+AH_APPLICATION_NAME="${ARO_HCP_DEV_AH_APPLICATION_NAME:-}"
+
+# Validate required variables are set
+validate_environment() {
+    local missing_vars=()
+    
+    [[ -z "$SUBSCRIPTION_ID" ]] && missing_vars+=("SUBSCRIPTION_ID")
+    [[ -z "$RESOURCE_GROUP" ]] && missing_vars+=("RESOURCE_GROUP") 
+    [[ -z "$KEY_VAULT_NAME" ]] && missing_vars+=("KEY_VAULT_NAME")
+    [[ -z "$FP_APPLICATION_NAME" ]] && missing_vars+=("FP_APPLICATION_NAME")
+    [[ -z "$FP_CERTIFICATE_NAME" ]] && missing_vars+=("FP_CERTIFICATE_NAME")
+    
+    if [[ ${#missing_vars[@]} -gt 0 ]]; then
+        echo -e "${RED}Error: Missing required environment variables: ${missing_vars[*]}${NC}"
+        echo "Make sure the dev applications are created first by running:"
+        echo "  $SCRIPT_DIR/dev-application.sh create"
+        exit 1
+    fi
+    
+    print_info "Environment validated successfully"
+}
+
+# Test results tracking
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_TOTAL=0
+
+print_header() {
+    echo -e "${BLUE}========================================${NC}"
+    echo -e "${BLUE}$1${NC}"
+    echo -e "${BLUE}========================================${NC}"
+}
+
+print_test() {
+    echo -e "${YELLOW}Testing: $1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✅ PASS: $1${NC}"
+    ((TESTS_PASSED++))
+    ((TESTS_TOTAL++))
+}
+
+print_failure() {
+    echo -e "${RED}❌ FAIL: $1${NC}"
+    ((TESTS_FAILED++))
+    ((TESTS_TOTAL++))
+}
+
+print_info() {
+    echo -e "${BLUE}ℹ️ INFO: $1${NC}"
+}
+
+# Test if an operation should succeed
+test_should_succeed() {
+    local test_name="$1"
+    local command="$2"
+    
+    print_test "$test_name (should succeed)"
+    
+    if eval "$command" >/dev/null 2>&1; then
+        print_success "$test_name"
+        return 0
+    else
+        print_failure "$test_name - Operation was blocked but should have succeeded"
+        return 1
+    fi
+}
+
+# Test if an operation should be blocked
+test_should_fail() {
+    local test_name="$1"
+    local command="$2"
+    
+    print_test "$test_name (should be blocked)"
+    
+    if eval "$command" >/dev/null 2>&1; then
+        print_failure "$test_name - Operation succeeded but should have been blocked"
+        return 1
+    else
+        print_success "$test_name - Correctly blocked"
+        return 0
+    fi
+}
+
+# Save current user context
+save_current_user() {
+    ORIGINAL_USER=$(az account show --query user.name -o tsv 2>/dev/null || echo "unknown")
+    ORIGINAL_USER_TYPE=$(az account show --query user.type -o tsv 2>/dev/null || echo "unknown")
+    print_info "Original user: $ORIGINAL_USER ($ORIGINAL_USER_TYPE)"
+}
+
+# Restore original user context
+restore_original_user() {
+    print_info "Restoring original user context..."
+    if [[ "$ORIGINAL_USER_TYPE" == "user" ]]; then
+        az login >/dev/null 2>&1 || {
+            echo -e "${YELLOW}⚠️  Please run 'az login' to restore your session${NC}"
+        }
+    else
+        echo -e "${YELLOW}⚠️  Please restore your original authentication context${NC}"
+    fi
+}
+
+# Get a test resource group for non-destructive tests
+get_test_resource_group() {
+    # Try to find an existing resource group, or use the dev application RG
+    TEST_RG=$(az group list --query "[0].name" -o tsv 2>/dev/null || echo "$RESOURCE_GROUP")
+    if [[ -z "$TEST_RG" ]]; then
+        print_failure "No resource groups found for testing"
+        exit 1
+    fi
+    print_info "Using test resource group: $TEST_RG"
+}
+
+# Test basic read operations (should work with Contributor role)
+test_read_operations() {
+    print_header "Testing Read Operations (Should Succeed)"
+    
+    test_should_succeed "List resource groups" \
+        "az group list --query '[].name' -o tsv"
+    
+    test_should_succeed "List storage accounts" \
+        "az storage account list --query '[].name' -o tsv"
+    
+    test_should_succeed "List virtual networks" \
+        "az network vnet list --query '[].name' -o tsv"
+    
+    test_should_succeed "List key vaults" \
+        "az keyvault list --query '[].name' -o tsv"
+    
+    test_should_succeed "Show subscription details" \
+        "az account show --query id -o tsv"
+}
+
+# Test check access operations (requires built-in role)
+test_check_access_operations() {
+    print_header "Testing Check Access Operations (Should Succeed)"
+    
+    # Get current user's object ID for check access tests
+    local current_user_id=$(az ad signed-in-user show --query id -o tsv 2>/dev/null || echo "")
+    
+    if [[ -n "$current_user_id" ]]; then
+        test_should_succeed "Check access for current user" \
+            "az role assignment list --assignee '$current_user_id' --query '[].roleDefinitionName' -o tsv"
+    else
+        print_info "Skipping check access test - cannot get current user ID"
+    fi
+    
+    test_should_succeed "List role definitions" \
+        "az role definition list --query '[0].roleName' -o tsv"
+}
+
+# Test policy-restricted operations (should be blocked)
+test_restricted_operations() {
+    print_header "Testing Restricted Operations (Should Be Blocked)"
+    
+    # Test role assignment creation (should be blocked)
+    test_should_fail "Create role assignment" \
+        "az role assignment create --assignee '$FP_APPLICATION_NAME' --role 'Reader' --scope '/subscriptions/$SUBSCRIPTION_ID' --dry-run"
+    
+    # Test role definition creation (should be blocked)
+    test_should_fail "Create custom role definition" \
+        "az role definition create --role-definition '{\"Name\":\"TestRole-$USER\",\"Description\":\"Test\",\"Actions\":[\"Microsoft.Storage/*/read\"],\"AssignableScopes\":[\"/subscriptions/$SUBSCRIPTION_ID\"]}'"
+    
+    # Test policy assignment creation (should be blocked)
+    test_should_fail "Create policy assignment" \
+        "az policy assignment create --name 'test-policy-$USER' --policy '/providers/Microsoft.Authorization/policyDefinitions/56a914f7-8874-476c-8bbc-d748663e4d06' --scope '/subscriptions/$SUBSCRIPTION_ID'"
+    
+    # Test critical resource deletion (should be blocked)
+    test_should_fail "Delete resource group (dry run)" \
+        "az group delete --name '$TEST_RG' --yes --dry-run"
+    
+    test_should_fail "Delete key vault (dry run)" \
+        "az keyvault delete --name '$KEY_VAULT_NAME' --dry-run"
+}
+
+# Test VM creation (should be blocked by policy)
+test_vm_operations() {
+    print_header "Testing VM Operations (Should Be Blocked)"
+    
+    # Test VM creation (should be blocked)
+    test_should_fail "Create virtual machine" \
+        "az vm create --resource-group '$TEST_RG' --name 'test-vm-$USER' --image 'UbuntuLTS' --admin-username 'testuser' --generate-ssh-keys --dry-run"
+}
+
+# Test network operations (service association links should be allowed)
+test_network_operations() {
+    print_header "Testing Network Operations"
+    
+    # Find a VNet/subnet for testing
+    local test_vnet=$(az network vnet list --resource-group "$TEST_RG" --query "[0].name" -o tsv 2>/dev/null || echo "")
+    local test_subnet=$(az network vnet subnet list --resource-group "$TEST_RG" --vnet-name "$test_vnet" --query "[0].name" -o tsv 2>/dev/null || echo "")
+    
+    if [[ -n "$test_vnet" && -n "$test_subnet" ]]; then
+        print_info "Testing with VNet: $test_vnet, Subnet: $test_subnet"
+        
+        # Reading subnet should work
+        test_should_succeed "Read subnet configuration" \
+            "az network vnet subnet show --resource-group '$TEST_RG' --vnet-name '$test_vnet' --name '$test_subnet' --query 'name' -o tsv"
+        
+        # Service association links should be allowed (but we'll just test read access)
+        test_should_succeed "List service association links" \
+            "az network vnet subnet show --resource-group '$TEST_RG' --vnet-name '$test_vnet' --name '$test_subnet' --query 'serviceAssociationLinks' -o tsv"
+    else
+        print_info "No VNet/subnet found for network operations testing"
+    fi
+}
+
+# Main test execution
+main() {
+    print_header "Mock FPA Policy Restriction Tests"
+    
+    # Validate environment variables
+    validate_environment
+    
+    print_info "Testing environment: $SUBSCRIPTION_ID"
+    print_info "Mock FPA Application: $FP_APPLICATION_NAME"
+    
+    # Save current context
+    save_current_user
+    
+    # Get test resources
+    get_test_resource_group
+    
+    # Login as mock FPA
+    print_info "Switching to mock FPA identity..."
+    if ! $SCRIPT_DIR/dev-application.sh login >/dev/null 2>&1; then
+        print_failure "Failed to login as mock FPA"
+        exit 1
+    fi
+    
+    # Verify we're logged in as the service principal
+    local current_user=$(az account show --query user.name -o tsv)
+    local current_type=$(az account show --query user.type -o tsv)
+    
+    if [[ "$current_type" != "servicePrincipal" ]]; then
+        print_failure "Not logged in as service principal (type: $current_type)"
+        restore_original_user
+        exit 1
+    fi
+    
+    print_info "Successfully logged in as: $current_user ($current_type)"
+    
+    # Run test suites
+    test_read_operations
+    test_check_access_operations
+    test_restricted_operations
+    test_vm_operations
+    test_network_operations
+    
+    # Restore original context
+    restore_original_user
+    
+    # Print summary
+    print_header "Test Results Summary"
+    echo -e "${GREEN}Tests Passed: $TESTS_PASSED${NC}"
+    echo -e "${RED}Tests Failed: $TESTS_FAILED${NC}"
+    echo -e "${BLUE}Total Tests: $TESTS_TOTAL${NC}"
+    
+    if [[ $TESTS_FAILED -eq 0 ]]; then
+        echo -e "${GREEN}🎉 All tests passed! Mock FPA policies are working correctly.${NC}"
+        exit 0
+    else
+        echo -e "${RED}❌ Some tests failed. Please review the policy configuration.${NC}"
+        exit 1
+    fi
+}
+
+# Handle script interruption
+trap 'restore_original_user; exit 1' INT TERM
+
+# Check if required tools are available
+if ! command -v az >/dev/null 2>&1; then
+    echo -e "${RED}Error: Azure CLI (az) is not installed or not in PATH${NC}"
+    exit 1
+fi
+
+
+
+# Run main function
+main "$@"

--- a/dev-infrastructure/scripts/test-mock-fpa-policies.sh
+++ b/dev-infrastructure/scripts/test-mock-fpa-policies.sh
@@ -308,11 +308,11 @@ test_check_access_operations() {
 
         # Test 4: Use Azure REST API to call check access directly (key FPA functionality)
         test_should_succeed "Call check access API for read permissions" \
-            "az rest --method POST --url 'https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Authorization/checkAccess?api-version=2015-07-01' --body '{\"subject\":{\"principalId\":\"$current_user_id\"},\"actions\":[\"Microsoft.Resources/subscriptions/read\"]}' --query 'accessDecision' -o tsv"
+            "az rest --method POST --url 'https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Authorization/checkAccess?api-version=2018-09-01-preview' --body '{\"subject\":{\"principalId\":\"$current_user_id\"},\"actions\":[\"Microsoft.Resources/subscriptions/read\"]}' --query 'accessDecision' -o tsv"
 
         # Test 4b: Check access for resource group operations
         test_should_succeed "Call check access API for resource group operations" \
-            "az rest --method POST --url 'https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$TEST_RG/providers/Microsoft.Authorization/checkAccess?api-version=2015-07-01' --body '{\"subject\":{\"principalId\":\"$current_user_id\"},\"actions\":[\"Microsoft.Resources/subscriptions/resourceGroups/read\"]}' --query 'accessDecision' -o tsv"
+            "az rest --method POST --url 'https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$TEST_RG/providers/Microsoft.Authorization/checkAccess?api-version=2018-09-01-preview' --body '{\"subject\":{\"principalId\":\"$current_user_id\"},\"actions\":[\"Microsoft.Resources/subscriptions/resourceGroups/read\"]}' --query 'accessDecision' -o tsv"
 
         # Test 5: Check permissions on storage accounts (common FPA use case)
         test_should_succeed "Check storage account permissions" \
@@ -324,11 +324,11 @@ test_check_access_operations() {
 
         # Test 6b: Check access for common Azure services (FPA use cases)
         test_should_succeed "Check access for storage operations" \
-            "az rest --method POST --url 'https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Authorization/checkAccess?api-version=2015-07-01' --body '{\"subject\":{\"principalId\":\"$current_user_id\"},\"actions\":[\"Microsoft.Storage/storageAccounts/read\"]}' --query 'accessDecision' -o tsv"
+            "az rest --method POST --url 'https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Authorization/checkAccess?api-version=2018-09-01-preview' --body '{\"subject\":{\"principalId\":\"$current_user_id\"},\"actions\":[\"Microsoft.Storage/storageAccounts/read\"]}' --query 'accessDecision' -o tsv"
 
         # Test 6c: Check access for network operations (relevant for ARO)
         test_should_succeed "Check access for network operations" \
-            "az rest --method POST --url 'https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Authorization/checkAccess?api-version=2015-07-01' --body '{\"subject\":{\"principalId\":\"$current_user_id\"},\"actions\":[\"Microsoft.Network/virtualNetworks/read\"]}' --query 'accessDecision' -o tsv"
+            "az rest --method POST --url 'https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Authorization/checkAccess?api-version=2018-09-01-preview' --body '{\"subject\":{\"principalId\":\"$current_user_id\"},\"actions\":[\"Microsoft.Network/virtualNetworks/read\"]}' --query 'accessDecision' -o tsv"
 
     else
         print_info "Skipping check access tests - cannot get service principal ID"


### PR DESCRIPTION
# Implement Mock FPA Policy Restrictions for Check Access API

## Problem

The ARO-HCP dev environment requires calling Azure's `checkAccess` V2 API to validate permissions using a mock First Party Application (FPA) token. However, the API returns 403 Forbidden when using custom roles:

```
POST https://westus3.authorization.azure.net/providers/Microsoft.Authorization/checkAccess
RESPONSE 403: 403 Forbidden
"Caller is unauthorized to call this endpoint"
```

**Root Cause**: Microsoft confirmed that `checkAccess` API only works with built-in Azure roles, not custom roles.

## Solution

Use the built-in **Contributor** role for the mock FPA while implementing Azure Policy restrictions to block dangerous operations. This provides the necessary permissions for `checkAccess` API calls while maintaining security through policy enforcement.

## Changes

### New Files

- **`mock-fpa-restrictions.bicep`** - Azure Policy template defining restrictions for the mock FPA
- **`mock-fpa-common.sh`** - Shared functions for mock FPA operations with isolated Azure CLI config
- **`test-mock-fpa-policies.sh`** - Comprehensive test suite validating policy restrictions

### Modified Files

- **`dev-application.sh`** - Integrated policy deployment and added new CLI commands

## Policy Restrictions

The Azure Policies block dangerous operations while allowing necessary FPA functionality:

**Blocked Operations:**
- Role assignments and definitions (privilege escalation)
- Policy assignments and definitions
- Critical resource deletion (VMs, storage accounts, key vaults, resource groups)
- VM creation

**Allowed Operations:**
- All read operations
- `checkAccess` API calls
- Network service association links (required for ARO)
- Resource creation (except restricted types)

## Usage

```bash
# Create mock FPA with policies (includes policy deployment)
./dev-infrastructure/scripts/dev-application.sh create

# Manage policies separately
./dev-infrastructure/scripts/dev-application.sh deploy-policies

# Login as mock FPA
./dev-infrastructure/scripts/dev-application.sh login

# Test policy enforcement
./dev-infrastructure/scripts/test-mock-fpa-policies.sh

# Delete policies
./dev-infrastructure/scripts/dev-application.sh delete-policies

# Delete infrastructure
./dev-infrastructure/scripts/dev-application.sh delete

# Cleanup certificates
./dev-infrastructure/scripts/dev-application.sh cleanup
```

## Testing

The test suite validates 21 scenarios including:
- ✅ Read operations and `checkAccess` API calls
- ❌ Restricted operations (role assignments, resource deletion)
- ✅ Network operations for ARO requirements
- Comprehensive reporting with pass/fail counts

## Benefits

- **Enables core functionality**: `checkAccess` API now works in dev environment
- **Maintains security**: Dangerous operations blocked by policy enforcement
- **Developer-friendly**: Isolated Azure CLI config prevents interference
- **Comprehensive testing**: Automated validation of restrictions
- **Audit trail**: Policy compliance reporting for blocked operations

## Migration Notes

- **Breaking change**: Mock FPA now uses Contributor role instead of custom role
- **No impact on production**: Changes only affect dev environment setup
- Existing environments automatically get policies deployed via `create` command
