### PR TITLE
bump: update acrpull image to v0.1.20

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -21,7 +21,7 @@ clouds:
           # ACR Pull
           acrPull:
             image:
-              digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664 #v0.1.18
+              digest: sha256:d0962cbd98b90a9c16933b33afaa27d72cc58f94322c93d1745388599562c37d #v0.1.20
           # Secret Sync Controller
           secretSyncController:
             image:
@@ -113,7 +113,7 @@ clouds:
           # ACR Pull
           acrPull:
             image:
-              digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664 #v0.1.14
+              digest: sha256:d0962cbd98b90a9c16933b33afaa27d72cc58f94322c93d1745388599562c37d #v0.1.20
           # Secret Sync Controller
           secretSyncController:
             image:
@@ -190,7 +190,7 @@ clouds:
           # ACR Pull
           acrPull:
             image:
-              digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664 #v0.1.14
+              digest: sha256:d0962cbd98b90a9c16933b33afaa27d72cc58f94322c93d1745388599562c37d #v0.1.20
           # Secret Sync Controller
           secretSyncController:
             image:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -796,7 +796,7 @@ clouds:
       # ACR Pull
       acrPull:
         image:
-          digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664 #v0.1.18
+          digest: sha256:d0962cbd98b90a9c16933b33afaa27d72cc58f94322c93d1745388599562c37d #v0.1.20
       # Secret Sync Controller
       secretSyncController:
         image:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 7aa45a58203dc44cfb42417fb23fb3659934ce3d87c57f482c375ecb32e61d1a
+          westus3: 20bdb3d906eadd683b46032bef81341c595f285207cb68d9e5e45cc98d85af1b
       dev:
         regions:
-          westus3: f945a0ff7a3c416de844f86086aeb1fdb3272f50fea9a887e22b622656ec2551
+          westus3: 08334f26c80f4ac6c9da65aee358e0d97f30f543a9a931a8b61f316c8647639c
       ntly:
         regions:
-          uksouth: 79717f5cc9c4954117e20305f2b780432cb9806e63e849244ab620d4489e9b32
+          uksouth: b9a2b4d0a7d6e9401cd169af78c10cec7e1cb48718c79494af6dbdf5c17b2a52
       perf:
         regions:
-          westus3: 287aebd0543df3053800670a49d062a839123f00ea8b36b6c33d1f0a6b82e522
+          westus3: 0eac2283e3b717b253d787e8d43e432ef04f74ee7d66f1190597c1c112e94a9d
       pers:
         regions:
-          westus3: 043d39a098c47475b4cea966a3b92bd627ff8e497de7732b6af652700d5ac1fa
+          westus3: 6c175fdbacb412d584d3bf923d9b4d0d11ca97b4283517b03766dd73b387d138
       swft:
         regions:
-          uksouth: cba3e3d840ac8e58a7521661128b62b674dec3de944e7e33938cd6f4da91d099
+          uksouth: f78ca863f34bea76afc934378858a36ae90c6ee4799a62c4c71de2a961c9c05c

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -29,7 +29,7 @@ acr:
     zoneRedundantMode: Disabled
 acrPull:
   image:
-    digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664
+    digest: sha256:d0962cbd98b90a9c16933b33afaa27d72cc58f94322c93d1745388599562c37d
     registry: mcr.microsoft.com
     repository: aks/msi-acrpull
 administration:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -29,7 +29,7 @@ acr:
     zoneRedundantMode: Disabled
 acrPull:
   image:
-    digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664
+    digest: sha256:d0962cbd98b90a9c16933b33afaa27d72cc58f94322c93d1745388599562c37d
     registry: mcr.microsoft.com
     repository: aks/msi-acrpull
 administration:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -29,7 +29,7 @@ acr:
     zoneRedundantMode: Disabled
 acrPull:
   image:
-    digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664
+    digest: sha256:d0962cbd98b90a9c16933b33afaa27d72cc58f94322c93d1745388599562c37d
     registry: mcr.microsoft.com
     repository: aks/msi-acrpull
 administration:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -29,7 +29,7 @@ acr:
     zoneRedundantMode: Disabled
 acrPull:
   image:
-    digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664
+    digest: sha256:d0962cbd98b90a9c16933b33afaa27d72cc58f94322c93d1745388599562c37d
     registry: mcr.microsoft.com
     repository: aks/msi-acrpull
 administration:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -29,7 +29,7 @@ acr:
     zoneRedundantMode: Disabled
 acrPull:
   image:
-    digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664
+    digest: sha256:d0962cbd98b90a9c16933b33afaa27d72cc58f94322c93d1745388599562c37d
     registry: mcr.microsoft.com
     repository: aks/msi-acrpull
 administration:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -29,7 +29,7 @@ acr:
     zoneRedundantMode: Disabled
 acrPull:
   image:
-    digest: sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664
+    digest: sha256:d0962cbd98b90a9c16933b33afaa27d72cc58f94322c93d1745388599562c37d
     registry: mcr.microsoft.com
     repository: aks/msi-acrpull
 administration:


### PR DESCRIPTION
[<!-- Link to Jira issue -->
](https://issues.redhat.com/browse/ARO-22123)

### What

Update the `acrpull` image to `v0.1.20` / `sha256:d0962cbd98b90a9c16933b33afaa27d72cc58f94322c93d1745388599562c37d`.

```
 trivy image $REPOSITORY@$(docker images --no-trunc --quiet $REPOSITORY:$(skopeo list-tags docker://$REPOSITORY | jq -r '.Tags[]'  | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1))
2025-10-14T17:35:23+02:00       INFO    [vuln] Vulnerability scanning is enabled
2025-10-14T17:35:23+02:00       INFO    [secret] Secret scanning is enabled
2025-10-14T17:35:23+02:00       INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-10-14T17:35:23+02:00       INFO    [secret] Please see https://trivy.dev/v0.67/docs/scanner/secret#recommendation for faster secret detection
2025-10-14T17:35:23+02:00       INFO    Detected OS     family="azurelinux" version="3.0"
2025-10-14T17:35:23+02:00       INFO    [azurelinux] Detecting vulnerabilities...       os_version="3.0" pkg_num=79
2025-10-14T17:35:23+02:00       INFO    Number of language-specific files       num=1
2025-10-14T17:35:23+02:00       INFO    [gobinary] Detecting vulnerabilities...
2025-10-14T17:35:23+02:00       WARN    Using severities from other vendors for some vulnerabilities. Read https://trivy.dev/v0.67/docs/scanner/vulnerability#severity-selection for details.

Report Summary

┌──────────────────────────────────────────────────────────────────────────────────┬────────────┬─────────────────┬─────────┐
│                                      Target                                      │    Type    │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┼─────────┤
│ mcr.microsoft.com/aks/msi-acrpull@sha256:d0962cbd98b90a9c16933b33afaa27d72cc58f- │ azurelinux │        0        │    -    │
│ 94322c93d1745388599562c37d (azurelinux 3.0)                                      │            │                 │         │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┼─────────┤
│ manager                                                                          │  gobinary  │        1        │    -    │
└──────────────────────────────────────────────────────────────────────────────────┴────────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


manager (gobinary)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                       Title                        │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-47910 │ MEDIUM   │ fixed  │ v1.25.0           │ 1.25.1        │ net/http: CrossOriginProtection bypass in net/http │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-47910         │
└──
```
### Why

Current version have vulnerabilities that need to be mitigated:

  | Bug ID | Package    | Update ID | CVE ID        | CVE URL                                                     |
  |--------|------------|-----------|---------------|-------------------------------------------------------------|
  | 915633 | libarchive | 63774     | CVE-2025-5916 | http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5916 |
  | 915646 | libarchive | 63783     | CVE-2025-5914 | http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5914 |
  | 915659 | libarchive | 63777     | CVE-2025-5917 | http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5917 |
  | 915665 | libarchive | 63780     | CVE-2025-5918 | http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5918 |
  | 915667 | libarchive | 63786     | CVE-2025-5915 | http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5915 |
  | 915651 | glibc      | 61877     | CVE-2025-4802 | http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-4802 |


```
❯ trivy image mcr.microsoft.com/aks/msi-acrpull@sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664
2025-10-14T17:37:27+02:00	INFO	[vuln] Vulnerability scanning is enabled
2025-10-14T17:37:27+02:00	INFO	[secret] Secret scanning is enabled
2025-10-14T17:37:27+02:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-10-14T17:37:27+02:00	INFO	[secret] Please see https://trivy.dev/v0.67/docs/scanner/secret#recommendation for faster secret detection
2025-10-14T17:37:28+02:00	INFO	Detected OS	family="azurelinux" version="3.0"
2025-10-14T17:37:28+02:00	INFO	[azurelinux] Detecting vulnerabilities...	os_version="3.0" pkg_num=79
2025-10-14T17:37:28+02:00	INFO	Number of language-specific files	num=1
2025-10-14T17:37:28+02:00	INFO	[gobinary] Detecting vulnerabilities...
2025-10-14T17:37:28+02:00	WARN	Using severities from other vendors for some vulnerabilities. Read https://trivy.dev/v0.67/docs/scanner/vulnerability#severity-selection for details.

Report Summary

┌──────────────────────────────────────────────────────────────────────────────────┬────────────┬─────────────────┬─────────┐
│                                      Target                                      │    Type    │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┼─────────┤
│ mcr.microsoft.com/aks/msi-acrpull@sha256:8535e678398d0c15bccc6e4383483f15ab9e24- │ azurelinux │        7        │    -    │
│ 8405c0fc1ce587e3999b39e664 (azurelinux 3.0)                                      │            │                 │         │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┼─────────┤
│ manager                                                                          │  gobinary  │        2        │    -    │
└──────────────────────────────────────────────────────────────────────────────────┴────────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


mcr.microsoft.com/aks/msi-acrpull@sha256:8535e678398d0c15bccc6e4383483f15ab9e248405c0fc1ce587e3999b39e664 (azurelinux 3.0)

Total: 7 (UNKNOWN: 0, LOW: 5, MEDIUM: 0, HIGH: 2, CRITICAL: 0)

┌─────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│   Library   │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                             │
├─────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ glibc       │ CVE-2025-4802 │ HIGH     │ fixed  │ 2.38-11.azl3      │ 2.38-12.azl3  │ glibc: static setuid binary dlopen may incorrectly search    │
│             │               │          │        │                   │               │ LD_LIBRARY_PATH                                              │
│             │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-4802                    │
├─────────────┼───────────────┼──────────┤        ├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libarchive  │ CVE-2025-5914 │ LOW      │        │ 3.7.7-2.azl3      │ 3.7.7-3.azl3  │ libarchive: Double free at                                   │
│             │               │          │        │                   │               │ archive_read_format_rar_seek_data() in                       │
│             │               │          │        │                   │               │ archive_read_support_format_rar.c                            │
│             │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-5914                    │
│             ├───────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│             │ CVE-2025-5915 │          │        │                   │               │ libarchive: Heap buffer over read in copy_from_lzss_window() │
│             │               │          │        │                   │               │ at archive_read_support_format_rar.c                         │
│             │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-5915                    │
│             ├───────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│             │ CVE-2025-5916 │          │        │                   │               │ libarchive: Integer overflow while reading warc files at     │
│             │               │          │        │                   │               │ archive_read_support_format_warc.c                           │
│             │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-5916                    │
│             ├───────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│             │ CVE-2025-5917 │          │        │                   │               │ libarchive: Off by one error in build_ustar_entry_name() at  │
│             │               │          │        │                   │               │ archive_write_set_format_pax.c                               │
│             │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-5917                    │
│             ├───────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│             │ CVE-2025-5918 │          │        │                   │               │ libarchive: Reading past EOF may be triggered for piped file │
│             │               │          │        │                   │               │ streams                                                      │
│             │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-5918                    │
├─────────────┼───────────────┼──────────┤        ├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ sqlite-libs │ CVE-2025-6965 │ HIGH     │        │ 3.44.0-1.azl3     │ 3.44.0-2.azl3 │ sqlite: Integer Truncation in SQLite                         │
│             │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-6965                    │
└─────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘

manager (gobinary)

Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-47907 │ HIGH     │ fixed  │ v1.23.11          │ 1.23.12, 1.24.6 │ database/sql: Postgres Scan Race Condition                  │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-47907                  │
│         ├────────────────┼──────────┤        │                   │                 ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2025-47906 │ MEDIUM   │        │                   │                 │ os/exec: Unexpected paths returned from LookPath in os/exec │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-47906                  │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴─────────────────────────────────────────────────────────────┘

```
