### PR TITLE
gc: bump frontend image to fix auth, list and verify test

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -73,7 +73,7 @@ clouds:
           # RP Frontend
           frontend:
             image:
-              digest: sha256:f3b2d83dca499d344e2fa343883d527a508c6dce03ef653ec659b640dcc6c4ce # e368a2f (2025-12-04 12:50)
+              digest: sha256:d4d47cb52c6fccd357e098f00e0dded9dd80af36a34f0572d86c4add80473df8 # 3e144a2 (2025-12-05 01:05)
             audit:
               connectSocket: true
           # RP Backend

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -917,7 +917,7 @@ clouds:
         cert:
           issuer: Self
         image:
-          digest: sha256:f3b2d83dca499d344e2fa343883d527a508c6dce03ef653ec659b640dcc6c4ce # e368a2f (2025-12-04 12:50)
+          digest: sha256:d4d47cb52c6fccd357e098f00e0dded9dd80af36a34f0572d86c4add80473df8 # 3e144a2 (2025-12-05 01:05)
       # Backend
       backend:
         image:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,22 +3,22 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 2f39efbc03f5b290bc508f6558e87d4f2886d97d751744325bd1346ea3fe100e
+          westus3: c510486568f4ef24958d7c6bafbde73a87ff76dcee41f2b0f93c010da0b02f5b
       dev:
         regions:
-          westus3: d2f584e88a3559a8204ca01ee1f4fb1d825e5bd329b2677cff29761f2ec83740
+          westus3: 8f2a9f816aac44b82aa62e739edfb35bee78617fc947d50bf4e94284b882e7b3
       ntly:
         regions:
-          uksouth: f868e6499e85651c8b4e620a0c7a4e1608898df57170b1f1e001628e998b39f9
+          uksouth: 3a926edf03554ace983e2bdd3e5401ae8f71fa6250887d3a816f7de02893db32
       perf:
         regions:
-          westus3: 3399c2fc97bc5aeaca1d32deab431aa490db6d8bfe351a27ab35decc7be5c881
+          westus3: f99fc815c804f6733e698fd4e9b478edf4f5a91866b589f50ef22cb9ce2bcc62
       pers:
         regions:
-          westus3: fbf6c0401a219820cc91205b2cf3e56782c1de51b472a4d691aabed84f9f4e36
+          westus3: 9198b3f970ad2f5f309bc748bac6377a5df243b227071958ae97a7106facd082
       prow:
         regions:
-          westus3: e38b3088908c21cd966b8a969582f31f06770474671105b693651c975344ae8e
+          westus3: 0180d50868bd4bf867df6f480170f4fb52dbfb3b8edfb8226c16da064a72498f
       swft:
         regions:
-          uksouth: e908866e4ca1e0828b226abacbe0235490c06e07fe7e23f372ea12f2a136add5
+          uksouth: 05f306dfc89ba767455beec19c003d2b3eb89ebafd0e9c5327fbd2b8f167f6c8

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -208,7 +208,7 @@ frontend:
     private: false
     zoneRedundantMode: Disabled
   image:
-    digest: sha256:f3b2d83dca499d344e2fa343883d527a508c6dce03ef653ec659b640dcc6c4ce
+    digest: sha256:d4d47cb52c6fccd357e098f00e0dded9dd80af36a34f0572d86c4add80473df8
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -208,7 +208,7 @@ frontend:
     private: false
     zoneRedundantMode: Disabled
   image:
-    digest: sha256:f3b2d83dca499d344e2fa343883d527a508c6dce03ef653ec659b640dcc6c4ce
+    digest: sha256:d4d47cb52c6fccd357e098f00e0dded9dd80af36a34f0572d86c4add80473df8
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   k8s:

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -208,7 +208,7 @@ frontend:
     private: false
     zoneRedundantMode: Disabled
   image:
-    digest: sha256:f3b2d83dca499d344e2fa343883d527a508c6dce03ef653ec659b640dcc6c4ce
+    digest: sha256:d4d47cb52c6fccd357e098f00e0dded9dd80af36a34f0572d86c4add80473df8
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -208,7 +208,7 @@ frontend:
     private: true
     zoneRedundantMode: Auto
   image:
-    digest: sha256:f3b2d83dca499d344e2fa343883d527a508c6dce03ef653ec659b640dcc6c4ce
+    digest: sha256:d4d47cb52c6fccd357e098f00e0dded9dd80af36a34f0572d86c4add80473df8
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -208,7 +208,7 @@ frontend:
     private: false
     zoneRedundantMode: Disabled
   image:
-    digest: sha256:f3b2d83dca499d344e2fa343883d527a508c6dce03ef653ec659b640dcc6c4ce
+    digest: sha256:d4d47cb52c6fccd357e098f00e0dded9dd80af36a34f0572d86c4add80473df8
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   k8s:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -208,7 +208,7 @@ frontend:
     private: false
     zoneRedundantMode: Disabled
   image:
-    digest: sha256:f3b2d83dca499d344e2fa343883d527a508c6dce03ef653ec659b640dcc6c4ce
+    digest: sha256:d4d47cb52c6fccd357e098f00e0dded9dd80af36a34f0572d86c4add80473df8
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   k8s:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -208,7 +208,7 @@ frontend:
     private: false
     zoneRedundantMode: Disabled
   image:
-    digest: sha256:f3b2d83dca499d344e2fa343883d527a508c6dce03ef653ec659b640dcc6c4ce
+    digest: sha256:d4d47cb52c6fccd357e098f00e0dded9dd80af36a34f0572d86c4add80473df8
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   k8s:


### PR DESCRIPTION
The main purpose is to deploy a new frontend image version (`sha256:d4d47cb52c6fccd357e098f00e0dded9dd80af36a34f0572d86c4add80473df8`) to dev and int. This new image fixes the Internal error being seen in Prow recently.

### Before:

```
$ curl -X PUT "localhost:8443/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/bvesel-net-rg-03/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/bvesel/externalauths/external-auth?api-version=2024-06-10-preview" --data "$(cat external-auth.json)" -H "Content-Type: application/json" -H 'X-Ms-Arm-Resource-System-Data: {"createdBy": "bvesel","createdByType": "User","createdAt": "2025-12-05T04:22:27+00:00"}' -vvv
* Host localhost:8443 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8443...
* Connected to localhost (::1) port 8443
> PUT /subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/bvesel-net-rg-03/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/bvesel/externalauths/external-auth?api-version=2024-06-10-preview HTTP/1.1
> Host: localhost:8443
> User-Agent: curl/8.9.1
> Accept: */*
> Content-Type: application/json
> X-Ms-Arm-Resource-System-Data: {"createdBy": "bvesel","createdByType": "User","createdAt": "2025-12-05T04:22:27+00:00"}
> Content-Length: 553
> 
* upload completely sent off: 553 bytes
< HTTP/1.1 500 Internal Server Error
< Content-Type: application/json
< X-Ms-Error-Code: InternalServerError
< X-Ms-Request-Id: be45656b-dcfb-4dd6-bb3b-f8abd4a79d6e
< Date: Fri, 05 Dec 2025 04:35:26 GMT
< Content-Length: 107
< 
{
    "error": {
        "code": "InternalServerError",
        "message": "Internal server error."
    }
* Connection #0 to host localhost left intact

---
$ cat external-auth.json 
  {
    "properties": {
      "issuer": {
        "url": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0",
        "audiences": ["00000000-0000-0000-0000-000000000001"],
        "ca": ""
      },
      "claim": {
        "mappings": {
          "username": {
            "claim": "sub",
            "prefixPolicy": "Prefix",
            "prefix": "my-prefix"
          },
          "groups": {
            "claim": "groups",
            "prefix": ""
          }
        },
        "validationRules": []
      }
    }
  }
```

### After:

```
$ curl -X PUT "localhost:8443/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/bvesel-net-rg-03/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/bvesel/externalauths/external-auth?api-version=2024-06-10-preview" --data "$(cat external-auth.json)" -H "Content-Type: application/json" -H 'X-Ms-Arm-Resource-System-Data: {"createdBy": "bvesel","createdByType": "User","createdAt": "2025-12-05T04:22:27+00:00"}' -vvv
* Host localhost:8443 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8443...
* Connected to localhost (::1) port 8443
> PUT /subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/bvesel-net-rg-03/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/bvesel/externalauths/external-auth?api-version=2024-06-10-preview HTTP/1.1
> Host: localhost:8443
> User-Agent: curl/8.9.1
> Accept: */*
> Content-Type: application/json
> X-Ms-Arm-Resource-System-Data: {"createdBy": "bvesel","createdByType": "User","createdAt": "2025-12-05T04:22:27+00:00"}
> Content-Length: 549
> 
* upload completely sent off: 549 bytes
< HTTP/1.1 200 OK
< Azure-Asyncoperation: http://localhost:8443/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/providers/Microsoft.RedHatOpenShift/locations/westus3/hcpOperationStatuses/cf6127d6-0d02-4804-abc7-150d0ea55eba?api-version=2024-06-10-preview
< Content-Type: application/json
< X-Ms-Request-Id: bb6b6588-dbde-43aa-b088-9f10e94428ce
< Date: Fri, 05 Dec 2025 04:44:13 GMT
< Content-Length: 1085
< 
{
    "id": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/bvesel-net-rg-03/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/bvesel/externalauths/external-auth",
    "name": "external-auth",
    "properties": {
        "claim": {
            "mappings": {
                "groups": {
                    "claim": "groups"
                },
                "username": {
                    "claim": "sub",
                    "prefix": "my-prefix",
                    "prefixPolicy": "Prefix"
                }
            },
            "validationRules": []
        },
        "issuer": {
            "audiences": [
                "00000000-0000-0000-0000-000000000001"
            ],
            "url": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
        },
        "provisioningState": "Accepted"
    },
    "systemData": {
        "createdAt": "2025-12-05T04:22:27Z",
        "createdBy": "bvesel",
        "createdByType": "User"
    },
    "type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalauths"
* Connection #0 to host localhost left intact
```