### PR TITLE
feat: support passing env variables to hypershift operator deployment

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1847,6 +1847,14 @@
         },
         "namespace": {
           "type": "string"
+        },
+        "sharedIngressIPTag": {
+          "type": "string",
+          "enum": [
+            "FirstPartyUsage=/aro-hcp-prod-inbound-customerapi",
+            "FirstPartyUsage=/NonProd",
+            ""
+          ]
         }
       },
       "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -201,6 +201,9 @@ defaults:
       repository: acm-d/rhtap-hypershift-operator
     namespace: hypershift
     additionalInstallArg: '--enable-cpo-overrides'
+    # By default we set it to empty as this tag is only required for msft environments. We override
+    # this value in sdp pipelines for msft environments.
+    sharedIngressIPTag: ''
   # Log settings
   logs:
     mdsd:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,22 +3,22 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: de93f2e73e9e7229cd3743e2a530d645e96e32d43c5401b6415a17c3a1c2d980
+          westus3: dbe6aa708b6578ae96470ad8566d1ebde14ce7707d27225071482b34f4e947f5
       dev:
         regions:
-          westus3: a26c90d848ec78786d52e12d1514d096b448c42293e8a37ffad7938e73b11884
+          westus3: 39f70e0106ff4cf2037a556baacea8838265a9bfebfbbc8d8bab1972ee5e3cc4
       ntly:
         regions:
-          uksouth: eb3f228ef8ea5cff487448347e1599516e83e6fa841ab5c90dbcbbf1018d45b9
+          uksouth: 56dac2cf98e2d514f25f9a272643db8b24ccbad5d158c5c01dfa05ab625062c2
       perf:
         regions:
-          westus3: f9929d8d140a74227a080d0136f427750e2d7441305c7903e711ae7a3498e624
+          westus3: f40dd291e5850abc4bae688aba566317db991b76b6517eebc444122d2f838046
       pers:
         regions:
-          westus3: 034ce93a8665b84e44e9ab1198d7fc2da7eceab64ec0838ced02f272d49945eb
+          westus3: c8af98105e6fe8fbbfaf22dda3eae5a40ea8302881bce3b9ac4aaf6ea16bc2a2
       prow:
         regions:
-          westus3: df715f76020f2bd7b5dda1b506e80cb3744c3ed5b0638f7764c1b48b3eb9f863
+          westus3: 8d2b8be810c3bf7b0cc4983c8a7cf65fceda515979161b307e3e936f8f8edd81
       swft:
         regions:
-          uksouth: 62e845042a0a3982dc0c8a9a9a658f08a0bd9409cd5b0efd946a5f749a4545f6
+          uksouth: 152f2923588e901b691035fbcdaf1140c5aa469c83cf970ffb09b6f3e4c84741

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -315,6 +315,7 @@ hypershift:
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift
+  sharedIngressIPTag: ""
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -315,6 +315,7 @@ hypershift:
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift
+  sharedIngressIPTag: ""
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -315,6 +315,7 @@ hypershift:
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift
+  sharedIngressIPTag: ""
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -315,6 +315,7 @@ hypershift:
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift
+  sharedIngressIPTag: ""
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -315,6 +315,7 @@ hypershift:
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift
+  sharedIngressIPTag: ""
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -315,6 +315,7 @@ hypershift:
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift
+  sharedIngressIPTag: ""
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -315,6 +315,7 @@ hypershift:
     registry: quay.io
     repository: acm-d/rhtap-hypershift-operator
   namespace: hypershift
+  sharedIngressIPTag: ""
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/hypershiftoperator/deploy/templates/installer.job.yaml
+++ b/hypershiftoperator/deploy/templates/installer.job.yaml
@@ -28,6 +28,9 @@ spec:
             --hypershift-image {{ .Values.image }}@{{ .Values.imageDigest }} \
             --platform-monitoring=None \
             --enable-size-tagging=true \
+            {{- if .Values.operatorEnvVars.sharedIngressIPTag }}
+            --additional-operator-env-vars SHARED_INGRESS_AZURE_PIP_IP_TAGS={{ .Values.operatorEnvVars.sharedIngressIPTag }} \
+            {{- end }}
             {{ .Values.additionalArgs }}
       restartPolicy: Never
       serviceAccountName: hypershift-installer

--- a/hypershiftoperator/values.yaml
+++ b/hypershiftoperator/values.yaml
@@ -7,3 +7,5 @@ imageDigest: "{{ .hypershift.image.digest }}"
 registryOverrides: "quay.io/openshift-release-dev/ocp-v4.0-art-dev={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-release={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release,registry.redhat.io/redhat={{ .acr.ocp.name }}.azurecr.io/redhat"
 azureKeyVaultClientId: "__csiSecretStoreClientId__"
 additionalArgs: "{{ .hypershift.additionalInstallArg }}"
+operatorEnvVars:
+  sharedIngressIPTag: "{{ .hypershift.sharedIngressIPTag }}"


### PR DESCRIPTION
As part of this change we allow passing "SHARED_INGRESS_AZURE_PIP_IP_TAGS" env variable whose value is evaluated based on the environment(dev/int/stage/prod).

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
