### PR TITLE
Remove make operator-roles for now

### DIFF
--- a/.github/workflows/aro-hcp-cd.yml
+++ b/.github/workflows/aro-hcp-cd.yml
@@ -91,7 +91,8 @@ jobs:
         make global acr
 
         # Setup operator roles for platform workload identity
-        make operator-roles
+        # jboll disabled for now until permissions are resolved
+        # make operator-roles
 
         # Manage Kusto in Dev
         make kusto


### PR DESCRIPTION


<!-- Link to Jira issue -->

### What

Remove make operator-roles for now

### Why

It requires elevated permissions on e2e sub, which need to be granted by cloudops first

### Special notes for your reviewer

<!-- optional -->
