### PR TITLE
tooling/prometheus-rules: remove unnecessary `concat()`

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -15,7 +15,7 @@ resource kasMonitorRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -40,7 +40,7 @@ resource kasMonitorRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -65,7 +65,7 @@ resource kasMonitorRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -90,7 +90,7 @@ resource kasMonitorRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -15,7 +15,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -40,7 +40,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -65,7 +65,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -90,7 +90,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -115,7 +115,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -140,7 +140,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -165,7 +165,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -190,7 +190,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -215,7 +215,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -240,7 +240,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -265,7 +265,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -290,7 +290,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -315,7 +315,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -339,7 +339,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -364,7 +364,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -389,7 +389,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -427,7 +427,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -452,7 +452,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -477,7 +477,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -502,7 +502,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -527,7 +527,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -552,7 +552,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -577,7 +577,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -602,7 +602,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -640,7 +640,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -665,7 +665,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -690,7 +690,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -715,7 +715,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -740,7 +740,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -778,7 +778,7 @@ resource kubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -803,7 +803,7 @@ resource kubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -841,7 +841,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -868,7 +868,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -895,7 +895,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -922,7 +922,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -962,7 +962,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -987,7 +987,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1012,7 +1012,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1036,7 +1036,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1061,7 +1061,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1086,7 +1086,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1124,7 +1124,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1149,7 +1149,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1174,7 +1174,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1199,7 +1199,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1224,7 +1224,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1249,7 +1249,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1274,7 +1274,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1298,7 +1298,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1322,7 +1322,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1346,7 +1346,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1370,7 +1370,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1395,7 +1395,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1420,7 +1420,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1458,7 +1458,7 @@ resource kubernetesSystemScheduler 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1496,7 +1496,7 @@ resource kubernetesSystemControllerManager 'Microsoft.AlertsManagement/prometheu
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1534,7 +1534,7 @@ resource prometheusWipRules 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1562,7 +1562,7 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1590,7 +1590,7 @@ Please check the status of the Prometheus pods, service endpoints, and network c
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1620,7 +1620,7 @@ Investigate the health and performance of the remote storage endpoint, network l
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1663,7 +1663,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1688,7 +1688,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1713,7 +1713,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1738,7 +1738,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1763,7 +1763,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1801,7 +1801,7 @@ resource prometheusOperatorRules 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1826,7 +1826,7 @@ resource prometheusOperatorRules 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1864,7 +1864,7 @@ resource mise 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1902,7 +1902,7 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1927,7 +1927,7 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1952,7 +1952,7 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1990,7 +1990,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -2017,7 +2017,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -2043,7 +2043,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -2071,7 +2071,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -2097,7 +2097,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -2125,7 +2125,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -2164,7 +2164,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -2189,7 +2189,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -2214,7 +2214,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }

--- a/dev-infrastructure/modules/metrics/rules/msftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/msftPrometheusAlertingRules.bicep
@@ -17,7 +17,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -42,7 +42,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -67,7 +67,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -92,7 +92,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -117,7 +117,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -142,7 +142,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -167,7 +167,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -192,7 +192,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -230,7 +230,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -268,7 +268,7 @@ resource kubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -293,7 +293,7 @@ resource kubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -331,7 +331,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -358,7 +358,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -385,7 +385,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -412,7 +412,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -452,7 +452,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -477,7 +477,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -502,7 +502,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -526,7 +526,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -551,7 +551,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -576,7 +576,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -614,7 +614,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -639,7 +639,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -664,7 +664,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -689,7 +689,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -714,7 +714,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -739,7 +739,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -764,7 +764,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -788,7 +788,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -812,7 +812,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -836,7 +836,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -860,7 +860,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -885,7 +885,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -910,7 +910,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -948,7 +948,7 @@ resource kubernetesSystemScheduler 'Microsoft.AlertsManagement/prometheusRuleGro
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -986,7 +986,7 @@ resource kubernetesSystemControllerManager 'Microsoft.AlertsManagement/prometheu
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1024,7 +1024,7 @@ resource prometheusWipRules 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1052,7 +1052,7 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1080,7 +1080,7 @@ Please check the status of the Prometheus pods, service endpoints, and network c
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1110,7 +1110,7 @@ Investigate the health and performance of the remote storage endpoint, network l
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1153,7 +1153,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1178,7 +1178,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1203,7 +1203,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1228,7 +1228,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1253,7 +1253,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1291,7 +1291,7 @@ resource prometheusOperatorRules 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1316,7 +1316,7 @@ resource prometheusOperatorRules 'Microsoft.AlertsManagement/prometheusRuleGroup
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }
@@ -1354,7 +1354,7 @@ resource mise 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
           for g in actionGroups: {
             actionGroupId: g
             actionProperties: {
-              'IcM.Title': concat('#$.labels.cluster#', ': ', '#$.annotations.description#')
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
             }
           }

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -390,7 +390,7 @@ resource {{.name}} 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' 
         actions: [for g in actionGroups: {
           actionGroupId: g
           actionProperties: {
-            'IcM.Title': concat('#$.labels.cluster#',': ','#$.annotations.description#')
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
             'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
         }]

--- a/tooling/prometheus-rules/testdata/generated.bicep
+++ b/tooling/prometheus-rules/testdata/generated.bicep
@@ -14,7 +14,7 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         actions: [for g in actionGroups: {
           actionGroupId: g
           actionProperties: {
-            'IcM.Title': concat('#$.labels.cluster#',': ','#$.annotations.description#')
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
             'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
         }]
@@ -35,7 +35,7 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         actions: [for g in actionGroups: {
           actionGroupId: g
           actionProperties: {
-            'IcM.Title': concat('#$.labels.cluster#',': ','#$.annotations.description#')
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
             'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
         }]

--- a/tooling/prometheus-rules/testdata/generated_5m.bicep
+++ b/tooling/prometheus-rules/testdata/generated_5m.bicep
@@ -14,7 +14,7 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         actions: [for g in actionGroups: {
           actionGroupId: g
           actionProperties: {
-            'IcM.Title': concat('#$.labels.cluster#',': ','#$.annotations.description#')
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
             'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
         }]
@@ -35,7 +35,7 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         actions: [for g in actionGroups: {
           actionGroupId: g
           actionProperties: {
-            'IcM.Title': concat('#$.labels.cluster#',': ','#$.annotations.description#')
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.description#'
             'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
         }]


### PR DESCRIPTION
We are just concatenating literal strings, so we can do that manually, no need for `concat()`.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
