### PR TITLE
Fix: Move maestro postgres output from regional to service scope

### DIFF
--- a/dev-infrastructure/configurations/maestro-server-lookup.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/maestro-server-lookup.tmpl.bicepparam
@@ -2,3 +2,6 @@ using '../modules/maestro/maestro-server-lookup.bicep'
 
 param maestroMsiName = '{{ .maestro.server.managedIdentityName }}'
 param imagePullerMsiName = 'image-puller'
+param useAzureDB = {{ .maestro.postgres.deploy }}
+param postgresName = '{{ .maestro.postgres.name }}'
+param regionalResourceGroup = '{{ .regionRG }}'

--- a/dev-infrastructure/configurations/output-region.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/output-region.tmpl.bicepparam
@@ -4,5 +4,3 @@ param azureMonitorWorkspaceName = '{{ .monitoring.svcWorkspaceName }}'
 param hcpAzureMonitorWorkspaceName = '{{ .monitoring.hcpWorkspaceName }}'
 param maestroEventGridNamespacesName = '{{ .maestro.eventGrid.name }}'
 param enableLogAnalytics = {{ .logs.loganalytics.enable }}
-param useAzureDB = {{ .maestro.postgres.deploy }}
-param postgresName = '{{ .maestro.postgres.name }}'

--- a/dev-infrastructure/modules/maestro/maestro-server-lookup.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-server-lookup.bicep
@@ -4,6 +4,15 @@ param maestroMsiName string
 @description('The name of the Image Puller MSI')
 param imagePullerMsiName string
 
+@description('Whether to use a database in Azure')
+param useAzureDB bool
+
+@description('The name of the Postgres server')
+param postgresName string
+
+@description('The regional resource group where postgres is deployed')
+param regionalResourceGroup string
+
 //
 //   M A E S T R O   S E R V E R   L O O K U P
 //
@@ -22,3 +31,14 @@ resource imagePullerIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2
 }
 
 output imagePullerMsiClientId string = imagePullerIdentity.properties.clientId
+
+//
+//   P O S T G R E S
+//
+
+resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview' existing = if (useAzureDB) {
+  scope: resourceGroup(regionalResourceGroup)
+  name: postgresName
+}
+
+output databaseHost string = useAzureDB ? postgres.properties.fullyQualifiedDomainName : 'maestro-db'

--- a/dev-infrastructure/templates/output-region.bicep
+++ b/dev-infrastructure/templates/output-region.bicep
@@ -7,12 +7,6 @@ param hcpAzureMonitorWorkspaceName string
 @description('The name of the eventgrid namespace for Maestro.')
 param maestroEventGridNamespacesName string
 
-@description('Whether to use a databse in Azure')
-param useAzureDB bool
-
-@description('The name of the Postgres server')
-param postgresName string
-
 @description('Enable Log Analytics')
 param enableLogAnalytics bool
 
@@ -44,16 +38,6 @@ resource maestroEventGridNamespace 'Microsoft.EventGrid/namespaces@2024-06-01-pr
 
 output maestroEventGridNamespaceId string = maestroEventGridNamespace.id
 output maestroEventGridNamespacesHostname string = maestroEventGridNamespace.properties.topicSpacesConfiguration.hostname
-
-//
-//  P O S T G R E S
-//
-
-resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview' existing = if (useAzureDB) {
-  name: postgresName
-}
-
-output databaseHost string = useAzureDB ? postgres.properties.fullyQualifiedDomainName : 'maestro-db'
 
 //
 //   L O G   A N A L Y T I C S

--- a/maestro/server/pipeline.yaml
+++ b/maestro/server/pipeline.yaml
@@ -74,7 +74,7 @@ resourceGroups:
         step: output
         name: imagePullerMsiClientId
       databaseHost:
-        resourceGroup: regional
+        resourceGroup: service
         step: output
         name: databaseHost
       brokerHost:


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-22021
https://issues.redhat.com/browse/AROSLSRE-103

### Problem
EV2 deployment fails when deploying to a new region with error:

```
The Resource 'Microsoft.DBforPostgreSQL/flexibleServers/arohcp-prod-dbmaestro-am'
under resource group 'westeurope-shared-resources' was not found
```

### Root Cause
Commit [943e88037](https://github.com/Azure/ARO-HCP/commit/943e88037d831bb974283e9a72c1419e82c75627) incorrectly added the maestro postgres output to `output-region.bicep` (regional scope) when it should have been added to the service scope.

**Timeline:**
- Maestro postgres is created by `svc-pipeline` → `svc-cluster.bicep` → `maestro-server.bicep` module
- During the maestro-server migration from Shell+Makefile to Helm native action, the postgres hostname could no longer be queried via `az` CLI
- A Bicep output was added to replace the CLI query, but was incorrectly placed in the regional scope
- The region pipeline's output step runs **before** the svc-pipeline creates the postgres → resource not found

**Why it wasn't caught:**
- Dev environments: Use `maestro.postgres.deploy: false` (containerized postgres), so the postgres resource reference is never evaluated
- Existing prod/stage regions: Postgres already existed from previous deployments, so the `existing` resource reference succeeded
- **New region deployment:** First deployment to a new region since the migration → postgres doesn't exist yet → ERROR

### Solution
Move the postgres output to the correct scope where it's actually created:

1. **Removed** from `output-region.bicep` and `output-region.tmpl.bicepparam`
2. **Added** to `maestro-server-lookup.bicep` and `maestro-server-lookup.tmpl.bicepparam` 
3. **Updated** `maestro/server/pipeline.yaml` to query `databaseHost` from service output instead of regional output

The postgres server is deployed to the regional RG but created during the svc-pipeline execution, so the output must be queried from the service scope (after creation) using cross-RG reference: `scope: resourceGroup(regionalResourceGroup)`.
