### PR TITLE
database: Fix Cosmos DB query syntax error

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -575,7 +575,7 @@ func (d *cosmosDBClient) ListActiveOperationDocs(pk azcosmos.PartitionKey, optio
 
 	if options != nil {
 		if options.Request != nil {
-			query += " AND c.properties.request == @request"
+			query += " AND c.properties.request = @request"
 			queryParameter := azcosmos.QueryParameter{
 				Name:  "@request",
 				Value: string(*options.Request),


### PR DESCRIPTION
[ARO-21043 - requestAdminCredential API request fails with InternalServerError](https://issues.redhat.com/browse/ARO-21043)

### What

Equality operator is '=' not '=='. This syntax error has been [present since April](https://github.com/Azure/ARO-HCP/commit/020209e3bf) and Cosmos DB tolerated it until recently.