### PR TITLE
Grafana dashboards add retries

### DIFF
--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -63,6 +63,11 @@ resourceGroups:
     omitFromServiceGroupCompletion: true
     command: ./add-grafana-datasource.sh
     workingDir: ./scripts
+    automatedRetry:
+      errorContainsAny:
+      - "is invalid as it is being provisioned with state"
+      maximumRetryCount: 5
+      durationBetweenRetries: 2m
     variables:
     - name: GRAFANA_RESOURCE_ID
       input:
@@ -89,6 +94,11 @@ resourceGroups:
     omitFromServiceGroupCompletion: true
     command: ./add-grafana-datasource.sh
     workingDir: ./scripts
+    automatedRetry:
+      errorContainsAny:
+      - "is invalid as it is being provisioned with state"
+      maximumRetryCount: 5
+      durationBetweenRetries: 2m
     variables:
     - name: GRAFANA_RESOURCE_ID
       input:


### PR DESCRIPTION

<!-- Link to Jira issue -->

### What

Add retries on errors indicating concurrent updates.

### Why

Sometimes Grafana is being updated by other pipeline and we can not apply this. 

### Special notes for your reviewer

<!-- optional -->
