### PR TITLE
feat: make CS K8s Deployment rolling update strategy configurable

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -85,6 +85,8 @@ deploy:
 	  --set pullBinding.scope=repository:${IMAGE_REPO}:pull \
 	  --set managedIdentitiesDataPlaneAudienceResource=${MI_DATAPLANE_AUDIENCE_RESOURCE} \
 	  --set tracing.address=${TRACING_ADDRESS} \
+	  --set csDeploymentStrategy.rollingUpdate.maxSurge=${CS_DEPLOYMENT_ROLLINGUPDATE_MAX_SURGE} \
+	  --set csDeploymentStrategy.rollingUpdate.maxUnavailable=${CS_DEPLOYMENT_ROLLINGUPDATE_MAX_UNAVAILABLE} \
 	  "$${OP_HELM_SET_FLAGS[@]}"
 
 deploy-pr-env-deps:

--- a/cluster-service/deploy/templates/deployment.yaml
+++ b/cluster-service/deploy/templates/deployment.yaml
@@ -10,6 +10,8 @@ spec:
     matchLabels:
       app: clusters-service
   replicas: {{ .Values.replicas }}
+  strategy:
+    {{- .Values.csDeploymentStrategy | toYaml | nindent 4 }}
   template:
     metadata:
       labels:

--- a/cluster-service/deploy/values.yaml
+++ b/cluster-service/deploy/values.yaml
@@ -242,3 +242,8 @@ pullBinding:
   workloadIdentityTenantId: ""
 tracing:
   address: ""
+csDeploymentStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -142,6 +142,10 @@ resourceGroups:
       configRef: clustersService.denyAssignments
     - name: MI_DATAPLANE_AUDIENCE_RESOURCE
       configRef: msiRp.dataPlaneAudienceResource
+    - name: CS_DEPLOYMENT_ROLLINGUPDATE_MAX_SURGE
+      configRef: clustersService.k8s.deploymentStrategy.rollingUpdate.maxSurge
+    - name: CS_DEPLOYMENT_ROLLINGUPDATE_MAX_UNAVAILABLE
+      configRef: clustersService.k8s.deploymentStrategy.rollingUpdate.maxUnavailable
     - name: OCP_ACR_RESOURCE_ID
       input:
         resourceGroup: global

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -17,6 +17,53 @@
       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
       "description": "A valid RFC1123 DNS subdomain. Multiple RFC1123 DNS label devided by a dot."
     },
+    "intOrString": {
+       "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type. This allows you to have, for example, a JSON field that can accept a name or number.",
+       "format": "int-or-string",
+       "oneOf": [
+         {
+           "type": "integer"
+         },
+         {
+           "type": "string"
+         }
+       ]
+    },
+    "k8sRollingUpdateDeploymentStrategy": {
+      "type": "object",
+      "description": "Spec to control the desired behavior of rolling update.",
+      "properties": {
+        "maxSurge": {
+          "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/intOrString"
+            }
+          ]
+        },
+        "maxUnavailable": {
+          "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/intOrString"
+            }
+          ]
+        }
+      }
+    },
+    "k8sDeploymentStrategy": {
+      "type": "object",
+      "properties": {
+        "rollingUpdate": {
+          "description": "Rolling update config params",
+          "allOf": [
+            {
+              "$ref": "#/definitions/k8sRollingUpdateDeploymentStrategy"
+            }
+          ]
+        }
+      }
+    },
     "k8sDeployment": {
       "type": "object",
       "properties": {
@@ -29,6 +76,9 @@
         "replicas": {
           "type": "number",
           "minimum": 1
+        },
+        "deploymentStrategy": {
+          "$ref": "#/definitions/k8sDeploymentStrategy"
         }
       },
       "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -608,6 +608,10 @@ defaults:
       replicas: 3
       namespace: clusters-service
       serviceAccountName: clusters-service
+      deploymentStrategy:
+        rollingUpdate:
+          maxUnavailable: 25%
+          maxSurge: 25%
     azureRuntimeConfig:
       tlsCertificatesIssuer: OneCertV2-PublicCA
   # Image Sync
@@ -777,6 +781,11 @@ clouds:
             roleNames: Azure Red Hat OpenShift KMS Plugin - Dev
         azureRuntimeConfig:
           tlsCertificatesIssuer: Self
+        k8s:
+          deploymentStrategy:
+            rollingUpdate:
+              maxUnavailable: 0
+              maxSurge: 1
       # Hypershift Operator
       hypershift:
         image:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 8e9a93b477e14d8afee9e722a8b32b9d1fc133a75e9670fc89706ae047ead3c4
+          westus3: 9a7c07839584849077d7aa3da051e4d34013ee30ad33f94dd6525dbe314a93f0
       dev:
         regions:
-          westus3: c3a1fe7183883fa8e6a80def42ea0b26243479ebf1574a5cc801afde9abab77b
+          westus3: 8331814749effdbca9dedf157cd5e52f0dead12c0a3b4a61f1bfdc2598bc6bf7
       ntly:
         regions:
-          uksouth: ab28e4c62df8c801a11630c368e99d90a43246ec6c96728b233338ed9d613056
+          uksouth: 870542956547464e778b2596329356340537a5e3cebc70b48b5efe0f8eb72630
       perf:
         regions:
-          westus3: a5afad9650479e7ed1f3042b025404e139484de22f5a2b3364b7f03780b0d45e
+          westus3: e0f75d62c6707faf97795510325ec24bee3d8ab900283f968ec074b994ccaf00
       pers:
         regions:
-          westus3: fbed023b73ed46fbb33daaa55f84cb363d6add76d07c0588aae17f50895d64c5
+          westus3: 451394ff1d2590bc720806f58a85198e3cb415c43241649e14195f980d20e466
       swft:
         regions:
-          uksouth: 1490e2f13dd701ca9a5e41dfdef19713d8d60b6c59fb54405846b3ce6265180e
+          uksouth: 557c629fad5296679175628ca6432e4c3e3701026bf588fdc330259c0cea7258

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -122,6 +122,10 @@ clustersService:
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:
+    deploymentStrategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     namespace: clusters-service
     replicas: 3
     serviceAccountName: clusters-service

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -122,6 +122,10 @@ clustersService:
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:
+    deploymentStrategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     namespace: clusters-service
     replicas: 3
     serviceAccountName: clusters-service

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -122,6 +122,10 @@ clustersService:
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:
+    deploymentStrategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     namespace: clusters-service
     replicas: 3
     serviceAccountName: clusters-service

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -122,6 +122,10 @@ clustersService:
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:
+    deploymentStrategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     namespace: clusters-service
     replicas: 3
     serviceAccountName: clusters-service

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -122,6 +122,10 @@ clustersService:
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:
+    deploymentStrategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     namespace: clusters-service
     replicas: 3
     serviceAccountName: clusters-service

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -122,6 +122,10 @@ clustersService:
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:
+    deploymentStrategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     namespace: clusters-service
     replicas: 3
     serviceAccountName: clusters-service


### PR DESCRIPTION
We add the ability to configure the rolling update strategy attributes for the components.

We introduce that configuration explicitly for Clusters Service. We start by introducing a default of maxSurge=25% and maxUnavailable=25% for Clusters Service in all environments, which is what we currently have as it is the default rolling update strategy but we make it explicit.

Additionally, we change the configuration for CS in dev based environments to be in absolute numbers instead of percentage. Specifically, we set maxSurge=1 and maxUnavailable=0. That should ensure that no matter the number of replicas we only deploy a new replica at a time and we only delete an old replica once a new replica has been deployed. This is the same behavior as what we have with maxSurge=25%, maxUnavailable=25% in our envs because of the current number of replicas there at the moment of writing this. Using absolute numbers should ensure that if in the future the number of replicas changes we will still have the same behavior. We intend to change this for all the other envs to the same absolute values.

In the future we can decide to relax this or moving it back to percentage based but when doing it we should carefully evaluate the implications and introduce it gradually to our environments making sure that there are no unintended side effects.