### PR TITLE
Add dev target for frontend and backend in image-updater tooling

### DIFF
--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -51,9 +51,13 @@ images:
     targets:
     - jsonPath: clouds.public.environments.int.defaults.frontend.image.digest
       filePath: ../../config/config.msft.clouds-overlay.yaml
+    - jsonPath: clouds.dev.defaults.frontend.image.digest
+      filePath: ../../config/config.yaml
   arohcpbackend:
     source:
       image: arohcpsvcdev.azurecr.io/arohcpbackend
     targets:
     - jsonPath: clouds.public.environments.int.defaults.backend.image.digest
       filePath: ../../config/config.msft.clouds-overlay.yaml
+    - jsonPath: clouds.dev.defaults.backend.image.digest
+      filePath: ../../config/config.yaml


### PR DESCRIPTION
Add dev target for frontend and backend in image-updater tooling as it was missing.
```
Updated images for dev/int:
arohcpfrontend: sha256:a4ff5bc53cd015380b314ba2bedb5408af7a1d7be9bed221f56f31cf110d9ad4 -> sha256:00d003f3b9626d2f9f8403ae7c94917350ee2f22559a7c368a159407d9adc647
arohcpbackend: sha256:5999536c1b4829e0fe344485b9e3e8b3de043cdafe39b967e873c87d3bad7d4f -> sha256:02afd8aa510bb13b368386c359e33fcfbda5a2084e8db7e2bc4fa6c0cb1745f8
```

After this merges, frontend and backend digests will be updated in dev as well and not only in int - https://github.com/Azure/ARO-HCP/pull/3204/files