### PR TITLE
bump: int maestro image to a52c8659

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -74,7 +74,7 @@ clouds:
           # Maestro
           maestro:
             image:
-              digest: sha256:d14c940a103d3811123c907bec610349960ac2028df508a1a8c89264bd3ed847
+              digest: sha256:a52c865958f35e7d2ed9f4215431e71ecf3fd405a6a864f130ae7c922dead8c4
             agent:
               sidecar:
                 image:


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-22120

### What

Bumps INT image to a52c865958f35e7d2ed9f4215431e71ecf3fd405a6a864f130ae7c922dead8c4.

This follows https://github.com/Azure/ARO-HCP/pull/2951 that did the bump in dev envs

### Why

To mitigate vulnerabilities.