### PR TITLE
test: move reader role assignment to a different bicep module

### DIFF
--- a/test/e2e-setup/bicep/modules/managed-identities-reader-roles.bicep
+++ b/test/e2e-setup/bicep/modules/managed-identities-reader-roles.bicep
@@ -1,0 +1,176 @@
+@description('The service managed identity resource ID')
+param serviceManagedIdentityId string
+
+@description('The cluster API Azure managed identity resource ID')
+param clusterApiAzureMiId string
+
+@description('The control plane managed identity resource ID')
+param controlPlaneMiId string
+
+@description('The cloud controller manager managed identity resource ID')
+param cloudControllerManagerMiId string
+
+@description('The ingress managed identity resource ID')
+param ingressMiId string
+
+@description('The disk CSI driver managed identity resource ID')
+param diskCsiDriverMiId string
+
+@description('The file CSI driver managed identity resource ID')
+param fileCsiDriverMiId string
+
+@description('The image registry managed identity resource ID')
+param imageRegistryMiId string
+
+@description('The cloud network config managed identity resource ID')
+param cloudNetworkConfigMiId string
+
+@description('The KMS managed identity resource ID')
+param kmsMiId string
+
+//
+// E X I S T I N G   R E S O U R C E S
+//
+
+resource serviceManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: last(split(serviceManagedIdentityId, '/'))
+}
+
+resource clusterApiAzureMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: last(split(clusterApiAzureMiId, '/'))
+}
+
+resource controlPlaneMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: last(split(controlPlaneMiId, '/'))
+}
+
+resource cloudControllerManagerMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: last(split(cloudControllerManagerMiId, '/'))
+}
+
+resource ingressMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: last(split(ingressMiId, '/'))
+}
+
+resource diskCsiDriverMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: last(split(diskCsiDriverMiId, '/'))
+}
+
+resource fileCsiDriverMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: last(split(fileCsiDriverMiId, '/'))
+}
+
+resource imageRegistryMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: last(split(imageRegistryMiId, '/'))
+}
+
+resource cloudNetworkConfigMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: last(split(cloudNetworkConfigMiId, '/'))
+}
+
+resource kmsMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: last(split(kmsMiId, '/'))
+}
+
+//
+// R O L E   D E F I N I T I O N S
+//
+
+var readerRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  'acdd72a7-3385-48ef-bd42-f606fba81ae7'
+)
+
+//
+// R E A D E R   R O L E   A S S I G N M E N T S
+//
+
+resource serviceManagedIdentityReaderOnClusterApiAzureMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, clusterApiAzureMi.id)
+  scope: clusterApiAzureMi
+  properties: {
+    principalId: serviceManagedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: readerRoleId
+  }
+}
+
+resource serviceManagedIdentityReaderOnControlPlaneMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, controlPlaneMi.id)
+  scope: controlPlaneMi
+  properties: {
+    principalId: serviceManagedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: readerRoleId
+  }
+}
+
+resource serviceManagedIdentityReaderOnCloudControllerManagerMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, cloudControllerManagerMi.id)
+  scope: cloudControllerManagerMi
+  properties: {
+    principalId: serviceManagedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: readerRoleId
+  }
+}
+
+resource serviceManagedIdentityReaderOnIngressMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, ingressMi.id)
+  scope: ingressMi
+  properties: {
+    principalId: serviceManagedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: readerRoleId
+  }
+}
+
+resource serviceManagedIdentityReaderOnDiskCsiDriverMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, diskCsiDriverMi.id)
+  scope: diskCsiDriverMi
+  properties: {
+    principalId: serviceManagedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: readerRoleId
+  }
+}
+
+resource serviceManagedIdentityReaderOnFileCsiDriverMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, fileCsiDriverMi.id)
+  scope: fileCsiDriverMi
+  properties: {
+    principalId: serviceManagedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: readerRoleId
+  }
+}
+
+resource serviceManagedIdentityReaderOnImageRegistryMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, imageRegistryMi.id)
+  scope: imageRegistryMi
+  properties: {
+    principalId: serviceManagedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: readerRoleId
+  }
+}
+
+resource serviceManagedIdentityReaderOnCloudNetworkMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, cloudNetworkConfigMi.id)
+  scope: cloudNetworkConfigMi
+  properties: {
+    principalId: serviceManagedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: readerRoleId
+  }
+}
+
+resource serviceManagedIdentityReaderOnKMSAzureMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, kmsMi.id)
+  scope: kmsMi
+  properties: {
+    principalId: serviceManagedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: readerRoleId
+  }
+}

--- a/test/e2e-setup/bicep/modules/managed-identities.bicep
+++ b/test/e2e-setup/bicep/modules/managed-identities.bicep
@@ -40,12 +40,6 @@ resource keyVault 'Microsoft.KeyVault/vaults@2024-12-01-preview' existing = {
 // C O N T R O L   P L A N E   I D E N T I T I E S
 //
 
-// Reader
-var readerRoleId = subscriptionResourceId(
-  'Microsoft.Authorization/roleDefinitions',
-  'acdd72a7-3385-48ef-bd42-f606fba81ae7'
-)
-
 //
 // C L U S T E R   A P I   A Z U R E   M I
 //
@@ -71,15 +65,6 @@ resource hcpClusterApiProviderRoleSubnetAssignment 'Microsoft.Authorization/role
   }
 }
 
-resource serviceManagedIdentityReaderOnClusterApiAzureMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, clusterApiAzureMi.id)
-  scope: clusterApiAzureMi
-  properties: {
-    principalId: serviceManagedIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: readerRoleId
-  }
-}
 
 //
 // C O N T R O L   P L A N E   O P E R A T O R   M A N A G E D   I D E N T I T Y
@@ -116,15 +101,6 @@ resource hcpControlPlaneOperatorNsgRoleAssignment 'Microsoft.Authorization/roleA
   }
 }
 
-resource serviceManagedIdentityReaderOnControlPlaneMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, controlPlaneMi.id)
-  scope: controlPlaneMi
-  properties: {
-    principalId: serviceManagedIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: readerRoleId
-  }
-}
 
 //
 // C L O U D   C O N T R O L L E R   M A N A G E R   M A N A G E D   I D E N T I T Y
@@ -161,15 +137,6 @@ resource cloudControllerManagerRoleNsgAssignment 'Microsoft.Authorization/roleAs
   }
 }
 
-resource serviceManagedIdentityReaderOnCloudControllerManagerMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, cloudControllerManagerMi.id)
-  scope: cloudControllerManagerMi
-  properties: {
-    principalId: serviceManagedIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: readerRoleId
-  }
-}
 
 //
 // I N G R E S S   M A N A G E D   I D E N T I T Y
@@ -196,15 +163,6 @@ resource ingressOperatorRoleSubnetAssignment 'Microsoft.Authorization/roleAssign
   }
 }
 
-resource serviceManagedIdentityReaderOnIngressMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, ingressMi.id)
-  scope: ingressMi
-  properties: {
-    principalId: serviceManagedIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: readerRoleId
-  }
-}
 
 //
 // D I S K   C S I   D R I V E R   M A N A G E D   I D E N T I T Y
@@ -215,15 +173,6 @@ resource diskCsiDriverMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-
   location: resourceGroup().location
 }
 
-resource serviceManagedIdentityReaderOnDiskCsiDriverMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, diskCsiDriverMi.id)
-  scope: diskCsiDriverMi
-  properties: {
-    principalId: serviceManagedIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: readerRoleId
-  }
-}
 
 //
 // F I L E   C S I   D R I V E R   M A N A G E D   I D E N T I T Y
@@ -260,15 +209,6 @@ resource fileStorageOperatorRoleNsgAssignment 'Microsoft.Authorization/roleAssig
   }
 }
 
-resource serviceManagedIdentityReaderOnFileCsiDriverMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, fileCsiDriverMi.id)
-  scope: fileCsiDriverMi
-  properties: {
-    principalId: serviceManagedIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: readerRoleId
-  }
-}
 
 //
 // I M A G E   R E G I S T R Y   M A N A G E D   I D E N T I T Y
@@ -279,15 +219,6 @@ resource imageRegistryMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-
   location: resourceGroup().location
 }
 
-resource serviceManagedIdentityReaderOnImageRegistryMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, imageRegistryMi.id)
-  scope: imageRegistryMi
-  properties: {
-    principalId: serviceManagedIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: readerRoleId
-  }
-}
 
 //
 // C L O U D   N E T W O R K   C O N F I G   M A N A G E D   I D E N T I T Y
@@ -324,15 +255,6 @@ resource networkOperatorRoleVnetAssignment 'Microsoft.Authorization/roleAssignme
   }
 }
 
-resource serviceManagedIdentityReaderOnCloudNetworkMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, cloudNetworkConfigMi.id)
-  scope: cloudNetworkConfigMi
-  properties: {
-    principalId: serviceManagedIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: readerRoleId
-  }
-}
 
 //
 // D A T A P L A N E   I D E N T I T I E S
@@ -483,13 +405,24 @@ resource keyVaultCryptoUserToKeyVaultRoleAssignment 'Microsoft.Authorization/rol
   }
 }
 
-resource serviceManagedIdentityReaderOnKMSAzureMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, kmsMi.id)
-  scope: kmsMi
-  properties: {
-    principalId: serviceManagedIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: readerRoleId
+
+//
+// R E A D E R    R O L E
+//
+
+module readerRoles 'managed-identities-reader-roles.bicep' = {
+  name: 'managedIdentitiesReaderRoles'
+  params: {
+    serviceManagedIdentityId: serviceManagedIdentity.id
+    clusterApiAzureMiId: clusterApiAzureMi.id
+    controlPlaneMiId: controlPlaneMi.id
+    cloudControllerManagerMiId: cloudControllerManagerMi.id
+    ingressMiId: ingressMi.id
+    diskCsiDriverMiId: diskCsiDriverMi.id
+    fileCsiDriverMiId: fileCsiDriverMi.id
+    imageRegistryMiId: imageRegistryMi.id
+    cloudNetworkConfigMiId: cloudNetworkConfigMi.id
+    kmsMiId: kmsMi.id
   }
 }
 


### PR DESCRIPTION
[ARO-21182](https://issues.redhat.com/browse/ARO-21182)

### What

Refactored managed identity reader role assignments into a separate access control module. Created managed-identities-access-control.bicep to handle all reader role assignments and updated managed-identities.bicep to call it internally. This separates identity creation from access control while maintaining backward compatibility with all parent templates.

### Why

Improves code organization and separation of concerns by isolating reader role assignments from managed identity creation. The original module was handling both identity provisioning and access control in a single file, making it harder to maintain and potentially contributing to deployment timeouts due to resource contention. This refactoring creates cleaner module boundaries while keeping the same external interface.

### Special notes for your reviewer
 
 - No breaking changes: All parent templates (demo.bicep, cluster-only.bicep, etc.) continue working unchanged
  - Only reader roles moved: The 9 serviceManagedIdentityReaderOn* assignments were extracted. The 19 functional role assignments (network, storage, crypto permissions) remain in the original module as they're tightly coupled to identity creation
  - Internal module call: managed-identities.bicep now acts as a facade that calls the new access control module with the created identity IDs
  - Architecture improvement: May help with deployment timeouts by sequencing identity creation before role assignments
