### PR TITLE
Make the APIRegistry new external functions roundtrippable.

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -604,7 +604,12 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 		case strings.ToLower(api.ClusterResourceType.String()):
 			// API version is already validated by this point.
 			versionedInterface, _ := f.apiRegistry.Lookup(preflightResource.APIVersion)
-			versionedCluster := versionedInterface.NewHCPOpenShiftCluster(nil)
+			versionedCluster := versionedInterface.NewHCPOpenShiftCluster(&api.HCPOpenShiftCluster{})
+			if err := versionedCluster.SetDefaultValues(versionedCluster); err != nil {
+				// Preflight is best effort: failure to parse a resource is not a validation failure.
+				logger.Warn("failed to set defaults", "error", err, "type", preflightResource.Type, "name", preflightResource.Name)
+				continue
+			}
 
 			err = preflightResource.Convert(versionedCluster)
 			if err != nil {
@@ -621,7 +626,12 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 		case strings.ToLower(api.NodePoolResourceType.String()):
 			// API version is already validated by this point.
 			versionedInterface, _ := f.apiRegistry.Lookup(preflightResource.APIVersion)
-			versionedNodePool := versionedInterface.NewHCPOpenShiftClusterNodePool(nil)
+			versionedNodePool := versionedInterface.NewHCPOpenShiftClusterNodePool(&api.HCPOpenShiftClusterNodePool{})
+			if err := versionedNodePool.SetDefaultValues(versionedNodePool); err != nil {
+				// Preflight is best effort: failure to parse a resource is not a validation failure.
+				logger.Warn("failed to set defaults", "error", err, "type", preflightResource.Type, "name", preflightResource.Name)
+				continue
+			}
 
 			err = preflightResource.Convert(versionedNodePool)
 			if err != nil {
@@ -638,7 +648,12 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 		case strings.ToLower(api.ExternalAuthResourceType.String()):
 			// API version is already validated by this point.
 			versionedInterface, _ := f.apiRegistry.Lookup(preflightResource.APIVersion)
-			versionedExternalAuth := versionedInterface.NewHCPOpenShiftClusterExternalAuth(nil)
+			versionedExternalAuth := versionedInterface.NewHCPOpenShiftClusterExternalAuth(&api.HCPOpenShiftClusterExternalAuth{})
+			if err := versionedExternalAuth.SetDefaultValues(versionedExternalAuth); err != nil {
+				// Preflight is best effort: failure to parse a resource is not a validation failure.
+				logger.Warn("failed to set defaults", "error", err, "type", preflightResource.Type, "name", preflightResource.Name)
+				continue
+			}
 
 			err = preflightResource.Convert(versionedExternalAuth)
 			if err != nil {

--- a/internal/api/registry.go
+++ b/internal/api/registry.go
@@ -114,7 +114,7 @@ type Version interface {
 	ValidationPathRewriter(obj any) (ValidationPathMapperFunc, error)
 
 	// Resource Types
-	// Passing a nil pointer creates a resource with default values.
+	// Passing a nil returns a nil
 	NewHCPOpenShiftCluster(*HCPOpenShiftCluster) VersionedHCPOpenShiftCluster
 	NewHCPOpenShiftClusterNodePool(*HCPOpenShiftClusterNodePool) VersionedHCPOpenShiftClusterNodePool
 	NewHCPOpenShiftClusterExternalAuth(*HCPOpenShiftClusterExternalAuth) VersionedHCPOpenShiftClusterExternalAuth

--- a/internal/api/v20240610preview/external_auth_methods.go
+++ b/internal/api/v20240610preview/external_auth_methods.go
@@ -321,9 +321,7 @@ func newTokenRequiredClaim(from *api.TokenRequiredClaim) generated.TokenRequired
 
 func (v version) NewHCPOpenShiftClusterExternalAuth(from *api.HCPOpenShiftClusterExternalAuth) api.VersionedHCPOpenShiftClusterExternalAuth {
 	if from == nil {
-		ret := &ExternalAuth{}
-		SetDefaultValuesExternalAuth(ret)
-		return ret
+		return nil
 	}
 
 	idString := ""

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -298,9 +298,7 @@ func newManagedServiceIdentity(from *arm.ManagedServiceIdentity) *generated.Mana
 
 func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.VersionedHCPOpenShiftCluster {
 	if from == nil {
-		ret := &HcpOpenShiftCluster{}
-		SetDefaultValuesCluster(ret)
-		return ret
+		return nil
 	}
 
 	idString := ""

--- a/internal/api/v20240610preview/nodepools_methods.go
+++ b/internal/api/v20240610preview/nodepools_methods.go
@@ -284,9 +284,7 @@ func newNodePoolAutoScaling(from *api.NodePoolAutoScaling) generated.NodePoolAut
 
 func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNodePool) api.VersionedHCPOpenShiftClusterNodePool {
 	if from == nil {
-		ret := &NodePool{}
-		SetDefaultValuesNodePool(ret)
-		return ret
+		return nil
 	}
 
 	idString := ""

--- a/internal/api/v20251223preview/external_auth_methods.go
+++ b/internal/api/v20251223preview/external_auth_methods.go
@@ -321,9 +321,7 @@ func newTokenRequiredClaim(from *api.TokenRequiredClaim) generated.TokenRequired
 
 func (v version) NewHCPOpenShiftClusterExternalAuth(from *api.HCPOpenShiftClusterExternalAuth) api.VersionedHCPOpenShiftClusterExternalAuth {
 	if from == nil {
-		ret := &ExternalAuth{}
-		SetDefaultValuesExternalAuth(ret)
-		return ret
+		return nil
 	}
 
 	idString := ""

--- a/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
@@ -298,9 +298,7 @@ func newManagedServiceIdentity(from *arm.ManagedServiceIdentity) *generated.Mana
 
 func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.VersionedHCPOpenShiftCluster {
 	if from == nil {
-		ret := &HcpOpenShiftCluster{}
-		SetDefaultValuesCluster(ret)
-		return ret
+		return nil
 	}
 
 	idString := ""

--- a/internal/api/v20251223preview/nodepools_methods.go
+++ b/internal/api/v20251223preview/nodepools_methods.go
@@ -283,9 +283,7 @@ func newNodePoolAutoScaling(from *api.NodePoolAutoScaling) generated.NodePoolAut
 
 func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNodePool) api.VersionedHCPOpenShiftClusterNodePool {
 	if from == nil {
-		ret := &NodePool{}
-		SetDefaultValuesNodePool(ret)
-		return ret
+		return nil
 	}
 
 	idString := ""


### PR DESCRIPTION
Previously, passing a nil for creating a new external instance got one that alreayd had defaulted values. this was surprising for a couple reasons, primarily because the output doesn't roundtrip and compare to the input, but also because nil and empty were treated differently. This also meant that creating a new instance using "nil" resulted in a value that would have latent, unexpected values after writing or deserializing into it.  While this may be done intentionally, it's a case where a caller can explicitly make that choice.

This change only impacted three callsites associated with preflights becuase the previous refactors have eliminated all other usages.
