### PR TITLE
feat: configure CS in tooling/image-updater for int and dev envs

### DIFF
--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -48,11 +48,15 @@ images:
       filePath: ../../config/config.msft.clouds-overlay.yaml
     - jsonPath: defaults.pko.remotePhaseManager.digest
       filePath: ../../config/config.yaml
+  # Clusters Service image
   clusters-service:
     source:
       image: quay.io/app-sre/aro-hcp-clusters-service
       tagPattern: "^[a-f0-9]{7}$"
       useAuth: true
+      keyVault:
+        url: "https://arohcpdev-global.vault.azure.net/"
+        secretName: "component-sync-pull-secret"
     targets:
     - jsonPath: clouds.dev.defaults.clustersService.image.digest
       filePath: ../../config/config.yaml


### PR DESCRIPTION
Add configuration in `tooling/image-updater/config.yaml` to include CS. Specifically, configure it for the following targets:

- ARO-HCP Integration
- ARO-HCP Development environments (shared-dev, personal, ...)