### PR TITLE
set back CS image from quay uhc repository in shared dev

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -969,10 +969,6 @@ clouds:
             cosmosDB:
               private: false
               zoneRedundantMode: 'Disabled'
-          clustersService:
-            image:
-              digest: sha256:733863739632e9f5722ea9e18067ee61d572895c1c99aade8d74226dcc487a42
-              repository: app-sre/aro-hcp-clusters-service
       cspr:
         # this is the cluster service PR check and full cycle test environment
         defaults:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -6,7 +6,7 @@ clouds:
           westus3: 9bd63d03f72cab6f8678abb661d1519091a6b3353852e08aead8c00e212a2568
       dev:
         regions:
-          westus3: d8c7837c33436f27aa168508666071917a2650acbe6f6122b9c7c20299302d08
+          westus3: bbf0ca846ad3acf7096ba465c1f7a9f557e93ca3a89003ba957365862db82fcf
       ntly:
         regions:
           uksouth: 0e017c34727ad0a053aeae48c2b7f673bcf7bfe7a942e1ee46f7e023d5cfd6c8

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -108,9 +108,9 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:733863739632e9f5722ea9e18067ee61d572895c1c99aade8d74226dcc487a42
+    digest: sha256:f0568be3327d5f051f6f4b9cf5998f61611f1ea86b2340fe2ae54b70c1641185
     registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    repository: app-sre/uhc-clusters-service
   k8s:
     deploymentStrategy:
       rollingUpdate:


### PR DESCRIPTION
Tests in shared dev to verify the deploy flow can reference the new CS quay repository images have finished.

We revert back to the CS image that was used before the tests.