### PR TITLE
tooling/templatize: write pipeline steps to jUnit file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,7 @@ LOG_LEVEL ?= 3
 DRY_RUN ?= "false"
 PERSIST ?= "false"
 TIMING_OUTPUT ?= timing/steps.yaml
+ENTRYPOINT_JUNIT_OUTPUT ?= _artifacts/junit_entrypoint.xml
 
 local-run: $(TEMPLATIZE)
 	$(TEMPLATIZE) entrypoint run --config-file "${CONFIG_FILE}" \
@@ -305,7 +306,8 @@ local-run: $(TEMPLATIZE)
 	                                 $(WHAT) $(EXTRA_ARGS) \
 	                                 --dry-run=$(DRY_RUN) \
 	                                 --verbosity=$(LOG_LEVEL) \
-	                                 --timing-output=$(TIMING_OUTPUT)
+	                                 --timing-output=$(TIMING_OUTPUT) \
+	                                 --junit-output=$(ENTRYPOINT_JUNIT_OUTPUT)
 
 
 ifeq ($(wildcard $(YQ)),$(YQ))

--- a/tooling/templatize/cmd/entrypoint/run/options.go
+++ b/tooling/templatize/cmd/entrypoint/run/options.go
@@ -36,6 +36,7 @@ func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
 	}
 
 	cmd.Flags().StringVar(&opts.TimingOutputFile, "timing-output", opts.TimingOutputFile, "Path to the file where timing outputs will be written.")
+	cmd.Flags().StringVar(&opts.JUnitOutputFile, "junit-output", opts.JUnitOutputFile, "If provided, jUnit outputs for pipeline steps will be written to this file.")
 
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", opts.DryRun, "validate the pipeline without executing it")
 	cmd.Flags().BoolVar(&opts.Persist, "persist-tag", opts.Persist, "toggle if persist tag should be set")
@@ -52,6 +53,7 @@ type RawOptions struct {
 	DeploymentTimeoutSeconds int
 
 	TimingOutputFile string
+	JUnitOutputFile  string
 }
 
 // validatedOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
@@ -74,6 +76,7 @@ type completedOptions struct {
 	DeploymentTimeoutSeconds int
 
 	TimingOutputFile string
+	JUnitOutputFile  string
 }
 
 type Options struct {
@@ -130,6 +133,7 @@ func (o *Options) Run(ctx context.Context) error {
 		SubsciptionLookupFunc: pipeline.LookupSubscriptionID(o.Subscriptions),
 		Concurrency:           o.Concurrency,
 		TimingOutputFile:      o.TimingOutputFile,
+		JUnitOutputFile:       o.JUnitOutputFile,
 	}
 
 	if o.Entrypoint != nil {

--- a/tooling/templatize/pkg/junit/types.go
+++ b/tooling/templatize/pkg/junit/types.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package junit
+
+import (
+	"encoding/xml"
+)
+
+// The below types are directly marshalled into XML. The types correspond to jUnit
+// XML schema, but do not contain all valid fields. For instance, the class name
+// field for test cases is omitted, as this concept does not directly apply to Go.
+// For XML specifications see http://help.catchsoftware.com/display/ET/JUnit+Format
+// or view the XSD included in this package as 'junit.xsd'
+
+// TestSuites represents a flat collection of jUnit test suites.
+type TestSuites struct {
+	XMLName xml.Name `xml:"testsuites"`
+
+	// Suites are the jUnit test suites held in this collection
+	Suites []*TestSuite `xml:"testsuite"`
+}
+
+// TestSuite represents a single jUnit test suite, potentially holding child suites.
+type TestSuite struct {
+	XMLName xml.Name `xml:"testsuite"`
+
+	// Name is the name of the test suite
+	Name string `xml:"name,attr"`
+
+	// NumTests records the number of tests in the TestSuite
+	NumTests uint `xml:"tests,attr"`
+
+	// NumSkipped records the number of skipped tests in the suite
+	NumSkipped uint `xml:"skipped,attr"`
+
+	// NumFailed records the number of failed tests in the suite
+	NumFailed uint `xml:"failures,attr"`
+
+	// Duration is the time taken in seconds to run all tests in the suite
+	Duration float64 `xml:"time,attr"`
+
+	// Properties holds other properties of the test suite as a mapping of name to value
+	Properties []*TestSuiteProperty `xml:"properties>property,omitempty"`
+
+	// TestCases are the test cases contained in the test suite
+	TestCases []*TestCase `xml:"testcase"`
+
+	// Children holds nested test suites
+	Children []*TestSuite `xml:"testsuite"`
+}
+
+// TestSuiteProperty contains a mapping of a property name to a value
+type TestSuiteProperty struct {
+	XMLName xml.Name `xml:"property"`
+
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// TestCase represents a jUnit test case
+type TestCase struct {
+	XMLName xml.Name `xml:"testcase"`
+
+	// Name is the name of the test case
+	Name string `xml:"name,attr"`
+
+	// Classname is an attribute set by the package type and is required
+	Classname string `xml:"classname,attr,omitempty"`
+
+	// Duration is the time taken in seconds to run the test
+	Duration float64 `xml:"time,attr"`
+
+	// SkipMessage holds the reason why the test was skipped
+	SkipMessage *SkipMessage `xml:"skipped"`
+
+	// FailureOutput holds the output from a failing test
+	FailureOutput *FailureOutput `xml:"failure"`
+
+	// SystemOut is output written to stdout during the execution of this test case
+	SystemOut string `xml:"system-out,omitempty"`
+
+	// SystemErr is output written to stderr during the execution of this test case
+	SystemErr string `xml:"system-err,omitempty"`
+}
+
+// SkipMessage holds a message explaining why a test was skipped
+type SkipMessage struct {
+	XMLName xml.Name `xml:"skipped"`
+
+	// Message explains why the test was skipped
+	Message string `xml:"message,attr,omitempty"`
+}
+
+// FailureOutput holds the output from a failing test
+type FailureOutput struct {
+	XMLName xml.Name `xml:"failure"`
+
+	// Message holds the failure message from the test
+	Message string `xml:"message,attr"`
+
+	// Output holds verbose failure output from the test
+	Output string `xml:",chardata"`
+}
+
+// TestResult is the result of a test case
+type TestResult string

--- a/tooling/templatize/pkg/junit/write.go
+++ b/tooling/templatize/pkg/junit/write.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package junit
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"sort"
+)
+
+// Write ensures stable sort order and emits jUnit data to disk.
+func Write(intoPath string, suites *TestSuites) error {
+	if suites == nil {
+		return nil
+	}
+	sort.Slice(suites.Suites, func(i, j int) bool {
+		return suites.Suites[i].Name < suites.Suites[j].Name
+	})
+	for i := range suites.Suites {
+		sortSuite(suites.Suites[i])
+	}
+	out, err := xml.MarshalIndent(suites, "", "  ")
+	if err != nil {
+		return fmt.Errorf("could not marshal jUnit XML: %w", err)
+	}
+	return os.WriteFile(intoPath, out, 0644)
+}
+
+func sortSuite(suite *TestSuite) {
+	sort.Slice(suite.Properties, func(i, j int) bool {
+		return suite.Properties[i].Name < suite.Properties[j].Name
+	})
+	sort.Slice(suite.Children, func(i, j int) bool {
+		return suite.Children[i].Name < suite.Children[j].Name
+	})
+	sort.Slice(suite.TestCases, func(i, j int) bool {
+		return suite.TestCases[i].Name < suite.TestCases[j].Name
+	})
+	for i := range suite.Children {
+		sortSuite(suite.Children[i])
+	}
+}


### PR DESCRIPTION
In CI, we want a nicer capture of failed steps than the current experience with a huge log capture for the entire job. We can emit a jUnit suite for the pipeline steps and capture logs from the step to succinctly show only the pertinent output on failure.
