### PR TITLE
remove unnecessary patches from the cluster create transaction

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -901,7 +901,7 @@ func (f *Frontend) OperationResult(writer http.ResponseWriter, request *http.Req
 		return fmt.Errorf("invalid operation status: %s", cosmosOperation.Status)
 	default:
 		// Operation is still in progress.
-		f.AddLocationHeader(writer, request, cosmosOperation.OperationID)
+		AddLocationHeader(writer, request, cosmosOperation.OperationID)
 		writer.WriteHeader(http.StatusAccepted)
 		return nil
 	}

--- a/frontend/pkg/frontend/operations.go
+++ b/frontend/pkg/frontend/operations.go
@@ -32,7 +32,7 @@ import (
 
 // AddAsyncOperationHeader adds an "Azure-AsyncOperation" header to the ResponseWriter
 // with a URL of the operation status endpoint.
-func (f *Frontend) AddAsyncOperationHeader(writer http.ResponseWriter, request *http.Request, operationID *azcorearm.ResourceID) {
+func AddAsyncOperationHeader(writer http.ResponseWriter, request *http.Request, operationID *azcorearm.ResourceID) {
 	logger := LoggerFromContext(request.Context())
 
 	// MiddlewareReferer ensures Referer is present.
@@ -56,7 +56,7 @@ func (f *Frontend) AddAsyncOperationHeader(writer http.ResponseWriter, request *
 
 // AddLocationHeader adds a "Location" header to the ResponseWriter with a URL of the
 // operation result endpoint.
-func (f *Frontend) AddLocationHeader(writer http.ResponseWriter, request *http.Request, operationID *azcorearm.ResourceID) {
+func AddLocationHeader(writer http.ResponseWriter, request *http.Request, operationID *azcorearm.ResourceID) {
 	logger := LoggerFromContext(request.Context())
 
 	// MiddlewareReferer ensures Referer is present.
@@ -118,10 +118,10 @@ func (f *Frontend) ExposeOperation(writer http.ResponseWriter, request *http.Req
 		// Add callback header(s) based on the request method.
 		switch request.Method {
 		case http.MethodDelete, http.MethodPatch, http.MethodPost:
-			f.AddLocationHeader(writer, request, operationResourceID)
+			AddLocationHeader(writer, request, operationResourceID)
 			fallthrough
 		case http.MethodPut:
-			f.AddAsyncOperationHeader(writer, request, operationResourceID)
+			AddAsyncOperationHeader(writer, request, operationResourceID)
 		}
 	})
 }

--- a/internal/api/types_cluster.go
+++ b/internal/api/types_cluster.go
@@ -63,6 +63,7 @@ type HCPOpenShiftClusterServiceProviderProperties struct {
 	ProvisioningState arm.ProvisioningState          `json:"provisioningState,omitempty"       visibility:"read"`
 	CosmosUID         string                         `json:"cosmosUID,omitempty"`
 	ClusterServiceID  InternalID                     `json:"clusterServiceID,omitempty"                visibility:"read"`
+	ActiveOperationID string                         `json:"activeOperationId,omitempty"`
 	DNS               ServiceProviderDNSProfile      `json:"dns,omitempty"`
 	Console           ServiceProviderConsoleProfile  `json:"console,omitempty"                 visibility:"read"`
 	API               ServiceProviderAPIProfile      `json:"api,omitempty"`

--- a/internal/api/v20240610preview/conversion_fuzz_test.go
+++ b/internal/api/v20240610preview/conversion_fuzz_test.go
@@ -41,6 +41,8 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 		},
 		func(j *api.HCPOpenShiftClusterServiceProviderProperties, c randfill.Continue) {
 			c.FillNoCustom(j)
+			// ActiveOperationID does not roundtrip through the external type because it is purely an internal detail
+			j.ActiveOperationID = ""
 			// CosmosUID does not roundtrip through the external type because it is purely an internal detail
 			j.CosmosUID = ""
 			// ClusterServiceID does not roundtrip through the external type because it is purely an internal detail

--- a/internal/api/v20251223preview/conversion_fuzz_test.go
+++ b/internal/api/v20251223preview/conversion_fuzz_test.go
@@ -41,6 +41,8 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 		},
 		func(j *api.HCPOpenShiftClusterServiceProviderProperties, c randfill.Continue) {
 			c.FillNoCustom(j)
+			// ActiveOperationID does not roundtrip through the external type because it is purely an internal detail
+			j.ActiveOperationID = ""
 			// CosmosUID does not roundtrip through the external type because it is purely an internal detail
 			j.CosmosUID = ""
 			// ClusterServiceID does not roundtrip through the external type because it is purely an internal detail

--- a/internal/conversion/readonly_cluster.go
+++ b/internal/conversion/readonly_cluster.go
@@ -37,11 +37,7 @@ func CopyReadOnlyClusterValues(dest, src *api.HCPOpenShiftCluster) {
 		copyReadOnlyManagedServiceIdentityValues(dest.Identity, src.Identity)
 	}
 
-	dest.ServiceProviderProperties.ProvisioningState = src.ServiceProviderProperties.ProvisioningState
-	dest.ServiceProviderProperties.Console = src.ServiceProviderProperties.Console
-	dest.ServiceProviderProperties.DNS.BaseDomain = src.ServiceProviderProperties.DNS.BaseDomain
-	dest.ServiceProviderProperties.API.URL = src.ServiceProviderProperties.API.URL
-	dest.ServiceProviderProperties.Platform.IssuerURL = src.ServiceProviderProperties.Platform.IssuerURL
+	dest.ServiceProviderProperties = src.ServiceProviderProperties
 }
 
 func copyReadOnlyManagedServiceIdentityValues(dest, src *arm.ManagedServiceIdentity) {

--- a/internal/database/convert_cluster.go
+++ b/internal/database/convert_cluster.go
@@ -35,10 +35,9 @@ func InternalToCosmosCluster(internalObj *api.HCPOpenShiftCluster) (*HCPCluster,
 		},
 		HCPClusterProperties: HCPClusterProperties{
 			ResourceDocument: ResourceDocument{
-				ResourceID: internalObj.ID,
-				InternalID: internalObj.ServiceProviderProperties.ClusterServiceID,
-				// TODO
-				//ActiveOperationID: "",
+				ResourceID:        internalObj.ID,
+				InternalID:        internalObj.ServiceProviderProperties.ClusterServiceID,
+				ActiveOperationID: internalObj.ServiceProviderProperties.ActiveOperationID,
 				ProvisioningState: internalObj.ServiceProviderProperties.ProvisioningState,
 				Identity:          toCosmosIdentity(internalObj.Identity),
 				SystemData:        internalObj.SystemData,
@@ -61,6 +60,7 @@ func InternalToCosmosCluster(internalObj *api.HCPOpenShiftCluster) (*HCPCluster,
 	cosmosObj.InternalState.InternalAPI.ServiceProviderProperties.ProvisioningState = ""
 	cosmosObj.InternalState.InternalAPI.ServiceProviderProperties.CosmosUID = ""
 	cosmosObj.InternalState.InternalAPI.ServiceProviderProperties.ClusterServiceID = ocm.InternalID{}
+	cosmosObj.InternalState.InternalAPI.ServiceProviderProperties.ActiveOperationID = ""
 
 	// This is not the place for validation, but during such a transition we need to ensure we fail quickly and certainly
 	// This flow will eventually be called when we replace the write path and we must always have a value.
@@ -135,6 +135,7 @@ func CosmosToInternalCluster(cosmosObj *HCPCluster) (*api.HCPOpenShiftCluster, e
 	internalObj.ServiceProviderProperties.ProvisioningState = cosmosObj.ProvisioningState
 	internalObj.ServiceProviderProperties.CosmosUID = cosmosObj.ID
 	internalObj.ServiceProviderProperties.ClusterServiceID = cosmosObj.InternalID
+	internalObj.ServiceProviderProperties.ActiveOperationID = cosmosObj.ActiveOperationID
 
 	// This is not the place for validation, but during such a transition we need to ensure we fail quickly and certainly
 	// This flow happens when reading both old and new data.  The old data should *always* have the internalID set


### PR DESCRIPTION
With the separation of create and update, along with the inclusion of typed for the database calls, we no longer have a need to perform create plus patching to create a full view of the object.  it is more clear to create the resource we want to store and store that.  Additionally, we want to validate what we actually store, so avoiding the patch is important to that end.
