### PR TITLE
set PremiumV2 as default storage class and update hcp cluster sizing configuration

### DIFF
--- a/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
+++ b/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
@@ -2,7 +2,6 @@ apiVersion: scheduling.hypershift.openshift.io/v1alpha1
 kind: ClusterSizingConfiguration
 metadata:
   name: cluster
-  namespace: default
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "2"
@@ -191,5 +190,5 @@ spec:
         memory: 2Gi
     name: xxlarge
   transitionDelay:
-    decrease: 0s
+    decrease: 20m
     increase: 0s

--- a/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
+++ b/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
@@ -1,0 +1,195 @@
+apiVersion: scheduling.hypershift.openshift.io/v1alpha1
+kind: ClusterSizingConfiguration
+metadata:
+  name: cluster
+  namespace: default
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "2"
+spec:
+  concurrency:
+    limit: 5
+    slidingWindow: 0s
+  sizes:
+  - criteria:
+      from: 0
+      to: 60
+    effects:
+      maximumMutatingRequestsInflight: 50
+      maximumRequestsInflight: 150
+      resourceRequests:
+      - containerName: kube-apiserver
+        deploymentName: kube-apiserver
+        memory: 8Gi
+      - containerName: openshift-controller-manager
+        deploymentName: openshift-controller-manager
+        memory: 1Gi
+      - containerName: cluster-policy-controller
+        deploymentName: cluster-policy-controller
+        memory: 1Gi
+      - containerName: kube-controller-manager
+        deploymentName: kube-controller-manager
+        memory: 1Gi
+      - containerName: openshift-apiserver
+        deploymentName: openshift-apiserver
+        memory: 1Gi
+      - containerName: etcd
+        deploymentName: etcd
+        memory: 1Gi
+      - containerName: ovnkube-control-plane
+        deploymentName: ovnkube-control-plane
+        memory: 500Mi
+    name: small
+  - criteria:
+      from: 61
+      to: 120
+    effects:
+      kasGoMemLimit: 12GiB
+      maximumMutatingRequestsInflight: 300
+      maximumRequestsInflight: 900
+      resourceRequests:
+      - containerName: kube-apiserver
+        deploymentName: kube-apiserver
+        memory: 16Gi
+      - containerName: openshift-controller-manager
+        deploymentName: openshift-controller-manager
+        memory: 2Gi
+      - containerName: cluster-policy-controller
+        deploymentName: cluster-policy-controller
+        memory: 2Gi
+      - containerName: kube-controller-manager
+        deploymentName: kube-controller-manager
+        memory: 2Gi
+      - containerName: cluster-autoscaler
+        deploymentName: cluster-autoscaler
+        memory: 2Gi
+      - containerName: openshift-apiserver
+        deploymentName: openshift-apiserver
+        memory: 1Gi
+      - containerName: etcd
+        deploymentName: etcd
+        memory: 1Gi
+      - containerName: kube-scheduler
+        deploymentName: kube-scheduler
+        memory: 1Gi
+      - containerName: ovnkube-control-plane
+        deploymentName: ovnkube-control-plane
+        memory: 500Mi
+    name: medium
+  - criteria:
+      from: 121
+      to: 252
+    effects:
+      kasGoMemLimit: 24GiB
+      maximumMutatingRequestsInflight: 400
+      maximumRequestsInflight: 1200
+      resourceRequests:
+      - containerName: kube-apiserver
+        deploymentName: kube-apiserver
+        memory: 32Gi
+      - containerName: openshift-controller-manager
+        deploymentName: openshift-controller-manager
+        memory: 3Gi        
+      - containerName: cluster-policy-controller
+        deploymentName: cluster-policy-controller
+        memory: 2Gi
+      - containerName: kube-controller-manager
+        deploymentName: kube-controller-manager
+        memory: 2Gi
+      - containerName: cluster-autoscaler
+        deploymentName: cluster-autoscaler
+        memory: 4Gi        
+      - containerName: openshift-apiserver
+        deploymentName: openshift-apiserver
+        memory: 2Gi
+      - containerName: etcd
+        deploymentName: etcd
+        memory: 2Gi
+      - containerName: kube-scheduler
+        deploymentName: kube-scheduler
+        memory: 2Gi
+      - containerName: multus-admission-controller
+        deploymentName: multus-admission-controller
+        memory: 1Gi
+      - containerName: ovnkube-control-plane
+        deploymentName: ovnkube-control-plane
+        memory: 1Gi        
+    name: large
+  - criteria:
+      from: 253
+      to: 360
+    effects:
+      kasGoMemLimit: 48GiB
+      maximumMutatingRequestsInflight: 600
+      maximumRequestsInflight: 2400
+      resourceRequests:
+      - containerName: kube-apiserver
+        deploymentName: kube-apiserver
+        memory: 64Gi
+      - containerName: openshift-controller-manager
+        deploymentName: openshift-controller-manager
+        memory: 6Gi
+      - containerName: cluster-policy-controller
+        deploymentName: cluster-policy-controller
+        memory: 6Gi
+      - containerName: kube-controller-manager
+        deploymentName: kube-controller-manager
+        memory: 6Gi
+      - containerName: openshift-apiserver
+        deploymentName: openshift-apiserver
+        memory: 8Gi
+      - containerName: cluster-autoscaler
+        deploymentName: cluster-autoscaler
+        memory: 6Gi        
+      - containerName: etcd
+        deploymentName: etcd
+        memory: 2Gi
+      - containerName: kube-scheduler
+        deploymentName: kube-scheduler
+        memory: 3Gi
+      - containerName: multus-admission-controller
+        deploymentName: multus-admission-controller
+        memory: 2Gi
+      - containerName: ovnkube-control-plane
+        deploymentName: ovnkube-control-plane
+        memory: 2Gi
+    name: xlarge        
+  - criteria:
+      from: 361
+    effects:      
+      kasGoMemLimit: 72GiB
+      resourceRequests:
+      - containerName: kube-apiserver
+        deploymentName: kube-apiserver
+        memory: 96Gi
+      - containerName: openshift-controller-manager
+        deploymentName: openshift-controller-manager
+        memory: 8Gi
+      - containerName: cluster-policy-controller
+        deploymentName: cluster-policy-controller
+        memory: 8Gi
+      - containerName: kube-controller-manager
+        deploymentName: kube-controller-manager
+        memory: 8Gi
+      - containerName: openshift-apiserver
+        deploymentName: openshift-apiserver
+        memory: 8Gi
+      - containerName: cluster-autoscaler
+        deploymentName: cluster-autoscaler
+        memory: 12Gi
+      - containerName: etcd
+        deploymentName: etcd
+        memory: 3Gi
+      - containerName: kube-scheduler
+        deploymentName: kube-scheduler
+        memory: 6Gi
+      - containerName: multus-admission-controller
+        deploymentName: multus-admission-controller
+        memory: 3Gi
+      - containerName: ovnkube-control-plane
+        deploymentName: ovnkube-control-plane
+        memory: 2Gi        
+    name: xxlarge
+  transitionDelay:
+    decrease: 0s
+    increase: 0s

--- a/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
+++ b/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
@@ -89,7 +89,7 @@ spec:
         memory: 32Gi
       - containerName: openshift-controller-manager
         deploymentName: openshift-controller-manager
-        memory: 3Gi        
+        memory: 3Gi
       - containerName: cluster-policy-controller
         deploymentName: cluster-policy-controller
         memory: 2Gi
@@ -98,7 +98,7 @@ spec:
         memory: 2Gi
       - containerName: cluster-autoscaler
         deploymentName: cluster-autoscaler
-        memory: 4Gi        
+        memory: 4Gi
       - containerName: openshift-apiserver
         deploymentName: openshift-apiserver
         memory: 2Gi
@@ -113,7 +113,7 @@ spec:
         memory: 1Gi
       - containerName: ovnkube-control-plane
         deploymentName: ovnkube-control-plane
-        memory: 1Gi        
+        memory: 1Gi
     name: large
   - criteria:
       from: 253
@@ -140,7 +140,7 @@ spec:
         memory: 8Gi
       - containerName: cluster-autoscaler
         deploymentName: cluster-autoscaler
-        memory: 6Gi        
+        memory: 6Gi
       - containerName: etcd
         deploymentName: etcd
         memory: 2Gi
@@ -153,10 +153,10 @@ spec:
       - containerName: ovnkube-control-plane
         deploymentName: ovnkube-control-plane
         memory: 2Gi
-    name: xlarge        
+    name: xlarge
   - criteria:
       from: 361
-    effects:      
+    effects:
       kasGoMemLimit: 72GiB
       resourceRequests:
       - containerName: kube-apiserver
@@ -188,7 +188,7 @@ spec:
         memory: 3Gi
       - containerName: ovnkube-control-plane
         deploymentName: ovnkube-control-plane
-        memory: 2Gi        
+        memory: 2Gi
     name: xxlarge
   transitionDelay:
     decrease: 0s

--- a/mgmt-fixes/Makefile
+++ b/mgmt-fixes/Makefile
@@ -11,6 +11,9 @@ deploy:
 
 	@kubectl create namespace aro-hcp-mitigations --dry-run=client -o json | kubectl apply -f - && \
 	../hack/helm.sh mitigations deploy/mitigations aro-hcp-mitigations
+
+	@kubectl annotate storageclass default storageclass.kubernetes.io/is-default-class-
+	../hack/helm.sh default-sc deploy/default-sc default
 .PHONY: deploy
 
 

--- a/mgmt-fixes/deploy/default-sc/Chart.yaml
+++ b/mgmt-fixes/deploy/default-sc/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: DefaultStorageClass
+description: Deploys PremiumV2 storage class
+version: 0.1.0
+appVersion: "0.1.0"

--- a/mgmt-fixes/deploy/default-sc/templates/managed-csi-premiumv2.storageclass.yaml
+++ b/mgmt-fixes/deploy/default-sc/templates/managed-csi-premiumv2.storageclass.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/mgmt-fixes/deploy/default-sc/templates/managed-csi-premiumv2.storageclass.yaml
+++ b/mgmt-fixes/deploy/default-sc/templates/managed-csi-premiumv2.storageclass.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  name: managed-csi-premiumv2
+parameters:
+  skuname: PremiumV2_LRS
+provisioner: disk.csi.azure.com
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-20208
https://issues.redhat.com/browse/ARO-20114

### What
- set default storage class to PremiumV2
- override default ClusterSizingConfiguration

### Why
Storage for HCPs, the use of Azure Premiumv2 Storage SKU is highly recommended. This is particularly important for ETCD, which lowers disk latency and increases performance and responsiveness.

Introduce a custom ClusterSizingConfiguration (CSC) for ARO-HCP, derived from recent performance and scale testing conducted on self-managed clusters. Based on these results, the team has defined this CSC as the minimal control plane resource sizing required to ensure a performant HCP. The configuration dynamically adjusts based on cluster size (node count) and is initially categorized into five baseline sizing tiers. This configuration can be further refined or tuned based on real-time performance metrics observed in the Managed Cluster.

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

Default storage class:
```
k get storageclass
NAME                              PROVISIONER          RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
azurefile                         file.csi.azure.com   Delete          Immediate              true                   3h50m
azurefile-csi                     file.csi.azure.com   Delete          Immediate              true                   3h50m
azurefile-csi-premium             file.csi.azure.com   Delete          Immediate              true                   3h50m
azurefile-premium                 file.csi.azure.com   Delete          Immediate              true                   3h50m
default                           disk.csi.azure.com   Delete          WaitForFirstConsumer   true                   3h50m
managed                           disk.csi.azure.com   Delete          WaitForFirstConsumer   true                   3h50m
managed-csi                       disk.csi.azure.com   Delete          WaitForFirstConsumer   true                   3h50m
managed-csi-premium               disk.csi.azure.com   Delete          WaitForFirstConsumer   true                   3h50m
managed-csi-premiumv2 (default)   disk.csi.azure.com   Delete          WaitForFirstConsumer   true                   3h20m
managed-premium                   disk.csi.azure.com   Delete          WaitForFirstConsumer   true                   3h50m
```

ClusterSizingConfiguration is in effect, hosted cluster has proper annotations

```
      resource-request-override.hypershift.openshift.io/cluster-policy-controller.cluster-policy-controller: memory=1Gi
      resource-request-override.hypershift.openshift.io/etcd.etcd: memory=1Gi
      resource-request-override.hypershift.openshift.io/kube-apiserver.kube-apiserver: memory=8Gi
      resource-request-override.hypershift.openshift.io/kube-controller-manager.kube-controller-manager: memory=1Gi
      resource-request-override.hypershift.openshift.io/openshift-apiserver.openshift-apiserver: memory=1Gi
      resource-request-override.hypershift.openshift.io/openshift-controller-manager.openshift-controller-manager: memory=1Gi
      resource-request-override.hypershift.openshift.io/ovnkube-control-plane.ovnkube-control-plane: memory=500Mi
```
<!-- optional -->
