### PR TITLE
Makefile: add some easier targets for validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,23 @@ test:
 	go list -f '{{.Dir}}/...' -m |RUN_TEMPLATIZE_E2E=true xargs go test -timeout 1200s -cover
 .PHONY: test
 
+test-unit:
+	go list -f '{{.Dir}}/...' -m | xargs go test -timeout 1200s -cover
+.PHONY: test-unit
+
 test-compile:
 	go list -f '{{.Dir}}/...' -m |xargs go test -c -o /dev/null
 .PHONY: test-compile
+
+generate: mocks fmt record-nonlocal-e2e all-tidy
+
+verify-generate: generate
+	./hack/verify.sh generate
+.PHONY: verify-generate
+
+verify-yamlfmt: yamlfmt
+	./hack/verify.sh yamlfmt
+.PHONY: verify-generate
 
 mocks: $(MOCKGEN) $(GOIMPORTS)
 	MOCKGEN=${MOCKGEN} go generate ./internal/mocks

--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ ! -z "$(git status --short)" ]]
+then
+  echo "there are some modified files, rerun 'make ${1:-'generate'}' to update them and check the changes in"
+  git status
+  git diff
+  exit 1
+fi


### PR DESCRIPTION
We want to run these from Prow with one easy top-level target, as each one runs in seconds and we don't need the overhead of individual jobs for them.
