### PR TITLE
deploy: add the automation account to the E2E subscription

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -28,10 +28,10 @@ ROLE_ASSIGNMENTS_DEPLOYMENT_NAME ?= role-assignments${DEPLOYMENT_NAME_SUFFIX}
 DEV_TESTING_SUBSCRIPTION_ID = 1d3378d3-5a3f-4712-85a1-2485495dfc4b
 INT_TESTING_SUBSCRIPTION_ID = 64f0619f-ebc2-4156-9d91-c4c781de7e54
 STAGE_TESTING_SUBSCRIPTION_ID = b23756f7-4594-40a3-980f-10bb6168fc20
-E2E_HOSTED_CLUSTER_SUBSCRIPTION_ID = 974ebd46-8ad3-41e3-afef-7ef25fd5c371
+E2E_TESTING_SUBSCRIPTION_ID = 974ebd46-8ad3-41e3-afef-7ef25fd5c371
 
 # Environments where automation accounts are deployed
-AUTOMATION_ACCOUNT_ENVS = dev stage int
+AUTOMATION_ACCOUNT_ENVS = dev stage int e2e
 
 list:
 	@grep '^[^#[:space:]].*:' Makefile
@@ -185,13 +185,13 @@ grant-e2e-access:
 	az role assignment create \
 		--role "dev-first-party-mock" \
 		--assignee "$(shell az ad app list --display-name aro-dev-first-party2 --query '[*]'.appId -o tsv)" \
-		--scope "/subscriptions/$(E2E_HOSTED_CLUSTER_SUBSCRIPTION_ID)" \
+		--scope "/subscriptions/$(E2E_TESTING_SUBSCRIPTION_ID)" \
 		--only-show-errors
 
 	az role assignment create \
 		--role "Contributor" \
 		--assignee "$(shell az ad app list --display-name aro-dev-arm-helper2 --query '[*]'.appId -o tsv)" \
-		--scope "/subscriptions/$(E2E_HOSTED_CLUSTER_SUBSCRIPTION_ID)" \
+		--scope "/subscriptions/$(E2E_TESTING_SUBSCRIPTION_ID)" \
 		--only-show-errors
 
 	az role assignment create \
@@ -203,13 +203,13 @@ grant-e2e-access:
 	az role assignment create \
 		--role "dev-msi-mock" \
 		--assignee "$(shell az ad app list --display-name aro-dev-msi-mock2 --query '[*]'.appId -o tsv)" \
-		--scope "/subscriptions/$(E2E_HOSTED_CLUSTER_SUBSCRIPTION_ID)" \
+		--scope "/subscriptions/$(E2E_TESTING_SUBSCRIPTION_ID)" \
 		--only-show-errors
 
 	az role assignment create \
 		--role "Azure Red Hat OpenShift KMS Plugin - Dev" \
 		--assignee "$(shell az ad app list --display-name aro-dev-msi-mock2 --query '[*]'.appId -o tsv)" \
-		--scope "/subscriptions/$(E2E_HOSTED_CLUSTER_SUBSCRIPTION_ID)" \
+		--scope "/subscriptions/$(E2E_TESTING_SUBSCRIPTION_ID)" \
 		--only-show-errors
 .PHONY: grant-e2e-access
 
@@ -481,7 +481,7 @@ operator-roles:
 		--template-file templates/dev-operator-roles.bicep \
 		$(PROMPT_TO_CONFIRM) \
 		--parameters configurations/dev-operator-roles.bicepparam \
-		--parameters e2eTestSubscription=$(E2E_HOSTED_CLUSTER_SUBSCRIPTION_ID)
+		--parameters e2eTestSubscription=$(E2E_TESTING_SUBSCRIPTION_ID)
 .PHONY: operator-roles
 
 operator-roles.what-if:
@@ -490,7 +490,7 @@ operator-roles.what-if:
 		--name operator-roles \
 		--template-file templates/dev-operator-roles.bicep \
 		--parameters configurations/dev-operator-roles.bicepparam \
-		--parameters e2eTestSubscription=$(E2E_HOSTED_CLUSTER_SUBSCRIPTION_ID)
+		--parameters e2eTestSubscription=$(E2E_TESTING_SUBSCRIPTION_ID)
 .PHONY: operator-roles.what-if
 
 #


### PR DESCRIPTION
This pull request updates the `dev-infrastructure/Makefile` to standardize and clarify the naming and usage of the E2E testing subscription variable. The changes primarily involve renaming the subscription ID variable and updating all relevant references, as well as ensuring automation account environments include E2E.

**Variable renaming and reference updates:**

* Renamed `E2E_HOSTED_CLUSTER_SUBSCRIPTION_ID` to `E2E_TESTING_SUBSCRIPTION_ID` and updated all references in the Makefile to use the new variable name for consistency and clarity. [[1]](diffhunk://#diff-31093ed673d9e3ffe2de36dafbad65ce16ee629bff0f3b42abab0ec6ead5eb60L31-R34) [[2]](diffhunk://#diff-31093ed673d9e3ffe2de36dafbad65ce16ee629bff0f3b42abab0ec6ead5eb60L188-R194) [[3]](diffhunk://#diff-31093ed673d9e3ffe2de36dafbad65ce16ee629bff0f3b42abab0ec6ead5eb60L206-R212) [[4]](diffhunk://#diff-31093ed673d9e3ffe2de36dafbad65ce16ee629bff0f3b42abab0ec6ead5eb60L484-R484) [[5]](diffhunk://#diff-31093ed673d9e3ffe2de36dafbad65ce16ee629bff0f3b42abab0ec6ead5eb60L493-R493)

**Automation account environment configuration:**

* Added `e2e` to the `AUTOMATION_ACCOUNT_ENVS` variable to ensure automation accounts are also deployed in the E2E environment.