### PR TITLE
ARO-21891: Add support for non-stable OpenShift channel groups

### DIFF
--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -29,6 +29,7 @@ import (
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
+	"github.com/Azure/ARO-HCP/internal/admission"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/conversion"
@@ -266,6 +267,16 @@ func (f *Frontend) createHCPCluster(writer http.ResponseWriter, request *http.Re
 	ctx := request.Context()
 	logger := utils.LoggerFromContext(ctx)
 
+	resourceID, err := utils.ResourceIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	subscription, err := f.dbClient.GetSubscriptionDoc(ctx, resourceID.SubscriptionID)
+	if err != nil {
+		return err
+	}
+
 	versionedInterface, err := VersionFromContext(ctx)
 	if err != nil {
 		return utils.TrackError(err)
@@ -282,6 +293,7 @@ func (f *Frontend) createHCPCluster(writer http.ResponseWriter, request *http.Re
 	}
 
 	validationErrs := validation.ValidateClusterCreate(ctx, newInternalCluster, api.Must(versionedInterface.ValidationPathRewriter(&api.HCPOpenShiftCluster{})))
+	validationErrs = append(validationErrs, admission.AdmitClusterOnCreate(ctx, newInternalCluster, subscription)...)
 	if err := arm.CloudErrorFromFieldErrors(validationErrs); err != nil {
 		return utils.TrackError(err)
 	}

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -36,6 +36,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
 	"github.com/Azure/ARO-HCP/frontend/pkg/metrics"
+	"github.com/Azure/ARO-HCP/internal/admission"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/api/v20240610preview"
@@ -588,6 +589,11 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 	ctx := request.Context()
 	logger := utils.LoggerFromContext(ctx)
 
+	subscription, err := f.dbClient.GetSubscriptionDoc(ctx, subscriptionID)
+	if err != nil {
+		return err
+	}
+
 	body, err := BodyFromContext(ctx)
 	if err != nil {
 		return utils.TrackError(err)
@@ -657,6 +663,7 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 			newInternalCluster := &api.HCPOpenShiftCluster{}
 			versionedCluster.Normalize(newInternalCluster)
 			validationErrs := validation.ValidateClusterCreate(ctx, newInternalCluster, api.Must(versionedInterface.ValidationPathRewriter(&api.HCPOpenShiftCluster{})))
+			validationErrs = append(validationErrs, admission.AdmitClusterOnCreate(ctx, newInternalCluster, subscription)...)
 			cloudError = arm.CloudErrorFromFieldErrors(validationErrs)
 
 		case strings.ToLower(api.NodePoolResourceType.String()):

--- a/frontend/test/simulate/artifacts/ClusterMutation/change-channel/expected-errors.txt
+++ b/frontend/test/simulate/artifacts/ClusterMutation/change-channel/expected-errors.txt
@@ -1,2 +1,2 @@
+InvalidRequestContent: properties.version.channelGroup: Forbidden: field is immutable
 InvalidRequestContent: properties.version.id: Required value
-InvalidRequestContent: properties.version.channelGroup: Unsupported value: "updated-channel": supported values: "stable"

--- a/frontend/test/simulate/artifacts/ClusterMutation/some-immutable-field-checks/expected-errors.txt
+++ b/frontend/test/simulate/artifacts/ClusterMutation/some-immutable-field-checks/expected-errors.txt
@@ -18,4 +18,3 @@ InvalidRequestContent: properties.network.networkType: Forbidden: field is immut
 InvalidRequestContent: properties.network.podCidr: Forbidden: field is immutable
 InvalidRequestContent: properties.network.serviceCidr: Forbidden: field is immutable
 InvalidRequestContent: properties.version.id: Forbidden: field is immutable
-InvalidRequestContent: properties.version.id: Invalid value: "illegal-change": Malformed version: illegal-change

--- a/internal/admission/admit_cluster.go
+++ b/internal/admission/admit_cluster.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admission
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/operation"
+	"k8s.io/apimachinery/pkg/api/validate"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/validation"
+)
+
+// AdmitCluster performs non-static checks of cluster.  Checks that require more information than is contained inside of
+// of the cluster instance itself.
+func AdmitClusterOnCreate(ctx context.Context, newVersion *api.HCPOpenShiftCluster, subscription *arm.Subscription) field.ErrorList {
+	op := operation.Operation{Type: operation.Create}
+	errs := admitVersionProfileOnCreate(ctx, &newVersion.CustomerProperties.Version, op, subscription)
+
+	return errs
+}
+
+// admitVersionProfile performs non-static check for a versionProfil of a cluster. This check requires subscription
+func admitVersionProfileOnCreate(ctx context.Context, newVersion *api.VersionProfile, op operation.Operation, subscription *arm.Subscription) field.ErrorList {
+	errs := field.ErrorList{}
+
+	fldPath := field.NewPath("properties", "version")
+	// Check if AllowDevNonStableChannels feature is enabled
+	allowNonStableChannels := subscription != nil && subscription.HasRegisteredFeature(api.FeatureAllowDevNonStableChannels)
+
+	// Version format validation depends on channel group and feature flag
+	if allowNonStableChannels && newVersion.ChannelGroup != "stable" {
+		// For non-stable channels with feature flag: allow full semver format (X.Y.Z-prerelease)
+		errs = append(errs, validation.OpenshiftVersionWithOptionalMicro(ctx, op, fldPath.Child("id"), &newVersion.ID, nil)...)
+	} else {
+		// For stable or without feature flag: only MAJOR.MINOR format
+		errs = append(errs, validation.OpenshiftVersionWithoutMicro(ctx, op, fldPath.Child("id"), &newVersion.ID, nil)...)
+	}
+
+	// Channel group validation based on subscription feature flags
+	if !allowNonStableChannels {
+		// Without feature flag: only "stable" is allowed (empty would have failed static validation)
+		errs = append(errs, validate.Enum(ctx, op, fldPath.Child("channelGroup"), &newVersion.ChannelGroup, nil, sets.New("stable"))...)
+	}
+
+	return errs
+}

--- a/internal/admission/admit_cluster_test.go
+++ b/internal/admission/admit_cluster_test.go
@@ -1,0 +1,336 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admission
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+type expectedError struct {
+	message   string // Expected error message (partial match)
+	fieldPath string // Expected field path for the error
+}
+
+func verifyErrorsMatch(t *testing.T, expectedErrors []expectedError, errs field.ErrorList) {
+	if len(expectedErrors) != len(errs) {
+		t.Errorf("expected %d errors, got %d: %v", len(expectedErrors), len(errs), errs)
+		return
+	}
+
+	// Check that each expected error message and field path is found
+	for _, expectedErr := range expectedErrors {
+		if len(strings.TrimSpace(expectedErr.fieldPath)) == 0 {
+			t.Errorf("expected error with path %s to be non-empty", expectedErr.fieldPath)
+		}
+		if len(strings.TrimSpace(expectedErr.message)) == 0 {
+			t.Errorf("expected error with msg %s to be non-empty", expectedErr.message)
+		}
+
+		found := false
+		for _, err := range errs {
+			messageMatch := strings.Contains(err.Detail, expectedErr.message) || strings.Contains(err.Error(), expectedErr.message)
+			fieldMatch := strings.Contains(err.Field, expectedErr.fieldPath)
+			if messageMatch && fieldMatch {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected error containing message '%s' at field '%s' but not found in: %v", expectedErr.message, expectedErr.fieldPath, errs)
+		}
+	}
+
+	for _, err := range errs {
+		found := false
+		for _, expectedErr := range expectedErrors {
+			messageMatch := strings.Contains(err.Detail, expectedErr.message) || strings.Contains(err.Error(), expectedErr.message)
+			fieldMatch := strings.Contains(err.Field, expectedErr.fieldPath)
+			if messageMatch && fieldMatch {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("actual error '%v' but not found in expected", err)
+		}
+	}
+}
+
+// Helper function to create a valid cluster for testing
+func createValidCluster() *api.HCPOpenShiftCluster {
+	cluster := api.NewDefaultHCPOpenShiftCluster(api.Must(azcorearm.ParseResourceID("/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster")))
+
+	// Set required fields
+	cluster.Location = "eastus"
+	cluster.CustomerProperties.Version.ID = "4.15"
+	cluster.CustomerProperties.Version.ChannelGroup = "stable"
+	cluster.CustomerProperties.DNS.BaseDomainPrefix = "test-cluster"
+	cluster.CustomerProperties.Platform.SubnetID = "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+	cluster.CustomerProperties.Platform.NetworkSecurityGroupID = "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+	cluster.CustomerProperties.Platform.ManagedResourceGroup = "managed-rg"
+
+	return cluster
+}
+
+// Helper function to create a subscription with AllowDevNonStableChannels feature flag
+func createSubscriptionWithNonStableChannels() *arm.Subscription {
+	return &arm.Subscription{
+		State:            arm.SubscriptionStateRegistered,
+		RegistrationDate: ptr.To(time.Now().Format(time.RFC1123)),
+		Properties: &arm.SubscriptionProperties{
+			RegisteredFeatures: &[]arm.Feature{
+				{
+					Name:  ptr.To(api.FeatureAllowDevNonStableChannels),
+					State: ptr.To("Registered"),
+				},
+			},
+		},
+	}
+}
+
+// Helper function to create a subscription without AllowDevNonStableChannels feature flag
+func createStandardSubscription() *arm.Subscription {
+	return &arm.Subscription{
+		State:            arm.SubscriptionStateRegistered,
+		RegistrationDate: ptr.To(time.Now().Format(time.RFC1123)),
+		Properties: &arm.SubscriptionProperties{
+			RegisteredFeatures: &[]arm.Feature{},
+		},
+	}
+}
+
+// Tests for AdmitClusterOnCreate without AllowDevNonStableChannels feature flag
+func TestAdmitClusterOnCreate(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		cluster      *api.HCPOpenShiftCluster
+		subscription *arm.Subscription
+		expectErrors []expectedError
+	}{
+		{
+			name:         "valid cluster with stable channel group",
+			cluster:      createValidCluster(),
+			subscription: createStandardSubscription(),
+			expectErrors: []expectedError{},
+		},
+		{
+			name:         "valid cluster with nil subscription",
+			cluster:      createValidCluster(),
+			subscription: nil,
+			expectErrors: []expectedError{},
+		},
+		{
+			name: "invalid channel group without feature flag - candidate",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ChannelGroup = "candidate"
+				c.CustomerProperties.Version.ID = "4.15"
+				return c
+			}(),
+			subscription: createStandardSubscription(),
+			expectErrors: []expectedError{
+				{message: "supported values: \"stable\"",
+					fieldPath: "properties.version.channelGroup",
+				},
+			},
+		},
+		{
+			name: "invalid channel group without feature flag - fast",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ChannelGroup = "fast"
+				c.CustomerProperties.Version.ID = "4.15"
+				return c
+			}(),
+			subscription: createStandardSubscription(),
+			expectErrors: []expectedError{
+				{message: "supported values: \"stable\"",
+					fieldPath: "properties.version.channelGroup"},
+			},
+		},
+		{
+			name: "invalid channel group without feature flag - nightly",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ChannelGroup = "nightly"
+				c.CustomerProperties.Version.ID = "4.15"
+				return c
+			}(),
+			subscription: createStandardSubscription(),
+			expectErrors: []expectedError{
+				{message: "supported values: \"stable\"",
+					fieldPath: "properties.version.channelGroup"},
+			},
+		},
+		{
+			name: "invalid version with malformed version",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "invalid-version"
+				return c
+			}(),
+			expectErrors: []expectedError{
+				{message: "Malformed version", fieldPath: "properties.version.id"},
+			},
+		},
+		{
+			name: "invalid version format with patch version",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "4.15.1"
+				return c
+			}(),
+			subscription: createStandardSubscription(),
+			expectErrors: []expectedError{
+				{message: "must be specified as MAJOR.MINOR", fieldPath: "properties.version.id"},
+			},
+		},
+		{
+			name: "invalid version format with prerelease",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "4.15.0-rc.1"
+				return c
+			}(),
+			subscription: createStandardSubscription(),
+			expectErrors: []expectedError{
+				{message: "must be specified as MAJOR.MINOR", fieldPath: "properties.version.id"},
+			},
+		},
+
+		{
+			name: "valid cluster with fast channel group",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ChannelGroup = "fast"
+				c.CustomerProperties.Version.ID = "4.17"
+				return c
+			}(),
+			expectErrors: []expectedError{{message: "Unsupported value", fieldPath: "properties.version.channelGroup"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := AdmitClusterOnCreate(ctx, tt.cluster, tt.subscription)
+			verifyErrorsMatch(t, tt.expectErrors, errs)
+		})
+	}
+}
+
+// Tests for AdmitClusterOnCreate with AllowDevNonStableChannels feature flag enabled
+func TestAdmitClusterOnCreateWithNonStableChannels(t *testing.T) {
+	ctx := context.Background()
+	subscription := createSubscriptionWithNonStableChannels()
+
+	tests := []struct {
+		name         string
+		cluster      *api.HCPOpenShiftCluster
+		expectErrors []expectedError
+	}{
+		{
+			name: "valid cluster with candidate channel group and MAJOR.MINOR version",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ChannelGroup = "candidate"
+				c.CustomerProperties.Version.ID = "4.15"
+				return c
+			}(),
+			expectErrors: []expectedError{},
+		},
+		{
+			name: "valid cluster with fast channel group and MAJOR.MINOR version",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ChannelGroup = "fast"
+				c.CustomerProperties.Version.ID = "4.16"
+				return c
+			}(),
+			expectErrors: []expectedError{},
+		},
+		{
+			name: "valid cluster with nightly channel group and full semver",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ChannelGroup = "nightly"
+				c.CustomerProperties.Version.ID = "4.17.0-0.nightly-2024-01-15-123456"
+				return c
+			}(),
+			expectErrors: []expectedError{},
+		},
+		{
+			name: "valid cluster with candidate channel group and prerelease version",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ChannelGroup = "candidate"
+				c.CustomerProperties.Version.ID = "4.15.0-rc.1"
+				return c
+			}(),
+			expectErrors: []expectedError{},
+		},
+		{
+			name: "valid cluster with custom channel group",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ChannelGroup = "custom-channel"
+				c.CustomerProperties.Version.ID = "4.15.0-custom.1"
+				return c
+			}(),
+			expectErrors: []expectedError{},
+		},
+		{
+			name: "stable channel group still requires MAJOR.MINOR version",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ChannelGroup = "stable"
+				c.CustomerProperties.Version.ID = "4.15"
+				return c
+			}(),
+			expectErrors: []expectedError{},
+		},
+		{
+			name: "stable channel group rejects full semver",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ChannelGroup = "stable"
+				c.CustomerProperties.Version.ID = "4.15.1"
+				return c
+			}(),
+			expectErrors: []expectedError{
+				{message: "must be specified as MAJOR.MINOR", fieldPath: "properties.version.id"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := AdmitClusterOnCreate(ctx, tt.cluster, subscription)
+			verifyErrorsMatch(t, tt.expectErrors, errs)
+		})
+	}
+}

--- a/internal/api/arm/subscription.go
+++ b/internal/api/arm/subscription.go
@@ -107,3 +107,22 @@ func ListSubscriptionStates() iter.Seq[SubscriptionState] {
 		SubscriptionStateSuspended,
 	})
 }
+
+// HasRegisteredFeature checks if a subscription has a specific feature registered.
+// The feature name should be in the format "Microsoft.Provider/FeatureName".
+// Returns true if the feature is present and its state is "Registered", false otherwise.
+func (s *Subscription) HasRegisteredFeature(featureName string) bool {
+	if s.Properties == nil || s.Properties.RegisteredFeatures == nil {
+		return false
+	}
+
+	for _, feature := range *s.Properties.RegisteredFeatures {
+		if feature.Name != nil && *feature.Name == featureName {
+			if feature.State != nil && *feature.State == "Registered" {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/internal/api/featureflags.go
+++ b/internal/api/featureflags.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+const (
+	// Feature flag FeatureAllowDevNonStableChannels is the feature in the subscription that
+	// allows the usage of non stable channels (i.e. candidate, nightly) for creation
+	// of new OpenShift clusters.
+	FeatureAllowDevNonStableChannels = "Microsoft.RedHatOpenShift/AllowDevNonStableChannels"
+)

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -597,7 +597,7 @@ func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpC
 			Enabled(csHypershifEnabled)).
 		CCS(arohcpv1alpha1.NewCCS().Enabled(csCCSEnabled)).
 		Version(arohcpv1alpha1.NewVersion().
-			ID(NewOpenShiftVersionXYZ(hcpCluster.CustomerProperties.Version.ID)).
+			ID(NewOpenShiftVersionXYZ(hcpCluster.CustomerProperties.Version.ID, hcpCluster.CustomerProperties.Version.ChannelGroup)).
 			ChannelGroup(hcpCluster.CustomerProperties.Version.ChannelGroup)).
 		Network(arohcpv1alpha1.NewNetwork().
 			Type(string(hcpCluster.CustomerProperties.Network.NetworkType)).
@@ -737,7 +737,7 @@ func BuildCSNodePool(ctx context.Context, nodePool *api.HCPOpenShiftClusterNodeP
 		nodePoolBuilder.
 			ID(strings.ToLower(nodePool.Name)).
 			Version(arohcpv1alpha1.NewVersion().
-				ID(ConvertOpenShiftVersionAddPrefix(nodePool.Properties.Version.ID)).
+				ID(NewOpenShiftVersionXYZ(nodePool.Properties.Version.ID, nodePool.Properties.Version.ChannelGroup)).
 				ChannelGroup(nodePool.Properties.Version.ChannelGroup)).
 			Subnet(nodePool.Properties.Platform.SubnetID).
 			AzureNodePool(arohcpv1alpha1.NewAzureNodePool().

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -159,6 +159,51 @@ func TestConvertCStoHCPOpenShiftCluster(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "converts stable version from CS to RP (X.Y.Z to X.Y)",
+			ocmClusterTweaks: arohcpv1alpha1.NewCluster().
+				Version(arohcpv1alpha1.NewVersion().
+					ID("openshift-v4.19.7").
+					ChannelGroup("stable")),
+			hcpClusterTweaks: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					Version: api.VersionProfile{
+						ID:           "4.19",
+						ChannelGroup: "stable",
+					},
+				},
+			},
+		},
+		{
+			name: "converts nightly version from CS to RP (strips channel suffix)",
+			ocmClusterTweaks: arohcpv1alpha1.NewCluster().
+				Version(arohcpv1alpha1.NewVersion().
+					ID("openshift-v4.19.0-0.nightly-2025-01-01-nightly").
+					ChannelGroup("nightly")),
+			hcpClusterTweaks: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					Version: api.VersionProfile{
+						ID:           "4.19",
+						ChannelGroup: "nightly",
+					},
+				},
+			},
+		},
+		{
+			name: "converts candidate version from CS to RP",
+			ocmClusterTweaks: arohcpv1alpha1.NewCluster().
+				Version(arohcpv1alpha1.NewVersion().
+					ID("openshift-v4.19.1-candidate").
+					ChannelGroup("candidate")),
+			hcpClusterTweaks: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					Version: api.VersionProfile{
+						ID:           "4.19",
+						ChannelGroup: "candidate",
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -183,6 +228,51 @@ func TestWithImmutableAttributes(t *testing.T) {
 			name:       "simple default",
 			hcpCluster: &api.HCPOpenShiftCluster{},
 			want:       ocmCluster(t, ocmClusterDefaults()),
+		},
+		{
+			name: "converts stable version from RP to CS (adds patch and prefix)",
+			hcpCluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					Version: api.VersionProfile{
+						ID:           "4.19",
+						ChannelGroup: "stable",
+					},
+				},
+			},
+			want: ocmCluster(t, ocmClusterDefaults().
+				Version(arohcpv1alpha1.NewVersion().
+					ID("openshift-v4.19.7").
+					ChannelGroup("stable"))),
+		},
+		{
+			name: "converts candidate version from RP to CS (preserves patch)",
+			hcpCluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					Version: api.VersionProfile{
+						ID:           "4.19.19",
+						ChannelGroup: "candidate",
+					},
+				},
+			},
+			want: ocmCluster(t, ocmClusterDefaults().
+				Version(arohcpv1alpha1.NewVersion().
+					ID("openshift-v4.19.19-candidate").
+					ChannelGroup("candidate"))),
+		},
+		{
+			name: "converts nightly version from RP to CS (preserves semver)",
+			hcpCluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					Version: api.VersionProfile{
+						ID:           "4.19.0-0.nightly-2025-01-01",
+						ChannelGroup: "nightly",
+					},
+				},
+			},
+			want: ocmCluster(t, ocmClusterDefaults().
+				Version(arohcpv1alpha1.NewVersion().
+					ID("openshift-v4.19.0-0.nightly-2025-01-01-nightly").
+					ChannelGroup("nightly"))),
 		},
 		{
 			name: "with version 4.19",
@@ -381,6 +471,51 @@ func TestBuildCSNodePool(t *testing.T) {
 						Key("").
 						Value(""),
 				}...),
+		},
+		{
+			name: "converts stable version from RP to CS (adds patch and prefix)",
+			hcpNodePool: getHCPNodePoolResource(
+				func(hsc *api.HCPOpenShiftClusterNodePool) {
+					hsc.Properties.Version = api.NodePoolVersionProfile{
+						ID:           "4.19",
+						ChannelGroup: "stable",
+					}
+				},
+			),
+			expectedCSNodePool: getBaseCSNodePoolBuilder().
+				Version(arohcpv1alpha1.NewVersion().
+					ID("openshift-v4.19.7").
+					ChannelGroup("stable")),
+		},
+		{
+			name: "converts candidate version from RP to CS (adds channel suffix)",
+			hcpNodePool: getHCPNodePoolResource(
+				func(hsc *api.HCPOpenShiftClusterNodePool) {
+					hsc.Properties.Version = api.NodePoolVersionProfile{
+						ID:           "4.19.19",
+						ChannelGroup: "candidate",
+					}
+				},
+			),
+			expectedCSNodePool: getBaseCSNodePoolBuilder().
+				Version(arohcpv1alpha1.NewVersion().
+					ID("openshift-v4.19.19-candidate").
+					ChannelGroup("candidate")),
+		},
+		{
+			name: "converts nightly version from RP to CS with semver",
+			hcpNodePool: getHCPNodePoolResource(
+				func(hsc *api.HCPOpenShiftClusterNodePool) {
+					hsc.Properties.Version = api.NodePoolVersionProfile{
+						ID:           "4.19.0-0.nightly-2025-01-01",
+						ChannelGroup: "nightly",
+					}
+				},
+			),
+			expectedCSNodePool: getBaseCSNodePoolBuilder().
+				Version(arohcpv1alpha1.NewVersion().
+					ID("openshift-v4.19.0-0.nightly-2025-01-01-nightly").
+					ChannelGroup("nightly")),
 		},
 	}
 	for _, tc := range testCases {

--- a/internal/validation/hcpopenshiftcluster_test.go
+++ b/internal/validation/hcpopenshiftcluster_test.go
@@ -51,15 +51,11 @@ func TestClusterRequired(t *testing.T) {
 				},
 				{
 					message:   "Required value",
-					fieldPath: "customerProperties.version.id",
+					fieldPath: "customerProperties.version.channelGroup",
 				},
 				{
 					message:   "Required value",
-					fieldPath: "customerProperties.version.channelGroup",
-				},
-				{
-					message:   "Unsupported value",
-					fieldPath: "customerProperties.version.channelGroup",
+					fieldPath: "customerProperties.version.id",
 				},
 				{
 					message:   "Unsupported value",
@@ -235,38 +231,6 @@ func TestClusterValidate(t *testing.T) {
 			},
 		},
 		{
-			name: "Bad openshift_version",
-			tweaks: &api.HCPOpenShiftCluster{
-				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
-					Version: api.VersionProfile{
-						ID: "bad.version",
-					},
-				},
-			},
-			expectErrors: []expectedError{
-				{
-					message:   "Malformed version",
-					fieldPath: "customerProperties.version.id",
-				},
-			},
-		},
-		{
-			name: "Version cannot be MAJOR.MINOR.PATCH",
-			tweaks: &api.HCPOpenShiftCluster{
-				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
-					Version: api.VersionProfile{
-						ID: "4.18.1",
-					},
-				},
-			},
-			expectErrors: []expectedError{
-				{
-					message:   "must be specified as MAJOR.MINOR; the PATCH value is managed",
-					fieldPath: "customerProperties.version.id",
-				},
-			},
-		},
-		{
 			name: "Bad enum_outboundtype",
 			tweaks: &api.HCPOpenShiftCluster{
 				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
@@ -279,6 +243,22 @@ func TestClusterValidate(t *testing.T) {
 				{
 					message:   "supported values: \"LoadBalancer\"",
 					fieldPath: "customerProperties.platform.outboundType",
+				},
+			},
+		},
+		{
+			name: "Bad required_unless",
+			tweaks: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					Version: api.VersionProfile{
+						ChannelGroup: "fast",
+					},
+				},
+			},
+			expectErrors: []expectedError{
+				{
+					message:   "Required value",
+					fieldPath: "customerProperties.version.id",
 				},
 			},
 		},
@@ -373,26 +353,6 @@ func TestClusterValidate(t *testing.T) {
 				{
 					message:   "must be less than or equal to 26",
 					fieldPath: "customerProperties.network.hostPrefix",
-				},
-			},
-		},
-		{
-			name: "Bad required_unless",
-			tweaks: &api.HCPOpenShiftCluster{
-				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
-					Version: api.VersionProfile{
-						ChannelGroup: "fast",
-					},
-				},
-			},
-			expectErrors: []expectedError{
-				{
-					message:   "Required value",
-					fieldPath: "customerProperties.version.id",
-				},
-				{
-					message:   "supported values: \"stable\"",
-					fieldPath: "customerProperties.version.channelGroup",
 				},
 			},
 		},
@@ -551,23 +511,6 @@ func TestClusterValidate(t *testing.T) {
 		// Complex multi-field validation
 		//--------------------------------
 
-		{
-			name: "Cluster with invalid channel group",
-			tweaks: &api.HCPOpenShiftCluster{
-				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
-					Version: api.VersionProfile{
-						ID:           "4.99",
-						ChannelGroup: "freshmeat",
-					},
-				},
-			},
-			expectErrors: []expectedError{
-				{
-					message:   "supported values: \"stable\"",
-					fieldPath: "customerProperties.version.channelGroup",
-				},
-			},
-		},
 		{
 			name: "Cluster with overlapping machine and service CIDRs",
 			tweaks: &api.HCPOpenShiftCluster{

--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/api/safe"
 	"k8s.io/apimachinery/pkg/api/validate"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -345,26 +344,28 @@ func validateClusterServiceProviderProperties(ctx context.Context, op operation.
 }
 
 var (
-	toVersionID = func(oldObj *api.VersionProfile) *string { return &oldObj.ID }
+	toVersionID    = func(oldObj *api.VersionProfile) *string { return &oldObj.ID }
+	toChannelGroup = func(oldObj *api.VersionProfile) *string { return &oldObj.ChannelGroup }
 )
 
 // Version                 VersionProfile              `json:"version,omitempty"`
 func validateVersionProfile(ctx context.Context, op operation.Operation, fldPath *field.Path, newObj, oldObj *api.VersionProfile) field.ErrorList {
 	errs := field.ErrorList{}
 
-	// ID           string `json:"id,omitempty"`
+	// Version should be immutable once is created
+	// additional validations may depend on the subscription, hence they will be done in the admission package
+	// ID           string `json:"id,omitempty"
 	errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath.Child("id"), &newObj.ID, safe.Field(oldObj, toVersionID))...)
+
+	// ChannelGroup string `json:"channelGroup,omitempty"`
+	errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath.Child("channelGroup"), &newObj.ChannelGroup, safe.Field(oldObj, toChannelGroup))...)
+
+	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("channelGroup"), &newObj.ChannelGroup, nil)...)
+
+	// Version ID is required for non-stable channel groups
 	if newObj.ChannelGroup != "stable" {
 		errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("id"), &newObj.ID, nil)...)
 	}
-	errs = append(errs, OpenshiftVersionWithoutMicro(ctx, op, fldPath.Child("id"), &newObj.ID, nil)...)
-
-	// ChannelGroup string `json:"channelGroup,omitempty"`
-	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("channelGroup"), &newObj.ChannelGroup, nil)...)
-	// XXX For now, "stable" is the only accepted value. In the future, we may
-	//     allow unlocking other channel groups through Azure Feature Exposure
-	//     Control (AFEC) flags or some other mechanism.
-	errs = append(errs, validate.Enum(ctx, op, fldPath.Child("channelGroup"), &newObj.ChannelGroup, nil, sets.New("stable"))...)
 
 	return errs
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-21891

## What

  Add support for creating ARO-HCP clusters using non-stable OpenShift
  channel groups (candidate, nightly) when the
  AllowDevNonStableChannels Azure Feature Exposure Control (AFEC) flag is
  registered on the subscription.

## Why
ARO-HCP developers currently can only provision clusters using stable OpenShift release channels. This limitation prevents early testing of upcoming OpenShift features and fixes. By enabling non-stable channel access for authorized developer subscriptions, the team can develop with early access OpenShift images.

### Key changes
  Key Changes Made:

  1. Validation Layer (internal/validation/validate_cluster.go) static validation
  - Make channelGroup an immutable field (it will not allow to update clusters with a different channel group)
  2.  Admission Layer (internal/admission/admit_cluster.go)
  For cluster creation.
  - Added subscription parameter to admission functions to check for AllowDevNonStableChannels AFEC flag
  - When feature flag is enabled:
    - Allow ANY channel group (not restricted to stable/candidate/nightly/fast)
    - Allow full semver format (X.Y.Z-prerelease) for version.id
  - Without feature flag: Only "stable" channel group allowed with X.Y format
  3. Update frontend to also call admission validation during cluster creation
  4. OCM Conversion Layer (internal/ocm/client.go and convert.go)
  - Updated NewOpenShiftVersionXYZ() to format versions as:
    - For stable: openshift-v4.18.7 (no channel group suffix)
    - For non-stable: openshift-v4.15.1-candidate (with channel group suffix)
  - Applied to both cluster and node pool conversions
  - Fixed edge case where empty inputs would produce "-" instead of ""
  - Only appends default patch ".7" for X.Y format inputs
  5. Test Updates
  - Updated comprehensive validation tests (validate_cluster_comprehensive_test.go)
  - Updated frontend node pool test to use the new version formatting
  - Updated convert_test to add channel-group cases different than stable
  - Created admit_cluster tests to check admission validation.
  
  Behavior:

  With AllowDevNonStableChannels AFEC flag enabled:
  {
    "version": {
      "id": "4.15.1",           // Full semver allowed
      "channelGroup": "candidate"  // Any channel group allowed
    }
  }
  → Sends to OCM as: openshift-v4.15.7-candidate

  Without feature flag (default):
  {
    "version": {
      "id": "4.15",            // X.Y format only
      "channelGroup": "stable"     // Only "stable" allowed
    }
  }
  → Sends to OCM as: openshift-v4.15.7

## Requirements:

## Future work:
- fuzz tests (?)
- e2e jobs (?)

(Updated with recent changes https://github.com/Azure/ARO-HCP/pull/3140#issuecomment-3528368060)