### PR TITLE
faithfully round trip identities

### DIFF
--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -282,11 +282,11 @@ func newSystemData(from *arm.SystemData) generated.SystemData {
 	}
 }
 
-func newManagedServiceIdentity(from *arm.ManagedServiceIdentity) generated.ManagedServiceIdentity {
+func newManagedServiceIdentity(from *arm.ManagedServiceIdentity) *generated.ManagedServiceIdentity {
 	if from == nil {
-		return generated.ManagedServiceIdentity{}
+		return nil
 	}
-	return generated.ManagedServiceIdentity{
+	return &generated.ManagedServiceIdentity{
 		Type:                   api.PtrOrNil(generated.ManagedServiceIdentityType(from.Type)),
 		PrincipalID:            api.PtrOrNil(from.PrincipalID),
 		TenantID:               api.PtrOrNil(from.TenantID),
@@ -322,7 +322,7 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 				ClusterImageRegistry:    api.PtrOrNil(newClusterImageRegistryProfile(&from.Properties.ClusterImageRegistry)),
 				Etcd:                    api.PtrOrNil(newEtcdProfile(&from.Properties.Etcd)),
 			},
-			Identity: api.PtrOrNil(newManagedServiceIdentity(from.Identity)),
+			Identity: newManagedServiceIdentity(from.Identity),
 		},
 	}
 

--- a/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
@@ -282,11 +282,11 @@ func newSystemData(from *arm.SystemData) generated.SystemData {
 	}
 }
 
-func newManagedServiceIdentity(from *arm.ManagedServiceIdentity) generated.ManagedServiceIdentity {
+func newManagedServiceIdentity(from *arm.ManagedServiceIdentity) *generated.ManagedServiceIdentity {
 	if from == nil {
-		return generated.ManagedServiceIdentity{}
+		return nil
 	}
-	return generated.ManagedServiceIdentity{
+	return &generated.ManagedServiceIdentity{
 		Type:                   api.PtrOrNil(generated.ManagedServiceIdentityType(from.Type)),
 		PrincipalID:            api.PtrOrNil(from.PrincipalID),
 		TenantID:               api.PtrOrNil(from.TenantID),
@@ -322,7 +322,7 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 				ClusterImageRegistry:    api.PtrOrNil(newClusterImageRegistryProfile(&from.Properties.ClusterImageRegistry)),
 				Etcd:                    api.PtrOrNil(newEtcdProfile(&from.Properties.Etcd)),
 			},
-			Identity: api.PtrOrNil(newManagedServiceIdentity(from.Identity)),
+			Identity: newManagedServiceIdentity(from.Identity),
 		},
 	}
 


### PR DESCRIPTION
fixes
``
--- FAIL: TestRoundTripInternalExternalInternal (0.00s)
    hcpopenshiftclusters_methods_test.go:31: seed: 3394727906922651625
    hcpopenshiftclusters_methods_test.go:72: Round trip failed:   &api.HCPOpenShiftCluster{
          	TrackedResource: {Resource: {ID: "戋獮紎EƁ} ʟīŰų)¢ÿmŉÞ", Name: "$媉e爺ɗ譱", Type: "ʘȓĶ湆姸蠶ƠȦ莡霾粱鉳", SystemData: &{CreatedBy: "ʃU嘄~稄ɣ抁", CreatedByType: "5ɦd椟a-ő悡`軦ɻƌ扂R謚棟", CreatedAt: &s"2810-01-06 17:23:32.71291213 +0000 UTC", LastModifiedBy: "Ű9ȴ湞ĸŤǏ1厎;d/", ...}}, Location: "ƫYJ^þ氒Ȼ[»亐Ȍ|w禣蔗V"},
          	Properties:      {ProvisioningState: "Ű唉¬2/Sʒę顢Õ", Version: {ID: "嫮A>嵢pXS?74ȮØŌİǦ孑", ChannelGroup: "Őlē戈"}, DNS: {BaseDomainPrefix: "鈩-逆7岘皸髊ʈ菉騐²´慒e"}, Network: {PodCIDR: "PƎ駢3ƶ繬ȏ皊¶顨ĥdf", ServiceCIDR: "Ĩ靪ŀ朶ɉ璃^ǝ", MachineCIDR: "珀åǛ莁D§ǓvȀĢ糝岍", HostPrefix: -78750441}, ...},
        - 	Identity:        &arm.ManagedServiceIdentity{},
        + 	Identity:        nil,
          }
FAIL
```