### PR TITLE
typo: Fix namespace for clusters-service port-forward command

### DIFF
--- a/docs/personal-dev.md
+++ b/docs/personal-dev.md
@@ -100,7 +100,7 @@ The cluster in personal DEV have no reachable ingress. To interact with the serv
 
   ```bash
   kubectl port-forward svc/aro-hcp-frontend 8443:8443 -n aro-hcp
-  kubectl port-forward svc/clusters-service 8000:8000 -n cluster-service
+  kubectl port-forward svc/clusters-service 8000:8000 -n clusters-service
   kubectl port-forward svc/maestro 8001:8000 -n maestro
   kubectl port-forward svc/maestro-grpc 8090 -n maestro
   ```


### PR DESCRIPTION
### What

Fixes a typo in the cluster service port forward.

### Why

The documented comman points to an unexisting service.
