### PR TITLE
Increase cluster creation timeout to 45 minutes

### DIFF
--- a/test/e2e/cluster_create_no_cni.go
+++ b/test/e2e/cluster_create_no_cni.go
@@ -52,7 +52,7 @@ var _ = Describe("Customer", func() {
 				map[string]interface{}{
 					"clusterName": customerClusterName,
 				},
-				30*time.Minute,
+				45*time.Minute,
 			)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION

### What

Increase cluster creation time to 45 minutes to match other test cases

### Why

This test case is a frequent visitor in the daily Quality call due to cluster creation timeout. Investigation has found that the cluster creation time allotment does not match the time limit present in other test cases. We should have a consistent time limit for cluster creation for all tests.

  | Test File                                | Timeout Value  |
  |------------------------------------------|----------------|
  | Single-step (infra + cluster + nodepool) |                |
  | gpu_nodepools_create_delete.go           | 45*time.Minute |
  | cluster_create_nodepool_osdisk.go        | 45*time.Minute |
  | cluster_pullsecret.go                    | 45*time.Minute |
  | Cluster only (no nodepool)               |                |
  | cluster_create_no_cni.go                 | 30*time.Minute |
  | complete_cluster_create.go               | 45*time.Minute |
  | external_auth_create.go                  | 45*time.Minute |
  | cluster_create_missing_info.go           | 45*time.Minute |
  | image_registry_cluster_create.go         | 45*time.Minute |
  | clusters_sharing_resgroup.go             | 45*time.Minute |
 