### PR TITLE
clean: remove decorators from bicepparam files

### DIFF
--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -73,7 +73,6 @@ param azureMonitoringWorkspaceId = '__azureMonitoringWorkspaceId__'
 param hcpAzureMonitoringWorkspaceId = '__hcpAzureMonitoringWorkspaceId__'
 
 // MDSD / Genevabits
-@description('The namespace of the logs')
 param logsNamespace = '{{ .logs.mdsd.namespace }}'
 param logsMSI = '{{ .logs.mdsd.msiName }}'
 param logsServiceAccount = '{{ .logs.mdsd.serviceAccountName }}'

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -138,7 +138,6 @@ param grafanaResourceId = '__grafanaResourceId__'
 param grafanaPrincipalId = '__grafanaPrincipalId__'
 
 // MDSD / Genevabits
-@description('The namespace of the logs')
 param logsNamespace = '{{ .logs.mdsd.namespace }}'
 param logsMSI = '{{ .logs.mdsd.msiName }}'
 param logsServiceAccount = '{{ .logs.mdsd.serviceAccountName }}'


### PR DESCRIPTION
### What

  This PR removes `@description` decorators from two bicepparam template files:
  - `dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam`
  - `dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam`

  Specifically, it removes the `@description('The namespace of the logs')` decorator from the `logsNamespace`
  parameter in both files.

### Why

  The EV2 pipelines were failing during bicepparam file validation with the following error:

```
  ERROR: invalid .bicepparam {
    "code": "BCP130",
    "err": "Decorators are not allowed here.",
    "range": "L140:0-L140:1",
    "service": "Microsoft.Azure.ARO.HCP.Service.Infra",
    "source": "/tmp/ev2-artifact-source-2gffms8r/hcp/ARO-HCP/dev-infrastructure/configurations/svc-cluster.tmpl.pu
  blic-int.bicepparam"
  }
```

Decorators like `@description()` are only allowed in Bicep template files (`.bicep`), not in Bicep parameter files (`.bicepparam`). This change fixes the validation error and allows the EV2 pipelines to successfully process these configuration files.

### Special notes for your reviewer

Follow the conversation at https://redhat-internal.slack.com/archives/C07A2CVUV44/p1763537676983009