### PR TITLE
Check if managed resource group was deleted during test teardown

### DIFF
--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -378,12 +378,6 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroupNoRP(ctx context.Conte
 		return fmt.Errorf("failed to search for managed resource groups: %w", err)
 	}
 
-	if len(managedResourceGroups) > 0 {
-		ginkgo.GinkgoLogr.Info("found managed resource groups for cleanup", "count", len(managedResourceGroups), "parentResourceGroup", resourceGroupName)
-	} else {
-		ginkgo.GinkgoLogr.Info("no left behind managed resource groups found", "resourceGroup", resourceGroupName)
-	}
-
 	for _, managedRG := range managedResourceGroups {
 		ginkgo.GinkgoLogr.Info("deleting managed resource group", "resourceGroup", managedRG, "parentResourceGroup", resourceGroupName)
 		if err := DeleteResourceGroup(ctx, resourceGroupsClient, managedRG, true, timeout); err != nil {


### PR DESCRIPTION
[ARO-22866](https://issues.redhat.com/browse/ARO-22866)

### What

A verifier to ensure managed resource groups are deleted during tear down. 

### How

1. Test runs and along with HCP clusters are created managed resource groups with a corresponding ManagedBy field
2. Delete HCP clusters
3. Delete managed resource groups (should be done by ARM)
4. Cleanup function pages through resource groups, checking their ManagedBy field and thus identifying orphaned managed resource groups
5. Each orphaned managed resource group is deleted 
6. Delete parent resource group
