### PR TITLE
Update configuration.md for clarity and corrections

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ Nested YAML structures, override layers, and region-agnostic templating of confi
 
 ## Nested YAML Structure
 
-Once the temaplates are rendered ARO HCP configuration data is stored in YAML format, allowing for a structured representation of settings. The configuration supports nested structures, enabling hierarchical organization of properties and logical grouping of related settings.
+Once the templates are rendered ARO HCP configuration is available in YAML format, allowing for a structured representation of settings. The configuration supports nested structures, enabling hierarchical organization of properties and logical grouping of related settings.
 
 ```yaml
 ...

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,8 @@
 # Configuration Management
-The ARO Tools Documentation explains in great detail about how the config templates are used. https://github.com/Azure/ARO-Tools/blob/main/pkg/config/README.md 
-It's important to note that these are **Go Templates** and won't render as YAML locally, this can be confusing with the .yaml file extensions, but is a very important as any misplaced linting would not catch the difference.
+The ARO Tools Documentation explains in greater detail about how the config templates are used. https://github.com/Azure/ARO-Tools/blob/main/pkg/config/README.md 
+It's important to note that these confirugation files are **Go Templates** and won't render as YAML locally, this can be confusing with the .yaml file extensions, but is a very important as any misplaced linting would not catch the difference. To render thesee files uer the aro-tools library. 
 
+## Purpose of configuration management strategy
 Managing configuration effectively is crucial for ensuring that deployments remain consistent and adaptable to various environments. Configuration data for every aspect of ARO HCP is stored in a configuration file and used for infrastructure and service deployments alike.
 
 Nested YAML structures, override layers, and region-agnostic templating of config values allow sharing common configuration elements across environments and regions. These mechanisms provide the flexibility to adapt settings for a specific cloud, environment, or region when necessary. The configuration structure is enforced by a schema, ensuring the correctness of the configuration while allowing for elaborate override scenarios.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Management
 The ARO Tools Documentation explains in greater detail about how the config templates are used. https://github.com/Azure/ARO-Tools/blob/main/pkg/config/README.md 
-It's important to note that these confirugation files are **Go Templates** and won't render as YAML locally, this can be confusing with the .yaml file extensions, but is a very important as any misplaced linting would not catch the difference. To render thesee files uer the aro-tools library. 
+It's important to note that these confiugation files are **Go Templates** and won't render as YAML locally, this can be confusing with the .yaml file extensions, but is a very important as any misplaced linting would not catch the difference. To render these files use the ARO-Tools library. 
 
 ## Purpose of configuration management strategy
 Managing configuration effectively is crucial for ensuring that deployments remain consistent and adaptable to various environments. Configuration data for every aspect of ARO HCP is stored in a configuration file and used for infrastructure and service deployments alike.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Management
 The ARO Tools Documentation explains in greater detail about how the config templates are used. https://github.com/Azure/ARO-Tools/blob/main/pkg/config/README.md 
-It's important to note that these confiugation files are **Go Templates** and won't render as YAML locally, this can be confusing with the .yaml file extensions, but is a very important as any misplaced linting would not catch the difference. To render these files use the ARO-Tools library. 
+It's important to note that these configuration files are **Go Templates** and won't render as YAML locally, this can be confusing with the .yaml file extensions, but is a very important as any misplaced linting would not catch the difference. To render these files use the ARO-Tools library. 
 
 ## Purpose of Configuration Management Strategy
 Managing configuration effectively is crucial for ensuring that deployments remain consistent and adaptable to various environments. Configuration data for every aspect of ARO HCP is stored in a configuration file and used for infrastructure and service deployments alike.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,6 @@
 # Configuration Management
+The ARO Tools Documentation explains in great detail about how the config templates are used. https://github.com/Azure/ARO-Tools/blob/main/pkg/config/README.md 
+It's important to note that these are **Go Templates** and won't render as YAML locally, this can be confusing with the .yaml file extensions, but is a very important as any misplaced linting would not catch the difference.
 
 Managing configuration effectively is crucial for ensuring that deployments remain consistent and adaptable to various environments. Configuration data for every aspect of ARO HCP is stored in a configuration file and used for infrastructure and service deployments alike.
 
@@ -6,7 +8,7 @@ Nested YAML structures, override layers, and region-agnostic templating of confi
 
 ## Nested YAML Structure
 
-ARO HCP configuration data is stored in YAML format, allowing for a structured representation of settings. The configuration supports nested structures, enabling hierarchical organization of properties and logical grouping of related settings.
+Once the temaplates are rendered ARO HCP configuration data is stored in YAML format, allowing for a structured representation of settings. The configuration supports nested structures, enabling hierarchical organization of properties and logical grouping of related settings.
 
 ```yaml
 ...

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 The ARO Tools Documentation explains in greater detail about how the config templates are used. https://github.com/Azure/ARO-Tools/blob/main/pkg/config/README.md 
 It's important to note that these confiugation files are **Go Templates** and won't render as YAML locally, this can be confusing with the .yaml file extensions, but is a very important as any misplaced linting would not catch the difference. To render these files use the ARO-Tools library. 
 
-## Purpose of configuration management strategy
+## Purpose of Configuration Management Strategy
 Managing configuration effectively is crucial for ensuring that deployments remain consistent and adaptable to various environments. Configuration data for every aspect of ARO HCP is stored in a configuration file and used for infrastructure and service deployments alike.
 
 Nested YAML structures, override layers, and region-agnostic templating of config values allow sharing common configuration elements across environments and regions. These mechanisms provide the flexibility to adapt settings for a specific cloud, environment, or region when necessary. The configuration structure is enforced by a schema, ensuring the correctness of the configuration while allowing for elaborate override scenarios.


### PR DESCRIPTION
Clarify the use of Go Templates in configuration management and correct a typo in the explanation of YAML storage.

<!-- Link to Jira issue -->

### What
This is a docmentation update to our developer documentation to explain that the config.yaml file is a go template and not YAML that will load without the the corresponding configuration library. 

### Why
To make it clearer to developers who may need to change or are trying to use the configuration files.

### Special notes for your reviewer

<!-- optional -->
