### PR TITLE
promotion: int to stg and prod

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -210,7 +210,7 @@ clouds:
           clustersService:
             deployDebugJobs: true
             image:
-              digest: sha256:a6c1df92344d5754e92bad90f41f89a44c1bea1230a8bf49fda3257ee7ff1967
+              digest: sha256:5aab3f8636ba482fb7e75b627b53b8c93fbaf2957a5f1af2432ebaa666e2dd1e
           # ACR Pull
           acrPull:
             image:
@@ -253,38 +253,38 @@ clouds:
             prometheus:
               prometheusOperator:
                 image:
-                  sha: 5c3fd99a70fb43aa5ea4672ccaf04c68ac60d7adb7e205d2bf75d1b46395455c
+                  sha: 6a3fe01e2d08228b241a4c0a2dcb7c7424b004fb5ad36430e206fa549d500038
               prometheusSpec:
                 image:
                   sha: 385d647d7c2027aa867da0afe30995726686237e473a3284962e4bad1ae3ef1e
               prometheusConfigReloader:
                 image:
-                  sha: 807993bae8544ca5dba1a088507c39adce29fef1afd2fb7492247b09e0cfa2a9
+                  sha: 7aaf789a403f1c75f86a34f470174d62a7f2c070852e2eedb5736fc63dc17e86
               kubeStateMetrics:
                 image:
                   digest: sha256:377bd55d97824dfee27b3c577869bc793fc3970623433627c7f0ee1b1b74e725 # v2.15.0-7
           # RP Frontend
           frontend:
             image:
-              digest: sha256:bb76f6e0e21a5e0d84636b9d392600c4694d8763f78e502298971a5da0f7a293 # 8289751
+              digest: sha256:5aeb23bf13c7e5ba2d9b3cb95587f1b190cbc48e25efe3807111bc6f5940287a
             audit:
               connectSocket: true
           # RP Backend
           backend:
             image:
-              digest: sha256:0d6038627507d36343aa60eb5ed38ffa0f74bdff1f3d1f53398b563733a8e14f # 8289751
+              digest: sha256:9ae1fa1eb4442f4d429eac7bff86321d6c043106204ab977b82548689d56fd35
           # Admin API
           adminApi:
             image:
-              digest: "sha256:4ddda08cb3389cf83383c5fae58c759ffa72c90fde94b2a9af519a6a3465ce17"
+              digest: sha256:6e8e4cad8e058e33ce859c1b33a2e26458792578b01f7e3ac3f88cc19c16d935
           # Hypershift
           hypershift:
             image:
-              digest: sha256:2b33a38c788fd8cbc16c1f353d417bee4646140dbfbfaa847b4d81941c601c36
+              digest: sha256:d0573db78b8a382b45db4674004e6e41dad33f9a072bc557108747a95ae89440
           # Maestro
           maestro:
             image:
-              digest: sha256:5a5f19580b2e4dca62661e0eeeb6e98e18f06f7a0750b9fb02f348bbfcf77cdf
+              digest: sha256:1bd32d0e4174e9ac84f73db7b94e5d5861d4802ca4f82d09a2edba2270da0ce1
             agent:
               sidecar:
                 image:
@@ -293,7 +293,7 @@ clouds:
           imageSync:
             ocMirror:
               image:
-                digest: sha256:0847731bbd2452e988dd765955602b490aa82d63652a0616d49b5978edc9c552
+                digest: sha256:4d20cfab10f1524779ca86a55894630ff13eb6da8e5bb58783fa4b058364b272
           # Mise
           mise:
             image:


### PR DESCRIPTION
This pull request updates several container image digests and shas in the `config/config.msft.clouds-overlay.yaml` file to newer versions. These changes affect a variety of core platform components, including Prometheus, RP frontend/backend, admin API, hypershift, maestro, and supporting services. The updates are aimed at ensuring the latest images are used, which may include bug fixes, security patches, or new features.

Container image updates:

- Updated the digests for `clustersService`, `frontend`, `backend`, `adminApi`, `hypershift`, `maestro`, and `ocMirror` images to newer versions. [[1]](diffhunk://#diff-87393c9c623ed02754c0934ec14fcaf20b39b10a7b9837bae5fc9d55b0e7207bL114-R114) [[2]](diffhunk://#diff-87393c9c623ed02754c0934ec14fcaf20b39b10a7b9837bae5fc9d55b0e7207bL157-R188) [[3]](diffhunk://#diff-87393c9c623ed02754c0934ec14fcaf20b39b10a7b9837bae5fc9d55b0e7207bL197-R197) [[4]](diffhunk://#diff-87393c9c623ed02754c0934ec14fcaf20b39b10a7b9837bae5fc9d55b0e7207bL213-R213) [[5]](diffhunk://#diff-87393c9c623ed02754c0934ec14fcaf20b39b10a7b9837bae5fc9d55b0e7207bL256-R287) [[6]](diffhunk://#diff-87393c9c623ed02754c0934ec14fcaf20b39b10a7b9837bae5fc9d55b0e7207bL296-R296)

Prometheus stack updates:

- Updated the `prometheusOperator` and `prometheusConfigReloader` image shas to newer versions, ensuring the monitoring stack uses the latest images. [[1]](diffhunk://#diff-87393c9c623ed02754c0934ec14fcaf20b39b10a7b9837bae5fc9d55b0e7207bL157-R188) [[2]](diffhunk://#diff-87393c9c623ed02754c0934ec14fcaf20b39b10a7b9837bae5fc9d55b0e7207bL256-R287)