### PR TITLE
MSFT promotion INT -> STG sep 30rd

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -147,11 +147,11 @@ clouds:
           # Hypershift
           hypershift:
             image:
-              digest: sha256:4897a5692b022459874e8a43e6a0c768dc38e332bb182e96e795ea4eaab18662
+              digest: sha256:51c4b99787b6ba4092e39fcb73bdb1ad3a1b240737b2ad2f43144e676df579c1
           # Maestro
           maestro:
             image:
-              digest: sha256:bc06d51c6df4b21fbbd5881a90b42931d254a836e270f723579718702cfdf48f
+              digest: sha256:d14c940a103d3811123c907bec610349960ac2028df508a1a8c89264bd3ed847
             agent:
               sidecar:
                 image:


### PR DESCRIPTION
## What

**Environment:** `int` → `stg`

**Updated 2 image digest(s):**

### 1. `hypershift.image.digest`
- [x] **Validated and ready for promotion by**  @mmazur 

**Old:** `sha256:4897a5692b022...`
**New:** `sha256:51c4b99787b6b...`

**Source:** [PR #2822](https://github.com/Azure/ARO-HCP/pull/2822) - Update hypershift operator to latest in dev and int
**PR Merged:** 2025-09-29 18:23 UTC
**PR Author:** @hbhushan3
**PR Approved by:** @mbarnes

### 2. `maestro.image.digest`
- [x] **Validated and ready for promotion by**  @geoberle

**Old:** `sha256:bc06d51c6df4b...`
**New:** `sha256:d14c940a103d3...`

**Source:** [PR #2826](https://github.com/Azure/ARO-HCP/pull/2826) - bump maestro in INT and DEV
**PR Merged:** 2025-09-30 06:30 UTC
**PR Author:** @geoberle

## Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
