### PR TITLE
Fix Azure CSI driver serviceaccount references for OCP 4.16+ compatibility

### DIFF
--- a/cluster-service/deploy/templates/azure-operators-managed-identities-config.configmap.yaml
+++ b/cluster-service/deploy/templates/azure-operators-managed-identities-config.configmap.yaml
@@ -87,8 +87,6 @@ data:
             name: '{{ .name }}'
         {{- end }}
         k8sServiceAccounts:
-          - name: 'azure-disk-csi-driver-operator'
-            namespace: 'openshift-cluster-csi-drivers'
           - name: 'azure-disk-csi-driver-controller-sa'
             namespace: 'openshift-cluster-csi-drivers'
         optional: false
@@ -113,8 +111,6 @@ data:
             name: '{{ .name }}'
         {{- end }}
         k8sServiceAccounts:
-          - name: 'azure-file-csi-driver-operator'
-            namespace: 'openshift-cluster-csi-drivers'
           - name: 'azure-file-csi-driver-controller-sa'
             namespace: 'openshift-cluster-csi-drivers'
           - name: 'azure-file-csi-driver-node-sa'


### PR DESCRIPTION
## Problem

Recent ARO-HCP cluster deployment failures in INT environment were caused by references to obsolete Azure CSI driver operator serviceaccounts:
- `azure-disk-csi-driver-operator` 
- `azure-file-csi-driver-operator`

These serviceaccounts no longer exist in OpenShift 4.16+ due to the [consolidation of individual CSI operators](https://github.com/openshift/enhancements/blob/master/enhancements/storage/csi-driver-operator-merge.md) into the unified `csi-operator`.

**Error observed:**
```
Error creating: pods "azure-file-csi-driver-operator-<hash>-" is forbidden: error looking up service account <namespace>/azure-file-csi-driver-operator: serviceaccount "azure-file-csi-driver-operator" not found
```

## Solution

Remove obsolete serviceaccount references from `azure-operators-managed-identities-config.configmap.yaml`. The functionality previously handled by the separate operator serviceaccounts has been consolidated into the controller serviceaccounts.

**Changes:**
- Removed: `azure-disk-csi-driver-operator` (obsolete)
- Removed: `azure-file-csi-driver-operator` (obsolete)
- Preserved: All existing `*-controller-sa` and `*-node-sa` serviceaccounts (these exist and function correctly)

**No functional changes** - only removal of non-existent serviceaccounts that were causing deployment failures.

## Testing

- Configuration syntax validated 
- No linter errors introduced
- Verified serviceaccounts exist in OCP 4.16+ csi-operator

## References

- [CSI Driver Operator Merge Enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/storage/csi-driver-operator-merge.md)
- [Azure File CSI Driver Operator (obsolete)](https://github.com/openshift/azure-file-csi-driver-operator) 
- [Current CSI Operator](https://github.com/openshift/csi-operator)
```
