### PR TITLE
Revert "Disable frontdoor management"

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -715,7 +715,7 @@ defaults:
       public: false
       privateLinkLocation: "{{ .ctx.region }}"
     frontdoor:
-      manage: false
+      manage: true
       subdomain: oic
       name: arohcp{{ .ctx.environment }}
       sku: Premium_AzureFrontDoor


### PR DESCRIPTION
This reverts commit 92be952294ded5f81aeab67efd7c68ecf31fa2ea.

AFD is no longer read-only for us (icm 704268261)
