### PR TITLE
Enable Otel audit logging for prod and stg

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -129,6 +129,8 @@ clouds:
           frontend:
             image:
               digest: "sha256:2d40f3eb66bf0fb8c696641b39aba2ed8105807df61c53778f6fb151567266c5"
+            audit:
+              connectSocket: true
           # RP Backend
           backend:
             image:
@@ -200,6 +202,8 @@ clouds:
           frontend:
             image:
               digest: "sha256:2d40f3eb66bf0fb8c696641b39aba2ed8105807df61c53778f6fb151567266c5"
+            audit:
+              connectSocket: true
           # RP Backend
           backend:
             image:


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://issues.redhat.com/browse/ARO-20061

### What
After confirming the OTEL audit logging in INT, enabling the usage of domain socket for STG and PROD

Confirmed INT using:
https://eng.ms/docs/products/geneva/collect/instrument/opentelemetryaudit/dotnet/validation
Dgrep query: https://jarvis-west.dc.ad.msft.net/C0EAFC71

<!-- Briefly describe what this PR does -->