### PR TITLE
feat: pass azure aks mgmt cluster resource id to cs provision shard config file

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -74,6 +74,7 @@ deploy:
 	  --set shard.maestroRestUrl="http://maestro.maestro.svc.cluster.local:8000" \
 	  --set shard.maestroGrpUrl="maestro-grpc.maestro.svc.cluster.local:8090" \
 	  --set shard.Id=$(PROVISION_SHARD_ID) \
+	  --set shard.aksManagementClusterResourceId=$(AKS_MGMT_CLUSTER_RESOURCE_ID) \
 	  --set databaseHost=$${DB_HOST} \
 	  --set azureMiMockServicePrincipalPrincipalId=${AZURE_MI_MOCK_SERVICE_PRINCIPAL_PRINCIPAL_ID} \
 	  --set azureMiMockServicePrincipalClientId=${AZURE_MI_MOCK_SERVICE_PRINCIPAL_CLIENT_ID} \
@@ -146,7 +147,7 @@ local-deploy-provision-shard:
 	CX_MI_KV_URL=$(shell az keyvault show -n ${CX_MI_KV_NAME} -g ${MGMT_RESOURCEGROUP} --query properties.vaultUri -o tsv) && \
 	CX_SECRETS_KV_MI_CLIENT_ID=$(shell az aks show -n ${MGMT_AKS_NAME} -g ${MGMT_RESOURCEGROUP} --query 'addonProfiles.azureKeyvaultSecretsProvider.identity.clientId' -o tsv) && \
 	if [ -z "$${CX_SECRETS_KV_MI_CLIENT_ID}" ]; then echo "Failed to get CX_SECRETS_KV_MI_CLIENT_ID - make sure to provision a MGMT cluster first" >&2; exit 1; fi && \
-	../templatize.sh $(DEPLOY_ENV) local/provisioning-shards.tmpl.yml local/local-provisioning-shards.yml -e zoneResourceId=$${ZONE_RESOURCE_ID},cxSecretsKeyVaultUrl=$${CX_SECRETS_KV_URL},cxMiKeyVaultUrl=$${CX_MI_KV_URL},cxSecretsKeyVaultMiClientId=$${CX_SECRETS_KV_MI_CLIENT_ID},maestroRestUrl=http://localhost:8001,maestroGrpUrl=localhost:8090,shardId=$(PROVISION_SHARD_ID)
+	../templatize.sh $(DEPLOY_ENV) local/provisioning-shards.tmpl.yml local/local-provisioning-shards.yml -e zoneResourceId=$${ZONE_RESOURCE_ID},cxSecretsKeyVaultUrl=$${CX_SECRETS_KV_URL},cxMiKeyVaultUrl=$${CX_MI_KV_URL},cxSecretsKeyVaultMiClientId=$${CX_SECRETS_KV_MI_CLIENT_ID},maestroRestUrl=http://localhost:8001,maestroGrpUrl=localhost:8090,shardId=$(PROVISION_SHARD_ID),aksManagementClusterResourceId=$(AKS_MGMT_CLUSTER_RESOURCE_ID)
 	@cat local/local-provisioning-shards.yml
 
 personal-runtime-config:

--- a/cluster-service/helm-charts/cluster-service/templates/provisioning-shards.secret.yaml
+++ b/cluster-service/helm-charts/cluster-service/templates/provisioning-shards.secret.yaml
@@ -29,3 +29,4 @@ stringData:
         cx_secrets_key_vault_url: "{{ .Values.shard.cxSecretsKeyVaultUrl }}"
         cx_managed_identities_key_vault_url: "{{ .Values.shard.cxMiKeyVaultUrl }}"
         cx_secrets_key_vault_managed_identity_client_id: "{{ .Values.shard.cxSecretsKeyVaultMiClientId }}"
+        aks_management_cluster_resource_id: "{{ .Values.shard.aksManagementClusterResourceId }}"

--- a/cluster-service/helm-charts/cluster-service/values.yaml
+++ b/cluster-service/helm-charts/cluster-service/values.yaml
@@ -191,6 +191,7 @@ shard:
   cxSecretsKeyVaultMiClientId: ""
   maestroRestUrl: ""
   maestroGrpUrl: ""
+  aksManagementClusterResourceId: ""
 # ocm client id
 clientId: "foo"
 # ocm secret

--- a/cluster-service/local/provisioning-shards.tmpl.yml
+++ b/cluster-service/local/provisioning-shards.tmpl.yml
@@ -20,3 +20,4 @@ provision_shards:
     cx_secrets_key_vault_url: "{{ .extraVars.cxSecretsKeyVaultUrl }}"
     cx_managed_identities_key_vault_url: "{{ .extraVars.cxMiKeyVaultUrl }}"
     cx_secrets_key_vault_managed_identity_client_id: "{{ .extraVars.cxSecretsKeyVaultMiClientId }}"
+    aks_management_cluster_resource_id: "{{ .extraVars.aksManagementClusterResourceId }}"

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -70,6 +70,11 @@ resourceGroups:
         resourceGroup: management
         step: output
         name: azureKeyvaultSecretsProviderIdentityClientId
+    - name: AKS_MGMT_CLUSTER_RESOURCE_ID
+      input:
+        resourceGroup: management
+        step: output
+        name: azureAksManagementClusterResourceId
     - name: OPERATOR_ROLE_SET_NAME
       configRef: clustersService.azureOperatorsManagedIdentities.roleSetName
     - name: REGION

--- a/dev-infrastructure/templates/output-mgmt.bicep
+++ b/dev-infrastructure/templates/output-mgmt.bicep
@@ -9,6 +9,8 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-10-01' exis
 }
 output azureKeyvaultSecretsProviderIdentityClientId string = aksCluster.properties.addonProfiles.azureKeyvaultSecretsProvider.identity.clientId
 
+output azureAksManagementClusterResourceId string = aksCluster.id
+
 // Why not retreive the account name from config/config.yaml?
 // Because the config could contain account name with an upper case (regionShortName), storage accounts must be lower case.
 resource hcpBackupsStorageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {


### PR DESCRIPTION
In preparation for when CS starts receiving it via provision shard configuration.