### PR TITLE
Fail fast during e2e cleanup if hcpOpenShiftClusters resources still exist after complete deletion

### DIFF
--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -16,7 +16,9 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -30,6 +32,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
@@ -120,6 +123,16 @@ func DeleteHCPCluster(
 	default:
 		fmt.Printf("#### unknown type %T: content=%v", m, spew.Sdump(m))
 		return fmt.Errorf("unknown type %T", m)
+	}
+
+	// ensure the resource is actually gone after the delete operation completes
+	_, err = hcpClient.Get(ctx, resourceGroupName, hcpClusterName, nil)
+	if err == nil {
+		return fmt.Errorf("hcpCluster=%q in resourcegroup=%q still present after delete operation", hcpClusterName, resourceGroupName)
+	}
+	var responseErr *azcore.ResponseError
+	if !errors.As(err, &responseErr) || responseErr.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("failed checking status of deleted hcpCluster=%q in resourcegroup=%q: %w", hcpClusterName, resourceGroupName, err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Link to Jira issue -->

[ARO-22847](https://issues.redhat.com/browse/ARO-22847)

### What

Add an explicit step during e2e test cleanup's `DeleteHCPCluster` to check and confirm the cluster is gone, and fail fast if the cluster resource still exists. While the existing implementation waits for the asynchronous DELETE operation to complete before proceeding, there may be cases where the RP reports a successful deletion before the resource is actually removed.  

Note: Instead of this approach, we may prefer instead to poll and wait for e.g. a cluster in `Deleting` provisioning state to actually be removed before proceeding, but if our RP is reporting a cluster as successfully deleted while the resource still exists we would likely consider that to be a blocking failure. 

### Why

We've observed that the subsequent `DeleteResourceGroup` cleanup step sometimes fails due to the resource group containing an hcpOpenShiftCluster resource still in Deleting. Ideally, all of these resources should be completely gone by the time we delete the resource group. 

### Special notes for your reviewer

<!-- optional -->
