### PR TITLE
Add CRUD for new type: ServiceProviderCluster for controllers

### DIFF
--- a/internal/api/registry.go
+++ b/internal/api/registry.go
@@ -78,6 +78,7 @@ const (
 var (
 	OperationStatusResourceType        = azcorearm.NewResourceType(ProviderNamespace, OperationStatusResourceTypeName)
 	ClusterResourceType                = azcorearm.NewResourceType(ProviderNamespace, ClusterResourceTypeName)
+	ServiceProviderClusterResourceType = azcorearm.NewResourceType(ProviderNamespace, ClusterResourceTypeName+"/serviceProviderCluster")
 	NodePoolResourceType               = azcorearm.NewResourceType(ProviderNamespace, ClusterResourceTypeName+"/"+NodePoolResourceTypeName)
 	ExternalAuthResourceType           = azcorearm.NewResourceType(ProviderNamespace, ClusterResourceTypeName+"/"+ExternalAuthResourceTypeName)
 	PreflightResourceType              = azcorearm.NewResourceType(ProviderNamespace, "deployments/preflight")

--- a/internal/api/types_cosmosdata.go
+++ b/internal/api/types_cosmosdata.go
@@ -15,8 +15,54 @@
 package api
 
 import (
+	"errors"
+	"strings"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
+
+// CosmosMetadata is metadata required for all data we store in cosmos
+type CosmosMetadata struct {
+	// resourceID is used as the cosmosUID after replacing all '/' with '|'
+	ResourceID azcorearm.ResourceID `json:"resourceID"`
+
+	// TODO add an etag that is not serialized to cosmos, but is set on read.
+	// When non-empty it will cause a conditional replace to be used
+	// When empty it will cause an unconditional replace
+}
+
+func (c *CosmosMetadata) GetResourceID() azcorearm.ResourceID {
+	return c.ResourceID
+}
+
+func (c *CosmosMetadata) SetResourceID(resourceID azcorearm.ResourceID) {
+	c.ResourceID = resourceID
+}
+
+type CosmosMetadataAccessor interface {
+	GetResourceID() azcorearm.ResourceID
+	SetResourceID(azcorearm.ResourceID)
+}
+
+var _ CosmosPersistable = &CosmosMetadata{}
+
+func (o *CosmosMetadata) GetCosmosData() CosmosData {
+	return CosmosData{
+		CosmosUID: Must(ResourceIDToCosmosID(&o.ResourceID)),
+		// partitionkeys are case-sensitive in cosmos, so we need all of our cases to be the same
+		// and we have no guarantee that prior to this the case is consistent.
+		PartitionKey: strings.ToLower(o.ResourceID.SubscriptionID),
+		ItemID:       &o.ResourceID,
+	}
+}
+
+func (o *CosmosMetadata) SetCosmosDocumentData(cosmosUID string) {
+	panic("not supported")
+}
+
+var _ CosmosMetadataAccessor = &CosmosMetadata{}
 
 type CosmosPersistable interface {
 	GetCosmosData() CosmosData
@@ -26,3 +72,24 @@ type CosmosPersistable interface {
 // CosmosData contains the information that persisted resources must have for us to support CRUD against them.
 // These are not (currently) all stored in the same place in our various types.
 type CosmosData = arm.CosmosData
+
+func ResourceIDToCosmosID(resourceID *azcorearm.ResourceID) (string, error) {
+	if resourceID == nil {
+		return "", errors.New("resource ID is nil")
+	}
+	return ResourceIDStringToCosmosID(resourceID.String())
+}
+
+func ResourceIDStringToCosmosID(resourceID string) (string, error) {
+	if len(resourceID) == 0 {
+		return "", errors.New("resource ID is empty")
+	}
+	// cosmos uses a REST API, which means that IDs that contain slashes cause problems with URL handling.
+	// We chose | because that is a delimiter that is not allowed inside of an ARM resource ID because it is a separator
+	// for multiple resource IDs.
+	return strings.ReplaceAll(strings.ToLower(resourceID), "/", "|"), nil
+}
+
+func CosmosIDToResourceID(resourceID string) (*azcorearm.ResourceID, error) {
+	return azcorearm.ParseResourceID(strings.ReplaceAll(resourceID, "|", "/"))
+}

--- a/internal/api/types_serviceprovider_cluster.go
+++ b/internal/api/types_serviceprovider_cluster.go
@@ -1,0 +1,32 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+)
+
+// ServiceProviderCluster is used internally by controllers to track and pass information between them.
+type ServiceProviderCluster struct {
+	// CosmosMetadata ResourceID is nested under the cluster so that association and cleanup work as expected
+	// it will be the ServiceProviderCluster type and the name default
+	CosmosMetadata `json:"cosmosMetadata"`
+
+	// resourceID exists to match cosmosMetadata.resourceID until we're able to transition all types to use cosmosMetadata,
+	// at which point we will stop using properties.resourceId in our queries. That will be about a month from now.
+	ResourceID azcorearm.ResourceID `json:"resourceId"`
+
+	LoadBalancerResourceID *azcorearm.ResourceID `json:"loadBalancerResourceID,omitempty"`
+}

--- a/internal/database/convert_any.go
+++ b/internal/database/convert_any.go
@@ -53,6 +53,9 @@ func CosmosToInternal[InternalAPIType, CosmosAPIType any](obj *CosmosAPIType) (*
 			return nil, fmt.Errorf("unexpected return type: %T", castObj)
 		}
 
+	case *GenericDocument[InternalAPIType]:
+		internalObj, err = CosmosGenericToInternal[InternalAPIType](cosmosObj)
+
 	default:
 		return nil, fmt.Errorf("unknown type %T", cosmosObj)
 	}
@@ -100,7 +103,7 @@ func InternalToCosmos[InternalAPIType, CosmosAPIType any](obj *InternalAPIType) 
 		}
 
 	default:
-		return nil, fmt.Errorf("unknown type %T", internalObj)
+		cosmosObj, err = InternalToCosmosGeneric[InternalAPIType](obj)
 	}
 
 	if err != nil {

--- a/internal/database/convert_generic.go
+++ b/internal/database/convert_generic.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/utils/ptr"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+func InternalToCosmosGeneric[InternalAPIType any](internalObj *InternalAPIType) (*GenericDocument[InternalAPIType], error) {
+	if internalObj == nil {
+		return nil, nil
+	}
+
+	metadata, ok := any(internalObj).(api.CosmosMetadataAccessor)
+	if !ok {
+		return nil, fmt.Errorf("internalObj must be an api.CosmosMetadataAccessor: %T", internalObj)
+	}
+
+	cosmosID, err := api.ResourceIDToCosmosID(ptr.To(metadata.GetResourceID()))
+	if err != nil {
+		return nil, err
+	}
+
+	cosmosObj := &GenericDocument[InternalAPIType]{
+		TypedDocument: TypedDocument{
+			BaseDocument: BaseDocument{
+				ID: cosmosID,
+			},
+			PartitionKey: strings.ToLower(metadata.GetResourceID().SubscriptionID),
+			ResourceType: metadata.GetResourceID().ResourceType.String(),
+		},
+		Content: *internalObj,
+	}
+
+	return cosmosObj, nil
+}
+
+func CosmosGenericToInternal[InternalAPIType any](cosmosObj *GenericDocument[InternalAPIType]) (*InternalAPIType, error) {
+	if cosmosObj == nil {
+		return nil, nil
+	}
+
+	return &cosmosObj.Content, nil
+}

--- a/internal/database/crud_helpers.go
+++ b/internal/database/crud_helpers.go
@@ -63,7 +63,7 @@ func getByItemID[InternalAPIType, CosmosAPIType any](ctx context.Context, contai
 
 func get[InternalAPIType, CosmosAPIType any](ctx context.Context, containerClient *azcosmos.ContainerClient, partitionKeyString string, completeResourceID *azcorearm.ResourceID) (*InternalAPIType, error) {
 	// try to see if the cosmosID we've passed is also the exact resource ID.  If so, then return the value we got.
-	if exactCosmosID, err := resourceIDToCosmosID(completeResourceID); err == nil {
+	if exactCosmosID, err := api.ResourceIDToCosmosID(completeResourceID); err == nil {
 		ret, err := getByItemID[InternalAPIType, CosmosAPIType](ctx, containerClient, partitionKeyString, exactCosmosID)
 		if err == nil {
 			return ret, nil

--- a/internal/database/crud_serviceprovider_types.go
+++ b/internal/database/crud_serviceprovider_types.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"path"
+	"strings"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+type ServiceProviderClusterCRUD interface {
+	ResourceCRUD[api.ServiceProviderCluster]
+}
+
+func NewClusterResourceID(subscriptionID, resourceGroupName, clusterName string) *azcorearm.ResourceID {
+	parts := []string{
+		"/subscriptions",
+		strings.ToLower(subscriptionID),
+		"resourceGroups",
+		resourceGroupName,
+		"providers",
+		api.ClusterResourceType.Namespace,
+		api.ClusterResourceType.Type,
+		clusterName,
+	}
+	return api.Must(azcorearm.ParseResourceID(strings.ToLower(path.Join(parts...))))
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
@@ -118,6 +119,8 @@ type DBClient interface {
 	Operations(subscriptionID string) OperationCRUD
 
 	Subscriptions() SubscriptionCRUD
+
+	ServiceProviderClusters(subscriptionID, resourceGroupName, clusterName string) ServiceProviderClusterCRUD
 }
 
 var _ DBClient = &cosmosDBClient{}
@@ -268,6 +271,12 @@ func (d *cosmosDBClient) Operations(subscriptionID string) OperationCRUD {
 
 func (d *cosmosDBClient) Subscriptions() SubscriptionCRUD {
 	return NewSubscriptionCRUD(d.resources)
+}
+
+func (d *cosmosDBClient) ServiceProviderClusters(subscriptionID, resourceGroupName, clusterName string) ServiceProviderClusterCRUD {
+	clusterResourceID := NewClusterResourceID(subscriptionID, resourceGroupName, clusterName)
+	return NewCosmosResourceCRUD[api.ServiceProviderCluster, GenericDocument[api.ServiceProviderCluster]](
+		d.resources, clusterResourceID, api.ServiceProviderClusterResourceType)
 }
 
 func (d *cosmosDBClient) UntypedCRUD(parentResourceID azcorearm.ResourceID) (UntypedResourceCRUD, error) {

--- a/internal/database/types_generic.go
+++ b/internal/database/types_generic.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+// pointer of InternalAPIType needs to be api.CosmosMetadataAccessor
+type GenericDocument[InternalAPIType any] struct {
+	TypedDocument `json:",inline"`
+
+	Content InternalAPIType `json:"properties"`
+}

--- a/internal/mocks/dbclient.go
+++ b/internal/mocks/dbclient.go
@@ -409,6 +409,44 @@ func (c *MockDBClientPatchBillingDocCall) DoAndReturn(f func(context.Context, *a
 	return c
 }
 
+// ServiceProviderClusters mocks base method.
+func (m *MockDBClient) ServiceProviderClusters(subscriptionID, resourceGroupName, clusterName string) database.ServiceProviderClusterCRUD {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceProviderClusters", subscriptionID, resourceGroupName, clusterName)
+	ret0, _ := ret[0].(database.ServiceProviderClusterCRUD)
+	return ret0
+}
+
+// ServiceProviderClusters indicates an expected call of ServiceProviderClusters.
+func (mr *MockDBClientMockRecorder) ServiceProviderClusters(subscriptionID, resourceGroupName, clusterName any) *MockDBClientServiceProviderClustersCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceProviderClusters", reflect.TypeOf((*MockDBClient)(nil).ServiceProviderClusters), subscriptionID, resourceGroupName, clusterName)
+	return &MockDBClientServiceProviderClustersCall{Call: call}
+}
+
+// MockDBClientServiceProviderClustersCall wrap *gomock.Call
+type MockDBClientServiceProviderClustersCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDBClientServiceProviderClustersCall) Return(arg0 database.ServiceProviderClusterCRUD) *MockDBClientServiceProviderClustersCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDBClientServiceProviderClustersCall) Do(f func(string, string, string) database.ServiceProviderClusterCRUD) *MockDBClientServiceProviderClustersCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDBClientServiceProviderClustersCall) DoAndReturn(f func(string, string, string) database.ServiceProviderClusterCRUD) *MockDBClientServiceProviderClustersCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Subscriptions mocks base method.
 func (m *MockDBClient) Subscriptions() database.SubscriptionCRUD {
 	m.ctrl.T.Helper()

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/02-create-another/00-key.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/02-create-another/00-key.json
@@ -1,0 +1,3 @@
+{
+	"parentResourceID": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster"
+}

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/02-create-another/default.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/02-create-another/default.json
@@ -1,0 +1,7 @@
+{
+	"cosmosMetadata": {
+		"resourceID": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/serviceProviderCluster/default"
+	},
+	"resourceId": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/serviceProviderCluster/default",
+	"loadBalancerResourceID": "/subscriptions/your-subscription-id/resourceGroups/myResourceGroup/providers/Microsoft.Network/loadBalancers/myLoadBalancer"
+}

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/03-get-new-instance/00-key.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/03-get-new-instance/00-key.json
@@ -1,0 +1,3 @@
+{
+	"parentResourceID": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster"
+}

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/03-get-new-instance/default.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/03-get-new-instance/default.json
@@ -1,0 +1,7 @@
+{
+	"cosmosMetadata": {
+		"resourceID": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/serviceProviderCluster/default"
+	},
+	"resourceId": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/serviceProviderCluster/default",
+	"loadBalancerResourceID": "/subscriptions/your-subscription-id/resourceGroups/myResourceGroup/providers/Microsoft.Network/loadBalancers/myLoadBalancer"
+}

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/04-replace-instance/00-key.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/04-replace-instance/00-key.json
@@ -1,0 +1,3 @@
+{
+	"parentResourceID": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster"
+}

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/04-replace-instance/default.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/04-replace-instance/default.json
@@ -1,0 +1,7 @@
+{
+	"cosmosMetadata": {
+		"resourceID": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/serviceProviderCluster/default"
+	},
+	"resourceId": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/serviceProviderCluster/default",
+	"loadBalancerResourceID": "/subscriptions/your-subscription-id/resourceGroups/myResourceGroup/providers/Microsoft.Network/loadBalancers/newLoadBalancer"
+}

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/06-list-instance/00-key.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/06-list-instance/00-key.json
@@ -1,0 +1,3 @@
+{
+	"parentResourceID": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster"
+}

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/06-list-instance/default.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/06-list-instance/default.json
@@ -1,0 +1,7 @@
+{
+	"cosmosMetadata": {
+		"resourceID": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/serviceProviderCluster/default"
+	},
+	"resourceId": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/serviceProviderCluster/default",
+	"loadBalancerResourceID": "/subscriptions/your-subscription-id/resourceGroups/myResourceGroup/providers/Microsoft.Network/loadBalancers/newLoadBalancer"
+}

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/07-delete-instance/00-key.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/07-delete-instance/00-key.json
@@ -1,0 +1,4 @@
+{
+	"parentResourceID": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster",
+	"deleteResourceName": "default"
+}

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/09-list-nothing/00-key.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ServiceProviderClusterCRUD/basic/09-list-nothing/00-key.json
@@ -1,0 +1,3 @@
+{
+	"parentResourceID": "/subscriptions/ca3b7be4-6ac8-4784-b2b5-0e398a60269a/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster"
+}

--- a/test-integration/frontend/database_crud_test.go
+++ b/test-integration/frontend/database_crud_test.go
@@ -67,6 +67,17 @@ func TestDatabaseCRUD(t *testing.T) {
 					crudSuiteDir)
 			})
 
+		case "ServiceProviderClusterCRUD":
+			t.Run(crudSuiteDirEntry.Name(), func(t *testing.T) {
+				testCRUDSuite(
+					ctx,
+					t,
+					databasemutationhelpers.GenericCRUDSpecializer[api.ServiceProviderCluster]{
+						ResourceType: api.ServiceProviderClusterResourceType,
+					},
+					crudSuiteDir)
+			})
+
 		case "UntypedCRUD":
 			t.Run(crudSuiteDirEntry.Name(), func(t *testing.T) {
 				testCRUDSuite(

--- a/test-integration/utils/databasemutationhelpers/per_resource_crud.go
+++ b/test-integration/utils/databasemutationhelpers/per_resource_crud.go
@@ -16,6 +16,7 @@ package databasemutationhelpers
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -222,4 +223,39 @@ func (SubscriptionCRUDSpecializer) NameFromInstance(obj *arm.Subscription) strin
 
 func (SubscriptionCRUDSpecializer) WriteCosmosID(newObj, oldObj *arm.Subscription) {
 	newObj.ResourceID = oldObj.ResourceID
+}
+
+type GenericCRUDSpecializer[InternalAPIType any] struct {
+	ResourceType azcorearm.ResourceType
+}
+
+var _ ResourceCRUDTestSpecializer[any] = &GenericCRUDSpecializer[any]{}
+
+func (c GenericCRUDSpecializer[InternalAPIType]) ResourceCRUDFromKey(t *testing.T, cosmosContainer *azcosmos.ContainerClient, key CosmosCRUDKey) database.ResourceCRUD[InternalAPIType] {
+	var instance InternalAPIType
+	_, ok := any(&instance).(api.CosmosMetadataAccessor)
+	if !ok {
+		panic(fmt.Sprintf("must be CosmosMetadataAccessor: %T", &instance))
+	}
+	clusterResourceID := api.Must(azcorearm.ParseResourceID(key.ParentResourceID))
+	return database.NewCosmosResourceCRUD[InternalAPIType, database.GenericDocument[InternalAPIType]](
+		cosmosContainer, clusterResourceID, c.ResourceType)
+}
+
+func (GenericCRUDSpecializer[InternalAPIType]) InstanceEquals(expected, actual *InternalAPIType) bool {
+	// clear the fields that don't compare
+	shallowExpected := *expected
+	shallowActual := *actual
+	return equality.Semantic.DeepEqual(shallowExpected, shallowActual)
+}
+
+func (GenericCRUDSpecializer[InternalAPIType]) NameFromInstance(obj *InternalAPIType) string {
+	if obj == nil {
+		return ""
+	}
+	return any(obj).(api.CosmosMetadataAccessor).GetResourceID().Name
+}
+
+func (GenericCRUDSpecializer[InternalAPIType]) WriteCosmosID(newObj, oldObj *InternalAPIType) {
+	// do nothing
 }

--- a/test-integration/utils/databasemutationhelpers/resource_crud_test_util.go
+++ b/test-integration/utils/databasemutationhelpers/resource_crud_test_util.go
@@ -102,7 +102,9 @@ func (tt *ResourceMutationTest) RunTest(t *testing.T) {
 
 	frontend, testInfo, err := integrationutils.NewFrontendFromTestingEnv(ctx, t)
 	require.NoError(t, err)
-	defer testInfo.Cleanup(context.Background())
+	cleanupCtx := context.Background()
+	cleanupCtx = utils.ContextWithLogger(cleanupCtx, slogt.New(t, slogt.JSON()))
+	defer testInfo.Cleanup(cleanupCtx)
 	go frontend.Run(ctx, ctx.Done())
 
 	// create anything and round trip anything for cluster-service
@@ -118,7 +120,10 @@ func (tt *ResourceMutationTest) RunTest(t *testing.T) {
 	}
 	for _, step := range tt.steps {
 		t.Logf("Running step %s", step.StepID())
-		step.RunTest(t.Context(), t, stepInput)
+		ctx := t.Context()
+		ctx = utils.ContextWithLogger(ctx, slogt.New(t, slogt.JSON()))
+
+		step.RunTest(ctx, t, stepInput)
 	}
 }
 


### PR DESCRIPTION
When bringing controllers from cluster-service, they need a place to save data.  To avoid conflicting with users and to allow future optimistic concurrency, this adds a new type to store in cosmos.

It builds on https://github.com/Azure/ARO-HCP/pull/3713 (green CI) and creates the first example of where we want to take all our stored types: GenericDocument storage that uses an InternalAPI type that is fully convertible between internal, cluster-service, cosmos, and ARM types.  That leverages our new hub type used throughout the frontend without any conversion.

/assign @mbarnes 
/cc @miguelsorianod