### PR TITLE
cfg: disable DNS childzone delegation steps

### DIFF
--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -113,37 +113,37 @@ resourceGroups:
         step: output
         name: globalMSIId
   # creates DNS delegation for the ARO HCP global SVC zone
-  - name: svcChildZone
-    action: DelegateChildZone
-    parentZone:
-      configRef: dns.parentZoneName
-    childZone:
-      configRef: dns.svcParentZoneName
-    secretKeyVault:
-      configRef: ev2.assistedId.certificate.keyVault
-    secretName:
-      configRef: ev2.assistedId.certificate.name
-    dstsHost:
-      configRef: ev2.assistedId.dstsHost
-    dependsOn:
-    - resourceGroup: global
-      step: infra
+  # - name: svcChildZone
+  #   action: DelegateChildZone
+  #   parentZone:
+  #     configRef: dns.parentZoneName
+  #   childZone:
+  #     configRef: dns.svcParentZoneName
+  #   secretKeyVault:
+  #     configRef: ev2.assistedId.certificate.keyVault
+  #   secretName:
+  #     configRef: ev2.assistedId.certificate.name
+  #   dstsHost:
+  #     configRef: ev2.assistedId.dstsHost
+  #   dependsOn:
+  #   - resourceGroup: global
+  #     step: infra
   # creates DNS delegation for the ARO HCP global CX zone
-  - name: cxChildZone
-    action: DelegateChildZone
-    parentZone:
-      configRef: dns.parentZoneName
-    childZone:
-      configRef: dns.cxParentZoneName
-    secretKeyVault:
-      configRef: ev2.assistedId.certificate.keyVault
-    secretName:
-      configRef: ev2.assistedId.certificate.name
-    dstsHost:
-      configRef: ev2.assistedId.dstsHost
-    dependsOn:
-    - resourceGroup: global
-      step: infra
+  # - name: cxChildZone
+  #   action: DelegateChildZone
+  #   parentZone:
+  #     configRef: dns.parentZoneName
+  #   childZone:
+  #     configRef: dns.cxParentZoneName
+  #   secretKeyVault:
+  #     configRef: ev2.assistedId.certificate.keyVault
+  #   secretName:
+  #     configRef: ev2.assistedId.certificate.name
+  #   dstsHost:
+  #     configRef: ev2.assistedId.dstsHost
+  #   dependsOn:
+  #   - resourceGroup: global
+  #     step: infra
   # create global ARO HCP ACRs for OCP and SVC images
   - name: acrs
     action: ARM


### PR DESCRIPTION
### What

due to the ongoing safedns migration we are currently not able to run DNS delegation steps within ev2. until this is mitigated, we need to disable these steps

there is no impact on any environments because these steps delegate from the parent-parent zones to our CX and SVC parent zones. since these delegations are in place for all environments, we don't loose anything but not running these for the time being.

Follows up on #3247 and #3245
