### PR TITLE
add a specific client for HCPClusters

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -434,7 +434,7 @@ func (f *Frontend) GetHCPCluster(writer http.ResponseWriter, request *http.Reque
 	resourceGroupName := request.PathValue(PathSegmentResourceGroupName)
 	resourceName := request.PathValue(PathSegmentResourceName)
 
-	hcpCluster, err := f.dbClient.HCPClusters().Get(ctx, subscriptionID, resourceGroupName, resourceName)
+	hcpCluster, err := f.dbClient.HCPClusters(subscriptionID, resourceGroupName).Get(ctx, resourceName)
 	if database.IsResponseError(err, http.StatusNotFound) {
 		reportingErr := arm.NewResourceNotFoundError(resourceID)
 		logger.Error(reportingErr.Error())

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -410,6 +410,63 @@ func (f *Frontend) ArmResourceRead(writer http.ResponseWriter, request *http.Req
 	}
 }
 
+// GetHCPCluster implements the GET single resource API contract for HCP Clusters
+// * 200 If the resource exists
+// * 404 If the resource does not exist
+func (f *Frontend) GetHCPCluster(writer http.ResponseWriter, request *http.Request) {
+	ctx := request.Context()
+	logger := LoggerFromContext(ctx)
+
+	versionedInterface, err := VersionFromContext(ctx)
+	if err != nil {
+		logger.Error(err.Error())
+		arm.WriteInternalServerError(writer)
+		return
+	}
+	resourceID, err := ResourceIDFromContext(ctx) // used for error reporting
+	if err != nil {
+		logger.Error(err.Error())
+		arm.WriteInternalServerError(writer)
+		return
+	}
+
+	subscriptionID := request.PathValue(PathSegmentSubscriptionID)
+	resourceGroupName := request.PathValue(PathSegmentResourceGroupName)
+	resourceName := request.PathValue(PathSegmentResourceName)
+
+	hcpCluster, err := f.dbClient.HCPClusters().Get(ctx, subscriptionID, resourceGroupName, resourceName)
+	if database.IsResponseError(err, http.StatusNotFound) {
+		reportingErr := arm.NewResourceNotFoundError(resourceID)
+		logger.Error(reportingErr.Error())
+		arm.WriteCloudError(writer, ocm.CSErrorToCloudError(reportingErr, resourceID, nil))
+		return
+	}
+	if err != nil {
+		logger.Error(err.Error())
+		arm.WriteInternalServerError(writer)
+		return
+	}
+
+	csCluster, err := f.clusterServiceClient.GetCluster(ctx, hcpCluster.InternalID)
+	if err != nil {
+		logger.Error(err.Error())
+		arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, hcpCluster.ResourceID, nil))
+		return
+	}
+
+	responseBody, err := marshalCSCluster(csCluster, hcpCluster.GetResourceDocument(), versionedInterface)
+	if err != nil {
+		logger.Error(err.Error())
+		arm.WriteInternalServerError(writer)
+		return
+	}
+
+	_, err = arm.WriteJSONResponse(writer, http.StatusOK, responseBody)
+	if err != nil {
+		logger.Error(err.Error())
+	}
+}
+
 func (f *Frontend) CreateOrUpdateHCPCluster(writer http.ResponseWriter, request *http.Request) {
 	var err error
 

--- a/frontend/pkg/frontend/helpers.go
+++ b/frontend/pkg/frontend/helpers.go
@@ -266,19 +266,6 @@ func (f *Frontend) MarshalResource(ctx context.Context, resourceID *azcorearm.Re
 	}
 
 	switch doc.InternalID.Kind() {
-	case arohcpv1alpha1.ClusterKind:
-		csCluster, err := f.clusterServiceClient.GetCluster(ctx, doc.InternalID)
-		if err != nil {
-			logger.Error(err.Error())
-			return nil, ocm.CSErrorToCloudError(err, resourceID, nil)
-		}
-
-		responseBody, err = marshalCSCluster(csCluster, doc, versionedInterface)
-		if err != nil {
-			logger.Error(err.Error())
-			return nil, arm.NewInternalServerError()
-		}
-
 	case arohcpv1alpha1.NodePoolKind:
 		csNodePool, err := f.clusterServiceClient.GetNodePool(ctx, doc.InternalID)
 		if err != nil {

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -112,7 +112,7 @@ func (f *Frontend) routes(r prometheus.Registerer) http.Handler {
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceRead))
+		postMuxMiddleware.HandlerFunc(f.GetHCPCluster))
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, PatternNodePools),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceRead))

--- a/internal/database/crud_hcpcluster.go
+++ b/internal/database/crud_hcpcluster.go
@@ -19,8 +19,8 @@ import "github.com/Azure/ARO-HCP/internal/api"
 type HCPClusterCRUD interface {
 	ResourceCRUD[HCPCluster]
 
-	ExternalAuthCRUD(hcpClusterID string) ResourceCRUD[ExternalAuth]
-	NodePoolCRUD(hcpClusterID string) ResourceCRUD[NodePool]
+	ExternalAuth(hcpClusterID string) ResourceCRUD[ExternalAuth]
+	NodePools(hcpClusterID string) ResourceCRUD[NodePool]
 }
 
 type hcpClusterCRUD struct {
@@ -29,10 +29,10 @@ type hcpClusterCRUD struct {
 
 var _ HCPClusterCRUD = &hcpClusterCRUD{}
 
-func (h *hcpClusterCRUD) ExternalAuthCRUD(hcpClusterID string) ResourceCRUD[ExternalAuth] {
+func (h *hcpClusterCRUD) ExternalAuth(hcpClusterID string) ResourceCRUD[ExternalAuth] {
 	return newNestedCosmosResourceCRUD[ExternalAuth](h.topLevelCosmosResourceCRUD, h.subscriptionID, h.resourceGroupName, hcpClusterID, api.ExternalAuthResourceType)
 }
 
-func (h *hcpClusterCRUD) NodePoolCRUD(hcpClusterID string) ResourceCRUD[NodePool] {
+func (h *hcpClusterCRUD) NodePools(hcpClusterID string) ResourceCRUD[NodePool] {
 	return newNestedCosmosResourceCRUD[NodePool](h.topLevelCosmosResourceCRUD, h.subscriptionID, h.resourceGroupName, hcpClusterID, api.NodePoolResourceType)
 }

--- a/internal/database/crud_hcpcluster.go
+++ b/internal/database/crud_hcpcluster.go
@@ -17,10 +17,10 @@ package database
 import "github.com/Azure/ARO-HCP/internal/api"
 
 type HCPClusterCRUD interface {
-	TopLevelResourceCRUD[HCPCluster]
+	ResourceCRUD[HCPCluster]
 
-	ExternalAuthCRUD(subscriptionID, resourceGroupID, hcpClusterID string) NestedResourceCRUD[ExternalAuth]
-	NodePoolCRUD(subscriptionID, resourceGroupID, hcpClusterID string) NestedResourceCRUD[NodePool]
+	ExternalAuthCRUD(hcpClusterID string) ResourceCRUD[ExternalAuth]
+	NodePoolCRUD(hcpClusterID string) ResourceCRUD[NodePool]
 }
 
 type hcpClusterCRUD struct {
@@ -29,10 +29,10 @@ type hcpClusterCRUD struct {
 
 var _ HCPClusterCRUD = &hcpClusterCRUD{}
 
-func (h *hcpClusterCRUD) ExternalAuthCRUD(subscriptionID, resourceGroupID, hcpClusterID string) NestedResourceCRUD[ExternalAuth] {
-	return newNestedCosmosResourceCRUD[ExternalAuth](h.topLevelCosmosResourceCRUD, subscriptionID, resourceGroupID, hcpClusterID, api.ExternalAuthResourceType)
+func (h *hcpClusterCRUD) ExternalAuthCRUD(hcpClusterID string) ResourceCRUD[ExternalAuth] {
+	return newNestedCosmosResourceCRUD[ExternalAuth](h.topLevelCosmosResourceCRUD, h.subscriptionID, h.resourceGroupName, hcpClusterID, api.ExternalAuthResourceType)
 }
 
-func (h *hcpClusterCRUD) NodePoolCRUD(subscriptionID, resourceGroupID, hcpClusterID string) NestedResourceCRUD[NodePool] {
-	return newNestedCosmosResourceCRUD[NodePool](h.topLevelCosmosResourceCRUD, subscriptionID, resourceGroupID, hcpClusterID, api.NodePoolResourceType)
+func (h *hcpClusterCRUD) NodePoolCRUD(hcpClusterID string) ResourceCRUD[NodePool] {
+	return newNestedCosmosResourceCRUD[NodePool](h.topLevelCosmosResourceCRUD, h.subscriptionID, h.resourceGroupName, hcpClusterID, api.NodePoolResourceType)
 }

--- a/internal/database/crud_hcpcluster.go
+++ b/internal/database/crud_hcpcluster.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import "github.com/Azure/ARO-HCP/internal/api"
+
+type HCPClusterCRUD interface {
+	TopLevelResourceCRUD[HCPCluster]
+
+	ExternalAuthCRUD(subscriptionID, resourceGroupID, hcpClusterID string) NestedResourceCRUD[ExternalAuth]
+	NodePoolCRUD(subscriptionID, resourceGroupID, hcpClusterID string) NestedResourceCRUD[NodePool]
+}
+
+type hcpClusterCRUD struct {
+	*topLevelCosmosResourceCRUD[HCPCluster]
+}
+
+var _ HCPClusterCRUD = &hcpClusterCRUD{}
+
+func (h *hcpClusterCRUD) ExternalAuthCRUD(subscriptionID, resourceGroupID, hcpClusterID string) NestedResourceCRUD[ExternalAuth] {
+	return newNestedCosmosResourceCRUD[ExternalAuth](h.topLevelCosmosResourceCRUD, subscriptionID, resourceGroupID, hcpClusterID, api.ExternalAuthResourceType)
+}
+
+func (h *hcpClusterCRUD) NodePoolCRUD(subscriptionID, resourceGroupID, hcpClusterID string) NestedResourceCRUD[NodePool] {
+	return newNestedCosmosResourceCRUD[NodePool](h.topLevelCosmosResourceCRUD, subscriptionID, resourceGroupID, hcpClusterID, api.NodePoolResourceType)
+}

--- a/internal/database/crud_helpers.go
+++ b/internal/database/crud_helpers.go
@@ -69,10 +69,11 @@ func get[T any](ctx context.Context, containerClient *azcosmos.ContainerClient, 
 		return nil, fmt.Errorf("failed to read Resources container item for '%s': %w", completeResourceID, err)
 	}
 
-	var ret T
-	if err := json.Unmarshal(responseItem, &ret); err != nil {
+	var obj T
+	if err := json.Unmarshal(responseItem, &obj); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal Resources container item for '%s': %w", completeResourceID, err)
 	}
+	ret := &obj
 
 	// Replace the key field from Cosmos with the given resourceID,
 	// which typically comes from the URL. This helps preserve the
@@ -90,11 +91,11 @@ func get[T any](ctx context.Context, containerClient *azcosmos.ContainerClient, 
 	// name must come from the URL and not the request body.
 	retAsResourceProperties, ok := any(ret).(ResourceProperties)
 	if !ok {
-		return nil, fmt.Errorf("type %T does not implement DocumentProperties interface", ret)
+		return nil, fmt.Errorf("type %T does not implement ResourceProperties interface", ret)
 	}
 	retAsResourceProperties.GetResourceDocument().ResourceID = completeResourceID
 
-	return &ret, nil
+	return ret, nil
 }
 
 func list[T any](ctx context.Context, containerClient *azcosmos.ContainerClient, resourceType azcorearm.ResourceType, prefix *azcorearm.ResourceID, options *DBClientListResourceDocsOptions) (DBClientIterator[T], error) {

--- a/internal/database/crud_helpers.go
+++ b/internal/database/crud_helpers.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+	"k8s.io/utils/ptr"
+)
+
+func get[T any](ctx context.Context, containerClient *azcosmos.ContainerClient, completeResourceID *azcorearm.ResourceID) (*T, error) {
+	var responseItem []byte
+
+	pk := NewPartitionKey(completeResourceID.SubscriptionID)
+
+	const query = "SELECT * FROM c WHERE STRINGEQUALS(c.resourceType, @resourceType, true) AND STRINGEQUALS(c.properties.resourceId, @resourceId, true)"
+	opt := azcosmos.QueryOptions{
+		QueryParameters: []azcosmos.QueryParameter{
+			{
+				Name:  "@resourceType",
+				Value: completeResourceID.ResourceType.String(),
+			},
+			{
+				Name:  "@resourceId",
+				Value: completeResourceID.String(),
+			},
+		},
+	}
+
+	queryPager := containerClient.NewQueryItemsPager(query, pk, &opt)
+
+	for queryPager.More() {
+		queryResponse, err := queryPager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to advance page while querying Resources container for '%s': %w", completeResourceID, err)
+		}
+
+		for _, item := range queryResponse.Items {
+			// Let the pager finish to ensure we get a single result.
+			if responseItem == nil {
+				responseItem = item
+			} else {
+				return nil, ErrAmbiguousResult
+			}
+		}
+	}
+
+	if responseItem == nil {
+		// Fabricate a "404 Not Found" ResponseError to wrap.
+		err := &azcore.ResponseError{StatusCode: http.StatusNotFound}
+		return nil, fmt.Errorf("failed to read Resources container item for '%s': %w", completeResourceID, err)
+	}
+
+	var ret T
+	if err := json.Unmarshal(responseItem, &ret); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal Resources container item for '%s': %w", completeResourceID, err)
+	}
+
+	// Replace the key field from Cosmos with the given resourceID,
+	// which typically comes from the URL. This helps preserve the
+	// casing of the resource group and resource name from the URL
+	// to meet RPC requirements:
+	//
+	// Put Resource | Arguments
+	//
+	// The resource group names and resource names should be matched
+	// case insensitively. ... Additionally, the Resource Provier must
+	// preserve the casing provided by the user. The service must return
+	// the most recently specified casing to the client and must not
+	// normalize or return a toupper or tolower form of the resource
+	// group or resource name. The resource group name and resource
+	// name must come from the URL and not the request body.
+	retAsResourceProperties, ok := any(ret).(ResourceProperties)
+	if !ok {
+		return nil, fmt.Errorf("type %T does not implement DocumentProperties interface", ret)
+	}
+	retAsResourceProperties.GetResourceDocument().ResourceID = completeResourceID
+
+	return &ret, nil
+}
+
+func list[T any](ctx context.Context, containerClient *azcosmos.ContainerClient, resourceType azcorearm.ResourceType, prefix *azcorearm.ResourceID, options *DBClientListResourceDocsOptions) (DBClientIterator[T], error) {
+	pk := NewPartitionKey(prefix.SubscriptionID)
+
+	query := "SELECT * FROM c WHERE STARTSWITH(c.properties.resourceId, @prefix, true)"
+
+	queryOptions := azcosmos.QueryOptions{
+		PageSizeHint: -1,
+		QueryParameters: []azcosmos.QueryParameter{
+			{
+				Name:  "@prefix",
+				Value: prefix.String() + "/",
+			},
+		},
+	}
+
+	query += " AND STRINGEQUALS(c.resourceType, @resourceType, true)"
+	queryParameter := azcosmos.QueryParameter{
+		Name:  "@resourceType",
+		Value: string(resourceType.String()),
+	}
+	queryOptions.QueryParameters = append(queryOptions.QueryParameters, queryParameter)
+
+	if options != nil {
+		// XXX The Cosmos DB REST API gives special meaning to -1 for "x-ms-max-item-count"
+		//     but it's not clear if it treats all negative values equivalently. The Go SDK
+		//     passes the PageSizeHint value as provided so normalize negative values to -1
+		//     to be safe.
+		if options.PageSizeHint != nil {
+			queryOptions.PageSizeHint = max(*options.PageSizeHint, -1)
+		}
+		queryOptions.ContinuationToken = options.ContinuationToken
+	}
+
+	pager := containerClient.NewQueryItemsPager(query, pk, &queryOptions)
+
+	if ptr.Deref(options.PageSizeHint, -1) > 0 {
+		return newQueryResourcesSinglePageIterator[T](pager), nil
+	} else {
+		return newQueryResourcesIterator[T](pager), nil
+	}
+}

--- a/internal/database/crud_nested_resource.go
+++ b/internal/database/crud_nested_resource.go
@@ -23,11 +23,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 )
 
-type NestedResourceCRUD[T any] interface {
-	Get(ctx context.Context, resourceID string) (*T, error)
-	List(ctx context.Context, opts *DBClientListResourceDocsOptions) (DBClientIterator[T], error)
-}
-
 type nestedCosmosResourceCRUD[T any] struct {
 	containerClient   *azcosmos.ContainerClient
 	providerNamespace string
@@ -45,7 +40,7 @@ type intermediateResource struct {
 	resourceID   string
 }
 
-var _ NestedResourceCRUD[NodePool] = &nestedCosmosResourceCRUD[NodePool]{}
+var _ ResourceCRUD[NodePool] = &nestedCosmosResourceCRUD[NodePool]{}
 
 func newNestedCosmosResourceCRUD[T any, V any](parent *topLevelCosmosResourceCRUD[V], subscriptionID, resourceGroupID, parentResourceID string, resourceType azcorearm.ResourceType) *nestedCosmosResourceCRUD[T] {
 	ret := &nestedCosmosResourceCRUD[T]{

--- a/internal/database/crud_nested_resource.go
+++ b/internal/database/crud_nested_resource.go
@@ -1,0 +1,110 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+type NestedResourceCRUD[T any] interface {
+	Get(ctx context.Context, resourceID string) (*T, error)
+	List(ctx context.Context, opts *DBClientListResourceDocsOptions) (DBClientIterator[T], error)
+}
+
+type nestedCosmosResourceCRUD[T any] struct {
+	containerClient   *azcosmos.ContainerClient
+	providerNamespace string
+	subscriptionID    string
+	resourceGroupID   string
+
+	// intermediateResources is optional and present when the resourceType is under another.  Think NodePools is under
+	// an HCPCluster, so the intermediate resource is the HCPCluster
+	intermediateResources []intermediateResource
+	resourceType          azcorearm.ResourceType
+}
+
+type intermediateResource struct {
+	resourceType azcorearm.ResourceType
+	resourceID   string
+}
+
+var _ NestedResourceCRUD[NodePool] = &nestedCosmosResourceCRUD[NodePool]{}
+
+func newNestedCosmosResourceCRUD[T any, V any](parent *topLevelCosmosResourceCRUD[V], subscriptionID, resourceGroupID, parentResourceID string, resourceType azcorearm.ResourceType) *nestedCosmosResourceCRUD[T] {
+	ret := &nestedCosmosResourceCRUD[T]{
+		containerClient:   parent.containerClient,
+		providerNamespace: parent.resourceType.Namespace,
+		subscriptionID:    subscriptionID,
+		resourceGroupID:   resourceGroupID,
+		resourceType:      resourceType,
+	}
+	ret.intermediateResources = append(ret.intermediateResources, intermediateResource{
+		resourceType: parent.resourceType,
+		resourceID:   parentResourceID,
+	})
+	return ret
+}
+
+func (d *nestedCosmosResourceCRUD[T]) makeResourceIDPath(resourceID string) (*azcorearm.ResourceID, error) {
+	if len(d.subscriptionID) == 0 {
+		return nil, fmt.Errorf("subscriptionID is required")
+	}
+	if len(d.resourceGroupID) == 0 && len(d.intermediateResources) > 0 {
+		return nil, fmt.Errorf("resourceGroupID is required for all subresources")
+	}
+
+	parts := []string{
+		"/subscriptions",
+		d.subscriptionID,
+		"resourceGroups",
+		d.resourceGroupID,
+		"providers",
+		d.providerNamespace,
+	}
+
+	for _, currIntermediateResource := range d.intermediateResources {
+		parts = append(parts, currIntermediateResource.resourceType.Type, currIntermediateResource.resourceID)
+	}
+	parts = append(parts, d.resourceType.Type)
+
+	if len(resourceID) > 0 {
+		parts = append(parts, resourceID)
+	}
+
+	return azcorearm.ParseResourceID(path.Join(parts...))
+}
+
+func (d *nestedCosmosResourceCRUD[T]) Get(ctx context.Context, resourceID string) (*T, error) {
+	completeResourceID, err := d.makeResourceIDPath(resourceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make ResourceID path for '%s': %w", resourceID, err)
+	}
+
+	return get[T](ctx, d.containerClient, completeResourceID)
+}
+
+func (d *nestedCosmosResourceCRUD[T]) List(ctx context.Context, options *DBClientListResourceDocsOptions) (DBClientIterator[T], error) {
+	prefix, err := d.makeResourceIDPath("")
+	if err != nil {
+		return nil, fmt.Errorf("failed to make ResourceID path for '%s': %w", d.resourceGroupID, err)
+	}
+
+	return list[T](ctx, d.containerClient, d.resourceType, prefix, options)
+}

--- a/internal/database/crud_toplevel_resource.go
+++ b/internal/database/crud_toplevel_resource.go
@@ -1,0 +1,103 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+type TopLevelResourceCRUD[T any] interface {
+	Get(ctx context.Context, subscriptionID, resourceGroup, resourceID string) (*T, error)
+	ListAll(ctx context.Context, subscriptionID string, opts *DBClientListResourceDocsOptions) (DBClientIterator[T], error)
+	List(ctx context.Context, subscriptionID, resourceGroup string, opts *DBClientListResourceDocsOptions) (DBClientIterator[T], error)
+}
+
+type topLevelCosmosResourceCRUD[T any] struct {
+	containerClient *azcosmos.ContainerClient
+	resourceType    azcorearm.ResourceType
+}
+
+func newTopLevelResourceCRUD[T any](resources *azcosmos.ContainerClient, resourceType azcorearm.ResourceType) *topLevelCosmosResourceCRUD[T] {
+	return &topLevelCosmosResourceCRUD[T]{
+		containerClient: resources,
+		resourceType:    resourceType,
+	}
+}
+
+var _ TopLevelResourceCRUD[HCPCluster] = &topLevelCosmosResourceCRUD[HCPCluster]{}
+
+func (d *topLevelCosmosResourceCRUD[T]) makeResourceIDPath(subscriptionID, resourceGroupID, resourceID string) (*azcorearm.ResourceID, error) {
+	if len(subscriptionID) == 0 {
+		return nil, fmt.Errorf("subscriptionID is required")
+	}
+
+	// this is valid for top level resource in azure.
+	if len(resourceGroupID) == 0 {
+		parts := []string{
+			"/subscriptions",
+			subscriptionID,
+		}
+		return azcorearm.ParseResourceID(path.Join(parts...))
+	}
+
+	parts := []string{
+		"/subscriptions",
+		subscriptionID,
+		"resourceGroups",
+		resourceGroupID,
+		"providers",
+		d.resourceType.Namespace,
+	}
+
+	parts = append(parts, d.resourceType.Type)
+
+	if len(resourceID) > 0 {
+		parts = append(parts, resourceID)
+	}
+
+	return azcorearm.ParseResourceID(path.Join(parts...))
+}
+
+func (d *topLevelCosmosResourceCRUD[T]) Get(ctx context.Context, subscriptionID, resourceGroup, resourceID string) (*T, error) {
+	completeResourceID, err := d.makeResourceIDPath(subscriptionID, resourceGroup, resourceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make ResourceID path for '%s': %w", resourceID, err)
+	}
+
+	return get[T](ctx, d.containerClient, completeResourceID)
+}
+
+func (d *topLevelCosmosResourceCRUD[T]) ListAll(ctx context.Context, subscriptionID string, options *DBClientListResourceDocsOptions) (DBClientIterator[T], error) {
+	prefix, err := d.makeResourceIDPath(subscriptionID, "", "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to make ResourceID path for '%s': %w", subscriptionID, err)
+	}
+
+	return list[T](ctx, d.containerClient, d.resourceType, prefix, options)
+}
+
+func (d *topLevelCosmosResourceCRUD[T]) List(ctx context.Context, subscriptionID, resourceGroup string, options *DBClientListResourceDocsOptions) (DBClientIterator[T], error) {
+	prefix, err := d.makeResourceIDPath(subscriptionID, resourceGroup, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to make ResourceID path for '%s': %w", resourceGroup, err)
+	}
+
+	return list[T](ctx, d.containerClient, d.resourceType, prefix, options)
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -109,7 +109,7 @@ type DBClient interface {
 	PatchBillingDoc(ctx context.Context, resourceID *azcorearm.ResourceID, ops BillingDocumentPatchOperations) error
 
 	// GetHCPClusterCRUD retrieves a CRUD interface for managing HCPCluster resources and their nested resources.
-	GetHCPClusterCRUD() HCPClusterCRUD
+	HCPClusters() HCPClusterCRUD
 
 	// GetResourceDoc queries the "Resources" container for a cluster or node pool document with a
 	// matching resourceID.
@@ -687,7 +687,7 @@ func (d *cosmosDBClient) ListAllSubscriptionDocs() DBClientIterator[arm.Subscrip
 	return newQueryItemsIterator[arm.Subscription](pager)
 }
 
-func (d *cosmosDBClient) GetHCPClusterCRUD() HCPClusterCRUD {
+func (d *cosmosDBClient) HCPClusters() HCPClusterCRUD {
 	return d.hcpClusterCRUD
 }
 

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -19,3 +19,11 @@ package database
 type DocumentProperties interface {
 	GetValidTypes() []string
 }
+
+// ResourceProperties is an interface for types that can serve as
+// TypedDocument.Properties.
+type ResourceProperties interface {
+	ValidateResourceType() error
+	GetTypedDocument() *TypedDocument
+	GetResourceDocument() *ResourceDocument
+}

--- a/internal/database/iterators.go
+++ b/internal/database/iterators.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+type queryResourcesIterator[T any] struct {
+	pager             *runtime.Pager[azcosmos.QueryItemsResponse]
+	singlePage        bool
+	continuationToken string
+	err               error
+}
+
+// newQueryResourcesIterator is a failable push iterator for a paged query response.
+func newQueryResourcesIterator[T any](pager *runtime.Pager[azcosmos.QueryItemsResponse]) DBClientIterator[T] {
+	return &queryResourcesIterator[T]{pager: pager}
+}
+
+// newQueryItemsSinglePageIterator is a failable push iterator for a paged
+// query response that stops at the end of the first page and includes a
+// continuation token if additional items are available.
+func newQueryResourcesSinglePageIterator[T any](pager *runtime.Pager[azcosmos.QueryItemsResponse]) DBClientIterator[T] {
+	return &queryResourcesIterator[T]{pager: pager, singlePage: true}
+}
+
+// Items returns a push iterator that can be used directly in for/range loops.
+// If an error occurs during paging, iteration stops and the error is recorded.
+func (iter *queryResourcesIterator[T]) Items(ctx context.Context) DBClientIteratorItem[T] {
+	return func(yield func(string, *T) bool) {
+		for iter.pager.More() {
+			response, err := iter.pager.NextPage(ctx)
+			if err != nil {
+				iter.err = err
+				return
+			}
+			if iter.singlePage && response.ContinuationToken != nil {
+				iter.continuationToken = *response.ContinuationToken
+			}
+			for _, itemJSON := range response.Items {
+				var decodedItem *T
+				if err := json.Unmarshal(itemJSON, decodedItem); err != nil {
+					iter.err = err
+					return
+				}
+
+				decodedItemAsResourceProperties, ok := any(decodedItem).(ResourceProperties)
+				if !ok {
+					iter.err = fmt.Errorf("type %T does not implement DocumentProperties interface", decodedItem)
+					return
+				}
+
+				if !yield(decodedItemAsResourceProperties.GetTypedDocument().ID, decodedItem) {
+					return
+				}
+			}
+			if iter.singlePage {
+				return
+			}
+		}
+	}
+}
+
+// GetContinuationToken returns a continuation token that can be used to obtain
+// the next page of results. This is only set when the iterator was created with
+// NewQueryItemsSinglePageIterator and additional items are available.
+func (iter queryResourcesIterator[T]) GetContinuationToken() string {
+	return iter.continuationToken
+}
+
+// GetError returns any error that occurred during iteration. Call this after the
+// for/range loop that calls Items() to check if iteration completed successfully.
+func (iter queryResourcesIterator[T]) GetError() error {
+	return iter.err
+}

--- a/internal/database/iterators.go
+++ b/internal/database/iterators.go
@@ -56,11 +56,12 @@ func (iter *queryResourcesIterator[T]) Items(ctx context.Context) DBClientIterat
 				iter.continuationToken = *response.ContinuationToken
 			}
 			for _, itemJSON := range response.Items {
-				var decodedItem *T
-				if err := json.Unmarshal(itemJSON, decodedItem); err != nil {
+				var obj T
+				if err := json.Unmarshal(itemJSON, &obj); err != nil {
 					iter.err = err
 					return
 				}
+				decodedItem := &obj
 
 				decodedItemAsResourceProperties, ok := any(decodedItem).(ResourceProperties)
 				if !ok {

--- a/internal/database/types_externalauth.go
+++ b/internal/database/types_externalauth.go
@@ -15,6 +15,8 @@
 package database
 
 import (
+	"fmt"
+
 	"github.com/Azure/ARO-HCP/internal/api"
 )
 
@@ -23,6 +25,8 @@ type ExternalAuth struct {
 
 	ExternalAuthProperties `json:"properties"`
 }
+
+var _ ResourceProperties = &ExternalAuth{}
 
 type ExternalAuthProperties struct {
 	ResourceDocument `json:",inline"`
@@ -46,6 +50,21 @@ type ServiceProviderExternalAuthState struct {
 	// Alternatively, we could choose a different structure, but it's probably easier to re-use this one.
 	// There is no validation on this structure.
 	ExternalAuth api.HCPOpenShiftClusterExternalAuthProperties `json:"externalAuthProperties"`
+}
+
+func (o *ExternalAuth) ValidateResourceType() error {
+	if o.ResourceType != api.ExternalAuthResourceType.String() {
+		return fmt.Errorf("invalid resource type: %s", o.ResourceType)
+	}
+	return nil
+}
+
+func (o *ExternalAuth) GetTypedDocument() *TypedDocument {
+	return &o.TypedDocument
+}
+
+func (o *ExternalAuth) GetResourceDocument() *ResourceDocument {
+	return &o.ResourceDocument
 }
 
 var FilterExternalAuthState ResourceDocumentStateFilter = newJSONRoundTripFilterer(

--- a/internal/database/types_hcpcluster.go
+++ b/internal/database/types_hcpcluster.go
@@ -27,6 +27,8 @@ type HCPCluster struct {
 	HCPClusterProperties `json:"properties"`
 }
 
+var _ ResourceProperties = &HCPCluster{}
+
 type HCPClusterProperties struct {
 	ResourceDocument `json:",inline"`
 
@@ -49,6 +51,21 @@ type ServiceProviderHCPClusterState struct {
 	// Alternatively, we could choose a different structure, but it's probably easier to re-use this one.
 	// There is no validation on this structure.
 	HCPOpenShiftCluster api.HCPOpenShiftClusterProperties `json:"clusterProperties"`
+}
+
+func (o *HCPCluster) ValidateResourceType() error {
+	if o.ResourceType != api.ClusterResourceType.String() {
+		return fmt.Errorf("invalid resource type: %s", o.ResourceType)
+	}
+	return nil
+}
+
+func (o *HCPCluster) GetTypedDocument() *TypedDocument {
+	return &o.TypedDocument
+}
+
+func (o *HCPCluster) GetResourceDocument() *ResourceDocument {
+	return &o.ResourceDocument
 }
 
 var FilterHCPClusterState ResourceDocumentStateFilter = newJSONRoundTripFilterer(

--- a/internal/database/types_nodepool.go
+++ b/internal/database/types_nodepool.go
@@ -15,6 +15,8 @@
 package database
 
 import (
+	"fmt"
+
 	"github.com/Azure/ARO-HCP/internal/api"
 )
 
@@ -23,6 +25,8 @@ type NodePool struct {
 
 	NodePoolProperties `json:"properties"`
 }
+
+var _ ResourceProperties = &NodePool{}
 
 type NodePoolProperties struct {
 	ResourceDocument `json:",inline"`
@@ -46,6 +50,21 @@ type ServiceProviderNodePoolState struct {
 	// Alternatively, we could choose a different structure, but it's probably easier to re-use this one.
 	// There is no validation on this structure.
 	NodePool api.HCPOpenShiftClusterNodePoolProperties `json:"nodePoolProperties"`
+}
+
+func (o *NodePool) ValidateResourceType() error {
+	if o.ResourceType != api.NodePoolResourceType.String() {
+		return fmt.Errorf("invalid resource type: %s", o.ResourceType)
+	}
+	return nil
+}
+
+func (o *NodePool) GetTypedDocument() *TypedDocument {
+	return &o.TypedDocument
+}
+
+func (o *NodePool) GetResourceDocument() *ResourceDocument {
+	return &o.ResourceDocument
 }
 
 var FilterNodePoolState ResourceDocumentStateFilter = newJSONRoundTripFilterer(

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -29,6 +29,7 @@ require (
 	go.uber.org/mock v0.5.2
 	gotest.tools v2.2.0+incompatible
 	k8s.io/apimachinery v0.34.0
+	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d
 	sigs.k8s.io/randfill v1.0.0
 )
 
@@ -114,5 +115,4 @@ require (
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
-	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d // indirect
 )

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -336,44 +336,6 @@ func (c *MockDBClientDeleteResourceDocCall) DoAndReturn(f func(context.Context, 
 	return c
 }
 
-// GetHCPClusterCRUD mocks base method.
-func (m *MockDBClient) HCPClusters() database.HCPClusterCRUD {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HCPClusters")
-	ret0, _ := ret[0].(database.HCPClusterCRUD)
-	return ret0
-}
-
-// GetHCPClusterCRUD indicates an expected call of GetHCPClusterCRUD.
-func (mr *MockDBClientMockRecorder) GetHCPClusterCRUD() *MockDBClientGetHCPClusterCRUDCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HCPClusters", reflect.TypeOf((*MockDBClient)(nil).HCPClusters))
-	return &MockDBClientGetHCPClusterCRUDCall{Call: call}
-}
-
-// MockDBClientGetHCPClusterCRUDCall wrap *gomock.Call
-type MockDBClientGetHCPClusterCRUDCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockDBClientGetHCPClusterCRUDCall) Return(arg0 database.HCPClusterCRUD) *MockDBClientGetHCPClusterCRUDCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockDBClientGetHCPClusterCRUDCall) Do(f func() database.HCPClusterCRUD) *MockDBClientGetHCPClusterCRUDCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDBClientGetHCPClusterCRUDCall) DoAndReturn(f func() database.HCPClusterCRUD) *MockDBClientGetHCPClusterCRUDCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetLockClient mocks base method.
 func (m *MockDBClient) GetLockClient() database.LockClientInterface {
 	m.ctrl.T.Helper()
@@ -526,6 +488,44 @@ func (c *MockDBClientGetSubscriptionDocCall) Do(f func(context.Context, string) 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockDBClientGetSubscriptionDocCall) DoAndReturn(f func(context.Context, string) (*arm.Subscription, error)) *MockDBClientGetSubscriptionDocCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// HCPClusters mocks base method.
+func (m *MockDBClient) HCPClusters(subscriptionID, resourceGroupName string) database.HCPClusterCRUD {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HCPClusters", subscriptionID, resourceGroupName)
+	ret0, _ := ret[0].(database.HCPClusterCRUD)
+	return ret0
+}
+
+// HCPClusters indicates an expected call of HCPClusters.
+func (mr *MockDBClientMockRecorder) HCPClusters(subscriptionID, resourceGroupName any) *MockDBClientHCPClustersCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HCPClusters", reflect.TypeOf((*MockDBClient)(nil).HCPClusters), subscriptionID, resourceGroupName)
+	return &MockDBClientHCPClustersCall{Call: call}
+}
+
+// MockDBClientHCPClustersCall wrap *gomock.Call
+type MockDBClientHCPClustersCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDBClientHCPClustersCall) Return(arg0 database.HCPClusterCRUD) *MockDBClientHCPClustersCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDBClientHCPClustersCall) Do(f func(string, string) database.HCPClusterCRUD) *MockDBClientHCPClustersCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDBClientHCPClustersCall) DoAndReturn(f func(string, string) database.HCPClusterCRUD) *MockDBClientHCPClustersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -22,19 +22,19 @@ import (
 )
 
 // MockDBClientIterator is a mock of DBClientIterator interface.
-type MockDBClientIterator[T database.DocumentProperties] struct {
+type MockDBClientIterator[T any] struct {
 	ctrl     *gomock.Controller
 	recorder *MockDBClientIteratorMockRecorder[T]
 	isgomock struct{}
 }
 
 // MockDBClientIteratorMockRecorder is the mock recorder for MockDBClientIterator.
-type MockDBClientIteratorMockRecorder[T database.DocumentProperties] struct {
+type MockDBClientIteratorMockRecorder[T any] struct {
 	mock *MockDBClientIterator[T]
 }
 
 // NewMockDBClientIterator creates a new mock instance.
-func NewMockDBClientIterator[T database.DocumentProperties](ctrl *gomock.Controller) *MockDBClientIterator[T] {
+func NewMockDBClientIterator[T any](ctrl *gomock.Controller) *MockDBClientIterator[T] {
 	mock := &MockDBClientIterator[T]{ctrl: ctrl}
 	mock.recorder = &MockDBClientIteratorMockRecorder[T]{mock}
 	return mock
@@ -61,7 +61,7 @@ func (mr *MockDBClientIteratorMockRecorder[T]) GetContinuationToken() *MockDBCli
 }
 
 // MockDBClientIteratorGetContinuationTokenCall wrap *gomock.Call
-type MockDBClientIteratorGetContinuationTokenCall[T database.DocumentProperties] struct {
+type MockDBClientIteratorGetContinuationTokenCall[T any] struct {
 	*gomock.Call
 }
 
@@ -99,7 +99,7 @@ func (mr *MockDBClientIteratorMockRecorder[T]) GetError() *MockDBClientIteratorG
 }
 
 // MockDBClientIteratorGetErrorCall wrap *gomock.Call
-type MockDBClientIteratorGetErrorCall[T database.DocumentProperties] struct {
+type MockDBClientIteratorGetErrorCall[T any] struct {
 	*gomock.Call
 }
 
@@ -137,7 +137,7 @@ func (mr *MockDBClientIteratorMockRecorder[T]) Items(ctx any) *MockDBClientItera
 }
 
 // MockDBClientIteratorItemsCall wrap *gomock.Call
-type MockDBClientIteratorItemsCall[T database.DocumentProperties] struct {
+type MockDBClientIteratorItemsCall[T any] struct {
 	*gomock.Call
 }
 
@@ -332,6 +332,44 @@ func (c *MockDBClientDeleteResourceDocCall) Do(f func(context.Context, *arm0.Res
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockDBClientDeleteResourceDocCall) DoAndReturn(f func(context.Context, *arm0.ResourceID) error) *MockDBClientDeleteResourceDocCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetHCPClusterCRUD mocks base method.
+func (m *MockDBClient) GetHCPClusterCRUD() database.HCPClusterCRUD {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHCPClusterCRUD")
+	ret0, _ := ret[0].(database.HCPClusterCRUD)
+	return ret0
+}
+
+// GetHCPClusterCRUD indicates an expected call of GetHCPClusterCRUD.
+func (mr *MockDBClientMockRecorder) GetHCPClusterCRUD() *MockDBClientGetHCPClusterCRUDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHCPClusterCRUD", reflect.TypeOf((*MockDBClient)(nil).GetHCPClusterCRUD))
+	return &MockDBClientGetHCPClusterCRUDCall{Call: call}
+}
+
+// MockDBClientGetHCPClusterCRUDCall wrap *gomock.Call
+type MockDBClientGetHCPClusterCRUDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDBClientGetHCPClusterCRUDCall) Return(arg0 database.HCPClusterCRUD) *MockDBClientGetHCPClusterCRUDCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDBClientGetHCPClusterCRUDCall) Do(f func() database.HCPClusterCRUD) *MockDBClientGetHCPClusterCRUDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDBClientGetHCPClusterCRUDCall) DoAndReturn(f func() database.HCPClusterCRUD) *MockDBClientGetHCPClusterCRUDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -337,9 +337,9 @@ func (c *MockDBClientDeleteResourceDocCall) DoAndReturn(f func(context.Context, 
 }
 
 // GetHCPClusterCRUD mocks base method.
-func (m *MockDBClient) GetHCPClusterCRUD() database.HCPClusterCRUD {
+func (m *MockDBClient) HCPClusters() database.HCPClusterCRUD {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHCPClusterCRUD")
+	ret := m.ctrl.Call(m, "HCPClusters")
 	ret0, _ := ret[0].(database.HCPClusterCRUD)
 	return ret0
 }
@@ -347,7 +347,7 @@ func (m *MockDBClient) GetHCPClusterCRUD() database.HCPClusterCRUD {
 // GetHCPClusterCRUD indicates an expected call of GetHCPClusterCRUD.
 func (mr *MockDBClientMockRecorder) GetHCPClusterCRUD() *MockDBClientGetHCPClusterCRUDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHCPClusterCRUD", reflect.TypeOf((*MockDBClient)(nil).GetHCPClusterCRUD))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HCPClusters", reflect.TypeOf((*MockDBClient)(nil).HCPClusters))
 	return &MockDBClientGetHCPClusterCRUDCall{Call: call}
 }
 


### PR DESCRIPTION
Adds and uses a database client for clusters in the frontend.  The `frontend/hack/test-simulation.sh` shows this is byte compatible for reads.