### PR TITLE
Update personal-dev.md

### DIFF
--- a/docs/personal-dev.md
+++ b/docs/personal-dev.md
@@ -21,6 +21,7 @@ Ensure you have access to the RH Azure tenant:
 The following additional tools are also required:
 
 - `jq`
+- `yq`
 - `make`
 - `kubelogin` - download from <https://azure.github.io/kubelogin/install.html>
 - `kubectl` version >= 1.30


### PR DESCRIPTION
add yq as required utility

<!-- Link to Jira issue -->

### What

yq is required to setup personal dev environment, but isn't listed as required utility.  Commands complete without error if it is NOT installed, but environment doesn't work.


