### PR TITLE
complete static validation for clusters

### DIFF
--- a/frontend/test/simulate/artifacts/ClusterMutation/change-channel/create.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/change-channel/create.json
@@ -37,9 +37,9 @@
     },
     "platform": {
       "managedResourceGroup": "managed-resource-group-name",
-      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
       "outboundType": "LoadBalancer",
-      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
     },
     "version": {
       "channelGroup": "stable"

--- a/frontend/test/simulate/artifacts/ClusterMutation/change-channel/expected-errors.txt
+++ b/frontend/test/simulate/artifacts/ClusterMutation/change-channel/expected-errors.txt
@@ -1,1 +1,2 @@
 InvalidRequestContent: properties.version.id: properties.version.id: Required value
+InvalidRequestContent: properties.version.channelGroup: Unsupported value: "updated-channel": supported values: "stable"

--- a/frontend/test/simulate/artifacts/ClusterMutation/change-channel/update.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/change-channel/update.json
@@ -37,9 +37,9 @@
     },
     "platform": {
       "managedResourceGroup": "managed-resource-group-name",
-      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
       "outboundType": "LoadBalancer",
-      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
     },
     "version": {
       "channelGroup": "updated-channel"

--- a/frontend/test/simulate/artifacts/ClusterMutation/create-with-illegal-value/create.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/create-with-illegal-value/create.json
@@ -37,7 +37,7 @@
     },
     "platform": {
       "managedResourceGroup": "managed-resource-group-name",
-      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
       "operatorsAuthentication": {
         "userAssignedIdentities": {
           "controlPlaneOperators": null,
@@ -46,7 +46,7 @@
         }
       },
       "outboundType": "LoadBalancer",
-      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
     },
     "version": {
       "channelGroup": "stable"

--- a/frontend/test/simulate/artifacts/ClusterMutation/disabled-image-registry-create/create.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/disabled-image-registry-create/create.json
@@ -37,9 +37,9 @@
     },
     "platform": {
       "managedResourceGroup": "managed-resource-group-name",
-      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
       "outboundType": "LoadBalancer",
-      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
     },
     "version": {
       "channelGroup": "stable"

--- a/frontend/test/simulate/artifacts/ClusterMutation/disabled-image-registry-create/expected.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/disabled-image-registry-create/expected.json
@@ -41,9 +41,9 @@
     },
     "platform": {
       "managedResourceGroup": "managed-resource-group-name",
-      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
       "outboundType": "LoadBalancer",
-      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
     },
     "provisioningState": "Accepted",
     "version": {

--- a/frontend/test/simulate/artifacts/ClusterMutation/missing-required-fields/expected-errors.txt
+++ b/frontend/test/simulate/artifacts/ClusterMutation/missing-required-fields/expected-errors.txt
@@ -9,3 +9,6 @@ InvalidRequestContent: properties.etcd.dataEncryption.customerManaged.kms.active
 InvalidRequestContent: properties.etcd.dataEncryption.customerManaged.kms.activeKey.version: properties.etcd.dataEncryption.customerManaged.kms.activeKey.version: Required value
 InvalidRequestContent: identity.type: identity.type: Required value
 InvalidRequestContent: identity.state: identity.state: Unsupported value: "": supported values: "None", "SystemAssigned", "SystemAssigned,UserAssigned", "UserAssigned"
+InvalidRequestContent: properties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[]: properties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[]: Required value
+InvalidRequestContent: properties.platform.operatorsAuthentication.userAssignedIdentities.dataPlaneOperators[]: properties.platform.operatorsAuthentication.userAssignedIdentities.dataPlaneOperators[]: Required value
+InvalidRequestContent: properties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[]: identity is not assigned to this resource

--- a/frontend/test/simulate/artifacts/ClusterMutation/noop-update/create.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/noop-update/create.json
@@ -37,9 +37,9 @@
     },
     "platform": {
       "managedResourceGroup": "managed-resource-group-name",
-      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
       "outboundType": "LoadBalancer",
-      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
     },
     "version": {
       "channelGroup": "stable"

--- a/frontend/test/simulate/artifacts/ClusterMutation/noop-update/expected.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/noop-update/expected.json
@@ -41,9 +41,9 @@
     },
     "platform": {
       "managedResourceGroup": "managed-resource-group-name",
-      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
       "outboundType": "LoadBalancer",
-      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
     },
     "provisioningState": "Accepted",
     "version": {

--- a/frontend/test/simulate/artifacts/ClusterMutation/noop-update/update.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/noop-update/update.json
@@ -37,9 +37,9 @@
     },
     "platform": {
       "managedResourceGroup": "managed-resource-group-name",
-      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
       "outboundType": "LoadBalancer",
-      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
     },
     "version": {
       "channelGroup": "stable"

--- a/frontend/test/simulate/artifacts/ClusterMutation/peer-field-validation/create.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/peer-field-validation/create.json
@@ -1,0 +1,54 @@
+{
+  "identity": {
+    "type": "UserAssigned",
+    "userAssignedIdentities": {
+      "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/unused-identity": {},
+      "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/shared-identity": {}
+    }
+  },
+  "name": "peer-field-validation",
+  "properties": {
+    "api": {
+      "visibility": "Public"
+    },
+    "clusterImageRegistry": {
+      "state": "Disabled"
+    },
+    "console": {},
+    "dns": {},
+    "etcd": {
+      "dataEncryption": {
+        "keyManagementMode": "PlatformManaged"
+      }
+    },
+    "network": {
+      "hostPrefix": 23,
+      "machineCidr": "10.0.0.0/16",
+      "networkType": "OVNKubernetes",
+      "podCidr": "10.0.1.0/24",
+      "serviceCidr": "10.0.2.0/24"
+    },
+    "platform": {
+      "managedResourceGroup": "some-resource-group",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/test-nsg",
+      "operatorsAuthentication": {
+        "userAssignedIdentities": {
+          "controlPlaneOperators": {
+            "operator1": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/shared-identity",
+            "operator2": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/shared-identity"
+          },
+          "dataPlaneOperators": {
+            "dataplane-operator": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/unused-identity"
+          },
+          "serviceManagedIdentity": "/subscriptions/different-sub/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service-identity"
+        }
+      },
+      "outboundType": "LoadBalancer",
+      "subnetId": "/subscriptions/different-sub/resourceGroups/some-resource-group/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+    },
+    "version": {
+      "channelGroup": "stable"
+    }
+  },
+  "type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/frontend/test/simulate/artifacts/ClusterMutation/peer-field-validation/expected-errors.txt
+++ b/frontend/test/simulate/artifacts/ClusterMutation/peer-field-validation/expected-errors.txt
@@ -1,0 +1,14 @@
+InvalidRequestContent: properties.network: machine CIDR '10.0.0.0/16' and service CIDR '10.0.2.0/24' overlap
+InvalidRequestContent: properties.network: machine CIDR '10.0.0.0/16' and pod CIDR '10.0.1.0/24' overlap
+InvalidRequestContent: properties.platform.subnetId: must not be the same resource group name: "some-resource-group"
+InvalidRequestContent: properties.platform.subnetId: properties.platform.subnetId: Invalid value: "/subscriptions/different-sub/resourceGroups/some-resource-group/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet": must be in the same Azure subscription: "0465bc32-c654-41b8-8d87-9815d7abe8f6"
+InvalidRequestContent: properties.platform.managedResourceGroup: must not be the same resource group name: "some-resource-group"
+InvalidRequestContent: properties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[operator1]: must not be the same resource group name: "some-resource-group"
+InvalidRequestContent: properties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[operator2]: must not be the same resource group name: "some-resource-group"
+InvalidRequestContent: properties.platform.operatorsAuthentication.userAssignedIdentities.dataPlaneOperators[dataplane-operator]: must not be the same resource group name: "some-resource-group"
+InvalidRequestContent: properties.platform.operatorsAuthentication.userAssignedIdentities.serviceManagedIdentity: must be in the same Azure subscription: "0465bc32-c654-41b8-8d87-9815d7abe8f6"
+InvalidRequestContent: properties.platform.operatorsAuthentication.userAssignedIdentities.serviceManagedIdentity: must not be the same resource group name: "some-resource-group"
+InvalidRequestContent: properties.platform.operatorsAuthentication.userAssignedIdentities.serviceManagedIdentity: identity is not assigned to this resource
+InvalidRequestContent: identity.userAssignedIdentities[/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/shared-identity]: identity is used multiple times
+InvalidRequestContent: identity.userAssignedIdentities[/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/unused-identity]: identity is assigned to this resource but not used
+InvalidRequestContent: properties.platform.operatorsAuthentication.userAssignedIdentities.dataPlaneOperators[dataplane-operator]: cannot use identity assigned to this resource by .identities.userAssignedIdentities

--- a/frontend/test/simulate/artifacts/ClusterMutation/some-immutable-field-checks/create.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/some-immutable-field-checks/create.json
@@ -37,9 +37,9 @@
     },
     "platform": {
       "managedResourceGroup": "managed-resource-group-name",
-      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
       "outboundType": "LoadBalancer",
-      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
     },
     "version": {
       "channelGroup": "stable"

--- a/frontend/test/simulate/artifacts/ClusterMutation/some-immutable-field-checks/update.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/some-immutable-field-checks/update.json
@@ -40,9 +40,9 @@
     },
     "platform": {
       "managedResourceGroup": "illegal-change",
-      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/illegal-change",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/illegal-change",
       "outboundType": "LoadBalancer",
-      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/illegal-change"
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/illegal-change"
     },
     "version": {
       "id": "illegal-change",

--- a/frontend/test/simulate/artifacts/ClusterMutation/update-to-illegal-value/create.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/update-to-illegal-value/create.json
@@ -37,9 +37,9 @@
     },
     "platform": {
       "managedResourceGroup": "managed-resource-group-name",
-      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
       "outboundType": "LoadBalancer",
-      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
     },
     "version": {
       "channelGroup": "stable"

--- a/frontend/test/simulate/artifacts/ClusterMutation/update-to-illegal-value/update.json
+++ b/frontend/test/simulate/artifacts/ClusterMutation/update-to-illegal-value/update.json
@@ -37,9 +37,9 @@
     },
     "platform": {
       "managedResourceGroup": "managed-resource-group-name",
-      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+      "networkSecurityGroupId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
       "outboundType": "LoadBalancer",
-      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+      "subnetId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
     },
     "version": {
       "channelGroup": "stable"

--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -141,6 +141,7 @@ func validateResourceIDsAgainstClusterID(ctx context.Context, op operation.Opera
 
 	// Validate that managed resource group is different from cluster resource group
 	errs = append(errs, DifferentResourceGroupName(ctx, op, field.NewPath("properties", "platform", "managedResourceGroup"), &newCluster.Properties.Platform.ManagedResourceGroup, nil, clusterResourceID.ResourceGroupName)...)
+	errs = append(errs, SameSubscription(ctx, op, field.NewPath("properties", "platform", "subnetId"), &newCluster.Properties.Platform.SubnetID, nil, clusterResourceID.SubscriptionID)...)
 	errs = append(errs, DifferentResourceGroupNameFromResourceID(ctx, op, field.NewPath("properties", "platform", "subnetId"), &newCluster.Properties.Platform.SubnetID, nil, newCluster.Properties.Platform.ManagedResourceGroup)...)
 
 	for operatorName, operatorIdentity := range newCluster.Properties.Platform.OperatorsAuthentication.UserAssignedIdentities.ControlPlaneOperators {

--- a/internal/validation/validate_cluster_test.go
+++ b/internal/validation/validate_cluster_test.go
@@ -67,7 +67,7 @@ func TestOpenshiftVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := OpenshiftVersion(ctx, op, fldPath, tt.value, nil)
+			errs := OpenshiftVersionWithoutMicro(ctx, op, fldPath, tt.value, nil)
 
 			if tt.expectErr && len(errs) == 0 {
 				t.Error("expected error but got none")

--- a/internal/validation/validate_cluster_test.go
+++ b/internal/validation/validate_cluster_test.go
@@ -44,9 +44,9 @@ func TestOpenshiftVersion(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:      "valid semver - valid",
+			name:      "semver with patch - invalid",
 			value:     ptr.To("4.15.1"),
-			expectErr: false,
+			expectErr: true,
 		},
 		{
 			name:      "valid major.minor - valid",


### PR DESCRIPTION
This moves the static, non-reflective validation from https://github.com/Azure/ARO-HCP/blob/main/internal/api/hcpopenshiftcluster.go#L481-L506 to the validation package.