### PR TITLE
prepare cs image from new quay repository app-sre/aro-hcp-clusters-service

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -805,7 +805,8 @@ clouds:
       clustersService:
         environment: "arohcpdev"
         image:
-          digest: sha256:6af9be4724b345e040f8f1718870fdcc43a8ece6dbf66d26abdefad243938e6e
+          digest: sha256:7966fb31c657d9ccd6333c40d30079f8fa9ced7cf1d89fcaf784c6f4ba569d30
+          repository: app-sre/aro-hcp-clusters-service
         azureOperatorsManagedIdentities:
           roleSetName: dev
         azureRuntimeConfig:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 5e606f5b4f5e10d58acbe6a48a1f358e5fac4f03acccee73e9a221a94e26aede
+          westus3: 2aab90eece247ff41c51d2b89c5c7e8dd6a287d0e7a7eb258cd3f52dcd8fdd6d
       dev:
         regions:
-          westus3: b5e53644cde2cc0acd908cdeca4cb06ec092a54b728277d9ddb6e15b7d7d66c1
+          westus3: a63b03b35059597a97101aaf6ad8a640c7fb507667ac6fa479436e580fdaf29f
       ntly:
         regions:
-          uksouth: 23cc67a2411cf79b5b7c2ee6e46456c1d33dca5c37bb6c278dbd150db37bba46
+          uksouth: 3e210497572bb859e82023cddf0371ed6c4beb7f9f88d5b3e35f09ee2d60def9
       perf:
         regions:
-          westus3: b80f108c13335d2da86443a0833dc6299128f38f93ec4de18dc75d1eb904c540
+          westus3: 964f9032d9438c7d4980902d5d2a89d435aa9c853a2799d6e8876b6a95dbbb02
       pers:
         regions:
-          westus3: a2c08384cd37243cbfb4208e67f60f4d2b2a2607b84acf7876eca42c617a0778
+          westus3: 5a5d44bae5cca7a11fa24162674cb431a68f87c27ace34482dc09e39e226da24
       swft:
         regions:
-          uksouth: 114cb2556c8b6508966fc726263ed0a36f1c396bef2719bf6be8744983e3772e
+          uksouth: 904cbe1d6e6e92bfce7945232af85e680ebf509ec9b640b200247900f284a40c

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -108,9 +108,9 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:6af9be4724b345e040f8f1718870fdcc43a8ece6dbf66d26abdefad243938e6e
+    digest: sha256:7966fb31c657d9ccd6333c40d30079f8fa9ced7cf1d89fcaf784c6f4ba569d30
     registry: quay.io
-    repository: app-sre/uhc-clusters-service
+    repository: app-sre/aro-hcp-clusters-service
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -108,9 +108,9 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:6af9be4724b345e040f8f1718870fdcc43a8ece6dbf66d26abdefad243938e6e
+    digest: sha256:7966fb31c657d9ccd6333c40d30079f8fa9ced7cf1d89fcaf784c6f4ba569d30
     registry: quay.io
-    repository: app-sre/uhc-clusters-service
+    repository: app-sre/aro-hcp-clusters-service
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -108,9 +108,9 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:6af9be4724b345e040f8f1718870fdcc43a8ece6dbf66d26abdefad243938e6e
+    digest: sha256:7966fb31c657d9ccd6333c40d30079f8fa9ced7cf1d89fcaf784c6f4ba569d30
     registry: quay.io
-    repository: app-sre/uhc-clusters-service
+    repository: app-sre/aro-hcp-clusters-service
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -108,9 +108,9 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:6af9be4724b345e040f8f1718870fdcc43a8ece6dbf66d26abdefad243938e6e
+    digest: sha256:7966fb31c657d9ccd6333c40d30079f8fa9ced7cf1d89fcaf784c6f4ba569d30
     registry: quay.io
-    repository: app-sre/uhc-clusters-service
+    repository: app-sre/aro-hcp-clusters-service
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -108,9 +108,9 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:6af9be4724b345e040f8f1718870fdcc43a8ece6dbf66d26abdefad243938e6e
+    digest: sha256:7966fb31c657d9ccd6333c40d30079f8fa9ced7cf1d89fcaf784c6f4ba569d30
     registry: quay.io
-    repository: app-sre/uhc-clusters-service
+    repository: app-sre/aro-hcp-clusters-service
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -108,9 +108,9 @@ clustersService:
   denyAssignments: disabled
   environment: arohcpdev
   image:
-    digest: sha256:6af9be4724b345e040f8f1718870fdcc43a8ece6dbf66d26abdefad243938e6e
+    digest: sha256:7966fb31c657d9ccd6333c40d30079f8fa9ced7cf1d89fcaf784c6f4ba569d30
     registry: quay.io
-    repository: app-sre/uhc-clusters-service
+    repository: app-sre/aro-hcp-clusters-service
   k8s:
     deploymentStrategy:
       rollingUpdate:


### PR DESCRIPTION
The image is 7966fb31c657d9ccd6333c40d30079f8fa9ced7cf1d89fcaf784c6f4ba569d30 and it is functionally equivalent to the image
6af9be4724b345e040f8f1718870fdcc43a8ece6dbf66d26abdefad243938e6e from app-sre/uhc-clusters-service
