### PR TITLE
Fix usePooledIdentities param wiring in e2e bicep

### DIFF
--- a/test/e2e-setup/bicep/cluster-nodepool-osdisk.bicep
+++ b/test/e2e-setup/bicep/cluster-nodepool-osdisk.bicep
@@ -9,6 +9,9 @@ param clusterName string
 @description('Managed identities to use')
 param identities object
 
+@description('When true, use the pre-created MSI pool instead of creating identities in the cluster resource group')
+param usePooledIdentities bool = false
+
 @description('Node pool osDisk Size in GiB')
 param nodePoolOsDiskSizeGiB int = 128
 
@@ -32,6 +35,7 @@ module managedIdentities 'modules/managed-identities.bicep' = {
     msiResourceGroupName: identities.resourceGroup
     clusterResourceGroupName: resourceGroup().name
     identities: identities.identities
+    useMsiPool: usePooledIdentities
     vnetName: customerInfra.outputs.vnetName
     subnetName: customerInfra.outputs.vnetSubnetName
     nsgName: customerInfra.outputs.nsgName

--- a/test/e2e-setup/bicep/cluster-only.bicep
+++ b/test/e2e-setup/bicep/cluster-only.bicep
@@ -9,6 +9,9 @@ param clusterName string
 @description('Managed identities to use')
 param identities object
 
+@description('When true, use the pre-created MSI pool instead of creating identities in the cluster resource group')
+param usePooledIdentities bool = false
+
 module customerInfra 'modules/customer-infra.bicep' = {
   name: 'customerInfra'
   params: {
@@ -23,6 +26,7 @@ module managedIdentities 'modules/managed-identities.bicep' = {
     msiResourceGroupName: identities.resourceGroup
     clusterResourceGroupName: resourceGroup().name
     identities: identities.identities
+    useMsiPool: usePooledIdentities
     vnetName: customerInfra.outputs.vnetName
     subnetName: customerInfra.outputs.vnetSubnetName
     nsgName: customerInfra.outputs.nsgName

--- a/test/e2e-setup/bicep/demo.bicep
+++ b/test/e2e-setup/bicep/demo.bicep
@@ -9,6 +9,9 @@ param clusterName string
 @description('Managed identities to use')
 param identities object
 
+@description('When true, use the pre-created MSI pool instead of creating identities in the cluster resource group')
+param usePooledIdentities bool = false
+
 module customerInfra 'modules/customer-infra.bicep' = {
   name: 'customerInfra'
   params: {
@@ -23,6 +26,7 @@ module managedIdentities 'modules/managed-identities.bicep' = {
     msiResourceGroupName: identities.resourceGroup
     clusterResourceGroupName: resourceGroup().name
     identities: identities.identities
+    useMsiPool: usePooledIdentities
     vnetName: customerInfra.outputs.vnetName
     subnetName: customerInfra.outputs.vnetSubnetName
     nsgName: customerInfra.outputs.nsgName


### PR DESCRIPTION
Fixes e2e errors related to bicep params. See https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel/2001243164727316480

Bug introduced with https://github.com/Azure/ARO-HCP/pull/3366