### PR TITLE
fix: ensure backend shuts down when receiving SIGINT signal

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -328,7 +328,7 @@ func Run(cmd *cobra.Command, args []string) error {
 	})
 
 	if err := group.Wait(); err != nil {
-		logger.Error(err.Error())
+		logger.Error("errgroup wait returned an error", "error", err.Error())
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This commit fixes the backend process not being able to shutdown because of the healthzserver http server never fully closing. We now call Close on the healthzserver http server to ensure the goroutine in the errorgroup can terminate.