### PR TITLE
prepare cs image to 2b972ac73f43 for rollout in int

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -12,7 +12,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:2fd93b7c85f860f893a7cd5d3920c34647314e33b12675a80fe81c2e6d31ba7a
+              digest: sha256:2b972ac73f43afe99d08161ec1cb192191ae06fc41f2fa8d5e2e84f1254257a9
             k8s:
               deploymentStrategy:
                 rollingUpdate:


### PR DESCRIPTION
image sha 2b972ac73f43afe99d08161ec1cb192191ae06fc41f2fa8d5e2e84f1254257a9 which corresponds to git commit be1b9b5.
