### PR TITLE
e2e: remove timeouts for GET calls as they are not async requests

### DIFF
--- a/test/e2e/cluster_create_no_cni.go
+++ b/test/e2e/cluster_create_no_cni.go
@@ -88,7 +88,6 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				customerNodePoolName,
-				5*time.Minute,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nodePool.Properties).ToNot(BeNil())

--- a/test/e2e/cluster_create_nodepool_osdisk.go
+++ b/test/e2e/cluster_create_nodepool_osdisk.go
@@ -87,7 +87,6 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				customerNodePoolName,
-				5*time.Minute,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(created.Properties).ToNot(BeNil())

--- a/test/e2e/cluster_update.go
+++ b/test/e2e/cluster_update.go
@@ -146,7 +146,6 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
 					clusterName,
-					5*time.Minute,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -177,7 +176,6 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
 					clusterName,
-					5*time.Minute,
 				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(got.Tags).ToNot(BeNil())

--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -211,7 +211,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying ExternalAuth is in a Succeeded state")
-			eaResult, err := framework.GetExternalAuth(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, customerClusterName, customerExternalAuthName, 5*time.Minute)
+			eaResult, err := framework.GetExternalAuth(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, customerClusterName, customerExternalAuthName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*eaResult.Properties.ProvisioningState).To(Equal(hcpsdk.ExternalAuthProvisioningStateSucceeded))
 

--- a/test/e2e/gpu_nodepools_create_delete.go
+++ b/test/e2e/gpu_nodepools_create_delete.go
@@ -117,7 +117,6 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 					*resourceGroup.Name,
 					customerClusterName,
 					npName,
-					5*time.Minute,
 				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(created.Properties).ToNot(BeNil())
@@ -144,7 +143,6 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 					*resourceGroup.Name,
 					customerClusterName,
 					npName,
-					2*time.Minute,
 				)
 				Expect(getErr).To(HaveOccurred())
 			},

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -38,7 +38,7 @@ func GetAdminRESTConfigForHCPCluster(
 	hcpClient *hcpsdk.HcpOpenShiftClustersClient,
 	resourceGroupName string,
 	hcpClusterName string,
-	timeout time.Duration,
+	timeout time.Duration, // this is a POST request, so keep the timeout as it's async
 ) (*rest.Config, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -148,17 +148,13 @@ func UpdateHCPCluster(
 	}
 }
 
-// GetHCPCluster fetches an HCP cluster with a timeout
+// GetHCPCluster fetches an HCP cluster
 func GetHCPCluster(
 	ctx context.Context,
 	hcpClient *hcpsdk.HcpOpenShiftClustersClient,
 	resourceGroupName string,
 	hcpClusterName string,
-	timeout time.Duration,
 ) (hcpsdk.HcpOpenShiftClustersClientGetResponse, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	return hcpClient.Get(ctx, resourceGroupName, hcpClusterName, nil)
 }
 
@@ -245,11 +241,7 @@ func GetNodePool(
 	resourceGroupName string,
 	hcpClusterName string,
 	nodePoolName string,
-	timeout time.Duration,
 ) (hcpsdk.NodePoolsClientGetResponse, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	return nodePoolsClient.Get(ctx, resourceGroupName, hcpClusterName, nodePoolName, nil)
 }
 
@@ -302,11 +294,7 @@ func GetExternalAuth(
 	resourceGroupName string,
 	hcpClusterName string,
 	externalAuthName string,
-	timeout time.Duration,
 ) (hcpsdk.ExternalAuthsClientGetResponse, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	return externalAuthClient.Get(
 		ctx,
 		resourceGroupName,


### PR DESCRIPTION


### What

These calls are expected to return in <1s according to RPC.  This does not impact `Get` methods that are actually POST HTTP verbs.  

### Why



### Special notes for your reviewer

<!-- optional -->
