### PR TITLE
New E2E test case: deployment of a node pool is not possible for hosted cluster in failed provisioning state

### DIFF
--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -388,13 +388,15 @@ func BeginCreateHCPCluster(
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
 	resourceGroupName string,
 	hcpClusterName string,
-	cluster hcpsdk20240610preview.HcpOpenShiftCluster,
-) error {
-	_, err := hcpClient.BeginCreateOrUpdate(ctx, resourceGroupName, hcpClusterName, cluster, nil)
+	clusterParams ClusterParams,
+	location string,
+) (*runtime.Poller[hcpsdk20240610preview.HcpOpenShiftClustersClientCreateOrUpdateResponse], error) {
+	cluster := BuildHCPClusterFromParams(clusterParams, location)
+	poller, err := hcpClient.BeginCreateOrUpdate(ctx, resourceGroupName, hcpClusterName, cluster, nil)
 	if err != nil {
-		return fmt.Errorf("failed starting cluster creation %q in resourcegroup=%q: %w", hcpClusterName, resourceGroupName, err)
+		return nil, fmt.Errorf("failed starting cluster creation %q in resourcegroup=%q: %w", hcpClusterName, resourceGroupName, err)
 	}
-	return nil
+	return poller, nil
 }
 
 func CreateHCPClusterAndWait(


### PR DESCRIPTION
[ARO-22116](https://issues.redhat.com/browse/ARO-22116)

### What

New negative E2E test case to ensure customer can't deploy a node pool into a hosted cluster in failed provisioning state

### How

1. Create a resource group
2. Create a cluster using ~~bicep template~~ API* with invalid ~~vnetName~~ subnet ID to force failure
3. Verify that an error does not occur before ARM resource creation
4. Verify the cluster resource exists
5. Verify the cluster provisioning state is failed (polls and logs current provisioning state)
6. Attempt node pool deployment into the cluster via API*
7. Verify the node pool deployment fails with appropriate error code

*using framework as per https://github.com/Azure/ARO-HCP/pull/3273