### PR TITLE
chore: bump CS image digest to b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459 for dev environments (weekly release)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -806,7 +806,7 @@ clouds:
       clustersService:
         environment: "arohcpdev"
         image:
-          digest: sha256:1b5433dbe4b5022c330b3c5cacedc5d4fe63592ab93f0884bcf960ee125fa090
+          digest: sha256:b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459
         azureOperatorsManagedIdentities:
           roleSetName: dev
         azureRuntimeConfig:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 1b31dfc1c236b7c18c179a501bc84994301c371745fa16ced15592b91a02196b
+          westus3: 5027c0d688c89060bb8e5eaf187a289e57f2b2af354b195c02b33302ed7f8212
       dev:
         regions:
-          westus3: fab8f89d45258c8b69d6ef1a568e7b5cd2748f2175607e8513845af3f9cf3fc1
+          westus3: dd87ed9fa7fe51a92d4d70948149776044176878b216c11baf9a1b392b8130a0
       ntly:
         regions:
-          uksouth: ca411480efd62bbadc551f25d406333c69e4f482ed7938806d0d36642c2bab6b
+          uksouth: 0158bfeec27d2dd56b1ec016bde4e7cf033cb5a44ccac732f5cd677e71ca0b7c
       perf:
         regions:
-          westus3: 0e014df33213986119c59f3171fd7e4dfef608c5a092ea28d708ce81d578cb62
+          westus3: f6980273ae65d5a5a1972039e71c3e2874fa70bcaddc1111a7c48836a8081f61
       pers:
         regions:
-          westus3: 1644f7fd8fe8f2b0ee6d5782dd8b04d19c02eb8b21792c9dc010b88f27c5da8c
+          westus3: 754347bb8ee2f1216ef7476883409c1ca7774b22dae9768c0fd7900baec60900
       swft:
         regions:
-          uksouth: a082ef07e6985949ba0a1183e31c3cf0f6348649cdea62aac7a46a1d604ea161
+          uksouth: e26a00ce82864c4cd602eaa015d42ce1ed92607b08ea762eb6342c566abd3172

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -108,7 +108,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:1b5433dbe4b5022c330b3c5cacedc5d4fe63592ab93f0884bcf960ee125fa090
+    digest: sha256:b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -108,7 +108,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:1b5433dbe4b5022c330b3c5cacedc5d4fe63592ab93f0884bcf960ee125fa090
+    digest: sha256:b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -108,7 +108,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:1b5433dbe4b5022c330b3c5cacedc5d4fe63592ab93f0884bcf960ee125fa090
+    digest: sha256:b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -108,7 +108,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:1b5433dbe4b5022c330b3c5cacedc5d4fe63592ab93f0884bcf960ee125fa090
+    digest: sha256:b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -108,7 +108,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:1b5433dbe4b5022c330b3c5cacedc5d4fe63592ab93f0884bcf960ee125fa090
+    digest: sha256:b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -108,7 +108,7 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:1b5433dbe4b5022c330b3c5cacedc5d4fe63592ab93f0884bcf960ee125fa090
+    digest: sha256:b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459
     registry: quay.io
     repository: app-sre/uhc-clusters-service
   k8s:


### PR DESCRIPTION
### What

bump CS image digest to b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459 for dev environments (weekly release)

### Why

Update cluster service image digest to sha256:b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459 for all dev environments as part of weekly Thursday release.

### Special notes for your reviewer

<!-- optional -->
