### PR TITLE
configure new aro-hcp cs sandbox quay repo caching

### DIFF
--- a/dev-infrastructure/configurations/acr-svc.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/acr-svc.tmpl.bicepparam
@@ -10,12 +10,25 @@ param quayRepositoriesToCache = [
     userIdentifier: 'quay-componentsync-username'
     passwordIdentifier: 'quay-componentsync-password'
   }
+  {
+    ruleName: 'aroHcpCsSandboxImages'
+    sourceRepo: 'quay.io/app-sre/aro-hcp-clusters-service-sandbox'
+    targetRepo: 'app-sre/aro-hcp-clusters-service-sandbox'
+    userIdentifier: 'quay-componentsync-username'
+    passwordIdentifier: 'quay-componentsync-password'
+  }
 ]
 
 param purgeJobs = [
   {
     name: 'ocm-clusters-service-sandbox-purge'
     purgeFilter: 'quay.io/app-sre/ocm-clusters-service-sandbox:.*'
+    purgeAfter: '2d'
+    imagesToKeep: 1
+  }
+  {
+    name: 'aro-hcp-clusters-service-sandbox-purge'
+    purgeFilter: 'quay.io/app-sre/aro-hcp-clusters-service-sandbox:.*'
     purgeAfter: '2d'
     imagesToKeep: 1
   }


### PR DESCRIPTION
We are going to move the aro-hcp cs sandbox images to a new repository as part of ocm cs split.
