### PR TITLE
Improve frontend e2e tests

### DIFF
--- a/test/e2e/cluster_versions.go
+++ b/test/e2e/cluster_versions.go
@@ -34,8 +34,8 @@ var _ = Describe("Customer", func() {
 		func(ctx context.Context) {
 			tc := framework.NewTestContext()
 
-			// Use uksouth as the test location for version listing
-			location := "uksouth"
+			// Use configured location for version listing
+			location := tc.Location()
 
 			By("listing HCP OpenShift versions via ARM API")
 			versionsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftVersionsClient()


### PR DESCRIPTION
• Fix admin_credential_lifecycle.go to use cluster-only.bicep template instead of manual multi-step deployment
• Replace hardcoded "uksouth" locations with tc.Location() in both test files