### PR TITLE
Frontend: Run lowercase middleware before logging

### DIFF
--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -70,13 +70,13 @@ func (f *Frontend) routes(r prometheus.Registerer) http.Handler {
 		MiddlewareCorrelationData,
 		newMiddlewareAudit(f.auditClient).handleRequest,
 		MiddlewareTracing,
+		MiddlewareLowercase,
 		MiddlewareLogging,
 		// NOTE: register panic middleware twice.
 		// Making sure we can capture panicked requests in our trace data.
 		// But we also can recover if the tracing or logging middleware caused a panic.
 		MiddlewarePanic,
 		MiddlewareBody,
-		MiddlewareLowercase,
 		MiddlewareSystemData,
 		MiddlewareValidateStatic,
 	)


### PR DESCRIPTION
no Jira

### What

Registers `MiddlewareLowercase` before `MiddlewareLogging` in frontend. This ensures that all resource IDs included in logs are lowercased. 

There should be no impact to any actual frontend flows - this middleware was already present so actual operations were handled with lowercase-named resources. 

### Why

Resource IDs are expected to be case-insensitive, so this will enable easier log searching and consistency across separate invocations against the same resource but with different casing. 

### Special notes for your reviewer


