### PR TITLE
feat: update maestro image digest to a52c865958f35e7d2ed9f4215431e71ecf3fd405a6a864f130ae7c922dead8c4 for INT environment

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -74,7 +74,7 @@ clouds:
           # Maestro
           maestro:
             image:
-              digest: sha256:d14c940a103d3811123c907bec610349960ac2028df508a1a8c89264bd3ed847
+              digest: sha256:a52c865958f35e7d2ed9f4215431e71ecf3fd405a6a864f130ae7c922dead8c4
             agent:
               sidecar:
                 image:


### PR DESCRIPTION
### What

<!-- Briefly describe what this PR does -->

feat: update maestro image digest to a52c865958f35e7d2ed9f4215431e71ecf3fd405a6a864f130ae7c922dead8c4 for INT environment

### Why

Follows https://github.com/Azure/ARO-HCP/pull/2951 for DEV environments.

Fixes issue observed in [ARO-22017](https://issues.redhat.com//browse/ARO-22017) by updating to maestro image that includes the fix from https://github.com/openshift-online/maestro/pull/382.

This resolves the 'cannot update deleting' issue by using GORM's unscoped update to allow status updates from maestro agent even when resources are being deleted, ensuring proper resource lifecycle management in INT environment.


### Special notes for your reviewer

<!-- optional -->
