### PR TITLE
Remove unnecessary buildtag

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -109,4 +109,4 @@ jobs:
       with:
         # The repo's top-level Makefile parses the version of golangci-lint from here
         version: v2.1.0
-        args: '-v --build-tags=containers_image_openpgp,E2Etests $(go list -f ''{{.Dir}}/...'' -m | xargs)'
+        args: '-v --build-tags=E2Etests $(go list -f ''{{.Dir}}/...'' -m | xargs)'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,6 @@ Each service follows consistent patterns:
 - Go services include standard `main.go`, `go.mod`
 
 ### Build Tags
-- Default build tags: `GOTAGS='containers_image_openpgp'`
 - Lint tags: `LINT_GOTAGS='${GOTAGS},E2Etests'`
 
 ### Infrastructure as Code

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,7 @@ include ./test/Makefile
 SHELL = /bin/bash
 PATH := $(GOBIN):$(PATH)
 
-# This build tag is currently leveraged by tooling/image-sync
-# https://github.com/containers/image?tab=readme-ov-file#building
-GOTAGS?='containers_image_openpgp'
-LINT_GOTAGS?='${GOTAGS},E2Etests'
+LINT_GOTAGS?='E2Etests'
 TOOLS_BIN_DIR := tooling/bin
 DEPLOY_ENV ?= pers
 CONFIG_FILE ?= config/config.yaml
@@ -21,7 +18,7 @@ all: test lint
 # There is currently no convenient way to run tests against a whole Go workspace
 # https://github.com/golang/go/issues/50745
 test:
-	go list -f '{{.Dir}}/...' -m |RUN_TEMPLATIZE_E2E=true xargs go test -timeout 1200s -tags=$(GOTAGS) -cover
+	go list -f '{{.Dir}}/...' -m |RUN_TEMPLATIZE_E2E=true xargs go test -timeout 1200s -cover
 .PHONY: test
 
 test-compile:


### PR DESCRIPTION
No jira

Removes the `containers_image_openpgp` build tag.  It used to be used in the image-sync go component, but we don't have it anymore.  

```
$ grep -nr "github.com/containers/image"  | grep -v .git
<no results>