### PR TITLE
prevent panics in line tracking error printing

### DIFF
--- a/internal/utils/line_tracking_error.go
+++ b/internal/utils/line_tracking_error.go
@@ -30,7 +30,7 @@ type LineTrackingError struct {
 
 // TrackError creates a new LineTrackingError that wraps the provided error
 // and captures the caller's file and line number information.
-func TrackError(err error) *LineTrackingError {
+func TrackError(err error) error {
 	if err == nil {
 		return nil
 	}

--- a/internal/utils/line_tracking_error_test.go
+++ b/internal/utils/line_tracking_error_test.go
@@ -32,8 +32,8 @@ func (e *CustomError) Error() string {
 }
 
 func TestReturningNilForNil(t *testing.T) {
-	wrappedErr := TrackError(nil)
-	if wrappedErr != nil {
+	var err = TrackError(nil)
+	if err != nil {
 		t.Error("expected nil for nil input error")
 	}
 }
@@ -73,7 +73,7 @@ func TestLineTrackingError_ErrorsAs(t *testing.T) {
 		originalErr := errors.New("standard error")
 		wrappedErr := TrackError(originalErr)
 
-		unwrapped := wrappedErr.Unwrap()
+		unwrapped := wrappedErr.(*LineTrackingError).Unwrap()
 		if unwrapped != originalErr {
 			t.Error("expected Unwrap to return original error")
 		}


### PR DESCRIPTION
We saw a panic like this and while I don't know how we got a nil error, we did, so this code is now updated to prevent panics.

2025-12-09T18:07:05.864Z    ERROR   panic: "invalid memory address or nil pointer dereference"
goroutine 2435 [running]:
runtime/debug.Stack()
    /usr/local/go/src/runtime/debug/stack.go:26 +0x5e
github.com/Azure/ARO-HCP/frontend/pkg/frontend.MiddlewarePanic.func1()
    /app/frontend/pkg/frontend/middleware_panic.go:32 +0x95
panic({0x1791900?, 0x2a60a50?})
    /usr/local/go/src/runtime/panic.go:792 +0x132
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
    /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.38.0/trace/span.go:468 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc00063c780, {0x0, 0x0, 0xc00063b880?})
    /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.38.0/trace/span.go:517 +0xc12
panic({0x1791900?, 0x2a60a50?})
    /usr/local/go/src/runtime/panic.go:792 +0x132
**_github.com/Azure/ARO-HCP/internal/utils.(*LineTrackingError).Error(0x0)
    /app/internal/utils/line_tracking_error.go:49 +0x1a_**
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).RecordError(0xc00063c780, {0x1c73b60, 0x0}, {0x0, 0x0, 0x0})
    /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.38.0/trace/span.go:546 +0x282
github.com/Azure/ARO-HCP/internal/ocm.(*clusterServiceClientWithTracing).DeleteCluster(0xc0003f82a0, {0x1c83d68?, 0xc0009b6730?}, {{0xc000374d00, 0x3f}, {0x1a4272f, 0x7}})
    /app/internal/ocm/tracing.go:138 +0x275
github.com/Azure/ARO-HCP/frontend/pkg/frontend.(*Frontend).DeleteResource(0xc000204f08, {0x1c83d68, 0xc0009b6730}, {0x1c8daa0, 0xc000660910}, {0xc00072ec00, 0x24}, 0xc000256150)
    /app/frontend/pkg/frontend/helpers.go:272 +0xfe
github.com/Azure/ARO-HCP/frontend/pkg/frontend.(*Frontend).ArmResourceDelete(0xc000204f08, {0x1c7f760, 0xc000349a60}, 0xc00046f2c0)
    /app/frontend/pkg/frontend/frontend.go:304 +0x2a5
github.com/Azure/ARO-HCP/frontend/pkg/frontend.(*Frontend).routes.reportError.func13({0x1c7f760, 0xc000349a60}, 0xc00046f2c0)
    /app/frontend/pkg/frontend/error.go:41 +0x26
net/http.HandlerFunc.ServeHTTP(0x0?, {0x1c7f760?, 0xc000349a60?}, 0xc0008559d8?)
    /usr/local/go/src/net/http/server.go:2294 +0x29

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
