### PR TITLE
Remove maxLength validation for hcpBackupsStorageAccountName parameter

### DIFF
--- a/dev-infrastructure/templates/mgmt-infra.bicep
+++ b/dev-infrastructure/templates/mgmt-infra.bicep
@@ -51,7 +51,7 @@ param logAnalyticsWorkspaceId string = ''
 
 // Storage Account for HCP Backups
 @minLength(3)
-@maxLength(24)
+// @maxLength(24) Fails on EV2 pipelines, probably because the EV2 placeholder is longer than 24.
 param hcpBackupsStorageAccountName string
 param hcpBackupsStorageAccountContainerName string = 'backups'
 param hcpBackupsStorageAccountZoneRedundantMode string = 'Auto'


### PR DESCRIPTION
The @maxLength(24) validation on hcpBackupsStorageAccountName causes failures in EV2 pipelines where the EV2 placeholder exceeds 24 characters.

cc @tony-schndr 