### PR TITLE
Stage and prod image digest promotion

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -94,7 +94,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:17ae3a480e74de9484471074fa9ebad10c82e848e3ebb853d53b945221c9d5f4
+              digest: sha256:2fd93b7c85f860f893a7cd5d3920c34647314e33b12675a80fe81c2e6d31ba7a
             k8s:
               deploymentStrategy:
                 rollingUpdate:
@@ -142,17 +142,17 @@ clouds:
           # RP Frontend
           frontend:
             image:
-              digest: "sha256:d285efee38209fdf612b6b5858f28cad43137759f193d19625745cefd0b9c039"
+              digest: "sha256:685e63a880d6170073138dc70cc720eb41184944615ec1575ee531c17a803df9"
             audit:
               connectSocket: true
           # RP Backend
           backend:
             image:
-              digest: "sha256:b1ef6283753e6b7b33e3ef698c211aa6565976dbe2eec089ca1c94e85af97dbd"
+              digest: "sha256:0d361a67ef3962b2336dc91349b96f568aeff7902a75e8a0dbe6c04716e3a877"
           # Hypershift
           hypershift:
             image:
-              digest: sha256:51c4b99787b6ba4092e39fcb73bdb1ad3a1b240737b2ad2f43144e676df579c1
+              digest: sha256:e6556e013459b4ce26cc464e23fddc952f4c57c1a0b4d63a7329acf804c8a5d8
           # Maestro
           maestro:
             image:
@@ -176,7 +176,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:17ae3a480e74de9484471074fa9ebad10c82e848e3ebb853d53b945221c9d5f4
+              digest: sha256:2fd93b7c85f860f893a7cd5d3920c34647314e33b12675a80fe81c2e6d31ba7a
           # ACR Pull
           acrPull:
             image:
@@ -219,17 +219,17 @@ clouds:
           # RP Frontend
           frontend:
             image:
-              digest: "sha256:d285efee38209fdf612b6b5858f28cad43137759f193d19625745cefd0b9c039"
+              digest: "sha256:685e63a880d6170073138dc70cc720eb41184944615ec1575ee531c17a803df9"
             audit:
               connectSocket: true
           # RP Backend
           backend:
             image:
-              digest: "sha256:b1ef6283753e6b7b33e3ef698c211aa6565976dbe2eec089ca1c94e85af97dbd"
+              digest: "sha256:0d361a67ef3962b2336dc91349b96f568aeff7902a75e8a0dbe6c04716e3a877"
           # Hypershift
           hypershift:
             image:
-              digest: sha256:51c4b99787b6ba4092e39fcb73bdb1ad3a1b240737b2ad2f43144e676df579c1
+              digest: sha256:e6556e013459b4ce26cc464e23fddc952f4c57c1a0b4d63a7329acf804c8a5d8
           # Maestro
           maestro:
             image:


### PR DESCRIPTION
## Promotion summary

**Environment:** `int` → `stg` and `prod`

**Updated 4 image digest(s):**

### 1. `clustersService.image.digest`

**Old:** `sha256:17ae3a480e74d...`
**New:** `sha256:2fd93b7c85f86...`

**Source:** [PR #2866](https://github.com/Azure/ARO-HCP/pull/2866) - Bump CS image to 2fd93b7c85f8 (INT environment)
**PR Merged:** 2025-10-03 14:35 UTC
**PR Author:** @JakobGray
**PR Approved by:** @machi1990

### 2. `frontend.image.digest`

**Old:** `sha256:d285efee38209...`
**New:** `sha256:685e63a880d61...`

**Source:** [PR #2896](https://github.com/Azure/ARO-HCP/pull/2896) - config: Bump frontend and backend images for INT
**PR Merged:** 2025-10-06 20:13 UTC
**PR Author:** @mbarnes
**PR Approved by:** @bennerv

### 3. `backend.image.digest`

**Old:** `sha256:b1ef6283753e6...`
**New:** `sha256:0d361a67ef396...`

**Source:** [PR #2896](https://github.com/Azure/ARO-HCP/pull/2896) - config: Bump frontend and backend images for INT
**PR Merged:** 2025-10-06 20:13 UTC
**PR Author:** @mbarnes
**PR Approved by:** @bennerv

### 4. `hypershift.image.digest`

**Old:** `sha256:51c4b99787b6b...`
**New:** `sha256:e6556e013459b...`

**Source:** [PR #2833](https://github.com/Azure/ARO-HCP/pull/2833) - hypershift operator to latest in dev and int
**PR Merged:** 2025-09-30 15:26 UTC
**PR Author:** @venkateshsredhat
**PR Approved by:** @mmazur

