### PR TITLE
changing tmp file location for edge cases

### DIFF
--- a/tooling/image-updater/internal/yaml/editor.go
+++ b/tooling/image-updater/internal/yaml/editor.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -129,10 +130,16 @@ func (e *Editor) ApplyUpdates(updates []Update) error {
 	}
 	defer file.Close()
 
-	tempFile, err := os.CreateTemp("/tmp", strings.Split(e.filePath, "/")[len(strings.Split(e.filePath, "/"))-1])
+	targetDir := filepath.Dir(e.filePath)
+	targetName := filepath.Base(e.filePath)
+
+	tempFile, err := os.CreateTemp(targetDir, targetName+".*")
 	if err != nil {
 		return fmt.Errorf("failed to create temp file for %s: %v", e.filePath, err)
 	}
+
+	// Ensure temp file is cleaned up if we panic or error out early
+	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
 	scanner := bufio.NewScanner(file)


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What
Changes the location the temp file is created in from /tmp to the repo itself.

### Why
If /tmp is mounted on a different partition, os.rename fails due to a cross-link error.  

### Special notes for your reviewer

