### PR TITLE
Migrate to topologyConstraints instead of anti affinity

### DIFF
--- a/admin/deploy/templates/admin.deployment.yaml
+++ b/admin/deploy/templates/admin.deployment.yaml
@@ -22,22 +22,20 @@ spec:
         app: admin-api
         azure.workload.identity/use: "true"
     spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: '{{ if eq (int .Values.deployment.zoneCount) 0 }}kubernetes.azure.com/agentpool{{ else }}topology.kubernetes.io/zone{{ end }}'
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: admin-api
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: admin-api
       serviceAccountName: {{ .Values.serviceAccount.name }}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: admin-api
-              topologyKey: topology.kubernetes.io/zone
-          - weight: 50
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: admin-api
-              topologyKey: kubernetes.io/hostname
       containers:
       - name: service
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"

--- a/admin/values.yaml
+++ b/admin/values.yaml
@@ -7,6 +7,7 @@ deployment:
   limits:
     cpu: 1
     memory: 1Gi
+  zoneCount: {{ .azureRegionAvailabilityZoneCount }}
 serviceAccount:
   name: "{{ .adminApi.k8s.serviceAccountName }}"
   workloadIdentityClientId: "__adminApiMsiClientId__"

--- a/backend/deploy/templates/backend.deployment.yaml
+++ b/backend/deploy/templates/backend.deployment.yaml
@@ -23,21 +23,19 @@ spec:
         app: aro-hcp-backend
         azure.workload.identity/use: "true"
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: aro-hcp-backend
-              topologyKey: topology.kubernetes.io/zone
-          - weight: 50
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: aro-hcp-backend
-              topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: '{{ if eq (int .Values.deployment.zoneCount) 0 }}kubernetes.azure.com/agentpool{{ else }}topology.kubernetes.io/zone{{ end }}'
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: aro-hcp-backend
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: aro-hcp-backend
       serviceAccountName: '{{ .Values.serviceAccount.name }}'
       containers:
       - name: aro-hcp-backend

--- a/backend/deploy/testdata/zz_fixture_TestHelmTemplate_backend_dev.yaml
+++ b/backend/deploy/testdata/zz_fixture_TestHelmTemplate_backend_dev.yaml
@@ -100,21 +100,19 @@ spec:
         app: aro-hcp-backend
         azure.workload.identity/use: "true"
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: aro-hcp-backend
-              topologyKey: topology.kubernetes.io/zone
-          - weight: 50
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: aro-hcp-backend
-              topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: 'topology.kubernetes.io/zone'
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: aro-hcp-backend
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: aro-hcp-backend
       serviceAccountName: 'backend'
       containers:
       - name: aro-hcp-backend

--- a/backend/values.yaml
+++ b/backend/values.yaml
@@ -11,6 +11,7 @@ configMap:
 deployment:
   replicas: {{ .backend.k8s.replicas }}
   imageName: "{{ .acr.svc.name }}.azurecr.io/{{ .backend.image.repository }}@{{ .backend.image.digest }}"
+  zoneCount: {{ .azureRegionAvailabilityZoneCount }}
 serviceAccount:
   name: "{{ .backend.k8s.serviceAccountName }}"
   workloadIdentityClientId: "__backendMsiClientId__"

--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -92,7 +92,8 @@ deploy:
 	  --set ocpVersions.defaultVersion.version=${OCP_VERSIONS_DEFAULT_VERSION_VERSION} \
 	  --set ocpVersions.channelGroups.stable.minVersion=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MIN_VERSION} \
 	  --set ocpVersions.channelGroups.stable.maxVersion=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MAX_VERSION} \
-	  --set azureOperatorsMI.roleSetName=${OPERATOR_ROLE_SET_NAME}
+	  --set azureOperatorsMI.roleSetName=${OPERATOR_ROLE_SET_NAME} \
+	  --set deployment.zoneCount=${AVAILABILITY_ZONE_COUNT}
 
 deploy-pr-env-deps:
 	AZURE_CS_MI_CLIENT_ID=$(shell az identity show -g ${RESOURCEGROUP} -n clusters-service --query clientId -o tsv) && \

--- a/cluster-service/deploy/templates/deployment.yaml
+++ b/cluster-service/deploy/templates/deployment.yaml
@@ -28,21 +28,19 @@ spec:
         checksum/cloudres: '{{ include (print $.Template.BasePath "/cloud-resources-config.configmap.yaml") . | sha256sum }}'
         checksum/sa: '{{ include (print $.Template.BasePath "/serviceaccount.yaml") . | sha256sum }}'
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: clusters-service
-              topologyKey: topology.kubernetes.io/zone
-          - weight: 50
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: clusters-service
-              topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: '{{ if eq (int .Values.deployment.zoneCount) 0 }}kubernetes.azure.com/agentpool{{ else }}topology.kubernetes.io/zone{{ end }}'
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: clusters-service
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: clusters-service
       serviceAccount: '{{ .Values.serviceAccountName }}'
       serviceAccountName: '{{ .Values.serviceAccountName }}'
       volumes:

--- a/cluster-service/deploy/values.yaml
+++ b/cluster-service/deploy/values.yaml
@@ -306,3 +306,5 @@ ocpVersions:
       url: ""
       minVersion: ""
       maxVersion: ""
+deployment:
+  zoneCount: ""

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -177,6 +177,8 @@ resourceGroups:
       configRef: clustersService.tracing.address
     - name: TLS_CERTIFICATES_ISSUER
       configRef: clustersService.azureRuntimeConfig.tlsCertificatesIssuer
+    - name: AVAILABILITY_ZONE_COUNT
+      configRef: azureRegionAvailabilityZoneCount
     shellIdentity:
       input:
         resourceGroup: global

--- a/frontend/deploy/templates/frontend.deployment.yaml
+++ b/frontend/deploy/templates/frontend.deployment.yaml
@@ -23,21 +23,19 @@ spec:
         app: aro-hcp-frontend
         azure.workload.identity/use: "true"
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: aro-hcp-frontend
-              topologyKey: topology.kubernetes.io/zone
-          - weight: 50
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: aro-hcp-frontend
-              topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: '{{ if eq (int .Values.deployment.zoneCount) 0 }}kubernetes.azure.com/agentpool{{ else }}topology.kubernetes.io/zone{{ end }}'
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: aro-hcp-frontend
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: aro-hcp-frontend
       serviceAccountName: '{{ .Values.serviceAccount.name }}'
       containers:
       - name: aro-hcp-frontend

--- a/frontend/deploy/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
+++ b/frontend/deploy/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
@@ -94,21 +94,19 @@ spec:
         app: aro-hcp-frontend
         azure.workload.identity/use: "true"
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: aro-hcp-frontend
-              topologyKey: topology.kubernetes.io/zone
-          - weight: 50
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: aro-hcp-frontend
-              topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: 'topology.kubernetes.io/zone'
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: aro-hcp-frontend
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: aro-hcp-frontend
       serviceAccountName: 'frontend'
       containers:
       - name: aro-hcp-frontend

--- a/frontend/deploy/testdata/zz_fixture_TestHelmTemplate_frontend_dev.yaml
+++ b/frontend/deploy/testdata/zz_fixture_TestHelmTemplate_frontend_dev.yaml
@@ -94,21 +94,19 @@ spec:
         app: aro-hcp-frontend
         azure.workload.identity/use: "true"
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: aro-hcp-frontend
-              topologyKey: topology.kubernetes.io/zone
-          - weight: 50
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: aro-hcp-frontend
-              topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: 'topology.kubernetes.io/zone'
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: aro-hcp-frontend
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: aro-hcp-frontend
       serviceAccountName: 'frontend'
       containers:
       - name: aro-hcp-frontend

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -13,6 +13,7 @@ credsKeyVault:
 deployment:
   replicas: {{ .frontend.k8s.replicas }}
   imageName: "{{ .acr.svc.name }}.azurecr.io/{{ .frontend.image.repository }}@{{ .frontend.image.digest }}"
+  zoneCount: {{ .azureRegionAvailabilityZoneCount }}
 serviceAccount:
   name: "{{ .frontend.k8s.serviceAccountName }}"
   workloadIdentityClientId: "__frontendMsiClientId__"

--- a/istio/deploy/charts/mise/templates/deployment.yaml
+++ b/istio/deploy/charts/mise/templates/deployment.yaml
@@ -13,21 +13,19 @@ spec:
       labels:
         app: mise
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: mise
-              topologyKey: topology.kubernetes.io/zone
-          - weight: 50
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: mise
-              topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: '{{ if eq (int .Values.deployment.zoneCount) 0 }}kubernetes.azure.com/agentpool{{ else }}topology.kubernetes.io/zone{{ end }}'
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: mise
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: mise
       containers:
       - name: mise
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"

--- a/istio/deploy/charts/mise/values.yaml
+++ b/istio/deploy/charts/mise/values.yaml
@@ -10,3 +10,5 @@ armAppId: ""
 tracing:
   address: ""
   exporter: ""
+deployment:
+  zoneCount: ""

--- a/istio/values.yaml
+++ b/istio/values.yaml
@@ -15,3 +15,5 @@ mise:
   tracing:
     address: "{{ .mise.tracing.address }}"
     exporter: "{{ .mise.tracing.exporter }}"
+  deployment:
+    zoneCount: {{ .azureRegionAvailabilityZoneCount }}

--- a/maestro/agent/deploy/templates/maestro-agent.deployment.yaml
+++ b/maestro/agent/deploy/templates/maestro-agent.deployment.yaml
@@ -18,21 +18,19 @@ spec:
         checksum/credsstore: '{{ include (print $.Template.BasePath "/maestro.secretproviderclass.yaml") . | sha256sum }}'
         checksum/config: '{{ include (print $.Template.BasePath "/maestro.secret.yaml") . | sha256sum }}'
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: maestro-agent
-              topologyKey: topology.kubernetes.io/zone
-          - weight: 50
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: maestro-agent
-              topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: '{{ if eq (int .Values.deployment.zoneCount) 0 }}kubernetes.azure.com/agentpool{{ else }}topology.kubernetes.io/zone{{ end }}'
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: maestro-agent
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: maestro-agent
       initContainers:
       - name: init
         image: "{{ .Values.sideCar.image.registry }}/{{ .Values.sideCar.image.repository }}@{{ .Values.sideCar.image.digest }}"

--- a/maestro/agent/values.yaml
+++ b/maestro/agent/values.yaml
@@ -21,3 +21,5 @@ sideCar:
     registry: "{{ .maestro.agent.sidecar.image.registry }}"
     repository: "{{ .maestro.agent.sidecar.image.repository }}"
     digest: "{{ .maestro.agent.sidecar.image.digest }}"
+deployment:
+  zoneCount: {{ .azureRegionAvailabilityZoneCount }}

--- a/maestro/server/deploy/templates/maestro.deployment.yaml
+++ b/maestro/server/deploy/templates/maestro.deployment.yaml
@@ -25,21 +25,19 @@ spec:
         checksum/config: '{{ include (print $.Template.BasePath "/maestro.secret.yaml") . | sha256sum }}'
         checksum/db: '{{ include (print $.Template.BasePath "/pg.secret.yaml") . | sha256sum }}'
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: maestro
-              topologyKey: topology.kubernetes.io/zone
-          - weight: 50
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: maestro
-              topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: '{{ if eq (int .Values.deployment.zoneCount) 0 }}kubernetes.azure.com/agentpool{{ else }}topology.kubernetes.io/zone{{ end }}'
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: maestro
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: maestro
       serviceAccountName: '{{ .Values.maestro.serviceAccount }}'
       volumes:
       - name: db

--- a/maestro/server/values.yaml
+++ b/maestro/server/values.yaml
@@ -6,6 +6,7 @@ deployment:
   limits:
     cpu: 1
     memory: 1Gi
+  zoneCount: {{ .azureRegionAvailabilityZoneCount }}
 tracing:
   address: "{{ .maestro.server.tracing.address }}"
   exporter: "{{ .maestro.server.tracing.exporter }}"

--- a/observability/prometheus/deploy/templates/prometheus.yaml
+++ b/observability/prometheus/deploy/templates/prometheus.yaml
@@ -15,20 +15,6 @@ spec:
             operator: In
             values:
             - infra
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: prometheus
-          topologyKey: topology.kubernetes.io/zone
-      - weight: 50
-        podAffinityTerm:
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: prometheus
-          topologyKey: kubernetes.io/hostname
   automountServiceAccountToken: true
   enableAdminAPI: false
   evaluationInterval: 30s
@@ -88,7 +74,13 @@ spec:
       matchLabels:
         app: prometheus
     maxSkew: 1
-    topologyKey: '{{ if eq (int .Values.prometheusSpec.zoneCount) 0 }}kubernetes.azure.com/agentpool{{ else }}failure-domain.beta.kubernetes.io/zone{{ end }}'
+    topologyKey: '{{ if eq (int .Values.prometheusSpec.zoneCount) 0 }}kubernetes.azure.com/agentpool{{ else }}topology.kubernetes.io/zone{{ end }}'
+    whenUnsatisfiable: ScheduleAnyway
+  - labelSelector:
+      matchLabels:
+        app: prometheus
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
   tsdb:
     outOfOrderTimeWindow: 0s


### PR DESCRIPTION

### What

Use topology constraints across our pods instead of pod anti-affinity.  

### Why

As we scale replicas, this will result in more balanced deployments.   It achieves a different goal than anti-affinity.  Rather than focusing on not scheduling, we focus on balancing our workloads to result in an HA deployment.  

### Special notes for your reviewer

<!-- optional -->
