### PR TITLE
test: allow re-trying APIService verifier for some time

### DIFF
--- a/test/util/verifiers/apiservice.go
+++ b/test/util/verifiers/apiservice.go
@@ -19,8 +19,12 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	apiregistrationv1client "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
@@ -39,43 +43,82 @@ func (v verifyAllAPIServicesAvailableImpl) Verify(ctx context.Context, adminREST
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 
-	allAPIServices, err := apiserviceClient.APIServices().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to list all APIServices: %w", err)
-	}
+	retryCtx, cancel := context.WithTimeoutCause(ctx, 5*time.Minute, errors.New("API service retry timeout"))
+	defer cancel()
 
-	requiredAPIServices := set.New("v1.route.openshift.io")
-	foundAPIServices := set.Set[string]{}
-	unavailableAPIServices := []apiregistrationv1.APIService{}
-	for _, apiService := range allAPIServices.Items {
-		foundAPIServices.Insert(apiService.Name)
-		availableConditon := getAPIServiceCondition(apiService.Status.Conditions, "Available")
-		if availableConditon == nil {
-			unavailableAPIServices = append(unavailableAPIServices, apiService)
-			continue
+	attempts := 0
+	var lastErr error
+	verifyErr := wait.ExponentialBackoffWithContext(retryCtx, wait.Backoff{
+		Duration: 800 * time.Millisecond,
+		Factor:   2,
+		Jitter:   0.1,
+		Steps:    10,
+		Cap:      20 * time.Second,
+	}, func(ctx context.Context) (done bool, err error) {
+		attempts++
+
+		allAPIServices, err := apiserviceClient.APIServices().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to list all APIServices: %w", err)
 		}
-		if availableConditon.Status != "True" {
-			unavailableAPIServices = append(unavailableAPIServices, apiService)
-			continue
-		}
-	}
-	if len(unavailableAPIServices) != 0 {
-		failureReasonErrs := []error{}
-		for _, unavailableAPIService := range unavailableAPIServices {
-			availableCondition := getAPIServiceCondition(unavailableAPIService.Status.Conditions, "Available")
-			if availableCondition == nil {
-				failureReasonErrs = append(failureReasonErrs, fmt.Errorf("apiservice/%s is not available because it has no status", unavailableAPIService.Name))
-			} else {
-				failureReasonErrs = append(failureReasonErrs, fmt.Errorf("apiservice/%s is not available because: %v", unavailableAPIService.Name, availableCondition.Message))
+
+		requiredAPIServices := set.New("v1.route.openshift.io")
+		foundAPIServices := set.Set[string]{}
+		unavailableAPIServices := []apiregistrationv1.APIService{}
+		for _, apiService := range allAPIServices.Items {
+			foundAPIServices.Insert(apiService.Name)
+			availableConditon := getAPIServiceCondition(apiService.Status.Conditions, "Available")
+			if availableConditon == nil {
+				unavailableAPIServices = append(unavailableAPIServices, apiService)
+				continue
+			}
+			if availableConditon.Status != "True" {
+				unavailableAPIServices = append(unavailableAPIServices, apiService)
+				continue
 			}
 		}
-		return errors.Join(failureReasonErrs...)
-	}
-	if !foundAPIServices.HasAll(requiredAPIServices.UnsortedList()...) {
-		return fmt.Errorf("required apiservices are missing: %v", strings.Join(requiredAPIServices.Difference(foundAPIServices).SortedList(), ", "))
+		if len(unavailableAPIServices) != 0 {
+			failureReasonErrs := []error{}
+			for _, unavailableAPIService := range unavailableAPIServices {
+				availableCondition := getAPIServiceCondition(unavailableAPIService.Status.Conditions, "Available")
+				if availableCondition == nil {
+					failureReasonErrs = append(failureReasonErrs, fmt.Errorf("apiservice/%s is not available because it has no status", unavailableAPIService.Name))
+				} else {
+					failureReasonErrs = append(failureReasonErrs, fmt.Errorf("apiservice/%s is not available because: %v", unavailableAPIService.Name, availableCondition.Message))
+				}
+			}
+			ginkgo.GinkgoLogr.Info("APIServices not yet ready.", "errors", errors.Join(failureReasonErrs...))
+			lastErr = errors.Join(failureReasonErrs...)
+			return false, nil
+		}
+		if !foundAPIServices.HasAll(requiredAPIServices.UnsortedList()...) {
+			ginkgo.GinkgoLogr.Info("required apiservices are missing", "missing", strings.Join(requiredAPIServices.Difference(foundAPIServices).SortedList(), ", "))
+			lastErr = fmt.Errorf("required apiservices are missing: %v", strings.Join(requiredAPIServices.Difference(foundAPIServices).SortedList(), ", "))
+			return false, nil
+		}
+		return true, nil
+	})
+
+	deadline, err := time.Parse(time.RFC3339, "2026-01-15T00:00:00Z")
+	if err != nil {
+		return fmt.Errorf("failed to parse deadline: %w", err)
 	}
 
-	return nil
+	if attempts > 1 && time.Now().After(deadline) {
+		return errors.New("the APIService verifier is not allowed to re-try after Jan 15th, 2026 - HyperShift should only post ready status once aggregated APIs are ready then")
+	}
+
+	if verifyErr == nil {
+		// even if we had an error at some point, the loop succeeded on the last run
+		return nil
+	}
+	if lastErr != nil {
+		// if the loop failed, and we have some specific error that caused it, return that so
+		// our consumers don't just get a "context deadline exceeded"
+		return lastErr
+	}
+
+	return verifyErr
 }
 
 func verifyAllAPIServicesAvailable() HostedClusterVerifier {


### PR DESCRIPTION
HyperShift currently doesn't wait for aggregated API servers to be ready before determining that a HostedCluster is finshed provisioning. They have committed to fixing this soon, but we're flaking on our cluster verifiers in the interim. This fix hopefully ameliorates our flakes while not papering over this issue forever.
