### PR TITLE
azure linux 3 non-root

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -8,6 +8,7 @@ ENV CGO_ENABLED=1 GOFLAGS='-tags=requirefips'
 RUN go build -o aro-hcp-admin
 
 FROM --platform=linux/amd64 mcr.microsoft.com/azurelinux/distroless/base:3.0
+USER 65532:65532
 WORKDIR /
 COPY --from=builder /app/admin/aro-hcp-admin .
 ENTRYPOINT ["/aro-hcp-admin"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,7 @@ RUN make --directory backend ARO_HCP_IMAGE_TAG=${TAG} ENV_VARS_FILE=/app/image-e
 
 # Deployment image copies aro-hcp-backend from builder image
 FROM --platform=${PLATFORM} mcr.microsoft.com/azurelinux/distroless/base:3.0
+USER 65532:65532
 WORKDIR /
 COPY --from=builder /app/backend/aro-hcp-backend .
 ARG REVISION

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,6 +14,7 @@ ENV CGO_ENABLED=1 GOFLAGS='-tags=requirefips'
 RUN make --directory frontend ARO_HCP_IMAGE_TAG=${TAG} ENV_VARS_FILE=/app/image-environment
 
 FROM --platform=${PLATFORM} mcr.microsoft.com/azurelinux/distroless/base:3.0
+USER 65532:65532
 WORKDIR /
 COPY --from=builder /app/frontend/aro-hcp-frontend .
 ARG REVISION


### PR DESCRIPTION
### What

make sure that the RP and admin api images run as non-root.
the chosen ID 65532 matches the previous one from the mariner non-root base image

follows up on #3095

### Why

mitigates `Error: container has runAsNonRoot and image will run as root`

### Special notes for your reviewer

<!-- optional -->
