### PR TITLE
honor the LOCATION env var for e2e tests

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -140,7 +140,7 @@ func main() {
 	registry.Register(ext)
 
 	root := &cobra.Command{
-		Long: "OpenShift Tests Extension Example",
+		Long: "ARO-HCP E2E Tests",
 	}
 
 	root.AddCommand(cmd.DefaultExtensionCommands(registry)...)

--- a/test/e2e/complete_cluster_create.go
+++ b/test/e2e/complete_cluster_create.go
@@ -53,7 +53,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			By("creating a resource group")
-			resourceGroup, err := tc.NewResourceGroup(ctx, "basic-cluster", "uksouth")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "basic-cluster", tc.Location())
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a customer-infra")

--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -60,7 +60,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			By("creating a resource group")
-			resourceGroup, err := tc.NewResourceGroup(ctx, "external-auth-cluster", "uksouth")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "external-auth-cluster", tc.Location())
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a customer-infra")

--- a/test/e2e/gpu_nodepools_create_delete.go
+++ b/test/e2e/gpu_nodepools_create_delete.go
@@ -61,9 +61,9 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 			labels.IntegrationOnly,
 			func(ctx context.Context) {
 				customerClusterName := "gpu-nodepool-cluster-" + rand.String(6)
-				location := "uksouth"
 
 				tc := framework.NewTestContext()
+				location := tc.Location()
 
 				By("creating a resource group")
 				resourceGroup, err := tc.NewResourceGroup(ctx, "gpu-nodepools-"+sku.display, location)

--- a/test/e2e/image_registry_cluster_create.go
+++ b/test/e2e/image_registry_cluster_create.go
@@ -49,7 +49,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			By("creating a resource group")
-			resourceGroup, err := tc.NewResourceGroup(ctx, "disabled-image-registry", "uksouth")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "disabled-image-registry", tc.Location())
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a customer-infra")


### PR DESCRIPTION
### What

use LOCATION as region for the RGs that are created by e2e tests.

### Why

the RG was statically created in uksouth and the cluster resources (HCP/nodepool) inherited the RG default. hence our PROW jobs outside of uksouth still targeted uksouth.

### Special notes for your reviewer

<!-- optional -->
