### PR TITLE
[wip] synchronize customer desired cluster state from cluster-service

### DIFF
--- a/backend/controllers/cs_customer_sync.go
+++ b/backend/controllers/cs_customer_sync.go
@@ -1,0 +1,234 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+)
+
+type Controller interface {
+	Run(ctx context.Context, threadiness int)
+}
+
+type hcpClusterKey struct {
+	subscriptionID  string
+	resourceGroupID string
+	hcpClusterID    string
+}
+
+type clusterServiceToCustomerSync struct {
+	cosmosClient database.DBClient
+
+	clusterServiceClient ocm.ClusterServiceClientSpec
+
+	// queue is where incoming work is placed to de-dup and to allow "easy"
+	// rate limited requeues on errors
+	queue workqueue.TypedRateLimitingInterface[hcpClusterKey]
+}
+
+func NewClusterServiceToCustomerSyncController(cosmosClient database.DBClient, clusterServiceClient ocm.ClusterServiceClientSpec) Controller {
+	c := &clusterServiceToCustomerSync{
+		cosmosClient:         cosmosClient,
+		clusterServiceClient: clusterServiceClient,
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[hcpClusterKey](),
+			workqueue.TypedRateLimitingQueueConfig[hcpClusterKey]{
+				Name: "cluster-service-customer-sync",
+			},
+		),
+	}
+
+	return c
+}
+
+func (c *clusterServiceToCustomerSync) synchronizeHCPCluster(ctx context.Context, key hcpClusterKey) error {
+	logger := klog.FromContext(ctx)
+
+	cosmosHCPCluster, err := c.cosmosClient.HCPClusters(key.subscriptionID, key.resourceGroupID).Get(ctx, key.hcpClusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get HCP cluster: %w", err)
+	}
+
+	csHCPCluster, err := c.clusterServiceClient.GetCluster(ctx, cosmosHCPCluster.InternalID)
+	if err != nil {
+		return fmt.Errorf("failed to get HCP cluster: %w", err)
+	}
+
+	desiredCosmosCluster := cosmosHCPCluster
+	desiredCosmosCluster.CustomerDesiredState, err = customerDesiredClusterFromClusterService(cosmosHCPCluster.ResourceID, csHCPCluster)
+	if err != nil {
+		return fmt.Errorf("failed to convert customer desired state: %w", err)
+	}
+
+	if equality.Semantic.DeepEqual(desiredCosmosCluster.CustomerDesiredState, cosmosHCPCluster.CustomerDesiredState) {
+		logger.V(4).Info("cosmos customer properties are up to date")
+		return nil
+	}
+
+	logger.V(4).Info("writing customer properties to cosmos", "desired_state", desiredCosmosCluster.CustomerDesiredState)
+	_, err = c.cosmosClient.HCPClusters(key.subscriptionID, key.resourceGroupID).Replace(ctx, desiredCosmosCluster)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func customerDesiredClusterFromClusterService(resourceID *azcorearm.ResourceID, csCluster *arohcpv1alpha1.Cluster) (database.CustomerDesiredHCPClusterState, error) {
+	internalCluster, err := ocm.ConvertCStoHCPOpenShiftCluster(resourceID, csCluster)
+	if err != nil {
+		return database.CustomerDesiredHCPClusterState{}, err
+	}
+	return database.CustomerDesiredHCPClusterState{
+		HCPOpenShiftCluster: internalCluster.Properties,
+	}, nil
+}
+
+func (c *clusterServiceToCustomerSync) synchronizeAndReport(ctx context.Context, key hcpClusterKey) error {
+	logger := klog.FromContext(ctx)
+	logger = logger.WithValues(
+		"subscription_id", key.subscriptionID,
+		"resource_group", key.resourceGroupID,
+		"hcp_cluster_name", key.resourceGroupID,
+	)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(4).Info("start synchronizing")
+	defer logger.V(4).Info("end synchronizing")
+
+	syncErr := c.synchronizeHCPCluster(ctx, key)
+	if syncErr == nil {
+		// TODO write condition indicating successful sync
+		return nil
+	}
+
+	// TODO write condition indicated failed sync
+	logger.Error(syncErr, "failed to synchronize")
+
+	return syncErr
+}
+
+func (c *clusterServiceToCustomerSync) queueAllHCPClusters(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+
+	allSubscriptions := c.cosmosClient.ListAllSubscriptionDocs()
+	for subscriptionID := range allSubscriptions.Items(ctx) {
+		allHCPClusters, err := c.cosmosClient.HCPClusters(subscriptionID, "").List(ctx, nil)
+		if err != nil {
+			logger.Error(err, "unable to list HCP clusters", "subscription_id", subscriptionID)
+			continue
+		}
+
+		for _, hcpCluster := range allHCPClusters.Items(ctx) {
+			c.queue.Add(hcpClusterKey{
+				subscriptionID:  hcpCluster.ResourceID.SubscriptionID,
+				resourceGroupID: hcpCluster.ResourceID.ResourceGroupName,
+				hcpClusterID:    hcpCluster.ResourceID.Name,
+			})
+		}
+		if err := allHCPClusters.GetError(); err != nil {
+			logger.Error(err, "unable to iterate over HCP clusters", "subscription_id", subscriptionID)
+		}
+	}
+	if err := allSubscriptions.GetError(); err != nil {
+		logger.Error(err, "unable to iterate over all subscriptions")
+	}
+}
+
+func (c *clusterServiceToCustomerSync) Run(ctx context.Context, threadiness int) {
+	// don't let panics crash the process
+	defer utilruntime.HandleCrash()
+	// make sure the work queue is shutdown which will trigger workers to end
+	defer c.queue.ShutDown()
+	logger := klog.FromContext(ctx)
+
+	logger.Info("Starting clusterServiceToCustomerSync controller")
+
+	// start up your worker threads based on threadiness.  Some controllers
+	// have multiple kinds of workers
+	for i := 0; i < threadiness; i++ {
+		// runWorker will loop until "something bad" happens.  The .Until will
+		// then rekick the worker after one second
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}
+
+	go wait.JitterUntilWithContext(ctx, c.queueAllHCPClusters, time.Minute, 0.1, true)
+
+	logger.Info("Started workers")
+
+	// wait until we're told to stop
+	<-ctx.Done()
+	logger.Info("Shutting down clusterServiceToCustomerSync controller")
+}
+
+func (c *clusterServiceToCustomerSync) runWorker(ctx context.Context) {
+	// hot loop until we're told to stop.  processNextWorkItem will
+	// automatically wait until there's work available, so we don't worry
+	// about secondary waits
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+// processNextWorkItem deals with one item off the queue.  It returns false
+// when it's time to quit.
+func (c *clusterServiceToCustomerSync) processNextWorkItem(ctx context.Context) bool {
+	// Pull the next work item from queue.  It will be an object reference that we use to lookup
+	// something in a cache
+	ref, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	// you always have to indicate to the queue that you've completed a piece of
+	// work
+	defer c.queue.Done(ref)
+
+	// Process the object reference.  This method will contains your "do stuff" logic
+	err := c.synchronizeAndReport(ctx, ref)
+	if err == nil {
+		// if you had no error, tell the queue to stop tracking history for your
+		// item. This will reset things like failure counts for per-item rate
+		// limiting
+		c.queue.Forget(ref)
+		return true
+	}
+
+	// there was a failure so be sure to report it.  This method allows for
+	// pluggable error handling which can be used for things like
+	// cluster-monitoring
+	utilruntime.HandleErrorWithContext(ctx, err, "Error syncing; requeuing for later retry", "objectReference", ref)
+
+	// since we failed, we should requeue the item to work on later.  This
+	// method will add a backoff to avoid hotlooping on particular items
+	// (they're probably still not going to work right away) and overall
+	// controller protection (everything I've done is broken, this controller
+	// needs to calm down or it can starve other useful work) cases.
+	c.queue.AddRateLimited(ref)
+
+	return true
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,7 @@ module github.com/Azure/ARO-HCP/backend
 go 1.24.3
 
 require (
+	github.com/Azure/ARO-HCP/frontend v0.0.0-20251020211942-f6e5b8cc37f5
 	github.com/Azure/ARO-HCP/internal v0.0.0-00010101000000-000000000000
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.1
@@ -17,6 +18,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.37.0
 	go.uber.org/mock v0.5.2
 	golang.org/x/sync v0.17.0
+	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
 	k8s.io/klog/v2 v2.130.1
 )
@@ -26,7 +28,6 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.11.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -68,7 +69,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
-	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -92,7 +92,6 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.13.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.37.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.0 // indirect
-	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.42.0 // indirect
@@ -110,7 +109,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.34.1 // indirect
-	k8s.io/apimachinery v0.34.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/Azure/ARO-HCP/frontend v0.0.0-20251020211942-f6e5b8cc37f5 h1:08JEks0qLjdLY+DD6ENPlE06NecmvFz9sRTQH3nbLgI=
+github.com/Azure/ARO-HCP/frontend v0.0.0-20251020211942-f6e5b8cc37f5/go.mod h1:p50a01MAlcRhgy9k/2F2Uj9akFEPH521ZYHaEDv779M=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1 h1:5YTBM8QDVIBN3sxBil89WfdAAqDZbyJTgh688DSxX5w=

--- a/internal/database/crud_nested_resource.go
+++ b/internal/database/crud_nested_resource.go
@@ -103,3 +103,7 @@ func (d *nestedCosmosResourceCRUD[T]) List(ctx context.Context, options *DBClien
 
 	return list[T](ctx, d.containerClient, d.resourceType, prefix, options)
 }
+
+func (d *nestedCosmosResourceCRUD[T]) Replace(ctx context.Context, desiredObj *T) (*T, error) {
+	return replace[T](ctx, d.containerClient, desiredObj)
+}

--- a/internal/database/crud_toplevel_resource.go
+++ b/internal/database/crud_toplevel_resource.go
@@ -26,6 +26,7 @@ import (
 type ResourceCRUD[T any] interface {
 	Get(ctx context.Context, resourceID string) (*T, error)
 	List(ctx context.Context, opts *DBClientListResourceDocsOptions) (DBClientIterator[T], error)
+	Replace(ctx context.Context, cluster *T) (*T, error)
 }
 
 type topLevelCosmosResourceCRUD[T any] struct {
@@ -95,4 +96,8 @@ func (d *topLevelCosmosResourceCRUD[T]) List(ctx context.Context, options *DBCli
 	}
 
 	return list[T](ctx, d.containerClient, d.resourceType, prefix, options)
+}
+
+func (d *topLevelCosmosResourceCRUD[T]) Replace(ctx context.Context, desiredObj *T) (*T, error) {
+	return replace[T](ctx, d.containerClient, desiredObj)
 }


### PR DESCRIPTION
This starts a control loop that reads from cluster-service and writes the customer desired state into cosmos.

before merge, we need
1. mechanism to store controller state per key (subscription, resourcegroup, control loop, hcp cluster, subresource)
2. probably break off the database client changes
3. other?

Future, we need
1. mechanism to dump the current state
2. refactor the launch to be more integrate testable
3. make it trivial to add more controllers