### PR TITLE
update hypershift-operator image to latest available in dev envs

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -759,7 +759,7 @@ clouds:
         image:
           registry: quay.io
           repository: acm-d/rhtap-hypershift-operator
-          digest: sha256:97fa6698d24c4a18e2d50aa1df51191d8c55099059e149f43a74940831f8591b
+          digest: sha256:6e58c196dc6175a60146d6f4660bda181203a0e1054de09015cc67841238c99b
       # Backplane API
       backplaneAPI:
         image:
@@ -957,7 +957,7 @@ clouds:
             image:
               registry: quay.io
               repository: acm-d/rhtap-hypershift-operator
-              digest: sha256:97fa6698d24c4a18e2d50aa1df51191d8c55099059e149f43a74940831f8591b
+              digest: sha256:6e58c196dc6175a60146d6f4660bda181203a0e1054de09015cc67841238c99b
       ntly:
         # this is an environment to test the deployability of infra nightly
         defaults:
@@ -1070,7 +1070,7 @@ clouds:
             image:
               registry: quay.io
               repository: acm-d/rhtap-hypershift-operator
-              digest: sha256:97fa6698d24c4a18e2d50aa1df51191d8c55099059e149f43a74940831f8591b
+              digest: sha256:6e58c196dc6175a60146d6f4660bda181203a0e1054de09015cc67841238c99b
           # MC
           mgmt:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: a94c47e7226afb1f4bce6bc12c072314e6f2bd298a68ecaa8017a3cef7885dd0
+          westus3: a88f97e06d55ad897620d532475adc52d4164b5929c3a2c370365c2d2312f7e5
       dev:
         regions:
-          westus3: bc4656872a7a741ce888cdda3cb60db7fa2982af89009a570ece70ebb42669ab
+          westus3: 725743ddbfa4312e59dbdddc1bf8e790df5ffa963ff04df27409acb9845c2044
       ntly:
         regions:
-          uksouth: 16ac9f1e7692dc3aa357ffffce65252f6a5ea0f25c6070f8d5f3698684752095
+          uksouth: 9df0e3a5b5dcfecd6caa47765c038c4dc29e99bb00cc5c9280354e12e6444458
       perf:
         regions:
-          westus3: 245c6e51647c77f7347483fe6ad709c571a8f6b99500db1e3ffb8663733cc627
+          westus3: 09c8ff4d7111838b4a02cf90a9a4f6b2ddf249ca58fdf42017f0b9d341791455
       pers:
         regions:
-          westus3: 93f5c6d6bcca51fd2920c6eccff664d146eecf5ef1b65d0fd5322a40bb4ebd7b
+          westus3: c74e98a3a1fa9b2d193defe0f3f83893b50c91396608b609c123f76f4cfda637
       swft:
         regions:
-          uksouth: 5a0f89044809e1fdc7565cf75aca87a634623fcb75d526e3b3aad6ae5767fa69
+          uksouth: 3cefc11a7110035e44135cb1b1a8e022daa096cd89f60769c62455a41a479aab

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -251,7 +251,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides=true
   image:
-    digest: sha256:97fa6698d24c4a18e2d50aa1df51191d8c55099059e149f43a74940831f8591b
+    digest: sha256:6e58c196dc6175a60146d6f4660bda181203a0e1054de09015cc67841238c99b
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -251,7 +251,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:97fa6698d24c4a18e2d50aa1df51191d8c55099059e149f43a74940831f8591b
+    digest: sha256:6e58c196dc6175a60146d6f4660bda181203a0e1054de09015cc67841238c99b
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -251,7 +251,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:97fa6698d24c4a18e2d50aa1df51191d8c55099059e149f43a74940831f8591b
+    digest: sha256:6e58c196dc6175a60146d6f4660bda181203a0e1054de09015cc67841238c99b
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -251,7 +251,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:97fa6698d24c4a18e2d50aa1df51191d8c55099059e149f43a74940831f8591b
+    digest: sha256:6e58c196dc6175a60146d6f4660bda181203a0e1054de09015cc67841238c99b
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -251,7 +251,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides=true
   image:
-    digest: sha256:97fa6698d24c4a18e2d50aa1df51191d8c55099059e149f43a74940831f8591b
+    digest: sha256:6e58c196dc6175a60146d6f4660bda181203a0e1054de09015cc67841238c99b
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -251,7 +251,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:97fa6698d24c4a18e2d50aa1df51191d8c55099059e149f43a74940831f8591b
+    digest: sha256:6e58c196dc6175a60146d6f4660bda181203a0e1054de09015cc67841238c99b
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift


### PR DESCRIPTION
### What

Update HO image to latest available in dev envs

image sha 6e58c196dc6175a60146d6f4660bda181203a0e1054de09015cc67841238c99b which corresponds to git commit 55ffa93.

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
