### PR TITLE
cfg: reduce svc prometheus resources

### DIFF
--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
@@ -68444,10 +68444,10 @@ spec:
   resources:
     requests:
       cpu: '1'
-      memory: '6Gi'
+      memory: '2Gi'
     limits:
       cpu: '2'
-      memory: '10Gi'
+      memory: '6Gi'
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/observability/prometheus/values-svc.yaml
+++ b/observability/prometheus/values-svc.yaml
@@ -84,10 +84,10 @@ prometheusSpec:
   resources:
     requests:
       cpu: 1
-      memory: 6Gi
+      memory: 2Gi
     limits:
       cpu: 2
-      memory: 10Gi
+      memory: "6Gi"
 prometheus:
   prometheusSpec:
     shards: {{ .svc.prometheus.prometheusSpec.shards }}


### PR DESCRIPTION
[ARO-22212](https://issues.redhat.com/browse/ARO-22212)

## What

Reduces Prometheus resource allocation in service clusters by:
- Memory request: `6Gi` → `2Gi`
- Memory limit: `10Gi` → `6Gi`

Changes applied to `observability/prometheus/values-svc.yaml` and reflected in the test fixtures.

## Why

The current Prometheus resource allocation in service clusters is overprovisioned. Based on actual usage patterns, we can safely reduce the memory footprint
while maintaining performance and stability. This change:
- Improves cluster resource utilization
- Reduces cloud infrastructure costs
- Allows for better bin-packing of workloads on cluster nodes

The CPU allocation remains unchanged (1 core request, 2 core limit) as it's appropriately sized for current workloads.