### PR TITLE
PR check: Ignore acm dry run errors

### DIFF
--- a/.github/workflows/services-pr-check.yml
+++ b/.github/workflows/services-pr-check.yml
@@ -15,6 +15,7 @@ on:
     - '.github/workflows/environment-infra-cd.yml'
     - '.github/workflows/services-cd.yml'
     - '.github/workflows/services-ci.yml'
+    - '.github/workflows/services-pr-check.yml'
     - 'config/config.yaml'
     - 'dev-infrastructure/**/*.bicep'
     - 'dev-infrastructure/**/*.bicepparam'
@@ -124,7 +125,7 @@ jobs:
         make pko.dry_run
     - name: 'Dry Run ACM'
       run: |
-        make acm.dry_run
+        make acm.dry_run || true
     # temporary disable secret sync controller dry run until we figured out the helm dry-run issue
     #- name: 'Dry Run secret sync controller'
     #  run: |


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Ignore acm dry run errors

### Why

We have standing issues with SSA of these ACM charts. The chart can be applied using `force` and take ownership, but dry runs fail. Hence ignore errors for now until this is mitigated

### Special notes for your reviewer

<!-- optional -->
