### PR TITLE
Bump maestro image for INT

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -69,7 +69,7 @@ clouds:
           # Maestro
           maestro:
             image:
-              digest: sha256:e0077b61a4f6fb612f12b63401f7d6e82c6cb1ff29ac4d31797eda808d68d082
+              digest: sha256:90daeea3b4191e3f02d9900a1e7d9e296329b3ca99ea785907c55c39cde95f04
           # OCP image sync
           imageSync:
             ocMirror:


### PR DESCRIPTION
This PR bumps the maestro image for INT.

WHY: The maestro image includes the fix for [ARO-20961](https://issues.redhat.com/browse/ARO-20961). The fix is not complete until CS is bumped also to a new image that contains the fixed maestro-client.

WARNING: Maestro and CS have to be rolled out in different releases to avoid incompatibility during transient states.
