### PR TITLE
Adjust function naming to reflect cost and return useful type

### DIFF
--- a/frontend/pkg/frontend/helpers.go
+++ b/frontend/pkg/frontend/helpers.go
@@ -250,7 +250,7 @@ func (f *Frontend) DeleteResource(ctx context.Context, transaction database.DBTr
 	return operationID, nil
 }
 
-func (f *Frontend) MarshalCluster(ctx context.Context, resourceID *azcorearm.ResourceID, versionedInterface api.Version) ([]byte, *arm.CloudError) {
+func (f *Frontend) GetExternalClusterFromStorage(ctx context.Context, resourceID *azcorearm.ResourceID, versionedInterface api.Version) (api.VersionedHCPOpenShiftCluster, *arm.CloudError) {
 	logger := LoggerFromContext(ctx)
 
 	internalCluster, err := f.dbClient.HCPClusters(resourceID.SubscriptionID, resourceID.ResourceGroupName).Get(ctx, resourceID.Name)
@@ -269,13 +269,13 @@ func (f *Frontend) MarshalCluster(ctx context.Context, resourceID *azcorearm.Res
 		return nil, ocm.CSErrorToCloudError(err, resourceID, nil)
 	}
 
-	responseBody, err := marshalCSCluster(csCluster, internalCluster, versionedInterface)
+	externalCluster, err := mergeToExternalCluster(csCluster, internalCluster, versionedInterface)
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, arm.NewInternalServerError()
 	}
 
-	return responseBody, nil
+	return externalCluster, nil
 }
 
 func (f *Frontend) MarshalResource(ctx context.Context, resourceID *azcorearm.ResourceID, versionedInterface api.Version) ([]byte, *arm.CloudError) {


### PR DESCRIPTION
Until we're able to cleanly transform cosmos API type to internal to external without secondary lookups, we'll have some data retrieval and merge functions.  This aligns the data retrieval function to show its cost and adjusts the return type so we have a type we can re-use the return value of somewhere internally.  The json.Marshal was ancillary to the body of the call.

IOU for @mbarnes 