### PR TITLE
frontend: Change response codes when failing to acquire lock

### DIFF
--- a/frontend/pkg/frontend/middleware_locksubscription.go
+++ b/frontend/pkg/frontend/middleware_locksubscription.go
@@ -56,7 +56,8 @@ func (h *middlewareLockSubscription) handleRequest(w http.ResponseWriter, r *htt
 				message += "timed out"
 				lockClient.SetRetryAfterHeader(w.Header())
 				arm.WriteError(
-					w, http.StatusConflict, arm.CloudErrorCodeConflict,
+					w, http.StatusServiceUnavailable,
+					arm.CloudErrorCodeLockContention,
 					"/subscriptions/"+subscriptionID, "%s", message)
 			} else {
 				message += err.Error()

--- a/internal/api/arm/error.go
+++ b/internal/api/arm/error.go
@@ -44,6 +44,7 @@ const (
 	CloudErrorCodeInvalidSubscriptionID    = "InvalidSubscriptionID"
 	CloudErrorCodeInvalidResourceName      = "InvalidResourceName"
 	CloudErrorCodeInvalidResourceGroupName = "InvalidResourceGroupName"
+	CloudErrorCodeLockContention           = "LockContention"
 )
 
 // CloudError represents a complete resource provider error.


### PR DESCRIPTION
[ARO-22219 - ARO HCP deployment fails on failed to acquire lock for subscription error](https://issues.redhat.com/browse/ARO-22219)

### What

The various Azure SDKs have a [fixed set of response codes](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore/policy#RetryOptions) that by default trigger a retry:

- **408** Request Timeout
- **429** Too Many Requests
- **500** Internal Server Error
- **502** Bad Gateway
- **503** Service Unavailable
- **504** Gateway Timeout

The response code we've been using for subscription lock contention (**409** Conflict) does not by default trigger a retry in the Azure SDKs, despite the response including a `Retry-After` header.

This has been causing Azure deployments via Bicep to fail when they should be retrying.

Instead return **503** Service Unavailable with a custom Azure error code indicating lock contention.