### PR TITLE
suspend the cluster-image-registry-operator-recycle CronJob

### DIFF
--- a/mgmt-fixes/deploy/mitigations/templates/cluster-image-registry-operator-recycle.yaml
+++ b/mgmt-fixes/deploy/mitigations/templates/cluster-image-registry-operator-recycle.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: cluster-image-registry-operator-recycle
 spec:
+  suspend: true
   schedule: "*/10 * * * *" # Every 10 minutes
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Suspend the cluster-image-registry-operator-recycle cron job.  The cron job should not be necessary as Hypershift/CPO contain the shared UID fix OCPBUGS-59736.  Suspending first and assuming no issues arise it will be removed completely in a follow up PR.

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
