### PR TITLE
tooling: Check for cluster permissions before assignment

### DIFF
--- a/tooling/templatize/pkg/aks/admin.go
+++ b/tooling/templatize/pkg/aks/admin.go
@@ -57,6 +57,12 @@ func EnsureClusterAdmin(ctx context.Context, kubeconfigPath, subscriptionID, res
 		return fmt.Errorf("failed to get current user object ID: %w", err)
 	}
 
+	// Check for permissions before assignment
+	err = CheckClusterAdminPermissions(ctx, kubeconfigPath)
+	if err == nil {
+		return nil
+	}
+
 	// Assign the Azure Kubernetes Service RBAC Cluster Admin role to the current user
 	err = assignClusterAdminRBACRole(ctx, subscriptionID, resourceGroupName, aksClusterName, userObjectID, clusterAdminRoleID)
 	if err != nil {

--- a/tooling/templatize/pkg/aks/admin.go
+++ b/tooling/templatize/pkg/aks/admin.go
@@ -180,8 +180,7 @@ func assignClusterAdminRBACRole(ctx context.Context, subscriptionID, resourceGro
 		if errors.As(err, &respErr) && respErr.ErrorCode == "RoleAssignmentExists" {
 			// we could check if the roleassignment exists upfront but even when
 			// the role exists, checking for it is not always reliably detect it
-			// so there is no point why we should check. all our users have
-			// permissions to create such role assignments anyways
+			// so there is no point why we should check.
 			return nil
 		}
 		return fmt.Errorf("failed to create role assignment: %w", err)


### PR DESCRIPTION
### What

Check for cluster permissions before assigning the admin role

### Why

Users on our team have cluster admin permissions, but they don't have permissions to assign cluster admin permissions. 

### Special notes for your reviewer

Being able to get a kubeconfig and list pods in the default namespace doesn't necessarily mean that the user has admin permissions. If it's a typical case that a user would have reader permissions for example, I can change this to try to assign the permission first and fall back on checking cluster perms even if that fails.
