### PR TITLE
e2e: admin lifecycle proper waiting

### DIFF
--- a/test/e2e/admin_credential_lifecycle.go
+++ b/test/e2e/admin_credential_lifecycle.go
@@ -196,7 +196,7 @@ var _ = Describe("Customer", func() {
 			By("validating all admin credentials now fail after revocation")
 			for i, cred := range credentials {
 				By(fmt.Sprintf("verifying admin credential %d now fails", i+1))
-				Expect(verifiers.VerifyHCPCluster(ctx, cred)).ToNot(Succeed(), "Revoked admin credential %d should no longer work", i+1)
+				Eventually(verifiers.VerifyHCPCluster(ctx, cred), 5*time.Minute, 15*time.Second).ToNot(Succeed(), "Revoked admin credential %d should no longer work", i+1)
 			}
 
 			By("verifying new admin credentials can still be requested after revocation")
@@ -213,9 +213,6 @@ var _ = Describe("Customer", func() {
 			Expect(newAdminRESTConfig).NotTo(BeNil())
 
 			By("verifying new admin credentials work after revocation")
-			// Use Eventually to handle timing issues where new credentials might take a moment to become active
-			Eventually(func() error {
-				return verifiers.VerifyHCPCluster(ctx, newAdminRESTConfig)
-			}, 2*time.Minute, 15*time.Second).Should(Succeed(), "New admin credentials should eventually work after revocation")
+			Expect(verifiers.VerifyHCPCluster(ctx, newAdminRESTConfig)).To(Succeed(), "New admin credentials should work after revocation")
 		})
 })


### PR DESCRIPTION
### What

When a certificate is revoked, it's possible it's still valid until the kube-apiservers reload their CA bundles.  The way the hypershift control-plane-pki-operator works is that it only looks at a single failure/success.  

We do expect that immediately when requesting a new certificate after revocation finished, it will work since the certificate revocation process generates a new CA bundle before removing the old one.

### Why

https://issues.redhat.com/browse/ARO-21142

### Special notes for your reviewer

<!-- optional -->
