### PR TITLE
tooling/templatize: set default slog logger

### DIFF
--- a/tooling/templatize/main.go
+++ b/tooling/templatize/main.go
@@ -85,10 +85,13 @@ func main() {
 }
 
 func createLogger(verbosity int) logr.Logger {
+	level := slog.Level(verbosity * -1)
 	prettyHandler := prettylog.NewHandler(&slog.HandlerOptions{
-		Level:       slog.Level(verbosity * -1),
+		Level:       level,
 		AddSource:   false,
 		ReplaceAttr: nil,
 	})
+	slog.SetDefault(slog.New(prettyHandler))
+	slog.SetLogLoggerLevel(level)
 	return logr.FromSlogHandler(prettyHandler)
 }


### PR DESCRIPTION
Some libraries (like Helm v4) don't do the work to pass through an actual logger object, instead using the package global. We need to update that global to honor our expectations.
