### PR TITLE
test new CS quay repository in shared dev

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -969,6 +969,10 @@ clouds:
             cosmosDB:
               private: false
               zoneRedundantMode: 'Disabled'
+          clustersService:
+            image:
+              digest: sha256:733863739632e9f5722ea9e18067ee61d572895c1c99aade8d74226dcc487a42
+              repository: app-sre/aro-hcp-clusters-service
       cspr:
         # this is the cluster service PR check and full cycle test environment
         defaults:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -6,7 +6,7 @@ clouds:
           westus3: 9bd63d03f72cab6f8678abb661d1519091a6b3353852e08aead8c00e212a2568
       dev:
         regions:
-          westus3: bbf0ca846ad3acf7096ba465c1f7a9f557e93ca3a89003ba957365862db82fcf
+          westus3: d8c7837c33436f27aa168508666071917a2650acbe6f6122b9c7c20299302d08
       ntly:
         regions:
           uksouth: 0e017c34727ad0a053aeae48c2b7f673bcf7bfe7a942e1ee46f7e023d5cfd6c8

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -108,9 +108,9 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:f0568be3327d5f051f6f4b9cf5998f61611f1ea86b2340fe2ae54b70c1641185
+    digest: sha256:733863739632e9f5722ea9e18067ee61d572895c1c99aade8d74226dcc487a42
     registry: quay.io
-    repository: app-sre/uhc-clusters-service
+    repository: app-sre/aro-hcp-clusters-service
   k8s:
     deploymentStrategy:
       rollingUpdate:


### PR DESCRIPTION
To test that the deploy flow can reference the new quay repository images. The image used contains the same code as the previously deployed image plus some changes specific to the new CS gitlab repository configuration. Once we have verified that referencing the new repository works in shared dev we will move back to the previously referenced CS image there.
