### PR TITLE
maestro: Add registration port to PeerAuthentication

### DIFF
--- a/maestro/server/deploy/templates/maestro.peerauthentication.yaml
+++ b/maestro/server/deploy/templates/maestro.peerauthentication.yaml
@@ -10,3 +10,5 @@ spec:
   portLevelMtls:
     8080:
       mode: PERMISSIVE
+    8000:
+      mode: PERMISSIVE


### PR DESCRIPTION
The registration job was failing because it was not allowed to contact the registration route for maestro in istio. Update the PeerAuthentication to include the 8000 port.

Tested locally, this was getting a connection refused error

```
oc logs -f job/registration-hcp-underlay-lnsjame-mgmt-1 -n maestro
Maestro consumer hcp-underlay-lnsjame-mgmt-1 registered successfully
```