### PR TITLE
ARO-17798

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -165,6 +165,16 @@ create-mock-identities: configurations/mock-identities.bicepparam
 		--scope "/subscriptions/$(shell az account show --query id --output tsv)" \
 		--only-show-errors
 
+# TODO: this is a workaround to enable the mock FPA to call the Check Access API with a built-in role.
+# The permissions should be reduced to match "dev-first-party-mock" role definition (ARO-17798).
+.PHONY: assign-role-for-rbac
+
+assign-role-for-rbac:
+	APPLICATION_NAME=aro-dev-first-party2 \
+	ROLE_DEFINITION_NAME=Contributor \
+	SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
+	./scripts/assign-role-for-rbac.sh
+
 .PHONY: create-mock-identities
 
 #

--- a/dev-infrastructure/scripts/assign-role-for-rbac.sh
+++ b/dev-infrastructure/scripts/assign-role-for-rbac.sh
@@ -1,0 +1,11 @@
+APP_ID=$(az ad app list --display-name ${APPLICATION_NAME} --query '[*]'.appId -o tsv)
+if [[ -n "${APP_ID}" ]];
+then
+    echo "Assigning role ${ROLE_DEFINITION_NAME} to appId ${APP_ID}"
+    az role assignment create \
+        --assignee "${APP_ID}" \
+        --role "${ROLE_DEFINITION_NAME}" \
+        --scope "/subscriptions/${SUBSCRIPTION_ID}"
+
+    exit 0
+fi

--- a/docs/sops/msit-int-credential-setup.md
+++ b/docs/sops/msit-int-credential-setup.md
@@ -28,7 +28,7 @@ The MSIT INT environment is unique because the first-party, MSI mock, and ARM he
 
    ```bash
    cd dev-infrastructure/
-   make create-int-mock-identities
+   make create-int-mock-identities assign-role-for-rbac
    ```
 
 1. **Update configuration**


### PR DESCRIPTION
[ARO-17798
](https://issues.redhat.com/browse/ARO-17798)
### What

Create a Contributor role assignment for aro-dev-first-party2 to enable the mock FPA to call the Check Access API in Dev & INT environments.

### Why

Enable user infra permissions inflights epic.

### Special notes for your reviewer

<!-- optional -->
