### PR TITLE
Add support for mirroring OpenShift 4.20 operator catalog images

### DIFF
--- a/image-sync/oc-mirror/Dockerfile
+++ b/image-sync/oc-mirror/Dockerfile
@@ -8,6 +8,7 @@ RUN set -eux; \
 
 ENV OC_MIRROR_4_16_VERSION=4.16.3
 ENV OC_MIRROR_4_18_VERSION=4.18.7
+ENV OC_MIRROR_4_20_VERSION=4.20.0
 ENV OC_VERSION=4.18.0-rc.9
 ENV YQ_VERSION=v4.45.1
 
@@ -24,6 +25,11 @@ RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_MIR
     -o oc-mirror.tar.gz && \
     tar -zvxf oc-mirror.tar.gz && \
     mv oc-mirror /usr/local/bin/oc-mirror-4.18
+
+RUN curl -sfL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_MIRROR_4_20_VERSION}/oc-mirror.tar.gz \
+    -o oc-mirror.tar.gz && \
+    tar -zvxf oc-mirror.tar.gz && \
+    mv oc-mirror /usr/local/bin/oc-mirror-4.20
 
 RUN curl -sfL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz \
     -o yq.tar.gz && \
@@ -47,6 +53,7 @@ ADD docker-login.sh /usr/local/bin/docker-login.sh
 COPY --chown=0:0 --chmod=755 --from=downloader \
     /usr/local/bin/oc-mirror-4.16 \
     /usr/local/bin/oc-mirror-4.18 \
+    /usr/local/bin/oc-mirror-4.20 \
     /usr/local/bin/oc \
     /usr/local/bin/kubectl \
     /usr/local/bin/yq \

--- a/image-sync/oc-mirror/mirror.sh
+++ b/image-sync/oc-mirror/mirror.sh
@@ -23,6 +23,8 @@ fi
 # * https://issues.redhat.com/browse/OCPBUGS-52471 - memory bug
 if [ "$OC_MIRROR_COMPATIBILITY" = "NOCATALOG" ]; then
     export OC_MIRROR_VERSION="4.16"
+elif [ "$OC_MIRROR_COMPATIBILITY" = "4.20" ]; then
+    export OC_MIRROR_VERSION="4.20"
 else
     export OC_MIRROR_VERSION="4.18"
 fi

--- a/image-sync/oc-mirror/test/ocp-image-set-config.yml
+++ b/image-sync/oc-mirror/test/ocp-image-set-config.yml
@@ -29,3 +29,7 @@ mirror:
   - name: registry.redhat.io/redhat/certified-operator-index:v4.18
   - name: registry.redhat.io/redhat/community-operator-index:v4.18
   - name: registry.redhat.io/redhat/redhat-marketplace-index:v4.18
+  - name: registry.redhat.io/redhat/redhat-operator-index:v4.20
+  - name: registry.redhat.io/redhat/certified-operator-index:v4.20
+  - name: registry.redhat.io/redhat/community-operator-index:v4.20
+  - name: registry.redhat.io/redhat/redhat-marketplace-index:v4.20


### PR DESCRIPTION

JIRA: [ARO-22403](https://issues.redhat.com//browse/ARO-22403)


### What

- Add oc-mirror 4.20.0 binary to Dockerfile
- Add OC_MIRROR_COMPATIBILITY=4.20 support to mirror.sh
- Add v4.20 operator catalog indexes to image set config:
  - redhat/redhat-operator-index:v4.20
  - redhat/certified-operator-index:v4.20
  - redhat/community-operator-index:v4.20
  - redhat/redhat-marketplace-index:v4.20

These operator catalogs will be mirrored from registry.redhat.io to ACR via the oc-mirror Container App Job.


### Why

While quay.io registries support cache-through capability, the operator catalog index images from registry.redhat.io requires explicit mirroring

### Special notes for your reviewer

<!-- optional -->
