### PR TITLE
Bump maestro and increase log level to 2 in dev and int

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -74,7 +74,7 @@ clouds:
           # Maestro
           maestro:
             image:
-              digest: sha256:a52c865958f35e7d2ed9f4215431e71ecf3fd405a6a864f130ae7c922dead8c4
+              digest: sha256:4cd299203a02271d58b1eb03a8186293e686833c6e4f5cee3cde6adf77715e2b
             agent:
               sidecar:
                 image:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -539,7 +539,7 @@ defaults:
         address: ""
         exporter: ""
       mqttClientName: 'maestro-server-{{ .ctx.regionShort }}'
-      loglevel: 1
+      loglevel: 2
       managedIdentityName: maestro-server
       k8s:
         replicas: 3
@@ -547,7 +547,7 @@ defaults:
         serviceAccountName: maestro
     agent:
       consumerName: "hcp-underlay-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}" # [env-unique]
-      loglevel: 1
+      loglevel: 2
       managedIdentityName: maestro-consumer
       k8s:
         replicas: 3
@@ -791,7 +791,7 @@ clouds:
         certDomain: selfsigned.maestro.keyvault.azure.com
         certIssuer: Self
         image:
-          digest: sha256:a52c865958f35e7d2ed9f4215431e71ecf3fd405a6a864f130ae7c922dead8c4
+          digest: sha256:4cd299203a02271d58b1eb03a8186293e686833c6e4f5cee3cde6adf77715e2b
       # ACR Pull
       acrPull:
         image:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 9bd63d03f72cab6f8678abb661d1519091a6b3353852e08aead8c00e212a2568
+          westus3: 04ea048637d06d2612cadd3266084fa4f04c294702b7bb15c6490d8a7ec5ac04
       dev:
         regions:
-          westus3: bbf0ca846ad3acf7096ba465c1f7a9f557e93ca3a89003ba957365862db82fcf
+          westus3: 60a842ef6258bbe362f739cdcd807146a995aabcc099df5dac1196e5d227cc02
       ntly:
         regions:
-          uksouth: 0e017c34727ad0a053aeae48c2b7f673bcf7bfe7a942e1ee46f7e023d5cfd6c8
+          uksouth: 0dc44b1a3b9bd0d45018a284cdcdc4f617d0143af5ec4f810a54b87a15e81e8d
       perf:
         regions:
-          westus3: 88f030775d96eed56786c7e23ceddd2195f5aaeb3872b12293dd0c5ec5f264a3
+          westus3: 493a292315746d22185eeb2fc56e43ee14ed0f82bddef558f9e2a8ca565e3c10
       pers:
         regions:
-          westus3: 3a5ec064600f1d9ac0f19c9cc8b386e8b745066b634443d1a7acf141b30965e1
+          westus3: c45b01a8534329657337f4bfdc6c11dd52bb1aa21e7fd375b71bb2ff4e5cefee
       swft:
         regions:
-          uksouth: a79542a5846454b0a05ca1ebc705f141f32f035751e589f347ff72c91089abc6
+          uksouth: 539936af790216b9aeaf90a7668e7c402a02dfe9488a3742a898661f5fb3e2ec

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -339,7 +339,7 @@ maestro:
       namespace: maestro
       replicas: 3
       serviceAccountName: maestro
-    loglevel: 1
+    loglevel: 2
     managedIdentityName: maestro-consumer
     sidecar:
       image:
@@ -353,7 +353,7 @@ maestro:
     name: arohcp-cspr-maestro-usw3
     private: false
   image:
-    digest: sha256:a52c865958f35e7d2ed9f4215431e71ecf3fd405a6a864f130ae7c922dead8c4
+    digest: sha256:4cd299203a02271d58b1eb03a8186293e686833c6e4f5cee3cde6adf77715e2b
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -377,7 +377,7 @@ maestro:
       namespace: maestro
       replicas: 3
       serviceAccountName: maestro
-    loglevel: 1
+    loglevel: 2
     managedIdentityName: maestro-server
     mqttClientName: maestro-server-usw3
     tracing:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -339,7 +339,7 @@ maestro:
       namespace: maestro
       replicas: 3
       serviceAccountName: maestro
-    loglevel: 1
+    loglevel: 2
     managedIdentityName: maestro-consumer
     sidecar:
       image:
@@ -353,7 +353,7 @@ maestro:
     name: arohcp-dev-maestro-usw3
     private: false
   image:
-    digest: sha256:a52c865958f35e7d2ed9f4215431e71ecf3fd405a6a864f130ae7c922dead8c4
+    digest: sha256:4cd299203a02271d58b1eb03a8186293e686833c6e4f5cee3cde6adf77715e2b
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -377,7 +377,7 @@ maestro:
       namespace: maestro
       replicas: 3
       serviceAccountName: maestro
-    loglevel: 1
+    loglevel: 2
     managedIdentityName: maestro-server
     mqttClientName: maestro-server-usw3-dev
     tracing:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -339,7 +339,7 @@ maestro:
       namespace: maestro
       replicas: 3
       serviceAccountName: maestro
-    loglevel: 1
+    loglevel: 2
     managedIdentityName: maestro-consumer
     sidecar:
       image:
@@ -353,7 +353,7 @@ maestro:
     name: arohcp-ntly-maestro-ln
     private: false
   image:
-    digest: sha256:a52c865958f35e7d2ed9f4215431e71ecf3fd405a6a864f130ae7c922dead8c4
+    digest: sha256:4cd299203a02271d58b1eb03a8186293e686833c6e4f5cee3cde6adf77715e2b
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -377,7 +377,7 @@ maestro:
       namespace: maestro
       replicas: 3
       serviceAccountName: maestro
-    loglevel: 1
+    loglevel: 2
     managedIdentityName: maestro-server
     mqttClientName: maestro-server-ln
     tracing:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -339,7 +339,7 @@ maestro:
       namespace: maestro
       replicas: 3
       serviceAccountName: maestro
-    loglevel: 1
+    loglevel: 2
     managedIdentityName: maestro-consumer
     sidecar:
       image:
@@ -353,7 +353,7 @@ maestro:
     name: arohcp-perf-maestro-usw3ptest
     private: false
   image:
-    digest: sha256:a52c865958f35e7d2ed9f4215431e71ecf3fd405a6a864f130ae7c922dead8c4
+    digest: sha256:4cd299203a02271d58b1eb03a8186293e686833c6e4f5cee3cde6adf77715e2b
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -377,7 +377,7 @@ maestro:
       namespace: maestro
       replicas: 3
       serviceAccountName: maestro
-    loglevel: 1
+    loglevel: 2
     managedIdentityName: maestro-server
     mqttClientName: maestro-server-usw3ptest
     tracing:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -339,7 +339,7 @@ maestro:
       namespace: maestro
       replicas: 3
       serviceAccountName: maestro
-    loglevel: 1
+    loglevel: 2
     managedIdentityName: maestro-consumer
     sidecar:
       image:
@@ -353,7 +353,7 @@ maestro:
     name: arohcp-pers-maestro-usw3test
     private: false
   image:
-    digest: sha256:a52c865958f35e7d2ed9f4215431e71ecf3fd405a6a864f130ae7c922dead8c4
+    digest: sha256:4cd299203a02271d58b1eb03a8186293e686833c6e4f5cee3cde6adf77715e2b
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -377,7 +377,7 @@ maestro:
       namespace: maestro
       replicas: 3
       serviceAccountName: maestro
-    loglevel: 1
+    loglevel: 2
     managedIdentityName: maestro-server
     mqttClientName: maestro-server-usw3test
     tracing:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -339,7 +339,7 @@ maestro:
       namespace: maestro
       replicas: 3
       serviceAccountName: maestro
-    loglevel: 1
+    loglevel: 2
     managedIdentityName: maestro-consumer
     sidecar:
       image:
@@ -353,7 +353,7 @@ maestro:
     name: arohcp-swft-maestro-lnstest
     private: false
   image:
-    digest: sha256:a52c865958f35e7d2ed9f4215431e71ecf3fd405a6a864f130ae7c922dead8c4
+    digest: sha256:4cd299203a02271d58b1eb03a8186293e686833c6e4f5cee3cde6adf77715e2b
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -377,7 +377,7 @@ maestro:
       namespace: maestro
       replicas: 3
       serviceAccountName: maestro
-    loglevel: 1
+    loglevel: 2
     managedIdentityName: maestro-server
     mqttClientName: maestro-server-lnstest
     tracing:


### PR DESCRIPTION
Bump maestro and increase log level to 2 to log important details that may correlate to significant changes in the system without exposing work manifests data.

Related to https://issues.redhat.com/browse/ACM-24719 

```$ oc image info quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro@sha256:4cd299203a02271d58b1eb03a8186293e686833c6e4f5cee3cde6adf77715e2b
Name:          quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro@sha256:4cd299203a02271d58b1eb03a8186293e686833c6e4f5cee3cde6adf77715e2b
Media Type:    application/vnd.docker.distribution.manifest.v2+json
Created:       13h ago
Image Size:    113.4MB in 2 layers
Layers:        39.65MB sha256:2920d84eafa0cf94806ab58f0a2124f7b2d35bcbb06fc89a9106dcc28efe397a
               73.79MB sha256:3abd111e42fad39211e0a2dbd5f1513cfc8ef4a45225938000b85c97d3a933b2
OS:            linux
Arch:          amd64
```



