### PR TITLE
update CS prod to use absolute numbers for rolling update strategy

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -13,11 +13,6 @@ clouds:
           clustersService:
             image:
               digest: sha256:b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459
-            k8s:
-              deploymentStrategy:
-                rollingUpdate:
-                  maxUnavailable: 0
-                  maxSurge: 1
           # ACR Pull
           acrPull:
             image:
@@ -105,11 +100,6 @@ clouds:
           clustersService:
             image:
               digest: sha256:1b5433dbe4b5022c330b3c5cacedc5d4fe63592ab93f0884bcf960ee125fa090
-            k8s:
-              deploymentStrategy:
-                rollingUpdate:
-                  maxUnavailable: 0
-                  maxSurge: 1
           # ACR Pull
           acrPull:
             image:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -650,8 +650,8 @@ defaults:
       serviceAccountName: clusters-service
       deploymentStrategy:
         rollingUpdate:
-          maxUnavailable: 25%
-          maxSurge: 25%
+          maxUnavailable: 0
+          maxSurge: 1
     azureRuntimeConfig:
       tlsCertificatesIssuer: OneCertV2-PublicCA
     # OCP Versions configuration
@@ -810,11 +810,6 @@ clouds:
           roleSetName: dev
         azureRuntimeConfig:
           tlsCertificatesIssuer: Self
-        k8s:
-          deploymentStrategy:
-            rollingUpdate:
-              maxUnavailable: 0
-              maxSurge: 1
       # Hypershift Operator
       hypershift:
         image:


### PR DESCRIPTION
Now that prod will use the setting we refactor the config files to use the global configuration around this.

Detailed context: https://github.com/Azure/ARO-HCP/pull/2733