### PR TITLE
Move resourceID overwrite into the frontend

### DIFF
--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -646,5 +646,25 @@ func (f *Frontend) getInternalClusterFromStorage(ctx context.Context, resourceID
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
+
+	// Replace the key field from Cosmos with the given resourceID,
+	// which typically comes from the URL. This helps preserve the
+	// casing of the resource group and resource name from the URL
+	// to meet RPC requirements:
+	//
+	// Put Resource | Arguments
+	//
+	// The resource group names and resource names should be matched
+	// case insensitively. ... Additionally, the Resource Provider must
+	// preserve the casing provided by the user. The service must return
+	// the most recently specified casing to the client and must not
+	// normalize or return a toupper or tolower form of the resource
+	// group or resource name. The resource group name and resource
+	// name must come from the URL and not the request body.
+	if !strings.EqualFold(internalCluster.ID.String(), resourceID.String()) {
+		return nil, fmt.Errorf("unexpected resourceID: %s", internalCluster.ID.String())
+	}
+	internalCluster.ID = resourceID
+
 	return f.readInternalClusterFromClusterService(ctx, internalCluster)
 }

--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -552,6 +552,25 @@ func (f *Frontend) getInternalExternalAuthFromStorage(ctx context.Context, resou
 		return nil, utils.TrackError(err)
 	}
 
+	// Replace the key field from Cosmos with the given resourceID,
+	// which typically comes from the URL. This helps preserve the
+	// casing of the resource group and resource name from the URL
+	// to meet RPC requirements:
+	//
+	// Put Resource | Arguments
+	//
+	// The resource group names and resource names should be matched
+	// case insensitively. ... Additionally, the Resource Provider must
+	// preserve the casing provided by the user. The service must return
+	// the most recently specified casing to the client and must not
+	// normalize or return a toupper or tolower form of the resource
+	// group or resource name. The resource group name and resource
+	// name must come from the URL and not the request body.
+	if !strings.EqualFold(internalExternalAuth.ID.String(), resourceID.String()) {
+		return nil, fmt.Errorf("unexpected resourceID: %s", internalExternalAuth.ID.String())
+	}
+	internalExternalAuth.ID = resourceID
+
 	return f.readInternalExternalAuthFromClusterService(ctx, internalExternalAuth)
 
 }

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -591,6 +591,25 @@ func (f *Frontend) getInternalNodePoolFromStorage(ctx context.Context, resourceI
 		return nil, utils.TrackError(err)
 	}
 
+	// Replace the key field from Cosmos with the given resourceID,
+	// which typically comes from the URL. This helps preserve the
+	// casing of the resource group and resource name from the URL
+	// to meet RPC requirements:
+	//
+	// Put Resource | Arguments
+	//
+	// The resource group names and resource names should be matched
+	// case insensitively. ... Additionally, the Resource Provider must
+	// preserve the casing provided by the user. The service must return
+	// the most recently specified casing to the client and must not
+	// normalize or return a toupper or tolower form of the resource
+	// group or resource name. The resource group name and resource
+	// name must come from the URL and not the request body.
+	if !strings.EqualFold(internalNodePool.ID.String(), resourceID.String()) {
+		return nil, fmt.Errorf("unexpected resourceID: %s", internalNodePool.ID.String())
+	}
+	internalNodePool.ID = resourceID
+
 	return f.readInternalNodePoolFromClusterService(ctx, internalNodePool)
 
 }

--- a/internal/database/crud_helpers.go
+++ b/internal/database/crud_helpers.go
@@ -82,26 +82,6 @@ func get[InternalAPIType, CosmosAPIType any](ctx context.Context, containerClien
 	}
 	cosmosObj := &obj
 
-	// Replace the key field from Cosmos with the given resourceID,
-	// which typically comes from the URL. This helps preserve the
-	// casing of the resource group and resource name from the URL
-	// to meet RPC requirements:
-	//
-	// Put Resource | Arguments
-	//
-	// The resource group names and resource names should be matched
-	// case insensitively. ... Additionally, the Resource Provier must
-	// preserve the casing provided by the user. The service must return
-	// the most recently specified casing to the client and must not
-	// normalize or return a toupper or tolower form of the resource
-	// group or resource name. The resource group name and resource
-	// name must come from the URL and not the request body.
-	retAsResourceProperties, ok := any(cosmosObj).(ResourceProperties)
-	if !ok {
-		return nil, fmt.Errorf("type %T does not implement ResourceProperties interface", cosmosObj)
-	}
-	retAsResourceProperties.SetResourceID(completeResourceID)
-
 	internalObj, err := CosmosToInternal[InternalAPIType, CosmosAPIType](cosmosObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert Cosmos object to internal type: %w", err)

--- a/internal/database/document.go
+++ b/internal/database/document.go
@@ -14,8 +14,6 @@
 
 package database
 
-import azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-
 // DocumentProperties is an interface for types that can serve as
 // TypedDocument.Properties.
 type DocumentProperties interface {
@@ -27,6 +25,4 @@ type DocumentProperties interface {
 type ResourceProperties interface {
 	ValidateResourceType() error
 	GetTypedDocument() *TypedDocument
-	// SetResourceID allows setting a value, but panics if it is not matching (case-insensitive)
-	SetResourceID(*azcorearm.ResourceID)
 }


### PR DESCRIPTION
This avoids trying to track the value to the data storage layer and lets the data storage layer return the exact data that is stored and not manipulate it.  This also makes it easier to add more storage.
