### PR TITLE
database: Improve the error message for a failed transaction

### DIFF
--- a/internal/database/transaction.go
+++ b/internal/database/transaction.go
@@ -194,12 +194,12 @@ func (t *cosmosDBTransaction) Execute(ctx context.Context, o *azcosmos.Transacti
 		}
 
 		if !response.Success {
-			for _, result := range response.OperationResults {
+			for step, result := range response.OperationResults {
 				if result.StatusCode != http.StatusFailedDependency {
 					// FIXME Return an error type that allows checking the StatusCode.
 					//       I was tempted to use azcore.ResponseError but it formats
 					//       poorly in a log message without an http.Response.
-					return nil, fmt.Errorf("%d %s", result.StatusCode, http.StatusText(int(result.StatusCode)))
+					return nil, fmt.Errorf("transaction step %d of %d failed with %d %s", step+1, len(response.OperationResults), result.StatusCode, http.StatusText(int(result.StatusCode)))
 				}
 			}
 		}


### PR DESCRIPTION
### What

Show the transaction step number that failed to aid debugging.

### Why

A recent test run failed due to a Cosmos DB transaction returning a 409 Conflict status, but it was not clear from the log message which step of the transaction failed.