### PR TITLE
frontend: Fix cluster not found regression

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -450,9 +450,8 @@ func (f *Frontend) GetHCPCluster(writer http.ResponseWriter, request *http.Reque
 
 	hcpCluster, err := f.dbClient.HCPClusters(subscriptionID, resourceGroupName).Get(ctx, resourceName)
 	if database.IsResponseError(err, http.StatusNotFound) {
-		reportingErr := arm.NewResourceNotFoundError(resourceID)
-		logger.Error(reportingErr.Error())
-		arm.WriteCloudError(writer, ocm.CSErrorToCloudError(reportingErr, resourceID, nil))
+		logger.Error(err.Error())
+		arm.WriteResourceNotFoundError(writer, resourceID)
 		return
 	}
 	if err != nil {


### PR DESCRIPTION
### What

Recent regression caused GET requests on non-existent cluster resources to return 500 instead of 404.