### PR TITLE
Makefile: Add install-tools as a dependency for personal-dev-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ generate-kiota:
 # One-Step Personal Dev Environment
 #
 ifeq ($(DEPLOY_ENV),pers)
-personal-dev-env: entrypoint/Region infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing
+personal-dev-env: install-tools entrypoint/Region infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing
 else
 personal-dev-env:
 	$(error personal-dev-env: DEPLOY_ENV must be set to "pers", not "$(DEPLOY_ENV)")


### PR DESCRIPTION
### What

When standing up a personal development environment, as a first step make sure necessary 3rd-party tools are installed.

Ultimately individual make goals should explicitly call out the specific tools they depend on, so we should aim to make this a temporary workaround.

### Why

This gap was identified in a [recent Slack thread](https://redhat-external.slack.com/archives/C075PHEFZKQ/p1765202860326749?thread_ts=1765185647.324199&cid=C075PHEFZKQ).
