### PR TITLE
Fix Kusto output

### DIFF
--- a/dev-infrastructure/configurations/kusto-lookup.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/kusto-lookup.tmpl.bicepparam
@@ -2,4 +2,4 @@ using '../templates/kusto-lookup.bicep'
 
 param kustoName = '{{ .kusto.kustoName }}'
 
-param manageInstance = {{ .kusto.manageInstance }}
+param kustoEnabled = {{ .arobit.kusto.enabled }}

--- a/dev-infrastructure/templates/kusto-lookup.bicep
+++ b/dev-infrastructure/templates/kusto-lookup.bicep
@@ -1,13 +1,13 @@
 @description('Name of the Kusto cluster to lookup')
 param kustoName string
 
-@description('Toggle if instance should be created/managed')
-param manageInstance bool
+@description('Toggle if instance is expected to exist')
+param kustoEnabled bool
 
-resource kusto 'Microsoft.Kusto/clusters@2024-04-13' existing = if (manageInstance) {
+resource kusto 'Microsoft.Kusto/clusters@2024-04-13' existing = if (kustoEnabled) {
   name: kustoName
 }
 
-output kustoResourceId string = manageInstance ? kusto.id : ''
-output kustoUri string = manageInstance ? kusto.properties.uri : ''
-output kustoDataIngestionUri string = manageInstance ? kusto.properties.dataIngestionUri : ''
+output kustoResourceId string = kustoEnabled ? kusto.id : ''
+output kustoUri string = kustoEnabled ? kusto.properties.uri : ''
+output kustoDataIngestionUri string = kustoEnabled ? kusto.properties.dataIngestionUri : ''


### PR DESCRIPTION
[AROSLSRE-245](https://issues.redhat.com/browse/AROSLSRE-245)
<!-- Link to Jira issue -->

### What

Use arobit toggle and not manage instance toggle for output.

### Why

This fixes the conditional kusto deployment. The output should only expect the kusto to be there if we actually want to use it (enable arobit output). The manageinstance flag is there to check if we actually want to deploy kusto.

### Special notes for your reviewer

<!-- optional -->
