### PR TITLE
bump: update AROBIT mdsd image to 1.38.0-20251007-2-pr

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -99,7 +99,7 @@ defaults:
       image:
         registry: linuxgeneva-microsoft.azurecr.io
         repository: genevamdsd
-        digest: sha256:756d114bbaecec418139b53bdf634a9677f71c5c501a4af901246ef2f2c5d468
+        digest: sha256:c63187bb16b7cf83940b3223643d4582aa4fe3d38940b5e34d12672f443914bc
   # Kube Events
   kubeEvents:
     enabled: true

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 20bdb3d906eadd683b46032bef81341c595f285207cb68d9e5e45cc98d85af1b
+          westus3: 1b31dfc1c236b7c18c179a501bc84994301c371745fa16ced15592b91a02196b
       dev:
         regions:
-          westus3: 08334f26c80f4ac6c9da65aee358e0d97f30f543a9a931a8b61f316c8647639c
+          westus3: 4f1f5f7ae4cb5f71e5c455f7700b7d1790c431c552fbced852767642a11674a3
       ntly:
         regions:
-          uksouth: b9a2b4d0a7d6e9401cd169af78c10cec7e1cb48718c79494af6dbdf5c17b2a52
+          uksouth: ca411480efd62bbadc551f25d406333c69e4f482ed7938806d0d36642c2bab6b
       perf:
         regions:
-          westus3: 0eac2283e3b717b253d787e8d43e432ef04f74ee7d66f1190597c1c112e94a9d
+          westus3: 0e014df33213986119c59f3171fd7e4dfef608c5a092ea28d708ce81d578cb62
       pers:
         regions:
-          westus3: 6c175fdbacb412d584d3bf923d9b4d0d11ca97b4283517b03766dd73b387d138
+          westus3: 1644f7fd8fe8f2b0ee6d5782dd8b04d19c02eb8b21792c9dc010b88f27c5da8c
       swft:
         regions:
-          uksouth: f78ca863f34bea76afc934378858a36ae90c6ee4799a62c4c71de2a961c9c05c
+          uksouth: a082ef07e6985949ba0a1183e31c3cf0f6348649cdea62aac7a46a1d604ea161

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -47,7 +47,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:756d114bbaecec418139b53bdf634a9677f71c5c501a4af901246ef2f2c5d468
+      digest: sha256:c63187bb16b7cf83940b3223643d4582aa4fe3d38940b5e34d12672f443914bc
       registry: linuxgeneva-microsoft.azurecr.io
       repository: genevamdsd
 automationDryRun: false

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -47,7 +47,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:756d114bbaecec418139b53bdf634a9677f71c5c501a4af901246ef2f2c5d468
+      digest: sha256:c63187bb16b7cf83940b3223643d4582aa4fe3d38940b5e34d12672f443914bc
       registry: linuxgeneva-microsoft.azurecr.io
       repository: genevamdsd
 automationDryRun: false

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -47,7 +47,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:756d114bbaecec418139b53bdf634a9677f71c5c501a4af901246ef2f2c5d468
+      digest: sha256:c63187bb16b7cf83940b3223643d4582aa4fe3d38940b5e34d12672f443914bc
       registry: linuxgeneva-microsoft.azurecr.io
       repository: genevamdsd
 automationDryRun: false

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -47,7 +47,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:756d114bbaecec418139b53bdf634a9677f71c5c501a4af901246ef2f2c5d468
+      digest: sha256:c63187bb16b7cf83940b3223643d4582aa4fe3d38940b5e34d12672f443914bc
       registry: linuxgeneva-microsoft.azurecr.io
       repository: genevamdsd
 automationDryRun: false

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -47,7 +47,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:756d114bbaecec418139b53bdf634a9677f71c5c501a4af901246ef2f2c5d468
+      digest: sha256:c63187bb16b7cf83940b3223643d4582aa4fe3d38940b5e34d12672f443914bc
       registry: linuxgeneva-microsoft.azurecr.io
       repository: genevamdsd
 automationDryRun: false

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -47,7 +47,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:756d114bbaecec418139b53bdf634a9677f71c5c501a4af901246ef2f2c5d468
+      digest: sha256:c63187bb16b7cf83940b3223643d4582aa4fe3d38940b5e34d12672f443914bc
       registry: linuxgeneva-microsoft.azurecr.io
       repository: genevamdsd
 automationDryRun: false


### PR DESCRIPTION
[<!-- Link to Jira issue -->
](https://issues.redhat.com/projects/ARO/issues/ARO-22121)

### What

Bumps the AROBIT mdsd image to `1.38.0-20251007-2-pr` / `sha256:c63187bb16b7cf83940b3223643d4582aa4fe3d38940b5e34d12672f443914bc`.

```
❯ trivy image linuxgeneva-microsoft.azurecr.io/genevamdsd@sha256:c63187bb16b7cf83940b3223643d4582aa4fe3d38940b5e34d12672f443914bc

2025-10-14T16:13:30+02:00	INFO	[vulndb] Need to update DB
2025-10-14T16:13:30+02:00	INFO	[vulndb] Downloading vulnerability DB...
2025-10-14T16:13:30+02:00	INFO	[vulndb] Downloading artifact...	repo="mirror.gcr.io/aquasec/trivy-db:2"
72.72 MiB / 72.72 MiB [-----------------------------------------------------------------------------------------------------------------------] 100.00% 7.08 MiB p/s 10s
2025-10-14T16:13:41+02:00	INFO	[vulndb] Artifact successfully downloaded	repo="mirror.gcr.io/aquasec/trivy-db:2"
2025-10-14T16:13:41+02:00	INFO	[vuln] Vulnerability scanning is enabled
2025-10-14T16:13:41+02:00	INFO	[secret] Secret scanning is enabled
2025-10-14T16:13:41+02:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-10-14T16:13:41+02:00	INFO	[secret] Please see https://trivy.dev/v0.67/docs/scanner/secret#recommendation for faster secret detection
2025-10-14T16:13:44+02:00	INFO	Detected OS	family="azurelinux" version="3.0"
2025-10-14T16:13:44+02:00	INFO	[azurelinux] Detecting vulnerabilities...	os_version="3.0" pkg_num=125
2025-10-14T16:13:44+02:00	INFO	Number of language-specific files	num=0

Report Summary

┌──────────────────────────────────────────────────────────────────────────────────┬────────────┬─────────────────┬─────────┐
│                                      Target                                      │    Type    │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┼─────────┤
│ linuxgeneva-microsoft.azurecr.io/genevamdsd@sha256:c63187bb16b7cf83940b3223643d- │ azurelinux │        0        │    -    │
│ 4582aa4fe3d38940b5e34d12672f443914bc (azurelinux 3.0)                            │            │                 │         │
└──────────────────────────────────────────────────────────────────────────────────┴────────────┴─────────────────┴─────────┘
```

### Why

Current image has critical vulnerabilitivites that need to be mitigated.

- Microsoft Azure Linux 3.0 Security Update for glibc (34732)
- Microsoft Azure Linux 3.0 Security Update for glibc (40288)

```
 trivy image linuxgeneva-microsoft.azurecr.io/genevamdsd@sha256:756d114bbaecec418139b53bdf634a9677f71c5c501a4af901246ef2f2c5d468
2025-10-14T16:14:06+02:00	INFO	[vuln] Vulnerability scanning is enabled
2025-10-14T16:14:06+02:00	INFO	[secret] Secret scanning is enabled
2025-10-14T16:14:06+02:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-10-14T16:14:06+02:00	INFO	[secret] Please see https://trivy.dev/v0.67/docs/scanner/secret#recommendation for faster secret detection
2025-10-14T16:16:09+02:00	INFO	Detected OS	family="azurelinux" version="3.0"
2025-10-14T16:16:09+02:00	INFO	[azurelinux] Detecting vulnerabilities...	os_version="3.0" pkg_num=125
2025-10-14T16:16:09+02:00	INFO	Number of language-specific files	num=0

Report Summary

┌──────────────────────────────────────────────────────────────────────────────────┬────────────┬─────────────────┬─────────┐
│                                      Target                                      │    Type    │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┼─────────┤
│ linuxgeneva-microsoft.azurecr.io/genevamdsd@sha256:756d114bbaecec418139b53bdf63- │ azurelinux │       22        │    -    │
│ 4a9677f71c5c501a4af901246ef2f2c5d468 (azurelinux 3.0)                            │            │                 │         │
└──────────────────────────────────────────────────────────────────────────────────┴────────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


linuxgeneva-microsoft.azurecr.io/genevamdsd@sha256:756d114bbaecec418139b53bdf634a9677f71c5c501a4af901246ef2f2c5d468 (azurelinux 3.0)

Total: 22 (UNKNOWN: 0, LOW: 10, MEDIUM: 4, HIGH: 6, CRITICAL: 2)

┌─────────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────────────┐
│           Library           │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                             │
├─────────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ elfutils                    │ CVE-2025-1352  │ LOW      │ fixed  │ 0.189-4.azl3      │ 0.189-5.azl3    │ elfutils: GNU elfutils eu-readelf libdw_alloc.c              │
│                             │                │          │        │                   │                 │ __libdw_thread_tail memory corruption                        │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-1352                    │
├─────────────────────────────┤                │          │        │                   │                 │                                                              │
│ elfutils-default-yama-scope │                │          │        │                   │                 │                                                              │
│                             │                │          │        │                   │                 │                                                              │
│                             │                │          │        │                   │                 │                                                              │
├─────────────────────────────┤                │          │        │                   │                 │                                                              │
│ elfutils-libelf             │                │          │        │                   │                 │                                                              │
│                             │                │          │        │                   │                 │                                                              │
│                             │                │          │        │                   │                 │                                                              │
├─────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ glibc                       │ CVE-2024-33599 │ HIGH     │        │ 2.38-10.azl3      │ 2.38-11.azl3    │ glibc: stack-based buffer overflow in netgroup cache         │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-33599                   │
│                             ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│                             │ CVE-2024-33601 │          │        │                   │                 │ glibc: netgroup cache may terminate daemon on memory         │
│                             │                │          │        │                   │                 │ allocation failure                                           │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-33601                   │
│                             ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│                             │ CVE-2025-4802  │          │        │                   │ 2.38-12.azl3    │ glibc: static setuid binary dlopen may incorrectly search    │
│                             │                │          │        │                   │                 │ LD_LIBRARY_PATH                                              │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-4802                    │
│                             ├────────────────┼──────────┤        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│                             │ CVE-2023-4527  │ MEDIUM   │        │                   │ 2.38-11.azl3    │ glibc: Stack read overflow in getaddrinfo in no-aaaa mode    │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-4527                    │
│                             ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│                             │ CVE-2023-4806  │          │        │                   │                 │ glibc: potential use-after-free in getaddrinfo()             │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-4806                    │
│                             ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│                             │ CVE-2024-33600 │          │        │                   │                 │ glibc: null pointer dereferences after failed netgroup cache │
│                             │                │          │        │                   │                 │ insertion                                                    │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-33600                   │
│                             ├────────────────┼──────────┤        │                   │                 ├──────────────────────────────────────────────────────────────┤
│                             │ CVE-2025-0395  │ LOW      │        │                   │                 │ glibc: buffer overflow in the GNU C Library's assert()       │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-0395                    │
├─────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ icu                         │ CVE-2025-5222  │ HIGH     │        │ 72.1.0.3-1.azl3   │ 72.1.0.3-2.azl3 │ icu: Stack buffer overflow in the SRBRoot::addTag function   │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-5222                    │
├─────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ libarchive                  │ CVE-2025-5914  │ LOW      │        │ 3.7.7-2.azl3      │ 3.7.7-3.azl3    │ libarchive: Double free at                                   │
│                             │                │          │        │                   │                 │ archive_read_format_rar_seek_data() in                       │
│                             │                │          │        │                   │                 │ archive_read_support_format_rar.c                            │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-5914                    │
│                             ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│                             │ CVE-2025-5915  │          │        │                   │                 │ libarchive: Heap buffer over read in copy_from_lzss_window() │
│                             │                │          │        │                   │                 │ at archive_read_support_format_rar.c                         │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-5915                    │
│                             ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│                             │ CVE-2025-5916  │          │        │                   │                 │ libarchive: Integer overflow while reading warc files at     │
│                             │                │          │        │                   │                 │ archive_read_support_format_warc.c                           │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-5916                    │
│                             ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│                             │ CVE-2025-5917  │          │        │                   │                 │ libarchive: Off by one error in build_ustar_entry_name() at  │
│                             │                │          │        │                   │                 │ archive_write_set_format_pax.c                               │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-5917                    │
│                             ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│                             │ CVE-2025-5918  │          │        │                   │                 │ libarchive: Reading past EOF may be triggered for piped file │
│                             │                │          │        │                   │                 │ streams                                                      │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-5918                    │
├─────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ libxml2                     │ CVE-2025-49794 │ CRITICAL │        │ 2.11.5-5.azl3     │ 2.11.5-6.azl3   │ libxml: Heap use after free (UAF) leads to Denial of service │
│                             │                │          │        │                   │                 │ (DoS)...                                                     │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-49794                   │
│                             ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│                             │ CVE-2025-49796 │          │        │                   │                 │ libxml: Type confusion leads to Denial of service (DoS)      │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-49796                   │
│                             ├────────────────┼──────────┤        │                   │                 ├──────────────────────────────────────────────────────────────┤
│                             │ CVE-2025-6021  │ MEDIUM   │        │                   │                 │ libxml2: Integer Overflow in xmlBuildQName() Leads to Stack  │
│                             │                │          │        │                   │                 │ Buffer Overflow in libxml2...                                │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-6021                    │
│                             ├────────────────┼──────────┤        │                   │                 ├──────────────────────────────────────────────────────────────┤
│                             │ CVE-2025-6170  │ LOW      │        │                   │                 │ libxml2: Stack Buffer Overflow in xmllint Interactive Shell  │
│                             │                │          │        │                   │                 │ Command Handling                                             │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-6170                    │
├─────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ pam                         │ CVE-2025-6020  │ HIGH     │        │ 1.5.3-4.azl3      │ 1.5.3-5.azl3    │ linux-pam: Linux-pam directory Traversal                     │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-6020                    │
├─────────────────────────────┼────────────────┤          │        ├───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ sqlite-libs                 │ CVE-2025-6965  │          │        │ 3.44.0-1.azl3     │ 3.44.0-2.azl3   │ sqlite: Integer Truncation in SQLite                         │
│                             │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-6965                    │
└─────────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────────────┘
```

### Special notes for your reviewer

The latest version was fetched using:

```
❯ skopeo list-tags docker://linuxgeneva-microsoft.azurecr.io/genevamdsd | jq -r '.Tags[] | select(test("[0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+-[0-9]+-pr")) | select(test("_(amd64|arm64)") | not)' | sort -r | head -n1
1.38.0-20251007-2-pr


❯ docker images --no-trunc --quiet linuxgeneva-microsoft.azurecr.io/genevamdsd:$(skopeo list-tags docker://linuxgeneva-microsoft.azurecr.io/genevamdsd | jq -r '.Tags[] | select(test("[0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+-[0-9]+-pr")) | select(test("_(amd64|arm64)") | not)' | sort -r | head -n1)
sha256:c63187bb16b7cf83940b3223643d4582aa4fe3d38940b5e34d12672f443914bc
```