### PR TITLE
Revert "rollout hypershift image to dev and int"

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -70,7 +70,7 @@ clouds:
           # Hypershift
           hypershift:
             image:
-              digest: sha256:9ec2b20756f820b34cf2aa6a2e7609b55945133de448cb8ef3da79f5ce3086ea
+              digest: sha256:e6556e013459b4ce26cc464e23fddc952f4c57c1a0b4d63a7329acf804c8a5d8
           # Maestro
           maestro:
             image:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -806,7 +806,7 @@ clouds:
         image:
           registry: quay.io
           repository: acm-d/rhtap-hypershift-operator
-          digest: sha256:9ec2b20756f820b34cf2aa6a2e7609b55945133de448cb8ef3da79f5ce3086ea
+          digest: sha256:e6556e013459b4ce26cc464e23fddc952f4c57c1a0b4d63a7329acf804c8a5d8
       # Backplane API
       backplaneAPI:
         image:
@@ -1007,7 +1007,7 @@ clouds:
             image:
               registry: quay.io
               repository: acm-d/rhtap-hypershift-operator
-              digest: sha256:9ec2b20756f820b34cf2aa6a2e7609b55945133de448cb8ef3da79f5ce3086ea
+              digest: sha256:e6556e013459b4ce26cc464e23fddc952f4c57c1a0b4d63a7329acf804c8a5d8
       ntly:
         # this is an environment to test the deployability of infra nightly
         defaults:
@@ -1132,7 +1132,7 @@ clouds:
             image:
               registry: quay.io
               repository: acm-d/rhtap-hypershift-operator
-              digest: sha256:9ec2b20756f820b34cf2aa6a2e7609b55945133de448cb8ef3da79f5ce3086ea
+              digest: sha256:e6556e013459b4ce26cc464e23fddc952f4c57c1a0b4d63a7329acf804c8a5d8
           # MC
           mgmt:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 216461b167b4ed0af9b0a70e33c149f8358a026687ab4fb533bb0ef2bc55452e
+          westus3: 9a230ceae0cb3c8b81d022e635aac9754e35b8935b1928d53fc02420b4126d4e
       dev:
         regions:
-          westus3: 8598d45720835b93125aef8e1aa97b6cd9b9ef267b224f36e194cedaa93f61e1
+          westus3: 1a6c49cb8630d2b521dce99b61d0c8dde6019dd6548841c623c4464071765db5
       ntly:
         regions:
-          uksouth: 0ab1b31b79547dd00d3238d434967c278ca5c3a1022157216fe0945a863b300d
+          uksouth: 6df7e2beac2dba6b357476dfe6f97d380ebbe602094f6eb129e46d18429efbb3
       perf:
         regions:
-          westus3: e92ff05ba957b85c66092fa89b77a64a9c6db7c4dcb79413e3d8f22a3ef09344
+          westus3: a850eec135c2ef1aa5f3f997eb7dd4bad260ff521c922df6fa8ceb03f0c01173
       pers:
         regions:
-          westus3: 831b5a8a1cbfb24c6c57625304a0e4ae7d780cba3c7dc98c09ff12c5c2f55791
+          westus3: a00312897819259ca97025e4f0db3da1b3545dcfcf573bc0a9bc54a550f8a20e
       swft:
         regions:
-          uksouth: c7e7056fa963fc828d88876c91b723599357d680925b018a7755c713ad5fca0b
+          uksouth: d5c76bdc690b4dbf333858d7b29bea1ecb10fb2d7929ad6bf7fd768e7b27f4d3

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -280,7 +280,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides=true
   image:
-    digest: sha256:9ec2b20756f820b34cf2aa6a2e7609b55945133de448cb8ef3da79f5ce3086ea
+    digest: sha256:e6556e013459b4ce26cc464e23fddc952f4c57c1a0b4d63a7329acf804c8a5d8
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -280,7 +280,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:9ec2b20756f820b34cf2aa6a2e7609b55945133de448cb8ef3da79f5ce3086ea
+    digest: sha256:e6556e013459b4ce26cc464e23fddc952f4c57c1a0b4d63a7329acf804c8a5d8
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -280,7 +280,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:9ec2b20756f820b34cf2aa6a2e7609b55945133de448cb8ef3da79f5ce3086ea
+    digest: sha256:e6556e013459b4ce26cc464e23fddc952f4c57c1a0b4d63a7329acf804c8a5d8
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -280,7 +280,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:9ec2b20756f820b34cf2aa6a2e7609b55945133de448cb8ef3da79f5ce3086ea
+    digest: sha256:e6556e013459b4ce26cc464e23fddc952f4c57c1a0b4d63a7329acf804c8a5d8
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -280,7 +280,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides=true
   image:
-    digest: sha256:9ec2b20756f820b34cf2aa6a2e7609b55945133de448cb8ef3da79f5ce3086ea
+    digest: sha256:e6556e013459b4ce26cc464e23fddc952f4c57c1a0b4d63a7329acf804c8a5d8
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -280,7 +280,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:9ec2b20756f820b34cf2aa6a2e7609b55945133de448cb8ef3da79f5ce3086ea
+    digest: sha256:e6556e013459b4ce26cc464e23fddc952f4c57c1a0b4d63a7329acf804c8a5d8
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift


### PR DESCRIPTION
This reverts commit 4bff70563fa30a2dfd34d6dfa51161bcb0086aba.

### What

fixes #2907 being wrong arch
### Why

#2907 introduced wrong arch image.  

### Special notes for your reviewer

<!-- optional -->
