### PR TITLE
disable prometheus deployment

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -202,71 +202,71 @@ resourceGroups:
       step: output
     - resourceGroup: management
       step: cluster
-  - name: prometheus
-    aksCluster: '{{ .mgmt.aks.name }}'
-    action: Shell
-    command: make -C ../observability/prometheus deploy
-    dryRun:
-      variables:
-      - name: DRY_RUN
-        value: "true"
-    variables:
-    - name: PROMETHEUS_OPERATOR_REGISTRY
-      configRef: mgmt.prometheus.prometheusOperator.image.registry
-    - name: PROMETHEUS_OPERATOR_REPOSITORY
-      configRef: mgmt.prometheus.prometheusOperator.image.repository
-    - name: PROMETHEUS_OPERATOR_DIGEST
-      configRef: mgmt.prometheus.prometheusOperator.image.digest
-    - name: PROMETHEUS_CONFIG_RELOADER_REGISTRY
-      configRef: mgmt.prometheus.prometheusConfigReloader.image.registry
-    - name: PROMETHEUS_CONFIG_RELOADER_REPOSITORY
-      configRef: mgmt.prometheus.prometheusConfigReloader.image.repository
-    - name: PROMETHEUS_CONFIG_RELOADER_DIGEST
-      configRef: mgmt.prometheus.prometheusConfigReloader.image.digest
-    - name: PROMETHEUS_SPEC_REGISTRY
-      configRef: mgmt.prometheus.prometheusSpec.image.registry
-    - name: PROMETHEUS_SPEC_REPOSITORY
-      configRef: mgmt.prometheus.prometheusSpec.image.repository
-    - name: PROMETHEUS_SPEC_DIGEST
-      configRef: mgmt.prometheus.prometheusSpec.image.digest
-    - name: PROMETHEUS_SPEC_REPLICAS
-      configRef: mgmt.prometheus.prometheusSpec.replicas
-    - name: PROMETHEUS_SPEC_SHARDS
-      configRef: mgmt.prometheus.prometheusSpec.shards
-    - name: PROMETHEUS_SPEC_VERSION
-      configRef: mgmt.prometheus.prometheusSpec.version
-    - name: PROMETHEUS_NAMESPACE_LABEL
-      configRef: mgmt.prometheus.namespaceLabel
-    - name: RESOURCE_GROUP
-      configRef: mgmt.rg
-    - name: CLUSTER_NAME
-      configRef: mgmt.aks.name
-    - name: CS_ENVIRONMENT
-      configRef: clustersService.environment
-    - name: DCR_REMOTE_WRITE_URL
-      input:
-        resourceGroup: management
-        step: cluster-output
-        name: dcrRemoteWriteUrl
-    - name: HCP_DCR_REMOTE_WRITE_URL
-      input:
-        resourceGroup: management
-        step: cluster-output
-        name: hcpDcrRemoteWriteUrl
-    - name: PROMETHEUS_UAMI_CLIENT_ID
-      input:
-        resourceGroup: management
-        step: cluster-output
-        name: prometheusUAMIClientId
-    dependsOn:
-    - resourceGroup: management
-      step: cluster
-    shellIdentity:
-      input:
-        resourceGroup: global
-        step: output
-        name: globalMSIId
-        # Install ACRpull
+  # - name: prometheus
+  #   aksCluster: '{{ .mgmt.aks.name }}'
+  #   action: Shell
+  #   command: make -C ../observability/prometheus deploy
+  #   dryRun:
+  #     variables:
+  #     - name: DRY_RUN
+  #       value: "true"
+  #   variables:
+  #   - name: PROMETHEUS_OPERATOR_REGISTRY
+  #     configRef: mgmt.prometheus.prometheusOperator.image.registry
+  #   - name: PROMETHEUS_OPERATOR_REPOSITORY
+  #     configRef: mgmt.prometheus.prometheusOperator.image.repository
+  #   - name: PROMETHEUS_OPERATOR_DIGEST
+  #     configRef: mgmt.prometheus.prometheusOperator.image.digest
+  #   - name: PROMETHEUS_CONFIG_RELOADER_REGISTRY
+  #     configRef: mgmt.prometheus.prometheusConfigReloader.image.registry
+  #   - name: PROMETHEUS_CONFIG_RELOADER_REPOSITORY
+  #     configRef: mgmt.prometheus.prometheusConfigReloader.image.repository
+  #   - name: PROMETHEUS_CONFIG_RELOADER_DIGEST
+  #     configRef: mgmt.prometheus.prometheusConfigReloader.image.digest
+  #   - name: PROMETHEUS_SPEC_REGISTRY
+  #     configRef: mgmt.prometheus.prometheusSpec.image.registry
+  #   - name: PROMETHEUS_SPEC_REPOSITORY
+  #     configRef: mgmt.prometheus.prometheusSpec.image.repository
+  #   - name: PROMETHEUS_SPEC_DIGEST
+  #     configRef: mgmt.prometheus.prometheusSpec.image.digest
+  #   - name: PROMETHEUS_SPEC_REPLICAS
+  #     configRef: mgmt.prometheus.prometheusSpec.replicas
+  #   - name: PROMETHEUS_SPEC_SHARDS
+  #     configRef: mgmt.prometheus.prometheusSpec.shards
+  #   - name: PROMETHEUS_SPEC_VERSION
+  #     configRef: mgmt.prometheus.prometheusSpec.version
+  #   - name: PROMETHEUS_NAMESPACE_LABEL
+  #     configRef: mgmt.prometheus.namespaceLabel
+  #   - name: RESOURCE_GROUP
+  #     configRef: mgmt.rg
+  #   - name: CLUSTER_NAME
+  #     configRef: mgmt.aks.name
+  #   - name: CS_ENVIRONMENT
+  #     configRef: clustersService.environment
+  #   - name: DCR_REMOTE_WRITE_URL
+  #     input:
+  #       resourceGroup: management
+  #       step: cluster-output
+  #       name: dcrRemoteWriteUrl
+  #   - name: HCP_DCR_REMOTE_WRITE_URL
+  #     input:
+  #       resourceGroup: management
+  #       step: cluster-output
+  #       name: hcpDcrRemoteWriteUrl
+  #   - name: PROMETHEUS_UAMI_CLIENT_ID
+  #     input:
+  #       resourceGroup: management
+  #       step: cluster-output
+  #       name: prometheusUAMIClientId
+  #   dependsOn:
+  #   - resourceGroup: management
+  #     step: cluster
+  #   shellIdentity:
+  #     input:
+  #       resourceGroup: global
+  #       step: output
+  #       name: globalMSIId
+  #       # Install ACRpull
   - name: acrpull
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell
@@ -284,7 +284,8 @@ resourceGroups:
       configRef: acrPull.image.registry
     dependsOn:
     - resourceGroup: management
-      step: prometheus
+      step: cluster
+      #step: prometheus
     shellIdentity:
       input:
         resourceGroup: global

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -144,64 +144,64 @@ resourceGroups:
     - resourceGroup: service
       step: cluster
   # Deploy prometheus first since istio depends on it's CRDs
-  - name: prometheus
-    aksCluster: '{{ .svc.aks.name }}'
-    action: Shell
-    command: make -C ../observability/prometheus deploy
-    dryRun:
-      variables:
-      - name: DRY_RUN
-        value: "true"
-    variables:
-    - name: PROMETHEUS_OPERATOR_REGISTRY
-      configRef: svc.prometheus.prometheusOperator.image.registry
-    - name: PROMETHEUS_OPERATOR_REPOSITORY
-      configRef: svc.prometheus.prometheusOperator.image.repository
-    - name: PROMETHEUS_OPERATOR_DIGEST
-      configRef: svc.prometheus.prometheusOperator.image.digest
-    - name: PROMETHEUS_CONFIG_RELOADER_REGISTRY
-      configRef: svc.prometheus.prometheusConfigReloader.image.registry
-    - name: PROMETHEUS_CONFIG_RELOADER_REPOSITORY
-      configRef: svc.prometheus.prometheusConfigReloader.image.repository
-    - name: PROMETHEUS_CONFIG_RELOADER_DIGEST
-      configRef: svc.prometheus.prometheusConfigReloader.image.digest
-    - name: PROMETHEUS_SPEC_REGISTRY
-      configRef: svc.prometheus.prometheusSpec.image.registry
-    - name: PROMETHEUS_SPEC_REPOSITORY
-      configRef: svc.prometheus.prometheusSpec.image.repository
-    - name: PROMETHEUS_SPEC_DIGEST
-      configRef: svc.prometheus.prometheusSpec.image.digest
-    - name: PROMETHEUS_SPEC_REPLICAS
-      configRef: svc.prometheus.prometheusSpec.replicas
-    - name: PROMETHEUS_SPEC_SHARDS
-      configRef: svc.prometheus.prometheusSpec.shards
-    - name: PROMETHEUS_SPEC_VERSION
-      configRef: svc.prometheus.prometheusSpec.version
-    - name: PROMETHEUS_NAMESPACE_LABEL
-      configRef: svc.prometheus.namespaceLabel
-    - name: RESOURCE_GROUP
-      configRef: svc.rg
-    - name: CLUSTER_NAME
-      configRef: svc.aks.name
-    - name: DCR_REMOTE_WRITE_URL
-      input:
-        resourceGroup: service
-        step: cluster-output
-        name: dcrRemoteWriteUrl
-    - name: PROMETHEUS_UAMI_CLIENT_ID
-      input:
-        resourceGroup: service
-        step: cluster-output
-        name: prometheusUAMIClientId
-    dependsOn:
-    - resourceGroup: service
-      step: cluster
-    shellIdentity:
-      input:
-        resourceGroup: global
-        step: output
-        name: globalMSIId
-        # configure istio
+  # - name: prometheus
+  #   aksCluster: '{{ .svc.aks.name }}'
+  #   action: Shell
+  #   command: make -C ../observability/prometheus deploy
+  #   dryRun:
+  #     variables:
+  #     - name: DRY_RUN
+  #       value: "true"
+  #   variables:
+  #   - name: PROMETHEUS_OPERATOR_REGISTRY
+  #     configRef: svc.prometheus.prometheusOperator.image.registry
+  #   - name: PROMETHEUS_OPERATOR_REPOSITORY
+  #     configRef: svc.prometheus.prometheusOperator.image.repository
+  #   - name: PROMETHEUS_OPERATOR_DIGEST
+  #     configRef: svc.prometheus.prometheusOperator.image.digest
+  #   - name: PROMETHEUS_CONFIG_RELOADER_REGISTRY
+  #     configRef: svc.prometheus.prometheusConfigReloader.image.registry
+  #   - name: PROMETHEUS_CONFIG_RELOADER_REPOSITORY
+  #     configRef: svc.prometheus.prometheusConfigReloader.image.repository
+  #   - name: PROMETHEUS_CONFIG_RELOADER_DIGEST
+  #     configRef: svc.prometheus.prometheusConfigReloader.image.digest
+  #   - name: PROMETHEUS_SPEC_REGISTRY
+  #     configRef: svc.prometheus.prometheusSpec.image.registry
+  #   - name: PROMETHEUS_SPEC_REPOSITORY
+  #     configRef: svc.prometheus.prometheusSpec.image.repository
+  #   - name: PROMETHEUS_SPEC_DIGEST
+  #     configRef: svc.prometheus.prometheusSpec.image.digest
+  #   - name: PROMETHEUS_SPEC_REPLICAS
+  #     configRef: svc.prometheus.prometheusSpec.replicas
+  #   - name: PROMETHEUS_SPEC_SHARDS
+  #     configRef: svc.prometheus.prometheusSpec.shards
+  #   - name: PROMETHEUS_SPEC_VERSION
+  #     configRef: svc.prometheus.prometheusSpec.version
+  #   - name: PROMETHEUS_NAMESPACE_LABEL
+  #     configRef: svc.prometheus.namespaceLabel
+  #   - name: RESOURCE_GROUP
+  #     configRef: svc.rg
+  #   - name: CLUSTER_NAME
+  #     configRef: svc.aks.name
+  #   - name: DCR_REMOTE_WRITE_URL
+  #     input:
+  #       resourceGroup: service
+  #       step: cluster-output
+  #       name: dcrRemoteWriteUrl
+  #   - name: PROMETHEUS_UAMI_CLIENT_ID
+  #     input:
+  #       resourceGroup: service
+  #       step: cluster-output
+  #       name: prometheusUAMIClientId
+  #   dependsOn:
+  #   - resourceGroup: service
+  #     step: cluster
+  #   shellIdentity:
+  #     input:
+  #       resourceGroup: global
+  #       step: output
+  #       name: globalMSIId
+  #       # configure istio
   - name: istio-config
     aksCluster: '{{ .svc.aks.name }}'
     action: Shell
@@ -215,7 +215,8 @@ resourceGroups:
       configRef: svc.istio.versions
     dependsOn:
     - resourceGroup: service
-      step: prometheus
+      #step: prometheus
+      step: cluster
     shellIdentity:
       input:
         resourceGroup: global
@@ -264,7 +265,8 @@ resourceGroups:
       configRef: acrPull.image.registry
     dependsOn:
     - resourceGroup: service
-      step: prometheus
+      step: cluster
+      #step: prometheus
     shellIdentity:
       input:
         resourceGroup: global


### PR DESCRIPTION
### What

because of an EV2 problem with the prometheus shell step, we need to disable it for now to unblock deployments to existing environments.

https://portal.microsofticm.com/imp/v5/incidents/details/685746934/summary

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
