### PR TITLE
tooling/templatize: allow using an explicit record of sub ids

### DIFF
--- a/tooling/templatize/cmd/pipeline/inspect/options.go
+++ b/tooling/templatize/cmd/pipeline/inspect/options.go
@@ -86,7 +86,7 @@ func (o *RawInspectOptions) Validate(ctx context.Context) (*ValidatedInspectOpti
 		return nil, err
 	}
 
-	inspectScopes := pipeline.NewStepInspectScopes()
+	inspectScopes := pipeline.NewStepInspectScopes(map[string]string{})
 	if _, ok := inspectScopes[o.Scope]; !ok {
 		scopes := make([]string, 0, len(inspectScopes))
 		for scope := range inspectScopes {
@@ -129,7 +129,7 @@ func (o *InspectOptions) RunInspect(ctx context.Context) error {
 	return pipeline.Inspect(
 		o.PipelineOptions.Pipeline, ctx, &pipeline.InspectOptions{
 			Scope:          o.Scope,
-			ScopeFunctions: pipeline.NewStepInspectScopes(),
+			ScopeFunctions: pipeline.NewStepInspectScopes(o.PipelineOptions.RolloutOptions.Subscriptions),
 			Format:         o.Format,
 			Step:           o.PipelineOptions.Step,
 			Region:         o.PipelineOptions.RolloutOptions.Region,

--- a/tooling/templatize/cmd/pipeline/run/options.go
+++ b/tooling/templatize/cmd/pipeline/run/options.go
@@ -109,7 +109,7 @@ func (o *RunOptions) RunPipeline(ctx context.Context) error {
 		Configuration:            o.PipelineOptions.RolloutOptions.Config,
 		Region:                   o.PipelineOptions.RolloutOptions.Region,
 		Step:                     o.PipelineOptions.Step,
-		SubsciptionLookupFunc:    pipeline.LookupSubscriptionID,
+		SubsciptionLookupFunc:    pipeline.LookupSubscriptionID(o.PipelineOptions.RolloutOptions.Subscriptions),
 		NoPersist:                o.NoPersist,
 		DeploymentTimeoutSeconds: o.DeploymentTimeoutSeconds,
 		PipelineFilePath:         o.PipelineOptions.PipelineFilePath,

--- a/tooling/templatize/cmd/rolloutoptions.go
+++ b/tooling/templatize/cmd/rolloutoptions.go
@@ -82,6 +82,8 @@ type RawRolloutOptions struct {
 type validatedRolloutOptions struct {
 	*RawRolloutOptions
 	*ValidatedOptions
+
+	Subscriptions map[string]string
 }
 
 type ValidatedRolloutOptions struct {
@@ -91,8 +93,9 @@ type ValidatedRolloutOptions struct {
 
 type completedRolloutOptions struct {
 	*ValidatedRolloutOptions
-	Options *Options
-	Config  config.Configuration
+	Options       *Options
+	Config        config.Configuration
+	Subscriptions map[string]string
 }
 
 type RolloutOptions struct {
@@ -104,6 +107,7 @@ func (o *RawRolloutOptions) Validate(ctx context.Context) (*ValidatedRolloutOpti
 	if o.DevEnvironment != "" && o.DevSettingsFile == "" {
 		return nil, fmt.Errorf("developer environment %s chosen, but not --dev-settings-file provided", o.DevEnvironment)
 	}
+	var subscriptions map[string]string
 	if o.DevEnvironment != "" && o.DevSettingsFile != "" {
 		for name, value := range map[string]string{
 			"environment":       o.BaseOptions.DeployEnv,
@@ -138,6 +142,7 @@ func (o *RawRolloutOptions) Validate(ctx context.Context) (*ValidatedRolloutOpti
 		o.Region = region
 		o.RegionShortSuffix = env.RegionShortSuffix
 		o.Stamp = strconv.Itoa(env.Stamp)
+		subscriptions = devSettings.Subscriptions
 	}
 
 	validatedBaseOptions, err := o.BaseOptions.Validate()
@@ -149,6 +154,7 @@ func (o *RawRolloutOptions) Validate(ctx context.Context) (*ValidatedRolloutOpti
 		validatedRolloutOptions: &validatedRolloutOptions{
 			RawRolloutOptions: o,
 			ValidatedOptions:  validatedBaseOptions,
+			Subscriptions:     subscriptions,
 		},
 	}, nil
 }
@@ -205,6 +211,7 @@ func (o *ValidatedRolloutOptions) Complete() (*RolloutOptions, error) {
 			ValidatedRolloutOptions: o,
 			Options:                 completed,
 			Config:                  variables,
+			Subscriptions:           o.Subscriptions,
 		},
 	}, nil
 }

--- a/tooling/templatize/internal/end2end/e2e.go
+++ b/tooling/templatize/internal/end2end/e2e.go
@@ -131,7 +131,7 @@ func (e *e2eImpl) UseRandomRG() func() error {
 	e.config["defaults"] = asMap
 
 	return func() error {
-		subsriptionID, err := pipeline.LookupSubscriptionID(context.Background(), "ARO Hosted Control Planes (EA Subscription 1)")
+		subsriptionID, err := pipeline.LookupSubscriptionID(map[string]string{})(context.Background(), "ARO Hosted Control Planes (EA Subscription 1)")
 		if err != nil {
 			return err
 		}

--- a/tooling/templatize/internal/end2end/e2e_test.go
+++ b/tooling/templatize/internal/end2end/e2e_test.go
@@ -129,7 +129,7 @@ param zoneName = 'e2etestarmdeploy.foo.bar.example.com'
 	persistAndRun(t, e2eImpl)
 
 	// Todo move to e2e module, if needed more than once
-	subsriptionID, err := pipeline.LookupSubscriptionID(context.Background(), "ARO Hosted Control Planes (EA Subscription 1)")
+	subsriptionID, err := pipeline.LookupSubscriptionID(map[string]string{})(context.Background(), "ARO Hosted Control Planes (EA Subscription 1)")
 	require.NoError(t, err)
 
 	cred, err := azauth.GetAzureTokenCredentials()
@@ -329,7 +329,7 @@ resource newRG 'Microsoft.Resources/resourceGroups@2024-03-01' = {
 
 	persistAndRun(t, e2eImpl)
 
-	subsriptionID, err := pipeline.LookupSubscriptionID(context.Background(), "ARO Hosted Control Planes (EA Subscription 1)")
+	subsriptionID, err := pipeline.LookupSubscriptionID(map[string]string{})(context.Background(), "ARO Hosted Control Planes (EA Subscription 1)")
 	require.NoError(t, err)
 
 	cred, err := azauth.GetAzureTokenCredentials()
@@ -369,7 +369,7 @@ param zoneName = 'e2etestarmdeploy.foo.bar.example.com'
 
 	persistAndRun(t, e2eImpl)
 
-	subsriptionID, err := pipeline.LookupSubscriptionID(context.Background(), "ARO Hosted Control Planes (EA Subscription 1)")
+	subsriptionID, err := pipeline.LookupSubscriptionID(map[string]string{})(context.Background(), "ARO Hosted Control Planes (EA Subscription 1)")
 	require.NoError(t, err)
 
 	cred, err := azauth.GetAzureTokenCredentials()

--- a/tooling/templatize/pkg/pipeline/inspect_test.go
+++ b/tooling/templatize/pkg/pipeline/inspect_test.go
@@ -111,7 +111,7 @@ func TestInspectVars(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			buf := new(bytes.Buffer)
 			tc.options.OutputFile = buf
-			err := inspectVars(context.Background(), &types.Pipeline{}, tc.caseStep, tc.options)
+			err := inspectVars(map[string]string{})(context.Background(), &types.Pipeline{}, tc.caseStep, tc.options)
 			if tc.err == "" {
 				assert.NoError(t, err)
 				assert.Equal(t, buf.String(), tc.expected)

--- a/tooling/templatize/pkg/settings/settings.go
+++ b/tooling/templatize/pkg/settings/settings.go
@@ -26,6 +26,8 @@ import (
 
 type Settings struct {
 	Environments []Environment `json:"environments"`
+	// Subscriptions holds a mapping of subscription key to the subscription ID.
+	Subscriptions map[string]string `json:"subscriptions"`
 }
 
 type Environment struct {


### PR DESCRIPTION
The existing lookup logic for subscription IDs is clever - in the development config, we use the subscription display name as the 'key' for Ev2, since Ev2 never touches these anyway. However, when trying to use the local runner to target actual subscriptions known to Ev2 with a real key, no longer will the display name of the subscription be the same as the 'key' in our config. We can expose a literal mapping of subscription key to ID in the dev settings file, though, as this set changes infrequently and is well-known. Then, the lookup is simple.
