### PR TITLE
vnet tagging explicit api version

### DIFF
--- a/dev-infrastructure/modules/network/vnet.bicep
+++ b/dev-infrastructure/modules/network/vnet.bicep
@@ -75,7 +75,9 @@ resource vnetWithSwiftDeployment 'Microsoft.Resources/deploymentScripts@2020-10-
         az resource tag \
           --tags stampcreatorserviceinfo=true \
           --resource-group "${VNET_RG}" \
-          --name "${VNET_NAME}" --resource-type Microsoft.Network/virtualnetworks
+          --name "${VNET_NAME}" \
+          --resource-type Microsoft.Network/virtualnetworks \
+          --api-version 2024-05-01
       fi
     '''
     timeout: 'PT5M'


### PR DESCRIPTION
### What

there are situations where the default api-version discovery for `az resource` operations can't be inferred correctly. e.g. for vnet tagging. hence we provide the api-version explicitely

https://redhat-internal.slack.com/archives/C07A2CVUV44/p1757514818377799?thread_ts=1757502413.483289&cid=C07A2CVUV44

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
