### PR TITLE
backend: add SLO metrics for resource operations

### DIFF
--- a/backend/operations_scanner_test.go
+++ b/backend/operations_scanner_test.go
@@ -594,3 +594,78 @@ func TestConvertClusterStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestRecordOperationResult(t *testing.T) {
+	// Test that recordOperationResult doesn't panic with nil metrics
+	t.Run("nil metrics doesn't panic", func(t *testing.T) {
+		scanner := &OperationsScanner{
+			operationResultsTotal:    nil,
+			operationDurationSeconds: nil,
+		}
+
+		internalID, err := api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/test-cluster")
+		require.NoError(t, err)
+
+		op := operation{
+			doc: &database.OperationDocument{
+				Request:    database.OperationRequestCreate,
+				InternalID: internalID,
+				StartTime:  time.Now().Add(-5 * time.Minute),
+			},
+			logger: slog.Default(),
+		}
+
+		// Should not panic
+		assert.NotPanics(t, func() {
+			scanner.recordOperationResult(op, arm.ProvisioningStateSucceeded)
+		})
+	})
+}
+
+func TestListResourceOperationTypes(t *testing.T) {
+	expected := []string{
+		"create",
+		"update",
+		"delete",
+		"requestcredential",
+		"revokecredentials",
+	}
+
+	var actual []string
+	for v := range listResourceOperationTypes() {
+		actual = append(actual, v)
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestListResourceOperationKinds(t *testing.T) {
+	expected := []string{
+		"cluster",
+		"nodepool",
+		"externalauth",
+		"breakglasscredential",
+	}
+
+	var actual []string
+	for v := range listResourceOperationKinds() {
+		actual = append(actual, v)
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestListResourceOperationStatuses(t *testing.T) {
+	expected := []string{
+		"succeeded",
+		"failed",
+		"canceled",
+	}
+
+	var actual []string
+	for v := range listResourceOperationStatuses() {
+		actual = append(actual, v)
+	}
+
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ARO-22283

### What

Add new Prometheus metrics to the Backend service for tracking ARM Resource Operation results and durations:

- `backend_resource_operations_total` - Counter tracking completed operations by type, resource kind, and status
- `backend_resource_operations_duration_seconds` - Histogram tracking operation duration from start to completion

Both metrics include labels for:
- `operation_type`: create, update, delete, requestcredential, revokecredentials
- `resource_kind`: cluster, nodepool, externalauth, breakglasscredential, unknown
    - NOTE: I thought about using `resource_type` - but not all of these are official ARM Resources...
- `status`: succeeded, failed, canceled

### Why

This is a precursor to enabling better black-box monitoring of customer user journeys and critical paths. These metrics will allow us to:

- Track cluster install success/failure rates
- Measure how long cluster installs and other operations take (P50, P95, P99)
- Set up SLO-based alerting on long-running/async operation outcomes
- Build dashboards showing operational health by resource type and operation

### Special notes for your reviewer

**Performance impact:**
- Label combinations: 5 op types × 5 resource kinds × 3 statuses = 75 combinations
- Counter: 75 time series
- Histogram: 75 combinations × 18 series each (15 buckets + +Inf + _sum + _count) = 1,350 time series
- **Total: ~1,425 new time series** (Azure Monitor Workspace default limit is 1 million per workspace)


**Example PromQL:**

Cluster create success rate (last 1h):
```
sum(rate(backend_resource_operations_total{operation_type="create",resource_kind="cluster",status="succeeded"}[1h]))
/
sum(rate(backend_resource_operations_total{operation_type="create",resource_kind="cluster"}[1h]))
```

P95 duration for successful cluster creates:
```
histogram_quantile(0.95,
sum(rate(backend_resource_operations_duration_seconds_bucket{
operation_type="create",
resource_kind="cluster",
status="succeeded"
}[1h])) by (le)
)
```

NodePool delete failure count (last 24h):
```
sum(increase(backend_resource_operations_total{
operation_type="delete",
resource_kind="nodepool",
status="failed"
}[24h]))
```

Average credential request duration:
```
sum(rate(backend_resource_operations_duration_seconds_sum{
operation_type="requestcredential",
resource_kind="breakglasscredential"
}[1h]))
/
sum(rate(backend_resource_operations_duration_seconds_count{
operation_type="requestcredential",
resource_kind="breakglasscredential"
}[1h]))
```

Example of a local E2E run (6 successful cluster creates) - and the average time for the Operation to complete (in minutes):

```
sum(backend_resource_operations_duration_seconds_sum{operation_type="create",resource_kind="cluster",status="succeeded"}) / sum(backend_resource_operations_duration_seconds_count{operation_type="create",resource_kind="cluster",status="succeeded"}) / 60
```

<img width="2532" height="932" alt="image" src="https://github.com/user-attachments/assets/1fe91cd0-1baf-42a8-9d54-8ea335507e82" />

This PR was co-authored by Claude AI.
