### PR TITLE
internal: divulge errors before swallowing them

### DIFF
--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"iter"
 	"net/http"
 	"reflect"
@@ -193,6 +194,8 @@ func ApplyRequestBody(requestMethod string, body []byte, v any) *arm.CloudError 
 	case http.MethodPatch:
 		originalData, err := json.Marshal(v)
 		if err != nil {
+			// there doesn't seem to be any sensible way to get at the logger in here, please forgive me
+			fmt.Printf(`{"level":"ERROR", "msg":"ApplyRequestBody: failed to marshal original data", "error":%q}\n`, err.Error())
 			return arm.NewInternalServerError()
 		}
 
@@ -235,6 +238,8 @@ func ApplyRequestBody(requestMethod string, body []byte, v any) *arm.CloudError 
 
 		err = mergo.Merge(v, src, mergo.WithOverride)
 		if err != nil {
+			// there doesn't seem to be any sensible way to get at the logger in here, please forgive me
+			fmt.Printf(`{"level":"ERROR", "msg":"ApplyRequestBody: failed to merge data", "error":%q}\n`, err.Error())
 			return arm.NewInternalServerError()
 		}
 	}

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -1032,5 +1032,7 @@ func CSErrorToCloudError(err error, resourceID *azcorearm.ResourceID, header htt
 		}
 	}
 
+	// there doesn't seem to be any sensible way to get at the logger in here, please forgive me
+	fmt.Printf(`{"level":"ERROR", "msg":"CSErrorToCloudError: failed to convert CS error to a cloud error, original error body", "error":%q}\n`, err.Error())
 	return arm.NewInternalServerError()
 }


### PR DESCRIPTION
There is no simple way to get a logger (even the default one) into the internal package, so I'm not trying here. A simple JSON record to stdout it is. We _must not_ swallow errors silently.
