### PR TITLE
fix: fix missing hyphen on find command that sets TEST_SOURCES

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,7 @@ $(BICEP_OUTPUT_DIR)%.json: $(TEST_BICEP_DIR)/%.bicep
 update: $(DEMO_BICEP_OUTPUTS) $(TEST_BICEP_OUTPUTS)
 .PHONY: update
 
-TEST_SOURCES = $(shell find $(TEST_DIR) -name '*.go' -o -name '*.json' -o name '*.bicep')
+TEST_SOURCES = $(shell find $(TEST_DIR) -name '*.go' -o -name '*.json' -o -name '*.bicep')
 ARO_HCP_TESTS = $(TEST_DIR)aro-hcp-tests
 $(ARO_HCP_TESTS): $(TEST_SOURCES) $(MAKEFILE_LIST) $(TEST_DIR)/go.mod $(TEST_DIR)/go.sum $(DEMO_BICEP_OUTPUTS) $(TEST_BICEP_OUTPUTS)
 	cd $(TEST_DIR) && go build -o $@ ./cmd/aro-hcp-tests


### PR DESCRIPTION
When running the top-level make there was an error indicating that the find command associated to it was malformed.

The message that was being shown was:

```
find: paths must precede expression: `name'
```