### PR TITLE
introduce dedicated kusto subscriptions

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1551,6 +1551,9 @@
     "kusto": {
       "type": "object",
       "properties": {
+        "subscription": {
+          "$ref": "#/definitions/subscriptionMetadata"
+        },
         "rg": {
           "type": "string"
         },
@@ -1608,7 +1611,8 @@
         "serviceLogsDatabase",
         "hostedControlPlaneLogsDatabase",
         "adminGroups",
-        "viewerGroups"
+        "viewerGroups",
+        "subscription"
       ]
     },
     "mise": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -194,6 +194,13 @@ defaults:
     viewerGroups: ""
     sku: ""
     tier: ""
+    subscription:
+      usePlannedQuota: false
+      key: "kusto-{{ .ev2.geoShortId }}"
+      displayName: "Azure Red Hat OpenShift HCP - Kusto - {{ .ev2.geoShortId }}"
+      providers:
+        'Microsoft.Kusto':
+          poll: true
   # Hypershift
   hypershift:
     image:
@@ -786,6 +793,8 @@ clouds:
     defaults:
       kusto:
         staticKustoName: "hcp-dev-us"
+        subscription:
+          key: ARO Hosted Control Planes (EA Subscription 1)
       tenantId: "64dc69e4-d083-49fc-9569-ebece1dd1408"
       kubeEvents:
         enabled: false

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,22 +3,22 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: f5dd40f7eb2561511a0d207e6f5ca97b4b3e6205c94e55cfce03f0902fe567ae
+          westus3: f2b04a61ff7b8088f83323881988a683cc0faf5a9db8352c847db597e4941162
       dev:
         regions:
-          westus3: c6611a7236d98b1ebc4394892c4076f13acb3558519c869cf54aec29d3ee7c64
+          westus3: 7a9098aa8882dea357577b61e645ba1d8e04b2d61766793455d7e7141aa18910
       ntly:
         regions:
-          uksouth: 1065152a8719ef01693353deb97bafa7eb892b5d7b8b4bd8dc165018fcebd6a0
+          uksouth: fa4278aaa56bec48259619dded8943402e3d5f1dfa74b9524a2119a0b320fbad
       perf:
         regions:
-          westus3: 840adbf96229287d481934d45b5452de7416c923b8749a0c358d7790319b39cb
+          westus3: 5e4131088ff8f410522882035bb9bbe58ff7b0500e1d74c9d90bc36472fbba65
       pers:
         regions:
-          westus3: 805d257424443f1fd63844b1b821aa51ff2dbf55bf51c4042b12e744967cf7b5
+          westus3: 44d172b519f97fb65b5b77af319c05c60c83ae2ae08133336130c06bf22c6b76
       prow:
         regions:
-          westus3: 9932fe465589133c432dc830f09b773d12f8d8b314ca59e9bb95946fccb856b9
+          westus3: d4819129fd90d054a6998374e16d0efe785e7b93fdbfa651b44724755fb6dae5
       swft:
         regions:
-          uksouth: f165c426a6c8f68eedb8fb175979d5aa3b6881163a402ae234111e74d849b07b
+          uksouth: e0e2353307bdc113909c5637309c0143c86886e6e9654e04a92ecded5a3252ac

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -345,6 +345,13 @@ kusto:
   serviceLogsDatabase: ServiceLogs
   sku: ""
   staticKustoName: hcp-dev-us
+  subscription:
+    displayName: Azure Red Hat OpenShift HCP - Kusto - us
+    key: ARO Hosted Control Planes (EA Subscription 1)
+    providers:
+      Microsoft.Kusto:
+        poll: true
+    usePlannedQuota: false
   tier: ""
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -345,6 +345,13 @@ kusto:
   serviceLogsDatabase: ServiceLogs
   sku: Dev(No SLA)_Standard_D11_v2
   staticKustoName: hcp-dev-us
+  subscription:
+    displayName: Azure Red Hat OpenShift HCP - Kusto - us
+    key: ARO Hosted Control Planes (EA Subscription 1)
+    providers:
+      Microsoft.Kusto:
+        poll: true
+    usePlannedQuota: false
   tier: Basic
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -345,6 +345,13 @@ kusto:
   serviceLogsDatabase: ServiceLogs
   sku: ""
   staticKustoName: hcp-dev-us
+  subscription:
+    displayName: Azure Red Hat OpenShift HCP - Kusto - uk
+    key: ARO Hosted Control Planes (EA Subscription 1)
+    providers:
+      Microsoft.Kusto:
+        poll: true
+    usePlannedQuota: false
   tier: ""
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -345,6 +345,13 @@ kusto:
   serviceLogsDatabase: ServiceLogs
   sku: ""
   staticKustoName: hcp-dev-us
+  subscription:
+    displayName: Azure Red Hat OpenShift HCP - Kusto - us
+    key: ARO Hosted Control Planes (EA Subscription 1)
+    providers:
+      Microsoft.Kusto:
+        poll: true
+    usePlannedQuota: false
   tier: ""
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -345,6 +345,13 @@ kusto:
   serviceLogsDatabase: ServiceLogs
   sku: ""
   staticKustoName: hcp-dev-us
+  subscription:
+    displayName: Azure Red Hat OpenShift HCP - Kusto - us
+    key: ARO Hosted Control Planes (EA Subscription 1)
+    providers:
+      Microsoft.Kusto:
+        poll: true
+    usePlannedQuota: false
   tier: ""
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -345,6 +345,13 @@ kusto:
   serviceLogsDatabase: ServiceLogs
   sku: ""
   staticKustoName: hcp-dev-us
+  subscription:
+    displayName: Azure Red Hat OpenShift HCP - Kusto - us
+    key: ARO Hosted Control Planes (EA Subscription 1)
+    providers:
+      Microsoft.Kusto:
+        poll: true
+    usePlannedQuota: false
   tier: ""
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -345,6 +345,13 @@ kusto:
   serviceLogsDatabase: ServiceLogs
   sku: ""
   staticKustoName: hcp-dev-us
+  subscription:
+    displayName: Azure Red Hat OpenShift HCP - Kusto - uk
+    key: ARO Hosted Control Planes (EA Subscription 1)
+    providers:
+      Microsoft.Kusto:
+        poll: true
+    usePlannedQuota: false
   tier: ""
   viewerGroups: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb


### PR DESCRIPTION
### What

introduce a dedicated subscription configuration for kusto. this allows for flexibility in kusto instance creation. depending on the chosen subscription key, a kusto instance can be per geography or even per region if required. but in any case it allows us to pick the right kusto instance for a region by constructing the kust subscription key in a certain way. e.g. for our current geography based strategy, our subscription key strategy will include the ev2 geo id.

having kusto instances keyed on a subscription allows for things like ARM lookup steps that emit data like the actual kusto instance ingress and read urls, as well as the actual resource id required for cross-subscription permission management in the svc and mgmt pipelines for arobit.

this PR does not touch the implications of adding kusto subscriptions yet. it is merely a way to define our intent and allows us to already create subscriptions in sdp-pipelines, before we need and use them.

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
