### PR TITLE
enable CS debug job to set provision shard 1 in maintenance for stg/prod

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -116,6 +116,7 @@ clouds:
               prowJobName: periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel
           # Cluster Service
           clustersService:
+            deployDebugJobs: true
             image:
               digest: sha256:ce22a392a836a3f415f11fe07e18d171ec5455608be905d2b460b67f6beedf1d
           # ACR Pull
@@ -216,6 +217,7 @@ clouds:
               prowJobName: periodic-ci-Azure-ARO-HCP-main-periodic-prod-e2e-parallel
           # Cluster Service
           clustersService:
+            deployDebugJobs: true
             image:
               digest: sha256:ce22a392a836a3f415f11fe07e18d171ec5455608be905d2b460b67f6beedf1d
           # ACR Pull


### PR DESCRIPTION
We have a new shard with a different id and we want to stop using the old shard with id '1'. This commit enables a CS debug job that takes care of setting the provision shard with id '1' to maintenance state. This debug job is enabled for stage and prod environments. In stage we already have the shard in maintenance state so the execution of the job should be a noop there.
