### PR TITLE
fix: log non found expected artifact documents content correctly in step cosmoscompare

### DIFF
--- a/test-integration/utils/databasemutationhelpers/step_cosmoscompare.go
+++ b/test-integration/utils/databasemutationhelpers/step_cosmoscompare.go
@@ -91,7 +91,7 @@ func (l *cosmosCompare) RunTest(ctx context.Context, t *testing.T, stepInput Ste
 			for _, diff := range currDiffs {
 				t.Log(diff)
 			}
-			t.Errorf("did not find: %v", currExpected)
+			t.Errorf("did not find:\n%v", stringifyResource(currExpected))
 		}
 	}
 }


### PR DESCRIPTION
### What

We now log the content of the expected document instead of the struct directly. Because the struct has a json.RawMessage type it was showing the bytes instead of the textual representation of them.

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
