### PR TITLE
CS settings for max cluster limit on MC

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -87,6 +87,7 @@ deploy:
 	  --set tracing.address=${TRACING_ADDRESS} \
 	  --set csDeploymentStrategy.rollingUpdate.maxSurge=${CS_DEPLOYMENT_ROLLINGUPDATE_MAX_SURGE} \
 	  --set csDeploymentStrategy.rollingUpdate.maxUnavailable=${CS_DEPLOYMENT_ROLLINGUPDATE_MAX_UNAVAILABLE} \
+	  --set provisionShardClusterLimit=${PROVISION_SHARD_CLUSTER_LIMIT} \
 	  "$${OP_HELM_SET_FLAGS[@]}"
 
 deploy-pr-env-deps:

--- a/cluster-service/deploy/templates/deployment.yaml
+++ b/cluster-service/deploy/templates/deployment.yaml
@@ -161,6 +161,7 @@ spec:
         - --runtime-mode={{ .Values.runtimeMode }}
         - --default-expiration={{ .Values.defaultExpiration }}
         - --maximum-expiration={{ .Values.maximumExpiration }}
+        - --provision-shard-cluster-limit={{ .Values.provisionShardClusterLimit }}
         - --db-host=@/secrets/rds/db.host
         - --db-port=@/secrets/rds/db.port
         - --db-name=@/secrets/rds/db.name

--- a/cluster-service/deploy/values.yaml
+++ b/cluster-service/deploy/values.yaml
@@ -48,7 +48,7 @@ environment: ""
 # thus making the Backplane CLI failover to check if the backplane user has an environment variable BACKPLANE_URL set and use it instead.
 backplaneURL: ""
 # Provision shard limit of managed clusters.
-provisionShardClusterLimit: "500"
+provisionShardClusterLimit: "100"
 # If not empty clears the dirty flag and forces the given migration version.
 forceMigration: ""
 # If set to true, a cluster error will trigger a report.

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -156,6 +156,8 @@ resourceGroups:
         resourceGroup: global
         step: output
         name: ocpAcrLoginServer
+    - name: PROVISION_SHARD_CLUSTER_LIMIT
+      configRef: clustersService.provisionShardClusterLimit
     # this is maestro consumer registration stuff
     # this goes away when we have a real registration process
     - name: CONSUMER_NAME

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -847,6 +847,10 @@
           "type": "string",
           "description": "The name of the MSI that will be used by CS to interact with Azure"
         },
+        "provisionShardClusterLimit": {
+          "type": "integer",
+          "description": "The maximum number of HCPs that can be placed on an MC, sadly not configurable per MC"
+        },
         "k8s": {
           "$ref": "#/definitions/k8sDeployment"
         },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -587,6 +587,8 @@ defaults:
     image:
       registry: quay.io
       repository: app-sre/uhc-clusters-service
+    # controls how many HCPs can be placed on an MC, sadly not configurable per MC
+    provisionShardClusterLimit: 100
     tracing: # NOTE: Currently only enabled for pers.
       address: ""
       exporter: ""

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: e1974037cc0699a8b0e65e71b702d813003d04f2b14524f3b3ba065aa99bf2a5
+          westus3: 3b4972c64a28924535f6d32f73446a184052174858b7e59c643cc294f159e7eb
       dev:
         regions:
-          westus3: b317fcbd725666e4a16834f5157376ad591609051070bc62155a6544e5073fd0
+          westus3: 3bc89dfc36feb52d60987dfb30f027c03c7806fea213b25d924bcf31ed146485
       ntly:
         regions:
-          uksouth: 42b43d9d0c42c12f796c54feb487516a2f6e0a4186b657b57eb5168746bd03f4
+          uksouth: 3b5c6b164ccb7607b302f6bb07b7a7f6b0b3089d368c32960abd11195796f961
       perf:
         regions:
-          westus3: 63b448c88773c5d084bbb5c6f5a3802c45604663ed99ab92fc35ef313328d14a
+          westus3: 2a3524b786148bb44582454428f3412484137ccc5aa2837991244f87d331c643
       pers:
         regions:
-          westus3: d4ac24fad835a6461df6a4a144d98ac7bead0bb74be195d0d84887a47cf6579a
+          westus3: cc763cbfda55d06842234dc59739dbd0382bdcf30f35be86c3894ada88e3920e
       swft:
         regions:
-          uksouth: 7200ce34d30fde21f5e3df4a0fd563105e92ac8a89de71725aa0ecbd26302dcc
+          uksouth: 293adc34747919953a201301303b47beb68331967075a990f21fcfb39c46b03d

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -141,6 +141,7 @@ clustersService:
     serverStorageSizeGB: 128
     serverVersion: "17"
     zoneRedundantMode: Auto
+  provisionShardClusterLimit: 100
   tracing:
     address: ""
     exporter: ""

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -141,6 +141,7 @@ clustersService:
     serverStorageSizeGB: 128
     serverVersion: "17"
     zoneRedundantMode: Auto
+  provisionShardClusterLimit: 100
   tracing:
     address: ""
     exporter: ""

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -141,6 +141,7 @@ clustersService:
     serverStorageSizeGB: 128
     serverVersion: "17"
     zoneRedundantMode: Auto
+  provisionShardClusterLimit: 100
   tracing:
     address: ""
     exporter: ""

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -141,6 +141,7 @@ clustersService:
     serverStorageSizeGB: 128
     serverVersion: "17"
     zoneRedundantMode: Auto
+  provisionShardClusterLimit: 100
   tracing:
     address: ""
     exporter: ""

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -141,6 +141,7 @@ clustersService:
     serverStorageSizeGB: 128
     serverVersion: "17"
     zoneRedundantMode: Auto
+  provisionShardClusterLimit: 100
   tracing:
     address: http://ingest.observability:4318
     exporter: otlp

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -141,6 +141,7 @@ clustersService:
     serverStorageSizeGB: 128
     serverVersion: "17"
     zoneRedundantMode: Auto
+  provisionShardClusterLimit: 100
   tracing:
     address: ""
     exporter: ""


### PR DESCRIPTION
### What

introduces a configuration option to control how many HCPs can be placed on an MC. this is a CS global option, so applies to all MCs registered with that CS instance.

this also reduced the limit to 100 right now as this is considered something a fully staffed MC can handle. depending on MC sizing in certain envs, this value needs to be lowered but keep in mind that this value applies to all MCs of a CS instance before adding new MCs to it.

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
