### PR TITLE
.github: stop using UAMSI federation for Go CI

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -27,21 +27,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.go == 'true'
     permissions:
-      id-token: 'write'
       contents: 'read'
     runs-on: 'ubuntu-latest'
     steps:
     - name: "install azure-cli"
       uses: "Azure/ARO-HCP@main"
-    - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
-      with:
-        kubelogin-version: 'v0.1.3'
-    - name: 'Az CLI login'
-      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
-      with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
       with:
         fetch-depth: 1


### PR DESCRIPTION
Not clear why this job ever was using the tokens or logging into Azure to run unit tests.
