### PR TITLE
Run service components on infra nodes in the management cluster

### DIFF
--- a/maestro/agent/deploy/templates/maestro-agent.deployment.yaml
+++ b/maestro/agent/deploy/templates/maestro-agent.deployment.yaml
@@ -81,6 +81,20 @@ spec:
           name: mqtt-creds
           readOnly: true
       serviceAccountName: '{{ .Values.serviceAccountName }}'
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: aro-hcp.azure.com/role
+                operator: In
+                values:
+                - infra
+      tolerations:
+      - effect: NoSchedule
+        key: infra
+        operator: "Equal"
+        value: "true"
       volumes:
       - name: nginx-config-tmp
         configMap:

--- a/observability/tracing/deploy/collector.yaml
+++ b/observability/tracing/deploy/collector.yaml
@@ -65,6 +65,20 @@ spec:
         volumeMounts:
         - name: otel-config
           mountPath: /etc/otel/config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: aro-hcp.azure.com/role
+                operator: In
+                values:
+                - infra
+      tolerations:
+      - effect: NoSchedule
+        key: infra
+        operator: "Equal"
+        value: "true"
       volumes:
       - name: otel-config
         configMap:

--- a/observability/tracing/deploy/jaeger.yaml
+++ b/observability/tracing/deploy/jaeger.yaml
@@ -45,3 +45,17 @@ spec:
             path: /
             port: 14269
           initialDelaySeconds: 1
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: aro-hcp.azure.com/role
+                operator: In
+                values:
+                - infra
+      tolerations:
+      - effect: NoSchedule
+        key: infra
+        operator: "Equal"
+        value: "true"

--- a/observability/tracing/deploy/lgtm.yaml
+++ b/observability/tracing/deploy/lgtm.yaml
@@ -62,6 +62,20 @@ spec:
           mountPath: /data/prometheus
         - name: pyroscope-storage
           mountPath: /data/pyroscope
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: aro-hcp.azure.com/role
+                operator: In
+                values:
+                - infra
+      tolerations:
+      - effect: NoSchedule
+        key: infra
+        operator: "Equal"
+        value: "true"
       volumes:
       - name: tempo-data
         emptyDir: {}

--- a/secret-sync-controller/deploy/templates/secrets-store-sync-controller.yaml
+++ b/secret-sync-controller/deploy/templates/secrets-store-sync-controller.yaml
@@ -172,6 +172,20 @@ spec:
           name: providervol
       serviceAccountName: "secrets-store-sync-controller-manager"
       terminationGracePeriodSeconds: 10
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: aro-hcp.azure.com/role
+                operator: In
+                values:
+                - infra
+      tolerations:
+      - effect: NoSchedule
+        key: infra
+        operator: "Equal"
+        value: "true"
       volumes:
       - name: providervol
         hostPath:


### PR DESCRIPTION

Why?
Refer: https://issues.redhat.com/browse/ARO-21859


### What
Adds node selectors and tolerations to maestro agent, observability stack deployments, secret sync controller deployments so that they run on infra nodes.


