### PR TITLE
split listing and use new database layer to list

### DIFF
--- a/frontend/pkg/frontend/helpers.go
+++ b/frontend/pkg/frontend/helpers.go
@@ -316,7 +316,13 @@ func (f *Frontend) MarshalResource(ctx context.Context, resourceID *azcorearm.Re
 			logger.Error(err.Error())
 			return nil, ocm.CSErrorToCloudError(err, resourceID, nil)
 		}
-		responseBody, err = marshalCSNodePool(csNodePool, doc, versionedInterface)
+		internalObj, err := database.ResourceDocumentToInternalAPI[api.HCPOpenShiftClusterNodePool, database.NodePool](doc)
+		if err != nil {
+			logger.Error(err.Error())
+			return nil, arm.NewInternalServerError()
+		}
+
+		responseBody, err = marshalCSNodePool(csNodePool, internalObj, versionedInterface)
 		if err != nil {
 			logger.Error(err.Error())
 			return nil, arm.NewInternalServerError()
@@ -328,7 +334,13 @@ func (f *Frontend) MarshalResource(ctx context.Context, resourceID *azcorearm.Re
 			logger.Error(err.Error())
 			return nil, ocm.CSErrorToCloudError(err, resourceID, nil)
 		}
-		responseBody, err = marshalCSExternalAuth(csExternalAuth, doc, versionedInterface)
+		internalObj, err := database.ResourceDocumentToInternalAPI[api.HCPOpenShiftClusterExternalAuth, database.ExternalAuth](doc)
+		if err != nil {
+			logger.Error(err.Error())
+			return nil, arm.NewInternalServerError()
+		}
+
+		responseBody, err = marshalCSExternalAuth(csExternalAuth, internalObj, versionedInterface)
 		if err != nil {
 			logger.Error(err.Error())
 			return nil, arm.NewInternalServerError()

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -90,19 +90,19 @@ func (f *Frontend) routes(r prometheus.Registerer) http.Handler {
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders, api.ClusterResourceTypeName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceList))
+		postMuxMiddleware.HandlerFunc(f.ArmResourceListClusters))
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, api.ClusterResourceTypeName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceList))
+		postMuxMiddleware.HandlerFunc(f.ArmResourceListClusters))
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, api.NodePoolResourceTypeName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceList))
+		postMuxMiddleware.HandlerFunc(f.ArmResourceListNodePools))
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, api.ExternalAuthResourceTypeName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceList))
+		postMuxMiddleware.HandlerFunc(f.ArmResourceListExternalAuths))
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders, PatternLocations, api.VersionResourceTypeName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceList))
+		postMuxMiddleware.HandlerFunc(f.ArmResourceListVersion))
 
 	// Resource read endpoints
 	postMuxMiddleware = NewMiddleware(

--- a/internal/database/crud_nested_resource.go
+++ b/internal/database/crud_nested_resource.go
@@ -81,7 +81,7 @@ func (d *nestedCosmosResourceCRUD[InternalAPIType, CosmosAPIType]) makeResourceI
 	for _, currIntermediateResource := range d.intermediateResources {
 		parts = append(parts, currIntermediateResource.resourceType.Type, currIntermediateResource.resourceID)
 	}
-	parts = append(parts, d.resourceType.Type)
+	parts = append(parts, d.resourceType.Types[len(d.resourceType.Types)-1])
 
 	if len(resourceID) > 0 {
 		parts = append(parts, resourceID)


### PR DESCRIPTION
This builds on the already merged frontend integration LIST test.  It also builds on the expanded internal API types that contain service provider specific data.

The separation allows usage of the new database client to list for the first time.  One bug showed up on frontend tests and was fixed (path prefixing issue).  The rest fell out as expected.
