### PR TITLE
feat: add support for authenticated quay and generic repos

### DIFF
--- a/tooling/image-updater/go.mod
+++ b/tooling/image-updater/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.4
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.12.0
 	github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-containerregistry v0.20.6
@@ -17,6 +18,7 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.5.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/tooling/image-updater/go.sum
+++ b/tooling/image-updater/go.sum
@@ -8,6 +8,10 @@ github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3 h1:l
 github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3/go.mod h1:MAm7bk0oDLmD8yIkvfbxPW04fxzphPyL+7GzwHxOp6Y=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0 h1:/g8S6wk65vfC6m3FIxJ+i5QDyN9JWwXI8Hb0Img10hU=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0/go.mod h1:gpl+q95AzZlKVI3xSoseF9QPrypk0hQqBiJYeB/cR/I=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfgcSyHZXJI8J0IWE5MsCGlb2xp9fJiXyxWgmOFg4=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.5.0 h1:XkkQbfMyuH2jTSjQjSoihryI8GINRcs4xp8lNawg0FI=

--- a/tooling/image-updater/internal/clients/auth.go
+++ b/tooling/image-updater/internal/clients/auth.go
@@ -1,0 +1,165 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clients
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+)
+
+// KeyVaultConfig holds configuration for fetching pull secrets from Azure Key Vault
+type KeyVaultConfig struct {
+	VaultURL   string // e.g., "https://aro-hcp-dev-global-kv.vault.azure.net/"
+	SecretName string // e.g., "component-sync-pull-secret"
+}
+
+// GetRemoteOptions returns remote options with Docker credentials if useAuth is true
+// It uses the default Docker config file (~/.docker/config.json) for authentication
+func GetRemoteOptions(useAuth bool) []remote.Option {
+	if !useAuth {
+		return nil
+	}
+
+	// Use the default keychain which reads from ~/.docker/config.json
+	// This automatically handles authentication for registries the user has logged into
+	return []remote.Option{
+		remote.WithAuthFromKeychain(authn.DefaultKeychain),
+	}
+}
+
+// FetchAndMergeKeyVaultPullSecret fetches a Docker pull secret from Azure Key Vault
+// and merges it with the existing Docker config file
+func FetchAndMergeKeyVaultPullSecret(ctx context.Context, kvConfig KeyVaultConfig) error {
+	if kvConfig.VaultURL == "" || kvConfig.SecretName == "" {
+		return fmt.Errorf("KeyVault URL and secret name must be provided")
+	}
+
+	// Create Azure credential using DefaultAzureCredential
+	// This supports Azure CLI, managed identity, environment variables, etc.
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return fmt.Errorf("failed to create Azure credential: %w", err)
+	}
+
+	// Create Key Vault client
+	client, err := azsecrets.NewClient(kvConfig.VaultURL, cred, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create KeyVault client: %w", err)
+	}
+
+	// Fetch the secret
+	resp, err := client.GetSecret(ctx, kvConfig.SecretName, "", nil)
+	if err != nil {
+		return fmt.Errorf("failed to get secret %s from KeyVault: %w", kvConfig.SecretName, err)
+	}
+
+	if resp.Value == nil {
+		return fmt.Errorf("secret %s is empty", kvConfig.SecretName)
+	}
+
+	// The secret value should be a base64-encoded Docker config JSON
+	secretValue := *resp.Value
+
+	// Try to decode as base64 first (common format for pull secrets)
+	var dockerConfigData []byte
+	decoded, err := base64.StdEncoding.DecodeString(secretValue)
+	if err == nil {
+		// Successfully decoded as base64
+		dockerConfigData = decoded
+	} else {
+		// Not base64, assume it's raw JSON
+		dockerConfigData = []byte(secretValue)
+	}
+
+	// Parse the Docker config JSON
+	var kvDockerConfig map[string]interface{}
+	if err := json.Unmarshal(dockerConfigData, &kvDockerConfig); err != nil {
+		return fmt.Errorf("failed to parse Docker config from KeyVault secret: %w", err)
+	}
+
+	// Merge with existing Docker config
+	if err := mergeDockerConfig(kvDockerConfig); err != nil {
+		return fmt.Errorf("failed to merge Docker config: %w", err)
+	}
+
+	return nil
+}
+
+// mergeDockerConfig merges a Docker config from KeyVault with the existing ~/.docker/config.json
+func mergeDockerConfig(kvConfig map[string]interface{}) error {
+	// Get Docker config path
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	dockerConfigPath := filepath.Join(homeDir, ".docker", "config.json")
+
+	// Read existing Docker config
+	var existingConfig map[string]interface{}
+	existingData, err := os.ReadFile(dockerConfigPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to read Docker config: %w", err)
+		}
+		// Config doesn't exist, create a new one
+		existingConfig = make(map[string]interface{})
+	} else {
+		if err := json.Unmarshal(existingData, &existingConfig); err != nil {
+			return fmt.Errorf("failed to parse existing Docker config: %w", err)
+		}
+	}
+
+	// Merge auths section
+	if kvAuths, ok := kvConfig["auths"].(map[string]interface{}); ok {
+		if existingConfig["auths"] == nil {
+			existingConfig["auths"] = make(map[string]interface{})
+		}
+		existingAuths := existingConfig["auths"].(map[string]interface{})
+
+		for registry, auth := range kvAuths {
+			existingAuths[registry] = auth
+		}
+	}
+
+	// Write merged config back
+	mergedData, err := json.MarshalIndent(existingConfig, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal merged Docker config: %w", err)
+	}
+
+	// Ensure .docker directory exists
+	dockerDir := filepath.Dir(dockerConfigPath)
+	if err := os.MkdirAll(dockerDir, 0700); err != nil {
+		return fmt.Errorf("failed to create .docker directory: %w", err)
+	}
+
+	// Write the merged config
+	if err := os.WriteFile(dockerConfigPath, mergedData, 0600); err != nil {
+		return fmt.Errorf("failed to write Docker config: %w", err)
+	}
+
+	return nil
+}

--- a/tooling/image-updater/internal/clients/auth_test.go
+++ b/tooling/image-updater/internal/clients/auth_test.go
@@ -1,0 +1,272 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clients
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMergeDockerConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingConfig map[string]any
+		kvConfig       map[string]any
+		wantAuths      map[string]any
+		wantErr        bool
+	}{
+		{
+			name:           "merge with empty existing config",
+			existingConfig: map[string]any{},
+			kvConfig: map[string]any{
+				"auths": map[string]any{
+					"quay.io": map[string]any{
+						"auth": "dGVzdDp0ZXN0",
+					},
+				},
+			},
+			wantAuths: map[string]any{
+				"quay.io": map[string]any{
+					"auth": "dGVzdDp0ZXN0",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "merge with existing auths",
+			existingConfig: map[string]any{
+				"auths": map[string]any{
+					"docker.io": map[string]any{
+						"auth": "ZG9ja2VyOnRlc3Q=",
+					},
+				},
+			},
+			kvConfig: map[string]any{
+				"auths": map[string]any{
+					"quay.io": map[string]any{
+						"auth": "cXVheTp0ZXN0",
+					},
+				},
+			},
+			wantAuths: map[string]any{
+				"docker.io": map[string]any{
+					"auth": "ZG9ja2VyOnRlc3Q=",
+				},
+				"quay.io": map[string]any{
+					"auth": "cXVheTp0ZXN0",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "overwrite existing registry auth",
+			existingConfig: map[string]any{
+				"auths": map[string]any{
+					"quay.io": map[string]any{
+						"auth": "b2xkOnRlc3Q=",
+					},
+				},
+			},
+			kvConfig: map[string]any{
+				"auths": map[string]any{
+					"quay.io": map[string]any{
+						"auth": "bmV3OnRlc3Q=",
+					},
+				},
+			},
+			wantAuths: map[string]any{
+				"quay.io": map[string]any{
+					"auth": "bmV3OnRlc3Q=",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "kv config without auths section",
+			existingConfig: map[string]any{},
+			kvConfig: map[string]any{
+				"credHelpers": map[string]any{
+					"gcr.io": "gcloud",
+				},
+			},
+			wantAuths: nil,
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp directory for test
+			tmpDir := t.TempDir()
+			dockerDir := filepath.Join(tmpDir, ".docker")
+			if err := os.MkdirAll(dockerDir, 0700); err != nil {
+				t.Fatalf("failed to create .docker directory: %v", err)
+			}
+
+			// Override home directory for this test
+			oldHome := os.Getenv("HOME")
+			os.Setenv("HOME", tmpDir)
+			defer os.Setenv("HOME", oldHome)
+
+			// Write existing config if provided
+			configPath := filepath.Join(dockerDir, "config.json")
+			if len(tt.existingConfig) > 0 {
+				data, err := json.MarshalIndent(tt.existingConfig, "", "  ")
+				if err != nil {
+					t.Fatalf("failed to marshal existing config: %v", err)
+				}
+				if err := os.WriteFile(configPath, data, 0600); err != nil {
+					t.Fatalf("failed to write existing config: %v", err)
+				}
+			}
+
+			// Run merge
+			err := mergeDockerConfig(tt.kvConfig)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mergeDockerConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			// Read and verify merged config
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatalf("failed to read merged config: %v", err)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("failed to unmarshal merged config: %v", err)
+			}
+
+			if tt.wantAuths == nil {
+				if _, exists := got["auths"]; exists {
+					t.Errorf("mergeDockerConfig() created auths section when it shouldn't have")
+				}
+				return
+			}
+
+			gotAuths, ok := got["auths"].(map[string]any)
+			if !ok {
+				t.Fatalf("merged config auths is not a map")
+			}
+
+			// Compare auths
+			if len(gotAuths) != len(tt.wantAuths) {
+				t.Errorf("mergeDockerConfig() auths count = %v, want %v", len(gotAuths), len(tt.wantAuths))
+			}
+
+			for registry, wantAuth := range tt.wantAuths {
+				gotAuth, exists := gotAuths[registry]
+				if !exists {
+					t.Errorf("mergeDockerConfig() missing registry %s", registry)
+					continue
+				}
+
+				gotAuthStr, _ := json.Marshal(gotAuth)
+				wantAuthStr, _ := json.Marshal(wantAuth)
+				if string(gotAuthStr) != string(wantAuthStr) {
+					t.Errorf("mergeDockerConfig() registry %s = %v, want %v", registry, string(gotAuthStr), string(wantAuthStr))
+				}
+			}
+		})
+	}
+}
+
+func TestDecodeSecretValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		secretValue string
+		wantDecoded map[string]any
+		wantErr     bool
+	}{
+		{
+			name: "base64 encoded JSON",
+			secretValue: base64.StdEncoding.EncodeToString([]byte(`{
+				"auths": {
+					"quay.io": {
+						"auth": "dGVzdDp0ZXN0"
+					}
+				}
+			}`)),
+			wantDecoded: map[string]any{
+				"auths": map[string]any{
+					"quay.io": map[string]any{
+						"auth": "dGVzdDp0ZXN0",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "raw JSON (not base64)",
+			secretValue: `{
+				"auths": {
+					"quay.io": {
+						"auth": "cXVheTp0ZXN0"
+					}
+				}
+			}`,
+			wantDecoded: map[string]any{
+				"auths": map[string]any{
+					"quay.io": map[string]any{
+						"auth": "cXVheTp0ZXN0",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Try to decode as base64 first
+			var dockerConfigData []byte
+			decoded, err := base64.StdEncoding.DecodeString(tt.secretValue)
+			if err == nil {
+				dockerConfigData = decoded
+			} else {
+				dockerConfigData = []byte(tt.secretValue)
+			}
+
+			// Parse JSON
+			var got map[string]any
+			err = json.Unmarshal(dockerConfigData, &got)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("decode error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			// Compare decoded data
+			gotStr, _ := json.Marshal(got)
+			wantStr, _ := json.Marshal(tt.wantDecoded)
+			if string(gotStr) != string(wantStr) {
+				t.Errorf("decoded = %v, want %v", string(gotStr), string(wantStr))
+			}
+		})
+	}
+}

--- a/tooling/image-updater/internal/clients/common.go
+++ b/tooling/image-updater/internal/clients/common.go
@@ -93,11 +93,11 @@ func NewRegistryClient(registryURL string, useAuth bool) (RegistryClient, error)
 	switch {
 	case strings.Contains(registryURL, "quay.io"):
 		// Quay has a proprietary API with better tag discovery
-		return NewQuayClient(), nil
+		return NewQuayClient(useAuth), nil
 	case strings.Contains(registryURL, "azurecr.io"):
 		return NewACRClient(registryURL, useAuth)
 	default:
 		// Use generic client for other Docker Registry v2 compatible registries (mcr.microsoft.com, etc.)
-		return NewGenericRegistryClient(registryURL), nil
+		return NewGenericRegistryClient(registryURL, useAuth), nil
 	}
 }

--- a/tooling/image-updater/internal/config/config.go
+++ b/tooling/image-updater/internal/config/config.go
@@ -35,11 +35,18 @@ type ImageConfig struct {
 
 // Source defines where to fetch the latest image digest from
 type Source struct {
-	Image        string `yaml:"image"`
-	TagPattern   string `yaml:"tagPattern,omitempty"`
-	Architecture string `yaml:"architecture,omitempty"` // Specific architecture to use (e.g., "amd64", "arm64"). Mutually exclusive with MultiArch.
-	MultiArch    bool   `yaml:"multiArch,omitempty"`    // If true, fetch the multi-arch manifest list digest instead of a specific architecture
-	UseAuth      *bool  `yaml:"useAuth,omitempty"`      // nil/true = use auth (default), false = anonymous only
+	Image        string          `yaml:"image"`
+	TagPattern   string          `yaml:"tagPattern,omitempty"`
+	Architecture string          `yaml:"architecture,omitempty"` // Specific architecture to use (e.g., "amd64", "arm64"). Mutually exclusive with MultiArch.
+	MultiArch    bool            `yaml:"multiArch,omitempty"`    // If true, fetch the multi-arch manifest list digest instead of a specific architecture
+	UseAuth      *bool           `yaml:"useAuth,omitempty"`      // nil/true = use auth (default), false = anonymous only
+	KeyVault     *KeyVaultConfig `yaml:"keyVault,omitempty"`     // Optional: Azure Key Vault config for fetching pull secrets
+}
+
+// KeyVaultConfig holds Azure Key Vault configuration for fetching pull secrets
+type KeyVaultConfig struct {
+	URL        string `yaml:"url"`        // Azure Key Vault URL (e.g., https://vault.vault.azure.net/)
+	SecretName string `yaml:"secretName"` // Name of the pull secret
 }
 
 // Target defines where to update the image digest


### PR DESCRIPTION
[AROSLSRE-259
](https://issues.redhat.com/projects/AROSLSRE/issues/AROSLSRE-259)

### What

Adds support for authenticated Quay.io and generic container registries in the image-updater tooling, with Azure Key Vault integration for secure credential management.

### Why

This enables the image-updater to:
- Pull from private Quay.io repositories (e.g., `quay.io/app-sre/aro-hcp-clusters-service`)
- Support any Docker Registry HTTP API v2 compatible registry with authentication
- Manage credentials securely via Azure Key Vault instead of local config files
- Support CI/CD pipelines that need automated access to private registries

### Implementation Details

**Authentication Layer** (`internal/clients/auth.go`):
- `GetRemoteOptions()` - Returns Docker credentials from `~/.docker/config.json` when `useAuth: true`
- `FetchAndMergeKeyVaultPullSecret()` - Fetches pull secrets from Azure Key Vault and merges with local Docker config
- `mergeDockerConfig()` - Smart merging that preserves existing credentials while adding new ones
- Supports both base64-encoded and raw JSON secret formats

**Configuration Changes**:
- Added per-image `useAuth` flag (defaults to `false` for backward compatibility)
- Added per-image `keyVault` section with `url` and `secretName` fields
- Automatic deduplication of Key Vault secret fetches across multiple images

**Client Updates**:
- **QuayClient**: Now accepts `useAuth` parameter, uses Docker credentials via `go-containerregistry`
- **GenericClient**: Enhanced to support authenticated registries (Docker Hub, Harbor, etc.)
- Both clients use `GetRemoteOptions()` for consistent authentication behavior

**Key Features**:
- Anonymous by default - no breaking changes to existing configs
- Opt-in authentication with `useAuth: true`
- Azure Key Vault integration using `DefaultAzureCredential` (supports `az login`, managed identity, etc.)
- Smart caching - same Key Vault secret fetched only once even if used by multiple images
- Credentials merged into `~/.docker/config.json` for compatibility with Docker tooling

**Test Coverage**:
- Added 272 lines of auth tests (`internal/clients/auth_test.go`)
- Added 104 lines of config tests for Key Vault parsing
- Added 184 lines of options tests for deduplication logic
- Overall coverage: Config parsing 97.9%, Options 78.5%, Auth 18.0%

### Special notes for your reviewer

The authentication is opt-in (`useAuth: false` by default) to maintain backward compatibility with existing configs that use public registries. Private registry access now requires
explicitly setting `useAuth: true` and optionally configuring Key Vault credentials.

Updated README with comprehensive authentication documentation including examples for Quay.io, ACR, MCR, and generic registries.
