### PR TITLE
fix: update SLO alert thresholds to use proper burn rate formula

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -521,7 +521,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'Cluster Service API availability error budget burn rate is too high'
           title: 'API is rapidly burning its 28 day availability error budget (99% SLO)'
         }
-        expression: '( sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44 and sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44 ) or ( sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6 and sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6 )'
+        expression: '( sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) ) or ( sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) )'
         for: 'PT5M'
         severity: 3
       }
@@ -548,7 +548,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'API is slowly but steadily burning its 28 day availability error budget (99% SLO)'
           title: 'This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days.'
         }
-        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934 and sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934'
+        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))'
         for: 'PT30M'
         severity: 3
       }
@@ -577,7 +577,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'Cluster Service API P99 latency error budget burn rate is too high'
           title: 'API is rapidly burning its 28 day 1s latency error budget (99% SLO)'
         }
-        expression: '( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44 and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44 ) or ( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6 and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6 )'
+        expression: '( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) ) or ( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) )'
         for: 'PT5M'
         severity: 3
       }
@@ -604,7 +604,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'API is slowly but steadily burning its 28 day 1s latency error budget (99% SLO)'
           title: 'This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days.'
         }
-        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934 and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934'
+        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))'
         for: 'PT30M'
         severity: 3
       }
@@ -633,7 +633,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'Cluster Service API P90 latency error budget burn rate is too high'
           title: 'API is rapidly burning its 28 day 0.1s latency error budget (90% SLO)'
         }
-        expression: '( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44 and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44 ) or ( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6 and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6 )'
+        expression: '( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.90)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.90)) ) or ( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.90)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.90)) )'
         for: 'PT5M'
         severity: 3
       }
@@ -660,7 +660,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'API is slowly but steadily burning its 28 day 0.1s latency error budget (90% SLO)'
           title: 'This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days.'
         }
-        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934 and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934'
+        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.90)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.90))'
         for: 'PT30M'
         severity: 3
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -96,98 +96,98 @@ resource arohcpCsApiLatencyRecordingRules 'Microsoft.AlertsManagement/prometheus
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate5m'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[5m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[5m]))) ) ) / (1 - 0.99), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[5m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[5m]))) ) ) / (1 - 0.99), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate30m'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[30m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[30m]))) ) ) / (1 - 0.99), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[30m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[30m]))) ) ) / (1 - 0.99), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate1h'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1h]))) ) ) / (1 - 0.99), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1h]))) ) ) / (1 - 0.99), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate6h'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[6h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[6h]))) ) ) / (1 - 0.99), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[6h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[6h]))) ) ) / (1 - 0.99), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate3d'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[3d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[3d]))) ) ) / (1 - 0.99), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[3d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[3d]))) ) ) / (1 - 0.99), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate2h'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[2h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[2h]))) ) ) / (1 - 0.99), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[2h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[2h]))) ) ) / (1 - 0.99), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p99_burnrate1d'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1d]))) ) ) / (1 - 0.99), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[1d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1d]))) ) ) / (1 - 0.99), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate5m'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[5m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[5m]))) ) ) / (1 - 0.90), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[5m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[5m]))) ) ) / (1 - 0.90), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate30m'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[30m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[30m]))) ) ) / (1 - 0.90), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[30m]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[30m]))) ) ) / (1 - 0.90), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate1h'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1h]))) ) ) / (1 - 0.90), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1h]))) ) ) / (1 - 0.90), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate6h'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[6h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[6h]))) ) ) / (1 - 0.90), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[6h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[6h]))) ) ) / (1 - 0.90), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate3d'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[3d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[3d]))) ) ) / (1 - 0.90), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[3d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[3d]))) ) ) / (1 - 0.90), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate2h'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[2h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[2h]))) ) ) / (1 - 0.90), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[2h]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[2h]))) ) ) / (1 - 0.90), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }
       }
       {
         record: 'latency:api_inbound_request_duration:p90_burnrate1d'
-        expression: 'clamp_min( round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1d]))) ) ) / (1 - 0.90), 0.01 ), 0)'
+        expression: 'round( ( 1 - ( sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[1d]))) / sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1d]))) ) ) / (1 - 0.90), 0.01)'
         labels: {
           service: 'clusters-service-metrics'
         }

--- a/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
+++ b/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
@@ -10,11 +10,25 @@ metadata:
   namespace: monitoring
 spec:
   groups:
+  # ========================================
   # API Availability Recording Rules
+  # ========================================
+  # These rules track the availability SLO for the Cluster Service API.
+  # SLO: 99% of requests should succeed (not return 5xx or code=0)
+  # Error Budget: 1% (1 - 0.99)
+  #
+  # The rules calculate:
+  # - Long-term SLI (28-day rolling window)
+  # - Burn rates across multiple time windows (5m, 30m, 1h, 2h, 6h, 1d, 3d)
+  #
+  # Burn rate formula: (error_rate / error_budget)
+  # - Burn rate = 1x means consuming error budget at exactly the allowed rate
+  # - Burn rate > 1x means consuming error budget faster than sustainable
   - name: arohcp_cs_api_availability_recording_rules
     interval: 1m
     rules:
-    # 28-day rolling SLI
+    # 28-day rolling SLI - measures actual availability over 28 days
+    # This is the baseline metric to compare against the 99% SLO target
     - record: availability:api_inbound_request_count:sli_ratio_28d
       expr: |
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service",code!~"5..", service="clusters-service-metrics"}[28d])))
@@ -22,8 +36,18 @@ spec:
         sum by(cluster, namespace, service) ((max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d]))))
       labels:
         service: "clusters-service-metrics"
-    # Burn rate recording rules for various time windows
+    # 5m burn rate - used for detecting rapid, severe outages
+    # Critical threshold: 13.44x (would exhaust 28d budget in ~2 days)
     - record: availability:api_inbound_request_count:burnrate5m
+      # ----------------------------------------
+      # Burn rate recording rules for various time windows
+      # ----------------------------------------
+      # These rules calculate how fast we're consuming the error budget.
+      # The round() function rounds to 2 decimal places (0.01 precision).
+      #
+      # Pattern: code=~"5..|0" matches 5xx errors and code=0 (connection failures)
+      # Note: Prometheus uses max without(prometheus_replica) to deduplicate metrics from HA replicas
+
       expr: |
         round(
         (
@@ -33,6 +57,8 @@ spec:
         ) / (1 - 0.99), 0.01)
       labels:
         service: "clusters-service-metrics"
+    # 30m burn rate - used with 6h window for medium-speed burn detection
+    # Critical threshold: 5.6x (would exhaust budget in ~5 days)
     - record: availability:api_inbound_request_count:burnrate30m
       expr: |
         round(
@@ -43,6 +69,7 @@ spec:
         ) / (1 - 0.99), 0.01)
       labels:
         service: "clusters-service-metrics"
+    # 1h burn rate - used with 5m window for fast burn detection (long window)
     - record: availability:api_inbound_request_count:burnrate1h
       expr: |
         round(
@@ -53,6 +80,8 @@ spec:
         ) / (1 - 0.99), 0.01)
       labels:
         service: "clusters-service-metrics"
+    # 6h burn rate - used for both medium burn (with 30m) and slow burn (with 3d) detection
+    # Warning threshold: 0.934x (would exhaust budget in ~30 days)
     - record: availability:api_inbound_request_count:burnrate6h
       expr: |
         round(
@@ -63,6 +92,7 @@ spec:
         ) / (1 - 0.99), 0.01)
       labels:
         service: "clusters-service-metrics"
+    # 3d burn rate - used with 6h window for slow burn detection (long window)
     - record: availability:api_inbound_request_count:burnrate3d
       expr: |
         round(
@@ -73,6 +103,7 @@ spec:
         ) / (1 - 0.99), 0.01)
       labels:
         service: "clusters-service-metrics"
+    # 2h and 1d burn rates (not currently used in alerts, but available for dashboards)
     - record: availability:api_inbound_request_count:burnrate2h
       expr: |
         round(
@@ -93,11 +124,33 @@ spec:
         ) / (1 - 0.99), 0.01)
       labels:
         service: "clusters-service-metrics"
+  # ========================================
   # API Latency Recording Rules
+  # ========================================
+  # These rules track latency SLOs for the Cluster Service API.
+  #
+  # TWO separate latency SLOs are tracked:
+  # - P99 SLO: 99% of successful requests should complete within 1 second
+  # - P90 SLO: 90% of successful requests should complete within 0.1 seconds (100ms)
+  #
+  # IMPORTANT: Latency SLOs only apply to successful requests (code!~"5..")
+  # Server errors (5xx) are excluded from latency calculations because they're already
+  # counted against the availability SLO.
+  #
+  # Histogram buckets used:
+  # - le="0.1": requests ≤100ms (for P90)
+  # - le="1": requests ≤1s (for P99)
+  # - le="+Inf": all requests (total count)
   - name: arohcp_cs_api_latency_recording_rules
     interval: 1m
     rules:
-    # P99 Latency SLI (28-day)
+    # ----------------------------------------
+    # P99 Latency SLI and Burn Rates
+    # ----------------------------------------
+    # P99 SLI: 99% of requests should complete within 1 second
+    # Error budget: 1% (1 - 0.99)
+
+    # P99 Latency SLI (28-day) - measures actual P99 latency over 28 days
     - record: latency:api_inbound_request_duration:p99_sli_ratio_28d
       expr: |
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="1", code!~"5.."}[28d])))
@@ -105,8 +158,14 @@ spec:
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics"}[28d])))
       labels:
         service: "clusters-service-metrics"
-    # P90 Latency SLI (28-day)
+    # P90 Latency SLI (28-day) - measures actual P90 latency over 28 days
     - record: latency:api_inbound_request_duration:p90_sli_ratio_28d
+      # ----------------------------------------
+      # P90 Latency SLI and Burn Rates
+      # ----------------------------------------
+      # P90 SLI: 90% of requests should complete within 0.1 seconds (100ms)
+      # Error budget: 10% (1 - 0.90)
+
       expr: |
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_duration_bucket{namespace="clusters-service", service="clusters-service-metrics", le="0.1", code!~"5.."}[28d])))
         /
@@ -114,6 +173,8 @@ spec:
       labels:
         service: "clusters-service-metrics"
     # P99 Latency Burn Rate Recording Rules
+    # Formula: (1 - (requests_within_1s / successful_requests)) / error_budget
+    # This calculates the percentage of requests that are TOO SLOW (>1s)
     - record: latency:api_inbound_request_duration:p99_burnrate5m
       expr: |
         round(
@@ -199,6 +260,9 @@ spec:
       labels:
         service: "clusters-service-metrics"
     # P90 Latency Burn Rate Recording Rules
+    # Formula: (1 - (requests_within_100ms / successful_requests)) / error_budget
+    # This calculates the percentage of requests that are TOO SLOW (>100ms)
+    # Note: Different error budget divisor (1 - 0.90 = 0.10) compared to P99
     - record: latency:api_inbound_request_duration:p90_burnrate5m
       expr: |
         round(
@@ -283,10 +347,29 @@ spec:
         ) / (1 - 0.90), 0.01)
       labels:
         service: "clusters-service-metrics"
-  # Alerts for SLOs
+  # ========================================
+  # SLO Alerts
+  # ========================================
+  # These alerts fire when error budgets are being consumed too quickly.
+  #
+  # Multi-window, multi-burn-rate alerting strategy (Google SRE Workbook):
+  # - Fast burn alerts (5m+1h or 30m+6h): Detect severe, rapid issues
+  # - Slow burn alerts (6h+3d): Detect persistent, gradual degradation
+  #
+  # Each alert requires BOTH windows to exceed threshold (AND logic):
+  # - Short window: Confirms issue is happening NOW
+  # - Long window: Confirms issue is sustained, not a transient spike
+  #
+  # This prevents alert fatigue from brief transient issues while ensuring
+  # we catch both sudden outages and slow degradation.
   - name: arohcp_cs_slo_availability_alerts
     rules:
+    # ----------------------------------------
     # API Availability Alerts
+    # ----------------------------------------
+    # Fast burn alert: Fires when both 5m+1h OR 30m+6h burn rates are too high
+    # Threshold: 13.44x (5m+1h) or 5.6x (30m+6h)
+    # These thresholds would exhaust the 28-day error budget in ~2-5 days
     - alert: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
       annotations:
         description: 'API is rapidly burning its 28 day availability error budget (99% SLO)'
@@ -309,6 +392,9 @@ spec:
         long: 6h
         severity: warning
         short: 30m
+    # Slow burn alert: Fires when both 6h+3d burn rates exceed threshold
+    # Threshold: 0.934x
+    # This detects persistent degradation that would exhaust budget in ~30 days
     - alert: ClustersServiceAPIAvailability6hto3dErrorBudgetBurn
       expr: |
         sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))
@@ -322,7 +408,11 @@ spec:
         summary: "API is slowly but steadily burning its 28 day availability error budget (99% SLO)"
         description: "This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days."
         runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
+    # ----------------------------------------
     # API Latency Alerts - P99 (1s threshold)
+    # ----------------------------------------
+    # Fast burn alert for P99 latency
+    # Fires when too many requests take >1s to complete
     - alert: ClustersServiceAPILatency5mto1hor30mto6hP99ErrorBudgetBurn
       annotations:
         description: 'API is rapidly burning its 28 day 1s latency error budget (99% SLO)'
@@ -346,6 +436,7 @@ spec:
         severity: warning
         short: 30m
         slo: api-latency-p99
+    # Slow burn alert for P99 latency
     - alert: ClustersServiceAPILatency6hto3dP99ErrorBudgetBurn
       expr: |
         sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))
@@ -359,7 +450,11 @@ spec:
         summary: "API is slowly but steadily burning its 28 day 1s latency error budget (99% SLO)"
         description: "This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days."
         runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
-    # API Latency Alerts - P90 (0.1s threshold)
+    # ----------------------------------------
+    # API Latency Alerts - P90 (100ms threshold)
+    # ----------------------------------------
+    # Fast burn alert for P90 latency
+    # Fires when too many requests take >100ms to complete
     - alert: ClustersServiceAPILatency5mto1hor30mto6hP90ErrorBudgetBurn
       annotations:
         description: 'API is rapidly burning its 28 day 0.1s latency error budget (90% SLO)'
@@ -383,6 +478,7 @@ spec:
         severity: warning
         short: 30m
         slo: api-latency-p90
+    # Slow burn alert for P90 latency
     - alert: ClustersServiceAPILatency6hto3dP90ErrorBudgetBurn
       expr: |
         sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.90))

--- a/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
+++ b/observability/alerts/tested-rules/cluster-service-slo-rules.yaml
@@ -116,7 +116,6 @@ spec:
     # P99 Latency Burn Rate Recording Rules
     - record: latency:api_inbound_request_duration:p99_burnrate5m
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -124,13 +123,11 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[5m])))
         )
-        ) / (1 - 0.99), 0.01
-        ), 0)
+        ) / (1 - 0.99), 0.01)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p99_burnrate30m
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -138,13 +135,11 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[30m])))
         )
-        ) / (1 - 0.99), 0.01
-        ), 0)
+        ) / (1 - 0.99), 0.01)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p99_burnrate1h
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -152,13 +147,11 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1h])))
         )
-        ) / (1 - 0.99), 0.01
-        ), 0)
+        ) / (1 - 0.99), 0.01)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p99_burnrate6h
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -166,13 +159,11 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[6h])))
         )
-        ) / (1 - 0.99), 0.01
-        ), 0)
+        ) / (1 - 0.99), 0.01)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p99_burnrate3d
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -180,13 +171,11 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[3d])))
         )
-        ) / (1 - 0.99), 0.01
-        ), 0)
+        ) / (1 - 0.99), 0.01)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p99_burnrate2h
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -194,13 +183,11 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[2h])))
         )
-        ) / (1 - 0.99), 0.01
-        ), 0)
+        ) / (1 - 0.99), 0.01)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p99_burnrate1d
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -208,14 +195,12 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1d])))
         )
-        ) / (1 - 0.99), 0.01
-        ), 0)
+        ) / (1 - 0.99), 0.01)
       labels:
         service: "clusters-service-metrics"
     # P90 Latency Burn Rate Recording Rules
     - record: latency:api_inbound_request_duration:p90_burnrate5m
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -223,13 +208,11 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[5m])))
         )
-        ) / (1 - 0.90), 0.01
-        ), 0)
+        ) / (1 - 0.90), 0.01)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p90_burnrate30m
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -237,13 +220,11 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[30m])))
         )
-        ) / (1 - 0.90), 0.01
-        ), 0)
+        ) / (1 - 0.90), 0.01)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p90_burnrate1h
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -251,13 +232,11 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1h])))
         )
-        ) / (1 - 0.90), 0.01
-        ), 0)
+        ) / (1 - 0.90), 0.01)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p90_burnrate6h
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -265,13 +244,11 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[6h])))
         )
-        ) / (1 - 0.90), 0.01
-        ), 0)
+        ) / (1 - 0.90), 0.01)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p90_burnrate3d
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -279,13 +256,11 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[3d])))
         )
-        ) / (1 - 0.90), 0.01
-        ), 0)
+        ) / (1 - 0.90), 0.01)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p90_burnrate2h
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -293,13 +268,11 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[2h])))
         )
-        ) / (1 - 0.90), 0.01
-        ), 0)
+        ) / (1 - 0.90), 0.01)
       labels:
         service: "clusters-service-metrics"
     - record: latency:api_inbound_request_duration:p90_burnrate1d
       expr: |
-        clamp_min(
         round(
         (
         1 - (
@@ -307,8 +280,7 @@ spec:
         /
         sum by(cluster, namespace, service) (max without(prometheus_replica) (rate(api_inbound_request_count{namespace="clusters-service", service="clusters-service-metrics", code!~"5.."}[1d])))
         )
-        ) / (1 - 0.90), 0.01
-        ), 0)
+        ) / (1 - 0.90), 0.01)
       labels:
         service: "clusters-service-metrics"
   # Alerts for SLOs
@@ -322,15 +294,15 @@ spec:
         summary: 'Cluster Service API availability error budget burn rate is too high'
       expr: |
         (
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99))
         and
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99))
         )
         or
         (
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99))
         and
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99))
         )
       for: 5m
       labels:
@@ -339,9 +311,9 @@ spec:
         short: 30m
     - alert: ClustersServiceAPIAvailability6hto3dErrorBudgetBurn
       expr: |
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))
         and
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))
       for: 30m
       labels:
         severity: warning
@@ -358,15 +330,15 @@ spec:
         summary: 'Cluster Service API P99 latency error budget burn rate is too high'
       expr: |
         (
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99))
         and
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99))
         )
         or
         (
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99))
         and
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99))
         )
       for: 5m
       labels:
@@ -376,9 +348,9 @@ spec:
         slo: api-latency-p99
     - alert: ClustersServiceAPILatency6hto3dP99ErrorBudgetBurn
       expr: |
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))
         and
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))
       for: 30m
       labels:
         severity: warning
@@ -395,15 +367,15 @@ spec:
         summary: 'Cluster Service API P90 latency error budget burn rate is too high'
       expr: |
         (
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.90))
         and
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > 13.44
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.90))
         )
         or
         (
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.90))
         and
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 5.6
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.90))
         )
       for: 5m
       labels:
@@ -413,9 +385,9 @@ spec:
         slo: api-latency-p90
     - alert: ClustersServiceAPILatency6hto3dP90ErrorBudgetBurn
       expr: |
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.90))
         and
-        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > 0.934
+        sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.90))
       for: 30m
       labels:
         severity: warning

--- a/observability/alerts/tested-rules/cluster-service-slo-rules_test.yaml
+++ b/observability/alerts/tested-rules/cluster-service-slo-rules_test.yaml
@@ -3,23 +3,30 @@ rule_files:
 evaluation_interval: 1m
 tests:
 # Test 1: Normal operation - no errors, no alert should fire
+# This test verifies that when the API is operating normally with all successful requests,
+# no availability alerts should trigger. The burn rate should be 0.
 - interval: 1m
   input_series:
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
-    # 100 requests per minute, all successful
+    # 100 requests per minute for 80 minutes, all successful (HTTP 200)
+    # Total duration: 80 minutes to cover all time windows (5m, 30m, 1h, 6h)
     values: "100+100x80"
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="201"}'
-    # Additional successful requests
+    # 50 additional successful requests per minute (HTTP 201 - Created)
+    # Shows that different 2xx codes are all treated as successful
     values: "50+50x80"
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500"}'
-    # No 5xx errors
+    # 0 server errors (5xx) - no SLO violations
+    # The SLI monitors code=~"5..|0" so 5xx codes count as errors
     values: "0+0x80"
   promql_expr_test:
   - expr: availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}
     eval_time: 70m
     exp_samples:
     - labels: 'availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}'
-      value: 0 # No errors = 0 burn rate
+      # Expected: 0 burn rate because error rate is 0%
+      # Burn rate = (error_rate / error_budget) where error_budget = 1 - SLO = 1 - 0.99 = 0.01 (1%)
+      value: 0
   alert_rule_test:
   - eval_time: 70m
     alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
@@ -28,20 +35,27 @@ tests:
     alertname: ClustersServiceAPIAvailability6hto3dErrorBudgetBurn
     # Should not fire - no errors
 # Test 2: Fast burn rate - high error rate triggering critical alert (5m + 1h windows)
+# This test simulates a severe outage with 80% error rate, which should trigger
+# the critical alert after 5 minutes. Burn rate = 80% / 1% = 80x
+# Alert fires when: burnrate5m > 13.44 * 0.01 AND burnrate1h > 13.44 * 0.01
 - interval: 1m
   input_series:
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
-    # 20% success rate (80% errors) for full test duration
+    # Only 20% of requests succeed (20 req/min for 80 minutes)
+    # This represents a severe service degradation
     values: "20+20x80"
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500"}'
-    # 80% error rate for full test duration
+    # 80% of requests fail with 5xx errors (80 req/min for 80 minutes)
+    # Total error rate: 80/(20+80) = 0.80 = 80%
     values: "80+80x80"
   promql_expr_test:
   - expr: availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}
     eval_time: 70m
     exp_samples:
     - labels: 'availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}'
-      value: 80 # 80% error rate / 1% budget = 80x burn rate
+      # Expected: 80x burn rate
+      # Calculation: 80% error rate / 1% error budget = 80
+      value: 80
   alert_rule_test:
   - eval_time: 70m
     alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
@@ -58,20 +72,27 @@ tests:
         runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
         summary: "Cluster Service API availability error budget burn rate is too high"
 # Test 3: Medium burn rate - triggering critical alert (30m + 6h windows)
+# This test simulates a moderate but sustained error rate (10%), which should trigger
+# the alert when both 30m and 6h burn rates exceed threshold. Burn rate = 10% / 1% = 10x
+# Alert fires when: burnrate30m > 5.6 * 0.01 AND burnrate6h > 5.6 * 0.01
 - interval: 1m
   input_series:
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
-    # Consistent 90% success rate (10% error rate)
+    # 90% success rate (90 req/min for 400 minutes = ~6.7 hours)
+    # Need enough data to cover the 6h window
     values: "90+90x400"
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500"}'
-    # Consistent 10% error rate
+    # 10% error rate (10 req/min for 400 minutes)
+    # Total error rate: 10/(90+10) = 0.10 = 10%
     values: "10+10x400"
   promql_expr_test:
   - expr: availability:api_inbound_request_count:burnrate30m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}
-    eval_time: 420m # 7 hours
+    eval_time: 420m # 7 hours - enough to cover 6h window
     exp_samples:
     - labels: 'availability:api_inbound_request_count:burnrate30m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}'
-      value: 10 # 10% error rate / 1% budget = 10x burn rate
+      # Expected: 10x burn rate
+      # Calculation: 10% error rate / 1% error budget = 10
+      value: 10
   alert_rule_test:
   - eval_time: 420m # 7 hours - after 6h window + buffer
     alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
@@ -88,20 +109,28 @@ tests:
         runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
         summary: "Cluster Service API availability error budget burn rate is too high"
 # Test 4: Slow burn rate - triggering warning alert (6h + 3d windows)
+# This test simulates a slow but persistent error rate (1.5%), which should trigger
+# the warning alert when both 6h and 3d burn rates exceed threshold. Burn rate = 1.5% / 1% = 1.5x
+# Alert fires when: burnrate6h > 0.934 * 0.01 AND burnrate3d > 0.934 * 0.01
+# Requires 3 days (4320 minutes) of data to properly evaluate 3d window
 - interval: 1m
   input_series:
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
-    # 98.5% success rate (1.5% error rate) - slow burn
-    values: "985+985x4320" # 3 days worth of data
+    # 98.5% success rate (985 req/min for 4320 minutes = 3 days)
+    # This is below the 99% SLO but above the 0.934% threshold for slow burn
+    values: "985+985x4320"
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500"}'
-    # 1.5% error rate consistently
+    # 1.5% error rate (15 req/min for 4320 minutes = 3 days)
+    # Total error rate: 15/(985+15) = 0.015 = 1.5%
     values: "15+15x4320"
   promql_expr_test:
   - expr: availability:api_inbound_request_count:burnrate6h{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}
-    eval_time: 4400m # After 3 days
+    eval_time: 4400m # After 3 days + buffer
     exp_samples:
     - labels: 'availability:api_inbound_request_count:burnrate6h{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}'
-      value: 1.5 # 1.5% error rate / 1% budget = 1.5x burn rate
+      # Expected: 1.5x burn rate
+      # Calculation: 1.5% error rate / 1% error budget = 1.5
+      value: 1.5
   alert_rule_test:
   - eval_time: 4400m # After 3 days + buffer
     alertname: ClustersServiceAPIAvailability6hto3dErrorBudgetBurn
@@ -198,24 +227,32 @@ tests:
   - eval_time: 135m
     alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
     # Should not fire - error rate has been recovered for 70 minutes (1h+ window clear)
-# Test 8: Mixed status codes (only 5xx should count as errors)
+# Test 8: Mixed status codes - verifies that only 5xx errors count as SLO breaches
+# IMPORTANT: This test demonstrates that 4xx (client errors) do NOT count against the SLO.
+# Only 5xx (server errors) count as SLO violations, as defined by code=~"5..|0" in the alert expr.
+# Distribution: 60% success (200), 20% client error (400), 20% server error (500)
+# Expected burn rate: 20% / 1% = 20x (only counting the 5xx errors)
 - interval: 1m
   input_series:
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
-    # 2xx successful
+    # 60% of requests succeed (HTTP 200)
     values: "60+60x80"
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="400"}'
-    # 4xx client errors (should not count as SLO breach)
+    # 20% are client errors (HTTP 400) - these DO NOT count as SLO violations
+    # Client errors are the client's fault, not the service's fault
     values: "20+20x80"
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500"}'
-    # 5xx server errors (should count as SLO breach) - 20% error rate
+    # 20% are server errors (HTTP 500) - these DO count as SLO violations
+    # Error rate for SLO: 20/(60+20+20) = 0.20 = 20%
     values: "20+20x80"
   promql_expr_test:
   - expr: availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}
     eval_time: 70m
     exp_samples:
     - labels: 'availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}'
-      value: 20 # 20% error rate / 1% budget = 20x burn rate
+      # Expected: 20x burn rate (only server errors count, not client errors)
+      # Calculation: 20% server error rate / 1% error budget = 20
+      value: 20
   alert_rule_test:
   - eval_time: 70m
     alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
@@ -232,19 +269,25 @@ tests:
         runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
         summary: "Cluster Service API availability error budget burn rate is too high"
 # Test 9: P99 Latency - Normal operation (no latency issues, no alert should fire)
+# This test verifies that when API latency is good (all requests < 1s), no P99 latency alert fires.
+# P99 SLO: 99% of successful (non-5xx) requests should complete within 1 second.
+# This test shows 100% of requests under 1s, which exceeds the 99% SLO target.
 - interval: 1m
   input_series:
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
-    # 1000 successful requests per minute - larger numbers for stability
+    # 1000 successful requests per minute (use larger numbers for numerical stability)
     values: "1000+1000x80"
   - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
-    # 900 requests under 0.1s (90%)
+    # Histogram bucket: 900 requests completed in ≤0.1s (90% of requests)
+    # This is for P90 latency tracking (separate SLO)
     values: "900+900x80"
   - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
-    # 1000 requests under 1s (100% - perfect P99 performance)
+    # Histogram bucket: 1000 requests completed in ≤1s (100% of requests)
+    # Perfect P99 performance: 100% under 1s exceeds 99% SLO requirement
     values: "1000+1000x80"
   - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
-    # All requests
+    # Histogram bucket: all requests (regardless of duration)
+    # This bucket always equals the total request count
     values: "1000+1000x80"
   alert_rule_test:
   - eval_time: 70m
@@ -276,19 +319,24 @@ tests:
     alertname: ClustersServiceAPILatency6hto3dP90ErrorBudgetBurn
     # Should not fire - no requests are slow
 # Test 11: P99 Latency - Critical burn rate triggering alert
+# This test simulates a latency degradation where only 80% of requests complete within 1s.
+# P99 SLO: 99% of requests should complete within 1s, but we only have 80%.
+# Latency error rate: (1 - 80%) = 20% of requests violate the 1s threshold
+# Burn rate: 20% / 1% = 20x, which exceeds the critical threshold (13.44x)
 - interval: 1m
   input_series:
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
-    # 1000 requests per minute
+    # 1000 successful requests per minute
     values: "1000+1000x80"
   - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="0.1", code="200"}'
-    # 500 under 0.1s (50%)
+    # Histogram bucket: 500 requests completed in ≤0.1s (50%)
     values: "500+500x80"
   - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="1", code="200"}'
-    # 800 under 1s (80% - violating P99 SLO significantly)
+    # Histogram bucket: 800 requests completed in ≤1s (80%)
+    # This means 20% of requests took >1s, violating the P99 SLO (which requires 99% ≤1s)
     values: "800+800x80"
   - series: 'api_inbound_request_duration_bucket{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", le="+Inf", code="200"}'
-    # All requests
+    # All requests (total count)
     values: "1000+1000x80"
   alert_rule_test:
   - eval_time: 70m

--- a/observability/alerts/tested-rules/cluster-service-slo-rules_test.yaml
+++ b/observability/alerts/tested-rules/cluster-service-slo-rules_test.yaml
@@ -116,25 +116,25 @@ tests:
         summary: "API is slowly but steadily burning its 28 day availability error budget (99% SLO)"
         description: "This indicates persistent underperformance that needs investigation to avoid an SLO breach. The alert will fire if the current burn rate exceeds 0.934 times the allowed rate for the last 6 hours and 3 days."
         runbook_url: "aka.ms/arohcp-runbook/cs-slo-monitoring"
-# Test 5: Edge case - exactly at 99% threshold (should not fire critical alert)
+# Test 5: Edge case - just below critical threshold (should not fire critical alert)
 - interval: 1m
   input_series:
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="200"}'
-    # 99.01% success rate (0.99% error rate) - just below 1% SLO breach
-    values: "9901+9901x80"
+    # 99.95% success rate (0.05% error rate) - just below 30m+6h threshold
+    values: "99950+99950x80"
   - series: 'api_inbound_request_count{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics", code="500"}'
-    # 0.99% error rate - just below threshold
-    values: "99+99x80"
+    # 0.05% error rate - just below 30m+6h threshold (0.056)
+    values: "50+50x80"
   promql_expr_test:
   - expr: availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}
     eval_time: 70m
     exp_samples:
     - labels: 'availability:api_inbound_request_count:burnrate5m{cluster="test-cluster", namespace="clusters-service", service="clusters-service-metrics"}'
-      value: 0.99 # 0.99% error rate / 1% budget = 0.99x burn rate
+      value: 0.05 # 0.05% error rate / 1% budget = 0.05x burn rate (rounded to 0.01)
   alert_rule_test:
   - eval_time: 70m
     alertname: ClustersServiceAPIAvailability5mto1hor30mto6hErrorBudgetBurn
-    # Should not fire - below critical threshold (< 13.44)
+    # Should not fire - just below 30m+6h threshold (0.05 < 0.056)
 # Test 6: Prometheus replica handling (deduplication)
 - interval: 1m
   input_series:


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Updated SLO alert thresholds to use the proper burn rate formula in cluster-service monitoring rules.

### Why

The existing SLO alert thresholds were using incorrect burn rate calculations, which could lead to false positives or missed alerts. This fix ensures the burn rate formula correctly calculates error budget consumption relative to the SLO targets.

### Special notes for your reviewer

- The burn rate formula now properly accounts for the SLO target (99% availability) in the threshold calculations

- Test cases have been updated to reflect the corrected burn rate values
