### PR TITLE
ARO-22318 migrate container images to azurelinux3.0

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,13 +1,13 @@
 # Base and builder image will need to be replaced by Fips compliant one
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0@sha256:374281fe968134a44bcc7bd4b9e2d55dda61dcaa942fee5dda28cd38d54619cd as builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-azurelinux3.0 as builder
 
 WORKDIR /app/admin
-COPY . . 
+COPY . .
 # https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips#build-option-to-require-fips-mode
 ENV CGO_ENABLED=1 GOFLAGS='-tags=requirefips'
 RUN go build -o aro-hcp-admin
 
-FROM --platform=linux/amd64 mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot@sha256:a5d5928601847a40c81fa397df33136c285866c974bf91ed94d688390fcc33f3
+FROM --platform=linux/amd64 mcr.microsoft.com/azurelinux/distroless/base:3.0
 WORKDIR /
 COPY --from=builder /app/admin/aro-hcp-admin .
 ENTRYPOINT ["/aro-hcp-admin"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,7 @@
 ARG PLATFORM
 
 # Builder image installs tools needed to build aro-hcp-backend
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0 AS builder
-RUN yum install --assumeyes jq
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-azurelinux3.0 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY backend/go.mod backend/go.sum backend/
 RUN cd backend && go mod download
@@ -15,7 +14,7 @@ RUN make --directory backend ARO_HCP_IMAGE_TAG=${TAG} ENV_VARS_FILE=/app/image-e
 
 
 # Deployment image copies aro-hcp-backend from builder image
-FROM --platform=${PLATFORM} mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot
+FROM --platform=${PLATFORM} mcr.microsoft.com/azurelinux/distroless/base:3.0
 WORKDIR /
 COPY --from=builder /app/backend/aro-hcp-backend .
 ARG REVISION

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,7 @@
 ARG PLATFORM
 
 # Base and builder image will need to be replaced by Fips compliant one
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0 AS builder
-RUN yum install --assumeyes jq
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-azurelinux3.0 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY frontend/go.mod frontend/go.sum frontend/
 COPY test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/
@@ -14,7 +13,7 @@ ARG TAG
 ENV CGO_ENABLED=1 GOFLAGS='-tags=requirefips'
 RUN make --directory frontend ARO_HCP_IMAGE_TAG=${TAG} ENV_VARS_FILE=/app/image-environment
 
-FROM --platform=${PLATFORM} mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot
+FROM --platform=${PLATFORM} mcr.microsoft.com/azurelinux/distroless/base:3.0
 WORKDIR /
 COPY --from=builder /app/frontend/aro-hcp-frontend .
 ARG REVISION

--- a/image-sync/oc-mirror/Dockerfile
+++ b/image-sync/oc-mirror/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 mcr.microsoft.com/cbl-mariner/base/core:2.0 AS downloader
+FROM --platform=linux/amd64 mcr.microsoft.com/azurelinux/base/core:3.0 AS downloader
 
 RUN set -eux; \
 # Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating

--- a/test/Containerfile.e2e
+++ b/test/Containerfile.e2e
@@ -1,11 +1,11 @@
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-cbl-mariner2.0 as builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.24-fips-azurelinux3.0 as builder
 
 WORKDIR /app
 COPY test /app/test
 COPY internal /app/internal
 RUN cd test/e2e && make e2etest
 
-FROM --platform=linux/amd64 mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot
+FROM --platform=linux/amd64 mcr.microsoft.com/azurelinux/distroless/base:3.0
 
 WORKDIR /
 ENV SETUP_FILEPATH=/test-artifacts/e2e-setup.json


### PR DESCRIPTION
### What

Azure linux 2.0 is end of life.  Start using the v3.0 images as part of SFI item.  [ARO-22318](https://issues.redhat.com//browse/ARO-22318).  

