### PR TITLE
Remove unused "systemAgentPoolCount" bicep param

### DIFF
--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -13,7 +13,6 @@ param aksEtcdKVEnableSoftDelete = {{ .mgmt.aks.etcd.softDelete }}
 param systemAgentMinCount = {{ .mgmt.aks.systemAgentPool.minCount}}
 param systemAgentMaxCount = {{ .mgmt.aks.systemAgentPool.maxCount }}
 param systemAgentVMSize = '{{ .mgmt.aks.systemAgentPool.vmSize }}'
-param systemAgentPoolCount = {{ .mgmt.aks.systemAgentPool.poolCount }}
 param systemAgentPoolZones = '{{ .mgmt.aks.systemAgentPool.zones }}'
 param systemOsDiskSizeGB = {{ .mgmt.aks.systemAgentPool.osDiskSizeGB }}
 param systemZoneRedundantMode = '{{ .mgmt.aks.systemAgentPool.zoneRedundantMode }}'

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -16,7 +16,6 @@ param aksKeyVaultTagValue = '{{ .svc.aks.etcd.tagValue }}'
 param aksEtcdKVEnableSoftDelete = {{ .svc.aks.etcd.softDelete }}
 param systemAgentMinCount = {{ .svc.aks.systemAgentPool.minCount}}
 param systemAgentMaxCount = {{ .svc.aks.systemAgentPool.maxCount }}
-param systemAgentPoolCount = {{ .svc.aks.systemAgentPool.poolCount }}
 param systemAgentPoolZones = '{{ .svc.aks.systemAgentPool.zones }}'
 param systemAgentVMSize = '{{ .svc.aks.systemAgentPool.vmSize }}'
 param systemZoneRedundantMode = '{{ .svc.aks.systemAgentPool.zoneRedundantMode }}'

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -330,7 +330,6 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-10-01' = {
         kubeletDiskType: 'OS'
         osDiskType: 'Ephemeral'
         osDiskSizeGB: systemOsDiskSizeGB
-        count: systemAgentMinCount
         minCount: systemAgentMinCount
         maxCount: systemAgentMaxCount
         vmSize: systemAgentVMSize

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -81,9 +81,6 @@ param systemAgentMaxCount int = 3
 @description('VM instance type for the system nodes')
 param systemAgentVMSize string = 'Standard_D2s_v3'
 
-@description('Number of pools to create for system nodes')
-param systemAgentPoolCount int
-
 @description('Zones to use for the system nodes')
 param systemAgentPoolZones string
 
@@ -342,7 +339,6 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     systemAgentMinCount: systemAgentMinCount
     systemAgentMaxCount: systemAgentMaxCount
     systemAgentVMSize: systemAgentVMSize
-    systemAgentPoolCount: systemAgentPoolCount
     systemAgentPoolZones: length(csvToArray(systemAgentPoolZones)) > 0
       ? csvToArray(systemAgentPoolZones)
       : locationAvailabilityZoneList

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -26,9 +26,6 @@ param systemAgentMaxCount int
 @description('VM instance type for the system nodes')
 param systemAgentVMSize string
 
-@description('Number of pools to create for system nodes')
-param systemAgentPoolCount int
-
 @description('Zones to use for the system nodes')
 param systemAgentPoolZones string
 
@@ -570,7 +567,6 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     systemAgentMinCount: systemAgentMinCount
     systemAgentMaxCount: systemAgentMaxCount
     systemAgentVMSize: systemAgentVMSize
-    systemAgentPoolCount: systemAgentPoolCount
     systemAgentPoolZones: length(csvToArray(systemAgentPoolZones)) > 0
       ? csvToArray(systemAgentPoolZones)
       : locationAvailabilityZoneList


### PR DESCRIPTION
Remove the `systemAgentPoolCount` unused parameter.  

Also no longer specify count in the AKS base, if we specify min/max, we let the autoscaler handle the count for us and resource allocation.  

We were already specifying the count as the min, so this shouldn't change any behavior.  