### PR TITLE
Remove buildout flag from westeurope

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -210,9 +210,6 @@ clouds:
               digest: sha256:4822b1998fafa4c7ed1e0723dfed8fd0562e1525545327b821e6d9ef29573c74
       prod:
         # this is the MSFT PRODUCTION environment
-        regions:
-          westeurope:
-            regionBuildout: true
         defaults:
           # E2E
           e2e:


### PR DESCRIPTION
### What

Removes the `regionBuildout: true` flag that disables IcM action groups for the region.

