### PR TITLE
add oras to symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ mocks: $(MOCKGEN) $(GOIMPORTS)
 	$(GOIMPORTS) -w -local github.com/Azure/ARO-HCP ./internal/mocks
 .PHONY: mocks
 
-install-tools: $(BINGO) $(HELM_LINK) $(YQ_LINK) $(JQ_LINK)
+install-tools: $(BINGO) $(HELM_LINK) $(YQ_LINK) $(JQ_LINK) $(ORAS_LINK)
 	$(BINGO) get
 .PHONY: install-tools
 


### PR DESCRIPTION
add oras to symlink to fix https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/69163/rehearse-69163-periodic-ci-Azure-ARO-HCP-main-periodic-create-dev-env/1975790407182716928 .