### PR TITLE
set E2E default NodePoolVersionId to 4.20.8

### DIFF
--- a/test/e2e-setup/bicep/cluster-nodepool-osdisk.bicep
+++ b/test/e2e-setup/bicep/cluster-nodepool-osdisk.bicep
@@ -16,7 +16,7 @@ param usePooledIdentities bool = false
 param openshiftControlPlaneVersionId string = '4.20'
 
 @description('NodePool OpenShift Version ID')
-param openshiftNodePoolVersionId string = '4.20.5'
+param openshiftNodePoolVersionId string = '4.20.8'
 
 @description('Node pool osDisk Size in GiB')
 param nodePoolOsDiskSizeGiB int = 128

--- a/test/e2e-setup/bicep/demo.bicep
+++ b/test/e2e-setup/bicep/demo.bicep
@@ -16,7 +16,7 @@ param usePooledIdentities bool = false
 param openshiftControlPlaneVersionId string = '4.20'
 
 @description('NodePool OpenShift Version ID')
-param openshiftNodePoolVersionId string = '4.20.5'
+param openshiftNodePoolVersionId string = '4.20.8'
 
 module customerInfra 'modules/customer-infra.bicep' = {
   name: 'customerInfra'

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -71,7 +71,7 @@ when deploying ARO HCP hosted cluster, eg.:
 
 ```bash
 $ export ARO_HCP_OPENSHIFT_CONTROLPLANE_VERSION=4.20
-$ export ARO_HCP_OPENSHIFT_NODEPOOL_VERSION=4.20.5
+$ export ARO_HCP_OPENSHIFT_NODEPOOL_VERSION=4.20.8
 ```
 
 So finally, you can run a particular test case:

--- a/test/util/framework/deployment_params.go
+++ b/test/util/framework/deployment_params.go
@@ -70,7 +70,7 @@ func DefaultOpenshiftControlPlaneVersionId() string {
 func DefaultOpenshiftNodePoolVersionId() string {
 	version := os.Getenv("ARO_HCP_OPENSHIFT_NODEPOOL_VERSION")
 	if version == "" {
-		return "4.20.5"
+		return "4.20.8"
 	}
 	return version
 }


### PR DESCRIPTION
[ARO-23277](https://issues.redhat.com//browse/ARO-23277) Update E2E node pool tests to use 4.20.8

### What

Update E2E test's default NodePoolVersionId to 4.20.8.

### Why

We want to run tests against 4.20.8 by default.

### Special notes for your reviewer

<!-- optional -->
