### PR TITLE
Remove acrpull role assignment to kubelet identity

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -17,7 +17,6 @@ param systemAgentMinCount int
 param systemAgentMaxCount int
 param systemAgentVMSize string
 param systemAgentPoolZones array
-param systemAgentPoolCount int
 param systemZoneRedundantMode string
 
 // User agentpool spec (Worker)
@@ -611,20 +610,6 @@ var acrPullRoleDefinitionId = subscriptionResourceId(
   '7f951dda-4ed3-4680-a7ca-43fe172d538d'
 )
 
-var acrReferences = [for acrId in pullAcrResourceIds: res.acrRefFromId(acrId)]
-
-module acrPullRole 'acr/acr-permissions.bicep' = [
-  for acrRef in acrReferences: {
-    name: guid(acrRef.name, aksCluster.id, acrPullRoleDefinitionId)
-    scope: resourceGroup(acrRef.resourceGroup.subscriptionId, acrRef.resourceGroup.name)
-    params: {
-      principalId: aksCluster.properties.identityProfile.kubeletidentity.objectId
-      acrName: acrRef.name
-      grantPullAccess: true
-    }
-  }
-]
-
 resource uami 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = [
   for wi in workloadIdentities: {
     location: location
@@ -654,6 +639,8 @@ resource pullerIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-0
   location: location
   name: 'image-puller'
 }
+
+var acrReferences = [for acrId in pullAcrResourceIds: res.acrRefFromId(acrId)]
 
 module acrPullerRoles 'acr/acr-permissions.bicep' = [
   for acrRef in acrReferences: {


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

We're still granting the kubelet identity permissions over the whole ACRs in question.  We need to start using msi-acrpull where applicable. 


### Special notes for your reviewer

I'm opening this in draft because for the ocp registry on mgmt cluster we may need this role assignment temporarily still.  But this PR should merge at some point with it fully plumbed for svc cluster.


Checks:
 - [ ] All images can be pulled on service cluster
     - [ ]  MISE Missing ACRPullBinding
     - [ ] Backend Missing ACRPullBinding
 - [ ] Method to delete role bindings on kubelet if we're not using complete deployments or a way to remove role assignments on our aks clusters
