### PR TITLE
add prometheus dependency to arobit

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -341,6 +341,9 @@ resourceGroups:
     releaseNamespace: 'arobit'
     chartDir: ../observability/arobit/deploy
     valuesFile: ../observability/arobit/values-mgmt.yaml
+    dependsOn:
+    - resourceGroup: management
+      step: prometheus
     inputVariables:
       tenantId:
         resourceGroup: management


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

adds prometheus step as a dependency to arobit installation

### Why
management cluster arobit installation fails since it needs prometheus servicemonitor CRD.
<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
