### PR TITLE
minimum reproducer showing type system difficulties when internal and…

### DIFF
--- a/internal/api/hcpopenshiftcluster.go
+++ b/internal/api/hcpopenshiftcluster.go
@@ -35,7 +35,7 @@ type HCPOpenShiftCluster struct {
 type HCPOpenShiftClusterProperties struct {
 	ProvisioningState       arm.ProvisioningState       `json:"provisioningState,omitempty"       visibility:"read"`
 	Version                 VersionProfile              `json:"version,omitempty"`
-	DNS                     DNSProfile                  `json:"dns,omitempty"`
+	NewDNS                  DNSProfile                  `json:"newDNS,omitempty"`
 	Network                 NetworkProfile              `json:"network,omitempty"                 visibility:"read create"`
 	Console                 ConsoleProfile              `json:"console,omitempty"                 visibility:"read"`
 	API                     APIProfile                  `json:"api,omitempty"`

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -221,7 +221,7 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 			Properties: &generated.HcpOpenShiftClusterProperties{
 				ProvisioningState:       api.PtrOrNil(generated.ProvisioningState(from.Properties.ProvisioningState)),
 				Version:                 api.PtrOrNil(newVersionProfile(&from.Properties.Version)),
-				DNS:                     api.PtrOrNil(newDNSProfile(&from.Properties.DNS)),
+				DNS:                     api.PtrOrNil(newDNSProfile(&from.Properties.NewDNS)),
 				Network:                 api.PtrOrNil(newNetworkProfile(&from.Properties.Network)),
 				Console:                 api.PtrOrNil(newConsoleProfile(&from.Properties.Console)),
 				API:                     api.PtrOrNil(newAPIProfile(&from.Properties.API)),
@@ -304,7 +304,7 @@ func (c *HcpOpenShiftCluster) Normalize(out *api.HCPOpenShiftCluster) {
 				normalizeVersion(c.Properties.Version, &out.Properties.Version)
 			}
 			if c.Properties.DNS != nil {
-				normailzeDNS(c.Properties.DNS, &out.Properties.DNS)
+				normailzeDNS(c.Properties.DNS, &out.Properties.NewDNS)
 			}
 			if c.Properties.Network != nil {
 				normalizeNetwork(c.Properties.Network, &out.Properties.Network)


### PR DESCRIPTION
… external aren't identical


/hold


this fails in at least this spot:

```
GOROOT=/home/deads/workspaces/aro-hcp/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.linux-amd64 #gosetup
GOPATH=/home/deads/go #gosetup
/home/deads/workspaces/aro-hcp/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.linux-amd64/bin/go test -c -o /home/deads/.cache/JetBrains/GoLand2025.1/tmp/GoLand/___TestClusterNullPatch_in_github_com_Azure_ARO_HCP_internal_api_v20240610preview.test github.com/Azure/ARO-HCP/internal/api/v20240610preview #gosetup
/home/deads/workspaces/aro-hcp/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.linux-amd64/bin/go tool test2json -t /home/deads/.cache/JetBrains/GoLand2025.1/tmp/GoLand/___TestClusterNullPatch_in_github_com_Azure_ARO_HCP_internal_api_v20240610preview.test -test.v=test2json -test.paniconexit0 -test.run ^\QTestClusterNullPatch\E$ #gosetup
=== RUN   TestClusterNullPatch
    testhelpers.go:364: 
        	Error Trace:	/home/deads/workspaces/aro-hcp/src/github.com/Azure/ARO-HCP/internal/api/testhelpers.go:364
        	            				/home/deads/workspaces/aro-hcp/src/github.com/Azure/ARO-HCP/internal/api/testhelpers.go:344
        	            				/home/deads/workspaces/aro-hcp/src/github.com/Azure/ARO-HCP/internal/api/testhelpers.go:366
        	            				/home/deads/workspaces/aro-hcp/src/github.com/Azure/ARO-HCP/internal/api/testhelpers.go:357
        	            				/home/deads/workspaces/aro-hcp/src/github.com/Azure/ARO-HCP/internal/api/testhelpers.go:344
        	            				/home/deads/workspaces/aro-hcp/src/github.com/Azure/ARO-HCP/internal/api/testhelpers.go:504
        	Error:      	Should NOT be empty, but was 
        	Test:       	TestClusterNullPatch
        	Messages:   	No JSON tag for "Properties.DNS"
=== RUN   TestClusterNullPatch/Properties.Network.HostPrefix
    testing.go:1679: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
--- FAIL: TestClusterNullPatch/Properties.Network.HostPrefix (0.00s)

--- FAIL: TestClusterNullPatch (0.00s)

FAIL

Process finished with the exit code 1
```