### PR TITLE
test: increase external auth list and verify timeout to 90m

### DIFF
--- a/test/e2e/external_auth_list_and_verify.go
+++ b/test/e2e/external_auth_list_and_verify.go
@@ -68,7 +68,7 @@ var _ = Describe("Customer", func() {
 			}
 
 			// Create ARO HCP cluster
-			timeout := 45 * time.Minute
+			timeout := 90 * time.Minute
 			deploymentCtx, deploymentCancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during external auth list and verify test", timeout.Minutes()))
 			defer deploymentCancel()
 


### PR DESCRIPTION
Since the timeout was fixed in https://github.com/Azure/ARO-HCP/pull/3448 and updated in https://github.com/Azure/ARO-HCP/pull/3466, this test is failing frecuently on all enviroments: int, stage and prod. Increasing the timeout to 90 minutes will allow to verify if that is just that the custer needs more than 45 minutes to be ready or there is another issue. This should be reverted at some point, this is just a test.