### PR TITLE
dev-infrastructure: add AKS maintenance windows

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -479,6 +479,98 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-10-01' = {
   ]
 }
 
+resource maintenanceWindow 'Microsoft.ContainerService/managedClusters/maintenanceConfigurations@2025-08-02-preview' = {
+  parent: aksCluster
+  name: guid(aksClusterName, 'maintenance-window')
+  properties: {
+    maintenanceWindow: {
+      durationHours: 10
+      startTime: '15:00'
+      notAllowedDates: [
+        {
+          start: '2025-11-16'
+          end: '2025-11-22'
+        }
+        {
+          start: '2025-11-24'
+          end: '2025-12-03'
+        }
+        {
+          start: '2025-12-22'
+          end: '2026-01-13'
+        }
+        {
+          start: '2026-02-16'
+          end: '2026-02-20'
+        }
+      ]
+      schedule: {
+        daily: {
+          intervalDays: 1
+        }
+      }
+    }
+    timeInWeek: [
+      {
+        day: 'Monday'
+        hourSlots: [
+          15
+          16
+          17
+          18
+          19
+          20
+          21
+          22
+          23
+        ]
+      }
+      {
+        day: 'Tuesday'
+        hourSlots: [
+          15
+          16
+          17
+          18
+          19
+          20
+          21
+          22
+          23
+        ]
+      }
+      {
+        day: 'Wednesday'
+        hourSlots: [
+          15
+          16
+          17
+          18
+          19
+          20
+          21
+          22
+          23
+        ]
+      }
+      {
+        day: 'Thursday'
+        hourSlots: [
+          15
+          16
+          17
+          18
+          19
+          20
+          21
+          22
+          23
+        ]
+      }
+    ]
+  }
+}
+
 module userAgentPools '../modules/aks/pool.bicep' = {
   name: 'user-agent-pools'
   params: {


### PR DESCRIPTION
Our AKS clusters opt into auto-upgrade for patch-level control plane upgrades and node image upgrades. While these upgrades are, in the abstract, fairly safe, they always carry some risk. We do not want to burden our on-call staff with middle-of-the-night calls or any weekend calls if we absolutely do not have to, so we need to use maintenance windows to forbid changes to the cluster during these times. The maintenance window also provides a simple way to capture CCOA periods.

As proposed, the maintenance window triggers daily, at 15:00 UTC, and lasts for 10 hours. This roughly captures the US working timezones for mountain and west coast time zones. We constrain the schedule to only be valid Monday-Thursday 15:00 UTC to 24:00 UTC.
