### PR TITLE
refactor: refactor helpers for admit cluster tests

### DIFF
--- a/internal/api/testhelpers.go
+++ b/internal/api/testhelpers.go
@@ -19,9 +19,12 @@ import (
 	"log/slog"
 	"path"
 	"testing"
+	"time"
 
 	"dario.cat/mergo"
 	"github.com/stretchr/testify/require"
+
+	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
@@ -139,4 +142,24 @@ func Must[T any](v T, err error) T {
 		panic(err)
 	}
 	return v
+}
+
+// CreateTestSubscription creates a test subscription with optional registered feature flags.
+// Call with no arguments for a standard subscription, or pass feature names to register them.
+func CreateTestSubscription(registeredFeatures ...string) *arm.Subscription {
+	features := make([]arm.Feature, len(registeredFeatures))
+	for i, feature := range registeredFeatures {
+		features[i] = arm.Feature{
+			Name:  ptr.To(feature),
+			State: ptr.To("Registered"),
+		}
+	}
+
+	return &arm.Subscription{
+		State:            arm.SubscriptionStateRegistered,
+		RegistrationDate: ptr.To(time.Now().Format(time.RFC1123)),
+		Properties: &arm.SubscriptionProperties{
+			RegisteredFeatures: &features,
+		},
+	}
 }


### PR DESCRIPTION
### What
Refactor the helper method used in admit_cluster_test, now this test will use the methods in testhelpers.

### Why

Follow up the comment https://github.com/Azure/ARO-HCP/pull/3140#discussion_r2585084939

