### PR TITLE
tooling: fix entrypoint runner

### DIFF
--- a/tooling/templatize/cmd/entrypoint/entrypointutils/options.go
+++ b/tooling/templatize/cmd/entrypoint/entrypointutils/options.go
@@ -163,6 +163,10 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 		}
 	}
 
+	if o.Entrypoint != "" && e == nil {
+		return nil, fmt.Errorf("entrypoint %s not found in topology", o.Entrypoint)
+	}
+
 	pipelines := map[string]*types.Pipeline{}
 	if err := LoadPipelines(service, filepath.Dir(o.TopologyFile), pipelines, completed.Config); err != nil {
 		return nil, fmt.Errorf("failed to load pipelines from %s: %w", o.TopologyFile, err)


### PR DESCRIPTION
Previously, specifying an invalid entrypoint would just run the pipeline. We should do better input sanitization.
