### PR TITLE
fix subscription resolution in GetAllRequiredAzureClients

### DIFF
--- a/tooling/templatize/cmd/entrypoint/run/options.go
+++ b/tooling/templatize/cmd/entrypoint/run/options.go
@@ -121,7 +121,7 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 }
 
 func (o *Options) Run(ctx context.Context) error {
-	subscriptionIdToAzureConfigDirectory, err := pipeline.GetAllRequiredAzureClients(ctx, o.Pipelines)
+	subscriptionIdToAzureConfigDirectory, err := pipeline.GetAllRequiredAzureClients(ctx, o.Pipelines, o.Subscriptions)
 	if err != nil {
 		return fmt.Errorf("failed to get all required Azure clients: %w", err)
 	}

--- a/tooling/templatize/cmd/pipeline/run/options.go
+++ b/tooling/templatize/cmd/pipeline/run/options.go
@@ -106,7 +106,7 @@ func (o *ValidatedRunOptions) Complete(ctx context.Context) (*RunOptions, error)
 }
 
 func (o *RunOptions) RunPipeline(ctx context.Context) error {
-	subscriptionIdToAzureConfigDirectory, err := pipeline.GetAllRequiredAzureClients(ctx, map[string]*types.Pipeline{"default": o.PipelineOptions.Pipeline})
+	subscriptionIdToAzureConfigDirectory, err := pipeline.GetAllRequiredAzureClients(ctx, map[string]*types.Pipeline{"default": o.PipelineOptions.Pipeline}, o.PipelineOptions.RolloutOptions.Subscriptions)
 	if err != nil {
 		return fmt.Errorf("failed to get all required Azure clients: %w", err)
 	}

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -754,10 +754,10 @@ func getAllSubscriptions(pipelines map[string]*types.Pipeline) []string {
 	return allSubs
 }
 
-func GetAllRequiredAzureClients(ctx context.Context, pipelines map[string]*types.Pipeline) (map[string]string, error) {
+func GetAllRequiredAzureClients(ctx context.Context, pipelines map[string]*types.Pipeline, subscriptions map[string]string) (map[string]string, error) {
 	subscriptionIdToAzureConfigDirectory := make(map[string]string)
 	for _, subscription := range getAllSubscriptions(pipelines) {
-		subscriptionID, err := LookupSubscriptionID(map[string]string{})(ctx, subscription)
+		subscriptionID, err := LookupSubscriptionID(subscriptions)(ctx, subscription)
 		if err != nil {
 			return nil, fmt.Errorf("failed to lookup subscription ID for %q: %w", subscription, err)
 		}


### PR DESCRIPTION
### What

- Adds subscriptions parameter to GetAllRequiredAzureClients signature
- Updates both pipeline and entrypoint callers to pass subscription maps

### Why

The GetAllRequiredAzureClients function was passing an empty map to LookupSubscriptionID, causing it to skip the dev-settings subscription mappings and attempt Azure API lookup by name. This failed for logical subscription names like "classic-global" that don't match Azure subscription display names.

### Special notes for your reviewer

<!-- optional -->
