### PR TITLE
change CS K8s Job script executor base image to azurelinux core 3.0

### DIFF
--- a/cluster-service/deploy/charts/debug-jobs/templates/shell-script-executor.yaml
+++ b/cluster-service/deploy/charts/debug-jobs/templates/shell-script-executor.yaml
@@ -21,7 +21,7 @@ spec:
           defaultMode: 0755
       containers:
       - name: cs-shell-script-executor
-        image: 'mcr.microsoft.com/aks/command/runtime:master.240118.1'
+        image: 'mcr.microsoft.com/azurelinux/base/core:3.0'
         command: ["/bin/sh", "-c"]
         args:
         - |
@@ -67,6 +67,15 @@ spec:
             echo "All image tag checks passed successfully for tag: $EXPECTED_TAG"
           }
 
+          # TODO create a custom image with the needed
+          # commands instead of installing them at runtime
+          echo "Setting up tools..."
+          tdnf update
+          echo "Installing kubectl..."
+          tdnf install -y kubectl
+          echo "Installing jq..."
+          tdnf install -y jq
+
           echo "Starting execution..."
 
           echo "Waiting for clusters-service deployment rollout to complete"
@@ -82,7 +91,7 @@ spec:
           echo "Running arbitrary commands..."
           /bin/bash /scripts/arbitrary-commands.sh
 
-          echo "\n\nExecution completed successfully"
+          echo "Execution completed successfully"
         volumeMounts:
         - name: scripts
           mountPath: /scripts


### PR DESCRIPTION
We change the base image used in the K8s Job script executor
from mcr.microsoft.com/aks/command/runtime:master.240118.1
to mcr.microsoft.com/azurelinux/base/core:3.0. The reason is
that the azurelinux base core image 3.0 allows us to install
additional tools useful for the scripts like for example jq,
as well as potentially allowing installation of new
software within it.