### PR TITLE
Refactor filtering

### DIFF
--- a/observability/arobit/deploy/templates/forwarder-configmap.yaml
+++ b/observability/arobit/deploy/templates/forwarder-configmap.yaml
@@ -153,19 +153,26 @@ data:
 
 {{- if .Values.forwarder.mdsd.enabled }}
     [FILTER]
-        Name          nest
-        Match         kubernetes.*
-        Operation     lift
-        Nested_under  kubernetes
-    
-    [FILTER]
         Name            rewrite_tag
         Alias           filter.namespace_router
         Match           kubernetes.var.log.containers.*
-        Rule            namespace_name ^ocm-.* ocm.logs false
-        Rule            namespace_name ^(?!ocm-).* other.logs false
-        Emitter_Name    re_emitted_namespace_router
-{{- else }}
+        Rule            $kubernetes['namespace_name'] ^ocm-.* mdsd-ocm.logs true
+        Rule            $kubernetes['namespace_name'] ^(?!ocm-).* mdsd-other.logs true
+        Emitter_Name    re_emitted_namespace_router_mdsd
+
+    [FILTER]
+        Name          nest
+        Match         mdsd-ocm.logs
+        Operation     lift
+        Nested_under  kubernetes
+
+    [FILTER]
+        Name          nest
+        Match         mdsd-other.logs
+        Operation     lift
+        Nested_under  kubernetes
+{{- end }}
+
     [FILTER]
         Name            rewrite_tag
         Alias           filter.namespace_router
@@ -173,7 +180,6 @@ data:
         Rule            $kubernetes['namespace_name'] ^ocm-.* ocm.logs false
         Rule            $kubernetes['namespace_name'] ^(?!ocm-).* other.logs false
         Emitter_Name    re_emitted_namespace_router
-{{- end}}
 
     [FILTER]
         # Other logs are keept, because want to send them to mdsd as well

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -153,6 +153,7 @@ data:
         Annotations         Off
         K8S-Logging.Exclude On
         Buffer_Size         64k
+
     [FILTER]
         Name            rewrite_tag
         Alias           filter.namespace_router

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -153,6 +153,7 @@ data:
         Annotations         Off
         K8S-Logging.Exclude On
         Buffer_Size         64k
+
     [FILTER]
         Name            rewrite_tag
         Alias           filter.namespace_router

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -154,17 +154,31 @@ data:
         K8S-Logging.Exclude On
         Buffer_Size         64k
     [FILTER]
+        Name            rewrite_tag
+        Alias           filter.namespace_router
+        Match           kubernetes.var.log.containers.*
+        Rule            $kubernetes['namespace_name'] ^ocm-.* mdsd-ocm.logs true
+        Rule            $kubernetes['namespace_name'] ^(?!ocm-).* mdsd-other.logs true
+        Emitter_Name    re_emitted_namespace_router_mdsd
+
+    [FILTER]
         Name          nest
-        Match         kubernetes.*
+        Match         mdsd-ocm.logs
         Operation     lift
         Nested_under  kubernetes
-    
+
+    [FILTER]
+        Name          nest
+        Match         mdsd-other.logs
+        Operation     lift
+        Nested_under  kubernetes
+
     [FILTER]
         Name            rewrite_tag
         Alias           filter.namespace_router
         Match           kubernetes.var.log.containers.*
-        Rule            namespace_name ^ocm-.* ocm.logs false
-        Rule            namespace_name ^(?!ocm-).* other.logs false
+        Rule            $kubernetes['namespace_name'] ^ocm-.* ocm.logs false
+        Rule            $kubernetes['namespace_name'] ^(?!ocm-).* other.logs false
         Emitter_Name    re_emitted_namespace_router
 
     [FILTER]

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -156,17 +156,31 @@ data:
         K8S-Logging.Exclude On
         Buffer_Size         64k
     [FILTER]
+        Name            rewrite_tag
+        Alias           filter.namespace_router
+        Match           kubernetes.var.log.containers.*
+        Rule            $kubernetes['namespace_name'] ^ocm-.* mdsd-ocm.logs true
+        Rule            $kubernetes['namespace_name'] ^(?!ocm-).* mdsd-other.logs true
+        Emitter_Name    re_emitted_namespace_router_mdsd
+
+    [FILTER]
         Name          nest
-        Match         kubernetes.*
+        Match         mdsd-ocm.logs
         Operation     lift
         Nested_under  kubernetes
-    
+
+    [FILTER]
+        Name          nest
+        Match         mdsd-other.logs
+        Operation     lift
+        Nested_under  kubernetes
+
     [FILTER]
         Name            rewrite_tag
         Alias           filter.namespace_router
         Match           kubernetes.var.log.containers.*
-        Rule            namespace_name ^ocm-.* ocm.logs false
-        Rule            namespace_name ^(?!ocm-).* other.logs false
+        Rule            $kubernetes['namespace_name'] ^ocm-.* ocm.logs false
+        Rule            $kubernetes['namespace_name'] ^(?!ocm-).* other.logs false
         Emitter_Name    re_emitted_namespace_router
 
     [FILTER]

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -155,17 +155,31 @@ data:
         K8S-Logging.Exclude On
         Buffer_Size         64k
     [FILTER]
+        Name            rewrite_tag
+        Alias           filter.namespace_router
+        Match           kubernetes.var.log.containers.*
+        Rule            $kubernetes['namespace_name'] ^ocm-.* mdsd-ocm.logs true
+        Rule            $kubernetes['namespace_name'] ^(?!ocm-).* mdsd-other.logs true
+        Emitter_Name    re_emitted_namespace_router_mdsd
+
+    [FILTER]
         Name          nest
-        Match         kubernetes.*
+        Match         mdsd-ocm.logs
         Operation     lift
         Nested_under  kubernetes
-    
+
+    [FILTER]
+        Name          nest
+        Match         mdsd-other.logs
+        Operation     lift
+        Nested_under  kubernetes
+
     [FILTER]
         Name            rewrite_tag
         Alias           filter.namespace_router
         Match           kubernetes.var.log.containers.*
-        Rule            namespace_name ^ocm-.* ocm.logs false
-        Rule            namespace_name ^(?!ocm-).* other.logs false
+        Rule            $kubernetes['namespace_name'] ^ocm-.* ocm.logs false
+        Rule            $kubernetes['namespace_name'] ^(?!ocm-).* other.logs false
         Emitter_Name    re_emitted_namespace_router
 
     [FILTER]


### PR DESCRIPTION
### What

Different output for kusto/mdsd and different kubernetes handling

### Why

Lift of kubernetes field must happen for MDSD, but it should not happen for kusto.  With this, logs are duplicated and handled as needed

### Special notes for your reviewer

<!-- optional -->
