### PR TITLE
make the api registry per instance versus global

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -36,6 +36,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/Azure/ARO-HCP/internal/api/v20240610preview"
+	"github.com/Azure/ARO-HCP/internal/api/v20251223preview"
+
 	"github.com/Azure/ARO-HCP/frontend/pkg/metrics"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -55,6 +58,8 @@ type Frontend struct {
 	done                 chan struct{}
 	collector            *metrics.SubscriptionCollector
 	healthGauge          prometheus.Gauge
+
+	apiRegistry api.APIRegistry
 }
 
 func NewFrontend(
@@ -66,6 +71,11 @@ func NewFrontend(
 	csClient ocm.ClusterServiceClientSpec,
 	auditClient audit.Client,
 ) *Frontend {
+	// zero side-effect registration path
+	apiRegistry := api.NewAPIRegistry()
+	api.Must[any](nil, v20240610preview.RegisterVersion(apiRegistry))
+	api.Must[any](nil, v20251223preview.RegisterVersion(apiRegistry))
+
 	f := &Frontend{
 		clusterServiceClient: csClient,
 		listener:             listener,
@@ -94,6 +104,7 @@ func NewFrontend(
 				Help: "Reports the health status of the service (0: not healthy, 1: healthy).",
 			},
 		),
+		apiRegistry: apiRegistry,
 	}
 
 	f.server.Handler = f.routes(reg)
@@ -1131,6 +1142,7 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 		return
 	}
 
+	// TODO explain why it is safe to decode this directly into an internal type
 	deploymentPreflight, cloudError := arm.UnmarshalDeploymentPreflight(body)
 	if cloudError != nil {
 		logger.Error(cloudError.Error())
@@ -1141,6 +1153,7 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 	validate := api.NewValidator()
 	preflightErrors := []arm.CloudErrorBody{}
 
+	availableAROHCPVersions := f.apiRegistry.ListVersions()
 	for index, raw := range deploymentPreflight.Resources {
 		var cloudError *arm.CloudError
 
@@ -1167,6 +1180,19 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 			continue
 		}
 
+		if !availableAROHCPVersions.Has(preflightResource.APIVersion) {
+			// Preflight is best-effort: a malformed resource is not a validation failure.
+			validationErr := arm.CloudErrorBody{
+				Code:    arm.CloudErrorCodeInvalidRequestContent,
+				Message: fmt.Sprintf("Unrecognized API version '%s'", preflightResource.APIVersion),
+				Target:  "apiVersion",
+			}
+			logger.Warn(
+				fmt.Sprintf("Resource #%d failed preliminary validation (see details)", index+1),
+				"details", validationErr)
+			continue
+		}
+
 		switch strings.ToLower(preflightResource.Type) {
 		case strings.ToLower(api.ClusterResourceType.String()):
 			// This is just "preliminary" validation to ensure all the base resource
@@ -1181,7 +1207,7 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 			}
 
 			// API version is already validated by this point.
-			versionedInterface, _ := api.Lookup(preflightResource.APIVersion)
+			versionedInterface, _ := f.apiRegistry.Lookup(preflightResource.APIVersion)
 			versionedCluster := versionedInterface.NewHCPOpenShiftCluster(nil)
 
 			err = preflightResource.Convert(versionedCluster)
@@ -1207,7 +1233,7 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 			}
 
 			// API version is already validated by this point.
-			versionedInterface, _ := api.Lookup(preflightResource.APIVersion)
+			versionedInterface, _ := f.apiRegistry.Lookup(preflightResource.APIVersion)
 			versionedNodePool := versionedInterface.NewHCPOpenShiftClusterNodePool(nil)
 
 			err = preflightResource.Convert(versionedNodePool)
@@ -1233,7 +1259,7 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 			}
 
 			// API version is already validated by this point.
-			versionedInterface, _ := api.Lookup(preflightResource.APIVersion)
+			versionedInterface, _ := f.apiRegistry.Lookup(preflightResource.APIVersion)
 			versionedExternalAuth := versionedInterface.NewHCPOpenShiftClusterExternalAuth(nil)
 
 			err = preflightResource.Convert(versionedExternalAuth)

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -86,7 +86,7 @@ func (f *Frontend) routes(r prometheus.Registerer) http.Handler {
 	// Resource list endpoints
 	postMuxMiddleware := NewMiddleware(
 		MiddlewareLoggingPostMux,
-		MiddlewareValidateAPIVersion,
+		newMiddlewareValidatedAPIVersion(f.apiRegistry).handleRequest,
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders, api.ClusterResourceTypeName),
@@ -108,7 +108,7 @@ func (f *Frontend) routes(r prometheus.Registerer) http.Handler {
 	postMuxMiddleware = NewMiddleware(
 		MiddlewareResourceID,
 		MiddlewareLoggingPostMux,
-		MiddlewareValidateAPIVersion,
+		newMiddlewareValidatedAPIVersion(f.apiRegistry).handleRequest,
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
@@ -127,7 +127,7 @@ func (f *Frontend) routes(r prometheus.Registerer) http.Handler {
 	postMuxMiddleware = NewMiddleware(
 		MiddlewareResourceID,
 		MiddlewareLoggingPostMux,
-		MiddlewareValidateAPIVersion,
+		newMiddlewareValidatedAPIVersion(f.apiRegistry).handleRequest,
 		newMiddlewareLockSubscription(f.dbClient).handleRequest,
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
 	middlewareMux.Handle(
@@ -168,7 +168,7 @@ func (f *Frontend) routes(r prometheus.Registerer) http.Handler {
 	postMuxMiddleware = NewMiddleware(
 		MiddlewareResourceID,
 		MiddlewareLoggingPostMux,
-		MiddlewareValidateAPIVersion,
+		newMiddlewareValidatedAPIVersion(f.apiRegistry).handleRequest,
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders, PatternLocations, PatternOperationResults),

--- a/internal/api/arm/preflight.go
+++ b/internal/api/arm/preflight.go
@@ -51,7 +51,7 @@ type DeploymentPreflightResource struct {
 	Name       string `json:"name"                 validate:"required"`
 	Type       string `json:"type"                 validate:"required"`
 	Location   string `json:"location"             validate:"required"`
-	APIVersion string `json:"apiVersion,omitempty" validate:"required,api_version"`
+	APIVersion string `json:"apiVersion,omitempty" validate:"required"`
 
 	// Preserve other tracked resource fields as raw data.
 	Identity   json.RawMessage `json:"identity,omitempty"`

--- a/internal/api/registry_test.go
+++ b/internal/api/registry_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	validator "github.com/go-playground/validator/v10"
+	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -84,27 +84,11 @@ func TestNewValidator(t *testing.T) {
 	var nilMap map[int]int
 	var nilPointer *int
 
-	// Register an API version without implementing the interface.
-	apiRegistry["valid-api-version"] = nil
-
 	tests := []struct {
 		name        string
 		resource    any
 		expectError bool
 	}{
-		{
-			name: "Validation passes on known API version",
-			resource: TestAPIVersionTag{
-				APIVersion: "valid-api-version",
-			},
-		},
-		{
-			name: "Validation fails on unknown API version",
-			resource: TestAPIVersionTag{
-				APIVersion: "bogus-api-version",
-			},
-			expectError: true,
-		},
 		{
 			name:     "Zero value is ok when not required",
 			resource: struct{ StructField int }{0},

--- a/internal/api/v20251223preview/register.go
+++ b/internal/api/v20251223preview/register.go
@@ -21,7 +21,15 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/v20251223preview/generated"
 )
 
-type version struct{}
+type version struct {
+	validator *validator.Validate
+}
+
+func newVersion() version {
+	return version{
+		validator: newValidator(),
+	}
+}
 
 // String returns the api-version parameter value for this API.
 func (v version) String() string {
@@ -31,12 +39,37 @@ func (v version) String() string {
 // GetValidator returns the validator.Validate instance configured
 // specifically for this API version.
 func (v version) GetValidator() *validator.Validate {
+	return v.validator
+}
+
+func newValidator() *validator.Validate {
+	validate := api.NewValidator()
+
+	// Register enum type validations
+	validate.RegisterAlias("enum_actiontype", api.EnumValidateTag(generated.PossibleActionTypeValues()...))
+	validate.RegisterAlias("enum_clusterimageregistryprofilestate", api.EnumValidateTag(generated.PossibleClusterImageRegistryProfileStateValues()...))
+	validate.RegisterAlias("enum_createdbytype", api.EnumValidateTag(generated.PossibleCreatedByTypeValues()...))
+	validate.RegisterAlias("enum_customermanagedencryptiontype", api.EnumValidateTag(generated.PossibleCustomerManagedEncryptionTypeValues()...))
+	validate.RegisterAlias("enum_diskstorageaccounttype", api.EnumValidateTag(generated.PossibleDiskStorageAccountTypeValues()...))
+	validate.RegisterAlias("enum_effect", api.EnumValidateTag(generated.PossibleEffectValues()...))
+	validate.RegisterAlias("enum_etcddataencryptionkeymanagementmodetype", api.EnumValidateTag(generated.PossibleEtcdDataEncryptionKeyManagementModeTypeValues()...))
+	validate.RegisterAlias("enum_externalauthclienttype", api.EnumValidateTag(generated.PossibleExternalAuthClientTypeValues()...))
+	validate.RegisterAlias("enum_externalauthconditionstatustype", api.EnumValidateTag(generated.PossibleStatusTypeValues()...))
+	validate.RegisterAlias("enum_externalauthconditiontype", api.EnumValidateTag(generated.PossibleExternalAuthConditionTypeValues()...))
+	validate.RegisterAlias("enum_managedserviceidentitytype", api.EnumValidateTag(generated.PossibleManagedServiceIdentityTypeValues()...))
+	validate.RegisterAlias("enum_networktype", api.EnumValidateTag(generated.PossibleNetworkTypeValues()...))
+	validate.RegisterAlias("enum_origin", api.EnumValidateTag(generated.PossibleOriginValues()...))
+	validate.RegisterAlias("enum_outboundtype", api.EnumValidateTag(generated.PossibleOutboundTypeValues()...))
+	validate.RegisterAlias("enum_provisioningstate", api.EnumValidateTag(generated.PossibleProvisioningStateValues()...))
+	validate.RegisterAlias("enum_tokenvalidationruletyperequiredclaim", api.EnumValidateTag(generated.PossibleTokenValidationRuleTypeValues()...))
+	validate.RegisterAlias("enum_usernameclaimprefixpolicy", api.EnumValidateTag(generated.PossibleUsernameClaimPrefixPolicyValues()...))
+	validate.RegisterAlias("enum_visibility", api.EnumValidateTag(generated.PossibleVisibilityValues()...))
+
 	return validate
 }
 
 var (
-	versionedInterface        = version{}
-	validate                  = api.NewValidator()
+	versionedInterface        = newVersion()
 	clusterVisibilityMap      = api.NewVisibilityMap[api.HCPOpenShiftCluster]()
 	nodePoolVisibilityMap     = api.NewVisibilityMap[api.HCPOpenShiftClusterNodePool]()
 	externalAuthVisibilityMap = api.NewVisibilityMap[api.HCPOpenShiftClusterExternalAuth]()
@@ -58,26 +91,11 @@ func init() {
 	// no normalized Label model with Key and Value fields.
 	nodePoolVisibilityMap["Properties.Labels.Key"] = nodePoolVisibilityMap["Properties.Labels"] & api.VisibilityDefault
 	nodePoolVisibilityMap["Properties.Labels.Value"] = nodePoolVisibilityMap["Properties.Labels"] & api.VisibilityDefault
+}
 
-	api.Register(versionedInterface)
-
-	// Register enum type validations
-	validate.RegisterAlias("enum_actiontype", api.EnumValidateTag(generated.PossibleActionTypeValues()...))
-	validate.RegisterAlias("enum_clusterimageregistryprofilestate", api.EnumValidateTag(generated.PossibleClusterImageRegistryProfileStateValues()...))
-	validate.RegisterAlias("enum_createdbytype", api.EnumValidateTag(generated.PossibleCreatedByTypeValues()...))
-	validate.RegisterAlias("enum_customermanagedencryptiontype", api.EnumValidateTag(generated.PossibleCustomerManagedEncryptionTypeValues()...))
-	validate.RegisterAlias("enum_diskstorageaccounttype", api.EnumValidateTag(generated.PossibleDiskStorageAccountTypeValues()...))
-	validate.RegisterAlias("enum_effect", api.EnumValidateTag(generated.PossibleEffectValues()...))
-	validate.RegisterAlias("enum_etcddataencryptionkeymanagementmodetype", api.EnumValidateTag(generated.PossibleEtcdDataEncryptionKeyManagementModeTypeValues()...))
-	validate.RegisterAlias("enum_externalauthclienttype", api.EnumValidateTag(generated.PossibleExternalAuthClientTypeValues()...))
-	validate.RegisterAlias("enum_externalauthconditionstatustype", api.EnumValidateTag(generated.PossibleStatusTypeValues()...))
-	validate.RegisterAlias("enum_externalauthconditiontype", api.EnumValidateTag(generated.PossibleExternalAuthConditionTypeValues()...))
-	validate.RegisterAlias("enum_managedserviceidentitytype", api.EnumValidateTag(generated.PossibleManagedServiceIdentityTypeValues()...))
-	validate.RegisterAlias("enum_networktype", api.EnumValidateTag(generated.PossibleNetworkTypeValues()...))
-	validate.RegisterAlias("enum_origin", api.EnumValidateTag(generated.PossibleOriginValues()...))
-	validate.RegisterAlias("enum_outboundtype", api.EnumValidateTag(generated.PossibleOutboundTypeValues()...))
-	validate.RegisterAlias("enum_provisioningstate", api.EnumValidateTag(generated.PossibleProvisioningStateValues()...))
-	validate.RegisterAlias("enum_tokenvalidationruletyperequiredclaim", api.EnumValidateTag(generated.PossibleTokenValidationRuleTypeValues()...))
-	validate.RegisterAlias("enum_usernameclaimprefixpolicy", api.EnumValidateTag(generated.PossibleUsernameClaimPrefixPolicyValues()...))
-	validate.RegisterAlias("enum_visibility", api.EnumValidateTag(generated.PossibleVisibilityValues()...))
+func RegisterVersion(apiRegistry api.APIRegistry) error {
+	if err := apiRegistry.Register(versionedInterface); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/api/validate.go
+++ b/internal/api/validate.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	validator "github.com/go-playground/validator/v10"
+	"github.com/go-playground/validator/v10"
 	semver "github.com/hashicorp/go-version"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 
@@ -97,19 +97,6 @@ func NewValidator() *validator.Validate {
 		ConditionStatusTypeTrue,
 		ConditionStatusTypeUnknown,
 	))
-
-	// Use this for string fields specifying an ARO-HCP API version.
-	err = validate.RegisterValidation("api_version", func(fl validator.FieldLevel) bool {
-		field := fl.Field()
-		if field.Kind() != reflect.String {
-			panic("String type required for api_version")
-		}
-		_, ok := Lookup(field.String())
-		return ok
-	})
-	if err != nil {
-		panic(err)
-	}
 
 	// Use this for string fields that must be a valid Kubernetes qualified name.
 	err = validate.RegisterValidation("k8s_qualified_name", func(fl validator.FieldLevel) bool {
@@ -290,8 +277,6 @@ func ValidateRequest[T any](validate *validator.Validate, resource T) []arm.Clou
 				}
 			} else {
 				switch tag {
-				case "api_version": // custom tag
-					message = fmt.Sprintf("Unrecognized API version '%s'", fieldErr.Value())
 				case "openshift_version": // custom tag
 					message = fmt.Sprintf("Invalid OpenShift version '%s'", fieldErr.Value())
 				case "pem_certificates": // custom tag


### PR DESCRIPTION
By making this type per instance as opposed to global, we're now able to see the dependency structure versus the side-effect/cyclical nature of before.  This exposed one cycle related to verifying api_versions which I moved to the single point of use.