### PR TITLE
test: increase parallelism

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -46,7 +46,7 @@ func main() {
 			// TODO we will need per-env markers eventually, but it's ok to start here
 			fmt.Sprintf(`labels.exists(l, l=="%s")`, labels.RequireNothing[0]),
 		},
-		Parallelism: 15,
+		Parallelism: 20,
 	})
 
 	ext.AddSuite(e.Suite{
@@ -56,7 +56,7 @@ func main() {
 			// TODO we will need per-env markers eventually, but it's ok to start here
 			fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0]),
 		},
-		Parallelism: 15,
+		Parallelism: 20,
 	})
 
 	ext.AddSuite(e.Suite{
@@ -66,7 +66,7 @@ func main() {
 			// TODO we will need per-env markers eventually, but it's ok to start here
 			fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0]),
 		},
-		Parallelism: 15,
+		Parallelism: 20,
 	})
 
 	ext.AddSuite(e.Suite{
@@ -77,7 +77,7 @@ func main() {
 			// TODO: revisit labels to tweak which tests to select here
 			fmt.Sprintf(`labels.exists(l, l=="%s" ) && labels.exists(l, l=="%s")`, labels.AroRpApiCompatible[0], labels.Positive[0]),
 		},
-		Parallelism: 15,
+		Parallelism: 20,
 	})
 
 	ext.AddSuite(e.Suite{
@@ -88,7 +88,7 @@ func main() {
 			// them against ARO HCP dev instance via RP API endpoint).
 			fmt.Sprintf(`labels.exists(l, l=="%s")`, labels.AroRpApiCompatible[0]),
 		},
-		Parallelism: 15,
+		Parallelism: 20,
 	})
 
 	// If using Ginkgo, build test specs automatically


### PR DESCRIPTION
Our actual limits lie on the infra we're deploying on top of, which can support at least twenty concurrent tests.
