### PR TITLE
expose admin API on istio gateway

### DIFF
--- a/frontend/deploy/templates/frontend.gateway.yaml
+++ b/frontend/deploy/templates/frontend.gateway.yaml
@@ -3,16 +3,27 @@ kind: Gateway
 metadata:
   name: aro-hcp-gateway-external
   namespace: aks-istio-ingress
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   selector:
     istio: aks-istio-ingressgateway-external
   servers:
   - port:
       number: 443
-      name: https
+      name: frontend-https
       protocol: HTTPS
     tls:
       mode: SIMPLE
       credentialName: frontend-credential
     hosts:
-    - "*"
+    - "{{ .Values.virtualService.host }}"
+  - port:
+      number: 443
+      name: admin-api-https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: admin-api-credential
+    hosts:
+    - "{{ .Values.adminApiHost }}"

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
@@ -283,19 +283,30 @@ kind: Gateway
 metadata:
   name: aro-hcp-gateway-external
   namespace: aks-istio-ingress
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   selector:
     istio: aks-istio-ingressgateway-external
   servers:
   - port:
       number: 443
-      name: https
+      name: frontend-https
       protocol: HTTPS
     tls:
       mode: SIMPLE
       credentialName: frontend-credential
     hosts:
-    - "*"
+    - "rp.westus3.hcpsvc.osadev.cloud"
+  - port:
+      number: 443
+      name: admin-api-https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: admin-api-credential
+    hosts:
+    - "admin.westus3.hcpsvc.osadev.cloud"
 ---
 # Source: frontend/templates/peerauthentication.yaml
 apiVersion: security.istio.io/v1beta1

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
@@ -291,19 +291,30 @@ kind: Gateway
 metadata:
   name: aro-hcp-gateway-external
   namespace: aks-istio-ingress
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   selector:
     istio: aks-istio-ingressgateway-external
   servers:
   - port:
       number: 443
-      name: https
+      name: frontend-https
       protocol: HTTPS
     tls:
       mode: SIMPLE
       credentialName: frontend-credential
     hosts:
-    - "*"
+    - "rp.westus3.hcpsvc.osadev.cloud"
+  - port:
+      number: 443
+      name: admin-api-https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: admin-api-credential
+    hosts:
+    - "admin.westus3.hcpsvc.osadev.cloud"
 ---
 # Source: frontend/templates/peerauthentication.yaml
 apiVersion: security.istio.io/v1beta1

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
@@ -317,19 +317,30 @@ kind: Gateway
 metadata:
   name: aro-hcp-gateway-external
   namespace: aks-istio-ingress
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   selector:
     istio: aks-istio-ingressgateway-external
   servers:
   - port:
       number: 443
-      name: https
+      name: frontend-https
       protocol: HTTPS
     tls:
       mode: SIMPLE
       credentialName: frontend-credential
     hosts:
-    - "*"
+    - "rp.westus3.hcpsvc.osadev.cloud"
+  - port:
+      number: 443
+      name: admin-api-https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: admin-api-credential
+    hosts:
+    - "admin.westus3.hcpsvc.osadev.cloud"
 ---
 # Source: frontend/templates/peerauthentication.yaml
 apiVersion: security.istio.io/v1beta1

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -39,3 +39,5 @@ adminApi:
 apiBindPort: 8443
 virtualService:
   host: "rp.{{ .dns.regionalSubdomain }}.{{ .dns.svcParentZoneName }}"
+# here just temporary until we move the gateway to the istio chart
+adminApiHost: "admin.{{ .dns.regionalSubdomain }}.{{ .dns.svcParentZoneName }}"


### PR DESCRIPTION

<!-- Link to Jira issue -->

### What

... also mark the gateway with `helm.sh/resource-policy: keep` so we can move it to the istio chart in a later PR


### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
