### PR TITLE
Add mgmt cluster capacity alerts with SL team routing

### DIFF
--- a/dev-infrastructure/modules/metrics/hcp-rules.bicep
+++ b/dev-infrastructure/modules/metrics/hcp-rules.bicep
@@ -1,15 +1,27 @@
-// Alerts and Recording Rules that apply to all services and svc/mgmt clusters.
-// Excludes Hosted Control Plane Alerts and Recording Rules.
+// Alerts and Recording Rules for Hosted Control Planes
+// Split into SRE-routed and SL-routed alerts
 
 @description('The Azure resource ID of the Azure Monitor Workspace (stores prometheus metrics for services/aks level metrics)')
 param azureMonitoringWorkspaceId string
 
-param actionGroups array
+@description('Action groups for SRE team alerts')
+param sreActionGroups array
 
-module generatedAlerts 'rules/generatedHCPPrometheusAlertingRules.bicep' = {
+@description('Action groups for Service Lifecycle team alerts')
+param slActionGroups array
+
+module generatedSREAlerts 'rules/generatedHCPPrometheusAlertingRules.bicep' = {
   name: 'generatedHCPPrometheusAlertingRules'
   params: {
     azureMonitoring: azureMonitoringWorkspaceId
-    actionGroups: actionGroups
+    actionGroups: sreActionGroups
+  }
+}
+
+module generatedSLAlerts 'rules/generatedHCPSLPrometheusAlertingRules.bicep' = {
+  name: 'generatedHCPSLPrometheusAlertingRules'
+  params: {
+    azureMonitoring: azureMonitoringWorkspaceId
+    actionGroups: slActionGroups
   }
 }

--- a/dev-infrastructure/modules/metrics/rules/generatedHCPSLPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPSLPrometheusAlertingRules.bicep
@@ -1,0 +1,70 @@
+#disable-next-line no-unused-params
+param azureMonitoring string
+
+#disable-next-line no-unused-params
+param actionGroups array
+
+resource mgmtCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'mgmt-capacity.rules'
+  location: resourceGroup().location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'MgmtClusterHCPCapacityWarning'
+        enabled: true
+        labels: {
+          severity: 'info'
+        }
+        annotations: {
+          correlationId: 'MgmtClusterHCPCapacityWarning/{{ $labels.cluster }}'
+          description: 'Management cluster {{ $labels.cluster }} is at {{ $value | humanizePercentage }} of its HCP capacity (60 HCP limit). Current count exceeds warning threshold of 60%.'
+          runbook_url: 'https://aka.ms/arohcp-runbook/mgmt-cluster-capacity'
+          summary: 'Management cluster HCP capacity is approaching limit (60% threshold).'
+          title: 'Management cluster {{ $labels.cluster }} is at {{ $value | humanizePercentage }} of its HCP capacity (60 HCP limit). Current count exceeds warning threshold of 60%.'
+        }
+        expression: '( count(kube_namespace_labels{namespace=~"^ocm-[^-]+-[^-]+$"}) by (cluster) / 60 ) > 0.60'
+        for: 'PT15M'
+        severity: 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'MgmtClusterHCPCapacityCritical'
+        enabled: true
+        labels: {
+          severity: 'info'
+        }
+        annotations: {
+          correlationId: 'MgmtClusterHCPCapacityCritical/{{ $labels.cluster }}'
+          description: 'Management cluster {{ $labels.cluster }} is at {{ $value | humanizePercentage }} of its HCP capacity (60 HCP limit). Current count exceeds critical threshold of 85%. Immediate action required to provision additional management cluster capacity.'
+          runbook_url: 'https://aka.ms/arohcp-runbook/mgmt-cluster-capacity'
+          summary: 'Management cluster HCP capacity is critically high (85% threshold).'
+          title: 'Management cluster {{ $labels.cluster }} is at {{ $value | humanizePercentage }} of its HCP capacity (60 HCP limit). Current count exceeds critical threshold of 85%. Immediate action required to provision additional management cluster capacity.'
+        }
+        expression: '( count(kube_namespace_labels{namespace=~"^ocm-[^-]+-[^-]+$"}) by (cluster) / 60 ) > 0.85'
+        for: 'PT5M'
+        severity: 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}

--- a/dev-infrastructure/templates/monitoring.bicep
+++ b/dev-infrastructure/templates/monitoring.bicep
@@ -93,7 +93,8 @@ module hcpAlerts '../modules/metrics/hcp-rules.bicep' = {
   name: 'hcpAlerts'
   params: {
     azureMonitoringWorkspaceId: hcpAzureMonitoringWorkspaceId
-    actionGroups: sreActionGroups
+    sreActionGroups: sreActionGroups
+    slActionGroups: slActionGroups
   }
 }
 

--- a/observability/Makefile
+++ b/observability/Makefile
@@ -17,6 +17,8 @@ alerts: kubernetesControlPlane-prometheusRule
 	az bicep format -f $$(yq '.prometheusRules.outputBicep' observability.yaml)
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules run-hcp
 	az bicep format -f $$(yq '.prometheusRules.outputBicep' observability-hcp.yaml)
+	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules run-hcp-sl
+	az bicep format -f $$(yq '.prometheusRules.outputBicep' observability-hcp-sl.yaml)
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules run-msft
 	az bicep format -f $$(yq '.prometheusRules.outputBicep' observability-msft.yaml)
 .PHONY: alerts

--- a/observability/alerts/mgmt-capacity-prometheusRule.yaml
+++ b/observability/alerts/mgmt-capacity-prometheusRule.yaml
@@ -1,0 +1,39 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: mgmt-capacity-monitoring-rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: mgmt-capacity.rules
+    rules:
+    # NOTE: Temporarily set to 'info' (Sev 4) during testing period to prevent incident spamming.
+    # Will be changed to 'warning' (Sev 3) after alert behavior is validated in production.
+    - alert: MgmtClusterHCPCapacityWarning
+      annotations:
+        description: Management cluster {{ $labels.cluster }} is at {{ $value | humanizePercentage }} of its HCP capacity (60 HCP limit). Current count exceeds warning threshold of 60%.
+        runbook_url: https://aka.ms/arohcp-runbook/mgmt-cluster-capacity
+        summary: Management cluster HCP capacity is approaching limit (60% threshold).
+      expr: |
+        (
+          count(kube_namespace_labels{namespace=~"^ocm-[^-]+-[^-]+$"}) by (cluster)
+          / 60
+        ) > 0.60
+      for: 15m
+      labels:
+        severity: info
+    # NOTE: Temporarily set to 'info' (Sev 4) during testing period to prevent incident spamming.
+    # Will be changed to 'critical' (Sev 2) after alert behavior is validated in production.
+    - alert: MgmtClusterHCPCapacityCritical
+      annotations:
+        description: Management cluster {{ $labels.cluster }} is at {{ $value | humanizePercentage }} of its HCP capacity (60 HCP limit). Current count exceeds critical threshold of 85%. Immediate action required to provision additional management cluster capacity.
+        runbook_url: https://aka.ms/arohcp-runbook/mgmt-cluster-capacity
+        summary: Management cluster HCP capacity is critically high (85% threshold).
+      expr: |
+        (
+          count(kube_namespace_labels{namespace=~"^ocm-[^-]+-[^-]+$"}) by (cluster)
+          / 60
+        ) > 0.85
+      for: 5m
+      labels:
+        severity: info

--- a/observability/alerts/mgmt-capacity-prometheusRule_test.yaml
+++ b/observability/alerts/mgmt-capacity-prometheusRule_test.yaml
@@ -1,0 +1,282 @@
+rule_files:
+- mgmt-capacity-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# Test warning threshold (60%) - need 37 namespaces (37/60 = 61.6% > 60%)
+- interval: 1m
+  input_series:
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-001"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-002"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-003"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-004"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-005"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-006"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-007"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-008"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-009"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-010"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-011"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-012"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-013"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-014"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-015"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-016"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-017"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-018"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-019"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-020"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-021"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-022"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-023"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-024"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-025"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-026"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-027"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-028"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-029"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-030"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-031"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-032"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-033"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-034"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-035"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-036"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-test",namespace="ocm-prod-037"}'
+    values: "1+0x20"
+  alert_rule_test:
+  # NOTE: Expecting 'info' severity during testing period. Change back to 'warning' after validation.
+  - eval_time: 15m
+    alertname: MgmtClusterHCPCapacityWarning
+    exp_alerts:
+    - exp_labels:
+        severity: info
+        cluster: mgmt-test
+      exp_annotations:
+        summary: Management cluster HCP capacity is approaching limit (60% threshold).
+        description: Management cluster mgmt-test is at 61.67% of its HCP capacity (60 HCP limit). Current count exceeds warning threshold of 60%.
+        runbook_url: https://aka.ms/arohcp-runbook/mgmt-cluster-capacity
+# Test critical threshold (85%) - need 52 namespaces (52/60 = 86.67% > 85%)
+- interval: 1m
+  input_series:
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-001"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-002"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-003"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-004"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-005"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-006"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-007"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-008"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-009"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-010"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-011"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-012"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-013"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-014"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-015"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-016"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-017"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-018"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-019"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-020"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-021"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-022"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-023"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-024"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-025"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-026"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-027"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-028"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-029"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-030"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-031"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-032"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-033"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-034"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-035"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-036"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-037"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-038"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-039"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-040"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-041"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-042"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-043"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-044"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-045"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-046"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-047"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-048"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-049"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-050"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-051"}'
+    values: "1+0x10"
+  - series: 'kube_namespace_labels{cluster="mgmt-critical",namespace="ocm-prod-052"}'
+    values: "1+0x10"
+  alert_rule_test:
+  # NOTE: Expecting 'info' severity during testing period. Change back to 'critical' after validation.
+  - eval_time: 5m
+    alertname: MgmtClusterHCPCapacityCritical
+    exp_alerts:
+    - exp_labels:
+        severity: info
+        cluster: mgmt-critical
+      exp_annotations:
+        summary: Management cluster HCP capacity is critically high (85% threshold).
+        description: Management cluster mgmt-critical is at 86.67% of its HCP capacity (60 HCP limit). Current count exceeds critical threshold of 85%. Immediate action required to provision additional management cluster capacity.
+        runbook_url: https://aka.ms/arohcp-runbook/mgmt-cluster-capacity
+# Test no alert when below threshold (30 namespaces = 50%)
+- interval: 1m
+  input_series:
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-001"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-002"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-003"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-004"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-005"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-006"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-007"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-008"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-009"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-010"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-011"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-012"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-013"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-014"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-015"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-016"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-017"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-018"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-019"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-020"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-021"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-022"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-023"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-024"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-025"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-026"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-027"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-028"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-029"}'
+    values: "1+0x20"
+  - series: 'kube_namespace_labels{cluster="mgmt-ok",namespace="ocm-prod-030"}'
+    values: "1+0x20"
+  alert_rule_test:
+  - eval_time: 20m
+    alertname: MgmtClusterHCPCapacityWarning
+    exp_alerts: []
+  - eval_time: 20m
+    alertname: MgmtClusterHCPCapacityCritical
+    exp_alerts: []

--- a/observability/observability-hcp-sl.yaml
+++ b/observability/observability-hcp-sl.yaml
@@ -1,0 +1,16 @@
+prometheusRules:
+  rulesFolders:
+  - ../observability/alerts/mgmt-capacity-prometheusRule.yaml
+  untestedRules: []
+  outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedHCPSLPrometheusAlertingRules.bicep
+  outputReplacements:
+  - from: 'job="kube-scheduler"'
+    to: 'job="controlplane-kube-scheduler"'
+  - from: 'job="apiserver"'
+    to: 'job="controlplane-apiserver"'
+  - from: 'job="etcd"'
+    to: 'job="controlplane-etcd"'
+  - from: 'job="cluster-autoscaler"'
+    to: 'job="controlplane-cluster-autoscaler"'
+  - from: 'job="kube-controller-manager"'
+    to: 'job="controlplane-kube-controller-manager"'

--- a/tooling/prometheus-rules/Makefile
+++ b/tooling/prometheus-rules/Makefile
@@ -24,6 +24,10 @@ run-hcp:
 	go run ./...  --config-file ../../observability/observability-hcp.yaml $(EXTRA_FLAGS)
 .PHONY: run-hcp
 
+run-hcp-sl:
+	go run ./...  --config-file ../../observability/observability-hcp-sl.yaml $(EXTRA_FLAGS)
+.PHONY: run-hcp-sl
+
 run-msft:
 	go run ./...  --config-file ../../observability/observability-msft.yaml $(EXTRA_FLAGS)
 .PHONY: run-msft


### PR DESCRIPTION

[<!-- [AROSLSRE-93](https://issues.redhat.com//browse/AROSLSRE-93)-->](https://issues.redhat.com/browse/AROSLSRE-93)

### What

Implements [AROSLSRE-93](https://issues.redhat.com//browse/AROSLSRE-93): Early warning system for mgmt cluster HCP capacity.

Architecture:
- Split HCP alerts by owning team (SRE vs Service Lifecycle)
- Created new observability-hcp-sl.yaml for SL-routed HCP alerts
- Updated hcp-rules.bicep to deploy both SRE and SL alert sets
- Updated monitoring.bicep to pass both action groups

Alerts:
- MgmtClusterHCPCapacityWarning: >60% capacity (15m duration)
- MgmtClusterHCPCapacityCritical: >85% capacity (5m duration)
- Routes to Service Lifecycle team (HCP-SL-STAGE/HCP-SL)
- Based on 60 HCP max capacity per mgmt cluster

Severity:
- Temporarily set to 'info' (Sev 4) during testing period to prevent incident spamming while validating alert behavior in production
- Will be changed to 'warning' (Sev 3) and 'critical' (Sev 2) respectively after validation period

All promtool tests passing.

### Why

Currently no visibility or automation to monitor management cluster saturation.

### Special notes for your reviewer

<!-- optional -->
