### PR TITLE
Grant Permissions to CS Global Approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,4 +4,5 @@ approvers:
   - geoberle
   - bennerv
   - service-lifecycle-global-approvers
+  - clusters-service-global-approvers
 reviewers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -17,3 +17,6 @@ aliases:
   - sclarkso 
   - venkateshsredhat 
   - weherdh
+  clusters-service-global-approvers:
+  - zgalor
+


### PR DESCRIPTION
Add CS Global Approvers alias to Maintainers
Initially, add zgalor as an approver

