### PR TITLE
api: Define TypeSpec enum for UsernameClaimPrefixPolicy

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -942,7 +942,8 @@ model UsernameClaimProfile {
   claim: string;
 
   /** Prefix for the claim external profile
-   * If this is specified prefixPolicy will be set to "Prefix" by default
+   * Must be set when the prefixPolicy field is set to 'Prefix' and must be unset
+   * otherwise.
    */
   prefix?: string;
 
@@ -969,7 +970,21 @@ model UsernameClaimProfile {
    *    - "username": the mapped value will be "https://myoidc.tld#userA"
    *    - "email": the mapped value will be "userA@myoidc.tld"
    */
-  prefixPolicy?: string;
+  prefixPolicy?: UsernameClaimPrefixPolicy;
+}
+
+/** UsernameClaimPrefixPolicy configures whether to add a prefix to a JWT claim. */
+union UsernameClaimPrefixPolicy {
+  string,
+
+  /** No opinion; the platform is left to choose a prefix for the JWT claim */
+  None: "None",
+
+  /** Add a user-provided prefix to the JWT claim */
+  Prefix: "Prefix",
+
+  /** Do not add a prefix to the JWT claim */
+  NoPrefix: "NoPrefix",
 }
 
 /** External Auth claim validation rule */

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -3572,6 +3572,36 @@
         ]
       }
     },
+    "UsernameClaimPrefixPolicy": {
+      "type": "string",
+      "description": "UsernameClaimPrefixPolicy configures whether to add a prefix to a JWT claim.",
+      "enum": [
+        "None",
+        "Prefix",
+        "NoPrefix"
+      ],
+      "x-ms-enum": {
+        "name": "UsernameClaimPrefixPolicy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No opinion; the platform is left to choose a prefix for the JWT claim"
+          },
+          {
+            "name": "Prefix",
+            "value": "Prefix",
+            "description": "Add a user-provided prefix to the JWT claim"
+          },
+          {
+            "name": "NoPrefix",
+            "value": "NoPrefix",
+            "description": "Do not add a prefix to the JWT claim"
+          }
+        ]
+      }
+    },
     "UsernameClaimProfile": {
       "type": "object",
       "description": "External Auth claim profile\nThis configures how the username of a cluster identity should be constructed\nfrom the claims in a JWT token issued by the identity provider.",
@@ -3584,10 +3614,10 @@
         },
         "prefix": {
           "type": "string",
-          "description": "Prefix for the claim external profile\nIf this is specified prefixPolicy will be set to \"Prefix\" by default"
+          "description": "Prefix for the claim external profile\nMust be set when the prefixPolicy field is set to 'Prefix' and must be unset\notherwise."
         },
         "prefixPolicy": {
-          "type": "string",
+          "$ref": "#/definitions/UsernameClaimPrefixPolicy",
           "description": "Prefix policy is an optional field that configures how a prefix should be\napplied to the value of the JWT claim specified in the 'claim' field.\n\nAllowed values are 'Prefix', 'NoPrefix', and 'None'.\n\nWhen set to 'Prefix', the value specified in the prefix field will be\nprepended to the value of the JWT claim.\nThe prefix field must be set when prefixPolicy is 'Prefix'.\n\nWhen set to 'NoPrefix', no prefix will be prepended to the value\nof the JWT claim.\n\nWhen set to 'None', this means no opinion and the platform is left to choose\nany prefixes that are applied which is subject to change over time.\nCurrently, the platform prepends `{issuerURL}#` to the value of the JWT claim\nwhen the claim is not 'email'.\nAs an example, consider the following scenario:\n`prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\nthe JWT claims include \"username\":\"userA\" and \"email\":\"userA"
         }
       },
@@ -3607,10 +3637,10 @@
         },
         "prefix": {
           "type": "string",
-          "description": "Prefix for the claim external profile\nIf this is specified prefixPolicy will be set to \"Prefix\" by default"
+          "description": "Prefix for the claim external profile\nMust be set when the prefixPolicy field is set to 'Prefix' and must be unset\notherwise."
         },
         "prefixPolicy": {
-          "type": "string",
+          "$ref": "#/definitions/UsernameClaimPrefixPolicy",
           "description": "Prefix policy is an optional field that configures how a prefix should be\napplied to the value of the JWT claim specified in the 'claim' field.\n\nAllowed values are 'Prefix', 'NoPrefix', and 'None'.\n\nWhen set to 'Prefix', the value specified in the prefix field will be\nprepended to the value of the JWT claim.\nThe prefix field must be set when prefixPolicy is 'Prefix'.\n\nWhen set to 'NoPrefix', no prefix will be prepended to the value\nof the JWT claim.\n\nWhen set to 'None', this means no opinion and the platform is left to choose\nany prefixes that are applied which is subject to change over time.\nCurrently, the platform prepends `{issuerURL}#` to the value of the JWT claim\nwhen the claim is not 'email'.\nAs an example, consider the following scenario:\n`prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\nthe JWT claims include \"username\":\"userA\" and \"email\":\"userA"
         }
       }

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -119,26 +119,26 @@ func convertCustomerManagedEncryptionTypeRPToCS(encryptionTypeRP api.CustomerMan
 	}
 }
 
-func convertUsernameClaimPrefixPolicyCSToRP(prefixPolicyCS string) (api.UsernameClaimPrefixPolicyType, error) {
+func convertUsernameClaimPrefixPolicyCSToRP(prefixPolicyCS string) (api.UsernameClaimPrefixPolicy, error) {
 	switch prefixPolicyCS {
 	case csUsernameClaimPrefixPolicyPrefix:
-		return api.UsernameClaimPrefixPolicyTypePrefix, nil
+		return api.UsernameClaimPrefixPolicyPrefix, nil
 	case csUsernameClaimPrefixPolicyNoPrefix:
-		return api.UsernameClaimPrefixPolicyTypeNoPrefix, nil
+		return api.UsernameClaimPrefixPolicyNoPrefix, nil
 	case "":
-		return api.UsernameClaimPrefixPolicyTypeNone, nil
+		return api.UsernameClaimPrefixPolicyNone, nil
 	default:
-		return "", conversionError[api.UsernameClaimPrefixPolicyType](prefixPolicyCS)
+		return "", conversionError[api.UsernameClaimPrefixPolicy](prefixPolicyCS)
 	}
 }
 
-func convertUsernameClaimPrefixPolicyRPToCS(prefixPolicyRP api.UsernameClaimPrefixPolicyType) (string, error) {
+func convertUsernameClaimPrefixPolicyRPToCS(prefixPolicyRP api.UsernameClaimPrefixPolicy) (string, error) {
 	switch prefixPolicyRP {
-	case api.UsernameClaimPrefixPolicyTypePrefix:
+	case api.UsernameClaimPrefixPolicyPrefix:
 		return csUsernameClaimPrefixPolicyPrefix, nil
-	case api.UsernameClaimPrefixPolicyTypeNoPrefix:
+	case api.UsernameClaimPrefixPolicyNoPrefix:
 		return csUsernameClaimPrefixPolicyNoPrefix, nil
-	case api.UsernameClaimPrefixPolicyTypeNone:
+	case api.UsernameClaimPrefixPolicyNone:
 		return "", nil
 	default:
 		return "", conversionError[string](prefixPolicyRP)

--- a/frontend/pkg/frontend/ocm_test.go
+++ b/frontend/pkg/frontend/ocm_test.go
@@ -430,10 +430,10 @@ func TestBuildCSExternalAuth(t *testing.T) {
 			expectedCSExternalAuth: getBaseCSExternalAuthBuilder(),
 		},
 		{
-			name: "correctly parse PrefixPolicyType",
+			name: "correctly parse PrefixPolicy",
 			hcpExternalAuth: externalAuthResource(
 				func(hsc *api.HCPOpenShiftClusterExternalAuth) {
-					hsc.Properties.Claim.Mappings.Username.PrefixPolicy = api.UsernameClaimPrefixPolicyTypePrefix
+					hsc.Properties.Claim.Mappings.Username.PrefixPolicy = api.UsernameClaimPrefixPolicyPrefix
 				},
 			),
 			expectedCSExternalAuth: getBaseCSExternalAuthBuilder().Claim(arohcpv1alpha1.NewExternalAuthClaim().
@@ -441,7 +441,7 @@ func TestBuildCSExternalAuth(t *testing.T) {
 					UserName(arohcpv1alpha1.NewUsernameClaim().
 						Claim("").
 						Prefix("").
-						PrefixPolicy(string(api.UsernameClaimPrefixPolicyTypePrefix)),
+						PrefixPolicy(string(api.UsernameClaimPrefixPolicyPrefix)),
 					),
 				)),
 		},

--- a/internal/api/enums.go
+++ b/internal/api/enums.go
@@ -123,13 +123,13 @@ const (
 	ConditionStatusTypeUnknown ConditionStatusType = "Unknown"
 )
 
-type UsernameClaimPrefixPolicyType string
+type UsernameClaimPrefixPolicy string
 
 const (
-	// UsernameClaimPrefixPolicyTypePrefix - prefix the JWT claim with the value of Prefix.
-	UsernameClaimPrefixPolicyTypePrefix UsernameClaimPrefixPolicyType = "Prefix"
-	// UsernameClaimPrefixPolicyTypeNoPrefix - do not prefix the JWT claim.
-	UsernameClaimPrefixPolicyTypeNoPrefix UsernameClaimPrefixPolicyType = "NoPrefix"
-	// UsernameClaimPrefixPolicyTypeNone - let the platform choose an appropriate prefix.
-	UsernameClaimPrefixPolicyTypeNone UsernameClaimPrefixPolicyType = "None"
+	// UsernameClaimPrefixPolicyPrefix - prefix the JWT claim with the value of Prefix.
+	UsernameClaimPrefixPolicyPrefix UsernameClaimPrefixPolicy = "Prefix"
+	// UsernameClaimPrefixPolicyNoPrefix - do not prefix the JWT claim.
+	UsernameClaimPrefixPolicyNoPrefix UsernameClaimPrefixPolicy = "NoPrefix"
+	// UsernameClaimPrefixPolicyNone - let the platform choose an appropriate prefix.
+	UsernameClaimPrefixPolicyNone UsernameClaimPrefixPolicy = "None"
 )

--- a/internal/api/hcpopenshiftclusterexternalauth.go
+++ b/internal/api/hcpopenshiftclusterexternalauth.go
@@ -113,9 +113,9 @@ type GroupClaimProfile struct {
 // from the claims in a JWT token issued by the identity provider.
 // Visibility for the entire struct is "read create update".
 type UsernameClaimProfile struct {
-	Claim        string                        `json:"claim"        validate:"required,max=256"`
-	Prefix       string                        `json:"prefix"       validate:"required_if=PrefixPolicy Prefix,excluded_unless=PrefixPolicy Prefix"`
-	PrefixPolicy UsernameClaimPrefixPolicyType `json:"prefixPolicy" validate:"enum_usernameclaimprefixpolicytype"`
+	Claim        string                    `json:"claim"        validate:"required,max=256"`
+	Prefix       string                    `json:"prefix"       validate:"required_if=PrefixPolicy Prefix,excluded_unless=PrefixPolicy Prefix"`
+	PrefixPolicy UsernameClaimPrefixPolicy `json:"prefixPolicy" validate:"enum_usernameclaimprefixpolicy"`
 }
 
 // External Auth claim validation rule
@@ -138,7 +138,7 @@ func NewDefaultHCPOpenShiftClusterExternalAuth() *HCPOpenShiftClusterExternalAut
 			Claim: ExternalAuthClaimProfile{
 				Mappings: TokenClaimMappingsProfile{
 					Username: UsernameClaimProfile{
-						PrefixPolicy: UsernameClaimPrefixPolicyTypeNone,
+						PrefixPolicy: UsernameClaimPrefixPolicyNone,
 					},
 				},
 			},

--- a/internal/api/hcpopenshiftclusterexternalauth_test.go
+++ b/internal/api/hcpopenshiftclusterexternalauth_test.go
@@ -215,7 +215,7 @@ func TestExternalAuthValidate(t *testing.T) {
 					Claim: ExternalAuthClaimProfile{
 						Mappings: TokenClaimMappingsProfile{
 							Username: UsernameClaimProfile{
-								PrefixPolicy: UsernameClaimPrefixPolicyTypePrefix,
+								PrefixPolicy: UsernameClaimPrefixPolicyPrefix,
 							},
 						},
 					},
@@ -236,7 +236,7 @@ func TestExternalAuthValidate(t *testing.T) {
 						Mappings: TokenClaimMappingsProfile{
 							Username: UsernameClaimProfile{
 								Prefix:       "prefix",
-								PrefixPolicy: UsernameClaimPrefixPolicyTypeNoPrefix,
+								PrefixPolicy: UsernameClaimPrefixPolicyNoPrefix,
 							},
 						},
 					},
@@ -257,7 +257,7 @@ func TestExternalAuthValidate(t *testing.T) {
 						Mappings: TokenClaimMappingsProfile{
 							Username: UsernameClaimProfile{
 								Prefix:       "prefix",
-								PrefixPolicy: UsernameClaimPrefixPolicyTypeNone,
+								PrefixPolicy: UsernameClaimPrefixPolicyNone,
 							},
 						},
 					},

--- a/internal/api/testhelpers.go
+++ b/internal/api/testhelpers.go
@@ -119,10 +119,10 @@ func NewTestValidator() *validator.Validate {
 	validate.RegisterAlias("enum_tokenvalidationruletyperequiredclaim", EnumValidateTag(
 		TokenValidationRuleTypeRequiredClaim,
 	))
-	validate.RegisterAlias("enum_usernameclaimprefixpolicytype", EnumValidateTag(
-		UsernameClaimPrefixPolicyTypePrefix,
-		UsernameClaimPrefixPolicyTypeNoPrefix,
-		UsernameClaimPrefixPolicyTypeNone,
+	validate.RegisterAlias("enum_usernameclaimprefixpolicy", EnumValidateTag(
+		UsernameClaimPrefixPolicyPrefix,
+		UsernameClaimPrefixPolicyNoPrefix,
+		UsernameClaimPrefixPolicyNone,
 	))
 	validate.RegisterAlias("enum_visibility", EnumValidateTag(
 		VisibilityPublic,

--- a/internal/api/v20240610preview/external_auth_methods.go
+++ b/internal/api/v20240610preview/external_auth_methods.go
@@ -218,7 +218,7 @@ func newExternalAuthClaimProfile(from *api.ExternalAuthClaimProfile) *generated.
 			Username: &generated.UsernameClaimProfile{
 				Claim:        api.PtrOrNil(from.Mappings.Username.Claim),
 				Prefix:       api.PtrOrNil(from.Mappings.Username.Prefix),
-				PrefixPolicy: api.PtrOrNil(string(from.Mappings.Username.PrefixPolicy)),
+				PrefixPolicy: api.PtrOrNil(generated.UsernameClaimPrefixPolicy(from.Mappings.Username.PrefixPolicy)),
 			},
 			Groups: groups,
 		},

--- a/internal/api/v20240610preview/external_auth_methods.go
+++ b/internal/api/v20240610preview/external_auth_methods.go
@@ -154,7 +154,7 @@ func normalizeTokenClaimMappingsProfile(p *generated.TokenClaimMappingsProfile, 
 			out.Username.Prefix = *p.Username.Prefix
 		}
 		if p.Username.PrefixPolicy != nil {
-			out.Username.PrefixPolicy = api.UsernameClaimPrefixPolicyType(*p.Username.PrefixPolicy)
+			out.Username.PrefixPolicy = api.UsernameClaimPrefixPolicy(*p.Username.PrefixPolicy)
 		}
 	}
 	if p.Groups != nil {

--- a/internal/api/v20240610preview/generated/constants.go
+++ b/internal/api/v20240610preview/generated/constants.go
@@ -374,6 +374,27 @@ func PossibleTokenValidationRuleTypeValues() []TokenValidationRuleType {
 	}
 }
 
+// UsernameClaimPrefixPolicy - UsernameClaimPrefixPolicy configures whether to add a prefix to a JWT claim.
+type UsernameClaimPrefixPolicy string
+
+const (
+	// UsernameClaimPrefixPolicyNoPrefix - Do not add a prefix to the JWT claim
+	UsernameClaimPrefixPolicyNoPrefix UsernameClaimPrefixPolicy = "NoPrefix"
+	// UsernameClaimPrefixPolicyNone - No opinion; the platform is left to choose a prefix for the JWT claim
+	UsernameClaimPrefixPolicyNone UsernameClaimPrefixPolicy = "None"
+	// UsernameClaimPrefixPolicyPrefix - Add a user-provided prefix to the JWT claim
+	UsernameClaimPrefixPolicyPrefix UsernameClaimPrefixPolicy = "Prefix"
+)
+
+// PossibleUsernameClaimPrefixPolicyValues returns the possible values for the UsernameClaimPrefixPolicy const type.
+func PossibleUsernameClaimPrefixPolicyValues() []UsernameClaimPrefixPolicy {
+	return []UsernameClaimPrefixPolicy{
+		UsernameClaimPrefixPolicyNoPrefix,
+		UsernameClaimPrefixPolicyNone,
+		UsernameClaimPrefixPolicyPrefix,
+	}
+}
+
 // Visibility - The internet visibility of the OpenShift API server
 type Visibility string
 

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -1101,7 +1101,7 @@ type UsernameClaimProfile struct {
 	// REQUIRED; Claim name of the external profile
 	Claim *string
 
-	// Prefix for the claim external profile If this is specified prefixPolicy will be set to "Prefix" by default
+	// Prefix for the claim external profile Must be set when the prefixPolicy field is set to 'Prefix' and must be unset otherwise.
 	Prefix *string
 
 	// Prefix policy is an optional field that configures how a prefix should be applied to the value of the JWT claim specified
@@ -1115,7 +1115,7 @@ type UsernameClaimProfile struct {
 	// value of the JWT claim when the claim is not 'email'. As an example, consider the following scenario:prefix is unset, issuerURL
 	// is set to https://myoidc.tld, the JWT claims include "username":"userA"
 	// and "email":"userA
-	PrefixPolicy *string
+	PrefixPolicy *UsernameClaimPrefixPolicy
 }
 
 // UsernameClaimProfileUpdate - External Auth claim profile This configures how the username of a cluster identity should
@@ -1124,7 +1124,7 @@ type UsernameClaimProfileUpdate struct {
 	// Claim name of the external profile
 	Claim *string
 
-	// Prefix for the claim external profile If this is specified prefixPolicy will be set to "Prefix" by default
+	// Prefix for the claim external profile Must be set when the prefixPolicy field is set to 'Prefix' and must be unset otherwise.
 	Prefix *string
 
 	// Prefix policy is an optional field that configures how a prefix should be applied to the value of the JWT claim specified
@@ -1138,7 +1138,7 @@ type UsernameClaimProfileUpdate struct {
 	// value of the JWT claim when the claim is not 'email'. As an example, consider the following scenario:prefix is unset, issuerURL
 	// is set to https://myoidc.tld, the JWT claims include "username":"userA"
 	// and "email":"userA
-	PrefixPolicy *string
+	PrefixPolicy *UsernameClaimPrefixPolicy
 }
 
 // VersionProfile - Versions represents an OpenShift version.

--- a/internal/api/v20240610preview/register.go
+++ b/internal/api/v20240610preview/register.go
@@ -33,21 +33,21 @@ var (
 	externalAuthStructTagMap = api.NewStructTagMap[api.HCPOpenShiftClusterExternalAuth]()
 )
 
-type UsernameClaimPrefixPolicyType string
+type UsernameClaimPrefixPolicy string
 
 const (
-	UsernameClaimPrefixPolicyTypePrefix   UsernameClaimPrefixPolicyType = "Prefix"
-	UsernameClaimPrefixPolicyTypeNoPrefix UsernameClaimPrefixPolicyType = "NoPrefix"
-	UsernameClaimPrefixPolicyTypeNone     UsernameClaimPrefixPolicyType = "None"
+	UsernameClaimPrefixPolicyPrefix   UsernameClaimPrefixPolicy = "Prefix"
+	UsernameClaimPrefixPolicyNoPrefix UsernameClaimPrefixPolicy = "NoPrefix"
+	UsernameClaimPrefixPolicyNone     UsernameClaimPrefixPolicy = "None"
 )
 
 // FIXME This is a hack because we typed this field as string and not an enum in the API spec.
-// PossibleUsernameClaimPrefixPolicyTypeValues returns the possible values for the UsernameClaimPrefixPolicyType const type.
-func PossibleUsernameClaimPrefixPolicyTypeValues() []UsernameClaimPrefixPolicyType {
-	return []UsernameClaimPrefixPolicyType{
-		UsernameClaimPrefixPolicyTypePrefix,
-		UsernameClaimPrefixPolicyTypeNoPrefix,
-		UsernameClaimPrefixPolicyTypeNone,
+// PossibleUsernameClaimPrefixPolicyValues returns the possible values for the UsernameClaimPrefixPolicy const type.
+func PossibleUsernameClaimPrefixPolicyValues() []UsernameClaimPrefixPolicy {
+	return []UsernameClaimPrefixPolicy{
+		UsernameClaimPrefixPolicyPrefix,
+		UsernameClaimPrefixPolicyNoPrefix,
+		UsernameClaimPrefixPolicyNone,
 	}
 }
 
@@ -82,6 +82,6 @@ func init() {
 	validate.RegisterAlias("enum_outboundtype", api.EnumValidateTag(generated.PossibleOutboundTypeValues()...))
 	validate.RegisterAlias("enum_provisioningstate", api.EnumValidateTag(generated.PossibleProvisioningStateValues()...))
 	validate.RegisterAlias("enum_tokenvalidationruletyperequiredclaim", api.EnumValidateTag(generated.PossibleTokenValidationRuleTypeValues()...))
-	validate.RegisterAlias("enum_usernameclaimprefixpolicytype", api.EnumValidateTag(PossibleUsernameClaimPrefixPolicyTypeValues()...))
+	validate.RegisterAlias("enum_usernameclaimprefixpolicy", api.EnumValidateTag(PossibleUsernameClaimPrefixPolicyValues()...))
 	validate.RegisterAlias("enum_visibility", api.EnumValidateTag(generated.PossibleVisibilityValues()...))
 }

--- a/internal/api/v20240610preview/register.go
+++ b/internal/api/v20240610preview/register.go
@@ -33,24 +33,6 @@ var (
 	externalAuthStructTagMap = api.NewStructTagMap[api.HCPOpenShiftClusterExternalAuth]()
 )
 
-type UsernameClaimPrefixPolicy string
-
-const (
-	UsernameClaimPrefixPolicyPrefix   UsernameClaimPrefixPolicy = "Prefix"
-	UsernameClaimPrefixPolicyNoPrefix UsernameClaimPrefixPolicy = "NoPrefix"
-	UsernameClaimPrefixPolicyNone     UsernameClaimPrefixPolicy = "None"
-)
-
-// FIXME This is a hack because we typed this field as string and not an enum in the API spec.
-// PossibleUsernameClaimPrefixPolicyValues returns the possible values for the UsernameClaimPrefixPolicy const type.
-func PossibleUsernameClaimPrefixPolicyValues() []UsernameClaimPrefixPolicy {
-	return []UsernameClaimPrefixPolicy{
-		UsernameClaimPrefixPolicyPrefix,
-		UsernameClaimPrefixPolicyNoPrefix,
-		UsernameClaimPrefixPolicyNone,
-	}
-}
-
 func init() {
 	// NOTE: If future versions of the API expand field visibility, such as
 	//       a field with @visibility("read","create") becoming updatable,
@@ -82,6 +64,6 @@ func init() {
 	validate.RegisterAlias("enum_outboundtype", api.EnumValidateTag(generated.PossibleOutboundTypeValues()...))
 	validate.RegisterAlias("enum_provisioningstate", api.EnumValidateTag(generated.PossibleProvisioningStateValues()...))
 	validate.RegisterAlias("enum_tokenvalidationruletyperequiredclaim", api.EnumValidateTag(generated.PossibleTokenValidationRuleTypeValues()...))
-	validate.RegisterAlias("enum_usernameclaimprefixpolicy", api.EnumValidateTag(PossibleUsernameClaimPrefixPolicyValues()...))
+	validate.RegisterAlias("enum_usernameclaimprefixpolicy", api.EnumValidateTag(generated.PossibleUsernameClaimPrefixPolicyValues()...))
 	validate.RegisterAlias("enum_visibility", api.EnumValidateTag(generated.PossibleVisibilityValues()...))
 }

--- a/internal/api/validate.go
+++ b/internal/api/validate.go
@@ -83,10 +83,10 @@ func NewValidator() *validator.Validate {
 		ExternalAuthClientTypeConfidential,
 		ExternalAuthClientTypePublic,
 	))
-	validate.RegisterAlias("enum_usernameclaimprefixpolicytype", EnumValidateTag(
-		UsernameClaimPrefixPolicyTypePrefix,
-		UsernameClaimPrefixPolicyTypeNoPrefix,
-		UsernameClaimPrefixPolicyTypeNone,
+	validate.RegisterAlias("enum_usernameclaimprefixpolicy", EnumValidateTag(
+		UsernameClaimPrefixPolicyPrefix,
+		UsernameClaimPrefixPolicyNoPrefix,
+		UsernameClaimPrefixPolicyNone,
 	))
 	validate.RegisterAlias("enum_externalauthconditiontype", EnumValidateTag(
 		ExternalAuthConditionTypeAvailable,


### PR DESCRIPTION
[ARO-21006 - UsernameClaimProfile PrefixPolicy should be an Enum](https://issues.redhat.com/browse/ARO-21006)

### What

We accidentally defined the `prefixPolicy` field for external auth username claims as a string rather than an enum in the TypeSpec models file, and have been getting by with a workaround in the RP.  It's time to fix it properly.

### Why

Needs to be done while we can still make breaking API changes.
