### PR TITLE
feat: add support for sha images

### DIFF
--- a/tooling/image-updater/README.md
+++ b/tooling/image-updater/README.md
@@ -18,6 +18,7 @@ The image-updater supports multiple container registry types with optimized clie
 - **Opt-in Authentication**: Explicitly enable authentication only for private registries
 - **Architecture-Aware**: Automatically filters images by architecture (defaults to amd64)
 - **Multi-Registry Client**: Automatically selects the appropriate client based on registry URL
+- **Flexible Digest Format**: Supports both `.digest` fields (with `sha256:` prefix) and `.sha` fields (hash only)
 
 ## Managed Images
 
@@ -124,6 +125,16 @@ images:
       multiArch: true  # Fetch multi-arch manifest list digest
     targets:
     - jsonPath: defaults.secretSyncController.image.digest
+      filePath: ../../config/config.yaml
+
+  # Example using .sha field (stores hash without sha256: prefix)
+  prometheus-operator:
+    source:
+      image: mcr.microsoft.com/oss/v2/prometheus/prometheus-operator
+      tagPattern: "^v\\d+\\.\\d+\\.\\d+-?\\d?$"
+      multiArch: true
+    targets:
+    - jsonPath: defaults.prometheus.prometheusOperator.image.sha
       filePath: ../../config/config.yaml
 ```
 
@@ -278,7 +289,12 @@ Flags:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `filePath` | string | Yes | Path to YAML file to update |
-| `jsonPath` | string | Yes | Dot-notation path to digest field (e.g., `defaults.image.digest`) |
+| `jsonPath` | string | Yes | Dot-notation path to digest field (e.g., `defaults.image.digest` or `defaults.image.sha`) |
+
+**Note on digest vs sha fields:**
+- Fields ending with `.digest` will store the full digest including the `sha256:` prefix
+- Fields ending with `.sha` will store only the hash value without the `sha256:` prefix
+- This allows the tool to work with different configuration formats that have different digest field conventions
 
 ## How It Works
 

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -1,4 +1,5 @@
 images:
+  # Maestro image
   maestro:
     source:
       image: quay.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
@@ -8,6 +9,7 @@ images:
       filePath: ../../config/config.msft.clouds-overlay.yaml
     - jsonPath: clouds.dev.defaults.maestro.image.digest
       filePath: ../../config/config.yaml
+  # Hypershift image
   hypershift:
     source:
       image: quay.io/acm-d/rhtap-hypershift-operator
@@ -18,6 +20,7 @@ images:
       filePath: ../../config/config.msft.clouds-overlay.yaml
     - jsonPath: clouds.dev.environments.pers.defaults.hypershift.image.digest
       filePath: ../../config/config.yaml
+  # PKO images
   pko-package:
     source:
       image: quay.io/package-operator/package-operator-package
@@ -45,6 +48,7 @@ images:
       filePath: ../../config/config.msft.clouds-overlay.yaml
     - jsonPath: defaults.pko.remotePhaseManager.digest
       filePath: ../../config/config.yaml
+  # Frontend and Backend images
   arohcpfrontend:
     source:
       image: arohcpsvcdev.azurecr.io/arohcpfrontend
@@ -63,6 +67,7 @@ images:
       filePath: ../../config/config.msft.clouds-overlay.yaml
     - jsonPath: clouds.dev.defaults.backend.image.digest
       filePath: ../../config/config.yaml
+  # Kube Events image
   kubeEvents:
     source:
       image: kubernetesshared.azurecr.io/shared/kube-events
@@ -70,6 +75,7 @@ images:
     targets:
     - jsonPath: defaults.kubeEvents.image.digest
       filePath: ../../config/config.yaml
+  # ACM images
   acm-operator:
     source:
       image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-214
@@ -84,6 +90,7 @@ images:
     targets:
     - jsonPath: defaults.acm.mce.bundle.digest
       filePath: ../../config/config.yaml
+  # MSI-Acrpull image
   acrPull:
     source:
       image: mcr.microsoft.com/aks/msi-acrpull
@@ -91,6 +98,7 @@ images:
     targets:
     - jsonPath: clouds.public.environments.int.defaults.acrPull.image.digest
       filePath: ../../config/config.msft.clouds-overlay.yaml
+  # Arobit images
   arobit-forwarder:
     source:
       image: mcr.microsoft.com/oss/v2/fluent/fluent-bit
@@ -107,6 +115,7 @@ images:
     targets:
     - jsonPath: defaults.arobit.mdsd.image.digest
       filePath: ../../config/config.yaml
+  # Secret Sync Controller image
   secretSyncController:
     source:
       image: registry.k8s.io/secrets-store-sync/controller
@@ -116,4 +125,59 @@ images:
     - jsonPath: clouds.public.environments.int.defaults.secretSyncController.image.digest
       filePath: ../../config/config.msft.clouds-overlay.yaml
     - jsonPath: clouds.dev.defaults.secretSyncController.image.digest
+      filePath: ../../config/config.yaml
+  # Prometheus images
+  prometheus-operator:
+    source:
+      image: mcr.microsoft.com/oss/v2/prometheus/prometheus-operator
+      tagPattern: "^v\\d+\\.\\d+\\.\\d+-?\\d?$"
+      multiArch: true # This image only publishes multi-arch manifests
+    targets:
+    - jsonPath: clouds.public.environments.int.defaults.svc.prometheus.prometheusOperator.image.sha
+      filePath: ../../config/config.msft.clouds-overlay.yaml
+    - jsonPath: clouds.public.environments.int.defaults.mgmt.prometheus.prometheusOperator.image.sha
+      filePath: ../../config/config.msft.clouds-overlay.yaml
+    - jsonPath: clouds.dev.defaults.svc.prometheus.prometheusOperator.image.sha
+      filePath: ../../config/config.yaml
+  prometheus:
+    source:
+      image: mcr.microsoft.com/oss/v2/prometheus/prometheus
+      tagPattern: "^v\\d+\\.\\d+\\.\\d+-?\\d?$"
+      multiArch: true # This image only publishes multi-arch manifests
+    targets:
+    - jsonPath: clouds.public.environments.int.defaults.svc.prometheus.prometheusSpec.image.sha
+      filePath: ../../config/config.msft.clouds-overlay.yaml
+    - jsonPath: clouds.public.environments.int.defaults.mgmt.prometheus.prometheusSpec.image.sha
+      filePath: ../../config/config.msft.clouds-overlay.yaml
+    - jsonPath: clouds.dev.defaults.svc.prometheus.prometheusSpec.image.sha
+      filePath: ../../config/config.yaml
+    - jsonPath: clouds.dev.defaults.mgmt.prometheus.prometheusSpec.image.sha
+      filePath: ../../config/config.yaml
+  prometheus-config-reloader:
+    source:
+      image: mcr.microsoft.com/oss/v2/prometheus/prometheus-config-reloader
+      tagPattern: "^v\\d+\\.\\d+\\.\\d+-?\\d?$"
+      multiArch: true # This image only publishes multi-arch manifests
+    targets:
+    - jsonPath: clouds.public.environments.int.defaults.svc.prometheus.prometheusConfigReloader.image.sha
+      filePath: ../../config/config.msft.clouds-overlay.yaml
+    - jsonPath: clouds.public.environments.int.defaults.mgmt.prometheus.prometheusConfigReloader.image.sha
+      filePath: ../../config/config.msft.clouds-overlay.yaml
+    - jsonPath: clouds.dev.defaults.svc.prometheus.prometheusConfigReloader.image.sha
+      filePath: ../../config/config.yaml
+    - jsonPath: clouds.dev.defaults.mgmt.prometheus.prometheusConfigReloader.image.sha
+      filePath: ../../config/config.yaml
+  kube-state-metrics:
+    source:
+      image: mcr.microsoft.com/oss/v2/kubernetes/kube-state-metrics
+      tagPattern: "^v\\d+\\.\\d+\\.\\d+-?\\d?$"
+      multiArch: true # This image only publishes multi-arch manifests
+    targets:
+    - jsonPath: clouds.public.environments.int.defaults.svc.prometheus.kubeStateMetrics.image.digest
+      filePath: ../../config/config.msft.clouds-overlay.yaml
+    - jsonPath: clouds.public.environments.int.defaults.mgmt.prometheus.kubeStateMetrics.image.digest
+      filePath: ../../config/config.msft.clouds-overlay.yaml
+    - jsonPath: clouds.dev.defaults.svc.prometheus.kubeStateMetrics.image.digest
+      filePath: ../../config/config.yaml
+    - jsonPath: clouds.dev.defaults.mgmt.prometheus.kubeStateMetrics.image.digest
       filePath: ../../config/config.yaml

--- a/tooling/image-updater/internal/updater/updater.go
+++ b/tooling/image-updater/internal/updater/updater.go
@@ -124,7 +124,14 @@ func (u *Updater) ProcessImageUpdates(ctx context.Context, name string, latestDi
 
 	logger.Info("Current digest", "name", name, "currentDigest", currentDigest)
 
-	if currentDigest == latestDigest {
+	// If the target path ends with .sha, we need to strip the sha256: prefix
+	// from the digest since sha fields only contain the hash value
+	newDigest := latestDigest
+	if strings.HasSuffix(target.JsonPath, ".sha") {
+		newDigest = strings.TrimPrefix(latestDigest, "sha256:")
+	}
+
+	if currentDigest == newDigest {
 		logger.Info("No update needed - digests match", "name", name)
 		return nil
 	}
@@ -138,13 +145,13 @@ func (u *Updater) ProcessImageUpdates(ctx context.Context, name string, latestDi
 			"filePath", target.FilePath,
 			"line", line,
 			"from", currentDigest,
-			"to", latestDigest)
+			"to", newDigest)
 		return nil
 	}
 
 	u.Updates[target.FilePath] = append(u.Updates[target.FilePath], yaml.Update{
 		Name:      name,
-		NewDigest: latestDigest,
+		NewDigest: newDigest,
 		OldDigest: currentDigest,
 		JsonPath:  target.JsonPath,
 		FilePath:  target.FilePath,

--- a/tooling/image-updater/internal/updater/updater_test.go
+++ b/tooling/image-updater/internal/updater/updater_test.go
@@ -465,6 +465,185 @@ func TestUpdater_GenerateCommitMessage(t *testing.T) {
 	}
 }
 
+func TestUpdater_ProcessImageUpdates_SHAFieldHandling(t *testing.T) {
+	tests := []struct {
+		name              string
+		jsonPath          string
+		currentValue      string
+		latestDigest      string
+		wantDigestInFile  string
+		wantUpdateDigest  string
+		wantUpdateCreated bool
+	}{
+		{
+			name:              "sha field strips sha256 prefix",
+			jsonPath:          "image.sha",
+			currentValue:      "olddigest123",
+			latestDigest:      "sha256:newdigest456",
+			wantDigestInFile:  "newdigest456",
+			wantUpdateDigest:  "newdigest456",
+			wantUpdateCreated: true,
+		},
+		{
+			name:              "digest field keeps sha256 prefix",
+			jsonPath:          "image.digest",
+			currentValue:      "sha256:olddigest123",
+			latestDigest:      "sha256:newdigest456",
+			wantDigestInFile:  "sha256:newdigest456",
+			wantUpdateDigest:  "sha256:newdigest456",
+			wantUpdateCreated: true,
+		},
+		{
+			name:              "sha field no update when digests match",
+			jsonPath:          "image.sha",
+			currentValue:      "abc123",
+			latestDigest:      "sha256:abc123",
+			wantDigestInFile:  "abc123",
+			wantUpdateDigest:  "",
+			wantUpdateCreated: false,
+		},
+		{
+			name:              "digest field no update when digests match",
+			jsonPath:          "image.digest",
+			currentValue:      "sha256:abc123",
+			latestDigest:      "sha256:abc123",
+			wantDigestInFile:  "sha256:abc123",
+			wantUpdateDigest:  "",
+			wantUpdateCreated: false,
+		},
+		{
+			name:              "nested sha field path",
+			jsonPath:          "prometheus.prometheusOperator.image.sha",
+			currentValue:      "oldsha",
+			latestDigest:      "sha256:newsha",
+			wantDigestInFile:  "newsha",
+			wantUpdateDigest:  "newsha",
+			wantUpdateCreated: true,
+		},
+		{
+			name:              "sha field with already stripped digest",
+			jsonPath:          "image.sha",
+			currentValue:      "olddigest",
+			latestDigest:      "newdigest",
+			wantDigestInFile:  "newdigest",
+			wantUpdateDigest:  "newdigest",
+			wantUpdateCreated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Create temp YAML file with initial content
+			tmpDir := t.TempDir()
+			yamlPath := filepath.Join(tmpDir, "test.yaml")
+
+			// Build YAML content based on jsonPath
+			var yamlContent string
+			if strings.HasPrefix(tt.jsonPath, "prometheus.") {
+				yamlContent = fmt.Sprintf(`
+prometheus:
+  prometheusOperator:
+    image:
+      sha: %s
+`, tt.currentValue)
+			} else {
+				// Set the appropriate field
+				if strings.Contains(tt.jsonPath, ".sha") {
+					yamlContent = fmt.Sprintf(`
+image:
+  sha: %s
+`, tt.currentValue)
+				} else {
+					yamlContent = fmt.Sprintf(`
+image:
+  digest: %s
+`, tt.currentValue)
+				}
+			}
+
+			if err := os.WriteFile(yamlPath, []byte(yamlContent), 0644); err != nil {
+				t.Fatalf("failed to create temp yaml: %v", err)
+			}
+
+			// Create YAML editor
+			editor, err := yaml.NewEditor(yamlPath)
+			if err != nil {
+				t.Fatalf("failed to create yaml editor: %v", err)
+			}
+
+			yamlEditors := map[string]*yaml.Editor{
+				yamlPath: editor,
+			}
+
+			// Create target
+			target := config.Target{
+				FilePath: yamlPath,
+				JsonPath: tt.jsonPath,
+			}
+
+			// Create updater
+			u := &Updater{
+				Config:      &config.Config{},
+				DryRun:      false,
+				YAMLEditors: yamlEditors,
+				Updates:     make(map[string][]yaml.Update),
+			}
+
+			// Process update
+			err = u.ProcessImageUpdates(ctx, "test-image", tt.latestDigest, target)
+			if err != nil {
+				t.Fatalf("ProcessImageUpdates() failed: %v", err)
+			}
+
+			// Verify update was or wasn't created
+			totalUpdates := 0
+			var update *yaml.Update
+			for _, updates := range u.Updates {
+				totalUpdates += len(updates)
+				if len(updates) > 0 {
+					update = &updates[0]
+				}
+			}
+
+			if tt.wantUpdateCreated && totalUpdates == 0 {
+				t.Errorf("Expected update to be created, but none was created")
+			}
+			if !tt.wantUpdateCreated && totalUpdates > 0 {
+				t.Errorf("Expected no update, but %d update(s) created", totalUpdates)
+			}
+
+			// If update was created, verify the digest format
+			if tt.wantUpdateCreated && update != nil {
+				if update.NewDigest != tt.wantUpdateDigest {
+					t.Errorf("Update.NewDigest = %v, want %v", update.NewDigest, tt.wantUpdateDigest)
+				}
+
+				// Apply the update
+				if err := editor.ApplyUpdates(u.Updates[yamlPath]); err != nil {
+					t.Fatalf("ApplyUpdates() failed: %v", err)
+				}
+
+				// Verify file content
+				newEditor, err := yaml.NewEditor(yamlPath)
+				if err != nil {
+					t.Fatalf("failed to read updated file: %v", err)
+				}
+
+				_, fileDigest, err := newEditor.GetUpdate(tt.jsonPath)
+				if err != nil {
+					t.Fatalf("failed to get digest from file: %v", err)
+				}
+
+				if fileDigest != tt.wantDigestInFile {
+					t.Errorf("File digest = %v, want %v", fileDigest, tt.wantDigestInFile)
+				}
+			}
+		})
+	}
+}
+
 func TestUpdater_FileUpdateIntegration(t *testing.T) {
 	t.Run("complete file update workflow", func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
[AROSLSRE-235](https://issues.redhat.com/browse/AROSLSRE-235)

## Why

The image-updater tool currently only supports storing image digests in the standard format with the `sha256:` prefix (e.g., `sha256:abc123...`). However, some configuration fields in our codebase use a `.sha` convention that stores only the hash value without the prefix (e.g., just `abc123...`).

The Prometheus operator images in our configuration use `.sha` fields rather than `.digest` fields, requiring the tool to support both formats to enable automated updates for these images.

## What

This PR extends the image-updater to support flexible digest formats based on field naming conventions:

- **Fields ending with `.digest`**: Store the full digest including `sha256:` prefix (existing behavior)
- **Fields ending with `.sha`**: Store only the hash value without the `sha256:` prefix (new behavior)

**Changes include:**
- Updated `updater.go` to detect `.sha` suffixed paths and strip the `sha256:` prefix before writing
- Added comprehensive test coverage in `updater_test.go` with 6 test cases covering both field types
- Updated `config.yaml` to add Prometheus image tracking (prometheus-operator, prometheus, prometheus-config-reloader, kube-state-metrics)
- Updated `README.md` documentation to explain the digest vs sha field conventions
- Added inline comments in config to organize image sections

**Example:**
```yaml
# Using .digest field
jsonPath: defaults.image.digest  # Stores: sha256:abc123...

# Using .sha field
jsonPath: defaults.image.sha     # Stores: abc123...
```

This enables the image-updater to manage Prometheus and other images that use the `.sha` field convention while maintaining backward compatibility with existing `.digest` fields.