### PR TITLE
run CS batch job dry run of ARO-20736 in shared dev environment

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -972,6 +972,9 @@ clouds:
             cosmosDB:
               private: false
               zoneRedundantMode: 'Disabled'
+          clustersService:
+            batchProcessesDryRun: true
+            batchProcesses: "ARO-20736"
       cspr:
         # this is the cluster service PR check and full cycle test environment
         defaults:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -6,7 +6,7 @@ clouds:
           westus3: 668c3ce15a0e04c033818f12748a33fd05cbd31599d053a88686e9417a9cce29
       dev:
         regions:
-          westus3: 462ed1c10ea9ccb8d6e784399673e99c2a0ea13c35d3aa039c46b9ad8583e411
+          westus3: 2b9e578623dd0105f741c4d9df276b177cbc9ca995efd6e2846acfe35e8177e3
       ntly:
         regions:
           uksouth: a8b66fcb2943058ad0f7108cbb10808a29c846dbe6c9a873ff8294a2382da939

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -103,7 +103,7 @@ clustersService:
     roleSetName: dev
   azureRuntimeConfig:
     tlsCertificatesIssuer: Self
-  batchProcesses: ""
+  batchProcesses: ARO-20736
   batchProcessesDryRun: true
   denyAssignments: disabled
   environment: arohcpdev


### PR DESCRIPTION
The purpose of this batch job is to ensure that existing clusters have the nodes outbound lb IP addresses persisted in the CS DB. This is needed so when we enable the k8s apiserver ip addresses allow list functionality these IPs are automatically configured by CS if end users end up setting the allow list, without causing network connectivity disruptions.
