### PR TITLE
fix local-aro-hcp-ocp-versions-config CS make target

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -162,6 +162,7 @@ local-aro-hcp-ocp-versions-config:
 	--set ocpVersions.defaultVersion.version=${OCP_VERSIONS_DEFAULT_VERSION_VERSION} \
 	--set ocpVersions.channelGroups.stable.minVersion=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MIN_VERSION} \
 	--set ocpVersions.channelGroups.stable.maxVersion=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MAX_VERSION} \
+	--set azureOperatorsMI.roleSetName=${OPERATOR_ROLE_SET_NAME} \
 	-s templates/aro-hcp-ocp-versions-config.configmap.yaml | yq '.data["aro-hcp-ocp-versions-config.yaml"]' > ./aro-hcp-ocp-versions-config.yaml
 .PHONY: local-aro-hcp-ocp-versions-config
 


### PR DESCRIPTION
It was missing referencing the azureOperatorsMI.roleSetName helm template parameter, which is needed in that target because it tries to render the deploy/templates/deployment.yaml file which in turn includes the
deploy/templates/azure-operators-managed-identities-config.configmap.yaml file, which was trying to set a variable by looking at the azureOperatorsMI helm parameter map with the key roleSetName, which because of it not being set was failing which in turn caused dereferencing of a variable fail making the make target fail.
