### PR TITLE
test: Refactor PATCH test cases to run against RP directly

### DIFF
--- a/nonlocal-e2e-specs.txt
+++ b/nonlocal-e2e-specs.txt
@@ -8,6 +8,7 @@
   "Get each nodepool from HCPOpenShiftCluster",
   "Successfully lists clusters filtered by resource group name",
   "Successfully lists clusters filtered by subscription ID",
+  "creates a cluster and fails to update its name with a PATCH request",
   "creates and deletes vm type NC6sv3 in a single cluster",
   "should be able to create a cluster with an external auth config and get the external auth config",
   "should be able to create an HCP cluster and custom node pool osDisk size using bicep template",

--- a/test/e2e/cluster_update.go
+++ b/test/e2e/cluster_update.go
@@ -42,7 +42,7 @@ func toIdentityUpdate(identity *hcpsdk20240610preview.ManagedServiceIdentity) *h
 var _ = Describe("Update HCPOpenShiftCluster", func() {
 	Context("Negative", func() {
 		It("creates a cluster and fails to update its name with a PATCH request",
-			labels.RequireNothing, labels.Medium, labels.Negative, labels.AroRpApiCompatible,
+			labels.RequireNothing, labels.Medium, labels.Negative,
 			func(ctx context.Context) {
 				const clusterName = "patch-name-cluster"
 


### PR DESCRIPTION
[ARO-22754](https://issues.redhat.com/browse/ARO-22754)

### What

Refactor patch tests to a new ARM and RP approach.

### Why

Refactoring PATCH test cases to be run against RP directly will help with early feedback in personal development environment.