### PR TITLE
Reduce the list of ARM64 types for testing.

### DIFF
--- a/test/e2e/arm64_nodepool.go
+++ b/test/e2e/arm64_nodepool.go
@@ -48,7 +48,7 @@ var _ = Describe("Customer", func() {
 				openshiftNodeVersionId           = "4.19.7"
 			)
 			// This pattern matches a subset of the smallest (2GiB) ARM64-capable VM sizes listed in https://issues.redhat.com/browse/ARO-22443
-			vmSizePattern := regexp.MustCompile(`^Standard_D(?:2|4|8|16|32|48|64|96)pl(?:d)?s_v6$`)
+			vmSizePattern := regexp.MustCompile(`^Standard_D(?:2|4)pl(?:d)?s_v6$`)
 
 			tc := framework.NewTestContext()
 


### PR DESCRIPTION
[<!-- Link to Jira issue -->](https://issues.redhat.com/browse/ARO-23143)

### What

Reduce the list of ARM64 types that are used in tests.

### Why

After the improvements added in [ARO-22556](https://issues.redhat.com/browse/ARO-22556), the tests are randomly picking available VM sizes. Some of those VM sizes have assigned a quota of 0, so they can't be used (even though they are listed as available).

### Special notes for your reviewer

<!-- optional -->
