### PR TITLE
fix: fix reference to templatize.sh from CS setup-env.mk

### DIFF
--- a/cluster-service/setup-env.mk
+++ b/cluster-service/setup-env.mk
@@ -3,7 +3,8 @@ SHELLFLAGS = -eu -o pipefail
 
 ifndef zz_injected_EV2
 ifndef RUNS_IN_TEMPLATIZE
-PROJECT_ROOT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+SCRIPT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+PROJECT_ROOT_DIR := $(realpath $(SCRIPT_DIR)/..)
 
 DEPLOY_ENV ?= pers
 PIPELINE ?= pipeline.yaml


### PR DESCRIPTION
setup-env.mk was moved from the project root to
cluster-service/setup-env.mk. This made references to the templatize.sh script within cluster-service/setup-env.mk start to fail which prevented the env vars file to be created.

This commit fixes the reference to point to templatize.sh correctly from within cluster-service/setup-env.mk.

This change is possible because even though templatize.sh is outside of the cluster-service directory the envvars file generation via setup-env.mk is not leveraged in the EV2 context.