### PR TITLE
frontend: Rework passing GroupsClaim to CS, again

### DIFF
--- a/frontend/pkg/frontend/external_auth_test.go
+++ b/frontend/pkg/frontend/external_auth_test.go
@@ -105,7 +105,7 @@ func TestCreateExternalAuth(t *testing.T) {
 					Prefix("").
 					PrefixPolicy(""),
 				).
-				Groups(arohcpv1alpha1.NewGroupsClaim()),
+				Groups(nil),
 			).
 			ValidationRules(),
 		).

--- a/frontend/pkg/frontend/ocm.go
+++ b/frontend/pkg/frontend/ocm.go
@@ -813,9 +813,9 @@ func buildClaims(externalAuthBuilder *arohcpv1alpha1.ExternalAuthBuilder, hcpExt
 		return err
 	}
 
-	groupsClaim := arohcpv1alpha1.NewGroupsClaim()
+	var groupsClaim *arohcpv1alpha1.GroupsClaimBuilder
 	if hcpExternalAuth.Properties.Claim.Mappings.Groups != nil {
-		groupsClaim.
+		groupsClaim = arohcpv1alpha1.NewGroupsClaim().
 			Claim(hcpExternalAuth.Properties.Claim.Mappings.Groups.Claim).
 			Prefix(hcpExternalAuth.Properties.Claim.Mappings.Groups.Prefix)
 	}

--- a/frontend/pkg/frontend/ocm_test.go
+++ b/frontend/pkg/frontend/ocm_test.go
@@ -415,7 +415,7 @@ func getBaseCSExternalAuthBuilder() *arohcpv1alpha1.ExternalAuthBuilder {
 					Prefix("").
 					PrefixPolicy(""),
 				).
-				Groups(arohcpv1alpha1.NewGroupsClaim()),
+				Groups(nil),
 			).
 			ValidationRules(),
 		).
@@ -448,7 +448,7 @@ func TestBuildCSExternalAuth(t *testing.T) {
 						Prefix("").
 						PrefixPolicy(string(api.UsernameClaimPrefixPolicyPrefix)),
 					).
-					Groups(arohcpv1alpha1.NewGroupsClaim()),
+					Groups(nil),
 				).
 				ValidationRules(),
 			),


### PR DESCRIPTION
### What

This is a followup correction to #2631 where I handled `GroupsClaim` wrong.

Passing CS an empty `GroupsClaim` object is rejected because the `claim` field is required. The way to unset `GroupsClaim` is to pass `nil` to [TokenClaimMappingsBuilder.Groups](https://pkg.go.dev/github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1#TokenClaimMappingsBuilder.Groups).