### PR TITLE
test: Print error from running aro-hcp-tests binary to stderr instead of stdout

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -177,7 +177,7 @@ func main() {
 	if err := func() error {
 		return root.Execute()
 	}(); err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
[ARO-23111](https://issues.redhat.com/browse/ARO-23111)

### What

Print error from running tests binary to stderr instead of stdout

### Why

Fixing deserialization error in CI failed tests results
