### PR TITLE
chore: bump CS image digest to 53c184b8b4e6d2e510220351a6831a00f19cf622a7ae867b64dcc0c1d9b58448 for INT environment

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -12,7 +12,12 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:b670b0501d93a7180e6c6fe500ca68e0d13c53211e9f3e03bfc251a82c571459
+              digest: sha256:53c184b8b4e6d2e510220351a6831a00f19cf622a7ae867b64dcc0c1d9b58448
+            k8s:
+              deploymentStrategy:
+                rollingUpdate:
+                  maxUnavailable: 0
+                  maxSurge: 1
           # ACR Pull
           acrPull:
             image:


### PR DESCRIPTION
### What

bump CS image digest to 53c184b8b4e6d2e510220351a6831a00f19cf622a7ae867b64dcc0c1d9b58448 for INT environment

### Why

Update cluster service image digest to sha256:53c184b8b4e6d2e510220351a6831a00f19cf622a7ae867b64dcc0c1d9b58448 for INT environment.

Follows: https://github.com/Azure/ARO-HCP/pull/3023

### Special notes for your reviewer

This PR can only be merged once https://github.com/Azure/ARO-HCP/actions/runs/18587436929 is successful.