### PR TITLE
frontend: Block nested resource requests when parent is provisioning

### DIFF
--- a/frontend/pkg/frontend/helpers_test.go
+++ b/frontend/pkg/frontend/helpers_test.go
@@ -32,6 +32,11 @@ import (
 )
 
 func TestCheckForProvisioningStateConflict(t *testing.T) {
+
+	parentConflictFunc := func(s arm.ProvisioningState) bool {
+		return s == arm.ProvisioningStateProvisioning || s == arm.ProvisioningStateDeleting
+	}
+
 	tests := []struct {
 		name             string
 		resourceID       string
@@ -74,21 +79,21 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 			resourceID:       api.TestNodePoolResourceID,
 			operationRequest: database.OperationRequestCreate,
 			directConflict:   func(s arm.ProvisioningState) bool { return false },
-			parentConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
+			parentConflict:   parentConflictFunc,
 		},
 		{
 			name:             "Delete node pool",
 			resourceID:       api.TestNodePoolResourceID,
 			operationRequest: database.OperationRequestDelete,
 			directConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
-			parentConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
+			parentConflict:   parentConflictFunc,
 		},
 		{
 			name:             "Update node pool",
 			resourceID:       api.TestNodePoolResourceID,
 			operationRequest: database.OperationRequestUpdate,
 			directConflict:   func(s arm.ProvisioningState) bool { return !s.IsTerminal() },
-			parentConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
+			parentConflict:   parentConflictFunc,
 		},
 	}
 


### PR DESCRIPTION
[ARO-22411 - User is able to create a node pool in non-ready cluster](https://issues.redhat.com/browse/ARO-22411)

### What

SSIA

### Why

Previously we were only blocking when the parent was deleting.

### Special notes for your reviewer

Tell me if you think my comment about the `Accepted` state seems reasonable.