### PR TITLE
api: Describe the default managed resource group name

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -244,7 +244,17 @@ union Visibility {
 
 /** Azure specific configuration */
 model PlatformProfile {
-  /** Resource group to put cluster resources */
+  /** Resource group name to put cluster resources
+   *
+   * If not specified then a unique name is generated from the
+   * following pattern
+   *
+   *   "aro-hcp-" + clusterName + "-" + UUID
+   *
+   * where clusterName means the hcpOpenShiftClusters resource name
+   * (up to 45 characters) followed by a 16-byte universally unique
+   * identifier per RFC 4122.
+   */
   @visibility(Lifecycle.Read, Lifecycle.Create)
   managedResourceGroup?: string;
 

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json
@@ -3102,7 +3102,7 @@
       "properties": {
         "managedResourceGroup": {
           "type": "string",
-          "description": "Resource group to put cluster resources",
+          "description": "Resource group name to put cluster resources\n\nIf not specified then a unique name is generated from the\nfollowing pattern\n\n\"aro-hcp-\" + clusterName + \"-\" + UUID\n\nwhere clusterName means the hcpOpenShiftClusters resource name\n(up to 45 characters) followed by a 16-byte universally unique\nidentifier per RFC 4122.",
           "x-ms-mutability": [
             "read",
             "create"

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -812,7 +812,11 @@ type PlatformProfile struct {
 	// REQUIRED; The Azure resource ID of the worker subnet Note that a subnet cannot be reused between ARO-HCP Clusters.
 	SubnetID *string
 
-	// Resource group to put cluster resources
+	// Resource group name to put cluster resources
+	// If not specified then a unique name is generated from the following pattern
+	// "aro-hcp-" + clusterName + "-" + UUID
+	// where clusterName means the hcpOpenShiftClusters resource name (up to 45 characters) followed by a 16-byte universally
+	// unique identifier per RFC 4122.
 	ManagedResourceGroup *string
 
 	// The core outgoing configuration


### PR DESCRIPTION
[ARO-18667 - REST Specs API: Document default naming convention of MRG](https://issues.redhat.com/browse/ARO-18667)

### What

SSIA

### Why

So customers can anticipate what the name will look like if not provided.

### Special notes for your reviewer

Link to the [managed resource group name generator function](https://github.com/Azure/ARO-HCP/blob/526f70d3d81fb4f4dbd56e7f5a170fe90530b97f/internal/ocm/convert.go#L418-L432) for verification.