### PR TITLE
fix: Typo in postgres-breakglass.md

### DIFF
--- a/docs/ops/postgres-breakglass.md
+++ b/docs/ops/postgres-breakglass.md
@@ -15,9 +15,9 @@ This guide describes how to access the Postgres database of ARO HCP service, spe
 1. Exec into the pod of the deployment
 
    ```/bin/sh
-   kubectl exec -ti (kubectl get pods -n  clusters-service -l app=postgres-breakglass -o name) -n clusters-service -- /bin/bash
+   kubectl exec -ti $(kubectl get pods -n  clusters-service -l app=postgres-breakglass -o name) -n clusters-service -- /bin/bash
    or
-   kubectl exec -ti (kubectl get pods -n  maestro -l app=postgres-breakglass -o name) -n maestro -- /bin/bash
+   kubectl exec -ti $(kubectl get pods -n  maestro -l app=postgres-breakglass -o name) -n maestro -- /bin/bash
    ```
 
 2. Run `connect` within the container to start a `psql` session


### PR DESCRIPTION
### What

Adds a missing $ to the get pods code snippet.

### Why

Is missing the $.
