### PR TITLE
Chore: Bump CS image to 56e0fc82fe8b for INT environment.

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -12,7 +12,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:17ae3a480e74de9484471074fa9ebad10c82e848e3ebb853d53b945221c9d5f4
+              digest: sha256:56e0fc82fe8b49bedfe092e611b43aaaa988145d0b37c15be9be176cca395805
             k8s:
               deploymentStrategy:
                 rollingUpdate:


### PR DESCRIPTION
### What

Bump CS image to 56e0fc82fe8b for INT environment.

### Why

As per weekly schedule.

### Special notes for your reviewer

Demo cluster in Shared Dev created successfully.