### PR TITLE
api: don't set max length on disk encryption set id

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -636,7 +636,6 @@ model OsDiskProfile {
    * https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-customer-managed-keys-portal#set-up-your-disk-encryption-set
    */
   @visibility(Lifecycle.Read, Lifecycle.Create)
-  @maxLength(285)
   encryptionSetId?: DiskEncryptionSetResourceId;
 }
 

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -3089,7 +3089,6 @@
         "encryptionSetId": {
           "$ref": "#/definitions/DiskEncryptionSetResourceId",
           "description": "The ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs.\nThis needs to exist in the same subscription id listed in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.SubscriptionID.\nDiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location\nlisted in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.Location.\n\nDetails on how to create a Disk Encryption Set can be found here:\nhttps://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-customer-managed-keys-portal#set-up-your-disk-encryption-set",
-          "maxLength": 285,
           "x-ms-mutability": [
             "read",
             "create"


### PR DESCRIPTION
### What

It doens't make sense to set a length on a resourceID.  It will actually fail schema validation if you attempt to validate it.  

### Why

Can't use aaz-dev to generate python models.
### Special notes for your reviewer

<!-- optional -->
