### PR TITLE
fix: simplify empty namespace check in orphaned-namespace-cleaner

### DIFF
--- a/cluster-service/cspr/orphaned-namespace-cleaner.yaml
+++ b/cluster-service/cspr/orphaned-namespace-cleaner.yaml
@@ -66,8 +66,7 @@ objects:
                 echo "Starting to clear orphaned namespaces"
                 # `select((now - (.metadata.creationTimestamp | fromdate)) / 120 > 120)` selects the namespaces which are older than 120 minutes.
                 NAMESPACES=$(kubectl get namespaces -o json | jq -r '.items[] | select(.metadata.labels."sandbox-jenkins-type"=="aro-hcp") | select((now - (.metadata.creationTimestamp | fromdate)) / 120 > 120) | .metadata.name')
-                NUMBER_OF_NAMESPACES=$(printf "%s" "$NAMESPACES" | wc -l);
-                if [ $NUMBER_OF_NAMESPACES -lt 1 ]; then
+                if [ -z "$NAMESPACES" ]; then
                   echo "no namespaces matching the criteria to delete, exiting"
                   exit 0
                 fi


### PR DESCRIPTION
### What

simplify empty namespace check in orphaned-namespace-cleaner

### Why

The previous implementation using wc -l was returning 0 when NAMESPACES contained one element because wc -l counts newline characters, not lines of content. A single namespace without a trailing newline would result in a count of 0, causing the script to incorrectly proceed with deletion.

Replace with a direct empty string check using [ -z ] which is simpler and correctly handles all cases.

### Special notes for your reviewer

in the cspr SVC cluster there is currently one left over namespace. 
```
sandbox-jenkins-0-aro-hcp    Active   46h
```

The cleaner job ran 
```
oc get pods -n orphaned-namespace-cleaner                                      [13:17:32]
NAME                                        READY   STATUS      RESTARTS   AGE
orphaned-namespace-cleaner-29360160-t8ptq   0/1     Completed   0          2d12h
orphaned-namespace-cleaner-29361600-rp6q8   0/1     Completed   0          36h
orphaned-namespace-cleaner-29363040-flvkz   0/1     Completed   0          12h
```

but it is showing
```
Starting to clear orphaned namespaces
no namespaces matching the criteria to delete, exiting
```
while it should've deleted the left over namespace