### PR TITLE
run CS batch job ARO-20736 in shared dev environment

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -973,7 +973,7 @@ clouds:
               private: false
               zoneRedundantMode: 'Disabled'
           clustersService:
-            batchProcessesDryRun: true
+            batchProcessesDryRun: false
             batchProcesses: "ARO-20736"
       cspr:
         # this is the cluster service PR check and full cycle test environment

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -6,7 +6,7 @@ clouds:
           westus3: 9244315cc521dea9a5de1eb4515ded6ce3f1d6e872d86ba4717943bdbcc5e045
       dev:
         regions:
-          westus3: e4c1e50bbd87ffdfabfecbc64ef9884762a7fafbb1709c3eb2465e2a1040d414
+          westus3: 0b660240a5d5174110b49f9e9737d9b03ee68d3c255645321d6047ca29e7557e
       ntly:
         regions:
           uksouth: 4ca1c5699aed0ba959baa1c12b7f754646848926c15a501e7c61ed6ba3a47e1e

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -104,7 +104,7 @@ clustersService:
   azureRuntimeConfig:
     tlsCertificatesIssuer: Self
   batchProcesses: ARO-20736
-  batchProcessesDryRun: true
+  batchProcessesDryRun: false
   denyAssignments: disabled
   environment: arohcpdev
   image:


### PR DESCRIPTION
The purpose of this batch job is to ensure that existing clusters have the nodes outbound lb IP addresses persisted in the CS DB. This is needed so when we enable the k8s apiserver ip addresses allow list functionality these IPs are automatically configured by CS if end users end up setting the allow list, without causing network connectivity disruptions.

We've run the job in dry run mode in https://github.com/Azure/ARO-HCP/pull/2966