### PR TITLE
Refactor 4 E2E tests to use direct RP approach

### DIFF
--- a/nonlocal-e2e-specs.txt
+++ b/nonlocal-e2e-specs.txt
@@ -9,15 +9,11 @@
   "Successfully lists clusters filtered by resource group name",
   "Successfully lists clusters filtered by subscription ID",
   "creates a cluster and fails to update its name with a PATCH request",
-  "creates and deletes vm type NC6sv3 in a single cluster",
-  "should be able to create a cluster with an external auth config and get the external auth config",
-  "should be able to create an HCP cluster and custom node pool osDisk size using bicep template",
   "should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group",
   "should be able to lifecycle and confirm external auth on a cluster",
   "should be able to list HCP clusters without node pools at both subscription and resource group levels",
   "should be able to list available HCP OpenShift versions and validate response content",
   "should be able to test admin credentials before cluster ready, then full admin credential lifecycle",
   "should confirm the HCP cluster is deleted (not found)",
-  "should create an HCP cluster and validate TLS certificates",
   "should not be able to create a 4.18 HCP cluster"
 ]

--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -44,8 +44,8 @@ var _ = Describe("Customer", func() {
 		func(ctx context.Context) {
 
 			const (
-				customerClusterName            = "tls-endpoint-hcp-cluster"
-				customerNodePoolName           = "np-1"
+				customerClusterName  = "tls-endpoint-hcp-cluster"
+				customerNodePoolName = "np-1"
 			)
 			tc := framework.NewTestContext()
 
@@ -78,70 +78,70 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-		By("ensuring the API TLS certificate issued is not an OpenShift root CA")
-		clusterResp, err := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().Get(ctx, *resourceGroup.Name, customerClusterName, nil)
-		Expect(err).NotTo(HaveOccurred())
+			By("ensuring the API TLS certificate issued is not an OpenShift root CA")
+			clusterResp, err := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+			Expect(err).NotTo(HaveOccurred())
 
-		Expect(clusterResp.Properties).NotTo(BeNil())
-		Expect(clusterResp.Properties.API).NotTo(BeNil())
-		Expect(clusterResp.Properties.API.URL).NotTo(BeNil())
+			Expect(clusterResp.Properties).NotTo(BeNil())
+			Expect(clusterResp.Properties.API).NotTo(BeNil())
+			Expect(clusterResp.Properties.API.URL).NotTo(BeNil())
 
-		apiServerURL := clusterResp.Properties.API.URL
-		actualAPICert, err := tlsCertFromURL(ctx, *apiServerURL)
-		Expect(err).NotTo(HaveOccurred())
+			apiServerURL := clusterResp.Properties.API.URL
+			actualAPICert, err := tlsCertFromURL(ctx, *apiServerURL)
+			Expect(err).NotTo(HaveOccurred())
 
-		fmt.Fprintf(GinkgoWriter, "Issuer: %v\n", actualAPICert.Issuer)
-		Expect(actualAPICert.Issuer).To(SatisfyAll(
-			HaveField("CommonName", MatchRegexp(`Microsoft\sAzure\sRSA\sTLS\sIssuing\sCA\s[0-9]+`)),
-			HaveField("Organization", ContainElement("Microsoft Corporation")),
-		), "expect certificate to be issued by Microsoft")
+			fmt.Fprintf(GinkgoWriter, "Issuer: %v\n", actualAPICert.Issuer)
+			Expect(actualAPICert.Issuer).To(SatisfyAll(
+				HaveField("CommonName", MatchRegexp(`Microsoft\sAzure\sRSA\sTLS\sIssuing\sCA\s[0-9]+`)),
+				HaveField("Organization", ContainElement("Microsoft Corporation")),
+			), "expect certificate to be issued by Microsoft")
 
-		By("creating the node pool")
-		nodePoolParams := framework.NewDefaultNodePoolParams()
-		nodePoolParams.ClusterName = customerClusterName
-		nodePoolParams.NodePoolName = customerNodePoolName
+			By("creating the node pool")
+			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams.ClusterName = customerClusterName
+			nodePoolParams.NodePoolName = customerNodePoolName
 
-		err = tc.CreateNodePoolFromParam(ctx,
-			*resourceGroup.Name,
-			customerClusterName,
-			nodePoolParams,
-			45*time.Minute,
-		)
-		Expect(err).NotTo(HaveOccurred())
+			err = tc.CreateNodePoolFromParam(ctx,
+				*resourceGroup.Name,
+				customerClusterName,
+				nodePoolParams,
+				45*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
 
-		By("ensuring the ingress TLS certificate issued by an OpenShift root CA")
-		hcpOpenShiftClustersClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			By("ensuring the ingress TLS certificate issued by an OpenShift root CA")
+			hcpOpenShiftClustersClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
 
-		By("waiting for the console URL to become available")
-		var consoleURL string
-		Eventually(func() bool {
-			resp, err := hcpOpenShiftClustersClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
-			if err != nil || resp.Properties == nil || resp.Properties.Console == nil || resp.Properties.Console.URL == nil {
-				return false
-			}
-			consoleURL = *resp.Properties.Console.URL
-			fmt.Fprintln(GinkgoWriter, "Ingress URL found:", consoleURL)
-			return true
-		}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
+			By("waiting for the console URL to become available")
+			var consoleURL string
+			Eventually(func() bool {
+				resp, err := hcpOpenShiftClustersClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+				if err != nil || resp.Properties == nil || resp.Properties.Console == nil || resp.Properties.Console.URL == nil {
+					return false
+				}
+				consoleURL = *resp.Properties.Console.URL
+				fmt.Fprintln(GinkgoWriter, "Ingress URL found:", consoleURL)
+				return true
+			}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
 
-		By("examining the server certificate returned by the default ingress when routing the console URL")
-		// Wait for the certificate to be loaded after console starts
-		sslPort := 443
-		consoleUrlWithPort := fmt.Sprintf("%s:%s", consoleURL, strconv.Itoa(sslPort))
+			By("examining the server certificate returned by the default ingress when routing the console URL")
+			// Wait for the certificate to be loaded after console starts
+			sslPort := 443
+			consoleUrlWithPort := fmt.Sprintf("%s:%s", consoleURL, strconv.Itoa(sslPort))
 
-		Eventually(func() (*x509.Certificate, error) {
-			actualCert, err := tlsCertFromURL(ctx, consoleUrlWithPort)
-			if err != nil {
-				fmt.Fprintf(GinkgoWriter, "error fetching cert: %v\n", err)
-				return nil, err
-			}
-			fmt.Fprintf(GinkgoWriter, "Issuer OU: %v", actualCert.Issuer.OrganizationalUnit)
-			return actualCert, nil
-		}).WithTimeout(4*time.Minute).WithPolling(10*time.Second).To(SatisfyAll(
-			HaveField("Issuer.CommonName", MatchRegexp(`Microsoft\sAzure\sRSA\sTLS\sIssuing\sCA\s[0-9]+`)),
-			HaveField("Issuer.Organization", ContainElement("Microsoft Corporation")),
-		), "expect certificate to be issued by Microsoft")
-	})
+			Eventually(func() (*x509.Certificate, error) {
+				actualCert, err := tlsCertFromURL(ctx, consoleUrlWithPort)
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "error fetching cert: %v\n", err)
+					return nil, err
+				}
+				fmt.Fprintf(GinkgoWriter, "Issuer OU: %v", actualCert.Issuer.OrganizationalUnit)
+				return actualCert, nil
+			}).WithTimeout(4*time.Minute).WithPolling(10*time.Second).To(SatisfyAll(
+				HaveField("Issuer.CommonName", MatchRegexp(`Microsoft\sAzure\sRSA\sTLS\sIssuing\sCA\s[0-9]+`)),
+				HaveField("Issuer.Organization", ContainElement("Microsoft Corporation")),
+			), "expect certificate to be issued by Microsoft")
+		})
 })
 
 func tlsCertFromURL(ctx context.Context, u string) (*x509.Certificate, error) {


### PR DESCRIPTION
[ARO-22959](https://issues.redhat.com/browse/ARO-22959)

### What

Refactored 4 E2E test cases to use direct RP API calls instead of Bicep templates:
- `cluster_create_nodepool_osdisk.go`
- `gpu_nodepools_create_delete.go`
- `cluster_tls_endpoints.go`
- `external_auth_create.go`

### Why

- **API compatibility**: Marked with `AroRpApiCompatible` label, which means that tests can run locally
- **Clearer errors**: Immediate validation with better error messages