### PR TITLE
define CS provision shard maestro config as structured yaml and remove unneeded attribute

### DIFF
--- a/cluster-service/helm-charts/cluster-service/templates/provisioning-shards.secret.yaml
+++ b/cluster-service/helm-charts/cluster-service/templates/provisioning-shards.secret.yaml
@@ -16,7 +16,6 @@ stringData:
           url: "{{ .Values.shard.maestroGrpUrl }}"
         consumer_name: "{{ .Values.shard.consumerName }}"
       status: active
-      management_cluster_id: local-cluster
       region: '{{ .Values.region }}'
       cloud_provider: azure
       topology: dedicated

--- a/cluster-service/local/provisioning-shards.tmpl.yml
+++ b/cluster-service/local/provisioning-shards.tmpl.yml
@@ -7,7 +7,6 @@ provision_shards:
       url: "{{ .extraVars.maestroGrpUrl }}"
     consumer_name: "{{ .maestro.agent.consumerName }}"
   status: active
-  management_cluster_id: local-cluster
   region: '{{ .region }}'
   cloud_provider: azure
   topology: dedicated


### PR DESCRIPTION
We change the maestro config definition within the provision
shard configuration as fully structured yaml. Before it was
an inline json which was more error prone.

This change is possible because we rolled out a new change in CS
that allows defining the maestro configuration of the provision
shard as structured yaml instead of as inline json as an alternative.

Additionally, we remove the management_cluster_id attribute from CS provision shard config.
That attribute represented the K8s Namespace where ACM expects
ManifestWorks to be created in the Management Cluster. That name was
confusing because it could be confused with an Azure AKS Management Cluster
Resource ID.

In CS we renamed the attribute to
`management_cluster_acm_manifestworks_k8s_namespace`, we also default
it to `local-cluster` and we also limit the set of accepted values to
that one.

We remove the setting of the `management_cluster_id` attribute because
of the mentioned reasons above. This will default that K8s Namespace
to `local-cluster` which means no change in behavior should occur with
this change.
