### PR TITLE
Fixed timeout for cluster deployment in external_auth_list_and_verify test

### DIFF
--- a/test/e2e/external_auth_list_and_verify.go
+++ b/test/e2e/external_auth_list_and_verify.go
@@ -86,7 +86,7 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = deploymentResp.PollUntilDone(ctx, nil)
+			_, err = deploymentResp.PollUntilDone(deploymentCtx, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedExternalAuth := hcpsdk.ExternalAuth{


### PR DESCRIPTION
[ARO-22467](https://issues.redhat.com/browse/ARO-22467)

### What

Fixed timeout handling in the `external_auth_list_and_verify` E2E test by passing the correct context to `PollUntilDone()`.

The test was using the parent context instead of the timeout context when polling for deployment completion, causing the 45-minute timeout to be ignored. This resulted in the test waiting indefinitely and being killed by Prow's job timeout (2 hours) rather than failing gracefully.