### PR TITLE
fix gci linting issue in test/e2e/cluster_list_no_infra.go

### DIFF
--- a/test/e2e/cluster_list_no_infra.go
+++ b/test/e2e/cluster_list_no_infra.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"


### PR DESCRIPTION
In the imports section there needs to be a newline between each different category defined in gci

