### PR TITLE
Adding msft specific alerts bicep generation with filtering

### DIFF
--- a/dev-infrastructure/modules/metrics/msft-rules.bicep
+++ b/dev-infrastructure/modules/metrics/msft-rules.bicep
@@ -6,8 +6,8 @@ param azureMonitoringWorkspaceId string
 
 param actionGroups array
 
-module prometheus 'rules/msftPrometheusAlertingRules.bicep' = {
-  name: 'msftPrometheusAlertingRules'
+module prometheus 'rules/generatedMsftPrometheusAlertingRules.bicep' = {
+  name: 'generatedMsftPrometheusAlertingRules'
   params: {
     azureMonitoring: azureMonitoringWorkspaceId
     actionGroups: actionGroups

--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -4,8 +4,6 @@ param azureMonitoring string
 #disable-next-line no-unused-params
 param actionGroups array
 
-// we are omitting apps for now, but will add namespace-restricted ones later
-
 resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
   name: 'kubernetes-resources'
   location: resourceGroup().location
@@ -140,7 +138,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         }
         expression: 'kube_resourcequota{job="kube-state-metrics", type="used"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0) > 0.9 < 1'
         for: 'PT15M'
-        severity: 3
+        severity: 4
       }
       {
         actions: [
@@ -166,7 +164,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         }
         expression: 'kube_resourcequota{job="kube-state-metrics", type="used"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0) == 1'
         for: 'PT15M'
-        severity: 3
+        severity: 4
       }
       {
         actions: [
@@ -231,7 +229,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         }
         expression: 'kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0'
         for: 'PT5M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -337,7 +335,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         }
         expression: 'sum(apiserver_request:burnrate1h) > (14.40 * 0.01000) and sum(apiserver_request:burnrate5m) > (14.40 * 0.01000)'
         for: 'PT2M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -365,7 +363,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         }
         expression: 'sum(apiserver_request:burnrate6h) > (6.00 * 0.01000) and sum(apiserver_request:burnrate30m) > (6.00 * 0.01000)'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -486,7 +484,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         }
         expression: 'apiserver_client_certificate_expiration_seconds_count{job="controlplane-apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="controlplane-apiserver"}[5m]))) < 86400'
         for: 'PT5M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -563,7 +561,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         }
         expression: 'absent(up{job="controlplane-apiserver"} == 1)'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -680,7 +678,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         }
         expression: 'count by(cluster, node) ( (kube_pod_status_phase{job="kube-state-metrics",phase="Running"} == 1) * on(instance,pod,namespace,cluster) group_left(node) topk by(instance,pod,namespace,cluster) (1, kube_pod_info{job="kube-state-metrics"}) ) / max by(cluster, node) ( kube_node_status_capacity{job="kube-state-metrics",resource="pods"} != 1 ) > 0.95'
         for: 'PT15M'
-        severity: 3
+        severity: 4
       }
       {
         actions: [
@@ -808,7 +806,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           title: 'Client certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.'
         }
         expression: 'kubelet_certificate_manager_client_ttl_seconds < 86400'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -858,7 +856,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           title: 'Server certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.'
         }
         expression: 'kubelet_certificate_manager_server_ttl_seconds < 86400'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -936,7 +934,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         }
         expression: 'absent(up{job="kubelet", metrics_path="/metrics"} == 1)'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -975,7 +973,7 @@ resource kubernetesSystemScheduler 'Microsoft.AlertsManagement/prometheusRuleGro
         }
         expression: 'absent(up{job="controlplane-kube-scheduler"} == 1)'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -1014,7 +1012,7 @@ resource kubernetesSystemControllerManager 'Microsoft.AlertsManagement/prometheu
         }
         expression: 'absent(up{job="controlplane-kube-controller-manager"} == 1)'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -1059,7 +1057,7 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
         }
         expression: 'min by (job, namespace) (up{job="prometheus/prometheus",namespace="prometheus"}) == 0'
         for: 'PT5M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1091,7 +1089,7 @@ Please check the status of the Prometheus pods, service endpoints, and network c
         }
         expression: 'avg by (job, namespace) (avg_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d])) < 0.95'
         for: 'PT10M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1127,7 +1125,7 @@ Investigate the health and performance of the remote storage endpoint, network l
         }
         expression: '( prometheus_remote_storage_samples_pending / prometheus_remote_storage_samples_in_flight ) > 0.4'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1163,7 +1161,7 @@ Please check the health and performance of the remote storage endpoint, network 
         }
         expression: '( rate(prometheus_remote_storage_samples_failed_total[5m]) / rate(prometheus_remote_storage_samples_total[5m]) ) > 0.1'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -1202,7 +1200,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         }
         expression: '((rate(prometheus_remote_storage_failed_samples_total{job="prometheus-prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus-prometheus",namespace="prometheus"}[5m])) / ((rate(prometheus_remote_storage_failed_samples_total{job="prometheus-prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus-prometheus",namespace="prometheus"}[5m])) + (rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus-prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_total{job="prometheus-prometheus",namespace="prometheus"}[5m])))) * 100 > 1'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1254,7 +1252,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         }
         expression: 'max_over_time(prometheus_config_last_reload_successful{job="prometheus-prometheus",namespace="prometheus"}[5m]) == 0'
         for: 'PT10M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1280,7 +1278,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         }
         expression: 'increase(prometheus_rule_evaluation_failures_total{job="prometheus-prometheus",namespace="prometheus"}[5m]) > 0'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1410,7 +1408,7 @@ resource mise 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
         }
         expression: 'absent(up{endpoint="http-envoy-prom", container="istio-proxy", namespace="mise"}) or (up{endpoint="http-envoy-prom", container="istio-proxy", namespace="mise"} == 0)'
         for: 'PT5M'
-        severity: 3
+        severity: 4
       }
     ]
     scopes: [
@@ -1442,14 +1440,14 @@ resource msiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGroups
         }
         annotations: {
           correlationId: 'ClusterCredentialExpiringSoon/{{ $labels.cluster }}'
-          description: 'Cluster credential for cluster #$.labels.cluster# is expiring in less than 30 days. Please follow TSG to diagnose rotation issues.'
+          description: 'Cluster credential for cluster {{ $labels.cluster }} is expiring in less than 30 days.'
           runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/doc/tsgs/credential-refresher-expiring-cert'
           summary: 'Cluster credential expiring in less than 30 days'
-          title: 'One or More Cluster Credentials are Expiring Soon.'
+          title: 'Cluster credential for cluster {{ $labels.cluster }} is expiring in less than 30 days.'
         }
         expression: 'increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="14"}[30m]) > 0'
         for: 'PT5M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -772,7 +772,7 @@ Check the status of the Arobit forwarder pods, service endpoints, and network co
         }
         expression: 'min by (job, namespace) (up{job="arobit-forwarder",namespace="arobit"}) == 0'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [

--- a/observability/Makefile
+++ b/observability/Makefile
@@ -17,6 +17,8 @@ alerts: kubernetesControlPlane-prometheusRule
 	az bicep format -f $$(yq '.prometheusRules.outputBicep' observability.yaml)
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules run-hcp
 	az bicep format -f $$(yq '.prometheusRules.outputBicep' observability-hcp.yaml)
+	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules run-msft
+	az bicep format -f $$(yq '.prometheusRules.outputBicep' observability-msft.yaml)
 .PHONY: alerts
 
 recording-rules:

--- a/observability/alerts/msi-credential-refresher-prometheusRule.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: msi-credential-refresher-prometheus-rule
+  namespace: monitoring
+spec:
+  groups:
+  - name: msi-credential-refresher
+    interval: 1m
+    rules:
+    - alert: ClusterCredentialExpiringSoon
+      expr: increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="14"}[30m]) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: 'Cluster credential for cluster {{ $labels.cluster }} is expiring in less than 30 days.'
+        summary: 'Cluster credential expiring in less than 30 days'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/doc/tsgs/credential-refresher-expiring-cert'
+        correlationId: 'ClusterCredentialExpiringSoon/{{ $labels.cluster }}'

--- a/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
@@ -1,0 +1,23 @@
+rule_files:
+- msi-credential-refresher-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+- interval: 1m
+  input_series:
+  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="14"}'
+    # Values need to increase over 30 minutes window for the increase() function to work
+    # Starting from 0 and increasing by 1 every minute for 35 minutes
+    values: '0+1x35'
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: ClusterCredentialExpiringSoon
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        cluster: test-cluster
+        le: "14"
+      exp_annotations:
+        description: 'Cluster credential for cluster test-cluster is expiring in less than 30 days.'
+        summary: 'Cluster credential expiring in less than 30 days'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/doc/tsgs/credential-refresher-expiring-cert'
+        correlationId: 'ClusterCredentialExpiringSoon/test-cluster'

--- a/observability/observability-msft.yaml
+++ b/observability/observability-msft.yaml
@@ -1,0 +1,91 @@
+prometheusRules:
+  # The msft bicep needs alerts from both HCP and main observability rules sources
+  rulesFolders:
+  - alerts/prometheus-prometheusRule.yaml
+  - ../frontend/alerts/mise-prometheusRule.yaml
+  - alerts/msi-credential-refresher-prometheusRule.yaml
+  untestedRules:
+  - alerts/kubernetesControlPlane-prometheusRule.yaml
+  outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+  # Explicitly lists all alerts wanted to prevent new Red Hat alerts from automatically being included here
+  # Make sure to include the alert under the correct groupName as defined in its prometheusRule file
+  includedAlertsByGroup:
+  - groupName: kube-apiserver-slos
+    alerts:
+    - KubeAPIErrorBudgetBurn
+  - groupName: kubernetes-resources
+    alerts:
+    - KubeCPUOvercommit
+    - KubeCPUQuotaOvercommit
+    - KubeMemoryOvercommit
+    - KubeMemoryQuotaOvercommit
+    - KubeQuotaAlmostFull
+    - KubeQuotaExceeded
+    - KubeQuotaFullyUsed
+  - groupName: kubernetes-storage
+    alerts:
+    - KubePersistentVolumeErrors
+  - groupName: kubernetes-system
+    alerts:
+    - KubeClientErrors
+    - KubeVersionMismatch
+  - groupName: kubernetes-system-apiserver
+    alerts:
+    - KubeAPIDown
+    - KubeAPITerminatedRequests
+    - KubeAggregatedAPIDown
+    - KubeAggregatedAPIErrors
+    - KubeClientCertificateExpiration
+  - groupName: kubernetes-system-controller-manager
+    alerts:
+    - KubeControllerManagerDown
+  - groupName: kubernetes-system-kubelet
+    alerts:
+    - KubeNodeNotReady
+    - KubeNodeReadinessFlapping
+    - KubeNodeUnreachable
+    - KubeletClientCertificateExpiration
+    - KubeletClientCertificateRenewalErrors
+    - KubeletDown
+    - KubeletPlegDurationHigh
+    - KubeletPodStartUpLatencyHigh
+    - KubeletServerCertificateExpiration
+    - KubeletServerCertificateRenewalErrors
+    - KubeletTooManyPods
+  - groupName: kubernetes-system-scheduler
+    alerts:
+    - KubeSchedulerDown
+  - groupName: prometheus-wip-rules
+    alerts:
+    - PrometheusFailedRate
+    - PrometheusJobUp
+    - PrometheusPendingRate
+    - PrometheusUptime
+  - groupName: prometheus-rules
+    alerts:
+    - PrometheusBadConfig
+    - PrometheusNotIngestingSamples
+    - PrometheusRemoteStorageFailures
+    - PrometheusRuleFailures
+    - PrometheusScrapeSampleLimitHit
+  - groupName: prometheus-operator-rules
+    alerts:
+    - PrometheusOperatorNotReady
+    - PrometheusOperatorRejectedResources
+  - groupName: mise
+    alerts:
+    - MiseEnvoyScrapeDown
+  - groupName: msi-credential-refresher
+    alerts:
+    - ClusterCredentialExpiringSoon
+  outputReplacements:
+  - from: 'job="kube-scheduler"'
+    to: 'job="controlplane-kube-scheduler"'
+  - from: 'job="apiserver"'
+    to: 'job="controlplane-apiserver"'
+  - from: 'job="etcd"'
+    to: 'job="controlplane-etcd"'
+  - from: 'job="cluster-autoscaler"'
+    to: 'job="controlplane-cluster-autoscaler"'
+  - from: 'job="kube-controller-manager"'
+    to: 'job="controlplane-kube-controller-manager"'

--- a/tooling/prometheus-rules/Makefile
+++ b/tooling/prometheus-rules/Makefile
@@ -24,6 +24,10 @@ run-hcp:
 	go run ./...  --config-file ../../observability/observability-hcp.yaml $(EXTRA_FLAGS)
 .PHONY: run-hcp
 
+run-msft:
+	go run ./...  --config-file ../../observability/observability-msft.yaml $(EXTRA_FLAGS)
+.PHONY: run-msft
+
 run-recording-rules:
 	go run ./...  --config-file ../../observability/observability-recording-rules.yaml
 .PHONY: run-recording-rules


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-22194

### What

- Automates the generation of `msftPrometheusAlertingRules.bicep` to eliminate manual copy-paste workflow that causes drift between source YAML rules and deployed alerts.
- Adds optional filtering capabilities to the Prometheus rules generator to support MSFT infrastructure-specific alert requirements. 
- Creates a new PrometheusRule file that includes msi-credential-refresher alert not included in the main PrometheusRule files

### Why

The MSFT bicep file (`msftPrometheusAlertingRules.bicep`) was manually maintained through a copy-paste workflow that would manually remove unwanted groups and specific alerts from certain groups, which would cause the following problems:
- Changes to source PrometheusRule YAML files didn't propagate to MSFT bicep. 
- Every alert update required manual review and editing.

### Special notes for your reviewer

<!-- optional -->
