### PR TITLE
removing non azure offering flavour id - osd

### DIFF
--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -58,7 +58,6 @@ import (
 // See docs/api-version-defaults-and-storage.md for the full design rationale.
 
 const (
-	csFlavourId        string = "osd-4" // managed cluster
 	csCloudProvider    string = "azure"
 	csProductId        string = "aro"
 	csHypershifEnabled bool   = true
@@ -880,8 +879,6 @@ func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpC
 
 	clusterBuilder.
 		Name(strings.ToLower(hcpCluster.Name)).
-		Flavour(arohcpv1alpha1.NewFlavour().
-			ID(csFlavourId)).
 		Region(arohcpv1alpha1.NewCloudRegion().
 			ID(hcpCluster.Location)).
 		CloudProvider(arohcpv1alpha1.NewCloudProvider().

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -592,8 +592,6 @@ func ocmClusterDefaults(azureLocation string) *arohcpv1alpha1.ClusterBuilder {
 		CloudProvider(arohcpv1alpha1.NewCloudProvider().
 			ID("azure")).
 		DomainPrefix("testcluster").
-		Flavour(arohcpv1alpha1.NewFlavour().
-			ID("osd-4")).
 		Hypershift(arohcpv1alpha1.NewHypershift().
 			Enabled(true)).
 		Name(strings.ToLower(api.TestClusterName)).

--- a/test-integration/admin/artifacts/AdminCRUD/HCP/breakglass/01-loadClusterService-initial-state/01-cluster.json
+++ b/test-integration/admin/artifacts/AdminCRUD/HCP/breakglass/01-loadClusterService-initial-state/01-cluster.json
@@ -49,10 +49,6 @@
 		"id": "azure",
 		"kind": "CloudProvider"
 	},
-	"flavour": {
-		"id": "osd-4",
-		"kind": "Flavour"
-	},
 	"href": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
 	"hypershift": {
 		"enabled": true

--- a/test-integration/admin/artifacts/AdminCRUD/HCP/cosmosdump/01-loadClusterService-initial-state/01-cluster.json
+++ b/test-integration/admin/artifacts/AdminCRUD/HCP/cosmosdump/01-loadClusterService-initial-state/01-cluster.json
@@ -49,10 +49,6 @@
 		"id": "azure",
 		"kind": "CloudProvider"
 	},
-	"flavour": {
-		"id": "osd-4",
-		"kind": "Flavour"
-	},
 	"href": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
 	"hypershift": {
 		"enabled": true

--- a/test-integration/admin/artifacts/AdminCRUD/HCP/hello-world/01-loadClusterService-initial-state/01-cluster.json
+++ b/test-integration/admin/artifacts/AdminCRUD/HCP/hello-world/01-loadClusterService-initial-state/01-cluster.json
@@ -49,10 +49,6 @@
 		"id": "azure",
 		"kind": "CloudProvider"
 	},
-	"flavour": {
-		"id": "osd-4",
-		"kind": "Flavour"
-	},
 	"href": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
 	"hypershift": {
 		"enabled": true

--- a/test-integration/admin/artifacts/AdminCRUD/HCP/lowercase-middleware/01-loadClusterService-initial-state/01-cluster.json
+++ b/test-integration/admin/artifacts/AdminCRUD/HCP/lowercase-middleware/01-loadClusterService-initial-state/01-cluster.json
@@ -50,10 +50,6 @@
 		"id": "azure",
 		"kind": "CloudProvider"
 	},
-	"flavour": {
-		"id": "osd-4",
-		"kind": "Flavour"
-	},
 	"href": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
 	"hypershift": {
 		"enabled": true

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/present_cluster/00-loadClusterService-initial_state/0_.api.clusters_mgmt.v1.clusters-create-with-tags-cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/present_cluster/00-loadClusterService-initial_state/0_.api.clusters_mgmt.v1.clusters-create-with-tags-cluster.json
@@ -49,10 +49,6 @@
 		"id": "azure",
 		"kind": "CloudProvider"
 	},
-	"flavour": {
-		"id": "osd-4",
-		"kind": "Flavour"
-	},
 	"href": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 	"hypershift": {
 		"enabled": true

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.9p2sk955gj-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.9p2sk955gj-cluster.json
@@ -49,10 +49,6 @@
 		"id": "azure",
 		"kind": "CloudProvider"
 	},
-	"flavour": {
-		"id": "osd-4",
-		"kind": "Flavour"
-	},
 	"href": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
 	"hypershift": {
 		"enabled": true

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/cluster-creating/01-loadClusterService-cluster/cs-cluster-creating-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/cluster-creating/01-loadClusterService-cluster/cs-cluster-creating-cluster.json
@@ -58,10 +58,6 @@
 		"id": "azure",
 		"kind": "CloudProvider"
 	},
-	"flavour": {
-		"id": "osd-4",
-		"kind": "Flavour"
-	},
 	"href": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-creating",
 	"hypershift": {
 		"enabled": true

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/cluster-deleting/01-loadClusterService-cluster/cs-cluster-deleting-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/cluster-deleting/01-loadClusterService-cluster/cs-cluster-deleting-cluster.json
@@ -58,10 +58,6 @@
 		"id": "azure",
 		"kind": "CloudProvider"
 	},
-	"flavour": {
-		"id": "osd-4",
-		"kind": "Flavour"
-	},
 	"href": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-deleting",
 	"hypershift": {
 		"enabled": true

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters-create-with-tags-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters-create-with-tags-cluster.json
@@ -49,10 +49,6 @@
 		"id": "azure",
 		"kind": "CloudProvider"
 	},
-	"flavour": {
-		"id": "osd-4",
-		"kind": "Flavour"
-	},
 	"href": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf",
 	"hypershift": {
 		"enabled": true

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.9p2sk955gj-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.9p2sk955gj-cluster.json
@@ -49,10 +49,6 @@
 		"id": "azure",
 		"kind": "CloudProvider"
 	},
-	"flavour": {
-		"id": "osd-4",
-		"kind": "Flavour"
-	},
 	"href": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
 	"hypershift": {
 		"enabled": true

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-creating/01-loadClusterService-cluster/cluster-creating-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-creating/01-loadClusterService-cluster/cluster-creating-cluster.json
@@ -58,10 +58,6 @@
 		"id": "azure",
 		"kind": "CloudProvider"
 	},
-	"flavour": {
-		"id": "osd-4",
-		"kind": "Flavour"
-	},
 	"href": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-creating",
 	"hypershift": {
 		"enabled": true

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-deleting/01-loadClusterService-cluster/cluster-deleting-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-deleting/01-loadClusterService-cluster/cluster-deleting-cluster.json
@@ -58,10 +58,6 @@
 		"id": "azure",
 		"kind": "CloudProvider"
 	},
-	"flavour": {
-		"id": "osd-4",
-		"kind": "Flavour"
-	},
 	"href": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-deleting",
 	"hypershift": {
 		"enabled": true

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.9p2sk955gj-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.9p2sk955gj-cluster.json
@@ -49,10 +49,6 @@
 		"id": "azure",
 		"kind": "CloudProvider"
 	},
-	"flavour": {
-		"id": "osd-4",
-		"kind": "Flavour"
-	},
 	"href": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
 	"hypershift": {
 		"enabled": true


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-20748

### What
Code changes to remove all identified non-Azure offering names ([osd-4](https://issues.redhat.com//browse/osd-4))  throughout the ARO HCP system.
Investigation results are documented with this issue : https://issues.redhat.com/browse/ARO-23124

