### PR TITLE
fix(templatize): gracefully handle corrupted cache instead of failing

### DIFF
--- a/tooling/templatize/pkg/pipeline/shell.go
+++ b/tooling/templatize/pkg/pipeline/shell.go
@@ -287,9 +287,11 @@ func checkCachedOutput[T any](logger logr.Logger, data any, stepCacheDir string)
 
 		var output T
 		if err := json.Unmarshal(content, &output); err != nil {
-			return "", nil, nil, fmt.Errorf("failed to deserialize output: %w", err)
+			logger.V(2).Info("Failed to deserialize cached output, ignoring cache", "err", err, "content", string(content))
+			// Don't fail, just proceed without cache
+		} else {
+			return digest, &output, nil, nil
 		}
-		return digest, &output, nil, nil
 	} else {
 		logger.V(4).Info("Did not find any content in cache.", "err", err)
 	}


### PR DESCRIPTION
## Summary

Fixes a critical issue where corrupted or incompatible cache files in the templatize pipeline would cause hard failures. The fix makes the cache system more resilient by gracefully degrading to non-cached execution when deserialization fails.

## Problem

The `checkCachedOutput` function in `tooling/templatize/pkg/pipeline/shell.go:290` would return an error when it couldn't deserialize cached step output. This caused pipeline failures in scenarios such as:

- Cache files corrupted due to incomplete writes
- Schema changes between templatize versions making old cache incompatible
- File system issues or permission problems
- Race conditions during concurrent pipeline executions

The error path meant that instead of simply re-running the step (which would work), the entire pipeline would fail.

## Solution

Modified the error handling in the `checkCachedOutput` function to:
1. Log a warning (at V2 level) when deserialization fails, including the error and content for debugging
2. Continue execution by ignoring the corrupted cache entry
3. Allow the step to execute normally and generate fresh output

This approach treats cache as an optimization rather than a requirement - if the cache is unavailable or corrupted, we fall back to executing the step.

## Changes
- **File**: `tooling/templatize/pkg/pipeline/shell.go:287-295`
- **Change**: Converted deserialization error from hard failure to logged warning
- **Behavior**: Pipeline continues without cache when deserialization fails

## Testing
- Manually tested with corrupted cache files
- Verified that pipelines continue successfully when cache is invalid
- Confirmed that valid cache entries still work correctly

## Risk Assessment
**Low risk** - This change only affects the error handling path and makes the system more resilient.
Valid cache entries continue to work as before, and invalid entries no longer cause failures.