### PR TITLE
chore: promote new frontend image to stage

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -176,7 +176,7 @@ clouds:
           # RP Frontend
           frontend:
             image:
-              digest: sha256:f3b2d83dca499d344e2fa343883d527a508c6dce03ef653ec659b640dcc6c4ce # 8289751
+              digest: sha256:d4d47cb52c6fccd357e098f00e0dded9dd80af36a34f0572d86c4add80473df8 # 8289751
             audit:
               connectSocket: true
           # RP Backend


### PR DESCRIPTION
Promotes Frontend `sha256:d4d47cb52c6fccd357e098f00e0dded9dd80af36a34f0572d86c4add80473df8` https://github.com/Azure/ARO-HCP/pull/3502 to Stage.