### PR TITLE
dev-infrastructure: remove the types in our .bicep

### DIFF
--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -9,13 +9,7 @@ param zoneRedundant bool
 param userAssignedMIs array
 param private bool
 
-// Local Params
-type Container = {
-  name: string
-  defaultTtl: int
-  partitionKeyPaths: array
-}
-var containers Container[] = [
+var containers = [
   {
     name: 'Resources'
     defaultTtl: -1 // On, no default expiration


### PR DESCRIPTION
For unknown reasons, the ADO build pipelines are freaking out about this now. Removing the types to get us back to green while we investigate.
