### PR TITLE
frontend: Fix bugs in building ExternalAuthClaim for CS

### DIFF
--- a/frontend/pkg/frontend/external_auth_test.go
+++ b/frontend/pkg/frontend/external_auth_test.go
@@ -104,8 +104,10 @@ func TestCreateExternalAuth(t *testing.T) {
 					Claim(dummyClaim).
 					Prefix("").
 					PrefixPolicy(""),
-				),
-			),
+				).
+				Groups(arohcpv1alpha1.NewGroupsClaim()),
+			).
+			ValidationRules(),
 		).
 		Clients().
 		Build()

--- a/frontend/pkg/frontend/ocm_test.go
+++ b/frontend/pkg/frontend/ocm_test.go
@@ -411,8 +411,10 @@ func getBaseCSExternalAuthBuilder() *arohcpv1alpha1.ExternalAuthBuilder {
 					Claim("").
 					Prefix("").
 					PrefixPolicy(""),
-				),
-			),
+				).
+				Groups(arohcpv1alpha1.NewGroupsClaim()),
+			).
+			ValidationRules(),
 		).
 		Clients()
 }
@@ -442,8 +444,11 @@ func TestBuildCSExternalAuth(t *testing.T) {
 						Claim("").
 						Prefix("").
 						PrefixPolicy(string(api.UsernameClaimPrefixPolicyPrefix)),
-					),
-				)),
+					).
+					Groups(arohcpv1alpha1.NewGroupsClaim()),
+				).
+				ValidationRules(),
+			),
 		},
 		{
 			name: "correctly parse Issuer",


### PR DESCRIPTION
### What

Always include `GroupsClaim` and `ValidationRules` when building the `ExternalAuthClaim`, even if the they're empty. Otherwise these optional fields cannot be removed once set.

### Special notes for your reviewer

Discovered while testing #2599 on external auth resources.
