### PR TITLE
Chore: Bump CS image to d5400c605d9a in MSFT INT env.

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -12,7 +12,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:e3c04c01e145d084405344bb5ab8f114a306caec7efa89c0ff25fe814d77d9f6
+              digest: sha256:d5400c605d9a5b05e5f961bf0dc2f3e663a40603faf108c9dc40cf7cadc4e205
             k8s:
               deploymentStrategy:
                 rollingUpdate:


### PR DESCRIPTION

### What

Promote CS image to d5400c605d9a in MSFT INT env. from Integrated Dev 

PR For Integrated Dev :  https://github.com/Azure/ARO-HCP/pull/2775


### Why

Update as per schedule.

### Special notes for your reviewer

