### PR TITLE
feat: update the aro-hcp openshift 4.20 patch version to 4.20.8

### DIFF
--- a/internal/ocm/client.go
+++ b/internal/ocm/client.go
@@ -30,7 +30,7 @@ import (
 // The patch version is managed by Red Hat.
 const (
 	OpenShift419Patch = "7"
-	OpenShift420Patch = "5"
+	OpenShift420Patch = "8"
 )
 
 type ClusterServiceClientSpec interface {

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -293,7 +293,7 @@ func TestWithImmutableAttributes(t *testing.T) {
 				},
 			},
 			want: ocmCluster(t, ocmClusterDefaults().Version(
-				arohcpv1alpha1.NewVersion().ID("openshift-v4.20.5").ChannelGroup("stable"))),
+				arohcpv1alpha1.NewVersion().ID("openshift-v4.20.8").ChannelGroup("stable"))),
 		},
 	}
 


### PR DESCRIPTION
### What
Updates the 4.20 patch version from '5' to '8' to allow 4.20.8 cluster installation.

JIRA: https://issues.redhat.com/browse/ARO-23276

### Why
4.20.8 will be the target z stream version for 4.20 moving forward as it contains a few required bug fixes and features including one that allows us to remove hardcoded rhcos images in cs.

### Special notes for your reviewer
We will roll out the CS config changes to make 4.20.8 available and this change in the RP at the same time to limit the amount of rollouts we'll need to do.
