### PR TITLE
enable leader election when maestro agent runs with multiple replicas

### DIFF
--- a/maestro/agent/deploy/templates/maestro-agent.deployment.yaml
+++ b/maestro/agent/deploy/templates/maestro-agent.deployment.yaml
@@ -56,6 +56,7 @@ spec:
         - --workload-source-driver=mqtt
         - --workload-source-config=/secrets/maestro/config.yaml
         - --cloudevents-client-id={{ .Values.consumerName }}-work-agent
+        - --disable-leader-election={{ if eq .Values.replicas 1 }}true{{ else }}false{{ end }}
         - -v={{ .Values.glog_v }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
### What

in case the maestro agent runs with multiple replicas, we need leader election between them so that only one acts on the cluster

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
