### PR TITLE
Bump CS Image to 28574667a937 (INT environment)

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -12,7 +12,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:2b972ac73f43afe99d08161ec1cb192191ae06fc41f2fa8d5e2e84f1254257a9
+              digest: sha256:28574667a937d23eff68c2f7bc21874e5818952e343d4906bbbe2ca30bfe512f
             k8s:
               deploymentStrategy:
                 rollingUpdate:


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Bump CS Image to 28574667a937 (INT environment)

### Why

<!-- Briefly explain why this change is needed -->

Weekly cadence to Bump CS Image. 
This follows the same digest update that was applied to DEV environment in https://github.com/Azure/ARO-HCP/pull/2947


### Special notes for your reviewer

<!-- optional -->
