### PR TITLE
aro-21889: configure non-stable cg for dev env

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -94,6 +94,10 @@ deploy:
 	  --set ocpVersions.defaultVersion.version=${OCP_VERSIONS_DEFAULT_VERSION_VERSION} \
 	  --set ocpVersions.channelGroups.stable.minVersion=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MIN_VERSION} \
 	  --set ocpVersions.channelGroups.stable.maxVersion=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MAX_VERSION} \
+	  --set ocpVersions.channelGroups.candidate.minVersion=${OCP_VERSIONS_CHANNEL_GROUPS_CANDIDATE_MIN_VERSION} \
+	  --set ocpVersions.channelGroups.candidate.maxVersion=${OCP_VERSIONS_CHANNEL_GROUPS_CANDIDATE_MAX_VERSION} \
+	  --set ocpVersions.channelGroups.nightly.minVersion=${OCP_VERSIONS_CHANNEL_GROUPS_NIGHTLY_MIN_VERSION} \
+	  --set ocpVersions.channelGroups.nightly.maxVersion=${OCP_VERSIONS_CHANNEL_GROUPS_NIGHTLY_MAX_VERSION} \
 	  --set azureOperatorsMI.roleSetName=${OPERATOR_ROLE_SET_NAME} \
 	  --set deployment.zoneCount=${AVAILABILITY_ZONE_COUNT}
 
@@ -172,6 +176,10 @@ local-aro-hcp-ocp-versions-config:
 	--set ocpVersions.defaultVersion.version=${OCP_VERSIONS_DEFAULT_VERSION_VERSION} \
 	--set ocpVersions.channelGroups.stable.minVersion=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MIN_VERSION} \
 	--set ocpVersions.channelGroups.stable.maxVersion=${OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MAX_VERSION} \
+	--set ocpVersions.channelGroups.candidate.minVersion=${OCP_VERSIONS_CHANNEL_GROUPS_CANDIDATE_MIN_VERSION} \
+	--set ocpVersions.channelGroups.candidate.maxVersion=${OCP_VERSIONS_CHANNEL_GROUPS_CANDIDATE_MAX_VERSION} \
+	--set ocpVersions.channelGroups.nightly.minVersion=${OCP_VERSIONS_CHANNEL_GROUPS_NIGHTLY_MIN_VERSION} \
+	--set ocpVersions.channelGroups.nightly.maxVersion=${OCP_VERSIONS_CHANNEL_GROUPS_NIGHTLY_MAX_VERSION} \
 	--set azureOperatorsMI.roleSetName=${OPERATOR_ROLE_SET_NAME} \
 	-s templates/aro-hcp-ocp-versions-config.configmap.yaml | yq '.data["aro-hcp-ocp-versions-config.yaml"]' > local/aro-hcp-ocp-versions-config.yaml
 .PHONY: local-aro-hcp-ocp-versions-config

--- a/cluster-service/helm-charts/cluster-service/templates/aro-hcp-ocp-versions-config.configmap.yaml
+++ b/cluster-service/helm-charts/cluster-service/templates/aro-hcp-ocp-versions-config.configmap.yaml
@@ -15,3 +15,19 @@ data:
         {{- if .Values.ocpVersions.channelGroups.stable.maxVersion }}
         maxVersion: {{ .Values.ocpVersions.channelGroups.stable.maxVersion }}
         {{- end }}
+      {{- if .Values.ocpVersions.channelGroups.candidate.minVersion }}
+      - url: https://api.openshift.com/api/upgrades_info/graph
+        channelGroupName: candidate
+        minVersion: {{ .Values.ocpVersions.channelGroups.candidate.minVersion }}
+        {{- if .Values.ocpVersions.channelGroups.candidate.maxVersion }}
+        maxVersion: {{ .Values.ocpVersions.channelGroups.candidate.maxVersion }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.ocpVersions.channelGroups.nightly.minVersion }}
+      - url: https://multi.ocp.releases.ci.openshift.org/graph
+        channelGroupName: nightly
+        minVersion: {{ .Values.ocpVersions.channelGroups.nightly.minVersion }}
+        {{- if .Values.ocpVersions.channelGroups.nightly.maxVersion }}
+        maxVersion: {{ .Values.ocpVersions.channelGroups.nightly.maxVersion }}
+        {{- end }}
+      {{- end }}

--- a/cluster-service/helm-charts/cluster-service/values.yaml
+++ b/cluster-service/helm-charts/cluster-service/values.yaml
@@ -310,6 +310,14 @@ ocpVersions:
       url: ""
       minVersion: ""
       maxVersion: ""
+    candidate:
+      url: ""
+      minVersion: ""
+      maxVersion: ""
+    nightly:
+      url: ""
+      minVersion: ""
+      maxVersion: ""
 deployment:
   zoneCount: ""
 # controls if a debug job is deployed to the cluster.

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -165,6 +165,14 @@ resourceGroups:
       configRef: clustersService.ocpVersions.channelGroups.stable.minVersion
     - name: OCP_VERSIONS_CHANNEL_GROUPS_STABLE_MAX_VERSION
       configRef: clustersService.ocpVersions.channelGroups.stable.maxVersion
+    - name: OCP_VERSIONS_CHANNEL_GROUPS_CANDIDATE_MIN_VERSION
+      configRef: clustersService.ocpVersions.channelGroups.candidate.minVersion
+    - name: OCP_VERSIONS_CHANNEL_GROUPS_CANDIDATE_MAX_VERSION
+      configRef: clustersService.ocpVersions.channelGroups.candidate.maxVersion
+    - name: OCP_VERSIONS_CHANNEL_GROUPS_NIGHTLY_MIN_VERSION
+      configRef: clustersService.ocpVersions.channelGroups.nightly.minVersion
+    - name: OCP_VERSIONS_CHANNEL_GROUPS_NIGHTLY_MAX_VERSION
+      configRef: clustersService.ocpVersions.channelGroups.nightly.maxVersion
     # this is maestro consumer registration stuff
     # this goes away when we have a real registration process
     - name: CONSUMER_NAME

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -55,6 +55,10 @@
       "type": "string",
       "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
     },
+    "semVerWithPrerelease": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+    },
     "k8sRollingUpdateDeploymentStrategy": {
       "type": "object",
       "description": "Spec to control the desired behavior of rolling update.",
@@ -1105,6 +1109,70 @@
                       "oneOf": [
                         {
                           "$ref": "#/definitions/semVer"
+                        },
+                        {
+                          "type": "string",
+                          "pattern": "^$"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "minVersion",
+                    "maxVersion"
+                  ],
+                  "additionalProperties": false
+                },
+                "candidate": {
+                  "type": "object",
+                  "properties": {
+                    "minVersion": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/definitions/semVerWithPrerelease"
+                        },
+                        {
+                          "type": "string",
+                          "pattern": "^$"
+                        }
+                      ]
+                    },
+                    "maxVersion": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/definitions/semVerWithPrerelease"
+                        },
+                        {
+                          "type": "string",
+                          "pattern": "^$"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "minVersion",
+                    "maxVersion"
+                  ],
+                  "additionalProperties": false
+                },
+                "nightly": {
+                  "type": "object",
+                  "properties": {
+                    "minVersion": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/definitions/semVerWithPrerelease"
+                        },
+                        {
+                          "type": "string",
+                          "pattern": "^$"
+                        }
+                      ]
+                    },
+                    "maxVersion": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/definitions/semVerWithPrerelease"
                         },
                         {
                           "type": "string",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -903,6 +903,12 @@ clouds:
             stable:
               minVersion: 4.19.0
               maxVersion: 4.20.6
+            candidate:
+              minVersion: 4.19.7
+              maxVersion: ""
+            nightly:
+              minVersion: 4.19.0-0.nightly-20200101
+              maxVersion: ""
       # Hypershift Operator
       hypershift:
         image:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,22 +3,22 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 7f7994c0ae30631510d63bff30dea6f212cf6b6fbbe225a73dd9e04fff441773
+          westus3: 253ece6f973334508bfc97a566b161f93e16686a80856fac229a1227ef3edb17
       dev:
         regions:
-          westus3: 860aa60f3bbe4699e42d0f1b0459ad4466470328cfe83f8a664c5feadbd7d52f
+          westus3: 12cfdff07c02cd70138251b597f869e631244d7523d3c6254e2c92ff808b4db2
       ntly:
         regions:
-          uksouth: 65582939a142ee5dc8494dfef7441f3ddf54b0bcd415d641bc03fe963bd2d7b9
+          uksouth: fdb3c7f547dadfe023597e13dcdfcc81fbacefb3374ab3a3054e8e88d09a4692
       perf:
         regions:
-          westus3: cb05c39b3de3e3dfb83ed34d6a0e196aa673ea2da7b2142314a669fc87847cad
+          westus3: 64ed3cd82f5dbe42eda5dda39475a46f49e8aa909f9b4f2f5df5b39a1d9cbe53
       pers:
         regions:
-          westus3: 1688e1fb04846627e73d4984f2fefec8daa41b7d5a398de3a8c20be7ec15ac8f
+          westus3: a93b1b648c9f710f710218c4f5861ee1ac3313aa7c43d82c8e8e676cdb456f17
       prow:
         regions:
-          westus3: c8d584efdf537eac23672710df6b4b24808a42b3e3b48b785294563b24b26551
+          westus3: d527bf8de405107f9dd672cfb672de003cc29658f8741f5d68835b6ab88e9bc3
       swft:
         regions:
-          uksouth: a2a61b677e61d8698d49c45c7424392b37b1b473db4c5e43cc6c666b7d8927b3
+          uksouth: 5f2095c5b81d002ec3d45f5d90a86375d809cf7737cee688781c03bed87ec703

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -139,6 +139,12 @@ clustersService:
   managedIdentityName: clusters-service
   ocpVersions:
     channelGroups:
+      candidate:
+        maxVersion: ""
+        minVersion: 4.19.7
+      nightly:
+        maxVersion: ""
+        minVersion: 4.19.0-0.nightly-20200101
       stable:
         maxVersion: 4.20.6
         minVersion: 4.19.0

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -139,6 +139,12 @@ clustersService:
   managedIdentityName: clusters-service
   ocpVersions:
     channelGroups:
+      candidate:
+        maxVersion: ""
+        minVersion: 4.19.7
+      nightly:
+        maxVersion: ""
+        minVersion: 4.19.0-0.nightly-20200101
       stable:
         maxVersion: 4.20.6
         minVersion: 4.19.0

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -139,6 +139,12 @@ clustersService:
   managedIdentityName: clusters-service
   ocpVersions:
     channelGroups:
+      candidate:
+        maxVersion: ""
+        minVersion: 4.19.7
+      nightly:
+        maxVersion: ""
+        minVersion: 4.19.0-0.nightly-20200101
       stable:
         maxVersion: 4.20.6
         minVersion: 4.19.0

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -139,6 +139,12 @@ clustersService:
   managedIdentityName: clusters-service
   ocpVersions:
     channelGroups:
+      candidate:
+        maxVersion: ""
+        minVersion: 4.19.7
+      nightly:
+        maxVersion: ""
+        minVersion: 4.19.0-0.nightly-20200101
       stable:
         maxVersion: 4.20.6
         minVersion: 4.19.0

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -139,6 +139,12 @@ clustersService:
   managedIdentityName: clusters-service
   ocpVersions:
     channelGroups:
+      candidate:
+        maxVersion: ""
+        minVersion: 4.19.7
+      nightly:
+        maxVersion: ""
+        minVersion: 4.19.0-0.nightly-20200101
       stable:
         maxVersion: 4.20.6
         minVersion: 4.19.0

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -139,6 +139,12 @@ clustersService:
   managedIdentityName: clusters-service
   ocpVersions:
     channelGroups:
+      candidate:
+        maxVersion: ""
+        minVersion: 4.19.7
+      nightly:
+        maxVersion: ""
+        minVersion: 4.19.0-0.nightly-20200101
       stable:
         maxVersion: 4.20.6
         minVersion: 4.19.0

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -139,6 +139,12 @@ clustersService:
   managedIdentityName: clusters-service
   ocpVersions:
     channelGroups:
+      candidate:
+        maxVersion: ""
+        minVersion: 4.19.7
+      nightly:
+        maxVersion: ""
+        minVersion: 4.19.0-0.nightly-20200101
       stable:
         maxVersion: 4.20.6
         minVersion: 4.19.0


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-21889

### What
This commit adds:
- a new definition for semVer with prerelease information
- candidate a nightly configuration support
- candidate is configured in dev envs to fetch version from [4.19.8, 4.21.0)
- nightly is configured in dev envs to fetch versions from [4.19.0, 4.21.0)

### Why

We want to be able to configure non-stable channel groups, such as nightly and candidate, different for each environment. With this change we add the support to do so and configure dev environments.

### Special notes for your reviewer

We should to make sure this change doesn't affect the other environments: int, stage, prod. 

Manual tested, deployed the infra and checked configMap is configured correctly for personal dev environment:

```
    defaultVersion:
      channelGroupName: stable
      version: 4.19.7
    channelGroups:
      - url: https://api.openshift.com/api/upgrades_info/graph
        channelGroupName: stable
        minVersion: 4.19.0
        maxVersion: 4.20.6
      - url: https://api.openshift.com/api/upgrades_info/graph
        channelGroupName: candidate
        minVersion: 4.19.7
      - url: https://multi.ocp.releases.ci.openshift.org/graph
        channelGroupName: nightly
        minVersion: 4.19.0-0.nightly-20200101
```
