### PR TITLE
Revert "Add configmap check annotations"

### DIFF
--- a/backend/deploy/templates/backend.deployment.yaml
+++ b/backend/deploy/templates/backend.deployment.yaml
@@ -5,8 +5,6 @@ metadata:
     app: aro-hcp-backend
   name: aro-hcp-backend
   namespace: '{{ .Release.Namespace }}'
-  annotations:
-    checksum/backend-config: '{{ include (print $.Template.BasePath "/backend.configmap.yaml") . | sha256sum }}'
 spec:
   progressDeadlineSeconds: 600
   replicas: {{ .Values.deployment.replicas }}

--- a/backend/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_backend_dev.yaml
+++ b/backend/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_backend_dev.yaml
@@ -82,8 +82,6 @@ metadata:
     app: aro-hcp-backend
   name: aro-hcp-backend
   namespace: 'aro-hcp'
-  annotations:
-    checksum/backend-config: 'ef7afbf82b0160a6e51717add505e718977e6f7ac2eae83200e16879e3a56e6b'
 spec:
   progressDeadlineSeconds: 600
   replicas: 2

--- a/frontend/deploy/templates/frontend.deployment.yaml
+++ b/frontend/deploy/templates/frontend.deployment.yaml
@@ -5,8 +5,6 @@ metadata:
     app: aro-hcp-frontend
   name: aro-hcp-frontend
   namespace: '{{ .Release.Namespace }}'
-  annotations:
-    checksum/frontend-config: '{{ include (print $.Template.BasePath "/frontend.configmap.yaml") . | sha256sum }}'
 spec:
   progressDeadlineSeconds: 600
   replicas: {{ .Values.deployment.replicas }}

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
@@ -76,8 +76,6 @@ metadata:
     app: aro-hcp-frontend
   name: aro-hcp-frontend
   namespace: 'aro-hcp'
-  annotations:
-    checksum/frontend-config: '73352f59540bfd8b828cda9443ccdc3eb4af33323816927b6d33792b468c0e5d'
 spec:
   progressDeadlineSeconds: 600
   replicas: 2

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
@@ -76,8 +76,6 @@ metadata:
     app: aro-hcp-frontend
   name: aro-hcp-frontend
   namespace: 'aro-hcp'
-  annotations:
-    checksum/frontend-config: '73352f59540bfd8b828cda9443ccdc3eb4af33323816927b6d33792b468c0e5d'
 spec:
   progressDeadlineSeconds: 600
   replicas: 2

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
@@ -76,8 +76,6 @@ metadata:
     app: aro-hcp-frontend
   name: aro-hcp-frontend
   namespace: 'aro-hcp'
-  annotations:
-    checksum/frontend-config: '73352f59540bfd8b828cda9443ccdc3eb4af33323816927b6d33792b468c0e5d'
 spec:
   progressDeadlineSeconds: 600
   replicas: 2

--- a/maestro/agent/deploy/templates/maestro-agent.deployment.yaml
+++ b/maestro/agent/deploy/templates/maestro-agent.deployment.yaml
@@ -5,8 +5,6 @@ metadata:
     app: maestro-agent
   name: maestro-agent
   namespace: '{{ .Release.Namespace }}'
-  annotations:
-    checksum/metrics-proxy-config: '{{ include (print $.Template.BasePath "/metrics-proxy.configmap.yaml") . | sha256sum }}'
 spec:
   replicas: {{ .Values.replicas }}
   selector:

--- a/maestro/agent/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_maestro_agent.yaml
+++ b/maestro/agent/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_maestro_agent.yaml
@@ -284,8 +284,6 @@ metadata:
     app: maestro-agent
   name: maestro-agent
   namespace: 'maestro'
-  annotations:
-    checksum/metrics-proxy-config: '732a4deca655361dfc30cc8459c50e6b5f1b6814a51bbe828bbdbd13ab81d93f'
 spec:
   replicas: 3
   selector:

--- a/observability/arobit/deploy/templates/forwarder-daemonset.yaml
+++ b/observability/arobit/deploy/templates/forwarder-daemonset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
     app: arobit-forwarder
-    checksum/forwarder-configmap: '{{ include (print $.Template.BasePath "/forwarder-configmap.yaml") . | sha256sum }}'
 spec:
   selector:
     matchLabels:

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -340,7 +340,6 @@ metadata:
     app.kubernetes.io/instance: 'dev-westus3-mgmt-1-arobit'
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
     app: arobit-forwarder
-    checksum/forwarder-configmap: '75fbd0a8144eb425790c250fb1e63d2926d594090e91aa11083ecdb90385bb42'
 spec:
   selector:
     matchLabels:

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -353,7 +353,6 @@ metadata:
     app.kubernetes.io/instance: 'dev-westus3-svc-1-arobit'
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
     app: arobit-forwarder
-    checksum/forwarder-configmap: '15e1ace85fe53df10528f981c43fc145658e07c821213ea2a305b6347097be1b'
 spec:
   selector:
     matchLabels:

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -359,7 +359,6 @@ metadata:
     app.kubernetes.io/instance: 'helmtest-kusto-disabled-svc'
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
     app: arobit-forwarder
-    checksum/forwarder-configmap: '846aacb1fbcf112e21eaa81050492618ff5de71142846fcfdae59b9c0fc17c76'
 spec:
   selector:
     matchLabels:

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -348,7 +348,6 @@ metadata:
     app.kubernetes.io/instance: 'helmtest-mdsd-and-kusto-enabled-mgmt'
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
     app: arobit-forwarder
-    checksum/forwarder-configmap: '22e05ebca7d507f07d79c6da24d8047c153974cbacd3c264f0584831e86a2307'
 spec:
   selector:
     matchLabels:

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -360,7 +360,6 @@ metadata:
     app.kubernetes.io/instance: 'helmtest-mdsd-and-kusto-enabled-svc'
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
     app: arobit-forwarder
-    checksum/forwarder-configmap: '2615d6881a001f96c60166be0a4e07081198dbff57dcc8045e929eb1f66c6a59'
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Reverts Azure/ARO-HCP#3425

This change generates labels larger than 64 characters and it's not supported by Kubernetes.

```
2025-11-27 17:01:18.917270: }
2025-11-27 17:01:18.947081: [17:01:18.947] INFO: Kusto configuration not provided, skipping Kusto deep link generation for kube events. {}
2025-11-27 17:01:18.947235: [17:01:18.947] INFO: Deployment complete. {}
2025-11-27 17:01:18.947541: [17:01:18.947] ERROR: Command failed. {
2025-11-27 17:01:18.947595:   "err": "DaemonSet.apps \"arobit-forwarder\" is invalid: metadata.labels: Invalid value: \"27ea917a37b61127b1b7a29f062db50345881ee454fbfcb363e2b3f842c7fdb5\": must be no more than 63 characters"
2025-11-27 17:01:18.947612: }
Seed-2025-11-27 17:01:18.963303: ##EXECUTION#COMPLETE####EXITCODE#1##
```