### PR TITLE
prepare cs image to latest available for rollout in int

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -8,7 +8,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:45225cadfc094896bb7147e1e2723f01f23a90f3bae111d70a803cece6311c6e
+              digest: sha256:aa0376a7826b62e47f542c49eeb1036753e40e0153836ca9725542125f4d21a0
           # ACR Pull
           acrPull:
             image:


### PR DESCRIPTION
### What

image sha aa0376a7826b62e47f542c49eeb1036753e40e0153836ca9725542125f4d21a0 which corresponds to git commit 15b4dc9.

This should include https://issues.redhat.com/browse/ARO-21030 among other changes.