### PR TITLE
Bump helm to latest (v3.18.6)

### DIFF
--- a/.github/workflows/aro-hcp-dev-what-if.yml
+++ b/.github/workflows/aro-hcp-dev-what-if.yml
@@ -32,7 +32,7 @@ jobs:
         fetch-depth: 1
     - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
       with:
-        version: 'v3.13.3'
+        version: 'v3.18.6'
     - name: 'Install helm diff'
       run: |
         helm plugin install https://github.com/databus23/helm-diff

--- a/.github/workflows/cs-pr-what-if.yml
+++ b/.github/workflows/cs-pr-what-if.yml
@@ -29,7 +29,7 @@ jobs:
         fetch-depth: 1
     - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
       with:
-        version: 'v3.13.3'
+        version: 'v3.18.6'
     - name: 'Install helm diff'
       run: |
         helm plugin install https://github.com/databus23/helm-diff

--- a/.github/workflows/environment-infra-cd.yml
+++ b/.github/workflows/environment-infra-cd.yml
@@ -147,7 +147,7 @@ jobs:
         fetch-depth: 1
     - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
       with:
-        version: 'v3.13.3'
+        version: 'v3.18.6'
     - name: 'Install helm diff'
       run: |
         helm plugin install https://github.com/databus23/helm-diff

--- a/.github/workflows/services-cd.yml
+++ b/.github/workflows/services-cd.yml
@@ -60,7 +60,7 @@ jobs:
     # Used to deploy Maestro Server, Frontend
     - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
       with:
-        version: 'v3.13.3'
+        version: 'v3.18.6'
     - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
       with:
         kubelogin-version: 'v0.1.3'
@@ -121,7 +121,7 @@ jobs:
         version: 1.2.3
     - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
       with:
-        version: 'v3.13.3'
+        version: 'v3.18.6'
     # Prepare kubeconfig
     - name: 'Prepare kubeconfig'
       run: |

--- a/.github/workflows/services-pr-check.yml
+++ b/.github/workflows/services-pr-check.yml
@@ -56,7 +56,7 @@ jobs:
     # Used to deploy Maestro Server, Frontend
     - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
       with:
-        version: 'v3.13.3'
+        version: 'v3.18.6'
     - uses: oras-project/setup-oras@v1
       with:
         version: 1.2.3
@@ -102,7 +102,7 @@ jobs:
     # Used to deploy Maestro Server, Frontend
     - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
       with:
-        version: 'v3.13.3'
+        version: 'v3.18.6'
     - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
       with:
         kubelogin-version: 'v0.1.3'


### PR DESCRIPTION
We've been running a way too old version.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

We're hitting compatibility issues at this point and there's no chance MS is running this old a version in ev2 (which we should be matching).

### Special notes for your reviewer

<!-- optional -->
