### PR TITLE
add internal external internal fuzz tests.

### DIFF
--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -15,8 +15,6 @@
 package v20240610preview
 
 import (
-	"strings"
-
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/api/v20240610preview/generated"
@@ -452,8 +450,7 @@ func normalizeEtcdDataEncryptionProfile(p *generated.EtcdDataEncryptionProfile, 
 
 func normalizeCustomerManaged(p *generated.CustomerManagedEncryptionProfile, out *api.CustomerManagedEncryptionProfile) {
 	if p.EncryptionType != nil {
-		// FIXME Temporarily allow "kms" instead of "KMS".
-		out.EncryptionType = api.CustomerManagedEncryptionType(strings.ToUpper(string(*p.EncryptionType)))
+		out.EncryptionType = api.CustomerManagedEncryptionType(*p.EncryptionType)
 	}
 	if p.Kms != nil && p.Kms.ActiveKey != nil {
 		if out.Kms == nil {
@@ -488,6 +485,19 @@ func normalizeOperatorsAuthentication(p *generated.OperatorsAuthenticationProfil
 }
 
 func normalizeUserAssignedIdentities(p *generated.UserAssignedIdentitiesProfile, out *api.UserAssignedIdentitiesProfile) {
+	switch {
+	case p.ControlPlaneOperators != nil && out.ControlPlaneOperators == nil:
+		out.ControlPlaneOperators = make(map[string]string)
+	case p.ControlPlaneOperators == nil && out.ControlPlaneOperators != nil:
+		out.ControlPlaneOperators = nil
+	}
+	switch {
+	case p.DataPlaneOperators != nil && out.DataPlaneOperators == nil:
+		out.DataPlaneOperators = make(map[string]string)
+	case p.DataPlaneOperators == nil && out.DataPlaneOperators != nil:
+		out.DataPlaneOperators = nil
+	}
+
 	api.MergeStringPtrMap(p.ControlPlaneOperators, &out.ControlPlaneOperators)
 	api.MergeStringPtrMap(p.DataPlaneOperators, &out.DataPlaneOperators)
 	if p.ServiceManagedIdentity != nil {
@@ -505,11 +515,16 @@ func normalizeIdentityUserAssignedIdentities(p map[string]*generated.UserAssigne
 				ClientID:    value.ClientID,
 				PrincipalID: value.PrincipalID,
 			}
+		} else {
+			(*out)[key] = nil
 		}
 	}
 }
 
 func convertUserAssignedIdentities(from map[string]*arm.UserAssignedIdentity) map[string]*generated.UserAssignedIdentity {
+	if from == nil {
+		return nil
+	}
 	converted := make(map[string]*generated.UserAssignedIdentity)
 	for key, value := range from {
 		if value != nil {
@@ -517,6 +532,8 @@ func convertUserAssignedIdentities(from map[string]*arm.UserAssignedIdentity) ma
 				ClientID:    value.ClientID,
 				PrincipalID: value.PrincipalID,
 			}
+		} else {
+			converted[key] = nil
 		}
 	}
 	return converted

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods_test.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v20240610preview
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/randfill"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+func TestRoundTripInternalExternalInternal(t *testing.T) {
+	seed := rand.Int63()
+	fuzzer := fuzzerFor([]interface{}{
+		func(j *azcorearm.ResourceID, c randfill.Continue) {
+			*j = *api.Must(azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg"))
+		},
+	}, rand.NewSource(seed))
+
+	// Try a few times, since runTest uses random values.
+	for i := 0; i < 20; i++ {
+		original := &api.HCPOpenShiftCluster{}
+		fuzzer.Fill(original)
+		roundTripHCPCluster(t, original)
+	}
+}
+
+// fuzzerFor can randomly populate api objects that are destined for version.
+func fuzzerFor(funcs []interface{}, src rand.Source) *randfill.Filler {
+	f := randfill.New().NilChance(.5).NumElements(0, 1)
+	if src != nil {
+		f.RandSource(src)
+	}
+	f.Funcs(funcs...)
+	return f
+}
+
+func roundTripHCPCluster(t *testing.T, original *api.HCPOpenShiftCluster) {
+	v := version{}
+	externalObj := v.NewHCPOpenShiftCluster(original)
+
+	roundTrippedObj := &api.HCPOpenShiftCluster{}
+	externalObj.Normalize(roundTrippedObj)
+
+	// useful for debugging
+	//originalJSON, _ := json.MarshalIndent(original, "", "    ")
+	//intermediateJSON, _ := json.MarshalIndent(externalObj, "", "    ")
+	//resultJSON, _ := json.MarshalIndent(roundTrippedObj, "", "    ")
+	//fmt.Printf("Original: %s\n\nIntermediat: %s\n\n result: %s\n\n", string(originalJSON), string(intermediateJSON), string(resultJSON))
+
+	// we compare the JSON here because many of these types have private fields that cannot be introspected
+	if !reflect.DeepEqual(original, roundTrippedObj) {
+		t.Errorf("Round trip failed: %v", cmp.Diff(original, roundTrippedObj))
+	}
+}

--- a/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
@@ -15,8 +15,6 @@
 package v20251223preview
 
 import (
-	"strings"
-
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/api/v20251223preview/generated"
@@ -452,8 +450,7 @@ func normalizeEtcdDataEncryptionProfile(p *generated.EtcdDataEncryptionProfile, 
 
 func normalizeCustomerManaged(p *generated.CustomerManagedEncryptionProfile, out *api.CustomerManagedEncryptionProfile) {
 	if p.EncryptionType != nil {
-		// FIXME Temporarily allow "kms" instead of "KMS".
-		out.EncryptionType = api.CustomerManagedEncryptionType(strings.ToUpper(string(*p.EncryptionType)))
+		out.EncryptionType = api.CustomerManagedEncryptionType(*p.EncryptionType)
 	}
 	if p.Kms != nil && p.Kms.ActiveKey != nil {
 		if out.Kms == nil {
@@ -488,6 +485,19 @@ func normalizeOperatorsAuthentication(p *generated.OperatorsAuthenticationProfil
 }
 
 func normalizeUserAssignedIdentities(p *generated.UserAssignedIdentitiesProfile, out *api.UserAssignedIdentitiesProfile) {
+	switch {
+	case p.ControlPlaneOperators != nil && out.ControlPlaneOperators == nil:
+		out.ControlPlaneOperators = make(map[string]string)
+	case p.ControlPlaneOperators == nil && out.ControlPlaneOperators != nil:
+		out.ControlPlaneOperators = nil
+	}
+	switch {
+	case p.DataPlaneOperators != nil && out.DataPlaneOperators == nil:
+		out.DataPlaneOperators = make(map[string]string)
+	case p.DataPlaneOperators == nil && out.DataPlaneOperators != nil:
+		out.DataPlaneOperators = nil
+	}
+
 	api.MergeStringPtrMap(p.ControlPlaneOperators, &out.ControlPlaneOperators)
 	api.MergeStringPtrMap(p.DataPlaneOperators, &out.DataPlaneOperators)
 	if p.ServiceManagedIdentity != nil {
@@ -505,11 +515,17 @@ func normalizeIdentityUserAssignedIdentities(p map[string]*generated.UserAssigne
 				ClientID:    value.ClientID,
 				PrincipalID: value.PrincipalID,
 			}
+		} else {
+			(*out)[key] = nil
 		}
 	}
 }
 
 func convertUserAssignedIdentities(from map[string]*arm.UserAssignedIdentity) map[string]*generated.UserAssignedIdentity {
+	if from == nil {
+		return nil
+	}
+
 	converted := make(map[string]*generated.UserAssignedIdentity)
 	for key, value := range from {
 		if value != nil {
@@ -517,6 +533,8 @@ func convertUserAssignedIdentities(from map[string]*arm.UserAssignedIdentity) ma
 				ClientID:    value.ClientID,
 				PrincipalID: value.PrincipalID,
 			}
+		} else {
+			converted[key] = nil
 		}
 	}
 	return converted

--- a/internal/api/v20251223preview/hcpopenshiftclusters_methods_test.go
+++ b/internal/api/v20251223preview/hcpopenshiftclusters_methods_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v20251223preview
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/randfill"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+func TestRoundTripInternalExternalInternal(t *testing.T) {
+	seed := rand.Int63()
+	fuzzer := fuzzerFor([]interface{}{
+		func(j *azcorearm.ResourceID, c randfill.Continue) {
+			*j = *api.Must(azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg"))
+		},
+	}, rand.NewSource(seed))
+
+	// Try a few times, since runTest uses random values.
+	for i := 0; i < 20; i++ {
+		original := &api.HCPOpenShiftCluster{}
+		fuzzer.Fill(original)
+		roundTripHCPCluster(t, original)
+	}
+}
+
+// fuzzerFor can randomly populate api objects that are destined for version.
+func fuzzerFor(funcs []interface{}, src rand.Source) *randfill.Filler {
+	f := randfill.New().NilChance(.5).NumElements(0, 1)
+	if src != nil {
+		f.RandSource(src)
+	}
+	f.Funcs(funcs...)
+	return f
+}
+
+func roundTripHCPCluster(t *testing.T, original *api.HCPOpenShiftCluster) {
+	v := version{}
+	externalObj := v.NewHCPOpenShiftCluster(original)
+
+	roundTrippedObj := &api.HCPOpenShiftCluster{}
+	externalObj.Normalize(roundTrippedObj)
+
+	// useful for debugging
+	//originalJSON, _ := json.MarshalIndent(original, "", "    ")
+	//intermediateJSON, _ := json.MarshalIndent(externalObj, "", "    ")
+	//resultJSON, _ := json.MarshalIndent(roundTrippedObj, "", "    ")
+	//fmt.Printf("Original: %s\n\nIntermediat: %s\n\n result: %s\n\n", string(originalJSON), string(intermediateJSON), string(resultJSON))
+
+	// we compare the JSON here because many of these types have private fields that cannot be introspected
+	if !reflect.DeepEqual(original, roundTrippedObj) {
+		t.Errorf("Round trip failed: %v", cmp.Diff(original, roundTrippedObj))
+	}
+}


### PR DESCRIPTION
replaces https://github.com/Azure/ARO-HCP/pull/2849 with right branch.



We cannot start from external yet because nil vs zero-value-pointer doesn't actually roundtrip (existing condition).
