### PR TITLE
fix/msft-overlays

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -167,6 +167,10 @@ clouds:
           backend:
             image:
               digest: "sha256:e4ea396bd51af4be33d4b6c53d635aff15ff39d8777a9a64705150bca2bfe905"
+          # Admin API
+          adminApi:
+            image:
+              digest: "sha256:da53a468fd70ddddfd21c23115ef709e2dece6d8e19f5161e417b878f80917a6"
           # Hypershift
           hypershift:
             image:
@@ -252,6 +256,10 @@ clouds:
           backend:
             image:
               digest: "sha256:e4ea396bd51af4be33d4b6c53d635aff15ff39d8777a9a64705150bca2bfe905"
+          # Admin API
+          adminApi:
+            image:
+              digest: "sha256:da53a468fd70ddddfd21c23115ef709e2dece6d8e19f5161e417b878f80917a6"
           # Hypershift
           hypershift:
             image:


### PR DESCRIPTION
Fixes several errors in the Microsoft envs cnofig overlay that are causing errors in sdp-pipelines config validation and preventing merges to main there.
