### PR TITLE
disable external depends on to enable MSFT promotions

### DIFF
--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -41,10 +41,10 @@ resourceGroups:
     parameters: ../dev-infrastructure/configurations/output-mgmt.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-    externalDependsOn:
-    - serviceGroup: Microsoft.Azure.ARO.HCP.Management.Infra
-      resourceGroup: management
-      step: cluster
+    # externalDependsOn:
+    # - serviceGroup: Microsoft.Azure.ARO.HCP.Management.Infra
+    #   resourceGroup: management
+    #   step: cluster
 - name: service
   resourceGroup: '{{ .svc.rg }}'
   subscription: '{{ .svc.subscription.key }}'

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -30,10 +30,10 @@ resourceGroups:
     parameters: configurations/output-svc.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-    externalDependsOn:
-    - serviceGroup: Microsoft.Azure.ARO.HCP.Service.Infra
-      resourceGroup: service
-      step: cluster
+    # externalDependsOn:
+    # - serviceGroup: Microsoft.Azure.ARO.HCP.Service.Infra
+    #   resourceGroup: service
+    #   step: cluster
 - name: regional
   resourceGroup: '{{ .regionRG }}'
   subscription: '{{ .svc.subscription.key }}'

--- a/maestro/agent/pipeline.yaml
+++ b/maestro/agent/pipeline.yaml
@@ -92,10 +92,10 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: deploy
-    externalDependsOn:
-    - serviceGroup: Microsoft.Azure.ARO.HCP.Maestro.Server
-      resourceGroup: service
-      step: deploy
+    # externalDependsOn:
+    # - serviceGroup: Microsoft.Azure.ARO.HCP.Maestro.Server
+    #   resourceGroup: service
+    #   step: deploy
     identityFrom:
       resourceGroup: global
       step: output

--- a/route-monitor-operator/pipeline.yaml
+++ b/route-monitor-operator/pipeline.yaml
@@ -84,10 +84,10 @@ resourceGroups:
       step: mirror-operator-image
     - resourceGroup: global
       step: mirror-blackbox-image
-    externalDependsOn:
-    - serviceGroup: Microsoft.Azure.ARO.HCP.ACM
-      resourceGroup: management
-      step: deploy
+    # externalDependsOn:
+    # - serviceGroup: Microsoft.Azure.ARO.HCP.ACM
+    #   resourceGroup: management
+    #   step: deploy
     shellIdentity:
       input:
         resourceGroup: global


### PR DESCRIPTION
### What

the external dependsOn declarations cause issues in ev2 manifest generation, so we disable them for now

https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=139603220

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
