### PR TITLE
feat: bump ocp version stable maxVersion to 4.20.9

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -723,7 +723,7 @@ defaults:
       channelGroups:
         stable:
           minVersion: 4.19.0
-          maxVersion: 4.19.8
+          maxVersion: 4.20.9
         candidate:
           minVersion: ""
           maxVersion: ""
@@ -907,9 +907,6 @@ clouds:
           defaultVersion:
             version: 4.19.7
           channelGroups:
-            stable:
-              minVersion: 4.19.0
-              maxVersion: 4.20.6
             candidate:
               minVersion: 4.19.7
             nightly:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,22 +3,22 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: a4022ca6391054c4dd0e1cff980b93219da3cf78912a38d4c52dfa9ec306774a
+          westus3: 58a8ee6639f9c985f9bd8fabd3ae996c071e0a04eeae856957e42958f8b8b85f
       dev:
         regions:
-          westus3: 40562e7d2d688a10e13e1b087dc545e337643f46f2c8052080fe350717b30134
+          westus3: 90d7ceb11f93a6da5d3efe0713832d151380d19b651a2cf54eb45b915d5627a4
       ntly:
         regions:
-          uksouth: 608c4bef5d55d2bfb16f314502d112051daf29fb9db7a85431d831932ccc1dc3
+          uksouth: fee8b4f3e562cb2f34c1744a3f70423d15c7399d1457ea3aa4cd838d94e70663
       perf:
         regions:
-          westus3: a4739062e40f13e88cf5a487ba0a86769b186089d3d10c44a9c0be4af035db09
+          westus3: 1dc39a0ff704d6637b084c2fe2388927ef73a48d677bc2a8a0ffd7b9f1027984
       pers:
         regions:
-          westus3: b7ddfe0c8f40540dc854d2e1e2cdecfddb8090adcbd3ff8fd37e1fbd7b421aaa
+          westus3: b6a215d4f447ac88610a511535822d2d646020eb9c66b6c922e560b743cf46d5
       prow:
         regions:
-          westus3: ae9e80a858ac7c80eabb4d66b176f81b7a9bed44c73fa74210fc818fd51b69d8
+          westus3: 2739aaca01d83bde47cdc867f6b5e83a1ca413ea474b489aea0a2fa4ed713b02
       swft:
         regions:
-          uksouth: c3107df67b6234292af85beaa366869ee4c71eae8a5315dd92f22b3c2312923e
+          uksouth: 4c4de5ccee452805731fd786b5c3b981dcd5f09d98c50e81e5afaeea87ab176c

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -146,7 +146,7 @@ clustersService:
         maxVersion: ""
         minVersion: 4.19.0-0.nightly-20200101
       stable:
-        maxVersion: 4.20.6
+        maxVersion: 4.20.9
         minVersion: 4.19.0
     defaultVersion:
       version: 4.19.7

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -146,7 +146,7 @@ clustersService:
         maxVersion: ""
         minVersion: 4.19.0-0.nightly-20200101
       stable:
-        maxVersion: 4.20.6
+        maxVersion: 4.20.9
         minVersion: 4.19.0
     defaultVersion:
       version: 4.19.7

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -146,7 +146,7 @@ clustersService:
         maxVersion: ""
         minVersion: 4.19.0-0.nightly-20200101
       stable:
-        maxVersion: 4.20.6
+        maxVersion: 4.20.9
         minVersion: 4.19.0
     defaultVersion:
       version: 4.19.7

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -146,7 +146,7 @@ clustersService:
         maxVersion: ""
         minVersion: 4.19.0-0.nightly-20200101
       stable:
-        maxVersion: 4.20.6
+        maxVersion: 4.20.9
         minVersion: 4.19.0
     defaultVersion:
       version: 4.19.7

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -146,7 +146,7 @@ clustersService:
         maxVersion: ""
         minVersion: 4.19.0-0.nightly-20200101
       stable:
-        maxVersion: 4.20.6
+        maxVersion: 4.20.9
         minVersion: 4.19.0
     defaultVersion:
       version: 4.19.7

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -146,7 +146,7 @@ clustersService:
         maxVersion: ""
         minVersion: 4.19.0-0.nightly-20200101
       stable:
-        maxVersion: 4.20.6
+        maxVersion: 4.20.9
         minVersion: 4.19.0
     defaultVersion:
       version: 4.19.7

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -146,7 +146,7 @@ clustersService:
         maxVersion: ""
         minVersion: 4.19.0-0.nightly-20200101
       stable:
-        maxVersion: 4.20.6
+        maxVersion: 4.20.9
         minVersion: 4.19.0
     defaultVersion:
       version: 4.19.7


### PR DESCRIPTION
### What
Updates the maxVersion of the stable channel in the ocp versions configuration to 4.20.9 in order to allow cluster and nodepool creation up to 4.20.8 (maxVersion is exclusive).

JIRA: [ARO-23275](https://issues.redhat.com/browse/ARO-23275)

### Why
4.20.8 will be the target z stream version for 4.20 moving forward as it contains a few required bug fixes and features including one that allows us to remove hardcoded rhcos images in cs.

minVersion needs to stay the same as we still require supporting 4.19 (default version has not been updated yet) and 4.20.5 (currently used by e2e tests)

### Special notes for your reviewer
A separate PR will be created in sdp-pipelines to bump the maxVersions for higher envs.
