### PR TITLE
fix: don't use globs/wildcards on .dockerignore because podman isn't compatible with them

### DIFF
--- a/backend/Dockerfile.dockerignore
+++ b/backend/Dockerfile.dockerignore
@@ -1,7 +1,12 @@
 **
 !image-environment
-!internal/go.*
-!internal/**/*.go
-!backend/go.*
-!backend/Makefile
-!backend/**/*.go
+!internal/
+!backend/
+
+# https://github.com/containers/podman/discussions/22910
+# !image-environment
+# !internal/go.*
+# !internal/**/*.go
+# !backend/go.*
+# !backend/Makefile
+# !backend/**/*.go

--- a/frontend/Dockerfile.dockerignore
+++ b/frontend/Dockerfile.dockerignore
@@ -1,8 +1,14 @@
 **
 !image-environment
-!internal/go.*
-!internal/**/*.go
-!test/sdk/**/go.*
-!frontend/go.*
-!frontend/Makefile
-!frontend/**/*.go
+!internal/
+!test/sdk/
+!frontend/
+
+# https://github.com/containers/podman/discussions/22910
+# !image-environment
+# !internal/go.*
+# !internal/**/*.go
+# !test/sdk/**/go.*
+# !frontend/go.*
+# !frontend/Makefile
+# !frontend/**/*.go


### PR DESCRIPTION
### What

podman builds fail because `!` + `*` directives end up excluding everything underneath them

```
[1/2] STEP 10/10: RUN make --directory frontend ARO_HCP_IMAGE_TAG=${TAG} ENV_VARS_FILE=/app/image-environment
make: Entering directory '/app/frontend'
go build -ldflags="-X github.com/Azure/ARO-HCP/internal/version.CommitSHA=test-bvesel-8a8e58f-dirty" -o aro-hcp-frontend .
main.go:22:2: github.com/Azure/ARO-HCP/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp@v0.0.0-00010101000000-000000000000 (replaced by ../test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp): reading ../test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod: open /app/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod: no such file or directory
main.go:23:2: github.com/Azure/ARO-HCP/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp@v0.0.0-00010101000000-000000000000 (replaced by ../test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp): reading ../test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod: open /app/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod: no such file or directory
apiversions.go:20:2: github.com/Azure/ARO-HCP/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp@v0.0.0-00010101000000-000000000000 (replaced by ../test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp): reading ../test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod: open /app/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod: no such file or directory
apiversions.go:21:2: github.com/Azure/ARO-HCP/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp@v0.0.0-00010101000000-000000000000 (replaced by ../test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp): reading ../test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod: open /app/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod: no such file or directory
make: *** [Makefile:14: frontend] Error 1
```

### Why

https://github.com/containers/podman/discussions/22910


Can also use inclusive rather than exclusive.  