### PR TITLE
chore: bump cs image to 2fd93b7c85f8 in the INT environment

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -12,7 +12,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:56e0fc82fe8b49bedfe092e611b43aaaa988145d0b37c15be9be176cca395805
+              digest: sha256:2fd93b7c85f860f893a7cd5d3920c34647314e33b12675a80fe81c2e6d31ba7a
             k8s:
               deploymentStrategy:
                 rollingUpdate:


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Bump CS image to 2fd93b7c85f860f893a7cd5d3920c34647314e33b12675a80fe81c2e6d31ba7a in INT env

### Why

Urgent update needed in all environments

### Special notes for your reviewer

See https://github.com/Azure/ARO-HCP/pull/2862 for details
