### PR TITLE
[wip] allow serializing internal objs to storage

### DIFF
--- a/frontend/test/simulate/utils.go
+++ b/frontend/test/simulate/utils.go
@@ -51,7 +51,7 @@ import (
 
 func SkipIfNotSimulationTesting(t *testing.T) {
 	if os.Getenv("FRONTEND_SIMULATION_TESTING") != "true" {
-		t.Skip("Skipping test")
+		//t.Skip("Skipping test")
 	}
 }
 

--- a/internal/database/crud_nested_resource.go
+++ b/internal/database/crud_nested_resource.go
@@ -103,3 +103,7 @@ func (d *nestedCosmosResourceCRUD[T]) List(ctx context.Context, options *DBClien
 
 	return list[T](ctx, d.containerClient, d.resourceType, prefix, options)
 }
+
+func (d *nestedCosmosResourceCRUD[T]) Replace(ctx context.Context, desiredObj *T) (*T, error) {
+	return replace[T](ctx, d.containerClient, desiredObj)
+}

--- a/internal/database/crud_toplevel_resource.go
+++ b/internal/database/crud_toplevel_resource.go
@@ -26,6 +26,7 @@ import (
 type ResourceCRUD[T any] interface {
 	Get(ctx context.Context, resourceID string) (*T, error)
 	List(ctx context.Context, opts *DBClientListResourceDocsOptions) (DBClientIterator[T], error)
+	Replace(ctx context.Context, cluster *T) (*T, error)
 }
 
 type topLevelCosmosResourceCRUD[T any] struct {
@@ -95,4 +96,8 @@ func (d *topLevelCosmosResourceCRUD[T]) List(ctx context.Context, options *DBCli
 	}
 
 	return list[T](ctx, d.containerClient, d.resourceType, prefix, options)
+}
+
+func (d *topLevelCosmosResourceCRUD[T]) Replace(ctx context.Context, desiredObj *T) (*T, error) {
+	return replace[T](ctx, d.containerClient, desiredObj)
 }


### PR DESCRIPTION
This serializes our internal types to storage and is exposing shortcomings where what we store is not roundtrippable back to the internal types.

Clearly must be fixed and tested prior to changing.