### PR TITLE
feat(demo): add role assignments for managed identities in cluster creation

### DIFF
--- a/demo/03-create-cluster.sh
+++ b/demo/03-create-cluster.sh
@@ -149,7 +149,196 @@ create_azure_managed_identities_for_cluster() {
 
   echo "creating azure user-assigned identity ${service_managed_identity_uami_name} in resource group ${CUSTOMER_RG_NAME}"
   az identity create --name "${service_managed_identity_uami_name}" --resource-group "${CUSTOMER_RG_NAME}"
-  echo "user-assigned identity ${uami_name} created"
+  echo "user-assigned identity ${service_managed_identity_uami_name} created"
+}
+
+assign_roles_to_managed_identities() {
+  # Reference: test/e2e-setup/bicep/modules/managed-identities.bicep
+  
+  # Get VNet ID
+  local vnet_id
+  vnet_id=$(az network vnet show \
+    --resource-group "${CUSTOMER_RG_NAME}" \
+    --name "${CUSTOMER_VNET_NAME}" \
+    --query id \
+    --output tsv)
+
+  # Role Definition IDs (from Azure built-in roles for ARO-HCP)
+  # Source: test/e2e-setup/bicep/modules/managed-identities.bicep
+  # TODO: Retrieve these dynamically from the HcpOperatorIdentityRoleSets API once available:
+  #   GET /subscriptions/{subscriptionId}/providers/Microsoft.RedHatOpenShift/locations/{location}/hcpOperatorIdentityRoleSets/{version}?api-version=2024-06-10-preview
+  local hcp_service_mi_role="c0ff367d-66d8-445e-917c-583feb0ef0d4"           # HCP Service Managed Identity
+  local hcp_cluster_api_provider_role="88366f10-ed47-4cc0-9fab-c8a06148393e" # HCP Cluster API Provider
+  local hcp_control_plane_operator_role="fc0c873f-45e9-4d0d-a7d1-585aab30c6ed" # HCP Control Plane Operator
+  local cloud_controller_manager_role="a1f96423-95ce-4224-ab27-4e3dc72facd4"  # Cloud Controller Manager
+  local ingress_operator_role="0336e1d3-7a87-462b-b6db-342b63f7802c"          # Cluster Ingress Operator
+  local file_storage_operator_role="0d7aedc0-15fd-4a67-a412-efad370c947e"     # File Storage Operator
+  local network_operator_role="be7a6435-15ae-4171-8f30-4a343eff9e8f"          # Network Operator
+  local key_vault_crypto_user_role="12338af0-0e69-4776-bea7-57ae8d297424"     # Key Vault Crypto User
+  local federated_credentials_role="ef318e2a-8334-4a05-9e4a-295a196c6a6e"     # Federated Credentials
+  local reader_role="acdd72a7-3385-48ef-bd42-f606fba81ae7"                    # Reader
+
+  # Helper function to get principal ID
+  get_principal_id() {
+    local uami_name=$1
+    az identity show \
+      --name "${uami_name}" \
+      --resource-group "${CUSTOMER_RG_NAME}" \
+      --query principalId \
+      --output tsv
+  }
+
+  # Helper function to assign role
+  assign_role() {
+    local principal_id=$1
+    local role_id=$2
+    local scope=$3
+    local description=$4
+    echo "  Assigning ${description}..."
+    az role assignment create \
+      --assignee-object-id "${principal_id}" \
+      --assignee-principal-type ServicePrincipal \
+      --role "${role_id}" \
+      --scope "${scope}" \
+      --output none 2>/dev/null || echo "    (may already exist)"
+  }
+
+  echo ""
+  echo "=========================================="
+  echo "=== ASSIGNING ROLES TO MANAGED IDENTITIES ==="
+  echo "=========================================="
+
+  # ============================================
+  # SERVICE MANAGED IDENTITY ROLES
+  # ============================================
+  echo ""
+  echo "=== Service Managed Identity ==="
+  local service_mi_principal_id
+  service_mi_principal_id=$(get_principal_id "${service_managed_identity_uami_name}")
+  
+  assign_role "${service_mi_principal_id}" "${hcp_service_mi_role}" "${vnet_id}" "HCP Service MI role on VNet"
+  assign_role "${service_mi_principal_id}" "${hcp_service_mi_role}" "${SUBNET_ID}" "HCP Service MI role on Subnet"
+  assign_role "${service_mi_principal_id}" "${hcp_service_mi_role}" "${NSG_ID}" "HCP Service MI role on NSG"
+
+  # Reader role on all control plane identities
+  for uami_name in "${CONTROL_PLANE_IDENTITIES_UAMIS_NAMES[@]}"
+  do
+    local uami_resource_id="${UAMIS_RESOURCE_IDS_PREFIX}/${uami_name}"
+    assign_role "${service_mi_principal_id}" "${reader_role}" "${uami_resource_id}" "Reader on ${uami_name}"
+  done
+
+  # Federated credentials role on data plane identities
+  for uami_name in "${DATA_PLANE_IDENTITIES_UAMIS_NAMES[@]}"
+  do
+    local uami_resource_id="${UAMIS_RESOURCE_IDS_PREFIX}/${uami_name}"
+    assign_role "${service_mi_principal_id}" "${federated_credentials_role}" "${uami_resource_id}" "Federated Credentials on ${uami_name}"
+  done
+
+  # ============================================
+  # CLUSTER-API-AZURE ROLES
+  # ============================================
+  echo ""
+  echo "=== cluster-api-azure Identity ==="
+  local cluster_api_azure_mi="${USER}-${CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}"
+  local cluster_api_azure_principal_id
+  cluster_api_azure_principal_id=$(get_principal_id "${cluster_api_azure_mi}")
+  
+  assign_role "${cluster_api_azure_principal_id}" "${hcp_cluster_api_provider_role}" "${SUBNET_ID}" "HCP Cluster API Provider on Subnet"
+
+  # ============================================
+  # CONTROL-PLANE ROLES
+  # ============================================
+  echo ""
+  echo "=== control-plane Identity ==="
+  local control_plane_mi="${USER}-${CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}"
+  local control_plane_principal_id
+  control_plane_principal_id=$(get_principal_id "${control_plane_mi}")
+  
+  assign_role "${control_plane_principal_id}" "${hcp_control_plane_operator_role}" "${vnet_id}" "HCP Control Plane Operator on VNet"
+  assign_role "${control_plane_principal_id}" "${hcp_control_plane_operator_role}" "${NSG_ID}" "HCP Control Plane Operator on NSG"
+
+  # ============================================
+  # CLOUD-CONTROLLER-MANAGER ROLES
+  # ============================================
+  echo ""
+  echo "=== cloud-controller-manager Identity ==="
+  local ccm_mi="${USER}-${CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}"
+  local ccm_principal_id
+  ccm_principal_id=$(get_principal_id "${ccm_mi}")
+  
+  assign_role "${ccm_principal_id}" "${cloud_controller_manager_role}" "${SUBNET_ID}" "Cloud Controller Manager on Subnet"
+  assign_role "${ccm_principal_id}" "${cloud_controller_manager_role}" "${NSG_ID}" "Cloud Controller Manager on NSG"
+
+  # ============================================
+  # INGRESS ROLES
+  # ============================================
+  echo ""
+  echo "=== ingress Identity ==="
+  local ingress_mi="${USER}-${CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}"
+  local ingress_principal_id
+  ingress_principal_id=$(get_principal_id "${ingress_mi}")
+  
+  assign_role "${ingress_principal_id}" "${ingress_operator_role}" "${SUBNET_ID}" "Ingress Operator on Subnet"
+
+  # ============================================
+  # FILE-CSI-DRIVER (Control Plane) ROLES
+  # ============================================
+  echo ""
+  echo "=== file-csi-driver (CP) Identity ==="
+  local file_csi_cp_mi="${USER}-${CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+  local file_csi_cp_principal_id
+  file_csi_cp_principal_id=$(get_principal_id "${file_csi_cp_mi}")
+  
+  assign_role "${file_csi_cp_principal_id}" "${file_storage_operator_role}" "${SUBNET_ID}" "File Storage Operator on Subnet"
+  assign_role "${file_csi_cp_principal_id}" "${file_storage_operator_role}" "${NSG_ID}" "File Storage Operator on NSG"
+
+  # ============================================
+  # CLOUD-NETWORK-CONFIG ROLES
+  # ============================================
+  echo ""
+  echo "=== cloud-network-config Identity ==="
+  local cloud_network_mi="${USER}-${CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}"
+  local cloud_network_principal_id
+  cloud_network_principal_id=$(get_principal_id "${cloud_network_mi}")
+  
+  assign_role "${cloud_network_principal_id}" "${network_operator_role}" "${SUBNET_ID}" "Network Operator on Subnet"
+  assign_role "${cloud_network_principal_id}" "${network_operator_role}" "${vnet_id}" "Network Operator on VNet"
+
+  # ============================================
+  # KMS ROLES
+  # ============================================
+  echo ""
+  echo "=== kms Identity ==="
+  local kms_mi="${USER}-${CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}"
+  local kms_principal_id
+  kms_principal_id=$(get_principal_id "${kms_mi}")
+  
+  # Get Key Vault ID
+  local keyvault_id
+  keyvault_id=$(az keyvault show \
+    --name "${CUSTOMER_KV_NAME}" \
+    --resource-group "${CUSTOMER_RG_NAME}" \
+    --query id \
+    --output tsv)
+  
+  assign_role "${kms_principal_id}" "${key_vault_crypto_user_role}" "${keyvault_id}" "Key Vault Crypto User on Key Vault"
+
+  # ============================================
+  # FILE-CSI-DRIVER (Data Plane) ROLES
+  # ============================================
+  echo ""
+  echo "=== file-csi-driver (DP) Identity ==="
+  local file_csi_dp_mi="${USER}-${CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+  local file_csi_dp_principal_id
+  file_csi_dp_principal_id=$(get_principal_id "${file_csi_dp_mi}")
+  
+  assign_role "${file_csi_dp_principal_id}" "${file_storage_operator_role}" "${SUBNET_ID}" "File Storage Operator on Subnet"
+  assign_role "${file_csi_dp_principal_id}" "${file_storage_operator_role}" "${NSG_ID}" "File Storage Operator on NSG"
+
+  echo ""
+  echo "=========================================="
+  echo "=== ALL ROLE ASSIGNMENTS COMPLETE ==="
+  echo "=========================================="
 }
 
 main() {
@@ -222,6 +411,10 @@ main() {
   CLUSTER_FILE="cluster.json"
 
   create_azure_managed_identities_for_cluster
+
+  # Assign required roles to all managed identities
+  # Reference: test/e2e-setup/bicep/modules/managed-identities.bicep
+  assign_roles_to_managed_identities
 
   ETCD_ENCRYPTION_JSON_MAP=""
   initialize_etcd_encryption_json_map


### PR DESCRIPTION
### What

<!-- Briefly describe what this PR does -->

Add assign_roles_to_managed_identities() function to automatically assign all required Azure RBAC roles when creating a new cluster.

Role assignments are based on:
- test/e2e-setup/bicep/modules/managed-identities.bicep
- test/e2e-setup/bicep/modules/managed-identities-reader-roles.bicep

Includes roles for:
- Service Managed Identity (HCP Service MI role, Reader, Federated Credentials)
- cluster-api-azure (HCP Cluster API Provider)
- control-plane (HCP Control Plane Operator)
- cloud-controller-manager (Cloud Controller Manager)
- ingress (Cluster Ingress Operator)
- file-csi-driver CP/DP (File Storage Operator)
- cloud-network-config (Network Operator)
- kms (Key Vault Crypto User)

### Why

Fixes cluster provisioning failures in Stage with the following errors:

1. VNet read permission missing: "The client '...' does not have authorization to perform action 'Microsoft.Network/virtualNetworks/read' over scope '.../virtualNetworks/customer-vnet'"

2. Managed Identity read permission missing: "The client '...' does not have authorization to perform action 'Microsoft.ManagedIdentity/userAssignedIdentities/read' over scope '.../userAssignedIdentities/...-cp-cloud-controller-manager-...'"

3. NSG read permission missing: "The client '...' does not have authorization to perform action 'Microsoft.Network/networkSecurityGroups/read' over scope '.../networkSecurityGroups/customer-nsg'"


### Special notes for your reviewer

<!-- optional -->
