### PR TITLE
Bump CS Image to 1b5433dbe4b5 (INT environment)

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -12,7 +12,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:28574667a937d23eff68c2f7bc21874e5818952e343d4906bbbe2ca30bfe512f
+              digest: sha256:1b5433dbe4b5022c330b3c5cacedc5d4fe63592ab93f0884bcf960ee125fa090
             k8s:
               deploymentStrategy:
                 rollingUpdate:


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Bump CS Image to 1b5433dbe4b5 (INT environment)

### Why

This follows https://github.com/Azure/ARO-HCP/pull/2979 which updated the same digest in DEV environment.
As partly of weekly cadence to rollout CS changes.


### Special notes for your reviewer

<!-- optional -->
~~Draft for now, until the change in https://github.com/Azure/ARO-HCP/pull/2979 has been deployed to shared dev~~