### PR TITLE
chore: add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ node_modules
 .DS_Store
 .idea
 env
+# Ignore .envrc files managed
+# by direnv https://github.com/direnv/direnv
+.envrc
 */archive.tar.gz
 tooling/bin
 **/venv


### PR DESCRIPTION
We add .envrc files to .gitignore. .envrc files are managed by direnv https://github.com/direnv/direnv to automatically load and unload environment variables depending on a directory. Some developers make use of that tool locally.

By adding it to .gitignore we prevent the .envrc files to be committed.