### PR TITLE
Improve kubectl exec command in postgres-breakglass.md

### DIFF
--- a/docs/ops/postgres-breakglass.md
+++ b/docs/ops/postgres-breakglass.md
@@ -15,9 +15,9 @@ This guide describes how to access the Postgres database of ARO HCP service, spe
 1. Exec into the pod of the deployment
 
    ```/bin/sh
-   kubectl exec -it postgres-breakglass-<pod-name> -n clusters-service -- /bin/bash
+   kubeclt exec -ti (kubeclt get pods -n  clusters-service -l app=postgres-breakglass -o name) -n clusters-service -- /bin/bash
    or
-   kubectl exec -it postgres-breakglass-<pod-name> -n maestro -- /bin/bash
+   kubeclt exec -ti (kubeclt get pods -n  clusters-service -l app=postgres-breakglass -o name) -n clusters-service -- /bin/bash
    ```
 
 2. Run `connect` within the container to start a `psql` session


### PR DESCRIPTION
### What

Improves the breakglass documentation using a label selector for the pods.

### Why

This command can be executed directly, the current one relies in a generated name.