### PR TITLE
dev-infrastructure: make output steps depend on infra

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -315,6 +315,9 @@ resourceGroups:
     parameters: configurations/arobit-lookup.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
+    dependsOn:
+    - resourceGroup: management
+      step: cluster
   - name: arobit
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Helm
@@ -331,9 +334,6 @@ resourceGroups:
         resourceGroup: management
         step: arobit-output
         name: msiClientId
-    dependsOn:
-    - resourceGroup: management
-      step: cluster
     identityFrom:
       resourceGroup: global
       step: output

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -271,6 +271,9 @@ resourceGroups:
     parameters: configurations/arobit-lookup.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
+    dependsOn:
+    - resourceGroup: service
+      step: cluster
   - name: arobit
     aksCluster: '{{ .svc.aks.name }}'
     action: Helm
@@ -287,9 +290,6 @@ resourceGroups:
         resourceGroup: service
         step: arobit-output
         name: msiClientId
-    dependsOn:
-    - resourceGroup: service
-      step: cluster
     identityFrom:
       resourceGroup: global
       step: output


### PR DESCRIPTION
These steps have a direct dependency on the infra steps being finished rolling out.
