### PR TITLE
frontend: Stop logging /healthz requests

### DIFF
--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -79,58 +79,6 @@ func newClusterInternalID(t *testing.T) ocm.InternalID {
 	return internalID
 }
 
-func TestReadiness(t *testing.T) {
-	tests := []struct {
-		name               string
-		ready              bool
-		expectedStatusCode int
-	}{
-		{
-			name:               "Not ready - returns 500",
-			ready:              false,
-			expectedStatusCode: http.StatusInternalServerError,
-		},
-		{
-			name:               "Ready - returns 200",
-			ready:              true,
-			expectedStatusCode: http.StatusOK,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			mockDBClient := mocks.NewMockDBClient(ctrl)
-			reg := prometheus.NewRegistry()
-
-			f := NewFrontend(
-				api.NewTestLogger(),
-				nil,
-				nil,
-				reg,
-				mockDBClient,
-				nil,
-				newNoopAuditClient(t),
-			)
-			f.ready.Store(test.ready)
-
-			mockDBClient.EXPECT().DBConnectionTest(gomock.Any())
-
-			ts := newHTTPServer(f, ctrl, mockDBClient, nil)
-
-			rs, err := ts.Client().Get(ts.URL + "/healthz")
-			require.NoError(t, err)
-			require.Equal(t, test.expectedStatusCode, rs.StatusCode)
-
-			lintMetrics(t, reg)
-
-			got, err := testutil.GatherAndCount(reg, healthGaugeName)
-			require.NoError(t, err)
-			assert.Equal(t, 1, got)
-		})
-	}
-}
-
 func TestSubscriptionsGET(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -59,11 +59,11 @@ func MuxPattern(method string, segments ...string) string {
 	return fmt.Sprintf("%s /%s", method, strings.ToLower(path.Join(segments...)))
 }
 
-func (f *Frontend) routes(r prometheus.Registerer) *MiddlewareMux {
+func (f *Frontend) routes(r prometheus.Registerer) http.Handler {
 	// Setup metrics middleware
 	metricsMiddleware := NewMetricsMiddleware(r, f.collector)
 
-	mux := NewMiddlewareMux(
+	middlewareMux := NewMiddlewareMux(
 		MiddlewarePanic,
 		MiddlewareReferer,
 		metricsMiddleware.Metrics(),
@@ -82,28 +82,28 @@ func (f *Frontend) routes(r prometheus.Registerer) *MiddlewareMux {
 	)
 
 	// Miscellaneous routes
-	mux.HandleFunc("/", f.NotFound)
-	mux.HandleFunc(MuxPattern(http.MethodGet, "healthz"), f.Healthz)
-	mux.HandleFunc(MuxPattern(http.MethodGet, "location"), f.Location)
+	middlewareMux.HandleFunc("/", f.NotFound)
+	middlewareMux.HandleFunc(MuxPattern(http.MethodGet, "healthz"), f.Healthz)
+	middlewareMux.HandleFunc(MuxPattern(http.MethodGet, "location"), f.Location)
 
 	// Resource list endpoints
 	postMuxMiddleware := NewMiddleware(
 		MiddlewareLoggingPostMux,
 		MiddlewareValidateAPIVersion,
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders, api.ClusterResourceTypeName),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceList))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, api.ClusterResourceTypeName),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceList))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, api.NodePoolResourceTypeName),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceList))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, api.ExternalAuthResourceTypeName),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceList))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders, PatternLocations, api.VersionResourceTypeName),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceList))
 
@@ -113,16 +113,16 @@ func (f *Frontend) routes(r prometheus.Registerer) *MiddlewareMux {
 		MiddlewareLoggingPostMux,
 		MiddlewareValidateAPIVersion,
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceRead))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, PatternNodePools),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceRead))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders, PatternLocations, PatternVersions),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceRead))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, PatternExternalAuth),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceRead))
 
@@ -133,37 +133,37 @@ func (f *Frontend) routes(r prometheus.Registerer) *MiddlewareMux {
 		MiddlewareValidateAPIVersion,
 		newMiddlewareLockSubscription(f.dbClient).handleRequest,
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodPut, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
 		postMuxMiddleware.HandlerFunc(f.CreateOrUpdateHCPCluster))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodPatch, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
 		postMuxMiddleware.HandlerFunc(f.CreateOrUpdateHCPCluster))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodDelete, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceDelete))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodPost, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, ActionRequestAdminCredential),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceActionRequestAdminCredential))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodPost, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, ActionRevokeCredentials),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceActionRevokeCredentials))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodPut, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, PatternNodePools),
 		postMuxMiddleware.HandlerFunc(f.CreateOrUpdateNodePool))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodPatch, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, PatternNodePools),
 		postMuxMiddleware.HandlerFunc(f.CreateOrUpdateNodePool))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodDelete, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, PatternNodePools),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceDelete))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodPut, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, PatternExternalAuth),
 		postMuxMiddleware.HandlerFunc(f.CreateOrUpdateExternalAuth))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodPatch, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, PatternExternalAuth),
 		postMuxMiddleware.HandlerFunc(f.CreateOrUpdateExternalAuth))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodDelete, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, PatternExternalAuth),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceDelete))
 
@@ -173,10 +173,10 @@ func (f *Frontend) routes(r prometheus.Registerer) *MiddlewareMux {
 		MiddlewareLoggingPostMux,
 		MiddlewareValidateAPIVersion,
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders, PatternLocations, PatternOperationResults),
 		postMuxMiddleware.HandlerFunc(f.OperationResult))
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders, PatternLocations, PatternOperationStatuses),
 		postMuxMiddleware.HandlerFunc(f.OperationStatus))
 	// Exclude ARO-HCP API version validation for the following endpoints defined by ARM.
@@ -185,14 +185,14 @@ func (f *Frontend) routes(r prometheus.Registerer) *MiddlewareMux {
 	postMuxMiddleware = NewMiddleware(
 		MiddlewareResourceID,
 		MiddlewareLoggingPostMux)
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions),
 		postMuxMiddleware.HandlerFunc(f.ArmSubscriptionGet))
 	postMuxMiddleware = NewMiddleware(
 		MiddlewareResourceID,
 		MiddlewareLoggingPostMux,
 		newMiddlewareLockSubscription(f.dbClient).handleRequest)
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodPut, PatternSubscriptions),
 		postMuxMiddleware.HandlerFunc(f.ArmSubscriptionPut))
 
@@ -200,14 +200,14 @@ func (f *Frontend) routes(r prometheus.Registerer) *MiddlewareMux {
 	postMuxMiddleware = NewMiddleware(
 		MiddlewareLoggingPostMux,
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
-	mux.Handle(
+	middlewareMux.Handle(
 		MuxPattern(http.MethodPost, PatternSubscriptions, PatternResourceGroups, "providers", api.ProviderNamespace, PatternDeployments, "preflight"),
 		postMuxMiddleware.HandlerFunc(f.ArmDeploymentPreflight))
 
-	return mux
+	return middlewareMux
 }
 
-func (f *Frontend) metricsRoutes() *http.ServeMux {
+func (f *Frontend) metricsRoutes() http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("GET /metrics", promhttp.Handler())
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -91,9 +91,6 @@ type DBClientListActiveOperationDocsOptions struct {
 // DBClient provides a customized interface to the Cosmos DB containers used by the
 // ARO-HCP resource provider.
 type DBClient interface {
-	// DBConnectionTest verifies the database is reachable. Intended for use in health checks.
-	DBConnectionTest(ctx context.Context) error
-
 	// GetLockClient returns a LockClient, or nil if the DBClient does not support a LockClient.
 	GetLockClient() LockClientInterface
 
@@ -223,14 +220,6 @@ func NewDBClient(ctx context.Context, database *azcosmos.DatabaseClient) (DBClie
 		resources:  resources,
 		lockClient: lockClient,
 	}, nil
-}
-
-func (d *cosmosDBClient) DBConnectionTest(ctx context.Context) error {
-	if _, err := d.database.Read(ctx, nil); err != nil {
-		return fmt.Errorf("failed to read Cosmos database information during healthcheck: %v", err)
-	}
-
-	return nil
 }
 
 func (d *cosmosDBClient) GetLockClient() LockClientInterface {

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -298,44 +298,6 @@ func (c *MockDBClientCreateSubscriptionDocCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
-// DBConnectionTest mocks base method.
-func (m *MockDBClient) DBConnectionTest(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DBConnectionTest", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DBConnectionTest indicates an expected call of DBConnectionTest.
-func (mr *MockDBClientMockRecorder) DBConnectionTest(ctx any) *MockDBClientDBConnectionTestCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DBConnectionTest", reflect.TypeOf((*MockDBClient)(nil).DBConnectionTest), ctx)
-	return &MockDBClientDBConnectionTestCall{Call: call}
-}
-
-// MockDBClientDBConnectionTestCall wrap *gomock.Call
-type MockDBClientDBConnectionTestCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockDBClientDBConnectionTestCall) Return(arg0 error) *MockDBClientDBConnectionTestCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockDBClientDBConnectionTestCall) Do(f func(context.Context) error) *MockDBClientDBConnectionTestCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDBClientDBConnectionTestCall) DoAndReturn(f func(context.Context) error) *MockDBClientDBConnectionTestCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // DeleteResourceDoc mocks base method.
 func (m *MockDBClient) DeleteResourceDoc(ctx context.Context, resourceID *arm0.ResourceID) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### What

In the spirit of @petrkotas's LogLight project, let's stop logging every `/healthz` request.  They just clog up frontend logs and force SREs to have to filter them out in their Kusto queries.

We have a Prometheus gauge named `"frontend_health"` that's emitted from the `/healthz` handler.  That should suffice for tracking frontend pod health, at least until we have `kubelet` logs.

I also simplified the `/healthz` handler to correct a [long-standing misbehavior](https://github.com/Azure/ARO-HCP/pull/529): we no longer factor database connectivity into our `/healthz` response.  If we're alive and we're able to respond then we're healthy.  Period.