### PR TITLE
extend test time for serving_app verifier, add log warning messages 

### DIFF
--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -138,7 +138,7 @@ func (v verifySimpleWebApp) Verify(ctx context.Context, adminRESTConfig *rest.Co
 	logged5Min := false
 	logged10Min := false
 	logged15Min := false
-	firstResponseReceived := false
+	// firstResponseReceived := false
 	err = wait.PollUntilContextTimeout(ctx, 10*time.Second, 25*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		elapsed := time.Since(startTime)
 
@@ -165,49 +165,13 @@ func (v verifySimpleWebApp) Verify(ctx context.Context, adminRESTConfig *rest.Co
 		}
 		defer resp.Body.Close()
 
-		// Check for successful HTTP status code (200-299)
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Check for successful HTTP status code (200)
+		if resp.StatusCode != 200 {
 			statusErr := fmt.Errorf("received non-success status code: %d %s", resp.StatusCode, resp.Status)
 			if lastErr == nil || statusErr.Error() != lastErr.Error() {
-				klog.Info(statusErr, "route returned non-success status code",
-					"url", url,
-					"statusCode", resp.StatusCode,
-				)
+				ginkgo.GinkgoWriter.Printf("%s: route returned non-success status code", statusErr)
 			}
 			lastErr = statusErr
-
-			// If this is the first response we've received, start retrying for 3 minutes
-			if !firstResponseReceived {
-				firstResponseReceived = true
-				firstResponseTime := time.Now()
-				ginkgo.GinkgoWriter.Printf("Got first response with status %d, will retry for 3 minutes: url=%s\n", resp.StatusCode, url)
-
-				// Retry every 10 seconds for 3 minutes
-				retryErr := wait.PollUntilContextTimeout(ctx, 10*time.Second, 3*time.Minute, true, func(ctx context.Context) (done bool, err error) {
-					retryResp, retryErr := http.Get(url)
-					if retryErr != nil {
-						return false, nil
-					}
-					defer retryResp.Body.Close()
-
-					if retryResp.StatusCode >= 200 && retryResp.StatusCode < 300 {
-						totalElapsed := time.Since(startTime)
-						retryElapsed := time.Since(firstResponseTime)
-						ginkgo.GinkgoWriter.Printf("Route became healthy after %v total (%v from first response): url=%s statusCode=%d\n", totalElapsed, retryElapsed, url, retryResp.StatusCode)
-
-						// Dump the successful response
-						responseByte, _ := httputil.DumpResponse(retryResp, true)
-						ginkgo.GinkgoWriter.Printf("got successful response from route: response=%s\n", string(responseByte))
-						return true, nil
-					}
-					return false, nil
-				})
-
-				if retryErr != nil {
-					return false, nil
-				}
-				return true, nil
-			}
 			return false, nil
 		}
 

--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -191,8 +191,9 @@ func (v verifySimpleWebApp) Verify(ctx context.Context, adminRESTConfig *rest.Co
 					defer retryResp.Body.Close()
 
 					if retryResp.StatusCode >= 200 && retryResp.StatusCode < 300 {
-						successTime := time.Since(firstResponseTime)
-						ginkgo.GinkgoWriter.Printf("Route became healthy after %v from first response: url=%s statusCode=%d\n", successTime, url, retryResp.StatusCode)
+						totalElapsed := time.Since(startTime)
+						retryElapsed := time.Since(firstResponseTime)
+						ginkgo.GinkgoWriter.Printf("Route became healthy after %v total (%v from first response): url=%s statusCode=%d\n", totalElapsed, retryElapsed, url, retryResp.StatusCode)
 
 						// Dump the successful response
 						responseByte, _ := httputil.DumpResponse(retryResp, true)

--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -220,7 +220,10 @@ func (v verifySimpleWebApp) Verify(ctx context.Context, adminRESTConfig *rest.Co
 			lastErr = err
 			return false, nil
 		}
-		if elapsed := time.Since(startTime); elapsed < 5*time.Minute {
+
+		// Log timing information for successful response
+		elapsed = time.Since(startTime)
+		if elapsed < 5*time.Minute {
 			ginkgo.GinkgoWriter.Printf("Route became available in less than 5 minutes: url=%s elapsed=%v\n", url, elapsed)
 		}
 		ginkgo.GinkgoWriter.Printf("got successful response from route: response=%s\n", string(responseByte))


### PR DESCRIPTION


https://issues.redhat.com/browse/ARO-21032

### What

extend serving app verifier time to 25 minutes, add interval log warnings at <5, <10, <15  and >15 minutes.


### Why

debugging assistance for slow/failing app deployment test. 

