### PR TITLE
fix backend image build and local deploy

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -44,7 +44,7 @@ clean:
 
 image: Dockerfile $(BACKEND_SOURCES) Makefile
 	cd $(BACKEND_DIR)/.. && \
-	docker build . --file frontend/Dockerfile \
+	docker build . --file backend/Dockerfile \
 		--build-arg PLATFORM=linux/amd64 \
 		--build-arg ARO_HCP_REVISION=${ARO_HCP_REVISION} \
 		--build-arg ARO_HCP_IMAGE_TAG=${BACKEND_IMAGE_TAG} \
@@ -71,5 +71,5 @@ record-override: $(YQ) $(ORAS)
 .PHONY: record-override
 
 deploy: build-and-push record-override
-	make -C .. pipeline/RP.Frontend OVERRIDE_CONFIG_FILE=$(OVERRIDE_CONFIG_FILE)
+	make -C .. pipeline/RP.Backend OVERRIDE_CONFIG_FILE=$(OVERRIDE_CONFIG_FILE)
 .PHONY: deploy


### PR DESCRIPTION
### What

* the frontend code was wrongly published as backend
* the local deploy target deployed the frontend instead of the backend

follows up on https://github.com/Azure/ARO-HCP/pull/3113

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
