### PR TITLE
Add start/end time to all verifiers to logs - WIP

### DIFF
--- a/test/e2e/complete_cluster_create.go
+++ b/test/e2e/complete_cluster_create.go
@@ -151,7 +151,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying a simple web app can run")
-			err = verifiers.VerifySimpleWebApp().Verify(ctx, adminRESTConfig)
+			err = verifiers.VerifyWithTiming(ctx, verifiers.VerifySimpleWebApp(), adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred())
 		})
 })


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-21032

### What

This adds start/end time to the logs for verifiers to assist with debugging log failures. 

### Why

The simple web app and occationally other verifiers fail due to timeouts and we want to gather data on how long a given verifier takes to run. 
