### PR TITLE
test: write timing metadata to shared dir

### DIFF
--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -702,7 +702,11 @@ func (tc *perItOrDescribeTestContext) commitTimingMetadata(ctx context.Context) 
 	hash := sha256.New()
 	hash.Write(encodedIdentifier)
 	hashBytes := hash.Sum(nil)
-	output := filepath.Join(tc.perBinaryInvocationTestContext.artifactDir, fmt.Sprintf("timing-metadata-%s.yaml", hex.EncodeToString(hashBytes)))
+	output := filepath.Join(tc.perBinaryInvocationTestContext.sharedDir, "test-timing", fmt.Sprintf("timing-metadata-%s.yaml", hex.EncodeToString(hashBytes)))
+	if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil {
+		ginkgo.GinkgoLogr.Error(err, "Failed to create directory for timing metadata")
+		return
+	}
 	if err := os.WriteFile(output, encoded, 0644); err != nil {
 		ginkgo.GinkgoLogr.Error(err, "Failed to write timing metadata")
 		return


### PR DESCRIPTION
We want to consume this in a post-step to generate visualizations.
