### PR TITLE
increasing max user nodepool size to decrease timeout failures

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1001,7 +1001,7 @@ clouds:
             maxCount: 4
             poolCount: 1
           userAgentPool:
-            maxCount: 6
+            maxCount: 14
             vmSize: 'Standard_D4s_v3'
             osDiskSizeGB: 100
           infraAgentPool:
@@ -1420,7 +1420,7 @@ clouds:
                 osDiskSizeGB: 32
                 vmSize: Standard_D2s_v3
               userAgentPool:
-                maxCount: 6
+                maxCount: 14
                 osDiskSizeGB: 100
                 vmSize: Standard_D4s_v3
               infraAgentPool:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -9,7 +9,7 @@ clouds:
           westus3: fdc4153aab061397bf8a31f765a61382dc91a3fb5f83548d31ac469bfec65afc
       ntly:
         regions:
-          uksouth: 1b67cfe2d1295d3f5b00881a70443d3ff963f677516b88274e7cb891e354744a
+          uksouth: 1784486f39fb5a56322033243be91fe04e03d3c6880d3ee230ee253a3a93d731
       perf:
         regions:
           westus3: d3596878288ab2e3c16b582ed197a1e43aa1c643047922565c09dcb0716e03dc
@@ -18,7 +18,7 @@ clouds:
           westus3: 2fb34d723c262fb634c891aab36bb78030970fc3b635466f949125a264adb90d
       prow:
         regions:
-          westus3: 8233b541cf9302edce5675e61c7072de7cfc918124fcb1b7ff4dc1e6a4eb6e09
+          westus3: e470f71535126f3c3fe44d5ebd1f0ab03ccd3cc2540d56882dc26015ad92484c
       swft:
         regions:
           uksouth: a05026ca896f30ae925c7e326d2de7994487b62a67ccc763af2aacad89b41484

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -453,7 +453,7 @@ mgmt:
       zoneRedundantMode: Auto
       zones: ""
     userAgentPool:
-      maxCount: 6
+      maxCount: 14
       minCount: 1
       osDiskSizeGB: 100
       poolCount: 3

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -453,7 +453,7 @@ mgmt:
       zoneRedundantMode: Auto
       zones: ""
     userAgentPool:
-      maxCount: 6
+      maxCount: 14
       minCount: 1
       osDiskSizeGB: 100
       poolCount: 3


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

increases the max size of the user nodepool 

### Why

kube-apiserver replicasets were timing out on e2e tests and the nodepool events had errors claiming no nodes were available, and they could not be scaled because maximum number had been reached.  

### Special notes for your reviewer

<!-- optional -->
