### PR TITLE
api: Fix visibility validation bug

### DIFF
--- a/internal/api/visibility.go
+++ b/internal/api/visibility.go
@@ -241,8 +241,12 @@ func (vv *validateVisibility) recurse(newVal, curVal reflect.Value, mapKey, name
 		}
 
 	case reflect.Slice:
-		if newVal.IsNil() != curVal.IsNil() {
-			vv.checkFlags(flags, namespace, fieldname, newVal.IsNil())
+		// Treat a nil slice and an empty slice as equal.
+		newValIsNil := (newVal.IsNil() || newVal.Len() == 0)
+		curValIsNil := (curVal.IsNil() || curVal.Len() == 0)
+
+		if newValIsNil != curValIsNil {
+			vv.checkFlags(flags, namespace, fieldname, newValIsNil)
 			return
 		}
 
@@ -259,9 +263,24 @@ func (vv *validateVisibility) recurse(newVal, curVal reflect.Value, mapKey, name
 		}
 
 	case reflect.Interface, reflect.Pointer:
-		if newVal.IsNil() != curVal.IsNil() {
-			vv.checkFlags(flags, namespace, fieldname, newVal.IsNil())
-		} else if !newVal.IsNil() && !curVal.IsNil() {
+		var newValIsNil, curValIsNil bool
+
+		// If the field is NOT nullable, treat a nil pointer and a
+		// pointer to the zero value of the pointer's type as equal.
+		if flags.IsNullable() {
+			newValIsNil = newVal.IsNil()
+			curValIsNil = newVal.IsNil()
+		} else {
+			newValIsNil = (newVal.IsNil() || newVal.Elem().IsZero())
+			curValIsNil = (curVal.IsNil() || curVal.Elem().IsZero())
+		}
+
+		if newValIsNil != curValIsNil {
+			if !vv.checkFlags(flags, namespace, fieldname, newValIsNil) {
+				return
+			}
+		}
+		if !newVal.IsNil() && !curVal.IsNil() {
 			vv.recurse(newVal.Elem(), curVal.Elem(), mapKey, namespace, fieldname)
 		}
 
@@ -269,7 +288,11 @@ func (vv *validateVisibility) recurse(newVal, curVal reflect.Value, mapKey, name
 		// Determine if newVal and curVal share identical keys.
 		var keysEqual = true
 
-		if newVal.IsNil() != curVal.IsNil() || newVal.Len() != curVal.Len() {
+		// Treat a nil map and an empty map as equal.
+		newValIsNil := (newVal.IsNil() || newVal.Len() == 0)
+		curValIsNil := (curVal.IsNil() || curVal.Len() == 0)
+
+		if newValIsNil != curValIsNil || newVal.Len() != curVal.Len() {
 			keysEqual = false
 		} else {
 			iter := newVal.MapRange()
@@ -282,7 +305,7 @@ func (vv *validateVisibility) recurse(newVal, curVal reflect.Value, mapKey, name
 		}
 
 		// Skip recursion if visibility check on the map itself fails.
-		if !keysEqual && !vv.checkFlags(flags, namespace, fieldname, newVal.IsNil()) {
+		if !keysEqual && !vv.checkFlags(flags, namespace, fieldname, newValIsNil) {
 			return
 		}
 

--- a/internal/api/visibility_test.go
+++ b/internal/api/visibility_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -416,6 +417,46 @@ func TestValidateVisibility(t *testing.T) {
 			m:              TestModelTypeVisibilityMap,
 			updating:       false,
 			errorsExpected: 1,
+		},
+		{
+			name: "Replace read-only nil struct with empty struct is accepted",
+			v: TestModelType{
+				B: &TestModelSubtype{},
+			},
+			w:              TestModelType{},
+			m:              TestModelTypeVisibilityMap,
+			updating:       false,
+			errorsExpected: 0,
+		},
+		{
+			name: "Replace read-only empty struct with nil struct is accepted",
+			v:    TestModelType{},
+			w: TestModelType{
+				B: &TestModelSubtype{},
+			},
+			m:              TestModelTypeVisibilityMap,
+			updating:       false,
+			errorsExpected: 0,
+		},
+		{
+			name: "Replace read-only nil slice with empty slice is accepted",
+			v: TestModelType{
+				C: []*string{},
+			},
+			w:              TestModelType{},
+			m:              TestModelTypeVisibilityMap,
+			updating:       false,
+			errorsExpected: 0,
+		},
+		{
+			name: "Replace read-only empty slice with nil slice is accepted",
+			v:    TestModelType{},
+			w: TestModelType{
+				C: []*string{},
+			},
+			m:              TestModelTypeVisibilityMap,
+			updating:       false,
+			errorsExpected: 0,
 		},
 		{
 			name: "Add map key with read-only value to nil map is accepted for zero value",
@@ -1036,7 +1077,9 @@ func TestValidateVisibility(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cloudErrors := ValidateVisibility(tt.v, tt.w, tt.m, StructTagMap{}, tt.updating)
-			assert.Len(t, cloudErrors, tt.errorsExpected)
+			if !assert.Len(t, cloudErrors, tt.errorsExpected) {
+				t.Log(spew.Sdump(cloudErrors))
+			}
 		})
 	}
 }

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.1
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/go-playground/validator/v10 v10.27.0
 	github.com/google/go-cmp v0.7.0
@@ -40,7 +41,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-json-experiment/json v0.0.0-20250517221953-25912455fbc8 // indirect


### PR DESCRIPTION
[ARO-21135 - Cluster deployment invalid request](https://issues.redhat.com/browse/ARO-21135)

### What

For the purpose of validation, treat `nil` slices and empty slices as equal when comparing values. Same goes for maps.

Treat a `nil` pointer and a pointer to a zero-value as equal only when the field is not nullable. (A nullable field treats a `nil` pointer as distinct from a pointer to a zero value.)

Also add some unit test cases to reproduce and verify the bug.

### Why

This came up because our [E2E cluster bicep template](https://github.com/Azure/ARO-HCP/blob/main/test/e2e-setup/bicep/modules/cluster.bicep) specifies
```
  console: {}
```
and the `"console"` field is read-only (and not nullable).

Submitting a read-only field is allowed as long as the field value matches the resource's current value.

Visibility validation was comparing the incoming `&ConsoleProfile{}` value to the resource's internal `nil` pointer and mistreating it as an attempt to change a read-only field.