### PR TITLE
Make the managed-identities.bicep sub scoped deployment name unique across e2e jobs

### DIFF
--- a/test/e2e-setup/bicep/cluster-nodepool-osdisk.bicep
+++ b/test/e2e-setup/bicep/cluster-nodepool-osdisk.bicep
@@ -29,7 +29,7 @@ module customerInfra 'modules/customer-infra.bicep' = {
 }
 
 module managedIdentities 'modules/managed-identities.bicep' = {
-  name: 'managedIdentities'
+  name: 'mi-${resourceGroup().name}'
   scope: subscription()
   params: {
     msiResourceGroupName: identities.resourceGroup

--- a/test/e2e-setup/bicep/cluster-only.bicep
+++ b/test/e2e-setup/bicep/cluster-only.bicep
@@ -20,7 +20,7 @@ module customerInfra 'modules/customer-infra.bicep' = {
 }
 
 module managedIdentities 'modules/managed-identities.bicep' = {
-  name: 'managedIdentities'
+  name: 'mi-${resourceGroup().name}'
   scope: subscription()
   params: {
     msiResourceGroupName: identities.resourceGroup

--- a/test/e2e-setup/bicep/demo.bicep
+++ b/test/e2e-setup/bicep/demo.bicep
@@ -20,7 +20,7 @@ module customerInfra 'modules/customer-infra.bicep' = {
 }
 
 module managedIdentities 'modules/managed-identities.bicep' = {
-  name: 'managedIdentities'
+  name: 'mi-${resourceGroup().name}'
   scope: subscription()
   params: {
     msiResourceGroupName: identities.resourceGroup


### PR DESCRIPTION
The managed-identities.bicep module is now subscription scoped and the name of the deployment needs to be unique across tests and jobs to avoid several tests from trying to act on the same deployment.
This was already done in https://github.com/Azure/ARO-HCP/blob/ea0975dc0259e9443aa96275cfbd92d25c08e793/test/util/framework/identities_helper.go#L163 for all other tests, but was missing from tests that use a different setup with a parent bicep module that orchestrates the whole test setup.
