### PR TITLE
backend: log out the operation failure should one occur

### DIFF
--- a/backend/operations_scanner.go
+++ b/backend/operations_scanner.go
@@ -840,7 +840,12 @@ func (s *OperationsScanner) patchOperationDocument(ctx context.Context, op opera
 				message = "Credential revocation failed"
 			}
 		}
-		op.logger.Info(message)
+
+		if opError != nil {
+			op.logger.With("cloud_error_code", opError.Code, "cloud_error_message", opError.Message).Error(message)
+		} else {
+			op.logger.Info(message)
+		}
 	} else if !database.IsResponseError(err, http.StatusPreconditionFailed) {
 		return err
 	}


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Currently there's no place tracking operation failures and the log message returned to customers.  Let's change that.  
### Why

Troubleshooting is easier hopefully

### Special notes for your reviewer

<!-- optional -->
