### PR TITLE
chore: bump CS image digest to b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459 for INT environment

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -12,7 +12,7 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:1b5433dbe4b5022c330b3c5cacedc5d4fe63592ab93f0884bcf960ee125fa090
+              digest: sha256:b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459
             k8s:
               deploymentStrategy:
                 rollingUpdate:


### PR DESCRIPTION


<!-- Link to Jira issue -->

### What

Update cluster service image digest 

### Why

Update cluster service image digest to sha256:b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459 for INT environment.

Follows: https://github.com/Azure/ARO-HCP/pull/3009

### Special notes for your reviewer

<!-- optional -->
