### PR TITLE
fix missing apiserver log

### DIFF
--- a/observability/arobit/deploy/values.yaml
+++ b/observability/arobit/deploy/values.yaml
@@ -126,6 +126,7 @@ forwarder:
             Kube_Tag_Prefix     kubernetes.var.log.containers.
             Annotations         Off
             K8S-Logging.Exclude On
+            Buffer_Size         64k
 
         [FILTER]
             Name          nest


### PR DESCRIPTION
The kubernetes filter uses an internal HTTP client to pull pod metadata; its default receive buffer is 32 KB. When the API server returns a larger payload, you get:
```
[ warn] [http_client] cannot increase buffer: current=32000 requested=64768 max=32000
```

Increasing `Buffer_Size` raises that max so the response fits.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
