### PR TITLE
geneva action onecert kv registration

### DIFF
--- a/dev-infrastructure/configurations/output-global.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/output-global.tmpl.bicepparam
@@ -8,3 +8,5 @@ param grafanaName = '{{ .monitoring.grafanaName }}'
 param azureFrontDoorProfileName = '{{ .oidc.frontdoor.name }}'
 param globalMSIName = '{{ .global.globalMSIName }}'
 param globalKVName = '{{ .global.keyVault.name }}'
+param genevaActionsKVName = '{{ .geneva.actions.keyVault.name }}'
+param genevaActionsEnabled = {{ .geneva.actions.enabled }}

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -44,6 +44,21 @@ resourceGroups:
         name: globalKeyVaultUrl
     issuer:
       value: OneCertV2-PrivateCA
+  - name: geneva-kv-private-issuer
+    action: SetCertificateIssuer
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
+    applicationId:
+      configRef: ev2.assistedId.applicationId
+    vaultBaseUrl:
+      input:
+        resourceGroup: global
+        step: output
+        name: genevaActionKeyVaultUrl
+    issuer:
+      value: OneCertV2-PrivateCA
   - name: certificates
     action: ARM
     template: templates/global-certificates.bicep

--- a/dev-infrastructure/templates/output-global.bicep
+++ b/dev-infrastructure/templates/output-global.bicep
@@ -22,6 +22,12 @@ param globalMSIName string
 @description('The name of the global KV')
 param globalKVName string
 
+@description('The name of the geneva actions KV')
+param genevaActionsKVName string
+
+@description('Should geneva actions be enabled')
+param genevaActionsEnabled bool
+
 //
 //   A C R
 //
@@ -93,3 +99,13 @@ resource globalKV 'Microsoft.KeyVault/vaults@2024-04-01-preview' existing = {
 }
 
 output globalKeyVaultUrl string = globalKV.properties.vaultUri
+
+//
+//   G E N E V A   A C T I O N S   KV
+//
+
+resource genevaActionsKV 'Microsoft.KeyVault/vaults@2024-04-01-preview' existing = if (genevaActionsEnabled) {
+  name: genevaActionsKVName
+}
+
+output genevaActionKeyVaultUrl string = genevaActionsEnabled ? genevaActionsKV.properties.vaultUri : ''


### PR DESCRIPTION
### What

use ev2 extension to register the onecert private signer with the geneva action kv

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
