### PR TITLE
bump ACM, MCE and Hypershift to latest

### DIFF
--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/values.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/values.yaml
@@ -1,11 +1,11 @@
 global:
   registryOverride: "registry.redhat.io/rhacm2"
   imageOverrides:
-    governance_policy_propagator: "governance-policy-propagator-rhel9@sha256:bbff1fa137214e11fc55edde3d0b7de25523ebef9c980c5bc3d84ed11d373e97"
-    governance_policy_addon_controller: "acm-governance-policy-addon-controller-rhel9@sha256:9dcd0d480a1aa1db1d982274b519338c7d8b75615bcec27a1fc7057a59ac307c"
-    config_policy_controller: "config-policy-controller-rhel9@sha256:1719ea5703c52e6ffa48c1319bbe240e927a6a163cbb7b9bcda0426b723912cb"
-    governance_policy_framework_addon: "acm-governance-policy-framework-addon-rhel9@sha256:ccb35702bb05e2277c93fdec1ffd9cdcea6287532b660f49ee3b97c67148bfb5"
-    klusterlet_addon_controller: "klusterlet-addon-controller-rhel9@sha256:ee8cde7e724f2debdfa9373ca9e56b05119a932c2a18275bfb9e633da5c26e60"
+    governance_policy_propagator: "governance-policy-propagator-rhel9@sha256:bbd724abad609b92e1785ad341ce0be9c76d19e7033866a044cbfdafcfc071fb"
+    governance_policy_addon_controller: "acm-governance-policy-addon-controller-rhel9@sha256:accd90b16bfda9bc1d42fede26e26c99f26f57a33fa9b5eeb4015632ee857be1"
+    config_policy_controller: "config-policy-controller-rhel9@sha256:1a375bf5af02ad89f2fe99884bc25dab77297c4874b5b0b9399bc6ff32a80c14"
+    governance_policy_framework_addon: "acm-governance-policy-framework-addon-rhel9@sha256:04426848b606dde8d417a5624b740f53eee74c859ded04eac15a3c3170fe1c12"
+    klusterlet_addon_controller: "klusterlet-addon-controller-rhel9@sha256:ad37b85c2d2e7471b634046704ea350e0a071b160d3a6df1f49fa8150a818194"
   namespace: multicluster-engine
   pullSecret: open-cluster-management-image-pull-credentials
   cma:

--- a/acm/deploy/helm/multicluster-engine-crds/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.11.0-141
+appVersion: 2.11.0-156
 description: A Helm chart for multicluster-engine - CRDs
 keywords:
 - mce
@@ -7,6 +7,6 @@ keywords:
 - multiclusterengine
 name: multicluster-engine-crds
 sources:
-- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:bd3cf8f532917c0b7492af3276f36140edd32709c91295992f4c26e8cd4fd0a0
+- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:0a4143f5c0ea610a64e6912cf05475449823ac4cc28a4150d5cf5f85d1f115c9
 type: application
-version: 2.11.0-141
+version: 2.11.0-156

--- a/acm/deploy/helm/multicluster-engine/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.11.0-141
+appVersion: 2.11.0-156
 description: A Helm chart for multicluster-engine
 keywords:
 - mce
@@ -7,6 +7,6 @@ keywords:
 - multiclusterengine
 name: multicluster-engine
 sources:
-- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:bd3cf8f532917c0b7492af3276f36140edd32709c91295992f4c26e8cd4fd0a0
+- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:0a4143f5c0ea610a64e6912cf05475449823ac4cc28a4150d5cf5f85d1f115c9
 type: application
-version: 2.11.0-141
+version: 2.11.0-156

--- a/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
+++ b/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
@@ -56,90 +56,92 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: OPERAND_IMAGE_ADDON_MANAGER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/addon-manager-rhel9@sha256:106959b6df70a2c73c97707efe9d05ae22d9ce052e2695581aa2c12ae312b43f'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/addon-manager-rhel9@sha256:822be7194548a12ee27d40badb3221650cc38c4db33fb058472e062539723fb5'
         - name: OPERAND_IMAGE_AZURE_SERVICE_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/azure-service-operator-rhel9@sha256:18d182872fe290f442cae5f004023d49d9289231c981756dd9657634cb45c80a'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/azure-service-operator-rhel9@sha256:9770815f1bd20b030f8b313fe62cfe6421f62419b583c414deb90f0d20c0b596'
         - name: OPERAND_IMAGE_BACKPLANE_MUST_GATHER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/must-gather-rhel9@sha256:4499f71cd6d02de437ec3934e792f129e15c3c9ddb72f540e41063423a424416'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/must-gather-rhel9@sha256:82aa85617806d25eb06a7381f7ecdb157cfb955e8bec88edd377253b3787f7a1'
         - name: OPERAND_IMAGE_BACKPLANE_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:22a5f3820b091789746f403ad88f04f2c432b9eb8db00da366d8e617b24df019'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:62a62f57a7b9b3dae76afdf52c0f559515c7f6779f144d007650fe9f096d2969'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AGENT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-agent-rhel9@sha256:d2fea62f1fc8d4530001d9cdcee613493bd9c77f4f4b174573d1b20cdda90835'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-agent-rhel9@sha256:93d691bd3cf91967b2c4d588a996c61eeabf19a8022dad2f08cf1c78b9a83065'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AWS_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-aws-rhel9@sha256:599f183e1304302dffa0853250877c957d8f77209fc1e713756a479c548e9b74'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-aws-rhel9@sha256:b80bb449ec03538a35113509ee61d57a26cfeb29e43b6c9641ebd8f5fd00ba3f'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AZURE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-azure-rhel9@sha256:380bb69df82a27a806d1f2e587e600eb64cad4250c89cb49be4727070cf4f8dc'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-azure-rhel9@sha256:e34be0ae9b352e56ac6590ea24b1b2ee2166918a5ab315fd3ce6c0dcefe32726'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_KUBEVIRT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-kubevirt-rhel9@sha256:890bcc1d0f59f33be538da108731a25dbb01f1dc2dcb87b3ffa212bbc6685897'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-kubevirt-rhel9@sha256:302578a11c2139af3ba177f8814b33c49d93c8f50f1f1ec244442105cb2d4add'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_OPENSHIFT_ASSISTED_BOOTSTRAP
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-bootstrap-rhel9@sha256:2abcfd9e7fa1b628b014f06d13e105b15c05d11b11874209da157d71f943cb34'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-bootstrap-rhel9@sha256:655ccc06b85487c73c0b407a6bbf4383410a8633240a084d57a368968e93ea0b'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_OPENSHIFT_ASSISTED_CONTROL_PLANE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-control-plane-rhel9@sha256:ffc50a302f9062dad5c4858b084c8c54602dd44d4b7bc019cf10f00f5f4907c6'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-control-plane-rhel9@sha256:9501170b2b9dbb36d22d6436f47ccaa8028835fbd21b1fb890269f9743c01b32'
         - name: OPERAND_IMAGE_MCE_CAPI_WEBHOOK_CONFIG_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/mce-capi-webhook-config-rhel9@sha256:1b41b3f26aa84327a1e686079f97f05bbb6e817be1d902b3aca7afa77d34237b'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/mce-capi-webhook-config-rhel9@sha256:406df167a9277f9657fac0ec153788fddb7b394c6140ff169d83961056a9f960'
         - name: OPERAND_IMAGE_CLUSTERCLAIMS_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterclaims-controller-rhel9@sha256:fbdefd85783e9d7b0e8873708102ebbaba610ebd68dff85066e18fa323c32330'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterclaims-controller-rhel9@sha256:5f8e3119e352379e069d4d40003d1a9e5a383ed37e507e950e2074de9e2a0717'
         - name: OPERAND_IMAGE_CLUSTER_CURATOR_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-curator-controller-rhel9@sha256:e164758346ceb6a9e73886600b6311143c5e6a7b53ec15d746efa99b00823efd'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-curator-controller-rhel9@sha256:acd6955b7d5d8f675fae0d5f3e8e7dbb9b4b7b633e08d614970ebbd4965c9098'
         - name: OPERAND_IMAGE_CLUSTER_IMAGE_SET_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-image-set-controller-rhel9@sha256:772994ac33a6636b238a16197f007439bd754c16457a66240ac2434ae32129e7'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-image-set-controller-rhel9@sha256:ecdb848581b260352d52d6537449efc62dbfdb2a401edb101e2f3c2f167f87b3'
         - name: OPERAND_IMAGE_CLUSTERLIFECYCLE_STATE_METRICS
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterlifecycle-state-metrics-rhel9@sha256:b948080629dc1b38a0226f740690d5f932e2e282228e5a48d438b42deda95cc1'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterlifecycle-state-metrics-rhel9@sha256:60ca5a412d66dfd58dcfb369f1bebb1770fc38699dc081f95a233900c075c5f8'
         - name: OPERAND_IMAGE_CLUSTER_PROXY
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-proxy-rhel9@sha256:ce064dad6217047e272c2b0256e91c7c7096b44a53bf244aac1041e81678375d'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-proxy-rhel9@sha256:465ff1e1b2d3cfbb24f6413fabe582edd33dea8a08378341a94c1de88641e5db'
         - name: OPERAND_IMAGE_CONSOLE_MCE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/console-mce-rhel9@sha256:6d9c46d8d5ce78c3ad4cf230fa0aa254f6567e20f665db204707e7fb7daff14d'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/console-mce-rhel9@sha256:ca9d64a72ea851490bead26185c1468907e4fdafc9ace4e0954b4ee64795fb2c'
         - name: OPERAND_IMAGE_DISCOVERY_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/discovery-rhel9@sha256:d09a27fad30581bf47698f734cd69daba975e952598b2e083f42ca8865fe3ba9'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/discovery-rhel9@sha256:d93fe88b07dca82a08b631cad91a03f58bab92715e1a340c2ec6a4e1c5133f0c'
         - name: OPERAND_IMAGE_OPENSHIFT_HIVE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hive-rhel9@sha256:6e634cd12d87db720ba3e950548ea4442ba456411c2f29ab8672c6cc338877fc'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hive-rhel9@sha256:1af7c85e114edd78bdba3de0178ad8c0f4853cd244b489bc45ad688680a20c3b'
         - name: OPERAND_IMAGE_HYPERSHIFT_ADDON_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-addon-rhel9-operator@sha256:9bae6233f966393dff70bbfc7ff5a22a627e9323943e234da61620e326667215'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-addon-rhel9-operator@sha256:08c6695411dd2921a3886f7ac1c41cbacb834ec428f9001b2fd98b3580a67263'
         - name: OPERAND_IMAGE_HYPERSHIFT_CLI
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-cli-rhel9@sha256:508fc94c6f22c2db0f76d35a556fc62e6bd42faf873559229d554dcdc04ab2a7'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-cli-rhel9@sha256:c4b0d97e40a668d461da280970c6b8beac62147d54896337854b1343dc45cb74'
         - name: OPERAND_IMAGE_HYPERSHIFT_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-rhel9-operator@sha256:9bebdf848852e3f8da8b8b9293f7aeb24762be7f95d46d7461aad46d4c51f7b2'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-rhel9-operator@sha256:349c1864d47eadd29f1ba5d7964bc3a32eac2b011b6a8a165d87a50a564c8aff'
         - name: OPERAND_IMAGE_IMAGE_BASED_INSTALL_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/image-based-install-rhel9@sha256:a121ac2281b5648c9cd176ec8b908d663bb232384f3b12ef1e9c42903b8d62bf'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/image-based-install-rhel9@sha256:0ae03f7efbfa4e564f16506e94e5076cf902506bc59b1a28599e642a22a9075b'
         - name: OPERAND_IMAGE_KUBE_RBAC_PROXY_MCE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/kube-rbac-proxy-mce-rhel9@sha256:6ebfff5958114bdcaab520947fb4d8048488d4034b4a0075c8108f08a534ed8d'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/kube-rbac-proxy-mce-rhel9@sha256:93841caef555d495a29b8361892105b2a2dcf19a35ce29b1918cca1e2d132407'
         - name: OPERAND_IMAGE_MANAGEDCLUSTER_IMPORT_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/managedcluster-import-controller-rhel9@sha256:8da412ec7b2ce91920c43017da12eefe1da081141e3dfab364a61b566dcec7f2'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/managedcluster-import-controller-rhel9@sha256:dbde74d30226d4871745e3f242984a2c417e53e5daa86608c55f1f8067f03416'
         - name: OPERAND_IMAGE_MANAGED_SERVICEACCOUNT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/managed-serviceaccount-rhel9@sha256:84090620b53b3f229fae3f34f3bf16f314df55d321f09b3cb0d770050b82f58b'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/managed-serviceaccount-rhel9@sha256:7112acb569d43d61cec8551c046ffb2326ea69f62f9aae4312d060395b873bad'
         - name: OPERAND_IMAGE_MULTICLOUD_MANAGER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/multicloud-manager-rhel9@sha256:a107edcf1a033b0b2f200790715bb029c724f9e17befa9d7568604b7c61c4a15'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/multicloud-manager-rhel9@sha256:a52772aa208dcc2f332754a6ff1213903b8165ee217c0a76ab8dd0229e045710'
         - name: OPERAND_IMAGE_PROVIDER_CREDENTIAL_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/provider-credential-controller-rhel9@sha256:111e87cbfdaf8ac0394f4ff40c835e173cff28dbee3f53b6796acae3b0bbd1ce'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/provider-credential-controller-rhel9@sha256:4e788430905d3b7b7a6cb9c93a28aaf42e36b5a3a965d1be561f76631972c7fc'
         - name: OPERAND_IMAGE_PLACEMENT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/placement-rhel9@sha256:4a5b50f768002c97479b9a33e57d427d040ef0b0ab11c83a308eb8b74ae8269b'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/placement-rhel9@sha256:15fdeca3fec38a0aff4a222f47ce3941f6fb74bb675473126821542935dc75a5'
         - name: OPERAND_IMAGE_REGISTRATION
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-rhel9@sha256:63d216964131fc944413403c0ddf9c54f75daf4a950003cf84db03547a5fe8e0'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-rhel9@sha256:d0a24e13d3bdcdea7b9e1fd3873f78b84afb71c8ab1559ff5f6771d5cee34b4c'
         - name: OPERAND_IMAGE_REGISTRATION_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-operator-rhel9@sha256:0a4298423909b7a4dc60869e87f68807b6290e11123be563ceb7f6107754695e'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-operator-rhel9@sha256:02a4c491fc3d36022f7ab3a8847b7dca8a9d4471312ca7b72bf6fe629b365602'
         - name: OPERAND_IMAGE_WORK
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/work-rhel9@sha256:b7f051905dc444c30ca163fb1e4da3b70a606adcb6bbe0d8f15a86fe74cf2268'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/work-rhel9@sha256:16218938c610cb743d055771e98c512711f6e80496564b5ebd2eaa7b34ca6333'
         - name: OPERAND_IMAGE_ASSISTED_IMAGE_SERVICE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-image-service-rhel9@sha256:9602fb0b986ccf8e2adc5c4e184d776fd582b0506994cb5bfa68ef40b98aa120'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-image-service-rhel9@sha256:5f41abafe6e982b22353fd41fe01be9da4ea480fe412124b3f88f75c69b310aa'
         - name: OPERAND_IMAGE_ASSISTED_INSTALLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-installer-rhel9@sha256:f203b59c12befca273493454259c180100e16ca5ae8437e71b8846f1a547f435'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-installer-rhel9@sha256:85b6773e31d01fe9182248315aa17c5d5cacd03e3bd55b77592dba90b99d9b81'
         - name: OPERAND_IMAGE_ASSISTED_INSTALLER_AGENT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-installer-agent-rhel9@sha256:6c72e4d5fbf050c2431a71e2bd8e200ec4ff53bc9e574f00558a90764bdf7847'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-installer-agent-rhel9@sha256:bbc8bf25847bb8b18f840b56afe394b8b10f2ba874e1a65df2e11b0029321603'
         - name: OPERAND_IMAGE_ASSISTED_INSTALLER_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-installer-controller-rhel9@sha256:25ad49633939d0fa82fd6d4fa81c9c96f867b38b31647003da9db0827569b2f8'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-installer-controller-rhel9@sha256:52220ed5e4b12def3536aab4617e8dd43311477db2f3605da6d1b1bc0c41a228'
         - name: OPERAND_IMAGE_ASSISTED_SERVICE_9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-service-9-rhel9@sha256:a3aebe9e4e5561b6f60f495a2475a21ebd60314019910cb2943d7dce736ea556'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-service-9-rhel9@sha256:fbee4e454a73dbb2741a20d56f605bf1f8555015911838b2a6461bb5a5a5a856'
         - name: OPERAND_IMAGE_OSE_CLUSTER_API_RHEL9
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-cluster-api-rhel9@sha256:abc97e6baa9060739781041b3674f536e1f7975f42857745836745aaea9bd047'
         - name: OPERAND_IMAGE_OSE_BAREMETAL_CLUSTER_API_CONTROLLERS_RHEL9
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-baremetal-cluster-api-controllers-rhel9@sha256:aec3f1ac219ef6fece04bfef7fb69f27683d2842ef713d30c0a5a2fa5e363574'
         - name: OPERAND_IMAGE_POSTGRESQL_12
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/postgresql-12@sha256:af1ab437b165fa4ee9dfd6ade637d7de5fa556d0b3851fb8edc78afe0e6fa95e'
+        - name: OPERAND_IMAGE_POSTGRESQL_13
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/postgresql-13@sha256:87efd49e2cb5ad857dffb126f4b365bd790fd722bcd4acf1e936287ec46d2816'
         - name: OPERATOR_VERSION
-          value: 2.11.0-141
+          value: 2.11.0-156
         - name: OPERATOR_PACKAGE
           value: multicluster-engine
-        image: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:22a5f3820b091789746f403ad88f04f2c432b9eb8db00da366d8e617b24df019'
+        image: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:62a62f57a7b9b3dae76afdf52c0f559515c7f6779f144d007650fe9f096d2969'
         livenessProbe:
           httpGet:
             path: /healthz

--- a/acm/deploy/helm/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
+++ b/acm/deploy/helm/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
@@ -1973,8 +1973,10 @@ spec:
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/ose-baremetal-cluster-api-controllers-rhel9@sha256:1234567890'
         - name: OPERAND_IMAGE_POSTGRESQL_12
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/postgresql-12@sha256:1234567890'
+        - name: OPERAND_IMAGE_POSTGRESQL_13
+          value: 'arohcpsvcdev.azurecr.io/acm-d-cache/postgresql-13@sha256:1234567890'
         - name: OPERATOR_VERSION
-          value: 2.11.0-141
+          value: 2.11.0-156
         - name: OPERATOR_PACKAGE
           value: multicluster-engine
         image: 'arohcpsvcdev.azurecr.io/acm-d-cache/backplane-rhel9-operator@sha256:1234567890'

--- a/acm/deploy/helm/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
+++ b/acm/deploy/helm/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
@@ -1,7 +1,6 @@
 ---
 # Source: multicluster-engine-local-cluster/charts/policy/crds/agent.open-cluster-management.io_klusterletaddonconfigs_crd.yaml
 # Copyright (c) 2020 Red Hat, Inc.
-
 # Copyright Contributors to the Open Cluster Management project
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/acm/deploy/helm/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
+++ b/acm/deploy/helm/testdata/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
@@ -1,6 +1,7 @@
 ---
 # Source: multicluster-engine-local-cluster/charts/policy/crds/agent.open-cluster-management.io_klusterletaddonconfigs_crd.yaml
 # Copyright (c) 2020 Red Hat, Inc.
+
 # Copyright Contributors to the Open Cluster Management project
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -82,7 +82,7 @@ clouds:
           # Hypershift
           hypershift:
             image:
-              digest: sha256:35789a5a7582bc9d4a796f247beafa6db1e06b59e8afd6c9f78fa3375ddf97d1 # 780f88b8979b363b5e65665242a9297fbaf806a7 (2025-12-19 17:34)
+              digest: sha256:1e735c123c9319eec7e7f19c93f4aaf809f8ed6226823d5d3024b7141cc544da # 1e735c123c9319eec7e7f19c93f4aaf809f8ed6226823d5d3024b7141cc544da (2026-01-6 11:30)
           # Maestro
           maestro:
             image:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -666,13 +666,13 @@ defaults:
       bundle:
         registry: quay.io
         repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
-        digest: sha256:a4e84e310476fb50044ed56b9560cca774f6c745671e3d446a4e299436b8576e # v2.16.0-111 (2025-12-23 04:25)
+        digest: sha256:25f29adbc56e0f65e85a86d376e69ce27a21c60b7e7f3623b79ace8444b7fb1b # v2.16.0-126 (2026-01-06 16:06)
     mce:
       version: "2.11.0"
       bundle:
         registry: quay.io
         repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
-        digest: sha256:bd3cf8f532917c0b7492af3276f36140edd32709c91295992f4c26e8cd4fd0a0 # v2.11.0-141 (2025-12-24 10:06)
+        digest: sha256:0a4143f5c0ea610a64e6912cf05475449823ac4cc28a4150d5cf5f85d1f115c9 # v2.11.0-156 (2026-01-06 16:03)
   # Cluster Service
   clustersService:
     image:
@@ -916,7 +916,7 @@ clouds:
         image:
           registry: quay.io
           repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
-          digest: sha256:35789a5a7582bc9d4a796f247beafa6db1e06b59e8afd6c9f78fa3375ddf97d1 # 780f88b8979b363b5e65665242a9297fbaf806a7 (2025-12-19 17:34)
+          digest: sha256:1e735c123c9319eec7e7f19c93f4aaf809f8ed6226823d5d3024b7141cc544da # 1e735c123c9319eec7e7f19c93f4aaf809f8ed6226823d5d3024b7141cc544da (2026-01-6 11:30)
       # Backplane API
       backplaneAPI:
         image:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -3,22 +3,22 @@ clouds:
     environments:
       cspr:
         regions:
-          westus3: 58a8ee6639f9c985f9bd8fabd3ae996c071e0a04eeae856957e42958f8b8b85f
+          westus3: 0b321dea0d10faea30ee498c5ecec0124857da36c2ed7c7a9a7d86e48e41f6e9
       dev:
         regions:
-          westus3: 90d7ceb11f93a6da5d3efe0713832d151380d19b651a2cf54eb45b915d5627a4
+          westus3: f743e2aae57926b47e3ef92e05ee3844845865c9f02529e475db62a170fff2c2
       ntly:
         regions:
-          uksouth: fee8b4f3e562cb2f34c1744a3f70423d15c7399d1457ea3aa4cd838d94e70663
+          uksouth: 51ec9e28d436fc36416a16ca7a97e477341608ed5a095c13406b60c7c46d2961
       perf:
         regions:
-          westus3: 1dc39a0ff704d6637b084c2fe2388927ef73a48d677bc2a8a0ffd7b9f1027984
+          westus3: c45e17904753f3c8676d79e87d7aee47056f02eef43613729361ff1bfe49f075
       pers:
         regions:
-          westus3: b6a215d4f447ac88610a511535822d2d646020eb9c66b6c922e560b743cf46d5
+          westus3: 117bfff053808b8935bd2f7bf0d8dc9245474512e365b59c1f086cbfc8d1f55c
       prow:
         regions:
-          westus3: 2739aaca01d83bde47cdc867f6b5e83a1ca413ea474b489aea0a2fa4ed713b02
+          westus3: e2493d7a5d0cd1e0a3ef90d2c27bc8dc370618f9e310dadea90885ec0ea42067
       swft:
         regions:
-          uksouth: 4c4de5ccee452805731fd786b5c3b981dcd5f09d98c50e81e5afaeea87ab176c
+          uksouth: 35cf7f0f66945573b6a821c7693ac688e845ec71da2a3c6c3303406c65187661

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -1,13 +1,13 @@
 acm:
   mce:
     bundle:
-      digest: sha256:bd3cf8f532917c0b7492af3276f36140edd32709c91295992f4c26e8cd4fd0a0
+      digest: sha256:0a4143f5c0ea610a64e6912cf05475449823ac4cc28a4150d5cf5f85d1f115c9
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
     version: 2.11.0
   operator:
     bundle:
-      digest: sha256:a4e84e310476fb50044ed56b9560cca774f6c745671e3d446a4e299436b8576e
+      digest: sha256:25f29adbc56e0f65e85a86d376e69ce27a21c60b7e7f3623b79ace8444b7fb1b
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
     version: 2.16.0
@@ -319,7 +319,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:35789a5a7582bc9d4a796f247beafa6db1e06b59e8afd6c9f78fa3375ddf97d1
+    digest: sha256:1e735c123c9319eec7e7f19c93f4aaf809f8ed6226823d5d3024b7141cc544da
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -1,13 +1,13 @@
 acm:
   mce:
     bundle:
-      digest: sha256:bd3cf8f532917c0b7492af3276f36140edd32709c91295992f4c26e8cd4fd0a0
+      digest: sha256:0a4143f5c0ea610a64e6912cf05475449823ac4cc28a4150d5cf5f85d1f115c9
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
     version: 2.11.0
   operator:
     bundle:
-      digest: sha256:a4e84e310476fb50044ed56b9560cca774f6c745671e3d446a4e299436b8576e
+      digest: sha256:25f29adbc56e0f65e85a86d376e69ce27a21c60b7e7f3623b79ace8444b7fb1b
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
     version: 2.16.0
@@ -319,7 +319,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:35789a5a7582bc9d4a796f247beafa6db1e06b59e8afd6c9f78fa3375ddf97d1
+    digest: sha256:1e735c123c9319eec7e7f19c93f4aaf809f8ed6226823d5d3024b7141cc544da
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/ntly/uksouth.yaml
+++ b/config/rendered/dev/ntly/uksouth.yaml
@@ -1,13 +1,13 @@
 acm:
   mce:
     bundle:
-      digest: sha256:bd3cf8f532917c0b7492af3276f36140edd32709c91295992f4c26e8cd4fd0a0
+      digest: sha256:0a4143f5c0ea610a64e6912cf05475449823ac4cc28a4150d5cf5f85d1f115c9
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
     version: 2.11.0
   operator:
     bundle:
-      digest: sha256:a4e84e310476fb50044ed56b9560cca774f6c745671e3d446a4e299436b8576e
+      digest: sha256:25f29adbc56e0f65e85a86d376e69ce27a21c60b7e7f3623b79ace8444b7fb1b
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
     version: 2.16.0
@@ -319,7 +319,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:35789a5a7582bc9d4a796f247beafa6db1e06b59e8afd6c9f78fa3375ddf97d1
+    digest: sha256:1e735c123c9319eec7e7f19c93f4aaf809f8ed6226823d5d3024b7141cc544da
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -1,13 +1,13 @@
 acm:
   mce:
     bundle:
-      digest: sha256:bd3cf8f532917c0b7492af3276f36140edd32709c91295992f4c26e8cd4fd0a0
+      digest: sha256:0a4143f5c0ea610a64e6912cf05475449823ac4cc28a4150d5cf5f85d1f115c9
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
     version: 2.11.0
   operator:
     bundle:
-      digest: sha256:a4e84e310476fb50044ed56b9560cca774f6c745671e3d446a4e299436b8576e
+      digest: sha256:25f29adbc56e0f65e85a86d376e69ce27a21c60b7e7f3623b79ace8444b7fb1b
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
     version: 2.16.0
@@ -319,7 +319,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:35789a5a7582bc9d4a796f247beafa6db1e06b59e8afd6c9f78fa3375ddf97d1
+    digest: sha256:1e735c123c9319eec7e7f19c93f4aaf809f8ed6226823d5d3024b7141cc544da
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -1,13 +1,13 @@
 acm:
   mce:
     bundle:
-      digest: sha256:bd3cf8f532917c0b7492af3276f36140edd32709c91295992f4c26e8cd4fd0a0
+      digest: sha256:0a4143f5c0ea610a64e6912cf05475449823ac4cc28a4150d5cf5f85d1f115c9
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
     version: 2.11.0
   operator:
     bundle:
-      digest: sha256:a4e84e310476fb50044ed56b9560cca774f6c745671e3d446a4e299436b8576e
+      digest: sha256:25f29adbc56e0f65e85a86d376e69ce27a21c60b7e7f3623b79ace8444b7fb1b
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
     version: 2.16.0
@@ -319,7 +319,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:35789a5a7582bc9d4a796f247beafa6db1e06b59e8afd6c9f78fa3375ddf97d1
+    digest: sha256:1e735c123c9319eec7e7f19c93f4aaf809f8ed6226823d5d3024b7141cc544da
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -1,13 +1,13 @@
 acm:
   mce:
     bundle:
-      digest: sha256:bd3cf8f532917c0b7492af3276f36140edd32709c91295992f4c26e8cd4fd0a0
+      digest: sha256:0a4143f5c0ea610a64e6912cf05475449823ac4cc28a4150d5cf5f85d1f115c9
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
     version: 2.11.0
   operator:
     bundle:
-      digest: sha256:a4e84e310476fb50044ed56b9560cca774f6c745671e3d446a4e299436b8576e
+      digest: sha256:25f29adbc56e0f65e85a86d376e69ce27a21c60b7e7f3623b79ace8444b7fb1b
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
     version: 2.16.0
@@ -319,7 +319,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:35789a5a7582bc9d4a796f247beafa6db1e06b59e8afd6c9f78fa3375ddf97d1
+    digest: sha256:1e735c123c9319eec7e7f19c93f4aaf809f8ed6226823d5d3024b7141cc544da
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   namespace: hypershift

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -1,13 +1,13 @@
 acm:
   mce:
     bundle:
-      digest: sha256:bd3cf8f532917c0b7492af3276f36140edd32709c91295992f4c26e8cd4fd0a0
+      digest: sha256:0a4143f5c0ea610a64e6912cf05475449823ac4cc28a4150d5cf5f85d1f115c9
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
     version: 2.11.0
   operator:
     bundle:
-      digest: sha256:a4e84e310476fb50044ed56b9560cca774f6c745671e3d446a4e299436b8576e
+      digest: sha256:25f29adbc56e0f65e85a86d376e69ce27a21c60b7e7f3623b79ace8444b7fb1b
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
     version: 2.16.0
@@ -319,7 +319,7 @@ global:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:35789a5a7582bc9d4a796f247beafa6db1e06b59e8afd6c9f78fa3375ddf97d1
+    digest: sha256:1e735c123c9319eec7e7f19c93f4aaf809f8ed6226823d5d3024b7141cc544da
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   namespace: hypershift


### PR DESCRIPTION
https://issues.redhat.com/browse/AROSLSRE-350
Upgrade to MCE v2.11.0-156 and ACM v2.16.0-126 and Hypershift 2026-01-6

MCE: v2.11.0-142 → v2.11.0-156 (sha256: 0a4143f5c0ea610a64e6912cf05475449823ac4cc28a4150d5cf5f85d1f115c9)
ACM: v2.16.0-111→ v2.16.0-126 (sha256: 25f29adbc56e0f65e85a86d376e69ce27a21c60b7e7f3623b79ace8444b7fb1b)
Hypershift  → sha256:1e735c123c9319eec7e7f19c93f4aaf809f8ed6226823d5d3024b7141cc544da 1e735c123c9319eec7e7f19c93f4aaf809f8ed6226823d5d3024b7141cc544da (2026-01-6)

```
$ kubectl get crd managedclusteraddons.addon.open-cluster-management.io 
NAME                                                    CREATED AT
managedclusteraddons.addon.open-cluster-management.io   2026-01-05T21:23:49Z
```

```
$ kubectl get pods -n multicluster-engine | grep -E "managedcluster-import-controller|ocm-controller" 
managedcluster-import-controller-v2-6df6bdf749-77tmx   1/1     Running   0             24m
managedcluster-import-controller-v2-6df6bdf749-fbrk4   1/1     Running   0             24m
ocm-controller-56c4bd777c-kclmq                        1/1     Running   0             24m
ocm-controller-56c4bd777c-m2l8p                        1/1     Running   0             24m
```
