### PR TITLE
env.mk hash recalc

### DIFF
--- a/setup-templatize-env.mk
+++ b/setup-templatize-env.mk
@@ -11,7 +11,7 @@ DEV_SETTINGS_FILE := $(PROJECT_ROOT_DIR)tooling/templatize/settings.yaml
 DEPLOY_ENV ?= pers
 ENV_MK_TMPL ?= Env.mk
 LOG_LEVEL ?= "0"
-HASH = $(shell echo -n "$(DEPLOY_ENV)$(ENV_MK_TMPL)$(PWD)$(LOG_LEVEL)" | sha256sum | cut -d " " -f 1)
+HASH = $(shell echo -n "$(DEPLOY_ENV)$(abspath $(ENV_MK_TMPL))$(LOG_LEVEL)" | sha256sum | cut -d " " -f 1)
 ENV_VARS_FILE ?= /tmp/env.$(HASH).mk
 
 # Target to generate the environment variables file


### PR DESCRIPTION
### What

the dynamic env.mk was not always generated when required when includind the setup-templatize-env.mk file because the input to HASH did not change. using the absolute path to the env.mk file helps as it generates a different hash

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
