### PR TITLE
Add pipelines to grant AKS access

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -272,6 +272,10 @@ svc.aks.kubeconfig:
 	@kubelogin convert-kubeconfig -l azurecli --kubeconfig "${SVC_KUBECONFIG_FILE}"
 .PHONY: svc.aks.kubeconfig
 
+svc.aks.kubeconfig.pipeline:
+	make -C .. pipeline/Service.Kubeconfig DEPLOY_ENV=$(DEPLOY_ENV)
+.PHONY: svc.aks.kubeconfig.pipeline
+
 svc.aks.kubeconfigfile:
 	@echo ${SVC_KUBECONFIG_FILE}
 .PHONY: svc.aks.kubeconfigfile
@@ -337,6 +341,10 @@ mgmt.aks.kubeconfig:
 	@az aks get-credentials --overwrite-existing --only-show-errors -n ${MGMT_AKS_NAME} -g $(MGMT_RESOURCEGROUP) -f "${MGMT_KUBECONFIG_FILE}"
 	@kubelogin convert-kubeconfig -l azurecli --kubeconfig "${MGMT_KUBECONFIG_FILE}"
 .PHONY: mgmt.aks.kubeconfig
+
+mgmt.aks.kubeconfig.pipeline:
+	make -C .. pipeline/Management.Kubeconfig DEPLOY_ENV=$(DEPLOY_ENV)
+.PHONY: mgmt.aks.kubeconfig.pipeline
 
 mgmt.aks.kubeconfigfile:
 	@echo ${MGMT_KUBECONFIG_FILE}

--- a/dev-infrastructure/mgmt-kubeconfig.yaml
+++ b/dev-infrastructure/mgmt-kubeconfig.yaml
@@ -1,0 +1,13 @@
+$schema: "pipeline.schema.v1"
+serviceGroup: Microsoft.Azure.ARO.HCP.Management.Kubeconfig
+rolloutName: Management Cluster Kubeconfig
+resourceGroups:
+- name: mgmt
+  resourceGroup: '{{ .mgmt.rg }}'
+  subscription: '{{ .mgmt.subscription.key }}'
+  steps:
+  - name: kubeconfig
+    aksCluster: '{{ .mgmt.aks.name }}'
+    action: Shell
+    command: make mgmt.aks.kubeconfig
+    workingDir: .

--- a/dev-infrastructure/svc-kubeconfig.yaml
+++ b/dev-infrastructure/svc-kubeconfig.yaml
@@ -1,0 +1,13 @@
+$schema: "pipeline.schema.v1"
+serviceGroup: Microsoft.Azure.ARO.HCP.Service.Kubeconfig
+rolloutName: Service Cluster Kubeconfig
+resourceGroups:
+- name: service
+  resourceGroup: '{{ .svc.rg }}'
+  subscription: '{{ .svc.subscription.key }}'
+  steps:
+  - name: kubeconfig
+    aksCluster: '{{ .svc.aks.name }}'
+    action: Shell
+    command: make svc.aks.kubeconfig
+    workingDir: .

--- a/topology.yaml
+++ b/topology.yaml
@@ -90,3 +90,9 @@ services:
 - serviceGroup: Microsoft.Azure.ARO.HCP.Log.Infra
   pipelinePath: dev-infrastructure/kusto-pipeline.yaml
   purpose: Deploy the kusto log infrastructure.
+- serviceGroup: Microsoft.Azure.ARO.HCP.Service.Kubeconfig
+  pipelinePath: dev-infrastructure/svc-kubeconfig.yaml
+  purpose: Grant access to AKS SVC AKS Clusters, mainly intended for E2E test setup.
+- serviceGroup: Microsoft.Azure.ARO.HCP.Management.Kubeconfig
+  pipelinePath: dev-infrastructure/mgmt-kubeconfig.yaml
+  purpose: Grant access to AKS SVC AKS Clusters, mainly intended for E2E test setup.


### PR DESCRIPTION



<!-- Link to Jira issue -->

### What

Create pipelines to grant AKS Access.

### Why

By using a pipeline to create AKS kubeconfig files we can leverage the capabilites of templatize, mainly the feature to support switching Subscriptions for ShellSteps. With this the correct Subscription can be chosen before configuring the kubeconfig file

### Special notes for your reviewer

<!-- optional -->
