### PR TITLE
test: fix 3min timeout in failed cluster test

### DIFF
--- a/test/e2e/nodepool_in_failed_cluster.go
+++ b/test/e2e/nodepool_in_failed_cluster.go
@@ -102,7 +102,7 @@ var _ = Describe("Customer", func() {
 					return currentState
 				}
 				return ""
-			}, 3*time.Minute, 10*time.Second).Should(Equal(hcpsdk20240610preview.ProvisioningStateFailed))
+			}, 30*time.Minute, 10*time.Second).Should(Equal(hcpsdk20240610preview.ProvisioningStateFailed))
 
 			By("attempting to deploy nodepool into cluster with failed provisioning state")
 			nodePoolParams := framework.NewDefaultNodePoolParams()


### PR DESCRIPTION
In practice, it is exceedingly rare that this ever passes, and is causing our suite to perma-fail.
