### PR TITLE
test: exit early when there's no timing to analyze

### DIFF
--- a/test/cmd/aro-hcp-tests/visualize/options.go
+++ b/test/cmd/aro-hcp-tests/visualize/options.go
@@ -311,6 +311,11 @@ func (o *Options) Visualize(ctx context.Context) error {
 		return err
 	}
 
+	if len(o.Times) == 0 {
+		logger.Info("No tests seem to have run, exiting.")
+		return nil
+	}
+
 	slices.SortFunc(o.Times, func(a, b TestInfo) int {
 		t := a.StartedAt.Compare(b.StartedAt)
 		if t != 0 {


### PR DESCRIPTION
fixes this stacktrace: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/3583/pull-ci-Azure-ARO-HCP-main-e2e-parallel/1999485486850117632#1:build-log.txt%3A1499