### PR TITLE
fix: Remove frontend dry run check

### DIFF
--- a/.github/workflows/services-pr-check.yml
+++ b/.github/workflows/services-pr-check.yml
@@ -74,9 +74,10 @@ jobs:
     - name: 'Dry Run Backend'
       run: |
         make backend.dry_run
-    - name: 'Dry Run Frontend'
-      run: |
-        make frontend.dry_run
+    # temporary disable frontend controller dry run until we figured out the helm dry-run issue
+    # - name: 'Dry Run Frontend'
+    #   run: |
+    #     make frontend.dry_run
     - name: 'Dry Run Maestro Server'
       run: |
         make maestro.server.dry_run


### PR DESCRIPTION
### What

Temporary disables the Frontend dry run helm test.

### Why

For the last 48 hours, this check has been failing on every single PR. It's a well known server side apply issue, not a real error, and we don't have time at this point to work on a long term solution. This issue is forcing PRs to be merged with failing checks, and that's something that only few users can do, so it's blocking PRs.

<img width="1664" height="1718" alt="image" src="https://github.com/user-attachments/assets/62bff736-a02f-4232-ba0c-1f6e98390985" />

### Special notes for your reviewer

Follow the conversation at https://redhat-internal.slack.com/archives/C07A2CVUV44/p1763454794372509