### PR TITLE
split the create and update cluster functions

### DIFF
--- a/frontend/test/simulate/artifacts/ClusterMutation/create-with-tags/create.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/create-with-tags/create.json
@@ -1,0 +1,52 @@
+{
+  "identity": {
+    "type": "UserAssigned",
+    "userAssignedIdentities": {}
+  },
+  "name": "create-with-tags",
+  "properties": {
+    "api": {
+      "visibility": "Public"
+    },
+    "clusterImageRegistry": {
+      "state": "Disabled"
+    },
+    "console": {},
+    "dns": {},
+    "etcd": {
+      "dataEncryption": {
+        "customerManaged": {
+          "encryptionType": "KMS",
+          "kms": {
+            "activeKey": {
+              "name": "encryptionKeyName",
+              "vaultName": "keyVaultName",
+              "version": "2024-12-01-preview"
+            }
+          }
+        },
+        "keyManagementMode": "CustomerManaged"
+      }
+    },
+    "network": {
+      "hostPrefix": 23,
+      "machineCidr": "10.0.0.0/16",
+      "networkType": "OVNKubernetes",
+      "podCidr": "10.128.0.0/14",
+      "serviceCidr": "172.30.0.0/16"
+    },
+    "platform": {
+      "managedResourceGroup": "managed-resource-group-name",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+      "outboundType": "LoadBalancer",
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+    },
+    "version": {
+      "channelGroup": "stable"
+    }
+  },
+  "tags": {
+    "one": "apple"
+  },
+  "type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/frontend/test/simulate/artifacts/ClusterMutation/create-with-tags/expected.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/create-with-tags/expected.json
@@ -9,6 +9,11 @@
     "api": {
       "visibility": "Public"
     },
+    "autoscaling": {
+      "maxNodeProvisionTimeSeconds": 900,
+      "maxPodGracePeriodSeconds": 600,
+      "podPriorityThreshold": -10
+    },
     "clusterImageRegistry": {
       "state": "Disabled"
     },

--- a/frontend/test/simulate/artifacts/ClusterMutation/create-with-tags/expected.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/create-with-tags/expected.json
@@ -1,0 +1,52 @@
+{
+  "id": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
+  "identity": {
+    "type": "UserAssigned"
+  },
+  "location": "globals-are-evil",
+  "name": "create-with-tags",
+  "properties": {
+    "api": {
+      "visibility": "Public"
+    },
+    "clusterImageRegistry": {
+      "state": "Disabled"
+    },
+    "etcd": {
+      "dataEncryption": {
+        "customerManaged": {
+          "encryptionType": "KMS",
+          "kms": {
+            "activeKey": {
+              "name": "encryptionKeyName",
+              "vaultName": "keyVaultName",
+              "version": "2024-12-01-preview"
+            }
+          }
+        },
+        "keyManagementMode": "CustomerManaged"
+      }
+    },
+    "network": {
+      "hostPrefix": 23,
+      "machineCidr": "10.0.0.0/16",
+      "networkType": "OVNKubernetes",
+      "podCidr": "10.128.0.0/14",
+      "serviceCidr": "172.30.0.0/16"
+    },
+    "platform": {
+      "managedResourceGroup": "managed-resource-group-name",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+      "outboundType": "LoadBalancer",
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+    },
+    "provisioningState": "Accepted",
+    "version": {
+      "channelGroup": "stable"
+    }
+  },
+  "tags": {
+    "one": "apple"
+  },
+  "type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}


### PR DESCRIPTION
This is a precursor to creating new CRUD functions for these and it eliminates branching.  Additionally, it allows for not reusing instance variables for different purposes, so we get more precise names to follow the code.

This further exposes some manipulation that ends up extraneous when we start directly storing the internal Cluster type, which is what led to this refactor.

This also replaces the usage of reflective validation for clusters with the new explicit validation.

/assign @mbarnes 