### PR TITLE
cfg: change role assignments cleanup schedule to run every 2 hours

### DIFF
--- a/dev-infrastructure/templates/automation-account.bicep
+++ b/dev-infrastructure/templates/automation-account.bicep
@@ -13,8 +13,8 @@ param automationAccountName string = 'hcp-${environment}-automation'
 @description('The start time for the nightly schedule')
 param dailyScheduleStartTime string = '${substring(dateTimeAdd(utcNow(), 'P1D'), 0, 10)}T06:00:00Z'
 
-@description('The start time for the nightly schedule')
-param ntlyScheduleStartTime string = '${substring(dateTimeAdd(utcNow(), 'P1D'), 0, 10)}T00:00:00Z'
+@description('The start time for the hourly schedule')
+param hourlyScheduleStartTime string = '${substring(dateTimeAdd(utcNow(), 'P1D'), 0, 10)}T00:00:00Z'
 
 @description('The commit hash of the script to use')
 param scriptVersion string = '0de69144a537d9e5a032605a5fa82e863fc45a9e'
@@ -113,7 +113,9 @@ module roleAssignmentsCleanup '../modules/automation-account/runbook.bicep' = {
       ref: scriptVersion
       path: 'tooling/azure-automation/resources-cleanup/src/clean-orphaned-role-assignments.ps1'
     }
-    scheduleName: 'nightly-schedule'
-    startTime: ntlyScheduleStartTime
+    scheduleName: 'bihourly-schedule'
+    startTime: hourlyScheduleStartTime
+    frequency: 'Hour'
+    interval: 2
   }
 }


### PR DESCRIPTION
Update the automation account runbook schedule from daily (every 1 day) to hourly execution (every 2 hours) to ensure more frequent cleanup of role assignments.
