### PR TITLE
New E2E test: Hosted Cluster name validations

### DIFF
--- a/test/e2e/cluster_name_validation.go
+++ b/test/e2e/cluster_name_validation.go
@@ -77,9 +77,8 @@ var _ = Describe("Customer", func() {
 					},
 					TestArtifactsFS,
 				)
-				if !deployment.shouldFail {
-					Expect(err).NotTo(HaveOccurred())
-				}
+
+				Expect(err).NotTo(HaveOccurred())
 
 				err = framework.CreateHCPClusterFromParam(ctx,
 					tc,


### PR DESCRIPTION
New E2E test case: Hosted Cluster name validations

[ARO-22511](https://issues.redhat.com/browse/ARO-22511)

### What
New negative test case to ensure:
- customer can't deploy 2 identically named clusters
- customer can't deploy a cluster with invalid name (length exceeding 54 characters, starting with non-letter character, or containing forbidden characters) 

### How

Duplicate name cluster deployment

1. Create a resource group
2. Deploy first cluster with own customer resources
3. Attempt to deploy second cluster with own customer resources, but same name as first cluster
4. Verify cluster deployment failed with the appropriate error code

Invalid name cluster deployment

1. Create a resource group
2. Create shared customer resources (for robustness, validation should fail even before that)
3. Attempt deploying cluster with:
- name exceeding the allowed length (54 characters)
- name starting with non-letter character
- name containing non-allowed characters
4. Verify each deployment failed with the appropriate error code 


