### PR TITLE
add new hcpcluster, externalauth, and nodepool types with compatible serialization

### DIFF
--- a/frontend/go.sum
+++ b/frontend/go.sum
@@ -325,3 +325,5 @@ k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d h1:wAhiDyZ4Tdtt7e46e9M5ZSAJ/MnPGPs+Ki1gHw4w1R0=
 k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
+sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=

--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -222,7 +222,7 @@ func (f *Frontend) CreateOrUpdateExternalAuth(writer http.ResponseWriter, reques
 	f.ExposeOperation(writer, request, operationID, transaction)
 
 	if !updating {
-		resourceItemID = transaction.CreateResourceDoc(resourceDoc, database.RemoveAllState, nil)
+		resourceItemID = transaction.CreateResourceDoc(resourceDoc, database.FilterExternalAuthState, nil)
 	}
 
 	var patchOperations database.ResourceDocumentPatchOperations

--- a/frontend/pkg/frontend/external_auth_test.go
+++ b/frontend/pkg/frontend/external_auth_test.go
@@ -210,7 +210,7 @@ func TestCreateExternalAuth(t *testing.T) {
 			// CreateOrUpdateExternalAuth
 			externalAuthItemID := uuid.New().String()
 			mockDBTransaction.EXPECT().
-				CreateResourceDoc(test.externalAuthDoc, database.RemoveAllState, nil).
+				CreateResourceDoc(test.externalAuthDoc, gomock.Any() /*functions aren't self-comparable*/, nil).
 				Return(externalAuthItemID)
 			// CreateOrUpdateExternalAuth
 			mockDBTransaction.EXPECT().

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -260,7 +260,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 	f.ExposeOperation(writer, request, operationID, transaction)
 
 	if !updating {
-		resourceItemID = transaction.CreateResourceDoc(resourceDoc, database.RemoveAllState, nil)
+		resourceItemID = transaction.CreateResourceDoc(resourceDoc, database.FilterNodePoolState, nil)
 	}
 
 	var patchOperations database.ResourceDocumentPatchOperations

--- a/frontend/pkg/frontend/node_pool_test.go
+++ b/frontend/pkg/frontend/node_pool_test.go
@@ -214,7 +214,7 @@ func TestCreateNodePool(t *testing.T) {
 			// CreateOrUpdateNodePool
 			nodePoolItemID := uuid.New().String()
 			mockDBTransaction.EXPECT().
-				CreateResourceDoc(test.nodePoolDoc, database.RemoveAllState, nil).
+				CreateResourceDoc(test.nodePoolDoc, gomock.Any() /*functions aren't self-comparable*/, nil).
 				Return(nodePoolItemID)
 			// CreateOrUpdateNodePool
 			mockDBTransaction.EXPECT().

--- a/internal/database/types_externalauth.go
+++ b/internal/database/types_externalauth.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+type ExternalAuth struct {
+	TypedDocument `json:",inline"`
+
+	ExternalAuthProperties `json:"properties"`
+}
+
+type ExternalAuthProperties struct {
+	ResourceDocument `json:",inline"`
+
+	CustomerDesiredState CustomerDesiredExternalAuthState `json:"customerDesiredState"`
+	ServiceProviderState ServiceProviderExternalAuthState `json:"serviceProviderState"`
+}
+
+type CustomerDesiredExternalAuthState struct {
+	// ExternalAuth contains the desired state from a customer.  It is filtered to only those fields that customers
+	// are able to set.
+	// We will eventually select specific fields which customers own and blank out everything else.
+	// Alternatively, we could choose a different structure, but it's probably easier to re-use this one.
+	// There is no validation on this structure.
+	ExternalAuth api.HCPOpenShiftClusterExternalAuthProperties `json:"externalAuthProperties"`
+}
+
+type ServiceProviderExternalAuthState struct {
+	// ExternalAuth contains the service provider owned state.  It is filtered to only those fields that the service provider owns.
+	// We will eventually select specific fields which the service provider owns and blank out everything else.
+	// Alternatively, we could choose a different structure, but it's probably easier to re-use this one.
+	// There is no validation on this structure.
+	ExternalAuth api.HCPOpenShiftClusterExternalAuthProperties `json:"externalAuthProperties"`
+}
+
+var FilterExternalAuthState ResourceDocumentStateFilter = newJSONRoundTripFilterer(
+	func() any { return &CustomerDesiredExternalAuthState{} },
+	func() any { return &ServiceProviderExternalAuthState{} },
+)

--- a/internal/database/types_externalauth_test.go
+++ b/internal/database/types_externalauth_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"math/rand"
+	"testing"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"sigs.k8s.io/randfill"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+)
+
+func TestExternalAuthJSONRoundTripThroughResourceDocument(t *testing.T) {
+	seed := rand.Int63()
+	fuzzer := fuzzerFor([]interface{}{
+		func(j *TypedDocument, c randfill.Continue) {
+			c.FillNoCustom(j)
+			j.ResourceType = api.ExternalAuthResourceType.String()
+		},
+		func(j *map[string]any, c randfill.Continue) {
+		},
+		func(j *azcorearm.ResourceID, c randfill.Continue) {
+			*j = *api.Must(azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg"))
+		},
+		func(j *ocm.InternalID, c randfill.Continue) {
+			*j = api.Must(ocm.NewInternalID("/api/clusters_mgmt/v1/clusters/fixed-value"))
+		},
+	}, rand.NewSource(seed))
+
+	// Try a few times, since runTest uses random values.
+	for i := 0; i < 20; i++ {
+		original := &ExternalAuth{}
+		roundTrippedObj := &ExternalAuth{}
+		fuzzer.Fill(original)
+		roundTrip(t, original, roundTrippedObj, FilterExternalAuthState)
+	}
+}

--- a/internal/database/types_hcpcluster.go
+++ b/internal/database/types_hcpcluster.go
@@ -40,7 +40,7 @@ type CustomerDesiredHCPClusterState struct {
 	// We will eventually select specific fields which customers own and blank out everything else.
 	// Alternatively, we could choose a different structure, but it's probably easier to re-use this one.
 	// There is no validation on this structure.
-	HCPOpenShiftCluster api.HCPOpenShiftCluster `json:"hcpOpenShiftCluster"`
+	HCPOpenShiftCluster api.HCPOpenShiftClusterProperties `json:"clusterProperties"`
 }
 
 type ServiceProviderHCPClusterState struct {
@@ -48,7 +48,7 @@ type ServiceProviderHCPClusterState struct {
 	// We will eventually select specific fields which the service provider owns and blank out everything else.
 	// Alternatively, we could choose a different structure, but it's probably easier to re-use this one.
 	// There is no validation on this structure.
-	HCPOpenShiftCluster api.HCPOpenShiftCluster `json:"hcpOpenShiftCluster"`
+	HCPOpenShiftCluster api.HCPOpenShiftClusterProperties `json:"clusterProperties"`
 }
 
 var FilterHCPClusterState ResourceDocumentStateFilter = newJSONRoundTripFilterer(

--- a/internal/database/types_hcpcluster.go
+++ b/internal/database/types_hcpcluster.go
@@ -21,6 +21,19 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 )
 
+type HCPCluster struct {
+	TypedDocument `json:",inline"`
+
+	HCPClusterProperties `json:"properties"`
+}
+
+type HCPClusterProperties struct {
+	ResourceDocument `json:",inline"`
+
+	CustomerDesiredState CustomerDesiredHCPClusterState `json:"customerDesiredState"`
+	ServiceProviderState ServiceProviderHCPClusterState `json:"serviceProviderState"`
+}
+
 type CustomerDesiredHCPClusterState struct {
 	// HCPOpenShiftCluster contains the desired state from a customer.  It is filtered to only those fields that customers
 	// are able to set.

--- a/internal/database/types_hcpcluster_test.go
+++ b/internal/database/types_hcpcluster_test.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/randfill"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+)
+
+// fuzzerFor can randomly populate api objects that are destined for version.
+func fuzzerFor(funcs []interface{}, src rand.Source) *randfill.Filler {
+	f := randfill.New().NilChance(.5).NumElements(0, 1)
+	if src != nil {
+		f.RandSource(src)
+	}
+	f.Funcs(funcs...)
+	return f
+}
+
+func TestHCPClusterJSONRoundTripThroughResourceDocument(t *testing.T) {
+	seed := rand.Int63()
+	fuzzer := fuzzerFor([]interface{}{
+		func(j *HCPCluster, c randfill.Continue) {
+			c.FillNoCustom(j)
+			j.ResourceType = api.ClusterResourceType.String()
+		},
+		func(j *map[string]any, c randfill.Continue) {
+		},
+		func(j *azcorearm.ResourceID, c randfill.Continue) {
+			fmt.Println("resourceID")
+			*j = *api.Must(azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg"))
+		},
+		func(j *ocm.InternalID, c randfill.Continue) {
+			*j = api.Must(ocm.NewInternalID("/api/clusters_mgmt/v1/clusters/fixed-value"))
+		},
+	}, rand.NewSource(seed))
+
+	// Try a few times, since runTest uses random values.
+	for i := 0; i < 20; i++ {
+		original := &HCPCluster{}
+		roundTrippedObj := &HCPCluster{}
+		fuzzer.Fill(original)
+		roundTrip(t, original, roundTrippedObj)
+	}
+}
+
+func roundTrip(t *testing.T, original, roundTrippedObj any) {
+	originalJSON, err := json.MarshalIndent(original, "", "    ")
+	if err != nil {
+		t.Fatalf("failed to marshal original: %v", err)
+	}
+	// useful for debugging
+	//t.Log(string(originalJSON))
+
+	typedDocument, resourceDocument, err := typedDocumentUnmarshal[ResourceDocument](originalJSON)
+	if err != nil {
+		t.Fatalf("failed to unmarshal into typedDocument: %v", err)
+	}
+
+	resourceDocumentJSON, err := resourceDocumentMarshal(typedDocument, resourceDocument, FilterHCPClusterState)
+	if err != nil {
+		t.Fatalf("failed to marshal ResourceDocument: %v", err)
+	}
+
+	err = json.Unmarshal(resourceDocumentJSON, roundTrippedObj)
+	if err != nil {
+		t.Fatalf("failed to unmarshal into roundTrippedObj: %v", err)
+	}
+
+	roundTrippedJSON, err := json.MarshalIndent(roundTrippedObj, "", "    ")
+	if err != nil {
+		t.Fatalf("failed to marshal roundTrippedObj: %v", err)
+	}
+
+	// we compare the JSON here because many of these types have private fields that cannot be introspected
+	if !reflect.DeepEqual(originalJSON, roundTrippedJSON) {
+		t.Errorf("Round trip failed: %v", cmp.Diff(originalJSON, roundTrippedJSON))
+	}
+}

--- a/internal/database/types_nodepool.go
+++ b/internal/database/types_nodepool.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+type NodePool struct {
+	TypedDocument `json:",inline"`
+
+	NodePoolProperties `json:"properties"`
+}
+
+type NodePoolProperties struct {
+	ResourceDocument `json:",inline"`
+
+	CustomerDesiredState CustomerDesiredNodePoolState `json:"customerDesiredState"`
+	ServiceProviderState ServiceProviderNodePoolState `json:"serviceProviderState"`
+}
+
+type CustomerDesiredNodePoolState struct {
+	// NodePool contains the desired state from a customer.  It is filtered to only those fields that customers
+	// are able to set.
+	// We will eventually select specific fields which customers own and blank out everything else.
+	// Alternatively, we could choose a different structure, but it's probably easier to re-use this one.
+	// There is no validation on this structure.
+	NodePool api.HCPOpenShiftClusterNodePoolProperties `json:"nodePoolProperties"`
+}
+
+type ServiceProviderNodePoolState struct {
+	// NodePool contains the service provider owned state.  It is filtered to only those fields that the service provider owns.
+	// We will eventually select specific fields which the service provider owns and blank out everything else.
+	// Alternatively, we could choose a different structure, but it's probably easier to re-use this one.
+	// There is no validation on this structure.
+	NodePool api.HCPOpenShiftClusterNodePoolProperties `json:"nodePoolProperties"`
+}
+
+var FilterNodePoolState ResourceDocumentStateFilter = newJSONRoundTripFilterer(
+	func() any { return &CustomerDesiredNodePoolState{} },
+	func() any { return &ServiceProviderNodePoolState{} },
+)

--- a/internal/database/types_nodepool_test.go
+++ b/internal/database/types_nodepool_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"math/rand"
+	"testing"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"sigs.k8s.io/randfill"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+)
+
+func TestNodePoolJSONRoundTripThroughResourceDocument(t *testing.T) {
+	seed := rand.Int63()
+	fuzzer := fuzzerFor([]interface{}{
+		func(j *TypedDocument, c randfill.Continue) {
+			c.FillNoCustom(j)
+			j.ResourceType = api.NodePoolResourceType.String()
+		},
+		func(j *map[string]any, c randfill.Continue) {
+		},
+		func(j *azcorearm.ResourceID, c randfill.Continue) {
+			*j = *api.Must(azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg"))
+		},
+		func(j *ocm.InternalID, c randfill.Continue) {
+			*j = api.Must(ocm.NewInternalID("/api/clusters_mgmt/v1/clusters/fixed-value"))
+		},
+	}, rand.NewSource(seed))
+
+	// Try a few times, since runTest uses random values.
+	for i := 0; i < 20; i++ {
+		original := &NodePool{}
+		roundTrippedObj := &NodePool{}
+		fuzzer.Fill(original)
+		roundTrip(t, original, roundTrippedObj, FilterNodePoolState)
+	}
+}

--- a/internal/database/types_typeddocument_test.go
+++ b/internal/database/types_typeddocument_test.go
@@ -154,23 +154,19 @@ func Test_resourceDocumentMarshal(t *testing.T) {
 				innerDoc: &ResourceDocument{
 					CustomerDesiredState: map[string]any{
 						"alligator": "adept",
-						"hcpOpenShiftCluster": map[string]any{
+						"clusterProperties": map[string]any{
 							"bat": "black",
-							"properties": map[string]any{
-								"version": map[string]any{
-									"id": "1.2.3",
-								},
+							"version": map[string]any{
+								"id": "1.2.3",
 							},
 						},
 					},
 					ServiceProviderState: map[string]any{
 						"alligator": "adept",
-						"hcpOpenShiftCluster": map[string]any{
+						"clusterProperties": map[string]any{
 							"bat": "black",
-							"properties": map[string]any{
-								"dns": map[string]any{
-									"baseDomain": "example.com",
-								},
+							"dns": map[string]any{
+								"baseDomain": "example.com",
 							},
 						},
 					},
@@ -184,20 +180,16 @@ func Test_resourceDocumentMarshal(t *testing.T) {
 				},
 				&ResourceDocument{},
 				CustomerDesiredHCPClusterState{
-					HCPOpenShiftCluster: api.HCPOpenShiftCluster{
-						Properties: api.HCPOpenShiftClusterProperties{
-							Version: api.VersionProfile{
-								ID: "1.2.3",
-							},
+					HCPOpenShiftCluster: api.HCPOpenShiftClusterProperties{
+						Version: api.VersionProfile{
+							ID: "1.2.3",
 						},
 					},
 				},
 				ServiceProviderHCPClusterState{
-					HCPOpenShiftCluster: api.HCPOpenShiftCluster{
-						Properties: api.HCPOpenShiftClusterProperties{
-							DNS: api.DNSProfile{
-								BaseDomain: "example.com",
-							},
+					HCPOpenShiftCluster: api.HCPOpenShiftClusterProperties{
+						DNS: api.DNSProfile{
+							BaseDomain: "example.com",
 						},
 					},
 				},

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -29,6 +29,7 @@ require (
 	go.uber.org/mock v0.5.2
 	gotest.tools v2.2.0+incompatible
 	k8s.io/apimachinery v0.34.0
+	sigs.k8s.io/randfill v1.0.0
 )
 
 require (

--- a/internal/go.sum
+++ b/internal/go.sum
@@ -318,3 +318,5 @@ k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d h1:wAhiDyZ4Tdtt7e46e9M5ZSAJ/MnPGPs+Ki1gHw4w1R0=
 k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
+sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=


### PR DESCRIPTION
This also makes use a new library for fuzzing structs so that we can ensure compatibility of conversion and roundtripping.