### PR TITLE
ocm: Handle 503 ServiceUnavailable errors

### DIFF
--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -99,7 +99,7 @@ func (f *Frontend) CreateOrUpdateExternalAuth(writer http.ResponseWriter, reques
 		csExternalAuth, err := f.clusterServiceClient.GetExternalAuth(ctx, resourceDoc.InternalID)
 		if err != nil {
 			logger.Error(fmt.Sprintf("failed to fetch CS external auth for %s: %v", resourceID, err))
-			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID))
+			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID, writer.Header()))
 			return
 		}
 
@@ -187,7 +187,7 @@ func (f *Frontend) CreateOrUpdateExternalAuth(writer http.ResponseWriter, reques
 		csExternalAuth, err = f.clusterServiceClient.UpdateExternalAuth(ctx, resourceDoc.InternalID, csExternalAuthBuilder)
 		if err != nil {
 			logger.Error(err.Error())
-			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID))
+			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID, writer.Header()))
 			return
 		}
 	} else {
@@ -202,7 +202,7 @@ func (f *Frontend) CreateOrUpdateExternalAuth(writer http.ResponseWriter, reques
 		csExternalAuth, err = f.clusterServiceClient.PostExternalAuth(ctx, clusterDoc.InternalID, csExternalAuthBuilder)
 		if err != nil {
 			logger.Error(err.Error())
-			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID))
+			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID, writer.Header()))
 			return
 		}
 

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -367,7 +367,7 @@ func (f *Frontend) ArmResourceList(writer http.ResponseWriter, request *http.Req
 	// Check for iteration error.
 	if err != nil {
 		logger.Error(err.Error())
-		arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, nil))
+		arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, nil, writer.Header()))
 		return
 	}
 
@@ -483,7 +483,7 @@ func (f *Frontend) CreateOrUpdateHCPCluster(writer http.ResponseWriter, request 
 		csCluster, err := f.clusterServiceClient.GetCluster(ctx, resourceDoc.InternalID)
 		if err != nil {
 			logger.Error(fmt.Sprintf("failed to fetch CS cluster for %s: %v", resourceID, err))
-			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID))
+			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID, writer.Header()))
 			return
 		}
 
@@ -591,7 +591,7 @@ func (f *Frontend) CreateOrUpdateHCPCluster(writer http.ResponseWriter, request 
 		csCluster, err = f.clusterServiceClient.UpdateCluster(ctx, resourceDoc.InternalID, csClusterBuilder)
 		if err != nil {
 			logger.Error(err.Error())
-			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID))
+			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID, writer.Header()))
 			return
 		}
 	} else {
@@ -599,7 +599,7 @@ func (f *Frontend) CreateOrUpdateHCPCluster(writer http.ResponseWriter, request 
 		csCluster, err = f.clusterServiceClient.PostCluster(ctx, csClusterBuilder)
 		if err != nil {
 			logger.Error(err.Error())
-			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID))
+			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID, writer.Header()))
 			return
 		}
 

--- a/frontend/pkg/frontend/helpers.go
+++ b/frontend/pkg/frontend/helpers.go
@@ -169,7 +169,7 @@ func (f *Frontend) DeleteResource(ctx context.Context, transaction database.DBTr
 	}
 
 	if err != nil {
-		cloudError := ocm.CSErrorToCloudError(err, resourceDoc.ResourceID)
+		cloudError := ocm.CSErrorToCloudError(err, resourceDoc.ResourceID, nil)
 		if cloudError.StatusCode == http.StatusNotFound {
 			// StatusNotFound means we have stale data in Cosmos DB.
 			// This can happen in test environments if a user bypasses
@@ -244,7 +244,7 @@ func (f *Frontend) MarshalResource(ctx context.Context, resourceID *azcorearm.Re
 		version, err := f.clusterServiceClient.GetVersion(ctx, versionName)
 		if err != nil {
 			logger.Error(err.Error())
-			return nil, ocm.CSErrorToCloudError(err, resourceID)
+			return nil, ocm.CSErrorToCloudError(err, resourceID, nil)
 		}
 		responseBody, err = marshalCSVersion(*resourceID, version, versionedInterface)
 		if err != nil {
@@ -270,7 +270,7 @@ func (f *Frontend) MarshalResource(ctx context.Context, resourceID *azcorearm.Re
 		csCluster, err := f.clusterServiceClient.GetCluster(ctx, doc.InternalID)
 		if err != nil {
 			logger.Error(err.Error())
-			return nil, ocm.CSErrorToCloudError(err, resourceID)
+			return nil, ocm.CSErrorToCloudError(err, resourceID, nil)
 		}
 
 		responseBody, err = marshalCSCluster(csCluster, doc, versionedInterface)
@@ -283,7 +283,7 @@ func (f *Frontend) MarshalResource(ctx context.Context, resourceID *azcorearm.Re
 		csNodePool, err := f.clusterServiceClient.GetNodePool(ctx, doc.InternalID)
 		if err != nil {
 			logger.Error(err.Error())
-			return nil, ocm.CSErrorToCloudError(err, resourceID)
+			return nil, ocm.CSErrorToCloudError(err, resourceID, nil)
 		}
 		responseBody, err = marshalCSNodePool(csNodePool, doc, versionedInterface)
 		if err != nil {
@@ -295,7 +295,7 @@ func (f *Frontend) MarshalResource(ctx context.Context, resourceID *azcorearm.Re
 		csExternalAuth, err := f.clusterServiceClient.GetExternalAuth(ctx, doc.InternalID)
 		if err != nil {
 			logger.Error(err.Error())
-			return nil, ocm.CSErrorToCloudError(err, resourceID)
+			return nil, ocm.CSErrorToCloudError(err, resourceID, nil)
 		}
 		responseBody, err = marshalCSExternalAuth(csExternalAuth, doc, versionedInterface)
 		if err != nil {

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -101,7 +101,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		csNodePool, err := f.clusterServiceClient.GetNodePool(ctx, resourceDoc.InternalID)
 		if err != nil {
 			logger.Error(fmt.Sprintf("failed to fetch CS node pool for %s: %v", resourceID, err))
-			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID))
+			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID, writer.Header()))
 			return
 		}
 
@@ -182,7 +182,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 	csCluster, err := f.clusterServiceClient.GetCluster(ctx, clusterResourceDoc.InternalID)
 	if err != nil {
 		logger.Error(err.Error())
-		arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID.Parent))
+		arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID.Parent, writer.Header()))
 		return
 	}
 
@@ -225,7 +225,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		csNodePool, err = f.clusterServiceClient.UpdateNodePool(ctx, resourceDoc.InternalID, csNodePoolBuilder)
 		if err != nil {
 			logger.Error(err.Error())
-			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID))
+			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID, writer.Header()))
 			return
 		}
 	} else {
@@ -240,7 +240,7 @@ func (f *Frontend) CreateOrUpdateNodePool(writer http.ResponseWriter, request *h
 		csNodePool, err = f.clusterServiceClient.PostNodePool(ctx, clusterDoc.InternalID, csNodePoolBuilder)
 		if err != nil {
 			logger.Error(err.Error())
-			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID))
+			arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID, writer.Header()))
 			return
 		}
 

--- a/internal/api/arm/error.go
+++ b/internal/api/arm/error.go
@@ -25,6 +25,7 @@ import (
 // CloudError codes
 const (
 	CloudErrorCodeInternalServerError      = "InternalServerError"
+	CloudErrorCodeServiceUnavailable       = "ServiceUnavailable"
 	CloudErrorCodeInvalidParameter         = "InvalidParameter"
 	CloudErrorCodeInvalidRequestContent    = "InvalidRequestContent"
 	CloudErrorCodeInvalidResource          = "InvalidResource"

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -864,7 +864,7 @@ func ConvertCStoHCPOpenShiftVersion(resourceID azcorearm.ResourceID, version *ar
 // CSErrorToCloudError attempts to convert various 4xx status codes from
 // Cluster Service to an ARM-compliant error structure, with 500 Internal
 // Server Error as a last-ditch fallback.
-func CSErrorToCloudError(err error, resourceID *azcorearm.ResourceID) *arm.CloudError {
+func CSErrorToCloudError(err error, resourceID *azcorearm.ResourceID, header http.Header) *arm.CloudError {
 	var ocmError *ocmerrors.Error
 
 	if errors.As(err, &ocmError) {


### PR DESCRIPTION
[ARO-21683 - Handle 503 Service Unavailable errors from CS](https://issues.redhat.com/browse/ARO-21683)

### What

Per a [recent discussion thread on Slack](https://redhat-external.slack.com/archives/C075PHEFZKQ/p1758706962628729), the RP should pass along 503 Service Unavailable errors from Clusters Service (including the error message) instead of converting them to opaque 500 Internal Server Errors.

For the use case in mind — Cluster Service reaching cluster capacity as per its `--provision-shard-cluster-limit` option and rejecting further cluster creation attempts — the RP frontend would receive this error immediately on a POST request to Cluster Service.

A 503 Service Unavailable would only reach the RP frontend after the OCM SDK has already retried several times so further immediate retries would likely be pointless. Instead, the frontend should include a `Retry-After` header when propagating this error code.

The `Retry-After` interval is currently a blind guess until we have better data. I'm choosing 60 seconds to match ARM's asynchronous operation polling interval.