### PR TITLE
feat: add new make target for local CS dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,36 @@ personal-dev-env:
 endif
 .PHONY: personal-dev-env
 
+#
+# Local Cluster Service Development Environment
+#
+ifeq ($(DEPLOY_ENV),pers)
+local-pers-dev-env: personal-dev-env
+	@echo ""
+	@echo "===================================================================="
+	@echo "Personal dev environment setup complete"
+	@echo "===================================================================="
+	@echo ""
+	@echo "Granting local development permissions..."
+	@$(MAKE) -C dev-infrastructure local-cs-permissions
+	@echo ""
+	@echo "===================================================================="
+	@echo "Local CS permissions granted successfully"
+	@echo "===================================================================="
+	@echo "Generating local provision-shard config..."
+	@echo ""
+	@cd cluster-service && $(MAKE) local-deploy-provision-shard && $(MAKE) personal-runtime-config && $(MAKE) local-aro-hcp-ocp-versions-config && $(MAKE) local-azure-operators-managed-identities-config
+	@echo ""
+	@echo "===================================================================="
+	@echo "Cluster service configuration files generated at:"
+	@echo "cluster-service/local/"
+	@echo "===================================================================="
+else
+local-pers-dev-env:
+	$(error local-pers-dev-env: DEPLOY_ENV must be set to "pers", not "$(DEPLOY_ENV)")
+endif
+.PHONY: local-pers-dev-env
+
 ifeq ($(wildcard $(YQ)),$(YQ))
 entrypoints = $(shell $(YQ) '.entrypoints[] | .identifier | sub("Microsoft.Azure.ARO.HCP.", "")' topology.yaml )
 pipelines = $(shell $(YQ) '.services[] | .. | select(key == "serviceGroup") | sub("Microsoft.Azure.ARO.HCP.", "")' topology.yaml )

--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -163,7 +163,7 @@ personal-runtime-config:
 local-azure-operators-managed-identities-config:
 	helm template helm-charts/cluster-service -s templates/azure-operators-managed-identities-config.configmap.yaml \
 	  --set azureOperatorsMI.roleSetName=${OPERATOR_ROLE_SET_NAME} \
-	  | yq '.data["azure-operators-managed-identities-config.yaml"]' > ./azure-operators-managed-identities-config.yaml
+	  | yq '.data["azure-operators-managed-identities-config.yaml"]' > local/azure-operators-managed-identities-config.yaml
 .PHONY: local-azure-operators-managed-identities-config
 
 local-aro-hcp-ocp-versions-config:
@@ -172,7 +172,7 @@ local-aro-hcp-ocp-versions-config:
 	--set ocpVersions.channelGroups.stable.minVersion=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MIN_VERSION} \
 	--set ocpVersions.channelGroups.stable.maxVersion=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MAX_VERSION} \
 	--set azureOperatorsMI.roleSetName=${OPERATOR_ROLE_SET_NAME} \
-	-s templates/aro-hcp-ocp-versions-config.configmap.yaml | yq '.data["aro-hcp-ocp-versions-config.yaml"]' > ./aro-hcp-ocp-versions-config.yaml
+	-s templates/aro-hcp-ocp-versions-config.configmap.yaml | yq '.data["aro-hcp-ocp-versions-config.yaml"]' > local/aro-hcp-ocp-versions-config.yaml
 .PHONY: local-aro-hcp-ocp-versions-config
 
 #

--- a/docs/personal-dev.md
+++ b/docs/personal-dev.md
@@ -53,6 +53,21 @@ This command creates a personal DEV environment with a unique name that is deriv
 > This command can be used to update your personal DEV environment as well. It will apply the latest changes to the infrastructure and services. Steps are cached, so it's quick and safe to re-run the entire environment setup.
 > If you only want to update individual aspects of the environment, follow the [partial setup](#partial-personal-dev-environment-setup) instructions.
 
+### Local Cluster Service Development Setup
+
+If you plan to run the Cluster Service locally (not deployed to Kubernetes) for development, use the following command instead:
+
+   ```bash
+   make local-pers-dev-env
+   ```
+
+This command performs all the steps of `personal-dev-env` plus:
+- Grants your user permissions to access Key Vaults (service and management)
+- Grants your user permissions to access OIDC storage
+- Generates the local configuration files for cluster service: provision-shards, ocp-versions, azure-runtime, azure-operators-mi
+
+After this, the config files are created in `cluster-service/local/`. This contains the configuration needed to run the Cluster Service locally against your personal dev environment.
+
 ## Partial Personal DEV Environment Setup
 
 The process described in the previous section caches steps, but even the process of determining that a step should not run again will take a second or two. In case you want to install or update only a specific part of the environment for maximum speed, you can use the following commands.


### PR DESCRIPTION
### What
Add a new make target that will deploy infra and services, configure the permissions and create the provision shard config for cluster-service.

### Why
This was part of the make infra.all, but it recently change. Will solve minor issues we have found trying to run CS locally.

