### PR TITLE
frontend: Fix parent resource conflict detection

### DIFF
--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -272,7 +272,7 @@ func (f *Frontend) createExternalAuth(writer http.ResponseWriter, request *http.
 	if err != nil {
 		return utils.TrackError(err)
 	}
-	if err := checkForProvisioningStateConflict(ctx, f.dbClient, database.OperationRequestUpdate, cluster.ID, cluster.ServiceProviderProperties.ProvisioningState); err != nil {
+	if err := checkForProvisioningStateConflict(ctx, f.dbClient, database.OperationRequestCreate, newInternalExternalAuth.ID, newInternalExternalAuth.Properties.ProvisioningState); err != nil {
 		return utils.TrackError(err)
 	}
 	csExternalAuthBuilder, err := ocm.BuildCSExternalAuth(ctx, newInternalExternalAuth, false)

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -279,7 +279,7 @@ func (f *Frontend) createNodePool(writer http.ResponseWriter, request *http.Requ
 	}
 
 	logger.Info(fmt.Sprintf("creating resource %s", resourceID))
-	if err := checkForProvisioningStateConflict(ctx, f.dbClient, database.OperationRequestUpdate, cluster.ID, cluster.ServiceProviderProperties.ProvisioningState); err != nil {
+	if err := checkForProvisioningStateConflict(ctx, f.dbClient, database.OperationRequestCreate, newInternalNodePool.ID, newInternalNodePool.Properties.ProvisioningState); err != nil {
 		return utils.TrackError(err)
 	}
 	csNodePoolBuilder, err := ocm.BuildCSNodePool(ctx, newInternalNodePool, false)

--- a/test-integration/frontend/artifacts/ExternalAuthMutation/cluster-creating/cosmos-state/cosmos-01-cluster.json
+++ b/test-integration/frontend/artifacts/ExternalAuthMutation/cluster-creating/cosmos-state/cosmos-01-cluster.json
@@ -1,0 +1,20 @@
+{
+  "id" : "29c5d490-ec04-11f0-b051-9c6b00c26e8e",
+  "partitionKey" : "0465bc32-c654-41b8-8d87-9815d7abe8f6",
+  "resourceType" : "microsoft.redhatopenshift/hcpopenshiftclusters",
+  "properties" : {
+    "resourceId" : "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-creating",
+    "internalId" : "/api/aro_hcp/v1alpha1/clusters/cs-cluster-creating",
+    "identity" : {
+      "principalId" : "the-principal",
+      "tenantId" : "the-tenant",
+      "type" : ""
+    },
+    "tags" : {
+      "foo" : "bar"
+    },
+    "provisioningState": "Provisioning",
+    "customerDesiredState" : null,
+    "serviceProviderState" : null
+  }
+}

--- a/test-integration/frontend/artifacts/ExternalAuthMutation/cluster-creating/create.json
+++ b/test-integration/frontend/artifacts/ExternalAuthMutation/cluster-creating/create.json
@@ -1,0 +1,19 @@
+{
+  "name": "test-auth",
+  "properties": {
+    "claim": {
+      "mappings": {
+        "username": {
+          "claim": "sub"
+        }
+      }
+    },
+    "issuer": {
+      "audiences": [
+        "87654321-4321-4321-4321-abcdefghijkl"
+      ],
+      "url": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789abc/v2.0"
+    }
+  },
+  "type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths"
+}

--- a/test-integration/frontend/artifacts/ExternalAuthMutation/cluster-creating/expected-errors.txt
+++ b/test-integration/frontend/artifacts/ExternalAuthMutation/cluster-creating/expected-errors.txt
@@ -1,0 +1,1 @@
+Conflict: /subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-creating/externalAuths/test-auth: Cannot create resource while parent resource is provisioning

--- a/test-integration/frontend/artifacts/ExternalAuthMutation/cluster-deleting/cosmos-state/cosmos-01-cluster.json
+++ b/test-integration/frontend/artifacts/ExternalAuthMutation/cluster-deleting/cosmos-state/cosmos-01-cluster.json
@@ -1,0 +1,20 @@
+{
+  "id" : "39885b40-ec04-11f0-b70f-9c6b00c26e8e",
+  "partitionKey" : "0465bc32-c654-41b8-8d87-9815d7abe8f6",
+  "resourceType" : "microsoft.redhatopenshift/hcpopenshiftclusters",
+  "properties" : {
+    "resourceId" : "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-deleting",
+    "internalId" : "/api/aro_hcp/v1alpha1/clusters/cs-cluster-deleting",
+    "identity" : {
+      "principalId" : "the-principal",
+      "tenantId" : "the-tenant",
+      "type" : ""
+    },
+    "tags" : {
+      "foo" : "bar"
+    },
+    "provisioningState": "Deleting",
+    "customerDesiredState" : null,
+    "serviceProviderState" : null
+  }
+}

--- a/test-integration/frontend/artifacts/ExternalAuthMutation/cluster-deleting/create.json
+++ b/test-integration/frontend/artifacts/ExternalAuthMutation/cluster-deleting/create.json
@@ -1,0 +1,19 @@
+{
+  "name": "test-auth",
+  "properties": {
+    "claim": {
+      "mappings": {
+        "username": {
+          "claim": "sub"
+        }
+      }
+    },
+    "issuer": {
+      "audiences": [
+        "87654321-4321-4321-4321-abcdefghijkl"
+      ],
+      "url": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789abc/v2.0"
+    }
+  },
+  "type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths"
+}

--- a/test-integration/frontend/artifacts/ExternalAuthMutation/cluster-deleting/expected-errors.txt
+++ b/test-integration/frontend/artifacts/ExternalAuthMutation/cluster-deleting/expected-errors.txt
@@ -1,0 +1,1 @@
+Conflict: /subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-deleting/externalAuths/test-auth: Cannot create resource while parent resource is deleting

--- a/test-integration/frontend/artifacts/NodePoolMutation/cluster-creating/cosmos-state/cosmos-01-cluster.json
+++ b/test-integration/frontend/artifacts/NodePoolMutation/cluster-creating/cosmos-state/cosmos-01-cluster.json
@@ -1,0 +1,20 @@
+{
+  "id" : "29c5d490-ec04-11f0-b051-9c6b00c26e8e",
+  "partitionKey" : "0465bc32-c654-41b8-8d87-9815d7abe8f6",
+  "resourceType" : "microsoft.redhatopenshift/hcpopenshiftclusters",
+  "properties" : {
+    "resourceId" : "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-creating",
+    "internalId" : "/api/aro_hcp/v1alpha1/clusters/cs-cluster-creating",
+    "identity" : {
+      "principalId" : "the-principal",
+      "tenantId" : "the-tenant",
+      "type" : ""
+    },
+    "tags" : {
+      "foo" : "bar"
+    },
+    "provisioningState": "Provisioning",
+    "customerDesiredState" : null,
+    "serviceProviderState" : null
+  }
+}

--- a/test-integration/frontend/artifacts/NodePoolMutation/cluster-creating/create.json
+++ b/test-integration/frontend/artifacts/NodePoolMutation/cluster-creating/create.json
@@ -1,0 +1,9 @@
+{
+  "name": "np1",
+  "properties": {
+    "platform": {
+      "vmSize": "large"
+    }
+  },
+  "type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/NodePoolMutation/cluster-creating/expected-errors.txt
+++ b/test-integration/frontend/artifacts/NodePoolMutation/cluster-creating/expected-errors.txt
@@ -1,0 +1,1 @@
+Conflict: /subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-creating/nodePools/np1: Cannot create resource while parent resource is provisioning

--- a/test-integration/frontend/artifacts/NodePoolMutation/cluster-deleting/cosmos-state/cosmos-01-cluster.json
+++ b/test-integration/frontend/artifacts/NodePoolMutation/cluster-deleting/cosmos-state/cosmos-01-cluster.json
@@ -1,0 +1,20 @@
+{
+  "id" : "39885b40-ec04-11f0-b70f-9c6b00c26e8e",
+  "partitionKey" : "0465bc32-c654-41b8-8d87-9815d7abe8f6",
+  "resourceType" : "microsoft.redhatopenshift/hcpopenshiftclusters",
+  "properties" : {
+    "resourceId" : "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-deleting",
+    "internalId" : "/api/aro_hcp/v1alpha1/clusters/cs-cluster-deleting",
+    "identity" : {
+      "principalId" : "the-principal",
+      "tenantId" : "the-tenant",
+      "type" : ""
+    },
+    "tags" : {
+      "foo" : "bar"
+    },
+    "provisioningState": "Deleting",
+    "customerDesiredState" : null,
+    "serviceProviderState" : null
+  }
+}

--- a/test-integration/frontend/artifacts/NodePoolMutation/cluster-deleting/create.json
+++ b/test-integration/frontend/artifacts/NodePoolMutation/cluster-deleting/create.json
@@ -1,0 +1,9 @@
+{
+  "name": "np1",
+  "properties": {
+    "platform": {
+      "vmSize": "large"
+    }
+  },
+  "type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/NodePoolMutation/cluster-deleting/expected-errors.txt
+++ b/test-integration/frontend/artifacts/NodePoolMutation/cluster-deleting/expected-errors.txt
@@ -1,0 +1,1 @@
+Conflict: /subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-deleting/nodePools/np1: Cannot create resource while parent resource is deleting

--- a/test-integration/frontend/artifacts/NodePoolMutation/initial-cluster-service-state/cluster-creating-cluster.json
+++ b/test-integration/frontend/artifacts/NodePoolMutation/initial-cluster-service-state/cluster-creating-cluster.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "listening": "external"
+  },
+  "autoscaler": {
+    "kind": "ClusterAutoscaler",
+    "max_node_provision_time": "15m",
+    "max_pod_grace_period": 600,
+    "pod_priority_threshold": -10,
+    "resource_limits": {
+      "max_nodes_total": 0
+    }
+  },
+  "azure": {
+    "etcd_encryption": {
+      "data_encryption": {
+        "customer_managed": {
+          "encryption_type": "kms",
+          "kms": {
+            "active_key": {
+              "key_name": "encryptionKeyName",
+              "key_vault_name": "keyVaultName",
+              "key_version": "2024-12-01-preview"
+            }
+          }
+        },
+        "key_management_mode": "customer_managed"
+      }
+    },
+    "managed_resource_group_name": "managed-resource-group-name",
+    "network_security_group_resource_id": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
+    "nodes_outbound_connectivity": {
+      "outbound_type": "load_balancer"
+    },
+    "operators_authentication": {
+      "managed_identities": {
+        "control_plane_operators_managed_identities": {},
+        "data_plane_operators_managed_identities": {},
+        "managed_identities_data_plane_identity_url": "",
+        "service_managed_identity": {
+          "client_id": "service-managed-identity_fake-client-id",
+          "principal_id": "service-managed-identity_fake-principal-id",
+          "resource_id": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service-managed-identity"
+        }
+      }
+    },
+    "resource_group_name": "some-resource-group",
+    "resource_name": "cluster-creating",
+    "subnet_resource_id": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+    "subscription_id": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
+    "tenant_id": "00000000-0000-0000-0000-000000000000"
+  },
+  "ccs": {
+    "enabled": true,
+    "kind": "CCS"
+  },
+  "cloud_provider": {
+    "id": "azure",
+    "kind": "CloudProvider"
+  },
+  "flavour": {
+    "id": "osd-4",
+    "kind": "Flavour"
+  },
+  "href": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-creating",
+  "hypershift": {
+    "enabled": true
+  },
+  "image_registry": {
+    "state": "disabled"
+  },
+  "kind": "Cluster",
+  "name": "cluster-creating",
+  "network": {
+    "host_prefix": 23,
+    "machine_cidr": "10.0.0.0/16",
+    "pod_cidr": "10.128.0.0/14",
+    "service_cidr": "172.30.0.0/16",
+    "type": "OVNKubernetes"
+  },
+  "node_drain_grace_period": {
+    "unit": "minutes",
+    "value": 0
+  },
+  "product": {
+    "id": "aro",
+    "kind": "Product"
+  },
+  "region": {
+    "id": "globals-are-evil",
+    "kind": "CloudRegion"
+  },
+  "version": {
+    "channel_group": "stable",
+    "id": "",
+    "kind": "Version"
+  }
+}

--- a/test-integration/frontend/artifacts/NodePoolMutation/initial-cluster-service-state/cluster-deleting-cluster.json
+++ b/test-integration/frontend/artifacts/NodePoolMutation/initial-cluster-service-state/cluster-deleting-cluster.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "listening": "external"
+  },
+  "autoscaler": {
+    "kind": "ClusterAutoscaler",
+    "max_node_provision_time": "15m",
+    "max_pod_grace_period": 600,
+    "pod_priority_threshold": -10,
+    "resource_limits": {
+      "max_nodes_total": 0
+    }
+  },
+  "azure": {
+    "etcd_encryption": {
+      "data_encryption": {
+        "customer_managed": {
+          "encryption_type": "kms",
+          "kms": {
+            "active_key": {
+              "key_name": "encryptionKeyName",
+              "key_vault_name": "keyVaultName",
+              "key_version": "2024-12-01-preview"
+            }
+          }
+        },
+        "key_management_mode": "customer_managed"
+      }
+    },
+    "managed_resource_group_name": "managed-resource-group-name",
+    "network_security_group_resource_id": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
+    "nodes_outbound_connectivity": {
+      "outbound_type": "load_balancer"
+    },
+    "operators_authentication": {
+      "managed_identities": {
+        "control_plane_operators_managed_identities": {},
+        "data_plane_operators_managed_identities": {},
+        "managed_identities_data_plane_identity_url": "",
+        "service_managed_identity": {
+          "client_id": "service-managed-identity_fake-client-id",
+          "principal_id": "service-managed-identity_fake-principal-id",
+          "resource_id": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service-managed-identity"
+        }
+      }
+    },
+    "resource_group_name": "some-resource-group",
+    "resource_name": "cluster-deleting",
+    "subnet_resource_id": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+    "subscription_id": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
+    "tenant_id": "00000000-0000-0000-0000-000000000000"
+  },
+  "ccs": {
+    "enabled": true,
+    "kind": "CCS"
+  },
+  "cloud_provider": {
+    "id": "azure",
+    "kind": "CloudProvider"
+  },
+  "flavour": {
+    "id": "osd-4",
+    "kind": "Flavour"
+  },
+  "href": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-deleting",
+  "hypershift": {
+    "enabled": true
+  },
+  "image_registry": {
+    "state": "disabled"
+  },
+  "kind": "Cluster",
+  "name": "cluster-deleting",
+  "network": {
+    "host_prefix": 23,
+    "machine_cidr": "10.0.0.0/16",
+    "pod_cidr": "10.128.0.0/14",
+    "service_cidr": "172.30.0.0/16",
+    "type": "OVNKubernetes"
+  },
+  "node_drain_grace_period": {
+    "unit": "minutes",
+    "value": 0
+  },
+  "product": {
+    "id": "aro",
+    "kind": "Product"
+  },
+  "region": {
+    "id": "globals-are-evil",
+    "kind": "CloudRegion"
+  },
+  "version": {
+    "channel_group": "stable",
+    "id": "",
+    "kind": "Version"
+  }
+}


### PR DESCRIPTION
### What

Regression slipped through where node pool and external auth requests were not being rejected with 409 Conflict when the parent resource is in a "Provisioning" or "Deleting" state.

This includes a number of new integration test cases to ensure this doesn't regress again.