### PR TITLE
chore: update JIRA links

### DIFF
--- a/cluster-service/deploy/templates/cloud-resource-constraints-config.configmap.yaml
+++ b/cluster-service/deploy/templates/cloud-resource-constraints-config.configmap.yaml
@@ -9,7 +9,7 @@ data:
   instance-type-constraints.yaml: |
     instance_types:
     # hand-crafted list to the ones mentioned in
-    # https://issues.redhat.com/browse/XCMSTRAT-1002
+    # https://issues.redhat.com/browse/ARO-21660
     # those are the instance types that are also enabled in ARO Classic.
     # We also include the ones mentioned in https://issues.redhat.com/browse/ARO-22443
     - id: Standard_D8s_v3

--- a/demo/delete-nodepool-rp.sh
+++ b/demo/delete-nodepool-rp.sh
@@ -3,6 +3,6 @@
 source env_vars
 source "$(dirname "$0")"/common.sh
 
-# The last node pool can not be deleted from a cluster. See https://issues.redhat.com/browse/XCMSTRAT-1069 for more details.
+# The last node pool can not be deleted from a cluster. See https://issues.redhat.com/browse/ARO-21617 for more details.
 
 rp_delete_request "${NODE_POOL_RESOURCE_ID}"

--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -246,7 +246,7 @@ var _ = Describe("Customer", func() {
 			client, err := kubernetes.NewForConfig(config)
 			Expect(err).NotTo(HaveOccurred())
 
-			// TODO (bvesel): XCMSTRAT-1292
+			// TODO (bvesel): ARO-21634
 			// The kube-apiserver restarts on external auth config creation, so we need to wait
 			// for it to completely restart. There doesn't appear to be a way to track this in the data plane
 			By("confirming we can list namespaces using entra OIDC token")


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What
With the upcoming JIRA migration, all automatic redirects from the XCMSTRAT to ARO JIRA projects will stop working. Changing these references to the correct new ARO JIRAs while we know what they are.
