### PR TITLE
use deployment stacks in pipelines

### DIFF
--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -16,10 +16,11 @@ resourceGroups:
   subscription: '{{ .global.subscription.key }}'
   steps:
   - name: infra
-    action: ARM
+    action: ARMStack
     template: templates/global-infra.bicep
     parameters: configurations/global-infra.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
   - name: output
     action: ARM
     template: templates/output-global.bicep
@@ -45,10 +46,11 @@ resourceGroups:
     issuer:
       value: OneCertV2-PrivateCA
   - name: certificates
-    action: ARM
+    action: ARMStack
     template: templates/global-certificates.bicep
     parameters: configurations/global-certificates.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
     dependsOn:
     - resourceGroup: global
       step: onecert-private-kv-issuer
@@ -114,10 +116,11 @@ resourceGroups:
       step: infra
   # create global ARO HCP ACRs for OCP and SVC images
   - name: acrs
-    action: ARM
+    action: ARMStack
     template: templates/global-acr.bicep
     parameters: configurations/global-acr.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
     dependsOn:
     - resourceGroup: global
       step: infra
@@ -161,10 +164,11 @@ resourceGroups:
         name: globalMSIId
   # deploys the image mirror for the ACRs
   - name: imagemirror
-    action: ARM
+    action: ARMStack
     template: templates/global-image-sync.bicep
     parameters: configurations/global-image-sync.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
     dependsOn:
     - resourceGroup: global
       step: mirror-oc-mirror-image

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -52,10 +52,11 @@ resourceGroups:
       step: output
       name: globalMSIId
   - name: infra
-    action: ARM
+    action: ARMStack
     template: templates/mgmt-infra.bicep
     parameters: configurations/mgmt-infra.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
     variables:
     - name: clusterServiceMIResourceId
       input:
@@ -128,10 +129,11 @@ resourceGroups:
       value: OneCertV2-PublicCA
   # Build the MC
   - name: cluster
-    action: ARM
+    action: ARMStack
     template: templates/mgmt-cluster.bicep
     parameters: configurations/mgmt-cluster.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
     variables:
     - name: ocpAcrResourceId
       input:
@@ -176,10 +178,11 @@ resourceGroups:
     - resourceGroup: management
       step: oncert-public-kv-issuer
   - name: nsp
-    action: ARM
+    action: ARMStack
     template: templates/mgmt-nsp.bicep
     parameters: configurations/mgmt-nsp.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
     variables:
     - name: serviceClusterSubscriptionId
       input:

--- a/dev-infrastructure/mgmt-solo-pipeline.yaml
+++ b/dev-infrastructure/mgmt-solo-pipeline.yaml
@@ -27,10 +27,11 @@ resourceGroups:
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
   - name: infra
-    action: ARM
+    action: ARMStack
     template: templates/mgmt-infra.bicep
     parameters: configurations/mgmt-infra.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
     variables:
     - name: clusterServiceMIResourceId
       # we don't need to grant KV permissions to CS as there is no CS in the MC solo deployment
@@ -42,10 +43,11 @@ resourceGroups:
         name: logAnalyticsWorkspaceId
   # Build the MC
   - name: cluster
-    action: ARM
+    action: ARMStack
     template: templates/mgmt-cluster.bicep
     parameters: configurations/mgmt-cluster.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
     variables:
     - name: ocpAcrResourceId
       input:

--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -124,10 +124,11 @@ resourceGroups:
     - resourceGroup: global
       step: ocp-acr-replication
   - name: infra
-    action: ARM
+    action: ARMStack
     template: templates/region.bicep
     parameters: configurations/region.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
     variables:
     - name: globalMSIId
       input:

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -44,10 +44,11 @@ resourceGroups:
   steps:
   # Create SVC KV
   - name: infra
-    action: ARM
+    action: ARMStack
     template: templates/svc-infra.bicep
     parameters: configurations/svc-infra.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
     variables:
     - name: globalMSIId
       input:
@@ -92,10 +93,11 @@ resourceGroups:
       value: OneCertV2-PublicCA
   # Create SVC cluster
   - name: cluster
-    action: ARM
+    action: ARMStack
     template: templates/svc-cluster.bicep
     parameters: configurations/svc-cluster.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
     variables:
     - name: globalMSIId
       input:

--- a/docs/pipeline-concept.md
+++ b/docs/pipeline-concept.md
@@ -64,16 +64,16 @@ Used for deploying Azure infrastructure using [Bicep](bicep.md) templates. These
   ...
   steps:
   - name: region-infra
-    action: ARM                                          (1)
+    action: ARM | ARMStack                               (1)
     template: templates/region.bicep                     (2)
     parameters: configurations/region.tmpl.bicepparam    (3)
-    deploymentLevel: ResourceGroup                       (4)
+    ...                                                  (4)
 ```
 
-1. `action: ARM` marks the step as an ARM step.
+1. `action: ARM` or `action: ARMStack` marks the step as an ARM step.
 2. `template`: The path to the Bicep template file that defines the infrastructure to be deployed.
 3. `parameters`: The path to the Bicep parameters file that provides input values for the template.
-4. `deploymentLevel`: The scope at which the deployment should occur. Valid values are `ResourceGroup` and `Subscription`.
+4. ... for more details see the [Bicep docs](bicep.md)
 
 This step type supports dry-run testing via [what-if](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-what-if?tabs=azure-powershell).
 


### PR DESCRIPTION
### What

leverage deployment stacks instead of deployments for bicep rollouts. this way we can do proper cleanup of orphaned resources

merge this only after deployment stack support has been added to the ev2 generator in sdp-pipelines

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
