### PR TITLE
Reduce stg&prod test parallelism even further

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -57,7 +57,7 @@ func main() {
 			// TODO we will need per-env markers eventually, but it's ok to start here
 			fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0]),
 		},
-		Parallelism: 10,
+		Parallelism: 4,
 	})
 
 	ext.AddSuite(e.Suite{
@@ -67,7 +67,7 @@ func main() {
 			// TODO we will need per-env markers eventually, but it's ok to start here
 			fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0]),
 		},
-		Parallelism: 10,
+		Parallelism: 4,
 	})
 
 	ext.AddSuite(e.Suite{


### PR DESCRIPTION
Int should be kept higher, so that we don't hide the issues. However failures on stage and prod are toily (they disrupt the release process) and a high percentage of flaky failures increases the risk of someone missing an actual problem during releases. For these reasons, let's keep stage and prod low so we reduce flakes in those environments.

Side note: ci runs against prod will be outliers compared to int and stage because int and stage will always be empty, while prod will be increasingly busy. At some point we'll start hitting scaling failures on prod that do not show up in int/stage. It's worth thinking about how to set up int/stg in such a way that we can simulate the busyness of prod clusters to the highest extent.
