### PR TITLE
move arobit.kusto.environmentName to defaults

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -100,6 +100,7 @@ defaults:
         digest: sha256:3ce905dcdeac0df2814da366e404589b8fa7a44e22856c19117b3923679fbd57
     kusto:
       enabled: false
+      environmentName: "{{ .ctx.environment }}"
     mdsd:
       enabled: true
       image:
@@ -785,7 +786,6 @@ clouds:
           enabled: false
         kusto:
           enabled: true
-          environmentName: "{{ .ctx.environment }}"
       regionRG: hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}
       global:
         rg: global

--- a/maestro/agent/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_maestro_agent.yaml
+++ b/maestro/agent/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_maestro_agent.yaml
@@ -188,6 +188,24 @@ subjects:
   name: metrics-proxy-sa
   namespace: 'maestro'
 ---
+# Source: maestro-agent/templates/maestro-agent.agent-extension-apiserver.role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: maestro-agent:agent:extension-apiserver-dev-westus3-mgmt-1-maestro-agent
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - extension-apiserver-authentication
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
 # Source: maestro-agent/templates/maestro-agent.agent.role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -228,23 +246,20 @@ rules:
   - patch
   - update
 ---
-# Source: maestro-agent/templates/maestro-agent.agent-extension-apiserver.role.yaml
+# Source: maestro-agent/templates/maestro-agent.agent-extension-apiserver.rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: RoleBinding
 metadata:
   name: maestro-agent:agent:extension-apiserver-dev-westus3-mgmt-1-maestro-agent
   namespace: kube-system
-rules:
-- apiGroups:
-  - ""
-  resourceNames:
-  - extension-apiserver-authentication
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: maestro-agent:agent:extension-apiserver-dev-westus3-mgmt-1-maestro-agent
+subjects:
+- kind: ServiceAccount
+  name: 'maestro'
+  namespace: 'maestro'
 ---
 # Source: maestro-agent/templates/maestro-agent.agent.rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -256,21 +271,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: maestro-agent:agent
-subjects:
-- kind: ServiceAccount
-  name: 'maestro'
-  namespace: 'maestro'
----
-# Source: maestro-agent/templates/maestro-agent.agent-extension-apiserver.rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: maestro-agent:agent:extension-apiserver-dev-westus3-mgmt-1-maestro-agent
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: maestro-agent:agent:extension-apiserver-dev-westus3-mgmt-1-maestro-agent
 subjects:
 - kind: ServiceAccount
   name: 'maestro'


### PR DESCRIPTION
### What

the `arobit.kusto.environmentName` value that defaults to ctx.environment was in the global defaults before the refactor https://github.com/Azure/ARO-HCP/pull/3122

so moving it back there as the sdp-pipelines does not specify a dedicated overwrite

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
