### PR TITLE
topology: annotate an entrypoint as incremental

### DIFF
--- a/topology.yaml
+++ b/topology.yaml
@@ -3,6 +3,7 @@ entrypoints:
   metadata:
     name: Global
     scopeDoc: high-level-architecture.md
+    incremental: "true"
 - identifier: 'Microsoft.Azure.ARO.HCP.Region'
   metadata:
     name: Region


### PR DESCRIPTION
We are building out infrastructure to support incremental deployments, but want to support it only on a small set of pipelines to start and maybe ever. Add an annotation on the obvious entrypoint that needs it so we can tell which ones to run infra for.
