### PR TITLE
Aro 22403 mirror ocp 4.20 images to acr

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -680,11 +680,11 @@ defaults:
     # OCP Versions configuration
     ocpVersions:
       defaultVersion:
-        version: 4.19.7
+        version: 4.20.2
       channelGroups:
         stable:
           minVersion: 4.19.0
-          maxVersion: 4.19.8
+          maxVersion: 4.20.2
   # Image Sync
   imageSync:
     environmentName: aro-hcp-image-sync
@@ -1151,6 +1151,10 @@ clouds:
           # Service Key Vault
           serviceKeyVault:
             assignNSP: false
+          # Logs
+          logs:
+            loganalytics:
+              enable: true
           # Cluster Service
           clustersService:
             postgres:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 42c803ba6ab75212ec5c2b655ddcba849e127eaa688a31e063cc1d353b3399a0
+          westus3: 9bea3c26cced36666012a329a1a45d331e8a8a562d59127ee6de84b134b1cef7
       dev:
         regions:
-          westus3: 613114da7e321354363addf0934a03d02cfcbdc9e1d3e65929b64f57e825debf
+          westus3: a36dbf99172b3c0aae65dcf019f6fa68b64c96163d27dfd03123b7b8d2682137
       ntly:
         regions:
-          uksouth: 00701a0f1f8b1beb438923e28fe7ca5804785f8a0990fe59450438fa87ec6ac6
+          uksouth: 0e58ce2fa8ce73d39b8d44d3c47b4531fa4e0ee22d96ab1d19a95dc58ce261dc
       perf:
         regions:
-          westus3: 61b177ecccf616bcd5580948cc07467ae1943bc11afa1eb64b6124053d88213b
+          westus3: 633a040382bb766773c50b506f2695140f280f60391e419baac113df993f655d
       pers:
         regions:
-          westus3: 3610affd57143dc50a88d1fce70d10a16dc58271b103572e6c7961c2f36a1739
+          westus3: 19e6f307bd725df65244198f2dad0128b5a61603b5548683802ea556e3a083f6
       swft:
         regions:
-          uksouth: e0b038a728b9da11dea7559e4a23caaf91f2a9ab13acc024ee4bab308c471abb
+          uksouth: 22ccebce54cf9a3a7ac5bb16b8e2247c927310df2aab76152585ca30142e41a3

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -137,10 +137,10 @@ clustersService:
   ocpVersions:
     channelGroups:
       stable:
-        maxVersion: 4.19.8
+        maxVersion: 4.20.2
         minVersion: 4.19.0
     defaultVersion:
-      version: 4.19.7
+      version: 4.20.2
   postgres:
     backupRetentionDays: 7
     containerizedDb:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -137,10 +137,10 @@ clustersService:
   ocpVersions:
     channelGroups:
       stable:
-        maxVersion: 4.19.8
+        maxVersion: 4.20.2
         minVersion: 4.19.0
     defaultVersion:
-      version: 4.19.7
+      version: 4.20.2
   postgres:
     backupRetentionDays: 7
     containerizedDb:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -137,10 +137,10 @@ clustersService:
   ocpVersions:
     channelGroups:
       stable:
-        maxVersion: 4.19.8
+        maxVersion: 4.20.2
         minVersion: 4.19.0
     defaultVersion:
-      version: 4.19.7
+      version: 4.20.2
   postgres:
     backupRetentionDays: 7
     containerizedDb:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -137,10 +137,10 @@ clustersService:
   ocpVersions:
     channelGroups:
       stable:
-        maxVersion: 4.19.8
+        maxVersion: 4.20.2
         minVersion: 4.19.0
     defaultVersion:
-      version: 4.19.7
+      version: 4.20.2
   postgres:
     backupRetentionDays: 7
     containerizedDb:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -137,10 +137,10 @@ clustersService:
   ocpVersions:
     channelGroups:
       stable:
-        maxVersion: 4.19.8
+        maxVersion: 4.20.2
         minVersion: 4.19.0
     defaultVersion:
-      version: 4.19.7
+      version: 4.20.2
   postgres:
     backupRetentionDays: 7
     containerizedDb:
@@ -341,7 +341,7 @@ kvCertAccessRoleId: ""
 kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
 logs:
   loganalytics:
-    enable: false
+    enable: true
   mdsd:
     cert:
       issuer: ""

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -137,10 +137,10 @@ clustersService:
   ocpVersions:
     channelGroups:
       stable:
-        maxVersion: 4.19.8
+        maxVersion: 4.20.2
         minVersion: 4.19.0
     defaultVersion:
-      version: 4.19.7
+      version: 4.20.2
   postgres:
     backupRetentionDays: 7
     containerizedDb:

--- a/image-sync/oc-mirror/Dockerfile
+++ b/image-sync/oc-mirror/Dockerfile
@@ -8,6 +8,7 @@ RUN set -eux; \
 
 ENV OC_MIRROR_4_16_VERSION=4.16.3
 ENV OC_MIRROR_4_18_VERSION=4.18.7
+ENV OC_MIRROR_4_20_VERSION=4.20.0
 ENV OC_VERSION=4.18.0-rc.9
 ENV YQ_VERSION=v4.45.1
 
@@ -24,6 +25,11 @@ RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_MIR
     -o oc-mirror.tar.gz && \
     tar -zvxf oc-mirror.tar.gz && \
     mv oc-mirror /usr/local/bin/oc-mirror-4.18
+
+RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_MIRROR_4_20_VERSION}/oc-mirror.tar.gz \
+    -o oc-mirror.tar.gz && \
+    tar -zvxf oc-mirror.tar.gz && \
+    mv oc-mirror /usr/local/bin/oc-mirror-4.20
 
 RUN curl -sfL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz \
     -o yq.tar.gz && \
@@ -47,6 +53,7 @@ ADD docker-login.sh /usr/local/bin/docker-login.sh
 COPY --chown=0:0 --chmod=755 --from=downloader \
     /usr/local/bin/oc-mirror-4.16 \
     /usr/local/bin/oc-mirror-4.18 \
+    /usr/local/bin/oc-mirror-4.20 \
     /usr/local/bin/oc \
     /usr/local/bin/kubectl \
     /usr/local/bin/yq \

--- a/image-sync/oc-mirror/mirror.sh
+++ b/image-sync/oc-mirror/mirror.sh
@@ -23,6 +23,8 @@ fi
 # * https://issues.redhat.com/browse/OCPBUGS-52471 - memory bug
 if [ "$OC_MIRROR_COMPATIBILITY" = "NOCATALOG" ]; then
     export OC_MIRROR_VERSION="4.16"
+elif [ "$OC_MIRROR_COMPATIBILITY" = "4.20" ]; then
+    export OC_MIRROR_VERSION="4.20"
 else
     export OC_MIRROR_VERSION="4.18"
 fi

--- a/image-sync/oc-mirror/test/ocp-image-set-config.yml
+++ b/image-sync/oc-mirror/test/ocp-image-set-config.yml
@@ -15,6 +15,10 @@ mirror:
       minVersion: 4.18.1
       full: true
       type: ocp
+    - name: stable-4.20
+      minVersion: 4.20.0
+      full: true
+      type: ocp
     graph: true
   additionalImages:
   - name: registry.redhat.io/redhat/redhat-operator-index:v4.16
@@ -29,3 +33,7 @@ mirror:
   - name: registry.redhat.io/redhat/certified-operator-index:v4.18
   - name: registry.redhat.io/redhat/community-operator-index:v4.18
   - name: registry.redhat.io/redhat/redhat-marketplace-index:v4.18
+  - name: registry.redhat.io/redhat/redhat-operator-index:v4.20
+  - name: registry.redhat.io/redhat/certified-operator-index:v4.20
+  - name: registry.redhat.io/redhat/community-operator-index:v4.20
+  - name: registry.redhat.io/redhat/redhat-marketplace-index:v4.20


### PR DESCRIPTION
[<[ARO-22403](https://issues.redhat.com//browse/ARO-22403)>](https://issues.redhat.com/browse/ARO-22403)

### What

1. image-sync/oc-mirror/test/ocp-image-set-config.yml - Added stable-4.20 channel and v4.20 operator indexes
2. config/config.yaml - Updated default OCP version to 4.20.0 (range: 4.19.0-4.20.99)
3. image-sync/oc-mirror/Dockerfile - Added oc-mirror 4.20.0 binary download and installation
4. image-sync/oc-mirror/mirror.sh - Added 4.20 compatibility mode selection

### Why

Blocks: [ARO-21590](https://issues.redhat.com/browse/ARO-21590) (all code changes depend on this) , must be completed prior to end of sprint

### Special notes for your reviewer

<!-- optional -->
