### PR TITLE
cfg: set current prod image to cs prod overlay

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -220,7 +220,7 @@ clouds:
           clustersService:
             deployDebugJobs: true
             image:
-              digest: sha256:a1046d7b1b2042b9b109b9c433521662f9c3280fa1a3a66f82e499ba2e9fc433
+              digest: sha256:ce22a392a836a3f415f11fe07e18d171ec5455608be905d2b460b67f6beedf1d
           # ACR Pull
           acrPull:
             image:


### PR DESCRIPTION
Rolls back the CS Prod promotion and sets the currently deployed one. Once we can resume EV2 rollouts, we will do a promotion again.

This should remove `prod---2025-11-24T10:28:32-05:00-d7ff8 was never tested in stage. Closest release is stg---2025-11-24T10:28:32-05:00-d7ff8 which differs by Cluster Service` warning.

https://service-status.apps.engineering.openshift.org/#prod

We are investigating why it's reporting that, as the current image in Stage is `a1046d7b1b2042b9b109b9c433521662f9c3280fa1a3a66f82e499ba2e9fc433`, the one defined in the prod overlay. So it's tested in Stage.