### PR TITLE
Add a one-step make goal to stand up a personal dev env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,16 @@ generate-kiota:
 	$(MAKE) fmt
 .PHONY: generate-kiota
 
+#
+# One-Step Personal Dev Environment
+#
+ifeq ($(DEPLOY_ENV),pers)
+personal-dev-env: entrypoint/Region infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing
+else
+personal-dev-env:
+	$(error personal-dev-env: DEPLOY_ENV must be set to "pers", not "$(DEPLOY_ENV)")
+endif
+.PHONY: personal-dev-env
 
 ifeq ($(wildcard $(YQ)),$(YQ))
 entrypoints = $(shell $(YQ) '.entrypoints[] | .identifier | sub("Microsoft.Azure.ARO.HCP.", "")' topology.yaml )

--- a/admin/README.md
+++ b/admin/README.md
@@ -21,7 +21,7 @@ Using the `make run` target, the Admin API binary can be run locally. At this po
 
 ### Personal DEV Environment deployment
 
-The local code can also be deployed directly into a personal DEV environment by running `make deplioy`. Understand that this requires such an environment to be created first via `make entrypoint/Region` from the root of the repository.
+The local code can also be deployed directly into a personal DEV environment by running `make deplioy`. Understand that this requires such an environment to be created first via `make personal-dev-env` from the root of the repository.
 
 `make deploy` builds a custom developer image from the local code and uploads it to the DEV service ACR (`arohcpsvcdev`) into a developer specific repository. This way developer images will not conflict with other develooper images or CI built ones. The actual deployment is delegated to the pipeline/AdminAPI target in the root of the repository, providing a configuration override for `adminApi.image.repository` and `adminApi.image.digest` respectively.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -15,7 +15,7 @@ Using the `make run` target, the Backend binary can be run locally.
 
 ### Personal DEV Environment deployment
 
-The local code can also be deployed directly into a personal DEV environment by running `make deploy`. Understand that this requires such an environment to be created first via `make entrypoint/Region` from the root of the repository.
+The local code can also be deployed directly into a personal DEV environment by running `make deploy`. Understand that this requires such an environment to be created first via `make personal-dev-env` from the root of the repository.
 
 `make deploy` builds a custom developer image from the local code and uploads it to the DEV service ACR (`arohcpsvcdev`) into a developer specific repository. This way developer images will not conflict with other develooper images or CI built ones. The actual deployment is delegated to the pipeline/AdminAPI target in the root of the repository, providing a configuration override for `frontend.image.repository` and `frontend.image.digest` respectively.
 

--- a/docs/personal-dev.md
+++ b/docs/personal-dev.md
@@ -44,7 +44,7 @@ All other tools should be transparently installed by the `make` targets that req
 The creation process can take up to 20 minutes.
 
    ```bash
-   make entrypoint/Region
+   make personal-dev-env
    ```
 
 This command creates a personal DEV environment with a unique name that is derived from your username and deploys all required infrastructure components.

--- a/docs/service-deployment-concept.md
+++ b/docs/service-deployment-concept.md
@@ -86,7 +86,7 @@ Using the `make run` target, the Frontend binary can be run locally.
 
 ### Personal DEV Environment deployment
 
-The local code can also be deployed directly into a personal DEV environment by running `make deploy`. Understand that this requires such an environment to be created first via `make entrypoint/Region` from the root of the repository.
+The local code can also be deployed directly into a personal DEV environment by running `make deploy`. Understand that this requires such an environment to be created first via `make persional-dev-env` from the root of the repository.
 
 `make deploy` builds a custom developer image from the local code and uploads it to the DEV service ACR (`arohcpsvcdev`) into a developer specific repository. This way developer images will not conflict with other developer images or CI built ones. The actual deployment is delegated to the pipeline/<service-group-suffix> target in the root of the repository, providing a configuration override for `<component>.image.repository` and `<component>.image.digest` respectively.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -15,7 +15,7 @@ Using the `make run` target, the Frontend binary can be run locally.
 
 ### Personal DEV Environment deployment
 
-The local code can also be deployed directly into a personal DEV environment by running `make deploy`. Understand that this requires such an environment to be created first via `make entrypoint/Region` from the root of the repository.
+The local code can also be deployed directly into a personal DEV environment by running `make deploy`. Understand that this requires such an environment to be created first via `make personal-dev-env` from the root of the repository.
 
 `make deploy` builds a custom developer image from the local code and uploads it to the DEV service ACR (`arohcpsvcdev`) into a developer specific repository. This way developer images will not conflict with other develooper images or CI built ones. The actual deployment is delegated to the pipeline/AdminAPI target in the root of the repository, providing a configuration override for `frontend.image.repository` and `frontend.image.digest` respectively.
 


### PR DESCRIPTION
### What

Adds a make goal to stand up a personal dev environment in one step:
```
$ make personal-dev-env
```

### Why

This is currently a multi-step process and the [personal dev environment documentation](https://github.com/Azure/ARO-HCP/blob/main/docs/personal-dev.md) is missing some steps.