### PR TITLE
chore: bump cs version to d089fd8 in integrated dev

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -730,7 +730,7 @@ clouds:
       clustersService:
         environment: "arohcpdev"
         image:
-          digest: sha256:a839e8fa1dfa14e9ba04a2ac192f32f5b8864af147ec5d9a6fa80a9c2c933cab
+          digest: sha256:48023c736c4479b22dc6b9416c7f25724a98952d883451a4d76f65dffeefaf3d
         # NOTE: The role names must not include commas(,) in the name as the roleNames field
         # here is a comma separated list of role definition names.
         azureOperatorsManagedIdentities:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: ec83390fe3a2a573090c0e85bd90dedcbb395b7fc043103a4f9861786c171807
+          westus3: 4d600e733e1144b2a9cd018e31ce15d7ff36b37ffe78a5369e61a7d05813cae0
       dev:
         regions:
-          westus3: 52f960d3fbd0b865bbabf1f535e0e0fa7ac01b073707abb2d9b5469a0b8524a0
+          westus3: ae761360479a236b59f36a2005510fba4a23d39bf1190747ef4b65d702d2c1e7
       ntly:
         regions:
-          uksouth: a5777b059dd18b30140aa5733f4796daaf157ed534b77aa781c31b59d6064149
+          uksouth: 16a8e3cd5c9991ec944aa52fe8071a869f3a4d72fead8a15380eeff7910df79a
       perf:
         regions:
-          westus3: 96b42b97510eaf157ee509a0d25bf570de80f6a5c23fa2e3bd03f88e3e880641
+          westus3: 4a83ec9df2a3fb64476f6ad64b79f325627e0b5e61d8948ad8939992fd7321d1
       pers:
         regions:
-          westus3: c18c696a0ce41a7482794e9d3ce31e8cddfd54cfef02a641311ba6153b5e1e89
+          westus3: 9dbd7960ae659cffa3da789c160cd17c203fb8615d5415ce4688c48dbc681bf2
       swft:
         regions:
-          uksouth: c93eae35c81572d8d241a6c327aa35f6606e89597358dc683bf9c4b5e5e944e2
+          uksouth: 0226013a9ce3daec4bd0f63b0afa3ccc758f43a8f491d0ab87448166d7d0136e

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:a839e8fa1dfa14e9ba04a2ac192f32f5b8864af147ec5d9a6fa80a9c2c933cab
+    digest: sha256:48023c736c4479b22dc6b9416c7f25724a98952d883451a4d76f65dffeefaf3d
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:a839e8fa1dfa14e9ba04a2ac192f32f5b8864af147ec5d9a6fa80a9c2c933cab
+    digest: sha256:48023c736c4479b22dc6b9416c7f25724a98952d883451a4d76f65dffeefaf3d
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:a839e8fa1dfa14e9ba04a2ac192f32f5b8864af147ec5d9a6fa80a9c2c933cab
+    digest: sha256:48023c736c4479b22dc6b9416c7f25724a98952d883451a4d76f65dffeefaf3d
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:a839e8fa1dfa14e9ba04a2ac192f32f5b8864af147ec5d9a6fa80a9c2c933cab
+    digest: sha256:48023c736c4479b22dc6b9416c7f25724a98952d883451a4d76f65dffeefaf3d
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:a839e8fa1dfa14e9ba04a2ac192f32f5b8864af147ec5d9a6fa80a9c2c933cab
+    digest: sha256:48023c736c4479b22dc6b9416c7f25724a98952d883451a4d76f65dffeefaf3d
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -113,7 +113,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:a839e8fa1dfa14e9ba04a2ac192f32f5b8864af147ec5d9a6fa80a9c2c933cab
+    digest: sha256:48023c736c4479b22dc6b9416c7f25724a98952d883451a4d76f65dffeefaf3d
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:


### PR DESCRIPTION
### What
Bumps cs version to [d089fd8](https://quay.io/repository/app-sre/uhc-clusters-service/manifest/sha256:48023c736c4479b22dc6b9416c7f25724a98952d883451a4d76f65dffeefaf3d) in integrated dev

Changes included: [76f0c38...d089fd8](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/compare/76f0c38...d089fd8)

### Why
Bumping cs to latest version in integrated dev

### Special notes for your reviewer
N/A
