### PR TITLE
CS reduce config variables

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -88,16 +88,10 @@ deploy:
 	  --set csDeploymentStrategy.rollingUpdate.maxSurge=${CS_DEPLOYMENT_ROLLINGUPDATE_MAX_SURGE} \
 	  --set csDeploymentStrategy.rollingUpdate.maxUnavailable=${CS_DEPLOYMENT_ROLLINGUPDATE_MAX_UNAVAILABLE} \
 	  --set provisionShardClusterLimit=${PROVISION_SHARD_CLUSTER_LIMIT} \
-	  --set ocpVersions.defaultVersion.channelGroupName=${OCP_VERSIONS_DEFAULT_VERSION_CHANNEL_GROUP_NAME} \
 	  --set ocpVersions.defaultVersion.version=${OCP_VERSIONS_DEFAULT_VERSION_VERSION} \
-	  --set ocpVersions.channelGroups.stable.enabled=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_ENABLED} \
 	  --set ocpVersions.channelGroups.stable.url=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_URL} \
 	  --set ocpVersions.channelGroups.stable.minVersion=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MIN_VERSION} \
 	  --set ocpVersions.channelGroups.stable.maxVersion=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MAX_VERSION} \
-	  --set ocpVersions.channelGroups.fast.enabled=${OCP_VERSIONS_CHANNEL_GROUPS_FAST_ENABLED} \
-	  --set ocpVersions.channelGroups.fast.url=${OCP_VERSIONS_CHANNEL_GROUPS_FAST_URL} \
-	  --set ocpVersions.channelGroups.fast.minVersion=${OCP_VERSIONS_CHANNEL_GROUPS_FAST_MIN_VERSION} \
-	  --set ocpVersions.channelGroups.fast.maxVersion=${OCP_VERSIONS_CHANNEL_GROUPS_FAST_MAX_VERSION} \
 	  "$${OP_HELM_SET_FLAGS[@]}"
 
 deploy-pr-env-deps:

--- a/cluster-service/deploy/templates/aro-hcp-ocp-versions-config.configmap.yaml
+++ b/cluster-service/deploy/templates/aro-hcp-ocp-versions-config.configmap.yaml
@@ -6,22 +6,12 @@ metadata:
 data:
   aro-hcp-ocp-versions-config.yaml: |
     defaultVersion:
-      channelGroupName: {{ .Values.ocpVersions.defaultVersion.channelGroupName }}
+      channelGroupName: stable
       version: {{ .Values.ocpVersions.defaultVersion.version }}
     channelGroups:
-      {{- if .Values.ocpVersions.channelGroups.stable.enabled }}
       - url: {{ .Values.ocpVersions.channelGroups.stable.url }}
         channelGroupName: stable
         minVersion: {{ .Values.ocpVersions.channelGroups.stable.minVersion }}
         {{- if .Values.ocpVersions.channelGroups.stable.maxVersion }}
         maxVersion: {{ .Values.ocpVersions.channelGroups.stable.maxVersion }}
         {{- end }}
-      {{- end }}
-      {{- if .Values.ocpVersions.channelGroups.fast.enabled }}
-      - url: {{ .Values.ocpVersions.channelGroups.fast.url }}
-        channelGroupName: fast
-        minVersion: {{ .Values.ocpVersions.channelGroups.fast.minVersion }}
-        {{- if .Values.ocpVersions.channelGroups.fast.maxVersion }}
-        maxVersion: {{ .Values.ocpVersions.channelGroups.fast.maxVersion }}
-        {{- end }}
-      {{- end }}

--- a/cluster-service/deploy/values.yaml
+++ b/cluster-service/deploy/values.yaml
@@ -249,16 +249,9 @@ csDeploymentStrategy:
     maxUnavailable: 0
 ocpVersions:
   defaultVersion:
-    channelGroupName: ""
     version: ""
   channelGroups:
     stable:
-      enabled: false
-      url: ""
-      minVersion: ""
-      maxVersion: ""
-    fast:
-      enabled: false
       url: ""
       minVersion: ""
       maxVersion: ""

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -158,26 +158,14 @@ resourceGroups:
         name: ocpAcrLoginServer
     - name: PROVISION_SHARD_CLUSTER_LIMIT
       configRef: clustersService.provisionShardClusterLimit
-    - name: OCP_VERSIONS_DEFAULT_VERSION_CHANNEL_GROUP_NAME
-      configRef: clustersService.ocpVersions.defaultVersion.channelGroupName
     - name: OCP_VERSIONS_DEFAULT_VERSION_VERSION
       configRef: clustersService.ocpVersions.defaultVersion.version
-    - name: OCP_VERSIONS_CHANNEL_GROUPS_STABLE_ENABLED
-      configRef: clustersService.ocpVersions.channelGroups.stable.enabled
     - name: OCP_VERSIONS_CHANNEL_GROUPS_STABLE_URL
       configRef: clustersService.ocpVersions.channelGroups.stable.url
     - name: OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MIN_VERSION
       configRef: clustersService.ocpVersions.channelGroups.stable.minVersion
     - name: OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MAX_VERSION
       configRef: clustersService.ocpVersions.channelGroups.stable.maxVersion
-    - name: OCP_VERSIONS_CHANNEL_GROUPS_FAST_ENABLED
-      configRef: clustersService.ocpVersions.channelGroups.fast.enabled
-    - name: OCP_VERSIONS_CHANNEL_GROUPS_FAST_URL
-      configRef: clustersService.ocpVersions.channelGroups.fast.url
-    - name: OCP_VERSIONS_CHANNEL_GROUPS_FAST_MIN_VERSION
-      configRef: clustersService.ocpVersions.channelGroups.fast.minVersion
-    - name: OCP_VERSIONS_CHANNEL_GROUPS_FAST_MAX_VERSION
-      configRef: clustersService.ocpVersions.channelGroups.fast.maxVersion
     # this is maestro consumer registration stuff
     # this goes away when we have a real registration process
     - name: CONSUMER_NAME

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -711,9 +711,6 @@
     "ocpVersionChannelGroupSpec": {
       "type": "object",
       "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
         "url": {
           "type": "string"
         },
@@ -726,7 +723,6 @@
       },
       "additionalProperties": false,
       "required": [
-        "enabled",
         "url",
         "minVersion"
       ]
@@ -954,14 +950,11 @@
             "defaultVersion": {
               "type": "object",
               "properties": {
-                "channelGroupName": {
-                  "type": "string"
-                },
                 "version": {
                   "type": "string"
                 }
               },
-              "required": ["channelGroupName", "version"],
+              "required": ["version"],
               "additionalProperties": false
             },
             "channelGroups": {
@@ -969,12 +962,9 @@
               "properties": {
                 "stable": {
                   "$ref": "#/definitions/ocpVersionChannelGroupSpec"
-                },
-                "fast": {
-                  "$ref": "#/definitions/ocpVersionChannelGroupSpec"
                 }
               },
-              "required": ["stable", "fast"],
+              "required": ["stable"],
               "additionalProperties": false
             }
           },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -626,16 +626,9 @@ defaults:
     # OCP Versions configuration
     ocpVersions:
       defaultVersion:
-        channelGroupName: stable
         version: 4.19.7
       channelGroups:
         stable:
-          enabled: true
-          url: https://api.openshift.com/api/upgrades_info/graph
-          minVersion: 4.19.0
-          maxVersion: 4.19.8
-        fast:
-          enabled: false
           url: https://api.openshift.com/api/upgrades_info/graph
           minVersion: 4.19.0
           maxVersion: 4.19.8

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 2a14ca0ebdb42e3f5c207b5b7369c047d1eca7432bbc0a5092be7a8ec444d86e
+          westus3: 3761414ca11082d90e12b1a1e3f2384f0dadc958a8ca90a4a6234e86ce78d48a
       dev:
         regions:
-          westus3: 508116837091aa0969a9ea5c254d2d9d4571210e22bd375888fae6000bbdfc97
+          westus3: c22546d65fb945bcb41006ecb595a58ed427191600ce13d911fd9731835443fd
       ntly:
         regions:
-          uksouth: b331d19d5f4ce7f6800fbd3860d29d4288db8eb597007fc10abda98eb8f69735
+          uksouth: c369367de714c004340a4f5b5fd961dcb25b251c4bb7925a971b05b5529164ec
       perf:
         regions:
-          westus3: 76dcc714b060d897604ef746e40e30d029744e472a76c410dd79fed34249f8c1
+          westus3: 7b124bd796b57d31e7abff919f5fa7e9eb43b401a19d7f29f7a0004f72bc14be
       pers:
         regions:
-          westus3: 777b75249348f6d79b0a4253e7fd8b809f1800ec987ba5d74cb9ce27d0ff463d
+          westus3: 719e365c73262fba0dc0f1a0b0e0c144336230164318aa7cf7901a6f7dbd9bf5
       swft:
         regions:
-          uksouth: a832e63168df448a457e4740451b712ea05cfbe76a31680922a2bf0ed7f6829c
+          uksouth: e655a6d742b44088524ce13abb0e7ecf3e7bdd124b128025dbcf42855eec40b6

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -132,18 +132,11 @@ clustersService:
   managedIdentityName: clusters-service
   ocpVersions:
     channelGroups:
-      fast:
-        enabled: false
-        maxVersion: 4.19.8
-        minVersion: 4.19.0
-        url: https://api.openshift.com/api/upgrades_info/graph
       stable:
-        enabled: true
         maxVersion: 4.19.8
         minVersion: 4.19.0
         url: https://api.openshift.com/api/upgrades_info/graph
     defaultVersion:
-      channelGroupName: stable
       version: 4.19.7
   postgres:
     backupRetentionDays: 7

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -132,18 +132,11 @@ clustersService:
   managedIdentityName: clusters-service
   ocpVersions:
     channelGroups:
-      fast:
-        enabled: false
-        maxVersion: 4.19.8
-        minVersion: 4.19.0
-        url: https://api.openshift.com/api/upgrades_info/graph
       stable:
-        enabled: true
         maxVersion: 4.19.8
         minVersion: 4.19.0
         url: https://api.openshift.com/api/upgrades_info/graph
     defaultVersion:
-      channelGroupName: stable
       version: 4.19.7
   postgres:
     backupRetentionDays: 7

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -132,18 +132,11 @@ clustersService:
   managedIdentityName: clusters-service
   ocpVersions:
     channelGroups:
-      fast:
-        enabled: false
-        maxVersion: 4.19.8
-        minVersion: 4.19.0
-        url: https://api.openshift.com/api/upgrades_info/graph
       stable:
-        enabled: true
         maxVersion: 4.19.8
         minVersion: 4.19.0
         url: https://api.openshift.com/api/upgrades_info/graph
     defaultVersion:
-      channelGroupName: stable
       version: 4.19.7
   postgres:
     backupRetentionDays: 7

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -132,18 +132,11 @@ clustersService:
   managedIdentityName: clusters-service
   ocpVersions:
     channelGroups:
-      fast:
-        enabled: false
-        maxVersion: 4.19.8
-        minVersion: 4.19.0
-        url: https://api.openshift.com/api/upgrades_info/graph
       stable:
-        enabled: true
         maxVersion: 4.19.8
         minVersion: 4.19.0
         url: https://api.openshift.com/api/upgrades_info/graph
     defaultVersion:
-      channelGroupName: stable
       version: 4.19.7
   postgres:
     backupRetentionDays: 7

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -132,18 +132,11 @@ clustersService:
   managedIdentityName: clusters-service
   ocpVersions:
     channelGroups:
-      fast:
-        enabled: false
-        maxVersion: 4.19.8
-        minVersion: 4.19.0
-        url: https://api.openshift.com/api/upgrades_info/graph
       stable:
-        enabled: true
         maxVersion: 4.19.8
         minVersion: 4.19.0
         url: https://api.openshift.com/api/upgrades_info/graph
     defaultVersion:
-      channelGroupName: stable
       version: 4.19.7
   postgres:
     backupRetentionDays: 7

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -132,18 +132,11 @@ clustersService:
   managedIdentityName: clusters-service
   ocpVersions:
     channelGroups:
-      fast:
-        enabled: false
-        maxVersion: 4.19.8
-        minVersion: 4.19.0
-        url: https://api.openshift.com/api/upgrades_info/graph
       stable:
-        enabled: true
         maxVersion: 4.19.8
         minVersion: 4.19.0
         url: https://api.openshift.com/api/upgrades_info/graph
     defaultVersion:
-      channelGroupName: stable
       version: 4.19.7
   postgres:
     backupRetentionDays: 7


### PR DESCRIPTION
there is a limit of 64 config variables in a single deployment step and we exceeded this. until we have a solution, this PR removes the config variables for the fast channel as we don't use it yet.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
