### PR TITLE
elminate unused old OperationDocument type

### DIFF
--- a/backend/operations_scanner_test.go
+++ b/backend/operations_scanner_test.go
@@ -71,7 +71,7 @@ func TestSetDeleteOperationAsCompleted(t *testing.T) {
 		},
 	}
 
-	// Placeholder InternalID for NewOperationDocument
+	// Placeholder InternalID for NewOperation
 	internalID, err := api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/placeholder")
 	require.NoError(t, err)
 
@@ -113,7 +113,7 @@ func TestSetDeleteOperationAsCompleted(t *testing.T) {
 				newTimestamp:       func() time.Time { return time.Now().UTC() },
 			}
 
-			operationDoc := database.NewOperationDocument(
+			operationDoc := database.NewOperation(
 				database.OperationRequestDelete,
 				resourceID,
 				internalID,
@@ -268,7 +268,7 @@ func TestUpdateOperationStatus(t *testing.T) {
 		},
 	}
 
-	// Placeholder InternalID for NewOperationDocument
+	// Placeholder InternalID for NewOperation
 	internalID, err := api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/placeholder")
 	require.NoError(t, err)
 
@@ -300,7 +300,7 @@ func TestUpdateOperationStatus(t *testing.T) {
 				newTimestamp:       func() time.Time { return time.Now().UTC() },
 			}
 
-			operationDoc := database.NewOperationDocument(
+			operationDoc := database.NewOperation(
 				database.OperationRequestCreate,
 				resourceID,
 				internalID,
@@ -569,7 +569,7 @@ func TestConvertClusterStatus(t *testing.T) {
 			ctx := context.Background()
 
 			op := operation{
-				doc: &database.OperationDocument{
+				doc: &api.Operation{
 					InternalID: tt.internalId,
 					Status:     tt.currentProvisioningState,
 				},

--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -323,7 +323,7 @@ func (f *Frontend) createHCPCluster(writer http.ResponseWriter, request *http.Re
 	transaction := f.dbClient.NewTransaction(newInternalCluster.ID.SubscriptionID)
 
 	// TODO extract to straight instance creation and then validation.
-	clusterCreateOperation := database.NewOperationDocument(
+	clusterCreateOperation := database.NewOperation(
 		database.OperationRequestCreate,
 		newInternalCluster.ID,
 		newInternalCluster.ServiceProviderProperties.ClusterServiceID,
@@ -578,7 +578,7 @@ func (f *Frontend) updateHCPClusterInCosmos(ctx context.Context, writer http.Res
 	}
 
 	transaction := f.dbClient.NewTransaction(oldInternalCluster.ID.SubscriptionID)
-	clusterUpdateOperation := database.NewOperationDocument(
+	clusterUpdateOperation := database.NewOperation(
 		database.OperationRequestUpdate,
 		oldInternalCluster.ID,
 		oldInternalCluster.ServiceProviderProperties.ClusterServiceID,
@@ -712,7 +712,7 @@ func (f *Frontend) addDeleteClusterToTransaction(ctx context.Context, writer htt
 		return utils.TrackError(err)
 	}
 
-	operationDoc := database.NewOperationDocument(
+	operationDoc := database.NewOperation(
 		database.OperationRequestDelete,
 		cluster.ID,
 		cluster.ServiceProviderProperties.ClusterServiceID,

--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -292,7 +292,7 @@ func (f *Frontend) createExternalAuth(writer http.ResponseWriter, request *http.
 
 	transaction := f.dbClient.NewTransaction(newInternalExternalAuth.ID.SubscriptionID)
 
-	createExternalAuthOperation := database.NewOperationDocument(
+	createExternalAuthOperation := database.NewOperation(
 		operationRequest,
 		newInternalExternalAuth.ID,
 		newInternalExternalAuth.ServiceProviderProperties.ClusterServiceID,
@@ -484,7 +484,7 @@ func (f *Frontend) updateExternalAuthInCosmos(ctx context.Context, writer http.R
 
 	transaction := f.dbClient.NewTransaction(oldInternalExternalAuth.ID.SubscriptionID)
 
-	externalAuthUpdateOperation := database.NewOperationDocument(
+	externalAuthUpdateOperation := database.NewOperation(
 		database.OperationRequestUpdate,
 		newInternalExternalAuth.ID,
 		newInternalExternalAuth.ServiceProviderProperties.ClusterServiceID,
@@ -620,7 +620,7 @@ func (f *Frontend) addDeleteExternalAuthToTransaction(ctx context.Context, write
 		return utils.TrackError(err)
 	}
 
-	operationDoc := database.NewOperationDocument(
+	operationDoc := database.NewOperation(
 		database.OperationRequestDelete,
 		externalAuth.ID,
 		externalAuth.ServiceProviderProperties.ClusterServiceID,

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -326,7 +326,7 @@ func (f *Frontend) ArmResourceActionRequestAdminCredential(writer http.ResponseW
 
 	transaction := f.dbClient.NewTransaction(clusterResourceID.SubscriptionID)
 
-	operationDoc := database.NewOperationDocument(
+	operationDoc := database.NewOperation(
 		operationRequest,
 		clusterResourceID,
 		csCredentialClusterServiceID,
@@ -412,7 +412,7 @@ func (f *Frontend) ArmResourceActionRevokeCredentials(writer http.ResponseWriter
 		return utils.TrackError(err)
 	}
 
-	operationDoc := database.NewOperationDocument(
+	operationDoc := database.NewOperation(
 		operationRequest,
 		clusterResourceID,
 		cluster.ServiceProviderProperties.ClusterServiceID,

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -673,19 +673,19 @@ func TestRequestAdminCredential(t *testing.T) {
 					},
 					nil)
 			if test.clusterProvisioningState.IsTerminal() {
-				revokeOperations := make(map[string]*database.OperationDocument)
+				revokeOperations := make(map[string]*api.Operation)
 				if !test.revokeCredentialsStatus.IsTerminal() {
-					revokeOperations[uuid.New().String()] = &database.OperationDocument{
+					revokeOperations[uuid.New().String()] = &api.Operation{
 						Request:    database.OperationRequestRevokeCredentials,
 						ExternalID: clusterResourceID,
 						InternalID: clusterInternalID,
 						Status:     test.revokeCredentialsStatus,
 					}
 				}
-				mockOperationIter := mocks.NewMockDBClientIterator[database.OperationDocument](ctrl)
+				mockOperationIter := mocks.NewMockDBClientIterator[api.Operation](ctrl)
 				mockOperationIter.EXPECT().
 					Items(gomock.Any()).
-					Return(database.DBClientIteratorItem[database.OperationDocument](maps.All(revokeOperations)))
+					Return(database.DBClientIteratorItem[api.Operation](maps.All(revokeOperations)))
 
 				// ArmResourceActionRequestAdminCredential
 				mockDBClient.EXPECT().
@@ -844,19 +844,19 @@ func TestRevokeCredentials(t *testing.T) {
 					},
 					nil)
 			if test.clusterProvisioningState.IsTerminal() {
-				revokeOperations := make(map[string]*database.OperationDocument)
+				revokeOperations := make(map[string]*api.Operation)
 				if !test.revokeCredentialsStatus.IsTerminal() {
-					revokeOperations[uuid.New().String()] = &database.OperationDocument{
+					revokeOperations[uuid.New().String()] = &api.Operation{
 						Request:    database.OperationRequestRevokeCredentials,
 						ExternalID: clusterResourceID,
 						InternalID: clusterInternalID,
 						Status:     test.revokeCredentialsStatus,
 					}
 				}
-				mockOperationIter := mocks.NewMockDBClientIterator[database.OperationDocument](ctrl)
+				mockOperationIter := mocks.NewMockDBClientIterator[api.Operation](ctrl)
 				mockOperationIter.EXPECT().
 					Items(gomock.Any()).
-					Return(database.DBClientIteratorItem[database.OperationDocument](maps.All(revokeOperations)))
+					Return(database.DBClientIteratorItem[api.Operation](maps.All(revokeOperations)))
 
 				// ArmResourceActionRequestAdminCredential
 				mockDBClient.EXPECT().
@@ -878,7 +878,7 @@ func TestRevokeCredentials(t *testing.T) {
 						Return(nil)
 
 					requestOperationID := string(arm.ProvisioningStateProvisioning)
-					requestOperations := map[string]*database.OperationDocument{
+					requestOperations := map[string]*api.Operation{
 						requestOperationID: {
 							Request:    database.OperationRequestRequestCredential,
 							ExternalID: clusterResourceID,
@@ -886,10 +886,10 @@ func TestRevokeCredentials(t *testing.T) {
 							Status:     arm.ProvisioningStateProvisioning,
 						},
 					}
-					mockOperationIter = mocks.NewMockDBClientIterator[database.OperationDocument](ctrl)
+					mockOperationIter = mocks.NewMockDBClientIterator[api.Operation](ctrl)
 					mockOperationIter.EXPECT().
 						Items(gomock.Any()).
-						Return(database.DBClientIteratorItem[database.OperationDocument](maps.All(requestOperations)))
+						Return(database.DBClientIteratorItem[api.Operation](maps.All(requestOperations)))
 					mockOperationIter.EXPECT().
 						GetError().
 						Return(nil)

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -297,7 +297,7 @@ func (f *Frontend) createNodePool(writer http.ResponseWriter, request *http.Requ
 
 	transaction := f.dbClient.NewTransaction(newInternalNodePool.ID.SubscriptionID)
 
-	createNodePoolOperation := database.NewOperationDocument(
+	createNodePoolOperation := database.NewOperation(
 		database.OperationRequestCreate,
 		newInternalNodePool.ID,
 		newInternalNodePool.ServiceProviderProperties.ClusterServiceID,
@@ -535,7 +535,7 @@ func (f *Frontend) updateNodePoolInCosmos(ctx context.Context, writer http.Respo
 
 	transaction := f.dbClient.NewTransaction(oldInternalNodePool.ID.SubscriptionID)
 
-	nodePoolUpdateOperation := database.NewOperationDocument(
+	nodePoolUpdateOperation := database.NewOperation(
 		database.OperationRequestUpdate,
 		newInternalNodePool.ID,
 		newInternalNodePool.ServiceProviderProperties.ClusterServiceID,
@@ -671,7 +671,7 @@ func (f *Frontend) addDeleteNodePoolToTransaction(ctx context.Context, writer ht
 		return utils.TrackError(err)
 	}
 
-	operationDoc := database.NewOperationDocument(
+	operationDoc := database.NewOperation(
 		database.OperationRequestDelete,
 		nodePool.ID,
 		nodePool.ServiceProviderProperties.ClusterServiceID,

--- a/internal/database/crud_hcpcluster.go
+++ b/internal/database/crud_hcpcluster.go
@@ -42,7 +42,7 @@ type OperationCRUD interface {
 	// Note that ListActiveOperations does not perform the search, but merely prepares an iterator
 	// to do so. Hence the lack of a Context argument. The search is performed by calling Items() on
 	// the iterator in a ranged for loop.
-	ListActiveOperations(options *DBClientListActiveOperationDocsOptions) DBClientIterator[OperationDocument]
+	ListActiveOperations(options *DBClientListActiveOperationDocsOptions) DBClientIterator[api.Operation]
 }
 
 type operationCRUD struct {
@@ -63,7 +63,7 @@ func NewOperationCRUD(containerClient *azcosmos.ContainerClient, subscriptionID 
 
 var _ OperationCRUD = &operationCRUD{}
 
-func (d *operationCRUD) ListActiveOperations(options *DBClientListActiveOperationDocsOptions) DBClientIterator[OperationDocument] {
+func (d *operationCRUD) ListActiveOperations(options *DBClientListActiveOperationDocsOptions) DBClientIterator[api.Operation] {
 	var queryOptions azcosmos.QueryOptions
 
 	query := fmt.Sprintf(

--- a/internal/database/types_operation.go
+++ b/internal/database/types_operation.go
@@ -42,7 +42,7 @@ const (
 type Operation struct {
 	TypedDocument `json:",inline"`
 
-	OperationProperties OperationDocument `json:"properties"`
+	OperationProperties api.Operation `json:"properties"`
 }
 
 func (o *Operation) GetTypedDocument() *TypedDocument {
@@ -54,19 +54,17 @@ func (o *Operation) SetResourceID(_ *azcorearm.ResourceID) {
 	// TODO, consider whether this should be done in the frontend and not in storage (likely)
 }
 
-type OperationDocument = api.Operation
-
-func NewOperationDocument(
+func NewOperation(
 	request OperationRequest,
 	externalID *azcorearm.ResourceID,
 	internalID ocm.InternalID,
 	tenantID, clientID, notificationURI string,
 	correlationData *arm.CorrelationData,
-) *OperationDocument {
+) *api.Operation {
 
 	now := time.Now().UTC()
 
-	doc := &OperationDocument{
+	doc := &api.Operation{
 		Request:            request,
 		ExternalID:         externalID,
 		InternalID:         internalID,
@@ -99,7 +97,7 @@ func NewOperationDocument(
 }
 
 // ToStatus converts an OperationDocument to the ARM operation status format.
-func ToStatus(doc *OperationDocument) *arm.Operation {
+func ToStatus(doc *api.Operation) *arm.Operation {
 	operation := &arm.Operation{
 		ID:        doc.OperationID,
 		Name:      doc.OperationID.Name,

--- a/internal/mocks/crud_hcpcluster.go
+++ b/internal/mocks/crud_hcpcluster.go
@@ -379,10 +379,10 @@ func (c *MockOperationCRUDListCall) DoAndReturn(f func(context.Context, *databas
 }
 
 // ListActiveOperations mocks base method.
-func (m *MockOperationCRUD) ListActiveOperations(options *database.DBClientListActiveOperationDocsOptions) database.DBClientIterator[database.OperationDocument] {
+func (m *MockOperationCRUD) ListActiveOperations(options *database.DBClientListActiveOperationDocsOptions) database.DBClientIterator[api.Operation] {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListActiveOperations", options)
-	ret0, _ := ret[0].(database.DBClientIterator[database.OperationDocument])
+	ret0, _ := ret[0].(database.DBClientIterator[api.Operation])
 	return ret0
 }
 
@@ -399,19 +399,19 @@ type MockOperationCRUDListActiveOperationsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockOperationCRUDListActiveOperationsCall) Return(arg0 database.DBClientIterator[database.OperationDocument]) *MockOperationCRUDListActiveOperationsCall {
+func (c *MockOperationCRUDListActiveOperationsCall) Return(arg0 database.DBClientIterator[api.Operation]) *MockOperationCRUDListActiveOperationsCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockOperationCRUDListActiveOperationsCall) Do(f func(*database.DBClientListActiveOperationDocsOptions) database.DBClientIterator[database.OperationDocument]) *MockOperationCRUDListActiveOperationsCall {
+func (c *MockOperationCRUDListActiveOperationsCall) Do(f func(*database.DBClientListActiveOperationDocsOptions) database.DBClientIterator[api.Operation]) *MockOperationCRUDListActiveOperationsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockOperationCRUDListActiveOperationsCall) DoAndReturn(f func(*database.DBClientListActiveOperationDocsOptions) database.DBClientIterator[database.OperationDocument]) *MockOperationCRUDListActiveOperationsCall {
+func (c *MockOperationCRUDListActiveOperationsCall) DoAndReturn(f func(*database.DBClientListActiveOperationDocsOptions) database.DBClientIterator[api.Operation]) *MockOperationCRUDListActiveOperationsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/test-integration/utils/databasemutationhelpers/step_list_active_operations.go
+++ b/test-integration/utils/databasemutationhelpers/step_list_active_operations.go
@@ -72,7 +72,7 @@ func (l *listActiveOperationsStep) RunTest(ctx context.Context, t *testing.T, st
 	actualControllersIterator := operationsCRUD.ListActiveOperations(nil)
 	require.NoError(t, err)
 
-	actualControllers := []*database.OperationDocument{}
+	actualControllers := []*api.Operation{}
 	for _, actual := range actualControllersIterator.Items(ctx) {
 		actualControllers = append(actualControllers, actual)
 	}


### PR DESCRIPTION
This type dates back to prior cosmos storage APIs before we coalesced the storage into a single shared flow for all types (subscriptions, resources, and operations).  This PR finishes the IOU for cleaning up the type alias used to make the PR easier to review in the past.
