### PR TITLE
test: provide CLI path to script in Ev2

### DIFF
--- a/test/e2e-pipeline.yaml
+++ b/test/e2e-pipeline.yaml
@@ -46,6 +46,8 @@ resourceGroups:
       configRef: region
     - name: KEY_VAULT_DNSSUFFIX
       configRef: keyVaultDNSSuffix
+    - name: PROW_JOB_EXECUTOR
+      value: './prow-job-executor'
     shellIdentity:
       input:
         resourceGroup: global


### PR DESCRIPTION
When we run this script directly in Ev2, we don't get the path set by the Makefile, so we need to set it ourselves.