### PR TITLE
For external to internal conversions to always use a new objects

### DIFF
--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -236,8 +236,7 @@ func decodeDesiredClusterCreate(ctx context.Context) (*api.HCPOpenShiftCluster, 
 		return nil, utils.TrackError(err)
 	}
 
-	newInternalCluster := &api.HCPOpenShiftCluster{}
-	externalClusterFromRequest.Normalize(newInternalCluster)
+	newInternalCluster := externalClusterFromRequest.ConvertToInternal()
 	// TrackedResource info doesn't appear to come from the external resource information
 	conversion.CopyReadOnlyTrackedResourceValues(&newInternalCluster.TrackedResource, ptr.To(arm.NewTrackedResource(resourceID)))
 
@@ -413,8 +412,7 @@ func decodeDesiredClusterReplace(ctx context.Context, oldInternalCluster *api.HC
 		return nil, utils.TrackError(err)
 	}
 
-	newInternalCluster := &api.HCPOpenShiftCluster{}
-	externalClusterFromRequest.Normalize(newInternalCluster)
+	newInternalCluster := externalClusterFromRequest.ConvertToInternal()
 
 	// values a user doesn't have to provide, but are not static defaults (set dynamically during create).  Set these from old value
 	if len(newInternalCluster.CustomerProperties.Version.ID) == 0 {
@@ -490,8 +488,7 @@ func decodeDesiredClusterPatch(ctx context.Context, oldInternalCluster *api.HCPO
 	if err := api.ApplyRequestBody(http.MethodPatch, body, newExternalCluster); err != nil {
 		return nil, utils.TrackError(err)
 	}
-	newInternalCluster := &api.HCPOpenShiftCluster{}
-	newExternalCluster.Normalize(newInternalCluster)
+	newInternalCluster := newExternalCluster.ConvertToInternal()
 
 	// ServiceProviderProperties contains two types of information
 	// 1. values that a user cannot change because the external type does not expose the information.

--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -228,8 +228,7 @@ func decodeDesiredExternalAuthCreate(ctx context.Context) (*api.HCPOpenShiftClus
 		return nil, utils.TrackError(err)
 	}
 
-	newInternalExternalAuth := &api.HCPOpenShiftClusterExternalAuth{}
-	externalExternalAuthFromRequest.Normalize(newInternalExternalAuth)
+	newInternalExternalAuth := externalExternalAuthFromRequest.ConvertToInternal()
 	// ProxyResource info doesn't to come from the external resource information
 	conversion.CopyReadOnlyProxyResourceValues(&newInternalExternalAuth.ProxyResource, ptr.To(arm.NewProxyResource(resourceID)))
 
@@ -385,8 +384,7 @@ func decodeDesiredExternalAuthReplace(ctx context.Context, oldInternalExternalAu
 		return nil, utils.TrackError(err)
 	}
 
-	newInternalExternalAuth := &api.HCPOpenShiftClusterExternalAuth{}
-	externalExternalAuthFromRequest.Normalize(newInternalExternalAuth)
+	newInternalExternalAuth := externalExternalAuthFromRequest.ConvertToInternal()
 
 	// ServiceProviderProperties contains two types of information
 	// 1. values that a user cannot change because the external type does not expose the information.
@@ -432,8 +430,7 @@ func decodeDesiredExternalAuthPatch(ctx context.Context, oldInternalExternalAuth
 	if err := api.ApplyRequestBody(http.MethodPatch, body, newExternalExternalAuth); err != nil {
 		return nil, utils.TrackError(err)
 	}
-	newInternalExternalAuth := &api.HCPOpenShiftClusterExternalAuth{}
-	newExternalExternalAuth.Normalize(newInternalExternalAuth)
+	newInternalExternalAuth := newExternalExternalAuth.ConvertToInternal()
 
 	conversion.CopyReadOnlyExternalAuthValues(newInternalExternalAuth, oldInternalExternalAuth)
 	newInternalExternalAuth.SystemData = systemData

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -603,8 +603,7 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 				continue
 			}
 
-			newInternalCluster := &api.HCPOpenShiftCluster{}
-			versionedCluster.Normalize(newInternalCluster)
+			newInternalCluster := versionedCluster.ConvertToInternal()
 			validationErrs := validation.ValidateClusterCreate(ctx, newInternalCluster, api.Must(versionedInterface.ValidationPathRewriter(&api.HCPOpenShiftCluster{})))
 			validationErrs = append(validationErrs, admission.AdmitClusterOnCreate(ctx, newInternalCluster, subscription)...)
 			cloudError = arm.CloudErrorFromFieldErrors(validationErrs)
@@ -622,8 +621,7 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 			}
 
 			// Perform static validation as if for a node pool creation request.
-			newInternalNodePool := &api.HCPOpenShiftClusterNodePool{}
-			versionedNodePool.Normalize(newInternalNodePool)
+			newInternalNodePool := versionedNodePool.ConvertToInternal()
 			validationErrs := validation.ValidateNodePoolCreate(ctx, newInternalNodePool)
 			cloudError = arm.CloudErrorFromFieldErrors(validationErrs)
 
@@ -640,8 +638,7 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 			}
 
 			// Perform static validation as if for an external auth creation request.
-			newInternalAuth := &api.HCPOpenShiftClusterExternalAuth{}
-			versionedExternalAuth.Normalize(newInternalAuth)
+			newInternalAuth := versionedExternalAuth.ConvertToInternal()
 			validationErrs := validation.ValidateExternalAuthCreate(ctx, newInternalAuth)
 			cloudError = arm.CloudErrorFromFieldErrors(validationErrs)
 

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -230,8 +230,7 @@ func decodeDesiredNodePoolCreate(ctx context.Context) (*api.HCPOpenShiftClusterN
 		return nil, utils.TrackError(err)
 	}
 
-	newInternalNodePool := &api.HCPOpenShiftClusterNodePool{}
-	externalNodePoolFromRequest.Normalize(newInternalNodePool)
+	newInternalNodePool := externalNodePoolFromRequest.ConvertToInternal()
 	// TrackedResource info doesn't appear to come from the external resource information
 	conversion.CopyReadOnlyTrackedResourceValues(&newInternalNodePool.TrackedResource, ptr.To(arm.NewTrackedResource(resourceID)))
 
@@ -391,8 +390,7 @@ func decodeDesiredNodePoolReplace(ctx context.Context, oldInternalNodePool *api.
 		return nil, utils.TrackError(err)
 	}
 
-	newInternalNodePool := &api.HCPOpenShiftClusterNodePool{}
-	externalNodePoolFromRequest.Normalize(newInternalNodePool)
+	newInternalNodePool := externalNodePoolFromRequest.ConvertToInternal()
 
 	// values a user doesn't have to provide, but are not static defaults (set dynamically during create).  Set these from old value
 	if len(newInternalNodePool.Properties.Version.ID) == 0 {
@@ -460,8 +458,7 @@ func decodeDesiredNodePoolPatch(ctx context.Context, oldInternalNodePool *api.HC
 	if err := api.ApplyRequestBody(http.MethodPatch, body, newExternalNodePool); err != nil {
 		return nil, utils.TrackError(err)
 	}
-	newInternalNodePool := &api.HCPOpenShiftClusterNodePool{}
-	newExternalNodePool.Normalize(newInternalNodePool)
+	newInternalNodePool := newExternalNodePool.ConvertToInternal()
 
 	conversion.CopyReadOnlyNodePoolValues(newInternalNodePool, oldInternalNodePool)
 	newInternalNodePool.SystemData = systemData

--- a/internal/api/registry.go
+++ b/internal/api/registry.go
@@ -88,14 +88,13 @@ var (
 )
 
 type VersionedResource interface {
-	GetVersion() Version
 }
 
-type VersionedCreatableResource[T any] interface {
+type VersionedCreatableResource[InternalAPIType any] interface {
 	VersionedResource
 	NewExternal() any
 	SetDefaultValues(any) error
-	Normalize(*T)
+	ConvertToInternal() *InternalAPIType
 }
 
 type VersionedHCPOpenShiftCluster VersionedCreatableResource[HCPOpenShiftCluster]

--- a/internal/api/testhelpers.go
+++ b/internal/api/testhelpers.go
@@ -131,8 +131,9 @@ func (m *ExternalTestResource) GetVersion() Version {
 	return nil
 }
 
-func (m *ExternalTestResource) Normalize(v *InternalTestResource) {
+func (m *ExternalTestResource) ConvertToInternal() *InternalTestResource {
 	// FIXME Implement if there's a need for it in tests.
+	return nil
 }
 
 // Must is a helper function that takes a value and error, returns the value if no error occurred,

--- a/internal/api/v20240610preview/conversion_fuzz_test.go
+++ b/internal/api/v20240610preview/conversion_fuzz_test.go
@@ -102,8 +102,7 @@ func roundTripHCPCluster(t *testing.T, original *api.HCPOpenShiftCluster) {
 	v := version{}
 	externalObj := v.NewHCPOpenShiftCluster(original)
 
-	roundTrippedObj := &api.HCPOpenShiftCluster{}
-	externalObj.Normalize(roundTrippedObj)
+	roundTrippedObj := externalObj.ConvertToInternal()
 
 	// we compare the JSON here because many of these types have private fields that cannot be introspected
 	if !equality.Semantic.DeepEqual(original, roundTrippedObj) {
@@ -120,8 +119,7 @@ func roundTripNodePool(t *testing.T, original *api.HCPOpenShiftClusterNodePool) 
 	v := version{}
 	externalObj := v.NewHCPOpenShiftClusterNodePool(original)
 
-	roundTrippedObj := &api.HCPOpenShiftClusterNodePool{}
-	externalObj.Normalize(roundTrippedObj)
+	roundTrippedObj := externalObj.ConvertToInternal()
 
 	// we compare the JSON here because many of these types have private fields that cannot be introspected
 	if !equality.Semantic.DeepEqual(original, roundTrippedObj) {
@@ -138,8 +136,7 @@ func roundTripExternalAuth(t *testing.T, original *api.HCPOpenShiftClusterExtern
 	v := version{}
 	externalObj := v.NewHCPOpenShiftClusterExternalAuth(original)
 
-	roundTrippedObj := &api.HCPOpenShiftClusterExternalAuth{}
-	externalObj.Normalize(roundTrippedObj)
+	roundTrippedObj := externalObj.ConvertToInternal()
 
 	// we compare the JSON here because many of these types have private fields that cannot be introspected
 	if !equality.Semantic.DeepEqual(original, roundTrippedObj) {

--- a/internal/api/v20240610preview/external_auth_methods.go
+++ b/internal/api/v20240610preview/external_auth_methods.go
@@ -69,7 +69,9 @@ func (h *ExternalAuth) GetVersion() api.Version {
 	return versionedInterface
 }
 
-func (h *ExternalAuth) Normalize(out *api.HCPOpenShiftClusterExternalAuth) {
+func (h *ExternalAuth) ConvertToInternal() *api.HCPOpenShiftClusterExternalAuth {
+	out := &api.HCPOpenShiftClusterExternalAuth{}
+
 	if h.ID != nil {
 		out.ID = api.Must(azcorearm.ParseResourceID(*h.ID))
 	}
@@ -125,6 +127,8 @@ func (h *ExternalAuth) Normalize(out *api.HCPOpenShiftClusterExternalAuth) {
 			normalizeExternalAuthClientProfile(h.Properties.Clients[i], &out.Properties.Clients[i])
 		}
 	}
+
+	return out
 }
 
 func normalizeExternalAuthClientProfile(p *generated.ExternalAuthClientProfile, out *api.ExternalAuthClientProfile) {

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -340,7 +340,9 @@ func (c *HcpOpenShiftCluster) GetVersion() api.Version {
 	return versionedInterface
 }
 
-func (c *HcpOpenShiftCluster) Normalize(out *api.HCPOpenShiftCluster) {
+func (c *HcpOpenShiftCluster) ConvertToInternal() *api.HCPOpenShiftCluster {
+	out := &api.HCPOpenShiftCluster{}
+
 	if c.ID != nil {
 		out.ID = api.Must(azcorearm.ParseResourceID(*c.ID))
 	}
@@ -416,6 +418,8 @@ func (c *HcpOpenShiftCluster) Normalize(out *api.HCPOpenShiftCluster) {
 			}
 		}
 	}
+
+	return out
 }
 
 func normalizeManagedIdentity(identity *generated.ManagedServiceIdentity) *arm.ManagedServiceIdentity {

--- a/internal/api/v20240610preview/nodepools_methods.go
+++ b/internal/api/v20240610preview/nodepools_methods.go
@@ -77,7 +77,9 @@ func (h *NodePool) GetVersion() api.Version {
 	return versionedInterface
 }
 
-func (h *NodePool) Normalize(out *api.HCPOpenShiftClusterNodePool) {
+func (h *NodePool) ConvertToInternal() *api.HCPOpenShiftClusterNodePool {
+	out := &api.HCPOpenShiftClusterNodePool{}
+
 	if h.ID != nil {
 		out.ID = api.Must(azcorearm.ParseResourceID(*h.ID))
 	}
@@ -181,6 +183,7 @@ func (h *NodePool) Normalize(out *api.HCPOpenShiftClusterNodePool) {
 
 	out.Identity = normalizeManagedIdentity(h.Identity)
 
+	return out
 }
 
 func normalizeNodePoolVersion(p *generated.NodePoolVersionProfile, out *api.NodePoolVersionProfile) {

--- a/internal/api/v20251223preview/conversion_fuzz_test.go
+++ b/internal/api/v20251223preview/conversion_fuzz_test.go
@@ -102,8 +102,7 @@ func roundTripHCPCluster(t *testing.T, original *api.HCPOpenShiftCluster) {
 	v := version{}
 	externalObj := v.NewHCPOpenShiftCluster(original)
 
-	roundTrippedObj := &api.HCPOpenShiftCluster{}
-	externalObj.Normalize(roundTrippedObj)
+	roundTrippedObj := externalObj.ConvertToInternal()
 
 	// we compare the JSON here because many of these types have private fields that cannot be introspected
 	if !equality.Semantic.DeepEqual(original, roundTrippedObj) {
@@ -120,8 +119,7 @@ func roundTripNodePool(t *testing.T, original *api.HCPOpenShiftClusterNodePool) 
 	v := version{}
 	externalObj := v.NewHCPOpenShiftClusterNodePool(original)
 
-	roundTrippedObj := &api.HCPOpenShiftClusterNodePool{}
-	externalObj.Normalize(roundTrippedObj)
+	roundTrippedObj := externalObj.ConvertToInternal()
 
 	// we compare the JSON here because many of these types have private fields that cannot be introspected
 	if !equality.Semantic.DeepEqual(original, roundTrippedObj) {
@@ -138,8 +136,7 @@ func roundTripExternalAuth(t *testing.T, original *api.HCPOpenShiftClusterExtern
 	v := version{}
 	externalObj := v.NewHCPOpenShiftClusterExternalAuth(original)
 
-	roundTrippedObj := &api.HCPOpenShiftClusterExternalAuth{}
-	externalObj.Normalize(roundTrippedObj)
+	roundTrippedObj := externalObj.ConvertToInternal()
 
 	// we compare the JSON here because many of these types have private fields that cannot be introspected
 	if !equality.Semantic.DeepEqual(original, roundTrippedObj) {

--- a/internal/api/v20251223preview/external_auth_methods.go
+++ b/internal/api/v20251223preview/external_auth_methods.go
@@ -69,7 +69,9 @@ func (h *ExternalAuth) GetVersion() api.Version {
 	return versionedInterface
 }
 
-func (h *ExternalAuth) Normalize(out *api.HCPOpenShiftClusterExternalAuth) {
+func (h *ExternalAuth) ConvertToInternal() *api.HCPOpenShiftClusterExternalAuth {
+	out := &api.HCPOpenShiftClusterExternalAuth{}
+
 	if h.ID != nil {
 		out.ID = api.Must(azcorearm.ParseResourceID(*h.ID))
 	}
@@ -125,6 +127,8 @@ func (h *ExternalAuth) Normalize(out *api.HCPOpenShiftClusterExternalAuth) {
 			normalizeExternalAuthClientProfile(h.Properties.Clients[i], &out.Properties.Clients[i])
 		}
 	}
+
+	return out
 }
 
 func normalizeExternalAuthClientProfile(p *generated.ExternalAuthClientProfile, out *api.ExternalAuthClientProfile) {

--- a/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
@@ -340,7 +340,9 @@ func (c *HcpOpenShiftCluster) GetVersion() api.Version {
 	return versionedInterface
 }
 
-func (c *HcpOpenShiftCluster) Normalize(out *api.HCPOpenShiftCluster) {
+func (c *HcpOpenShiftCluster) ConvertToInternal() *api.HCPOpenShiftCluster {
+	out := &api.HCPOpenShiftCluster{}
+
 	if c.ID != nil {
 		out.ID = api.Must(azcorearm.ParseResourceID(*c.ID))
 	}
@@ -416,6 +418,8 @@ func (c *HcpOpenShiftCluster) Normalize(out *api.HCPOpenShiftCluster) {
 			}
 		}
 	}
+
+	return out
 }
 
 func normalizeManagedIdentity(identity *generated.ManagedServiceIdentity) *arm.ManagedServiceIdentity {

--- a/internal/api/v20251223preview/nodepools_methods.go
+++ b/internal/api/v20251223preview/nodepools_methods.go
@@ -77,7 +77,9 @@ func (h *NodePool) GetVersion() api.Version {
 	return versionedInterface
 }
 
-func (h *NodePool) Normalize(out *api.HCPOpenShiftClusterNodePool) {
+func (h *NodePool) ConvertToInternal() *api.HCPOpenShiftClusterNodePool {
+	out := &api.HCPOpenShiftClusterNodePool{}
+
 	if h.ID != nil {
 		out.ID = api.Must(azcorearm.ParseResourceID(*h.ID))
 	}
@@ -179,6 +181,8 @@ func (h *NodePool) Normalize(out *api.HCPOpenShiftClusterNodePool) {
 	}
 
 	out.Identity = normalizeManagedIdentity(h.Identity)
+
+	return out
 }
 
 func normalizeNodePoolVersion(p *generated.NodePoolVersionProfile, out *api.NodePoolVersionProfile) {


### PR DESCRIPTION
While theoretically less efficient if we built our own object nursery and managed clearning manually, in practice the potential for passing an object that has some unrelated values set, then using it to convert to internal, and then having the converted object NOT be equivalent to the external is incredibly painful.  this change makes that error impossible.

No functional changes because over the course of the refactor, we eliminated all usages of partially complete starting points for conversion.