### PR TITLE
revert CS image sha change preparation for prod

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -176,7 +176,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:2b972ac73f43afe99d08161ec1cb192191ae06fc41f2fa8d5e2e84f1254257a9
+              digest: sha256:17ae3a480e74de9484471074fa9ebad10c82e848e3ebb853d53b945221c9d5f4
           # ACR Pull
           acrPull:
             image:


### PR DESCRIPTION
We revert to what's currently in prod. The new sha change for prod should only be merged in the aro-hcp repository once it's been rolled out to stage and tests pass.