### PR TITLE
frontend: Fix search parameter for listing CS resources

### DIFF
--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -86,7 +86,7 @@ func (f *Frontend) ArmResourceListClusters(writer http.ResponseWriter, request *
 	}
 	clustersByClusterServiceID := make(map[string]*api.HCPOpenShiftCluster)
 	for _, internalCluster := range internalClusterIterator.Items(ctx) {
-		clustersByClusterServiceID[internalCluster.ServiceProviderProperties.ClusterServiceID.String()] = internalCluster
+		clustersByClusterServiceID[internalCluster.ServiceProviderProperties.ClusterServiceID.ID()] = internalCluster
 	}
 	err = internalClusterIterator.GetError()
 	if err != nil {
@@ -110,7 +110,7 @@ func (f *Frontend) ArmResourceListClusters(writer http.ResponseWriter, request *
 	csIterator := f.clusterServiceClient.ListClusters(query)
 
 	for csCluster := range csIterator.Items(ctx) {
-		if internalCluster, ok := clustersByClusterServiceID[csCluster.HREF()]; ok {
+		if internalCluster, ok := clustersByClusterServiceID[csCluster.ID()]; ok {
 			resultingExternalCluster, err := mergeToExternalCluster(csCluster, internalCluster, versionedInterface)
 			if err != nil {
 				return err

--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -96,7 +96,7 @@ func (f *Frontend) ArmResourceListExternalAuths(writer http.ResponseWriter, requ
 		return err
 	}
 	for _, externalAuth := range internalExternalAuthIteraotr.Items(ctx) {
-		externalAuthsByClusterServiceID[externalAuth.ServiceProviderProperties.ClusterServiceID.String()] = externalAuth
+		externalAuthsByClusterServiceID[externalAuth.ServiceProviderProperties.ClusterServiceID.ID()] = externalAuth
 	}
 	err = internalExternalAuthIteraotr.GetError()
 	if err != nil {
@@ -120,7 +120,7 @@ func (f *Frontend) ArmResourceListExternalAuths(writer http.ResponseWriter, requ
 
 	csIterator := f.clusterServiceClient.ListExternalAuths(internalCluster.ServiceProviderProperties.ClusterServiceID, query)
 	for csExternalAuth := range csIterator.Items(ctx) {
-		if internalExternalAuth, ok := externalAuthsByClusterServiceID[csExternalAuth.HREF()]; ok {
+		if internalExternalAuth, ok := externalAuthsByClusterServiceID[csExternalAuth.ID()]; ok {
 			value, err := mergeToExternalExternalAuth(csExternalAuth, internalExternalAuth, versionedInterface)
 			if err != nil {
 				return err

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -98,7 +98,7 @@ func (f *Frontend) ArmResourceListNodePools(writer http.ResponseWriter, request 
 		return err
 	}
 	for _, nodePool := range internalNodePoolIterator.Items(ctx) {
-		nodePoolsByClusterServiceID[nodePool.ServiceProviderProperties.ClusterServiceID.String()] = nodePool
+		nodePoolsByClusterServiceID[nodePool.ServiceProviderProperties.ClusterServiceID.ID()] = nodePool
 	}
 	err = internalNodePoolIterator.GetError()
 	if err != nil {
@@ -122,7 +122,7 @@ func (f *Frontend) ArmResourceListNodePools(writer http.ResponseWriter, request 
 
 	csIterator := f.clusterServiceClient.ListNodePools(internalCluster.ServiceProviderProperties.ClusterServiceID, query)
 	for csNodePool := range csIterator.Items(ctx) {
-		if internalNodePool, ok := nodePoolsByClusterServiceID[csNodePool.HREF()]; ok {
+		if internalNodePool, ok := nodePoolsByClusterServiceID[csNodePool.ID()]; ok {
 			value, err := mergeToExternalNodePool(csNodePool, internalNodePool, versionedInterface)
 			if err != nil {
 				return err


### PR DESCRIPTION
[ARO-22829 - Subscription level cluster listing is incomplete](https://issues.redhat.com/browse/ARO-22829)

### What

When handling a collection GET request, the RP first queries Cosmos DB for a "page" worth of resources. It then asks Cluster Service to list those specific resources by building a request parameter that looks like:

```
   search="id in (comma-separated list of IDs)"
```

The list in the search parameter must be JUST the resources' "id" value, not their full API path / "href" value.