### PR TITLE
adjust hcp kas burn alert to reduce flappiness

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -1600,14 +1600,14 @@ resource kasMonitorRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         labels: {
           long_window: '1h'
           severity: 'warning'
-          short_window: '5m'
+          short_window: '30m'
         }
         annotations: {
           correlationId: 'kas-monitor-ErrorBudgetBurn/{{ $labels.cluster }}/{{ $labels.probe_url }}'
           description: 'High error budget burn for {{ $labels.probe_url }} (current value: {{ $value }})'
           title: 'High error budget burn for {{ $labels.probe_url }} (current value: {{ $value }})'
         }
-        expression: '1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{}[5m])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[5m]))) > (14.4 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[5m])) > 5 and 1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{}[1h])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[1h]))) > (14.4 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[1h])) > 60'
+        expression: '1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{}[30m])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[30m]))) > (14.4 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[30m])) > 5 and 1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{}[1h])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[1h]))) > (14.4 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[1h])) > 60'
         for: 'PT2M'
         severity: 3
       }
@@ -1634,7 +1634,7 @@ resource kasMonitorRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           title: 'High error budget burn for {{ $labels.probe_url }} (current value: {{ $value }})'
         }
         expression: '1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{}[30m])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[30m]))) > (6 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[30m])) > 30 and 1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{}[6h])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[6h]))) > (6 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[6h])) > 360'
-        for: 'PT15M'
+        for: 'PT2H10M'
         severity: 3
       }
       {

--- a/observability/alerts/HCPkasMonitor-prometheusRule.yaml
+++ b/observability/alerts/HCPkasMonitor-prometheusRule.yaml
@@ -9,17 +9,17 @@ spec:
     rules:
     - alert: kas-monitor-ErrorBudgetBurn
       expr: |
-        1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{}[5m])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[5m]))) > (14.4 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[5m])) > 5 and 1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{}[1h])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[1h]))) > (14.4 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[1h])) > 60
+        1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{}[30m])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[30m]))) > (14.4 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[30m])) > 5 and 1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{}[1h])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[1h]))) > (14.4 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[1h])) > 60
       for: 2m
       labels:
         long_window: 1h
         severity: warning
-        short_window: 5m
+        short_window: 30m
       annotations:
         description: "High error budget burn for {{ $labels.probe_url }} (current value: {{ $value }})"
     - alert: kas-monitor-ErrorBudgetBurn
       expr: 1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{}[30m])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[30m]))) > (6 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[30m])) > 30 and 1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{}[6h])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[6h]))) > (6 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{}[6h])) > 360
-      for: 15m
+      for: 130m
       labels:
         long_window: 6h
         severity: warning

--- a/observability/alerts/HCPkasMonitor-prometheusRule_test.yaml
+++ b/observability/alerts/HCPkasMonitor-prometheusRule_test.yaml
@@ -8,18 +8,18 @@ tests:
   - series: 'probe_success{probe_url="https://api.example.com/health", namespace="test-hcp-namespace", _id="test-hcp-id", cluster="test-cluster"}'
     values: "1+0x70" # Perfect success for sufficient time
   alert_rule_test:
-  - eval_time: 65m
+  - eval_time: 630m
     alertname: kas-monitor-ErrorBudgetBurn
     exp_alerts: [] # Should not fire with perfect success
-# Test 2: Complete failure should trigger fast burn alert (5m/1h windows, for: 2m)
+# Test 2: Complete failure should trigger fast burn alert (30m/1h windows, for: 2m)
 - interval: 30s # Generate data every 30 seconds to meet sample count requirements
   input_series:
   - series: 'probe_success{probe_url="https://api.example.com/health", namespace="test-hcp-namespace", _id="test-hcp-id", cluster="test-cluster"}'
     # Complete failure: 0% success (100% failure) for sufficient duration
-    # With 30s interval: 5m window has 10 samples (>5 ✓), 1h window has 120 samples (>60 ✓)
+    # With 30s interval: 30m window has 10 samples (>5 ✓), 1h window has 120 samples (>60 ✓)
     # Alert condition: 1 - (0/10) > 0.0072 AND 1 - (0/120) > 0.0072 = TRUE
     # With 'for: 2m', alert should fire at 63m (condition true at 61m + 2m)
-    values: "0+0x130" # Complete failure for 65+ minutes (130 * 30s = 65m)
+    values: "0+0x130" # Complete failure for 65+ minutes (130 * 30s = 630m)
   alert_rule_test:
   - eval_time: 63m # When first alert should fire (after 'for' condition satisfied)
     alertname: kas-monitor-ErrorBudgetBurn
@@ -27,14 +27,14 @@ tests:
     - exp_labels:
         severity: warning
         long_window: 1h
-        short_window: 5m
+        short_window: 30m
         probe_url: https://api.example.com/health
         namespace: test-hcp-namespace
         _id: test-hcp-id
         cluster: test-cluster
       exp_annotations:
         description: "High error budget burn for https://api.example.com/health (current value: 1)"
-# Test 3: Medium burn rate - Alert 2 (30m/6h windows, for: 15m)
+# Test 3: Medium burn rate - Alert 2 (30m/6h windows, for: 130m)
 - interval: 30s # Generate data every 30 seconds
   input_series:
   - series: 'probe_success{probe_url="https://api.example.com/health", namespace="test-hcp-namespace", _id="test-hcp-id", cluster="test-cluster"}'
@@ -42,13 +42,13 @@ tests:
     # With 30s interval: 30m window has 60 samples (>30 ✓), 6h window has 720 samples (>360 ✓)
     values: "0+0x800" # Complete failure for 400+ minutes (800 * 30s = 400m)
   alert_rule_test:
-  - eval_time: 390m # After 6h+30m to satisfy both windows and 'for' condition (15m)
+  - eval_time: 390m # After 6h+30m to satisfy both windows and 'for' condition (130m)
     alertname: kas-monitor-ErrorBudgetBurn
     exp_alerts:
     - exp_labels:
         severity: warning
         long_window: 1h
-        short_window: 5m
+        short_window: 30m
         probe_url: https://api.example.com/health
         namespace: test-hcp-namespace
         _id: test-hcp-id
@@ -78,7 +78,7 @@ tests:
     - exp_labels:
         severity: warning
         long_window: 1h
-        short_window: 5m
+        short_window: 30m
         probe_url: https://api.example.com/health
         namespace: test-hcp-namespace
         _id: test-hcp-id


### PR DESCRIPTION
[<!-- Link to Jira issue -->](https://issues.redhat.com/browse/AROSLSRE-107?filter=-1)

### What

Changes '5m and' condition to '30m and'

### Why

This alert was very flappy.  This change reduces flapping by 35% based on historic alert data.

### Special notes for your reviewer

<!-- optional -->
