### PR TITLE
prepare update cs image in int using new quay repository app-sre/aro-hcp-clusters-service

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -12,7 +12,8 @@ clouds:
           # Cluster Service
           clustersService:
             image:
-              digest: sha256:6af9be4724b345e040f8f1718870fdcc43a8ece6dbf66d26abdefad243938e6e
+              digest: sha256:7966fb31c657d9ccd6333c40d30079f8fa9ced7cf1d89fcaf784c6f4ba569d30
+              repository: app-sre/aro-hcp-clusters-service
           # ACR Pull
           acrPull:
             image:


### PR DESCRIPTION
The image is 7966fb31c657d9ccd6333c40d30079f8fa9ced7cf1d89fcaf784c6f4ba569d30 and it is functionally equivalent to the image
6af9be4724b345e040f8f1718870fdcc43a8ece6dbf66d26abdefad243938e6e from app-sre/uhc-clusters-service
