### PR TITLE
Remove quotes from environmentName in config.yaml

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -175,7 +175,7 @@ defaults:
     resourceGroup: ""
     cluster: ""
     ingestionUrl: ""
-    environmentName: '{{ .ctx.environment }}'
+    environmentName: {{ .ctx.environment }}
   # Hypershift
   hypershift:
     image:


### PR DESCRIPTION
Quotes here do not serve the correct purpose because this is a template file and not a true YAML file. See updated configuration.md documentation PR for more.

<!-- Link to Jira issue -->

### What

The quotes were added due to unlcear understanding of the config.yaml file which is a template and not literal YAML. 

### Why

Quotes don't have the correct behavior in templates.

### Special notes for your reviewer

<!-- optional -->
