### PR TITLE
updating msft envoy stats mise rule to match red hat

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/msftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/msftPrometheusAlertingRules.bicep
@@ -1408,7 +1408,7 @@ resource mise 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
           summary: 'Envoy scrape target down for namespace=mise'
           title: 'Prometheus scrape for envoy-stats job in namespace mise is failing or missing.'
         }
-        expression: 'absent(up{job="envoy-stats", namespace="mise"}) or (up{job="envoy-stats", namespace="mise"} == 0)'
+        expression: 'absent(up{endpoint="http-envoy-prom", container="istio-proxy", namespace="mise"}) or (up{endpoint="http-envoy-prom", container="istio-proxy", namespace="mise"} == 0)'
         for: 'PT5M'
         severity: 3
       }


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

updating msft envoy stats mise rule to match red hat
### Why

We've been getting alerts for a non-existent metric. Matching [deploy: regenerate alerts · Azure/ARO-HCP@f531cd6](https://github.com/Azure/ARO-HCP/commit/f531cd63e322f262aa931396b8f1f3ad3be4bc6b)

### Special notes for your reviewer

<!-- optional -->
