### PR TITLE
fix workdir for grafana-dashboards

### DIFF
--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -73,8 +73,8 @@ resourceGroups:
       step: infra
   - name: grafana-dashboards
     action: Shell
-    command: ./deploy.sh
-    workingDir: ./../observability/grafana
+    command: ./grafana/deploy.sh
+    workingDir: ./../observability/
     dependsOn:
     - resourceGroup: global
       step: housekeeping


### PR DESCRIPTION
### What

the grafana script uses a file from the parent directory (observability.yaml). adapt the workdir for that. otherwise this fails in EV2 as the shell step has only access to the defined workdir

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
