### PR TITLE
ARO-22863 | Create a Contributor role assignment for the ARM helper

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -117,6 +117,11 @@ create-int-mock-identities: configurations/mock-identities.bicepparam
 	ROLE_DEFINITION_NAME='Role Based Access Control Administrator' \
 	SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
 	./scripts/create-sp-for-rbac.sh && \
+	az role assignment create \
+		--role "Contributor" \
+		--assignee "$(shell az ad app list --display-name aro-hcp-int-arm-helper --query '[*]'.appId -o tsv)" \
+		--scope "/subscriptions/$(shell az account show --query id --output tsv)" \
+		--only-show-errors
 	APPLICATION_NAME=aro-hcp-int-msi-mock \
 	KEY_VAULT_NAME=aro-hcp-int-kv \
 	CERTIFICATE_NAME=$${MSI_MOCK_CERT_NAME} \
@@ -151,6 +156,12 @@ create-mock-identities: configurations/mock-identities.bicepparam
 	ROLE_DEFINITION_NAME='Role Based Access Control Administrator' \
 	SUBSCRIPTION_ID=$(shell az account show --query id --output tsv) \
 	./scripts/create-sp-for-rbac.sh
+
+	az role assignment create \
+		--role "Contributor" \
+		--assignee "$(shell az ad app list --display-name aro-dev-arm-helper2 --query '[*]'.appId -o tsv)" \
+		--scope "/subscriptions/$(shell az account show --query id --output tsv)" \
+		--only-show-errors
 
 	APPLICATION_NAME=aro-dev-msi-mock2 \
 	KEY_VAULT_NAME=aro-hcp-dev-svc-kv \


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-22863

### What

Update the create-mock-identities targets for INT & Dev to create a role assignment.

### Why

To use the identity to run inflights.

### Special notes for your reviewer

Dev:
```
az ad sp list --display-name aro-dev-arm-helper2 --query "[*].id" -o tsv
ddeffa11-e3d9-487d-8fc9-9a9e26f64975

az role assignment list \
  --assignee ddeffa11-e3d9-487d-8fc9-9a9e26f64975 \
  --all \
  --output table
Principal                             Role                                     Scope
------------------------------------  ---------------------------------------  ---------------------------------------------------
3331e670-0804-48e8-a086-6241671ddc93  Role Based Access Control Administrator  /subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b
3331e670-0804-48e8-a086-6241671ddc93  Contributor                              /subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b
```

INT:
```
az ad app list --display-name aro-hcp-int-arm-helper --query '[*]'.appId -o tsv
356c7253-24f3-4dc5-b4e1-498c73331cf4

az role assignment list \
  --assignee 356c7253-24f3-4dc5-b4e1-498c73331cf4 \
  --all \
  --output table
  Principal                             Role                                     Scope
------------------------------------  ---------------------------------------  ---------------------------------------------------
356c7253-24f3-4dc5-b4e1-498c73331cf4  Role Based Access Control Administrator  /subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54
356c7253-24f3-4dc5-b4e1-498c73331cf4  Contributor                              /subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54
```
