### PR TITLE
fix aks reference to acrpull deployment to svc cluster

### DIFF
--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -249,7 +249,7 @@ resourceGroups:
         name: globalMSIId
         # Install ACRpull
   - name: acrpull
-    aksCluster: '{{ .mgmt.aks.name }}'
+    aksCluster: '{{ .svc.aks.name }}'
     action: Helm
     releaseName: acrpull
     releaseNamespace: acrpull


### PR DESCRIPTION
### What

fix deploy step AKS reference to use svc cluster instead of mgmt cluster

follows up on https://github.com/Azure/ARO-HCP/pull/2705

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
