### PR TITLE
fix: channelGroup configuration

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -724,6 +724,12 @@ defaults:
         stable:
           minVersion: 4.19.0
           maxVersion: 4.19.8
+        candidate:
+          minVersion: ""
+          maxVersion: ""
+        nightly:
+          minVersion: ""
+          maxVersion: ""
   # Image Sync
   imageSync:
     environmentName: aro-hcp-image-sync
@@ -906,10 +912,8 @@ clouds:
               maxVersion: 4.20.6
             candidate:
               minVersion: 4.19.7
-              maxVersion: ""
             nightly:
               minVersion: 4.19.0-0.nightly-20200101
-              maxVersion: ""
       # Hypershift Operator
       hypershift:
         image:


### PR DESCRIPTION
### What
This commits adds empty configuration in the global configuration for candidate and nightly 

### Why
Previous change https://github.com/Azure/ARO-HCP/pull/3631 added a bug for integration builds.

### Special notes for your reviewer

I wanted to add them as optional, but they are required for the Makefile. So this is the easy fix for this problem. 
