### PR TITLE
Adding fpa tenant id to credential refresher

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1397,6 +1397,10 @@
           "type": "string",
           "description": "The client ID of the first party application that will be used by the refresher"
         },
+        "firstPartyAppTenantId": {
+          "type": "string",
+          "description": "The client ID of the first party application that will be used by the refresher"
+        },
         "earlyRefreshFrequency": {
           "type": "string",
           "description": "Early refresh interval before credential is eligible for refresh. For testing, 0 means no early refresh. Example: 24h"
@@ -1441,6 +1445,8 @@
       },
       "additionalProperties": false,
       "required": [
+        "firstPartyAppTenantId",
+        "firstPartyAppClientId",
         "managedIdentityName",
         "k8s",
         "image",

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1399,7 +1399,7 @@
         },
         "firstPartyAppTenantId": {
           "type": "string",
-          "description": "The client ID of the first party application that will be used by the refresher"
+          "description": "The tenant ID of the first party application that will be used by the refresher"
         },
         "earlyRefreshFrequency": {
           "type": "string",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -492,6 +492,7 @@ defaults:
   msiCredentialsRefresher:
     managedIdentityName: msi-credential-refresher
     firstPartyAppClientId: ""
+    firstPartyAppTenantId: ""
     k8s:
       namespace: msi-credential-refresher
       serviceAccountName: msi-credential-refresher


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Adding fpa tenant id to credential refresher
### Why

Getting auth errors when I try to auth with the first party app. They say I need to specify the tenant when I make the client credential.

### Special notes for your reviewer

<!-- optional -->
