### PR TITLE
fix: secret-too-long

### DIFF
--- a/observability/prometheus/values-mgmt.yaml
+++ b/observability/prometheus/values-mgmt.yaml
@@ -1,7 +1,7 @@
+crds:
+  enabled: true
 kube-prometheus-stack:
   fullnameOverride: "prometheus"
-  crds:
-    enabled: true
   global:
     rbac:
       create: true

--- a/observability/prometheus/values-svc.yaml
+++ b/observability/prometheus/values-svc.yaml
@@ -1,7 +1,7 @@
+crds:
+  enabled: true
 kube-prometheus-stack:
   fullnameOverride: "prometheus"
-  crds:
-    enabled: true
   global:
     rbac:
       create: true


### PR DESCRIPTION
Trying to resolve the error which prevents deployment


[error running Helm release deployment Step, failed to deploy helm release: create: failed to create: Secret \"sh.helm.release.v1.arohcp-monitor.v377\" is invalid: data: Too long: may not be more than 1048576 bytes]"