### PR TITLE
chore: bump int cs image to stg

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -118,7 +118,7 @@ clouds:
           clustersService:
             deployDebugJobs: true
             image:
-              digest: sha256:4eece9b42afe23a6bbbf9831a3f27983b3aa555d62cc4dac5c54e04fcb3da422
+              digest: sha256:4ad62664e56d5d72bf619a793dd21f7515e2a042f89b5bea96cc91c621733a52
           # ACR Pull
           acrPull:
             image:


### PR DESCRIPTION
### What

Bumps CS image to `4ad62664e56d5d72bf619a793dd21f7515e2a042f89b5bea96cc91c621733a52` for STAGE.

### Why

Promotes https://github.com/Azure/ARO-HCP/pull/3350.