### PR TITLE
prepare hypershift-operator image to latest available for rollout in int

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -59,7 +59,7 @@ clouds:
           # Hypershift
           hypershift:
             image:
-              digest: sha256:97fa6698d24c4a18e2d50aa1df51191d8c55099059e149f43a74940831f8591b
+              digest: sha256:6e58c196dc6175a60146d6f4660bda181203a0e1054de09015cc67841238c99b
           # Maestro
           maestro:
             image:


### PR DESCRIPTION
### What
parepare HO image to latest available for rollout in int.

image sha 6e58c196dc6175a60146d6f4660bda181203a0e1054de09015cc67841238c99b which corresponds to git commit 55ffa93.

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
