### PR TITLE
refactor the frontend mutation test to be reuseable for other types

### DIFF
--- a/frontend/hack/test-simulation.sh
+++ b/frontend/hack/test-simulation.sh
@@ -11,7 +11,7 @@ DEFAULT_COSMOS_KEY="C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mG
 DEFAULT_COSMOS_CONN_STRING="AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;"
 
 USE_GOTESTSUM=false
-if [ -n "${ARTIFACT_DIR}" ]; then
+if [ -n "${ARTIFACT_DIR:-}" ]; then
   echo "artifact dir found: ${ARTIFACT_DIR}"
   USE_GOTESTSUM=true
 else

--- a/frontend/test/simulate/cluster_mutation_test.go
+++ b/frontend/test/simulate/cluster_mutation_test.go
@@ -15,32 +15,19 @@
 package simulate
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
-	"io"
 	"io/fs"
-	"os"
-	"strings"
 	"testing"
 
-	"dario.cat/mergo"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
-	csarhcpv1alpha1 "github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1"
-	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/ptr"
 
 	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 
-	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/ocm"
-
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
 
 func TestFrontendClusterMutation(t *testing.T) {
@@ -62,60 +49,7 @@ func TestFrontendClusterMutation(t *testing.T) {
 	require.NoError(t, err)
 
 	// create anything and round trip anything for cluster-service
-	internalIDToCluster := map[string][]*csarhcpv1alpha1.Cluster{}
-	require.NoError(t, testInfo.AddMockData(t.Name(), internalIDToCluster))
-	testInfo.MockClusterServiceClient.EXPECT().PostCluster(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, builder *csarhcpv1alpha1.ClusterBuilder) (*csarhcpv1alpha1.Cluster, error) {
-		internalID := "/api/clusters_mgmt/v1/clusters/" + rand.String(10)
-		builder = builder.HREF(internalID)
-		ret, err := builder.Build()
-		if err != nil {
-			return nil, err
-		}
-
-		internalIDToCluster[internalID] = append(internalIDToCluster[internalID], ret)
-		return ret, nil
-	}).AnyTimes()
-	testInfo.MockClusterServiceClient.EXPECT().UpdateCluster(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, id ocm.InternalID, builder *arohcpv1alpha1.ClusterBuilder) (*arohcpv1alpha1.Cluster, error) {
-		ret, err := builder.Build()
-		if err != nil {
-			return nil, err
-		}
-
-		internalIDToCluster[id.String()] = append(internalIDToCluster[id.String()], ret)
-		return ret, nil
-	}).AnyTimes()
-	testInfo.MockClusterServiceClient.EXPECT().GetCluster(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, id ocm.InternalID) (*csarhcpv1alpha1.Cluster, error) {
-		ret := internalIDToCluster[id.String()]
-		if ret != nil {
-			// this looks insane, but cluster-service has some of the toughest API and client constructs to manage.
-			// we need to merge the history together, but the CS types resist that, so taking it all back to maps is easier.
-			dest := map[string]any{}
-			for _, curr := range ret {
-				buf := &bytes.Buffer{}
-				if err := csarhcpv1alpha1.MarshalCluster(curr, buf); err != nil {
-					return nil, fmt.Errorf("failed to marshal cluster: %w", err)
-				}
-				currMap := map[string]any{}
-				if err := json.Unmarshal(buf.Bytes(), &currMap); err != nil {
-					return nil, fmt.Errorf("failed to unmarshal cluster: %w", err)
-				}
-				if err := mergo.Merge(&dest, currMap, mergo.WithOverride); err != nil {
-					return nil, fmt.Errorf("failed to merge cluster: %w", err)
-				}
-			}
-			mergedJSON, err := json.Marshal(dest)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal merged cluster: %w", err)
-			}
-			final, err := csarhcpv1alpha1.UnmarshalCluster(mergedJSON)
-			if err != nil {
-				return nil, fmt.Errorf("failed to unmarshal merged cluster: %w", err)
-			}
-
-			return final, nil
-		}
-		return nil, fmt.Errorf("not found: %q", id.String())
-	}).AnyTimes()
+	trivialPassThroughClusterServiceMock(t, testInfo)
 
 	dirContent := api.Must(artifacts.ReadDir("artifacts/ClusterMutation"))
 	for _, dirEntry := range dirContent {
@@ -124,7 +58,8 @@ func TestFrontendClusterMutation(t *testing.T) {
 		}
 		createTestDir, err := fs.Sub(artifacts, "artifacts/ClusterMutation/"+dirEntry.Name())
 		require.NoError(t, err)
-		currTest := newClusterMutationTest(ctx, createTestDir, testInfo, subscriptionID, resourceGroupName)
+		currTest, err := newClusterMutationTest(ctx, createTestDir, testInfo, subscriptionID, resourceGroupName)
+		require.NoError(t, err)
 		t.Run(dirEntry.Name(), currTest.runTest)
 	}
 }
@@ -135,85 +70,36 @@ type clusterMutationTest struct {
 	testInfo          *SimulationTestInfo
 	subscriptionID    string
 	resourceGroupName string
+
+	genericMutationTestInfo *genericMutationTest
 }
 
-func newClusterMutationTest(ctx context.Context, testDir fs.FS, testInfo *SimulationTestInfo, subscriptionID, resourceGroupName string) *clusterMutationTest {
+func newClusterMutationTest(ctx context.Context, testDir fs.FS, testInfo *SimulationTestInfo, subscriptionID, resourceGroupName string) (*clusterMutationTest, error) {
+	genericMutationTestInfo, err := readGenericMutationTest(testDir)
+	if err != nil {
+		return nil, err
+	}
+
 	return &clusterMutationTest{
-		ctx:               ctx,
-		testDir:           testDir,
-		testInfo:          testInfo,
-		subscriptionID:    subscriptionID,
-		resourceGroupName: resourceGroupName,
-	}
-}
-
-type expectedFieldError struct {
-	code    string
-	field   string
-	message string
-}
-
-func (e expectedFieldError) String() string {
-	return fmt.Sprintf("%s: %s: %s", e.code, e.field, e.message)
-}
-
-func (e expectedFieldError) matches(actualError arm.CloudErrorBody) error {
-	if actualError.Code != e.code {
-		return fmt.Errorf("expected code %q, got %q", e.code, actualError.Code)
-	}
-	if actualError.Target != e.field {
-		return fmt.Errorf("expected target %q, got %q", e.field, actualError.Target)
-	}
-	if !strings.Contains(actualError.Message, e.message) {
-		return fmt.Errorf("expected message %q, got %q", e.message, actualError.Message)
-	}
-	return nil
+		ctx:                     ctx,
+		testDir:                 testDir,
+		testInfo:                testInfo,
+		subscriptionID:          subscriptionID,
+		resourceGroupName:       resourceGroupName,
+		genericMutationTestInfo: genericMutationTestInfo,
+	}, nil
 }
 
 func (tt *clusterMutationTest) runTest(t *testing.T) {
 	ctx := tt.ctx
 
-	isUpdateTest := false
-	if _, err := fs.ReadFile(tt.testDir, "update.json"); err == nil {
-		isUpdateTest = true
-	}
-
-	var err error
-	expectedErrors := []expectedFieldError{}
-
-	expectedJSON, err := fs.ReadFile(tt.testDir, "expected.json")
-	switch {
-	case os.IsNotExist(err):
-		expectedErrorBytes, err := fs.ReadFile(tt.testDir, "expected-errors.txt")
-		require.NoError(t, err)
-		expectedErrorLines := strings.Split(string(expectedErrorBytes), "\n")
-		for _, currLine := range expectedErrorLines {
-			if len(strings.TrimSpace(currLine)) == 0 {
-				continue
-			}
-			tokens := strings.SplitN(currLine, ":", 3)
-			currExpected := expectedFieldError{
-				code:    strings.TrimSpace(tokens[0]),
-				field:   strings.TrimSpace(tokens[1]),
-				message: strings.TrimSpace(tokens[2]),
-			}
-			expectedErrors = append(expectedErrors, currExpected)
-		}
-
-	case err != nil:
-		t.Fatal(err)
-
-	default:
-
-	}
-
 	toCreate := &hcpsdk20240610preview.HcpOpenShiftCluster{}
-	require.NoError(t, json.Unmarshal(api.Must(fs.ReadFile(tt.testDir, "create.json")), toCreate))
+	require.NoError(t, json.Unmarshal(tt.genericMutationTestInfo.createJSON, toCreate))
 	clusterClient := tt.testInfo.Get20240610ClientFactory(tt.subscriptionID).NewHcpOpenShiftClustersClient()
-	_, err = clusterClient.BeginCreateOrUpdate(ctx, tt.resourceGroupName, *toCreate.Name, *toCreate, nil)
+	_, mutationErr := clusterClient.BeginCreateOrUpdate(ctx, tt.resourceGroupName, *toCreate.Name, *toCreate, nil)
 
-	if isUpdateTest {
-		require.NoError(t, err)
+	if tt.genericMutationTestInfo.isUpdateTest() {
+		require.NoError(t, mutationErr)
 
 		operationsIterator := tt.testInfo.DBClient.ListActiveOperationDocs(azcosmos.NewPartitionKeyString(tt.subscriptionID), nil)
 		for _, operation := range operationsIterator.Items(ctx) {
@@ -226,79 +112,19 @@ func (tt *clusterMutationTest) runTest(t *testing.T) {
 		require.NoError(t, operationsIterator.GetError())
 
 		toUpdate := &hcpsdk20240610preview.HcpOpenShiftCluster{}
-		require.NoError(t, json.Unmarshal(api.Must(fs.ReadFile(tt.testDir, "update.json")), toUpdate))
-		_, err = clusterClient.BeginCreateOrUpdate(ctx, tt.resourceGroupName, *toUpdate.Name, *toUpdate, nil)
+		require.NoError(t, json.Unmarshal(tt.genericMutationTestInfo.updateJSON, toUpdate))
+		_, mutationErr = clusterClient.BeginCreateOrUpdate(ctx, tt.resourceGroupName, *toUpdate.Name, *toUpdate, nil)
 
 	}
 
-	if len(expectedErrors) > 0 {
-		require.Error(t, err)
-
-		azureErr, ok := err.(*azcore.ResponseError)
-		if !ok {
-			t.Fatal(err)
-		}
-
-		actualErrors := &arm.CloudError{}
-		body, err := io.ReadAll(azureErr.RawResponse.Body)
-		require.NoError(t, err)
-		require.NoError(t, json.Unmarshal(body, actualErrors))
-		if len(actualErrors.Details) == 0 { // if we have details, then simulate one so the checking code works easily
-			actualErrors.Details = []arm.CloudErrorBody{
-				{
-					Code:    actualErrors.Code,
-					Message: actualErrors.Message,
-					Target:  actualErrors.Target,
-				},
-			}
-		}
-
-		for _, actualError := range actualErrors.Details {
-			found := false
-			for _, expectedErr := range expectedErrors {
-				if err := expectedErr.matches(actualError); err == nil {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Errorf("unexpected error: %s: %s: %s", actualError.Code, actualError.Target, actualError.Message)
-			}
-		}
-
-		for _, expectedErr := range expectedErrors {
-			found := false
-			for _, actualError := range actualErrors.Details {
-				if err := expectedErr.matches(actualError); err == nil {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Errorf("missing expected error: %#v", expectedErr)
-			}
-		}
-
-		if t.Failed() {
-			t.Logf("Actual errors: %v", actualErrors)
-		}
-
+	tt.genericMutationTestInfo.verifyActualError(t, mutationErr)
+	if !tt.genericMutationTestInfo.expectsResult() {
 		return
 	}
-	require.NoError(t, err)
 
 	// polling the result will never complete because we aren't actually working on the operation.  We want to do a GET to see
 	// if the data we read back matches what we expect.
 	actualCreated, err := clusterClient.Get(ctx, tt.resourceGroupName, *toCreate.Name, nil)
 	require.NoError(t, err)
-
-	actualJSON, err := json.MarshalIndent(actualCreated, "", "    ")
-	require.NoError(t, err)
-	actualMap := map[string]any{}
-	require.NoError(t, json.Unmarshal(actualJSON, &actualMap))
-	expectedMap := map[string]any{}
-	require.NoError(t, json.Unmarshal(expectedJSON, &expectedMap))
-
-	t.Logf("Actual: %s", actualJSON)
-	require.Equal(t, expectedMap, actualMap)
+	tt.genericMutationTestInfo.verifyActualResult(t, actualCreated)
 }

--- a/frontend/test/simulate/mutation_test_utils.go
+++ b/frontend/test/simulate/mutation_test_utils.go
@@ -1,0 +1,290 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simulate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+
+	"dario.cat/mergo"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	csarhcpv1alpha1 "github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1"
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+)
+
+func trivialPassThroughClusterServiceMock(t *testing.T, testInfo *SimulationTestInfo) {
+	internalIDToCluster := map[string][]any{}
+	require.NoError(t, testInfo.AddMockData(t.Name()+"_clusters", internalIDToCluster))
+
+	testInfo.MockClusterServiceClient.EXPECT().PostCluster(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, builder *csarhcpv1alpha1.ClusterBuilder) (*csarhcpv1alpha1.Cluster, error) {
+		internalID := "/api/clusters_mgmt/v1/clusters/" + rand.String(10)
+		builder = builder.HREF(internalID)
+		ret, err := builder.Build()
+		if err != nil {
+			return nil, err
+		}
+
+		internalIDToCluster[internalID] = append(internalIDToCluster[internalID], ret)
+		return ret, nil
+	}).AnyTimes()
+	testInfo.MockClusterServiceClient.EXPECT().UpdateCluster(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, id ocm.InternalID, builder *arohcpv1alpha1.ClusterBuilder) (*arohcpv1alpha1.Cluster, error) {
+		ret, err := builder.Build()
+		if err != nil {
+			return nil, err
+		}
+
+		internalIDToCluster[id.String()] = append(internalIDToCluster[id.String()], ret)
+		return ret, nil
+	}).AnyTimes()
+	testInfo.MockClusterServiceClient.EXPECT().GetCluster(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, id ocm.InternalID) (*csarhcpv1alpha1.Cluster, error) {
+		history := internalIDToCluster[id.String()]
+		if len(history) == 0 {
+			return nil, fmt.Errorf("not found: %q", id.String())
+		}
+		mergedJSON, err := mergeClusterServiceReturn(history)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal merged cluster-service type: %w", err)
+		}
+		return csarhcpv1alpha1.UnmarshalCluster(mergedJSON)
+	}).AnyTimes()
+}
+
+func mergeClusterServiceReturn(history []any) ([]byte, error) {
+	// this looks insane, but cluster-service has some of the toughest API and client constructs to manage.
+	// we need to merge the history together, but the CS types resist that, so taking it all back to maps is easier.
+	dest := map[string]any{}
+	for _, curr := range history {
+		clusterServiceJSON, err := marshalClusterServiceAny(curr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal cluster-service type: %w", err)
+		}
+		currMap := map[string]any{}
+		if err := json.Unmarshal(clusterServiceJSON, &currMap); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal cluster-service type: %w", err)
+		}
+		if err := mergo.Merge(&dest, currMap, mergo.WithOverride); err != nil {
+			return nil, fmt.Errorf("failed to merge cluster-service type: %w", err)
+		}
+	}
+	return json.Marshal(dest)
+}
+
+// cluster service types fight the standard golang stack and don't conform to standard json interfaces.
+func marshalClusterServiceAny(clusterServiceData any) ([]byte, error) {
+	switch castObj := clusterServiceData.(type) {
+	case *csarhcpv1alpha1.Cluster:
+		buf := &bytes.Buffer{}
+		if err := csarhcpv1alpha1.MarshalCluster(castObj, buf); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	case *csarhcpv1alpha1.ExternalAuth:
+		buf := &bytes.Buffer{}
+		if err := csarhcpv1alpha1.MarshalExternalAuth(castObj, buf); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	case *csarhcpv1alpha1.NodePool:
+		buf := &bytes.Buffer{}
+		if err := csarhcpv1alpha1.MarshalNodePool(castObj, buf); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	default:
+		return nil, fmt.Errorf("unknown type: %T", castObj)
+	}
+}
+
+func readGenericMutationTest(testDir fs.FS) (*genericMutationTest, error) {
+	createJSON, err := fs.ReadFile(testDir, "create.json")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read create.json: %w", err)
+	}
+
+	updateJSON, err := fs.ReadFile(testDir, "update.json")
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to read update.json: %w", err)
+	}
+
+	expectedErrors := []expectedFieldError{}
+	expectedJSON, err := fs.ReadFile(testDir, "expected.json")
+	switch {
+	case os.IsNotExist(err):
+		expectedErrors, err = readExpectedErrors(testDir)
+		if err != nil {
+			return nil, err
+		}
+
+	case err != nil:
+		return nil, fmt.Errorf("failed to read expected.json: %w", err)
+	}
+
+	return &genericMutationTest{
+		createJSON:     createJSON,
+		updateJSON:     updateJSON,
+		expectedJSON:   expectedJSON,
+		expectedErrors: expectedErrors,
+	}, nil
+}
+
+type genericMutationTest struct {
+	createJSON     []byte
+	updateJSON     []byte
+	expectedJSON   []byte
+	expectedErrors []expectedFieldError
+}
+
+func (h *genericMutationTest) isUpdateTest() bool {
+	return len(h.updateJSON) > 0
+}
+
+func (h *genericMutationTest) expectsResult() bool {
+	return len(h.expectedJSON) > 0
+}
+
+func (h *genericMutationTest) verifyActualError(t *testing.T, actualErr error) {
+	if len(h.expectedErrors) == 0 {
+		require.NoError(t, actualErr)
+
+		return
+	}
+
+	require.Error(t, actualErr)
+
+	azureErr, ok := actualErr.(*azcore.ResponseError)
+	if !ok {
+		t.Fatal(actualErr)
+	}
+
+	actualErrors := &arm.CloudError{}
+	body, err := io.ReadAll(azureErr.RawResponse.Body)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(body, actualErrors))
+	if len(actualErrors.Details) == 0 { // if we have details, then simulate one so the checking code works easily
+		actualErrors.Details = []arm.CloudErrorBody{
+			{
+				Code:    actualErrors.Code,
+				Message: actualErrors.Message,
+				Target:  actualErrors.Target,
+			},
+		}
+	}
+
+	for _, actualError := range actualErrors.Details {
+		found := false
+		for _, expectedErr := range h.expectedErrors {
+			if err := expectedErr.matches(actualError); err == nil {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("unexpected error: %s: %s: %s", actualError.Code, actualError.Target, actualError.Message)
+		}
+	}
+
+	for _, expectedErr := range h.expectedErrors {
+		found := false
+		for _, actualError := range actualErrors.Details {
+			if err := expectedErr.matches(actualError); err == nil {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing expected error: %#v", expectedErr)
+		}
+	}
+
+	if t.Failed() {
+		t.Logf("Actual errors: %v", actualErrors)
+	}
+}
+
+func (h *genericMutationTest) verifyActualResult(t *testing.T, actualCreated any) {
+	actualJSON, err := json.MarshalIndent(actualCreated, "", "    ")
+	require.NoError(t, err)
+	actualMap := map[string]any{}
+	require.NoError(t, json.Unmarshal(actualJSON, &actualMap))
+	expectedMap := map[string]any{}
+	require.NoError(t, json.Unmarshal(h.expectedJSON, &expectedMap))
+
+	t.Logf("Actual: %s", actualJSON)
+	require.Equal(t, expectedMap, actualMap)
+}
+
+func readExpectedErrors(testDir fs.FS) ([]expectedFieldError, error) {
+	expectedErrorBytes, err := fs.ReadFile(testDir, "expected-errors.txt")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read expected-errors.txt: %w", err)
+	}
+
+	expectedErrors := []expectedFieldError{}
+	expectedErrorLines := strings.Split(string(expectedErrorBytes), "\n")
+	for _, currLine := range expectedErrorLines {
+		if len(strings.TrimSpace(currLine)) == 0 {
+			continue
+		}
+		tokens := strings.SplitN(currLine, ":", 3)
+		currExpected := expectedFieldError{
+			code:    strings.TrimSpace(tokens[0]),
+			field:   strings.TrimSpace(tokens[1]),
+			message: strings.TrimSpace(tokens[2]),
+		}
+		expectedErrors = append(expectedErrors, currExpected)
+	}
+
+	if len(expectedErrors) == 0 {
+		return nil, fmt.Errorf("no expected errors found")
+	}
+
+	return expectedErrors, nil
+}
+
+type expectedFieldError struct {
+	code    string
+	field   string
+	message string
+}
+
+func (e expectedFieldError) String() string {
+	return fmt.Sprintf("%s: %s: %s", e.code, e.field, e.message)
+}
+
+func (e expectedFieldError) matches(actualError arm.CloudErrorBody) error {
+	if actualError.Code != e.code {
+		return fmt.Errorf("expected code %q, got %q", e.code, actualError.Code)
+	}
+	if actualError.Target != e.field {
+		return fmt.Errorf("expected target %q, got %q", e.field, actualError.Target)
+	}
+	if !strings.Contains(actualError.Message, e.message) {
+		return fmt.Errorf("expected message %q, got %q", e.message, actualError.Message)
+	}
+	return nil
+}

--- a/frontend/test/simulate/utils.go
+++ b/frontend/test/simulate/utils.go
@@ -30,7 +30,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
-	csarhcpv1alpha1 "github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -116,7 +115,7 @@ func NewFrontendFromTestingEnv(ctx context.Context, t *testing.T) (*frontend.Fro
 	frontend := frontend.NewFrontend(logger, listener, metricsListener, metricsRegistry, dbClient, clusterServiceClient, noOpAuditClient)
 	testInfo := &SimulationTestInfo{
 		ArtifactsDir:             artifactDir,
-		mockClusters:             make(map[string]map[string][]*csarhcpv1alpha1.Cluster),
+		mockData:                 make(map[string]map[string][]any),
 		CosmosDatabaseClient:     cosmosDatabaseClient,
 		DBClient:                 dbClient,
 		MockClusterServiceClient: clusterServiceClient,


### PR DESCRIPTION
This is a contained refactor (no new capability) that eases our next step of adding more mutation tests.