### PR TITLE
add data dumps just prior to deletion and for every long running oper…

### DIFF
--- a/admin/server/handlers/cosmosdump/dump_cosmos.go
+++ b/admin/server/handlers/cosmosdump/dump_cosmos.go
@@ -15,12 +15,11 @@
 package cosmosdump
 
 import (
-	"encoding/json"
-	"errors"
 	"net/http"
 
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/errorutils"
+	"github.com/Azure/ARO-HCP/internal/serverutils"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
@@ -38,7 +37,6 @@ func (h *CosmosDumpHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 
 func (h *CosmosDumpHandler) serveHTTP(w http.ResponseWriter, request *http.Request) error {
 	ctx := request.Context()
-	logger := utils.LoggerFromContext(ctx)
 
 	// get the azure resource ID for this HCP
 	resourceID, err := utils.ResourceIDFromContext(request.Context())
@@ -46,38 +44,5 @@ func (h *CosmosDumpHandler) serveHTTP(w http.ResponseWriter, request *http.Reque
 		return utils.TrackError(err)
 	}
 
-	// load the HCP from the cosmos DB
-	cosmosCRUD, err := h.cosmosClient.UntypedCRUD(*resourceID)
-	if err != nil {
-		return utils.TrackError(err)
-	}
-	startingCosmosRecord, err := cosmosCRUD.Get(ctx, resourceID)
-	if err != nil {
-		return utils.TrackError(err)
-	}
-	allCosmosRecords, err := cosmosCRUD.ListRecursive(ctx, nil)
-	if err != nil {
-		return utils.TrackError(err)
-	}
-
-	errs := []error{}
-	content, err := json.Marshal(startingCosmosRecord)
-	if err != nil {
-		errs = append(errs, err)
-	}
-	logger.Info(string(content))
-
-	for _, typedDocument := range allCosmosRecords.Items(ctx) {
-		content, err := json.Marshal(typedDocument)
-		if err != nil {
-			errs = append(errs, err)
-		}
-		logger.Info(string(content))
-	}
-	if err := allCosmosRecords.GetError(); err != nil {
-		return utils.TrackError(err)
-	}
-
-	return utils.TrackError(errors.Join(errs...))
-
+	return serverutils.DumpDataToLogger(ctx, h.cosmosClient, resourceID)
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -19,6 +19,7 @@ require (
 	golang.org/x/sync v0.17.0
 	k8s.io/client-go v0.34.1
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d
 )
 
 require (
@@ -112,7 +113,6 @@ require (
 	k8s.io/api v0.34.1 // indirect
 	k8s.io/apimachinery v0.34.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
-	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect

--- a/internal/serverutils/dump_data.go
+++ b/internal/serverutils/dump_data.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serverutils
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func DumpDataToLogger(ctx context.Context, cosmosClient database.DBClient, resourceID *azcorearm.ResourceID) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	// load the HCP from the cosmos DB
+	cosmosCRUD, err := cosmosClient.UntypedCRUD(*resourceID)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	startingCosmosRecord, err := cosmosCRUD.Get(ctx, resourceID)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	allCosmosRecords, err := cosmosCRUD.ListRecursive(ctx, nil)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	errs := []error{}
+	content, err := json.Marshal(startingCosmosRecord)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	logger.Info(string(content))
+
+	for _, typedDocument := range allCosmosRecords.Items(ctx) {
+		content, err := json.Marshal(typedDocument)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		logger.Info(string(content))
+	}
+	if err := allCosmosRecords.GetError(); err != nil {
+		return utils.TrackError(err)
+	}
+
+	return utils.TrackError(errors.Join(errs...))
+}


### PR DESCRIPTION
…ation

We will dump about every five minutes, limited by an LRU cache to prevent explosions in logging.  Once we have a better way to hit the admin API, we can remove the periodic dump.  This will grow in value, the more information we place in cosmos and can be harvested in kusto and must-gather.
