### PR TITLE
adding sclarkso and wenqih to /config in codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,7 +24,7 @@ go.work* @bennerv @geoberle @janboll @weinong @whober0521 @jonathan34c @tony-sch
 /backend/ @bennerv @mbarnes @SudoBrendan @mociarain @venkateshsredhat @nanyte25 @kostola @DennisJWheeler @avollmer-redhat @hbhushan3 @oriAdler @sclarkso @tsatam @katherinelc321
 /internal/ @bennerv @mbarnes @SudoBrendan @mociarain @venkateshsredhat @nanyte25 @kostola @DennisJWheeler @avollmer-redhat @hbhushan3 @oriAdler @sclarkso @tsatam @katherinelc321
 /tooling/ @bennerv @geoberle @janboll @weinong @whober0521 @jonathan34c @tony-schndr @mmazur @roivaz @raelga @stevekuznetsov
-/config/ @bennerv @geoberle @janboll @weinong @whober0521 @jonathan34c @tony-schndr @mmazur @roivaz @raelga @stevekuznetsov @mbarnes @SudoBrendan @JameelB @miguelsorianod @katherinelc321 @tsatam @mociarain @oriAdler @nimrodshn @zgalor @patilsuraj767 @machi1990 @trevorwilliams2025
+/config/ @bennerv @geoberle @janboll @weinong @whober0521 @jonathan34c @tony-schndr @mmazur @roivaz @raelga @stevekuznetsov @mbarnes @SudoBrendan @JameelB @miguelsorianod @katherinelc321 @tsatam @mociarain @oriAdler @nimrodshn @zgalor @patilsuraj767 @machi1990 @trevorwilliams2025 @sclarkso @weherdh
 /metrics/ @bennerv @geoberle @janboll @weinong @whober0521 @jonathan34c @tony-schndr @mmazur @roivaz @raelga @stevekuznetsov
 /cluster-service/ @machi1990 @miguelsorianod @JameelB @oriAdler @nimrodshn @zgalor @patilsuraj767
 /observability/tracing/ @frzifus @simonpasquier @dinhxuanvu @mbarnes


### PR DESCRIPTION
need added to /config in codeowners to be able to do promotions.
