### PR TITLE
Add a Helm resource policy annotation to avoid secret deletion

### DIFF
--- a/cluster-service/deploy/templates/provisioning-shards.secret.yaml
+++ b/cluster-service/deploy/templates/provisioning-shards.secret.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: provision-shards
   namespace: '{{ .Release.Namespace }}'
+  annotations:
+    helm.sh/resource-policy: keep
 stringData:
   config: |
     provision_shards:


### PR DESCRIPTION
https://issues.redhat.com/browse/AROSLSRE-142

### What

Adds the `helm.sh/resource-policy: keep` annotation to the provision-shards secret

### Why

This is a required step to split the CS chart in two and move the shard registration secret to a different chart. Without this annotation, the CS chart will delete the live resource if the template is moved out of its control.

### Special notes for your reviewer

Pre-requisite to merge https://github.com/Azure/ARO-HCP/pull/2930. A release with this change needs to be deployed all the way up to production to make the Helm chart split a safe operation.
