### PR TITLE
ARO-22858|feat: add support for 4.20 on the hcp cluster to cs cluster version conversion

### DIFF
--- a/internal/ocm/client.go
+++ b/internal/ocm/client.go
@@ -28,7 +28,10 @@ import (
 )
 
 // The patch version is managed by Red Hat.
-const OpenShift419Patch = "7"
+const (
+	OpenShift419Patch = "7"
+	OpenShift420Patch = "5"
+)
 
 type ClusterServiceClientSpec interface {
 	// GetCluster sends a GET request to fetch a cluster from Cluster Service.
@@ -605,9 +608,18 @@ func NewOpenShiftVersionXYZ(v string) string {
 		if len(parts) == 1 {
 			parts = append(parts, "0")
 		}
-		// FIXME This assumes X.Y is 4.19. Eventually
-		//       we may need a switch statement here.
-		parts = append(parts[:2], OpenShift419Patch)
+
+		// TODO: Will change once we support allowing users to select a cluster installation version.
+		// hardcode patch versions for now
+		switch v {
+		case "4.19":
+			parts = append(parts, OpenShift419Patch)
+		case "4.20":
+			parts = append(parts, OpenShift420Patch)
+		default:
+			parts = append(parts, "0")
+		}
+
 		csVersion = api.OpenShiftVersionPrefix + strings.Join(parts, ".")
 	}
 

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -184,6 +184,26 @@ func TestWithImmutableAttributes(t *testing.T) {
 			hcpCluster: &api.HCPOpenShiftCluster{},
 			want:       ocmCluster(t, ocmClusterDefaults()),
 		},
+		{
+			name: "with version 4.19",
+			hcpCluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					Version: api.VersionProfile{ID: "4.19", ChannelGroup: "stable"},
+				},
+			},
+			want: ocmCluster(t, ocmClusterDefaults().Version(
+				arohcpv1alpha1.NewVersion().ID("openshift-v4.19.7").ChannelGroup("stable"))),
+		},
+		{
+			name: "with version 4.20",
+			hcpCluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					Version: api.VersionProfile{ID: "4.20", ChannelGroup: "stable"},
+				},
+			},
+			want: ocmCluster(t, ocmClusterDefaults().Version(
+				arohcpv1alpha1.NewVersion().ID("openshift-v4.20.5").ChannelGroup("stable"))),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### What
Set the patch version during the cluster version conversion from hcp cluster to cs cluster based on the minor version. The changes here only supports 4.19 and 4.20.
* Added a switch case based on the version received by the `NewOpenShiftVersionXY`. 
  *  The format of the incoming version will always be `MAJOR.MINOR` - there are validations in place to ensure this (see [validateVersionProfile](https://github.com/Azure/ARO-HCP/blob/59c49d6a43e806f68ab5357bac0e993d742783ff/internal/validation/validate_cluster.go#L352-L370) and [OpenshiftVersionWithoutMicro](https://github.com/Azure/ARO-HCP/blob/59c49d6a43e806f68ab5357bac0e993d742783ff/internal/validation/validators.go#L65-L84))
* Removed `[:2]` when appending to 'parts' as it should always have a length of 2
* Added some test cases to verify the changes as part of `TestWithImmutableAttributes`

For now, we can hardcode these patch versions. This will no longer be needed once we have support for allowing users to select a cluster installation version [ARO-21565](https://issues.redhat.com/browse/ARO-21565).

Related JIRA issue: [ARO-22858)](https://issues.redhat.com/browse/ARO-22858)

### Why

Required to add support for creating clusters with ocp 4.20 version ([ARO-21590](https://issues.redhat.com/browse/ARO-21590))

### Special notes for your reviewer
* Should be ok to merge ahead of the changes to add support of 4.20 in CS. Requesting a cluster with this version will return an error stating the version isn't supported until then
