### PR TITLE
tooling: add a charting CLI for deployment timing

### DIFF
--- a/tooling/templatize/cmd/entrypoint/cmd.go
+++ b/tooling/templatize/cmd/entrypoint/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/templatize/cmd/entrypoint/cleanup"
 	"github.com/Azure/ARO-HCP/tooling/templatize/cmd/entrypoint/graph"
 	"github.com/Azure/ARO-HCP/tooling/templatize/cmd/entrypoint/run"
+	"github.com/Azure/ARO-HCP/tooling/templatize/cmd/entrypoint/visualize"
 )
 
 func NewCommand() (*cobra.Command, error) {
@@ -38,6 +39,7 @@ func NewCommand() (*cobra.Command, error) {
 		run.NewCommand,
 		graph.NewCommand,
 		cleanup.NewCommand,
+		visualize.NewCommand,
 	}
 	for _, newCmd := range commands {
 		c, err := newCmd()

--- a/tooling/templatize/cmd/entrypoint/visualize/cmd.go
+++ b/tooling/templatize/cmd/entrypoint/visualize/cmd.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package visualize
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/azauth"
+)
+
+func NewCommand() (*cobra.Command, error) {
+	opts := DefaultOptions()
+	cmd := &cobra.Command{
+		Use:           "visualize",
+		Short:         "Generate visualizations of executing timing.",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return Visualize(cmd.Context(), opts)
+		},
+	}
+	if err := BindOptions(opts, cmd); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
+func Visualize(ctx context.Context, opts *RawOptions) error {
+	validated, err := opts.Validate()
+	if err != nil {
+		return err
+	}
+	completed, err := validated.Complete()
+	if err != nil {
+		return err
+	}
+	err = azauth.SetupAzureAuth(ctx)
+	if err != nil {
+		return err
+	}
+	return completed.Visualize(ctx)
+}

--- a/tooling/templatize/cmd/entrypoint/visualize/options.go
+++ b/tooling/templatize/cmd/entrypoint/visualize/options.go
@@ -1,0 +1,275 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package visualize
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/go-echarts/go-echarts/v2/charts"
+	"github.com/go-echarts/go-echarts/v2/opts"
+	"github.com/go-echarts/go-echarts/v2/render"
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/pipeline"
+)
+
+func DefaultOptions() *RawOptions {
+	return &RawOptions{}
+}
+
+func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
+	cmd.Flags().StringVar(&opts.TimingInputFile, "timing-input", opts.TimingInputFile, "Path to the file holding timing outputs from an entrypoint run.")
+	cmd.Flags().StringVar(&opts.OutputFile, "output", opts.OutputFile, "Path to the file where visualizations will be written.")
+
+	return nil
+}
+
+type RawOptions struct {
+	TimingInputFile string
+	OutputFile      string
+}
+
+// validatedOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
+type validatedOptions struct {
+	*RawOptions
+}
+
+type ValidatedOptions struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*validatedOptions
+}
+
+// completedOptions is a private wrapper that enforces a call of Complete() before config generation can be invoked.
+type completedOptions struct {
+	Times      []NodeInfo
+	OutputFile string
+}
+
+type Options struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*completedOptions
+}
+
+func (o *RawOptions) Validate() (*ValidatedOptions, error) {
+	for _, item := range []struct {
+		flag  string
+		name  string
+		value *string
+	}{
+		{flag: "timing-input", name: "timing input file", value: &o.TimingInputFile},
+		{flag: "output", name: "output file", value: &o.OutputFile},
+	} {
+		if item.value == nil || *item.value == "" {
+			return nil, fmt.Errorf("the %s must be provided with --%s", item.name, item.flag)
+		}
+	}
+
+	return &ValidatedOptions{
+		validatedOptions: &validatedOptions{
+			RawOptions: o,
+		},
+	}, nil
+}
+
+func (o *ValidatedOptions) Complete() (*Options, error) {
+	rawTiming, err := os.ReadFile(o.TimingInputFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read timing input file: %w", err)
+	}
+
+	var rawTimes []pipeline.NodeInfo
+	if err := yaml.Unmarshal(rawTiming, &rawTimes); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal timing input file: %w", err)
+	}
+
+	var times []NodeInfo
+	for _, item := range rawTimes {
+		q, err := time.Parse(time.RFC3339Nano, item.Info.QueuedAt)
+		if err != nil {
+			return nil, fmt.Errorf("%s: failed to parse queue date: %w", item.Identifier, err)
+		}
+		s, err := time.Parse(time.RFC3339Nano, item.Info.StartedAt)
+		if err != nil {
+			return nil, fmt.Errorf("%s: failed to parse start date: %w", item.Identifier, err)
+		}
+		f, err := time.Parse(time.RFC3339Nano, item.Info.FinishedAt)
+		if err != nil {
+			return nil, fmt.Errorf("%s: failed to parse finish date: %w", item.Identifier, err)
+		}
+		times = append(times, NodeInfo{
+			Identifier: item.Identifier,
+			Info: ExecutionInfo{
+				QueuedAt:   q,
+				StartedAt:  s,
+				FinishedAt: f,
+			},
+		})
+	}
+
+	return &Options{
+		completedOptions: &completedOptions{
+			Times:      times,
+			OutputFile: o.OutputFile,
+		},
+	}, nil
+}
+
+type NodeInfo struct {
+	Identifier pipeline.Identifier
+	Info       ExecutionInfo
+}
+
+type ExecutionInfo struct {
+	QueuedAt   time.Time
+	StartedAt  time.Time
+	FinishedAt time.Time
+}
+
+func (o *Options) Visualize(ctx context.Context) error {
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	slices.SortFunc(o.Times, func(a, b NodeInfo) int {
+		t := a.Info.QueuedAt.Compare(b.Info.QueuedAt)
+		if t != 0 {
+			return t
+		}
+		return strings.Compare(a.Identifier.String(), b.Identifier.String())
+	})
+
+	startTime := o.Times[0].Info.QueuedAt
+
+	var names []string
+	var highWaterMark []opts.BarData
+	var bars []opts.BarData
+	for _, item := range o.Times {
+		if item.Info.FinishedAt.Sub(item.Info.StartedAt) < time.Second {
+			continue
+		}
+
+		names = append(names, item.Identifier.String())
+		highWaterMark = append(highWaterMark, opts.BarData{
+			Value: item.Info.StartedAt.Sub(startTime).Seconds(),
+			Tooltip: &opts.Tooltip{
+				Show: ptr.To(false),
+			},
+		})
+		bars = append(bars, opts.BarData{
+			Value: item.Info.FinishedAt.Sub(item.Info.StartedAt).Seconds(),
+		})
+	}
+
+	waterfall := charts.NewBar()
+	waterfall.SetGlobalOptions(
+		charts.WithInitializationOpts(opts.Initialization{
+			PageTitle: "Timing Analysis",
+			Renderer:  "svg",
+			Height:    "1024px",
+		}),
+		charts.WithTitleOpts(opts.Title{
+			Title:      "ARO HCP entrypoint/Region Deployment Timing",
+			TitleStyle: &opts.TextStyle{Align: "left"},
+			TextAlign:  "left",
+			Left:       "center",
+		}),
+		charts.WithTooltipOpts(opts.Tooltip{
+			Trigger: "axis",
+			AxisPointer: &opts.AxisPointer{
+				Type: "shadow",
+			},
+		}),
+		charts.WithLegendOpts(opts.Legend{Show: ptr.To(false)}),
+		charts.WithYAxisOpts(opts.YAxis{Show: ptr.To(false)}),
+		charts.WithXAxisOpts(opts.XAxis{AxisLabel: &opts.AxisLabel{Rotate: -22.5}}),
+	)
+	waterfall.AddJSFuncStrs(
+		opts.FuncOpts(render.EchartsInstancePlaceholder+`.setOption({"xAxis": {"axisLabel": {"formatter": `+axisFormatter(startTime)+`}}});`),
+		opts.FuncOpts(render.EchartsInstancePlaceholder+`.setOption({"tooltip": {"formatter": `+valueFormatter+`}});`),
+	)
+	waterfall.SetXAxis(names).
+		AddSeries("Placeholder", highWaterMark,
+			charts.WithBarChartOpts(opts.BarChart{
+				Stack: "total",
+			}),
+			charts.WithItemStyleOpts(opts.ItemStyle{
+				BorderColor: "transparent",
+				Color:       "transparent",
+			})).
+		AddSeries("Step Timing", bars,
+			charts.WithBarChartOpts(opts.BarChart{
+				Stack: "total",
+			})).
+		XYReversal()
+
+	output, err := os.Create(o.OutputFile)
+	if err != nil {
+		return fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer func() {
+		if err := output.Close(); err != nil {
+			logger.Error(err, "failed to close output file")
+		}
+	}()
+	if err := waterfall.Render(output); err != nil {
+		return fmt.Errorf("failed to render output: %w", err)
+	}
+
+	logger.Info("Created visualization.", "output", o.OutputFile)
+	return nil
+}
+
+const valueFormatter = `(params) => {
+	const totalSeconds = params[1].value;
+    
+	const hours = Math.floor(totalSeconds / (60 * 60));
+    const minutes = Math.floor((totalSeconds % (60 * 60)) / (60));
+    const seconds = Math.floor(totalSeconds % (60));
+
+    let result = '';
+    if (hours > 0) {
+        result += ` + "`${hours}h`" + `;
+    }
+    if (minutes > 0 || hours > 0) {
+        result += ` + "`${minutes}m`" + `;
+    }
+    result += ` + "`${seconds}s`" + `;
+    return params[1].name + ": " + result;
+}`
+
+func axisFormatter(base time.Time) string {
+	return `(value, index) => {
+    const baseDate = new Date('` + base.Format(time.RFC3339) + `');
+    const resultDate = new Date(baseDate.getTime() + value * 1000);
+	const options = {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        timeZoneName: 'short'
+    };
+    return resultDate.toLocaleTimeString('en-US', options);
+}`
+}

--- a/tooling/templatize/go.mod
+++ b/tooling/templatize/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/dusted-go/logging v1.3.0
+	github.com/go-echarts/go-echarts/v2 v2.6.5
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0

--- a/tooling/templatize/go.sum
+++ b/tooling/templatize/go.sum
@@ -139,6 +139,8 @@ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sa
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/geoberle/helm/v4 v4.0.0-20251102095138-e64345e0f7ed h1:HHlCYK8mQpgdAblF72xDU2OvoL44N2mHidtwYnsfmas=
 github.com/geoberle/helm/v4 v4.0.0-20251102095138-e64345e0f7ed/go.mod h1:G1Y5AE+lJPQSAjh7nbXnhZrtGtxo+I6POSu9DruYiGI=
+github.com/go-echarts/go-echarts/v2 v2.6.5 h1:f6h2Yt8j8G2profitrlhZvE7mJe6iAI7vYmG2Qqil+M=
+github.com/go-echarts/go-echarts/v2 v2.6.5/go.mod h1:Z+spPygZRIEyqod69r0WMnkN5RV3MwhYDtw601w3G8w=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs=

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -133,6 +133,10 @@ type Identifier struct {
 	Step          string `json:"step"`
 }
 
+func (i Identifier) String() string {
+	return fmt.Sprintf("%s/%s/%s", i.ServiceGroup, i.ResourceGroup, i.Step)
+}
+
 func RunPipeline(service *topology.Service, pipeline *types.Pipeline, ctx context.Context, options *PipelineRunOptions, executor Executor) (Outputs, error) {
 	logger, err := logr.FromContext(ctx)
 	if err != nil {


### PR DESCRIPTION
This new `templatize entrypoint visualize` command uses the Go bindings to the Apache E-Charts library in order to create an interactive waterfall chart of the deployment of a local/personal environment. We can use this visualization tool to investigate why it takes so long to deploy a region.

Example visualization:
[visualization.html](https://github.com/user-attachments/files/23264879/visualization.html)
