### PR TITLE
bump cs image to b1aa3239 in the INT environment

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -12,7 +12,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:56e0fc82fe8b49bedfe092e611b43aaaa988145d0b37c15be9be176cca395805
+              digest: sha256:b1aa32393e151c73ede61277c77a8ac1c0137261a20afe06aaff8a1b4072fe39
             k8s:
               deploymentStrategy:
                 rollingUpdate:


### PR DESCRIPTION
### What

bump cs image to b1aa32393e151c73ede61277c77a8ac1c0137261a20afe06aaff8a1b4072fe39 in the INT environment

See https://github.com/Azure/ARO-HCP/pull/2855 for the dev env one

### Why

Weekly schedule

### Special notes for your reviewer

<!-- optional -->
