### PR TITLE
Streamline errors in frontend by allowing early return

### DIFF
--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -32,50 +32,42 @@ import (
 // GetHCPCluster implements the GET single resource API contract for HCP Clusters
 // * 200 If the resource exists
 // * 404 If the resource does not exist
-func (f *Frontend) GetHCPCluster(writer http.ResponseWriter, request *http.Request) {
+func (f *Frontend) GetHCPCluster(writer http.ResponseWriter, request *http.Request) error {
 	ctx := request.Context()
-	logger := LoggerFromContext(ctx)
 
 	versionedInterface, err := VersionFromContext(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 	resourceID, err := ResourceIDFromContext(ctx) // used for error reporting
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	resultingExternalCluster, cloudError := f.GetExternalClusterFromStorage(ctx, resourceID, versionedInterface)
 	if cloudError != nil {
-		arm.WriteCloudError(writer, cloudError)
-		return
+		return err
 	}
 	responseBytes, err := arm.MarshalJSON(resultingExternalCluster)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	_, err = arm.WriteJSONResponse(writer, http.StatusOK, responseBytes)
 	if err != nil {
-		logger.Error(err.Error())
+		return err
 	}
+
+	return nil
 }
 
-func (f *Frontend) ArmResourceListClusters(writer http.ResponseWriter, request *http.Request) {
+func (f *Frontend) ArmResourceListClusters(writer http.ResponseWriter, request *http.Request) error {
 	ctx := request.Context()
 	logger := LoggerFromContext(ctx)
 
 	versionedInterface, err := VersionFromContext(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	subscriptionID := request.PathValue(PathSegmentSubscriptionID)
@@ -90,9 +82,7 @@ func (f *Frontend) ArmResourceListClusters(writer http.ResponseWriter, request *
 
 	internalClusterIterator, err := f.dbClient.HCPClusters(subscriptionID, resourceGroupName).List(ctx, dbListOptionsFromRequest(request))
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 	clustersByClusterServiceID := make(map[string]*api.HCPOpenShiftCluster)
 	for _, internalCluster := range internalClusterIterator.Items(ctx) {
@@ -100,16 +90,12 @@ func (f *Frontend) ArmResourceListClusters(writer http.ResponseWriter, request *
 	}
 	err = internalClusterIterator.GetError()
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 	// MiddlewareReferer ensures Referer is present.
 	err = pagedResponse.SetNextLink(request.Referer(), internalClusterIterator.GetContinuationToken())
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	// Build a Cluster Service query that looks for
@@ -127,15 +113,11 @@ func (f *Frontend) ArmResourceListClusters(writer http.ResponseWriter, request *
 		if internalCluster, ok := clustersByClusterServiceID[csCluster.HREF()]; ok {
 			resultingExternalCluster, err := mergeToExternalCluster(csCluster, internalCluster, versionedInterface)
 			if err != nil {
-				logger.Error(err.Error())
-				arm.WriteInternalServerError(writer)
-				return
+				return err
 			}
 			jsonBytes, err := arm.MarshalJSON(resultingExternalCluster)
 			if err != nil {
-				logger.Error(err.Error())
-				arm.WriteInternalServerError(writer)
-				return
+				return err
 			}
 			pagedResponse.AddValue(jsonBytes)
 		}
@@ -144,18 +126,18 @@ func (f *Frontend) ArmResourceListClusters(writer http.ResponseWriter, request *
 
 	// Check for iteration error.
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, nil, writer.Header()))
-		return
+		return ocm.CSErrorToCloudError(err, nil, writer.Header())
 	}
 
 	_, err = arm.WriteJSONResponse(writer, http.StatusOK, pagedResponse)
 	if err != nil {
-		logger.Error(err.Error())
+		return err
 	}
+
+	return nil
 }
 
-func (f *Frontend) CreateOrUpdateHCPCluster(writer http.ResponseWriter, request *http.Request) {
+func (f *Frontend) CreateOrUpdateHCPCluster(writer http.ResponseWriter, request *http.Request) error {
 	var err error
 
 	// This handles both PUT and PATCH requests. PATCH requests will
@@ -171,33 +153,27 @@ func (f *Frontend) CreateOrUpdateHCPCluster(writer http.ResponseWriter, request 
 	// that represents an existing resource to be updated.
 
 	ctx := request.Context()
-	logger := LoggerFromContext(ctx)
 
 	resourceID, err := ResourceIDFromContext(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	resourceItemID, resourceDoc, err := f.dbClient.GetResourceDoc(ctx, resourceID)
 	if err != nil && !database.IsResponseError(err, http.StatusNotFound) {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	updating := resourceDoc != nil
 
 	if updating {
-		f.updateHCPCluster(writer, request, resourceItemID, resourceDoc)
-		return
+		return f.updateHCPCluster(writer, request, resourceItemID, resourceDoc)
 	}
 
-	f.createHCPCluster(writer, request)
+	return f.createHCPCluster(writer, request)
 }
 
-func (f *Frontend) createHCPCluster(writer http.ResponseWriter, request *http.Request) {
+func (f *Frontend) createHCPCluster(writer http.ResponseWriter, request *http.Request) error {
 	var err error
 
 	// This handles both PUT and PATCH requests. PATCH requests will
@@ -217,52 +193,37 @@ func (f *Frontend) createHCPCluster(writer http.ResponseWriter, request *http.Re
 
 	resourceID, err := ResourceIDFromContext(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	switch request.Method {
 	case http.MethodPut:
 		// expected
 	case http.MethodPatch:
-		// PATCH requests never create a new resource.
-		logger.Error("Resource not found")
-		arm.WriteResourceNotFoundError(writer, resourceID)
-		return
+		return arm.NewResourceNotFoundError(resourceID)
 	default:
-		logger.Error("unexpected method: " + request.Method)
-		arm.WriteResourceNotFoundError(writer, resourceID)
-		return
+		return arm.NewResourceNotFoundError(resourceID)
 
 	}
 
 	versionedInterface, err := VersionFromContext(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	body, err := BodyFromContext(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	systemData, err := SystemDataFromContext(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	correlationData, err := CorrelationDataFromContext(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	operationRequest := database.OperationRequestCreate
@@ -274,11 +235,8 @@ func (f *Frontend) createHCPCluster(writer http.ResponseWriter, request *http.Re
 	newExternalCluster := versionedInterface.NewHCPOpenShiftCluster(api.NewDefaultHCPOpenShiftCluster(resourceID))
 	successStatusCode := http.StatusCreated
 
-	cloudError := api.ApplyRequestBody(request, body, newExternalCluster)
-	if cloudError != nil {
-		logger.Error(cloudError.Error())
-		arm.WriteCloudError(writer, cloudError)
-		return
+	if err := api.ApplyRequestBody(request, body, newExternalCluster); err != nil {
+		return err
 	}
 
 	// this sets many default values, which are then sometimes overridden by Normalize
@@ -287,34 +245,23 @@ func (f *Frontend) createHCPCluster(writer http.ResponseWriter, request *http.Re
 	}
 	newExternalCluster.Normalize(newInternalCluster)
 	validationErrs := validation.ValidateClusterCreate(ctx, newInternalCluster, api.Must(versionedInterface.ValidationPathRewriter(&api.HCPOpenShiftCluster{})))
-	newValidationErr := arm.CloudErrorFromFieldErrors(validationErrs)
-
-	// prefer new validation.  Have a fallback for old validation.
-	if newValidationErr != nil {
-		logger.Error(newValidationErr.Error())
-		arm.WriteCloudError(writer, newValidationErr)
-		return
+	if err := arm.CloudErrorFromFieldErrors(validationErrs); err != nil {
+		return err
 	}
 
 	newClusterServiceClusterBuilder, err := ocm.BuildCSCluster(resourceID, request.Header, newInternalCluster, false)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 	logger.Info(fmt.Sprintf("creating resource %s", resourceID))
 	resultingClusterServiceCluster, err := f.clusterServiceClient.PostCluster(ctx, newClusterServiceClusterBuilder, nil)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID, writer.Header()))
-		return
+		return ocm.CSErrorToCloudError(err, resourceID, writer.Header())
 	}
 
 	newInternalCluster.ServiceProviderProperties.ClusterServiceID, err = api.NewInternalID(resultingClusterServiceCluster.HREF())
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	pk := database.NewPartitionKey(resourceID.SubscriptionID)
@@ -364,45 +311,36 @@ func (f *Frontend) createHCPCluster(writer http.ResponseWriter, request *http.Re
 		EnableContentResponseOnWrite: true,
 	})
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	// Read back the resource document so the response body is accurate.
 	resultingCosmosCluster, err := transactionResult.GetResourceDoc(resourceItemID)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 	resultingInternalCluster, err := database.ResourceDocumentToInternalAPI[api.HCPOpenShiftCluster, database.HCPCluster](resultingCosmosCluster)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	resultingExternalCluster, err := mergeToExternalCluster(resultingClusterServiceCluster, resultingInternalCluster, versionedInterface)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 	responseBytes, err := arm.MarshalJSON(resultingExternalCluster)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	_, err = arm.WriteJSONResponse(writer, successStatusCode, responseBytes)
 	if err != nil {
-		logger.Error(err.Error())
+		return err
 	}
+	return nil
 }
 
-func (f *Frontend) updateHCPCluster(writer http.ResponseWriter, request *http.Request, cosmosID string, oldCosmosCluster *database.ResourceDocument) {
+func (f *Frontend) updateHCPCluster(writer http.ResponseWriter, request *http.Request, cosmosID string, oldCosmosCluster *database.ResourceDocument) error {
 	var err error
 
 	// This handles both PUT and PATCH requests. PATCH requests will
@@ -422,37 +360,27 @@ func (f *Frontend) updateHCPCluster(writer http.ResponseWriter, request *http.Re
 
 	versionedInterface, err := VersionFromContext(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	resourceID, err := ResourceIDFromContext(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	body, err := BodyFromContext(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	systemData, err := SystemDataFromContext(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	correlationData, err := CorrelationDataFromContext(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	operationRequest := database.OperationRequestUpdate
@@ -462,16 +390,12 @@ func (f *Frontend) updateHCPCluster(writer http.ResponseWriter, request *http.Re
 
 	oldClusterServiceCluster, err := f.clusterServiceClient.GetCluster(ctx, oldCosmosCluster.InternalID)
 	if err != nil {
-		logger.Error(fmt.Sprintf("failed to fetch CS cluster for %s: %v", resourceID, err))
-		arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID, writer.Header()))
-		return
+		return ocm.CSErrorToCloudError(err, resourceID, writer.Header())
 	}
 
 	internalOldCluster, err := ocm.ConvertCStoHCPOpenShiftCluster(resourceID, oldClusterServiceCluster)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	// Do not set the TrackedResource.Tags field here. We need
@@ -519,25 +443,19 @@ func (f *Frontend) updateHCPCluster(writer http.ResponseWriter, request *http.Re
 		newExternalCluster = versionedInterface.NewHCPOpenShiftCluster(internalOldCluster)
 		successStatusCode = http.StatusAccepted
 	default:
-		logger.Error("unexpected method: " + request.Method)
-		arm.WriteResourceNotFoundError(writer, resourceID)
-		return
+		return arm.NewResourceNotFoundError(resourceID)
 	}
 
 	// CheckForProvisioningStateConflict does not log conflict errors
 	// but does log unexpected errors like database failures.
-	cloudError := f.CheckForProvisioningStateConflict(ctx, operationRequest, oldCosmosCluster)
-	if cloudError != nil {
-		arm.WriteCloudError(writer, cloudError)
-		return
+	if err := f.CheckForProvisioningStateConflict(ctx, operationRequest, oldCosmosCluster); err != nil {
+		return err
 	}
 
 	// TODO we appear to lack a test, but this seems to take an original, apply the patch and unmarshal the result, meaning the above patch step is just incorrect.
-	cloudError = api.ApplyRequestBody(request, body, newExternalCluster)
-	if cloudError != nil {
-		logger.Error(cloudError.Error())
-		arm.WriteCloudError(writer, cloudError)
-		return
+
+	if err := api.ApplyRequestBody(request, body, newExternalCluster); err != nil {
+		return err
 	}
 
 	newInternalCluster := &api.HCPOpenShiftCluster{}
@@ -546,28 +464,19 @@ func (f *Frontend) updateHCPCluster(writer http.ResponseWriter, request *http.Re
 	oldInternalCluster := &api.HCPOpenShiftCluster{}
 	oldExternalCluster.Normalize(oldInternalCluster)
 	validationErrs := validation.ValidateClusterUpdate(ctx, newInternalCluster, oldInternalCluster, api.Must(versionedInterface.ValidationPathRewriter(&api.HCPOpenShiftCluster{})))
-	newValidationErr := arm.CloudErrorFromFieldErrors(validationErrs)
-
-	// prefer new validation.  Have a fallback for old validation.
-	if newValidationErr != nil {
-		logger.Error(newValidationErr.Error())
-		arm.WriteCloudError(writer, newValidationErr)
-		return
+	if err := arm.CloudErrorFromFieldErrors(validationErrs); err != nil {
+		return err
 	}
 
 	newClusterServiceClusterBuilder, err := ocm.BuildCSCluster(resourceID, request.Header, newInternalCluster, true)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	logger.Info(fmt.Sprintf("updating resource %s", resourceID))
 	resultingClusterServiceCluster, err := f.clusterServiceClient.UpdateCluster(ctx, oldCosmosCluster.InternalID, newClusterServiceClusterBuilder)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteCloudError(writer, ocm.CSErrorToCloudError(err, resourceID, writer.Header()))
-		return
+		return ocm.CSErrorToCloudError(err, resourceID, writer.Header())
 	}
 
 	pk := database.NewPartitionKey(resourceID.SubscriptionID)
@@ -611,40 +520,31 @@ func (f *Frontend) updateHCPCluster(writer http.ResponseWriter, request *http.Re
 		EnableContentResponseOnWrite: true,
 	})
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	// Read back the resource document so the response body is accurate.
 	resultingCosmosCluster, err := transactionResult.GetResourceDoc(cosmosID)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 	resultingInternalCluster, err := database.ResourceDocumentToInternalAPI[api.HCPOpenShiftCluster, database.HCPCluster](resultingCosmosCluster)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	resultingExternalCluster, err := mergeToExternalCluster(resultingClusterServiceCluster, resultingInternalCluster, versionedInterface)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 	responseBytes, err := arm.MarshalJSON(resultingExternalCluster)
 	if err != nil {
-		logger.Error(err.Error())
-		arm.WriteInternalServerError(writer)
-		return
+		return err
 	}
 
 	_, err = arm.WriteJSONResponse(writer, successStatusCode, responseBytes)
 	if err != nil {
-		logger.Error(err.Error())
+		return err
 	}
+	return nil
 }

--- a/frontend/pkg/frontend/error.go
+++ b/frontend/pkg/frontend/error.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+// erroringHTTPHandler is an http handler that leaves error reporting to a higher layer
+// This allows the function itself to return errors for consistent logging and returning to users instead of
+// leaving the error handling itself where we see problems with inconsistent logging, forgotten returns, and
+// missing metadata.
+type erroringHTTPHandlerFunc func(w http.ResponseWriter, r *http.Request) error
+
+// reportError allows an http handler to have an error handling flow that is "normal" where encountered errors are
+// returned.  If the error is non-nil, then the standard error reporting (special cases baked in for known types of errors)
+// are logged and then reported to a client with an appropriate http code.
+func reportError(delegate erroringHTTPHandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		err := delegate(w, r)
+		if err == nil {
+			return
+		}
+
+		ctx := r.Context()
+		_ = writeError(ctx, w, err) // return is always nil
+	}
+}
+
+// writeError handles any error correctly with the response writer and logs the failure to stdout.
+// errors that are not cloud errors are assumed to be internal errors.
+// The return value is always nil.  This allows direct usage in an http handler to local context
+// and allows the same handler function to return an error
+func writeError(ctx context.Context, w http.ResponseWriter, err error, args ...interface{}) error {
+	logger := LoggerFromContext(ctx)
+
+	logger.Error(fmt.Sprintf("%v", err), args...) // fmt used to handle nil
+
+	var cloudErr *arm.CloudError
+	if errors.As(err, &cloudErr) {
+		arm.WriteCloudError(w, cloudErr)
+		return nil
+	}
+
+	arm.WriteInternalServerError(w)
+	return nil
+}

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -90,10 +90,10 @@ func (f *Frontend) routes(r prometheus.Registerer) http.Handler {
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternProviders, api.ClusterResourceTypeName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceListClusters))
+		postMuxMiddleware.HandlerFunc(reportError(f.ArmResourceListClusters)))
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, api.ClusterResourceTypeName),
-		postMuxMiddleware.HandlerFunc(f.ArmResourceListClusters))
+		postMuxMiddleware.HandlerFunc(reportError(f.ArmResourceListClusters)))
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, api.NodePoolResourceTypeName),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceListNodePools))
@@ -112,7 +112,7 @@ func (f *Frontend) routes(r prometheus.Registerer) http.Handler {
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
-		postMuxMiddleware.HandlerFunc(f.GetHCPCluster))
+		postMuxMiddleware.HandlerFunc(reportError(f.GetHCPCluster)))
 	middlewareMux.Handle(
 		MuxPattern(http.MethodGet, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters, PatternNodePools),
 		postMuxMiddleware.HandlerFunc(f.GetNodePool))
@@ -132,10 +132,10 @@ func (f *Frontend) routes(r prometheus.Registerer) http.Handler {
 		newMiddlewareValidateSubscriptionState(f.dbClient).handleRequest)
 	middlewareMux.Handle(
 		MuxPattern(http.MethodPut, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
-		postMuxMiddleware.HandlerFunc(f.CreateOrUpdateHCPCluster))
+		postMuxMiddleware.HandlerFunc(reportError(f.CreateOrUpdateHCPCluster)))
 	middlewareMux.Handle(
 		MuxPattern(http.MethodPatch, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
-		postMuxMiddleware.HandlerFunc(f.CreateOrUpdateHCPCluster))
+		postMuxMiddleware.HandlerFunc(reportError(f.CreateOrUpdateHCPCluster)))
 	middlewareMux.Handle(
 		MuxPattern(http.MethodDelete, PatternSubscriptions, PatternResourceGroups, PatternProviders, PatternClusters),
 		postMuxMiddleware.HandlerFunc(f.ArmResourceDelete))


### PR DESCRIPTION
Since we have a lot of logic and error handling, rather than handling locally at each instance, we encourage doing a simple return (or an inline handle as shown here that also returns) so that we get consistent error handling without having to decide "what kind of error is this" and remember to log consistently, hide from clients when appropriate, and return to avoid continued execution.

@stevekuznetsov You've got a decade or so of golang experience and no attachment. Improvement?