### PR TITLE
Add pod antiAffinity rules to deployments to prefer scheduling highly available or on different nodes

### DIFF
--- a/backend/deploy/templates/backend.deployment.yaml
+++ b/backend/deploy/templates/backend.deployment.yaml
@@ -23,6 +23,21 @@ spec:
         app: aro-hcp-backend
         azure.workload.identity/use: "true"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: aro-hcp-backend
+              topologyKey: topology.kubernetes.io/zone
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: aro-hcp-backend
+              topologyKey: kubernetes.io/hostname
       serviceAccountName: '{{ .Values.serviceAccount.name }}'
       containers:
       - name: aro-hcp-backend

--- a/cluster-service/deploy/templates/deployment.yaml
+++ b/cluster-service/deploy/templates/deployment.yaml
@@ -28,6 +28,21 @@ spec:
         checksum/cloudres: '{{ include (print $.Template.BasePath "/cloud-resources-config.configmap.yaml") . | sha256sum }}'
         checksum/sa: '{{ include (print $.Template.BasePath "/serviceaccount.yaml") . | sha256sum }}'
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: clusters-service
+              topologyKey: topology.kubernetes.io/zone
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: clusters-service
+              topologyKey: kubernetes.io/hostname
       serviceAccount: '{{ .Values.serviceAccountName }}'
       serviceAccountName: '{{ .Values.serviceAccountName }}'
       volumes:

--- a/frontend/deploy/templates/frontend.deployment.yaml
+++ b/frontend/deploy/templates/frontend.deployment.yaml
@@ -23,6 +23,21 @@ spec:
         app: aro-hcp-frontend
         azure.workload.identity/use: "true"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: aro-hcp-frontend
+              topologyKey: topology.kubernetes.io/zone
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: aro-hcp-frontend
+              topologyKey: kubernetes.io/hostname
       serviceAccountName: '{{ .Values.serviceAccount.name }}'
       containers:
       - name: aro-hcp-frontend

--- a/istio/deploy/charts/mise/templates/deployment.yaml
+++ b/istio/deploy/charts/mise/templates/deployment.yaml
@@ -13,6 +13,21 @@ spec:
       labels:
         app: mise
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: mise
+              topologyKey: topology.kubernetes.io/zone
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: mise
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: mise
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"

--- a/maestro/agent/deploy/templates/maestro-agent.deployment.yaml
+++ b/maestro/agent/deploy/templates/maestro-agent.deployment.yaml
@@ -18,6 +18,21 @@ spec:
         checksum/credsstore: '{{ include (print $.Template.BasePath "/maestro.secretproviderclass.yaml") . | sha256sum }}'
         checksum/config: '{{ include (print $.Template.BasePath "/maestro.secret.yaml") . | sha256sum }}'
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: maestro-agent
+              topologyKey: topology.kubernetes.io/zone
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: maestro-agent
+              topologyKey: kubernetes.io/hostname
       initContainers:
       - name: init
         image: "{{ .Values.sideCar.image.registry }}/{{ .Values.sideCar.image.repository }}@{{ .Values.sideCar.image.digest }}"

--- a/maestro/server/deploy/templates/maestro.deployment.yaml
+++ b/maestro/server/deploy/templates/maestro.deployment.yaml
@@ -25,6 +25,21 @@ spec:
         checksum/config: '{{ include (print $.Template.BasePath "/maestro.secret.yaml") . | sha256sum }}'
         checksum/db: '{{ include (print $.Template.BasePath "/pg.secret.yaml") . | sha256sum }}'
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: maestro
+              topologyKey: topology.kubernetes.io/zone
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: maestro
+              topologyKey: kubernetes.io/hostname
       serviceAccountName: '{{ .Values.maestro.serviceAccount }}'
       volumes:
       - name: db

--- a/observability/prometheus/deploy/templates/prometheus.yaml
+++ b/observability/prometheus/deploy/templates/prometheus.yaml
@@ -15,6 +15,20 @@ spec:
             operator: In
             values:
             - infra
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+          topologyKey: topology.kubernetes.io/zone
+      - weight: 50
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+          topologyKey: kubernetes.io/hostname
   automountServiceAccountToken: true
   enableAdminAPI: false
   evaluationInterval: 30s


### PR DESCRIPTION
### What
Add pod anti affinity rules (preferred, not required) to deployments which run more than one replica.  

### Why

If pods end up scheduling on the same node and that node falls over, the service will go down temporarily while pods reschedule.  

### Special notes for your reviewer
🚢 