### PR TITLE
prepare maestro image for rollout to prod

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -211,7 +211,7 @@ clouds:
           # Maestro
           maestro:
             image:
-              digest: sha256:e0077b61a4f6fb612f12b63401f7d6e82c6cb1ff29ac4d31797eda808d68d082
+              digest: sha256:90daeea3b4191e3f02d9900a1e7d9e296329b3ca99ea785907c55c39cde95f04
           # OCP image sync
           imageSync:
             ocMirror:


### PR DESCRIPTION
Image SHA is 90daeea3b4191e3f02d9900a1e7d9e296329b3ca99ea785907c55c39cde95f04.

It impacts both maestro server and maestro agent.
