### PR TITLE
test: increase timeout for ext auth access token retrieval

### DIFF
--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -225,7 +225,7 @@ var _ = Describe("Customer", func() {
 			cred, err := azidentity.NewClientSecretCredential(tc.TenantID(), app.AppID, pass.SecretText, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			// MSGraph is eventually consistent, wait up to 2 minutes for the token to be valid
+			// MSGraph is eventually consistent, wait up to 5 minutes for the token to be valid
 			var accessToken azcore.AccessToken
 			Eventually(func() error {
 				var err error
@@ -237,7 +237,7 @@ var _ = Describe("Customer", func() {
 					GinkgoWriter.Printf("GetToken failed: %v\n", err)
 				}
 				return err
-			}, 2*time.Minute, 10*time.Second).Should(Succeed())
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 
 			config := &rest.Config{
 				Host:        adminRESTConfig.Host,


### PR DESCRIPTION
[ARO-21082](https://issues.redhat.com/browse/ARO-21082)

### What
Follows on from https://github.com/Azure/ARO-HCP/pull/2723. Increases time to 5 minutes since the stage e2e parallel failed with the same error.

### Why
There's a delay to propagate aad/msgraph. If we attempt to fetch a token and it fails, it should wait for a bit longer. Fixes [ARO-21082](https://issues.redhat.com/browse/ARO-21082)


### Special notes for your reviewer

<!-- optional -->
