### PR TITLE
SL global approval permissions

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,5 +3,5 @@ approvers:
   - stevekuznetsov
   - geoberle
   - bennerv
-  - janboll
+  - service-lifecycle-global-approvers
 reviewers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,19 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+
+aliases:
+  service-lifecycle-global-approvers:
+  - janboll 
+  - mmazur
+  - raelga 
+  - roivaz 
+  service-lifecycle:
+  - ashishmax31
+  - avollmer-redhat
+  - hbhushan3
+  - janboll 
+  - mmazur
+  - raelga 
+  - roivaz 
+  - sclarkso 
+  - venkateshsredhat 
+  - weherdh


### PR DESCRIPTION
Eventually most of SL will have (close to) global approval status due to requirements for regions to react to issues independently.

For now let's start smaller and we'll build to that over time.
