### PR TITLE
e2e: fix bug in constructing the armresources client factory

### DIFF
--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -348,7 +348,7 @@ func (tc *perItOrDescribeTestContext) getARMSubscriptionsClientFactoryUnlocked()
 
 func (tc *perItOrDescribeTestContext) GetARMResourcesClientFactory(ctx context.Context) (*armresources.ClientFactory, error) {
 	tc.contextLock.RLock()
-	if tc.clientFactory20240610 != nil {
+	if tc.armResourcesClientFactory != nil {
 		defer tc.contextLock.RUnlock()
 		return tc.armResourcesClientFactory, nil
 	}


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

The client factory incorrectly checks the wrong internal var being `nil` in armresources client factory construction.  
### Why

Tests that do not instantiate the armresources client factory before the hcpCluster client factory will fail without this change.  

### Special notes for your reviewer
