### PR TITLE
update CS int to use absolute numbers for rolling update strategy

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -13,6 +13,11 @@ clouds:
           clustersService:
             image:
               digest: sha256:e3c04c01e145d084405344bb5ab8f114a306caec7efa89c0ff25fe814d77d9f6
+            k8s:
+              deploymentStrategy:
+                rollingUpdate:
+                  maxUnavailable: 0
+                  maxSurge: 1
           # ACR Pull
           acrPull:
             image:


### PR DESCRIPTION
Like we have in dev environments. There should not be any change in behavior based on the current number of replicas set in the environment.

Detailed context: https://github.com/Azure/ARO-HCP/pull/2733