### PR TITLE
frontend: Fix bug in getSubscriptionDifferences

### DIFF
--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -16,6 +16,7 @@ package frontend
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -149,6 +150,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 		urlPath            string
 		subscription       *arm.Subscription
 		subDoc             *arm.Subscription
+		expectUpdated      bool
 		expectedStatusCode int
 	}{
 		{
@@ -177,7 +179,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 		},
 		{
-			name:    "PUT Subscription - Doc Exists",
+			name:    "PUT Subscription - Update with no changes",
 			urlPath: api.TestSubscriptionResourceID,
 			subscription: &arm.Subscription{
 				State:            arm.SubscriptionStateRegistered,
@@ -189,6 +191,30 @@ func TestSubscriptionsPUT(t *testing.T) {
 				RegistrationDate: api.Ptr(time.Now().String()),
 				Properties:       nil,
 			},
+			expectUpdated:      false,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:    "PUT Subscription - Update registered features",
+			urlPath: api.TestSubscriptionResourceID,
+			subscription: &arm.Subscription{
+				State:            arm.SubscriptionStateRegistered,
+				RegistrationDate: api.Ptr(time.Now().String()),
+				Properties: &arm.SubscriptionProperties{
+					RegisteredFeatures: &[]arm.Feature{
+						{
+							Name:  api.Ptr("Microsoft.RedHatOpenShift/TestFeature"),
+							State: api.Ptr("Registered"),
+						},
+					},
+				},
+			},
+			subDoc: &arm.Subscription{
+				State:            arm.SubscriptionStateRegistered,
+				RegistrationDate: api.Ptr(time.Now().String()),
+				Properties:       nil,
+			},
+			expectUpdated:      true,
 			expectedStatusCode: http.StatusOK,
 		},
 		{
@@ -270,7 +296,12 @@ func TestSubscriptionsPUT(t *testing.T) {
 						CreateSubscriptionDoc(gomock.Any(), gomock.Any(), gomock.Any())
 				} else {
 					mockDBClient.EXPECT().
-						UpdateSubscriptionDoc(gomock.Any(), gomock.Any(), gomock.Any())
+						UpdateSubscriptionDoc(gomock.Any(), gomock.Any(), gomock.Any()).
+						DoAndReturn(func(ctx context.Context, subscriptionID string, callback func(updateSubscription *arm.Subscription) bool) (bool, error) {
+							updated := callback(test.subDoc)
+							assert.Equal(t, test.expectUpdated, updated)
+							return updated, nil
+						})
 				}
 			}
 


### PR DESCRIPTION
Related to [ARO-21891 - Implement AFEC flag validation in RP for non-stable channel groups](https://issues.redhat.com/browse/ARO-21891)

### What

If a subscription field wasn't populated in the first PUT request then it could never be updated in subsequent PUT requests due to faulty nil checks.

@ahitacat discovered this bug while working on the above Jira.