### PR TITLE
fix: ensure needed variables for frontend make run target are set

### DIFF
--- a/frontend/Env.mk
+++ b/frontend/Env.mk
@@ -1,3 +1,5 @@
 LOCATION ?= {{ .region }}
 ARO_HCP_IMAGE_ACR ?= {{ .acr.svc.name }}
 FRONTEND_IMAGE_REPOSITORY ?= {{ .frontend.image.repository }}
+DB_NAME ?= {{ .frontend.cosmosDB.name }}
+DB_URL ?= $(shell az cosmosdb show -n {{ .frontend.cosmosDB.name }} -g {{ .regionRG }} --query documentEndpoint -o tsv)

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -31,11 +31,10 @@ $(BINARY): $(FRONTEND_SOURCES)
 	go build $(LDFLAGS) -o $(BINARY) .
 
 run: $(BINARY)
-	DB_URL=$$(az cosmosdb show -n ${DB_NAME} -g ${REGION_RG} --query documentEndpoint -o tsv) && \
-	./$(BINARY)--location ${LOCATION} \
+	./$(BINARY) --location ${LOCATION} \
 		--clusters-service-url http://localhost:8000 \
 		--cosmos-name ${DB_NAME} \
-		--cosmos-url $${DB_URL}
+		--cosmos-url ${DB_URL}
 .PHONY: run
 
 clean:


### PR DESCRIPTION
The run target of the frontend's Makefile was not working because some of the variables that it referenced were not being set correctly.

This commit updates Frontend's Env.mk to ensure that those end up being resolved and resolved with the expected contents when it is included in the Makefile via the setup-templatize-env.mk in the project root.