### PR TITLE
Add an override for Kusto in dev

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1575,6 +1575,10 @@
         "viewerGroups": {
           "type": "string"
         },
+        "staticKustoName": {
+          "type": "string",
+          "description": "Name of the static Kusto cluster to use for dev environments"
+        },
         "resourceGroup": {
           "description": "DEPRECATED, for backward compatibility only",
           "type": "string"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -187,6 +187,7 @@ defaults:
   kusto:
     manageInstance: false
     rg: "hcp-kusto-us"
+    staticKustoName: ""
     serviceLogsDatabase: "ServiceLogs"
     hostedControlPlaneLogsDatabase: "HostedControlPlaneLogs"
     adminGroups: ""
@@ -780,6 +781,8 @@ clouds:
   dev:
     # this configuration serves as a template for for all RH DEV subscription deployments
     defaults:
+      kusto:
+        staticKustoName: "hcp-dev-us"
       tenantId: "64dc69e4-d083-49fc-9569-ebece1dd1408"
       kubeEvents:
         enabled: false

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,22 +3,22 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: e706deb9d1c89a231629a8d1d792a64500ab17e1e441ef05e1b9b84b31067f25
+          westus3: a27f47709a9e1bc9a166392b4a38f2e16b103735716ef7d6f53b13b93e8ca346
       dev:
         regions:
-          westus3: 68a7a29d0fab5e2641e3cdcc4c688c6136656076a411ed85d7a3bbc0a11bf188
+          westus3: 061bfa6abe9b8bcd0b562f24e8489f004bfc281b6d2c4fcbf1bf6bacb7bfd1ba
       ntly:
         regions:
-          uksouth: 77368a81c5e7dfd8075f3d54c0f16ec9c086c90623ab5e348a269ada4bc4de00
+          uksouth: eb7ec46a641069ff71a9d1056cabe07ab91c847c37b31b890c901db0aa9c3c71
       perf:
         regions:
-          westus3: e7e77ca691a221ff12e773b66721d2063df4a847195f80a7fab80ea2168ca8b1
+          westus3: a324077c01ff263fe4f572d8d8ba2d32ac41613a9340d4b69a99626bbaf2cccc
       pers:
         regions:
-          westus3: d040c200150c744bb81a66ab19f0f509a7cd20f53b379133a9b5d442355a1b3a
+          westus3: 8409a7f84686f27fc60ee6dc30f6a4dbd44307ee714cae5d04f92eea69e566e3
       prow:
         regions:
-          westus3: 8527f4b1c424d184f11d16e75d4bf839db1b9f6431c5538cc830e6da7f3ed6c4
+          westus3: 30dcc0478d1a12297c6b936b37c0f19c4b76bc07ca22180a9b53a4fa18044bf5
       swft:
         regions:
-          uksouth: 348edeca4d4573feaf616d1debf03eca66a3dbadb21122ada313c3efd6457483
+          uksouth: 769e6414fdc1c52dca192ee1787889ced3610fb7fe9d4526f28d88b22fb1e7f5

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -343,6 +343,7 @@ kusto:
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs
   sku: ""
+  staticKustoName: hcp-dev-us
   tier: ""
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -343,6 +343,7 @@ kusto:
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs
   sku: Dev(No SLA)_Standard_D11_v2
+  staticKustoName: hcp-dev-us
   tier: Basic
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -343,6 +343,7 @@ kusto:
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs
   sku: ""
+  staticKustoName: hcp-dev-us
   tier: ""
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -343,6 +343,7 @@ kusto:
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs
   sku: ""
+  staticKustoName: hcp-dev-us
   tier: ""
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -343,6 +343,7 @@ kusto:
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs
   sku: ""
+  staticKustoName: hcp-dev-us
   tier: ""
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -343,6 +343,7 @@ kusto:
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs
   sku: ""
+  staticKustoName: hcp-dev-us
   tier: ""
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -343,6 +343,7 @@ kusto:
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs
   sku: ""
+  staticKustoName: hcp-dev-us
   tier: ""
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -92,3 +92,6 @@ param serviceLogsDatabase = '{{ .kusto.serviceLogsDatabase }}'
 param hostedControlPlaneLogsDatabase = '{{ .kusto.hostedControlPlaneLogsDatabase }}'
 param geoShortId = '{{ .geoShortId }}'
 param environmentName = '{{ .environmentName }}'
+
+// Override for dev, cause here we share one kusto instance for all environments
+param staticKustoName = '{{ .kusto.staticKustoName }}'

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -159,3 +159,6 @@ param arobitKustoEnabled = {{ .arobit.kusto.enabled }}
 param serviceLogsDatabase = '{{ .kusto.serviceLogsDatabase }}'
 param geoShortId = '{{ .geoShortId }}'
 param environmentName = '{{ .environmentName }}'
+
+// Override for dev, cause here we share one kusto instance for all environments
+param staticKustoName = '{{ .kusto.staticKustoName }}'

--- a/dev-infrastructure/modules/logs/kusto/grant-ingest.bicep
+++ b/dev-infrastructure/modules/logs/kusto/grant-ingest.bicep
@@ -2,13 +2,8 @@ param clusterLogManagedIdentityId string
 
 param databaseName string
 
-@description('Geo short ID of the region')
-param geoShortId string
-
-@description('Environment name')
-param environmentName string
-
-var kustoName = 'hcp-${environmentName}-${geoShortId}'
+@description('Name of the Kusto cluster to grant ingest to')
+param kustoName string
 
 resource database 'Microsoft.Kusto/clusters/databases@2024-04-13' existing = {
   name: '${kustoName}/${databaseName}'

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -409,6 +409,9 @@ param serviceLogsDatabase string
 @description('Geo short ID of the region')
 param geoShortId string
 
+@description('Name of the static Kusto cluster to use for dev environments')
+param staticKustoName string
+
 @description('Environment name')
 param environmentName string
 
@@ -1030,13 +1033,14 @@ module svcKVNSPProfile '../modules/network/nsp-profile.bicep' = if (serviceKeyVa
 //  K U S T O   I N G E S T    P E R M I S S I O N S
 //
 
+var kustoName = staticKustoName != '' ? staticKustoName : 'hcp-${environmentName}-${geoShortId}'
+
 module grantKustIngest '../modules/logs/kusto/grant-ingest.bicep' = if (arobitKustoEnabled) {
   name: 'grantKustoIngest'
   params: {
     clusterLogManagedIdentityId: mi.getManagedIdentityByName(managedIdentities.outputs.managedIdentities, logsMSI).uamiPrincipalID
-    geoShortId: geoShortId
     databaseName: serviceLogsDatabase
-    environmentName: environmentName
+    kustoName: kustoName
   }
   scope: resourceGroup(kustoResourceGroup)
 }


### PR DESCRIPTION


<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

in dev kust clusters are shared over all environments. Therefore, provide an override, so we can set a static name of the kusto instance in dev

### Special notes for your reviewer

<!-- optional -->
