### PR TITLE
e2e: add logging of cluster name and resource group

### DIFF
--- a/test/e2e/admin_credential_lifecycle.go
+++ b/test/e2e/admin_credential_lifecycle.go
@@ -84,6 +84,7 @@ var _ = Describe("Customer", func() {
 
 			_, err = framework.BeginCreateHCPCluster(
 				deploymentCtx,
+				GinkgoLogr,
 				clusterClient,
 				*resourceGroup.Name,
 				clusterName,

--- a/test/e2e/arm64_nodepool.go
+++ b/test/e2e/arm64_nodepool.go
@@ -83,7 +83,9 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam(
+				ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
 				45*time.Minute,

--- a/test/e2e/cluster_create_no_cni.go
+++ b/test/e2e/cluster_create_no_cni.go
@@ -74,7 +74,9 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating no-cni HCP cluster")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam(
+				ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
 				45*time.Minute,

--- a/test/e2e/cluster_name_validation.go
+++ b/test/e2e/cluster_name_validation.go
@@ -84,7 +84,9 @@ var _ = Describe("Customer", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 
-				err = tc.CreateHCPClusterFromParam(ctx,
+				err = tc.CreateHCPClusterFromParam(
+					ctx,
+					GinkgoLogr,
 					*resourceGroup.Name,
 					clusterParams,
 					45*time.Minute,
@@ -158,7 +160,9 @@ var _ = Describe("Customer", func() {
 				testClusterParams := baseClusterParams
 				testClusterParams.ClusterName = nameCase.clusterName
 
-				err = tc.CreateHCPClusterFromParam(ctx,
+				err = tc.CreateHCPClusterFromParam(
+					ctx,
+					GinkgoLogr,
 					*resourceGroup.Name,
 					testClusterParams,
 					45*time.Minute,

--- a/test/e2e/cluster_update.go
+++ b/test/e2e/cluster_update.go
@@ -75,7 +75,9 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				By("creating the HCP cluster")
-				err = tc.CreateHCPClusterFromParam(ctx,
+				err = tc.CreateHCPClusterFromParam(
+					ctx,
+					GinkgoLogr,
 					*resourceGroup.Name,
 					clusterParams,
 					45*time.Minute,
@@ -150,7 +152,9 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				By("creating the HCP cluster")
-				err = tc.CreateHCPClusterFromParam(ctx,
+				err = tc.CreateHCPClusterFromParam(
+					ctx,
+					GinkgoLogr,
 					*resourceGroup.Name,
 					clusterParams,
 					45*time.Minute,

--- a/test/e2e/complete_cluster_create.go
+++ b/test/e2e/complete_cluster_create.go
@@ -83,7 +83,9 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam(
+				ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
 				45*time.Minute,

--- a/test/e2e/image_registry_cluster_create.go
+++ b/test/e2e/image_registry_cluster_create.go
@@ -81,7 +81,9 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating the hcp cluster with the image registry disabled")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam(
+				ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
 				45*time.Minute,

--- a/test/util/framework/deployment_helper.go
+++ b/test/util/framework/deployment_helper.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -319,6 +321,7 @@ func ListAllOperations(
 
 func (tc *perItOrDescribeTestContext) CreateHCPClusterFromParam(
 	ctx context.Context,
+	logger logr.Logger,
 	resourceGroupName string,
 	parameters ClusterParams,
 	timeout time.Duration,
@@ -340,6 +343,7 @@ func (tc *perItOrDescribeTestContext) CreateHCPClusterFromParam(
 
 	if _, err := CreateHCPClusterAndWait(
 		ctx,
+		logger,
 		tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 		resourceGroupName,
 		clusterName,

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/sync/errgroup"
@@ -469,6 +470,7 @@ func CreateClusterRoleBinding(ctx context.Context, subject string, adminRESTConf
 
 func BeginCreateHCPCluster(
 	ctx context.Context,
+	logger logr.Logger,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
 	resourceGroupName string,
 	hcpClusterName string,
@@ -476,6 +478,7 @@ func BeginCreateHCPCluster(
 	location string,
 ) (*runtime.Poller[hcpsdk20240610preview.HcpOpenShiftClustersClientCreateOrUpdateResponse], error) {
 	cluster := BuildHCPClusterFromParams(clusterParams, location)
+	logger.Info("Starting HCP cluster creation", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName)
 	poller, err := hcpClient.BeginCreateOrUpdate(ctx, resourceGroupName, hcpClusterName, cluster, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed starting cluster creation %q in resourcegroup=%q: %w", hcpClusterName, resourceGroupName, err)
@@ -487,6 +490,7 @@ func BeginCreateHCPCluster(
 // the function won't wait for the deployment to be ready.
 func CreateHCPClusterAndWait(
 	ctx context.Context,
+	logger logr.Logger,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
 	resourceGroupName string,
 	hcpClusterName string,
@@ -499,6 +503,7 @@ func CreateHCPClusterAndWait(
 		defer cancel()
 	}
 
+	logger.Info("Starting HCP cluster creation", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName)
 	poller, err := hcpClient.BeginCreateOrUpdate(ctx, resourceGroupName, hcpClusterName, cluster, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed starting cluster creation %q in resourcegroup=%q: %w", hcpClusterName, resourceGroupName, err)


### PR DESCRIPTION
Adds cluster name and resource group on creation of an e2e cluster when using the test/util/framework helpers.  

This doesn't cover use cases for bicep as we do not inspect the bicep for an hcp resource.  The cluster name is not logged anywhere else in some tests.  