### PR TITLE
cfg: Infra Node pools update

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -895,7 +895,7 @@ clouds:
             softDelete: false
           infraAgentPool:
             poolCount: 1
-            vmSize: 'Standard_D2ds_v5'
+            vmSize: 'Standard_D2s_v3'
           systemAgentPool:
             poolCount: 1
         prometheus:
@@ -930,7 +930,7 @@ clouds:
             osDiskSizeGB: 100
           infraAgentPool:
             poolCount: 2
-            vmSize: 'Standard_D2ds_v5'
+            vmSize: 'Standard_D2s_v3'
           etcd:
             softDelete: false
           enableSwiftV2Vnet: false
@@ -1140,6 +1140,7 @@ clouds:
                   zones: '1'
                 infraAgentPool:
                   zones: '1'
+                  vmSize: 'Standard_D2s_v3'
                 systemAgentPool:
                   zones: '1'
             mgmt:
@@ -1148,6 +1149,7 @@ clouds:
                   zones: '1'
                 infraAgentPool:
                   zones: '1'
+                  vmSize: 'Standard_D2s_v3'
                 systemAgentPool:
                   zones: '1'
         # this is the personal DEV environment

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,19 +3,19 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 37a92235cdad4dc74832baa3e5e7462b95c1c5b38e42ee1c6a79aa810c784f38
+          westus3: 79406262a305b5e6431ee08b4f575c151ccdb51fd2f8d17e74861c5f6ebf3daa
       dev:
         regions:
-          westus3: 63f33f78cc67441ba157e1947859dc16747ccdd4e109aa203be15bcb3cbf0281
+          westus3: 78d8e0e97c97e4a1b4a35c67968668000e17bb34f7397d3c3fe8631f47a3076f
       ntly:
         regions:
-          uksouth: bf64871a8bdd3be7bc3247f0dc06462f3edcb7ebb0ed382cfb763ade4e663399
+          uksouth: 3df790e4da9101ffee41a2a7aca8bb13e9d23567701f194379323963585c9712
       perf:
         regions:
-          westus3: 428b20eb557e06f9ecc695caa23e681951305f9d5e8cba9475f77e7e806a9622
+          westus3: a07729a363b52e167abd5bcb8f13cbba888af54e30eb236d08c0f8914eee0efb
       pers:
         regions:
-          westus3: 39f9bcf0462e8ef9e5a05c3cce0899b24e89caa014ae10af37dfd12448f308c8
+          westus3: 809b78ada0e88eb8060e40b18dc8f647024f21a7b795a72631303f01cf0b71c5
       swft:
         regions:
-          uksouth: b9f465c6e1091a5ea38bb302443c1a45161d44940b33c5bd6323cbc6c38a860a
+          uksouth: b182073c3654a879d067533a8e2bfa3583f439115e52475b80f40910ec9b4fc0

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -419,7 +419,7 @@ mgmt:
       minCount: 1
       osDiskSizeGB: 32
       poolCount: 2
-      vmSize: Standard_D2ds_v5
+      vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.32.5
@@ -658,7 +658,7 @@ svc:
       minCount: 1
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D2ds_v5
+      vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.32.5

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -419,7 +419,7 @@ mgmt:
       minCount: 1
       osDiskSizeGB: 32
       poolCount: 2
-      vmSize: Standard_D2ds_v5
+      vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.32.5
@@ -658,7 +658,7 @@ svc:
       minCount: 1
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D2ds_v5
+      vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.32.5

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -419,7 +419,7 @@ mgmt:
       minCount: 1
       osDiskSizeGB: 32
       poolCount: 2
-      vmSize: Standard_D2ds_v5
+      vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.32.5
@@ -658,7 +658,7 @@ svc:
       minCount: 1
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D2ds_v5
+      vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.32.5

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -419,7 +419,7 @@ mgmt:
       minCount: 1
       osDiskSizeGB: 32
       poolCount: 2
-      vmSize: Standard_D2ds_v5
+      vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.32.5
@@ -658,7 +658,7 @@ svc:
       minCount: 1
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D2ds_v5
+      vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.32.5

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -419,7 +419,7 @@ mgmt:
       minCount: 1
       osDiskSizeGB: 32
       poolCount: 2
-      vmSize: Standard_D2ds_v5
+      vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.32.5
@@ -660,7 +660,7 @@ svc:
       minCount: 1
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D2ds_v5
+      vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.32.5

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -419,7 +419,7 @@ mgmt:
       minCount: 1
       osDiskSizeGB: 32
       poolCount: 2
-      vmSize: Standard_D2ds_v5
+      vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.32.5
@@ -660,7 +660,7 @@ svc:
       minCount: 1
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D2ds_v5
+      vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.32.5


### PR DESCRIPTION
[ARO-22212](https://issues.redhat.com/browse/ARO-22212)

### What

#### Configuration Changes (`config/config.yaml`)

1. **Updated default management infraAgentPool VM size** (line 410):
   - Changed from `Standard_D2ds_v6` → `Standard_D4ds_v5`
   - This affects all environments unless overridden

2. **Added dev environment service cluster override** (line 898):
   - Service cluster infraAgentPool: `Standard_D2s_v3 ` (current setting)
   - Reduces costs in dev environments while maintaining compatibility

3. **Added dev environment management cluster override** (line 932):
   - Management cluster infraAgentPool: `Standard_D2s_v3` (current setting)
   - Reduces costs in dev environments while maintaining compatibility

### Why

Follows https://github.com/Azure/ARO-HCP/pull/3252

- **Dev environments** (cspr, dev, ntly, perf, pers, swft): Management and service clusters will use the same `Standard_D2s_v3` VMs to avoid breaking changes.
- **Public/Int environment**: Management clusters will use `Standard_D4ds_v5` (default), which is available in the Microsoft tenant and will allow Prometheus workloads to run without scheduling issues.
