### PR TITLE
add new HCPCluster fields

### DIFF
--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -220,7 +220,7 @@ func (f *Frontend) CreateOrUpdateExternalAuth(writer http.ResponseWriter, reques
 	f.ExposeOperation(writer, request, operationID, transaction)
 
 	if !updating {
-		resourceItemID = transaction.CreateResourceDoc(resourceDoc, nil)
+		resourceItemID = transaction.CreateResourceDoc(resourceDoc, database.RemoveAllState, nil)
 	}
 
 	var patchOperations database.ResourceDocumentPatchOperations

--- a/frontend/pkg/frontend/external_auth_test.go
+++ b/frontend/pkg/frontend/external_auth_test.go
@@ -214,7 +214,7 @@ func TestCreateExternalAuth(t *testing.T) {
 			// CreateOrUpdateExternalAuth
 			externalAuthItemID := uuid.New().String()
 			mockDBTransaction.EXPECT().
-				CreateResourceDoc(test.externalAuthDoc, nil).
+				CreateResourceDoc(test.externalAuthDoc, database.RemoveAllState, nil).
 				Return(externalAuthItemID)
 			// CreateOrUpdateExternalAuth
 			mockDBTransaction.EXPECT().

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -433,7 +433,7 @@ func (f *Frontend) ArmResourceRead(writer http.ResponseWriter, request *http.Req
 	}
 }
 
-func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request *http.Request) {
+func (f *Frontend) CreateOrUpdateHCPCluster(writer http.ResponseWriter, request *http.Request) {
 	var err error
 
 	// This handles both PUT and PATCH requests. PATCH requests will
@@ -640,7 +640,7 @@ func (f *Frontend) ArmResourceCreateOrUpdate(writer http.ResponseWriter, request
 	f.ExposeOperation(writer, request, operationID, transaction)
 
 	if !updating {
-		resourceItemID = transaction.CreateResourceDoc(resourceDoc, nil)
+		resourceItemID = transaction.CreateResourceDoc(resourceDoc, database.FilterHCPClusterState, nil)
 	}
 
 	var patchOperations database.ResourceDocumentPatchOperations

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -258,7 +258,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 	f.ExposeOperation(writer, request, operationID, transaction)
 
 	if !updating {
-		resourceItemID = transaction.CreateResourceDoc(resourceDoc, nil)
+		resourceItemID = transaction.CreateResourceDoc(resourceDoc, database.RemoveAllState, nil)
 	}
 
 	var patchOperations database.ResourceDocumentPatchOperations

--- a/frontend/pkg/frontend/node_pool_test.go
+++ b/frontend/pkg/frontend/node_pool_test.go
@@ -217,7 +217,7 @@ func TestCreateNodePool(t *testing.T) {
 			// CreateOrUpdateNodePool
 			nodePoolItemID := uuid.New().String()
 			mockDBTransaction.EXPECT().
-				CreateResourceDoc(test.nodePoolDoc, nil).
+				CreateResourceDoc(test.nodePoolDoc, database.RemoveAllState, nil).
 				Return(nodePoolItemID)
 			// CreateOrUpdateNodePool
 			mockDBTransaction.EXPECT().

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -135,10 +135,10 @@ func (f *Frontend) routes(r prometheus.Registerer) *MiddlewareMux {
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
 	mux.Handle(
 		MuxPattern(http.MethodPut, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceCreateOrUpdate))
+		postMuxMiddleware.HandlerFunc(f.CreateOrUpdateHCPCluster))
 	mux.Handle(
 		MuxPattern(http.MethodPatch, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceCreateOrUpdate))
+		postMuxMiddleware.HandlerFunc(f.CreateOrUpdateHCPCluster))
 	mux.Handle(
 		MuxPattern(http.MethodDelete, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceDelete))

--- a/internal/api/testhelpers.go
+++ b/internal/api/testhelpers.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 
 	"dario.cat/mergo"
-	validator "github.com/go-playground/validator/v10"
+	"github.com/go-playground/validator/v10"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -526,4 +526,13 @@ func TestVersionedNullPatch[T any](t *testing.T, newResource func() VersionedCre
 			}
 		})
 	}
+}
+
+// Must is a helper function that takes a value and error, returns the value if no error occurred,
+// or panics if an error occurred. This is useful for test setup where we don't expect errors.
+func Must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -113,9 +113,6 @@ type DBClient interface {
 	// matching resourceID.
 	GetResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID) (string, *ResourceDocument, error)
 
-	// CreateResourceDoc creates a new cluster or node pool document in the "Resources" container.
-	CreateResourceDoc(ctx context.Context, doc *ResourceDocument) error
-
 	// PatchResourceDoc patches a cluster or node pool document in the "Resources" container by
 	// applying a sequence of patch operations. The patch operations may include a precondition
 	// which, if not satisfied, will cause the function to return an azcore.ResponseError with
@@ -407,22 +404,6 @@ func (d *cosmosDBClient) GetResourceDoc(ctx context.Context, resourceID *azcorea
 	innerDoc.ResourceID = resourceID
 
 	return typedDoc.ID, innerDoc, nil
-}
-
-func (d *cosmosDBClient) CreateResourceDoc(ctx context.Context, doc *ResourceDocument) error {
-	typedDoc := newTypedDocument(doc.ResourceID.SubscriptionID, doc.ResourceID.ResourceType)
-
-	data, err := typedDocumentMarshal(typedDoc, doc)
-	if err != nil {
-		return fmt.Errorf("failed to marshal Resources container item for '%s': %w", doc.ResourceID, err)
-	}
-
-	_, err = d.resources.CreateItem(ctx, typedDoc.getPartitionKey(), data, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create Resources container item for '%s': %w", doc.ResourceID, err)
-	}
-
-	return nil
 }
 
 func (d *cosmosDBClient) PatchResourceDoc(ctx context.Context, resourceID *azcorearm.ResourceID, ops ResourceDocumentPatchOperations) (*ResourceDocument, error) {

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -104,6 +104,9 @@ type ResourceDocument struct {
 	Identity          *arm.ManagedServiceIdentity `json:"identity,omitempty"`
 	SystemData        *arm.SystemData             `json:"systemData,omitempty"`
 	Tags              map[string]string           `json:"tags,omitempty"`
+
+	CustomerDesiredState map[string]any `json:"customerDesiredState"`
+	ServiceProviderState map[string]any `json:"serviceProviderState"`
 }
 
 func NewResourceDocument(resourceID *azcorearm.ResourceID) *ResourceDocument {
@@ -119,6 +122,16 @@ func (doc ResourceDocument) GetValidTypes() []string {
 		api.NodePoolResourceType.String(),
 		api.ExternalAuthResourceType.String(),
 	}
+}
+
+// ResourceDocumentStateFilter is used to remove unknown fields from ResourceDocumentProperties.
+// Long-term, we want to reach a point where we store different types so we have full type-safety
+// throughout the stack.
+// Short-term, we want a low-touch modification that makes it safe to store new fields.
+type ResourceDocumentStateFilter interface {
+	// RemoveUnknownFields checks the customerDesiredState and serviceProviderState and removes unknown fields.
+	// The simplest implementation is "remove everything" and the next simplest is round-tripping through JSON.
+	RemoveUnknownFields(*ResourceDocument) error
 }
 
 const (

--- a/internal/database/transaction.go
+++ b/internal/database/transaction.go
@@ -29,7 +29,7 @@ type DBTransaction interface {
 
 	// CreateResourceDoc adds a create request to the transaction
 	// and returns the tentative item ID.
-	CreateResourceDoc(doc *ResourceDocument, o *azcosmos.TransactionalBatchItemOptions) string
+	CreateResourceDoc(doc *ResourceDocument, documentFilter ResourceDocumentStateFilter, o *azcosmos.TransactionalBatchItemOptions) string
 
 	// PatchResourceDoc adds a set of patch operations to the transaction.
 	PatchResourceDoc(itemID string, ops ResourceDocumentPatchOperations, o *azcosmos.TransactionalBatchItemOptions)
@@ -104,7 +104,7 @@ func (t *cosmosDBTransaction) DeleteDoc(itemID string, o *azcosmos.Transactional
 	})
 }
 
-func (t *cosmosDBTransaction) CreateResourceDoc(doc *ResourceDocument, o *azcosmos.TransactionalBatchItemOptions) string {
+func (t *cosmosDBTransaction) CreateResourceDoc(doc *ResourceDocument, documentFilter ResourceDocumentStateFilter, o *azcosmos.TransactionalBatchItemOptions) string {
 	typedDoc := newTypedDocument(doc.ResourceID.SubscriptionID, doc.ResourceID.ResourceType)
 
 	t.steps = append(t.steps, func(b *azcosmos.TransactionalBatch) (string, error) {
@@ -112,7 +112,7 @@ func (t *cosmosDBTransaction) CreateResourceDoc(doc *ResourceDocument, o *azcosm
 		var err error
 
 		if reflect.DeepEqual(t.pk, typedDoc.getPartitionKey()) {
-			data, err = typedDocumentMarshal(typedDoc, doc)
+			data, err = resourceDocumentMarshal(typedDoc, doc, documentFilter)
 		} else {
 			err = ErrWrongPartition
 		}

--- a/internal/database/typeddocument.go
+++ b/internal/database/typeddocument.go
@@ -86,6 +86,30 @@ func (td *typedDocument) validateType(properties DocumentProperties) error {
 	}
 }
 
+// resourceDocumentMarshal returns the JSON encoding of typedDoc with innerDoc
+// as the properties value. First, however, typedDocumentMarshal validates
+// the type field in typeDoc against innerDoc to ensure compatibility. If
+// validation fails, typedDocumentMarshal returns a typedDocumentError.
+func resourceDocumentMarshal(typedDoc *typedDocument, innerDoc *ResourceDocument, documentFilter ResourceDocumentStateFilter) ([]byte, error) {
+	err := typedDoc.validateType(*innerDoc)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := documentFilter.RemoveUnknownFields(innerDoc); err != nil {
+		return nil, fmt.Errorf("failed to remove unknown fields from ResourceDocument: %w", err)
+	}
+
+	data, err := json.Marshal(innerDoc)
+	if err != nil {
+		return nil, err
+	}
+
+	typedDoc.Properties = data
+
+	return json.Marshal(typedDoc)
+}
+
 // typedDocumentMarshal returns the JSON encoding of typedDoc with innerDoc
 // as the properties value. First, however, typedDocumentMarshal validates
 // the type field in typeDoc against innerDoc to ensure compatibility. If

--- a/internal/database/types_empty.go
+++ b/internal/database/types_empty.go
@@ -1,0 +1,25 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+type removeAllState struct{}
+
+func (r removeAllState) RemoveUnknownFields(toMutate *ResourceDocument) error {
+	toMutate.CustomerDesiredState = nil
+	toMutate.ServiceProviderState = nil
+	return nil
+}
+
+var RemoveAllState ResourceDocumentStateFilter = &removeAllState{}

--- a/internal/database/types_hcpcluster.go
+++ b/internal/database/types_hcpcluster.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+type CustomerDesiredHCPClusterState struct {
+	// HCPOpenShiftCluster contains the desired state from a customer.  It is filtered to only those fields that customers
+	// are able to set.
+	// We will eventually select specific fields which customers own and blank out everything else.
+	// Alternatively, we could choose a different structure, but it's probably easier to re-use this one.
+	// There is no validation on this structure.
+	HCPOpenShiftCluster api.HCPOpenShiftCluster `json:"hcpOpenShiftCluster"`
+}
+
+type ServiceProviderHCPClusterState struct {
+	// HCPOpenShiftCluster contains the service provider owned state.  It is filtered to only those fields that the service provider owns.
+	// We will eventually select specific fields which the service provider owns and blank out everything else.
+	// Alternatively, we could choose a different structure, but it's probably easier to re-use this one.
+	// There is no validation on this structure.
+	HCPOpenShiftCluster api.HCPOpenShiftCluster `json:"hcpOpenShiftCluster"`
+}
+
+var FilterHCPClusterState ResourceDocumentStateFilter = newJSONRoundTripFilterer(
+	func() any { return &CustomerDesiredHCPClusterState{} },
+	func() any { return &ServiceProviderHCPClusterState{} },
+)
+
+type jsonRoundTripFilterer struct {
+	newCustomerDesiredStateFn func() any
+	newServiceProviderStateFn func() any
+}
+
+func newJSONRoundTripFilterer(newCustomerDesiredStateFn, newServiceProviderStateFn func() any) ResourceDocumentStateFilter {
+	return jsonRoundTripFilterer{
+		newCustomerDesiredStateFn: newCustomerDesiredStateFn,
+		newServiceProviderStateFn: newServiceProviderStateFn,
+	}
+}
+
+func (r jsonRoundTripFilterer) RemoveUnknownFields(toMutate *ResourceDocument) error {
+	filteredCustomerDesiredState, err := superExpensiveButSimpleRoundFilterForUnknownFields(toMutate.CustomerDesiredState, r.newCustomerDesiredStateFn())
+	if err != nil {
+		return err
+	}
+	toMutate.CustomerDesiredState = filteredCustomerDesiredState
+
+	filteredServiceProviderState, err := superExpensiveButSimpleRoundFilterForUnknownFields(toMutate.ServiceProviderState, r.newCustomerDesiredStateFn())
+	if err != nil {
+		return err
+	}
+	toMutate.ServiceProviderState = filteredServiceProviderState
+
+	return nil
+}
+
+func superExpensiveButSimpleRoundFilterForUnknownFields(startingMap map[string]any, filterObj any) (map[string]any, error) {
+	if len(startingMap) == 0 {
+		return startingMap, nil
+	}
+	currBytes, err := json.Marshal(startingMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal original: %w", err)
+	}
+	if err := json.Unmarshal(currBytes, filterObj); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal into filterObj: %w", err)
+	}
+	filteredBytes, err := json.Marshal(filterObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal filterObj: %w", err)
+	}
+	filteredMap := map[string]any{}
+	if err := json.Unmarshal(filteredBytes, &filteredMap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal into filtered map: %w", err)
+	}
+
+	return filteredMap, nil
+}

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -260,44 +260,6 @@ func (c *MockDBClientCreateOperationDocCall) DoAndReturn(f func(context.Context,
 	return c
 }
 
-// CreateResourceDoc mocks base method.
-func (m *MockDBClient) CreateResourceDoc(ctx context.Context, doc *database.ResourceDocument) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateResourceDoc", ctx, doc)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateResourceDoc indicates an expected call of CreateResourceDoc.
-func (mr *MockDBClientMockRecorder) CreateResourceDoc(ctx, doc any) *MockDBClientCreateResourceDocCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateResourceDoc", reflect.TypeOf((*MockDBClient)(nil).CreateResourceDoc), ctx, doc)
-	return &MockDBClientCreateResourceDocCall{Call: call}
-}
-
-// MockDBClientCreateResourceDocCall wrap *gomock.Call
-type MockDBClientCreateResourceDocCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockDBClientCreateResourceDocCall) Return(arg0 error) *MockDBClientCreateResourceDocCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockDBClientCreateResourceDocCall) Do(f func(context.Context, *database.ResourceDocument) error) *MockDBClientCreateResourceDocCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDBClientCreateResourceDocCall) DoAndReturn(f func(context.Context, *database.ResourceDocument) error) *MockDBClientCreateResourceDocCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // CreateSubscriptionDoc mocks base method.
 func (m *MockDBClient) CreateSubscriptionDoc(ctx context.Context, subscriptionID string, subscription *arm.Subscription) error {
 	m.ctrl.T.Helper()

--- a/internal/mocks/dbtransaction.go
+++ b/internal/mocks/dbtransaction.go
@@ -82,17 +82,17 @@ func (c *MockDBTransactionCreateOperationDocCall) DoAndReturn(f func(*database.O
 }
 
 // CreateResourceDoc mocks base method.
-func (m *MockDBTransaction) CreateResourceDoc(doc *database.ResourceDocument, o *azcosmos.TransactionalBatchItemOptions) string {
+func (m *MockDBTransaction) CreateResourceDoc(doc *database.ResourceDocument, documentFilter database.ResourceDocumentStateFilter, o *azcosmos.TransactionalBatchItemOptions) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateResourceDoc", doc, o)
+	ret := m.ctrl.Call(m, "CreateResourceDoc", doc, documentFilter, o)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // CreateResourceDoc indicates an expected call of CreateResourceDoc.
-func (mr *MockDBTransactionMockRecorder) CreateResourceDoc(doc, o any) *MockDBTransactionCreateResourceDocCall {
+func (mr *MockDBTransactionMockRecorder) CreateResourceDoc(doc, documentFilter, o any) *MockDBTransactionCreateResourceDocCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateResourceDoc", reflect.TypeOf((*MockDBTransaction)(nil).CreateResourceDoc), doc, o)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateResourceDoc", reflect.TypeOf((*MockDBTransaction)(nil).CreateResourceDoc), doc, documentFilter, o)
 	return &MockDBTransactionCreateResourceDocCall{Call: call}
 }
 
@@ -108,13 +108,13 @@ func (c *MockDBTransactionCreateResourceDocCall) Return(arg0 string) *MockDBTran
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockDBTransactionCreateResourceDocCall) Do(f func(*database.ResourceDocument, *azcosmos.TransactionalBatchItemOptions) string) *MockDBTransactionCreateResourceDocCall {
+func (c *MockDBTransactionCreateResourceDocCall) Do(f func(*database.ResourceDocument, database.ResourceDocumentStateFilter, *azcosmos.TransactionalBatchItemOptions) string) *MockDBTransactionCreateResourceDocCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDBTransactionCreateResourceDocCall) DoAndReturn(f func(*database.ResourceDocument, *azcosmos.TransactionalBatchItemOptions) string) *MockDBTransactionCreateResourceDocCall {
+func (c *MockDBTransactionCreateResourceDocCall) DoAndReturn(f func(*database.ResourceDocument, database.ResourceDocumentStateFilter, *azcosmos.TransactionalBatchItemOptions) string) *MockDBTransactionCreateResourceDocCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
Minimal change to add fields for HCP Cluster elements.  This adds fields on all `ResourceDocument` deserialization and filters the data on write. This approach keeps the change small, but still allows storing state for HCPClusters.  For other ResourceDocuments (NodePool and ExternalAuth) the fields are force cleared.  For HCPClusters, the unknown fields are removed to prevent squatting.

Once we have this, the next step is to add a loop to the backend that every minute reads the cluster-service clusters and writes customer desired values and serviceprovider values.

The overall flow will be.
1. prod-release/1 start synchronizing customer owned fields from cluster-service to cosmos. frontend writes to cluster-service then to cosmos. customer spec reads come from cluster-service. customer status reads come from cluster-service. This will get all low throughput customer desired state into the instances. During this phase, cluster-service is the source of truth for customer spec fields.
2. prod-release/2 frontend writes to cosmos then to cluster-service. customer spec reads come from cosmos. customer status reads come from cluster-service. This state ensures that cluster-service is no longer the source of truth.
3. prod-release/3 frontend writes to cosmos. backend writes to cluster-service. customer reads come from cluster-service. This state removes the direct cluster-service write.
4. prod-release/4 frontend writes to cosmos, backend writes to cluster-service, sychronize status from cluster-service to cosmos, customer spec reads come from cosmos, customer status reads come from cluster-service. This will get all low throughput status into the instances. During "active" times we read from cluster-service pretty aggressively.
5. prod-release/5 frontend writes to cosmos, backend writes to cluster-service, sychronize status from cluster-service to cosmos, customer spec reads come from cosmos, customer status reads come from cosmos. At this point the data model has shifted and we're going to be talking about bringing individual pieces of cluster-service into ARO-HCP.
