### PR TITLE
e2e: use log fields for provisioningState instead of fmt.Sprintf

### DIFF
--- a/test/e2e/admin_credential_lifecycle.go
+++ b/test/e2e/admin_credential_lifecycle.go
@@ -105,7 +105,7 @@ var _ = Describe("Customer", func() {
 
 				// only log state changes
 				if previousState != *cluster.Properties.ProvisioningState {
-					GinkgoLogr.Info(fmt.Sprintf("Cluster provisioning state changed: '%v' -> '%v'", previousState, *cluster.Properties.ProvisioningState))
+					GinkgoLogr.Info("Cluster provisioning state updated", "provisioningState", *cluster.Properties.ProvisioningState)
 					previousState = *cluster.Properties.ProvisioningState
 				}
 


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Use structured logging instead of fmt.Sprintf where applicable in a test. 

