### PR TITLE
Add timestamps to test logger

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0
-	github.com/bombsimon/logrusr/v4 v4.1.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/dusted-go/logging v1.3.0
 	github.com/google/uuid v1.6.0
@@ -71,6 +70,7 @@ require (
 	github.com/aws/smithy-go v1.22.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
+	github.com/bombsimon/logrusr/v4 v4.1.0 // indirect
 	github.com/bwmarrin/snowflake v0.0.0 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -18,17 +18,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
 
-	"github.com/bombsimon/logrusr/v4"
 	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -46,14 +45,10 @@ import (
 
 // testLogger is a logr-compatible logger with timestamps enabled for test framework logging
 var testLogger logr.Logger = func() logr.Logger {
-	logrusLogger := logrus.New()
-	logrusLogger.SetOutput(ginkgo.GinkgoWriter)
-	logrusLogger.SetFormatter(&logrus.TextFormatter{
-		DisableColors:   true,
-		FullTimestamp:   true,
-		TimestampFormat: time.RFC3339,
+	handler := slog.NewTextHandler(ginkgo.GinkgoWriter, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
 	})
-	return logrusr.New(logrusLogger)
+	return logr.FromSlogHandler(handler)
 }()
 
 type perItOrDescribeTestContext struct {


### PR DESCRIPTION
[Slack-Directive](https://redhat-external.slack.com/archives/C075PHEFZKQ/p1763577305076369?thread_ts=1763569418.200829&cid=C075PHEFZKQ)

### What

-Add timestamps to loglines for test logger
-Removes %w from log lines as they aren't used for that.

### Why

Timestamps were needed for logging in per_test_framework.go  which uses ginkgo logging and doesn't allow for timestamps. A wrapper was introduced to add them.

A second commit removes %w which isn't used for logging.

### Special notes for your reviewer

A test application was made to inject values into the test. Timestamps were added and the %w was removed.
Test for test was not committed
Example output:
time="2025-11-19T15:21:29-05:00" level=info msg="creating resource group"
resourceGroup=test-rg-abc123
