### PR TITLE
cfg: temporary disable PKO service group

### DIFF
--- a/topology.yaml
+++ b/topology.yaml
@@ -51,9 +51,9 @@ services:
       - serviceGroup: Microsoft.Azure.ARO.HCP.RP.HypershiftOperator
         pipelinePath: hypershiftoperator/pipeline.yaml
         purpose: Deploy the HyperShift operator.
-      - serviceGroup: Microsoft.Azure.ARO.HCP.PKO
-        pipelinePath: pko/pipeline.yaml
-        purpose: Deploy the Package Operator.
+      # - serviceGroup: Microsoft.Azure.ARO.HCP.PKO
+      #   pipelinePath: pko/pipeline.yaml
+      #   purpose: Deploy the Package Operator.
       - serviceGroup: Microsoft.Azure.ARO.HCP.Maestro.Agent
         pipelinePath: maestro/agent/pipeline.yaml
         purpose: Deploy the Maestro Agent and register it with the MQTT stream.


### PR DESCRIPTION
### What

Temporarily disable PKO (Package Operator) service group deployment in topology.yaml to halt its rollout to management clusters.

### Why

This change comments out the PKO service group entry to prevent it from being deployed while we address issues or wait for the right time to enable
it.

### Special notes for your reviewer

- The PKO service group is simply commented out in `topology.yaml:53-55` rather than removed, making it easy to re-enable when needed
- Other service groups in the management cluster topology are unaffected by this change
