### PR TITLE
Skipping image mirror step for oci-layout

### DIFF
--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -407,7 +407,7 @@ func RunStep(id graph.Identifier, s types.Step, ctx context.Context, executionTa
 
 		if step.CopyFrom == "oci-layout" {
 			logger.Info("OCI layout image copy is not supported for run step, skipping")
-			continue
+			return nil, nil
 		}
 
 		err := runImageMirrorStep(id, ctx, step, options, state, &buf)


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Skipping image mirror step for oci-layout

### Why

This generally doesn't work out of the box because the step is expecting that ADO will place the file in the right place.

### Special notes for your reviewer

<!-- optional -->
