### PR TITLE
add frontend testing for nodes to gather exist cosmos data for testing future changes

### DIFF
--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/cluster-create-with-tags.json
@@ -1,0 +1,83 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"00000000-0000-0000-7121-fd067c0501dc\"",
+	"_rid": "WZlNALYurecDAAAAAAAAAA==",
+	"_self": "dbs/WZlNAA==/colls/WZlNALYurec=/docs/WZlNALYurecDAAAAAAAAAA==/",
+	"_ts": 1766174370,
+	"id": "c893be2c-80b0-497f-8490-e3e5fd2b2cc4",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
+		"identity": {
+			"type": "UserAssigned"
+		},
+		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
+		"internalState": {
+			"internalAPI": {
+				"customerProperties": {
+					"api": {
+						"visibility": "Public"
+					},
+					"autoscaling": {
+						"maxNodeProvisionTimeSeconds": 900,
+						"maxPodGracePeriodSeconds": 600,
+						"podPriorityThreshold": -10
+					},
+					"clusterImageRegistry": {
+						"state": "Disabled"
+					},
+					"dns": {},
+					"etcd": {
+						"dataEncryption": {
+							"customerManaged": {
+								"encryptionType": "KMS",
+								"kms": {
+									"activeKey": {
+										"name": "encryptionKeyName",
+										"vaultName": "keyVaultName",
+										"version": "2024-12-01-preview"
+									}
+								}
+							},
+							"keyManagementMode": "CustomerManaged"
+						}
+					},
+					"network": {
+						"hostPrefix": 23,
+						"machineCidr": "10.0.0.0/16",
+						"networkType": "OVNKubernetes",
+						"podCidr": "10.128.0.0/14",
+						"serviceCidr": "172.30.0.0/16"
+					},
+					"platform": {
+						"managedResourceGroup": "managed-resource-group-name",
+						"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+						"operatorsAuthentication": {
+							"userAssignedIdentities": {}
+						},
+						"outboundType": "LoadBalancer",
+						"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+					},
+					"version": {
+						"channelGroup": "stable"
+					}
+				},
+				"location": "fake-location",
+				"serviceProviderProperties": {
+					"api": {},
+					"clusterServiceID": "",
+					"console": {},
+					"dns": {},
+					"platform": {}
+				}
+			}
+		},
+		"provisioningState": "Succeeded",
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
+		"systemData": {},
+		"tags": {
+			"one": "apple"
+		}
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-basic-node-pool.json
@@ -1,0 +1,54 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"00000000-0000-0000-712b-4dda080501dc\"",
+	"_rid": "SdEpAPzZNVkFAAAAAAAAAA==",
+	"_self": "dbs/SdEpAA==/colls/SdEpAPzZNVk=/docs/SdEpAPzZNVkFAAAAAAAAAA==/",
+	"_ts": 1766178371,
+	"id": "23bd08bc-2ed3-40be-8c9e-7e005f8a421f",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+		"internalState": {
+			"internalAPI": {
+				"location": "fake-location",
+				"properties": {
+					"autoRepair": true,
+					"autoScaling": {
+						"max": 5,
+						"min": 1
+					},
+					"labels": {
+						"label-ky": "label-value"
+					},
+					"nodeDrainTimeoutMinutes": 2,
+					"platform": {
+						"enableEncryptionAtHost": false,
+						"osDisk": {
+							"diskStorageAccountType": "Premium_LRS",
+							"sizeGiB": 64
+						},
+						"vmSize": "large"
+					},
+					"taints": [
+						{
+							"effect": "NoExecute",
+							"key": "foo.com/key",
+							"value": "valid"
+						}
+					],
+					"version": {
+						"channelGroup": "stable"
+					}
+				},
+				"serviceProviderProperties": {
+					"clusterServiceID": ""
+				}
+			}
+		},
+		"provisioningState": "Accepted",
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+		"systemData": {}
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-node-pool-02.json
@@ -1,0 +1,54 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"00000000-0000-0000-712b-4e012c0501dc\"",
+	"_rid": "SdEpAPzZNVkHAAAAAAAAAA==",
+	"_self": "dbs/SdEpAA==/colls/SdEpAPzZNVk=/docs/SdEpAPzZNVkHAAAAAAAAAA==/",
+	"_ts": 1766178372,
+	"id": "405f85e0-9528-458d-abbf-b16e2319c833",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
+		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+		"internalState": {
+			"internalAPI": {
+				"location": "fake-location",
+				"properties": {
+					"autoRepair": true,
+					"autoScaling": {
+						"max": 5,
+						"min": 1
+					},
+					"labels": {
+						"label-ky": "label-value"
+					},
+					"nodeDrainTimeoutMinutes": 2,
+					"platform": {
+						"enableEncryptionAtHost": false,
+						"osDisk": {
+							"diskStorageAccountType": "Premium_LRS",
+							"sizeGiB": 64
+						},
+						"vmSize": "large"
+					},
+					"taints": [
+						{
+							"effect": "NoExecute",
+							"key": "foo.com/key",
+							"value": "valid"
+						}
+					],
+					"version": {
+						"channelGroup": "stable"
+					}
+				},
+				"serviceProviderProperties": {
+					"clusterServiceID": ""
+				}
+			}
+		},
+		"provisioningState": "Accepted",
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
+		"systemData": {}
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -1,0 +1,22 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"00000000-0000-0000-7121-fd067c0501dc\"",
+	"_rid": "WZlNALYurecCAAAAAAAAAA==",
+	"_self": "dbs/WZlNAA==/colls/WZlNALYurec=/docs/WZlNALYurecCAAAAAAAAAA==/",
+	"_ts": 1766174370,
+	"id": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
+		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
+		"lastTransitionTime": "2025-12-19T19:59:30.714826736Z",
+		"operationId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/locations/fake-location/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
+		"request": "Create",
+		"resourceId": null,
+		"startTime": "2025-12-19T19:59:30.714826736Z",
+		"status": "Succeeded",
+		"tenantId": "00000000-0000-0000-0000-000000000000"
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
+	"ttl": 604800
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-basicnodepool.json
@@ -1,0 +1,22 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"00000000-0000-0000-80d9-f0cdd80501dc\"",
+	"_rid": "3+dlAMzyjkYEAAAAAAAAAA==",
+	"_self": "dbs/3+dlAA==/colls/3+dlAMzyjkY=/docs/3+dlAMzyjkYEAAAAAAAAAA==/",
+	"_ts": 1767902645,
+	"id": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+		"lastTransitionTime": "2026-01-08T20:04:05.054190978Z",
+		"operationId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/locations/fake-location/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+		"request": "Create",
+		"resourceId": null,
+		"startTime": "2026-01-08T20:04:05.054190978Z",
+		"status": "Accepted",
+		"tenantId": "00000000-0000-0000-0000-000000000000"
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
+	"ttl": 604800
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-nodepool-02.json
@@ -1,0 +1,22 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"00000000-0000-0000-80d9-f0f7840501dc\"",
+	"_rid": "3+dlAMzyjkYGAAAAAAAAAA==",
+	"_self": "dbs/3+dlAA==/colls/3+dlAMzyjkY=/docs/3+dlAMzyjkYGAAAAAAAAAA==/",
+	"_ts": 1767902645,
+	"id": "4067756a-fcc1-4732-a211-d785d888203c",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
+		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+		"lastTransitionTime": "2026-01-08T20:04:05.330050272Z",
+		"operationId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/locations/fake-location/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
+		"request": "Create",
+		"resourceId": null,
+		"startTime": "2026-01-08T20:04:05.330050272Z",
+		"status": "Accepted",
+		"tenantId": "00000000-0000-0000-0000-000000000000"
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
+	"ttl": 604800
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/subscription.json
@@ -1,0 +1,16 @@
+{
+    "_attachments": "attachments/",
+    "_etag": "\"00000000-0000-0000-7121-fcdc980501dc\"",
+    "_rid": "WZlNALYurecBAAAAAAAAAA==",
+    "_self": "dbs/WZlNAA==/colls/WZlNALYurec=/docs/WZlNALYurecBAAAAAAAAAA==/",
+    "_ts": 1766174370,
+    "id": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+    "partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+    "properties": {
+        "properties": null,
+        "registrationDate": "2025-12-19T19:53:15+00:00",
+        "resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+        "state": "Registered"
+    },
+    "resourceType": "Microsoft.Resources/subscriptions"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.5pgpxt9pzj.node_pools.59mkgdzg9s-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.5pgpxt9pzj.node_pools.59mkgdzg9s-nodepool.json
@@ -1,0 +1,43 @@
+{
+	"auto_repair": true,
+	"autoscaling": {
+		"kind": "NodePoolAutoscaling",
+		"max_replica": 5,
+		"min_replica": 1
+	},
+	"availability_zone": "",
+	"azure_node_pool": {
+		"encryption_at_host": {
+			"state": "disabled"
+		},
+		"os_disk": {
+			"size_gibibytes": 64,
+			"storage_account_type": "Premium_LRS"
+		},
+		"resource_name": "basic-node-pool",
+		"vm_size": "large"
+	},
+	"href": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+	"id": "59mkgdzg9s",
+	"kind": "NodePool",
+	"labels": {
+		"label-ky": "label-value"
+	},
+	"node_drain_grace_period": {
+		"unit": "minutes",
+		"value": 2
+	},
+	"subnet": "",
+	"taints": [
+		{
+			"effect": "NoExecute",
+			"key": "foo.com/key",
+			"value": "valid"
+		}
+	],
+	"version": {
+		"channel_group": "stable",
+		"id": "",
+		"kind": "Version"
+	}
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.5pgpxt9pzj.node_pools.v4lx7rv2r4-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.5pgpxt9pzj.node_pools.v4lx7rv2r4-nodepool.json
@@ -1,0 +1,43 @@
+{
+	"auto_repair": true,
+	"autoscaling": {
+		"kind": "NodePoolAutoscaling",
+		"max_replica": 5,
+		"min_replica": 1
+	},
+	"availability_zone": "",
+	"azure_node_pool": {
+		"encryption_at_host": {
+			"state": "disabled"
+		},
+		"os_disk": {
+			"size_gibibytes": 64,
+			"storage_account_type": "Premium_LRS"
+		},
+		"resource_name": "node-pool-02",
+		"vm_size": "large"
+	},
+	"href": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+	"id": "v4lx7rv2r4",
+	"kind": "NodePool",
+	"labels": {
+		"label-ky": "label-value"
+	},
+	"node_drain_grace_period": {
+		"unit": "minutes",
+		"value": 2
+	},
+	"subnet": "",
+	"taints": [
+		{
+			"effect": "NoExecute",
+			"key": "foo.com/key",
+			"value": "valid"
+		}
+	],
+	"version": {
+		"channel_group": "stable",
+		"id": "",
+		"kind": "Version"
+	}
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.9p2sk955gj-autoscaler.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.9p2sk955gj-autoscaler.json
@@ -1,0 +1,10 @@
+{
+    "href": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
+    "kind": "ClusterAutoscaler",
+    "max_node_provision_time": "15m",
+    "max_pod_grace_period": 600,
+    "pod_priority_threshold": -10,
+    "resource_limits": {
+        "max_nodes_total": 0
+    }
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.9p2sk955gj-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/02-loadClusterService-old-data/0_.api.clusters_mgmt.v1.clusters.9p2sk955gj-cluster.json
@@ -1,0 +1,90 @@
+{
+	"api": {
+		"cidr_block_access": {
+			"allow": {
+				"mode": "allow_all"
+			}
+		},
+		"listening": "external"
+	},
+	"azure": {
+		"etcd_encryption": {
+			"data_encryption": {
+				"customer_managed": {
+					"encryption_type": "kms",
+					"kms": {
+						"active_key": {
+							"key_name": "encryptionKeyName",
+							"key_vault_name": "keyVaultName",
+							"key_version": "2024-12-01-preview"
+						}
+					}
+				},
+				"key_management_mode": "customer_managed"
+			}
+		},
+		"managed_resource_group_name": "managed-resource-group-name",
+		"network_security_group_resource_id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+		"nodes_outbound_connectivity": {
+			"outbound_type": "load_balancer"
+		},
+		"operators_authentication": {
+			"managed_identities": {
+				"control_plane_operators_managed_identities": {},
+				"data_plane_operators_managed_identities": {},
+				"managed_identities_data_plane_identity_url": ""
+			}
+		},
+		"resource_group_name": "resourcegroupname",
+		"resource_name": "create-with-tags",
+		"subnet_resource_id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+		"subscription_id": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+		"tenant_id": "00000000-0000-0000-0000-000000000000"
+	},
+	"ccs": {
+		"enabled": true,
+		"kind": "CCS"
+	},
+	"cloud_provider": {
+		"id": "azure",
+		"kind": "CloudProvider"
+	},
+	"flavour": {
+		"id": "osd-4",
+		"kind": "Flavour"
+	},
+	"href": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
+	"hypershift": {
+		"enabled": true
+	},
+	"id": "9p2sk955gj",
+	"image_registry": {
+		"state": "disabled"
+	},
+	"kind": "Cluster",
+	"name": "create-with-tags",
+	"network": {
+		"host_prefix": 23,
+		"machine_cidr": "10.0.0.0/16",
+		"pod_cidr": "10.128.0.0/14",
+		"service_cidr": "172.30.0.0/16",
+		"type": "OVNKubernetes"
+	},
+	"node_drain_grace_period": {
+		"unit": "minutes",
+		"value": 0
+	},
+	"product": {
+		"id": "aro",
+		"kind": "Product"
+	},
+	"region": {
+		"id": "fake-location",
+		"kind": "CloudRegion"
+	},
+	"version": {
+		"channel_group": "stable",
+		"id": "",
+		"kind": "Version"
+	}
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/03-httpGet-node-pool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/03-httpGet-node-pool/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/03-httpGet-node-pool/basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/03-httpGet-node-pool/basic-node-pool.json
@@ -1,0 +1,39 @@
+{
+	"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+	"location": "fake-location",
+	"name": "basic-node-pool",
+	"properties": {
+		"autoRepair": true,
+		"autoScaling": {
+			"max": 5,
+			"min": 1
+		},
+		"labels": [
+			{
+				"key": "label-ky",
+				"value": "label-value"
+			}
+		],
+		"nodeDrainTimeoutMinutes": 2,
+		"platform": {
+			"enableEncryptionAtHost": false,
+			"osDisk": {
+				"diskStorageAccountType": "Premium_LRS",
+				"sizeGiB": 64
+			},
+			"vmSize": "large"
+		},
+		"provisioningState": "Accepted",
+		"taints": [
+			{
+				"effect": "NoExecute",
+				"key": "foo.com/key",
+				"value": "valid"
+			}
+		],
+		"version": {
+			"channelGroup": "stable"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-httpList-nodepools/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-httpList-nodepools/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/dummy"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-httpList-nodepools/basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-httpList-nodepools/basic-node-pool.json
@@ -1,0 +1,39 @@
+{
+	"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+	"location": "fake-location",
+	"name": "basic-node-pool",
+	"properties": {
+		"autoRepair": true,
+		"autoScaling": {
+			"max": 5,
+			"min": 1
+		},
+		"labels": [
+			{
+				"key": "label-ky",
+				"value": "label-value"
+			}
+		],
+		"nodeDrainTimeoutMinutes": 2,
+		"platform": {
+			"enableEncryptionAtHost": false,
+			"osDisk": {
+				"diskStorageAccountType": "Premium_LRS",
+				"sizeGiB": 64
+			},
+			"vmSize": "large"
+		},
+		"provisioningState": "Accepted",
+		"taints": [
+			{
+				"effect": "NoExecute",
+				"key": "foo.com/key",
+				"value": "valid"
+			}
+		],
+		"version": {
+			"channelGroup": "stable"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-httpList-nodepools/nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-httpList-nodepools/nodepool-02.json
@@ -1,0 +1,39 @@
+{
+	"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
+	"location": "fake-location",
+	"name": "node-pool-02",
+	"properties": {
+		"autoRepair": true,
+		"autoScaling": {
+			"max": 5,
+			"min": 1
+		},
+		"labels": [
+			{
+				"key": "label-ky",
+				"value": "label-value"
+			}
+		],
+		"nodeDrainTimeoutMinutes": 2,
+		"platform": {
+			"enableEncryptionAtHost": false,
+			"osDisk": {
+				"diskStorageAccountType": "Premium_LRS",
+				"sizeGiB": 64
+			},
+			"vmSize": "large"
+		},
+		"provisioningState": "Accepted",
+		"taints": [
+			{
+				"effect": "NoExecute",
+				"key": "foo.com/key",
+				"value": "valid"
+			}
+		],
+		"version": {
+			"channelGroup": "stable"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-listActiveOperations-node-create/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-listActiveOperations-node-create/00-key.json
@@ -1,0 +1,3 @@
+{
+	"parentResourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-listActiveOperations-node-create/operation-nodepool-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-listActiveOperations-node-create/operation-nodepool-create-basicnodepool.json
@@ -1,0 +1,11 @@
+{
+	"resourceId": null,
+	"tenantId": "00000000-0000-0000-0000-000000000000",
+	"request": "Create",
+	"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+	"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+	"operationId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/locations/fake-location/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+	"startTime": "2026-01-08T20:04:05.054190978Z",
+	"lastTransitionTime": "2026-01-08T20:04:05.054190978Z",
+	"status": "Accepted"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-listActiveOperations-node-create/operation-nodepool-create-nodepool02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-listActiveOperations-node-create/operation-nodepool-create-nodepool02.json
@@ -1,0 +1,11 @@
+{
+	"resourceId": null,
+	"tenantId": "00000000-0000-0000-0000-000000000000",
+	"request": "Create",
+	"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
+	"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+	"operationId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/locations/fake-location/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
+	"startTime": "2026-01-08T20:04:05.330050272Z",
+	"lastTransitionTime": "2026-01-08T20:04:05.330050272Z",
+	"status": "Accepted"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/06-completeOperation-nodepool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/06-completeOperation-nodepool/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/07-httpReplace-field/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/07-httpReplace-field/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/07-httpReplace-field/basic-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/07-httpReplace-field/basic-nodepool.json
@@ -1,0 +1,39 @@
+{
+	"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+	"location": "fake-location",
+	"name": "basic-node-pool",
+	"properties": {
+		"autoRepair": true,
+		"autoScaling": {
+			"max": 5,
+			"min": 1
+		},
+		"labels": [
+			{
+				"key": "label-ky",
+				"value": "label-value"
+			}
+		],
+		"nodeDrainTimeoutMinutes": 2,
+		"platform": {
+			"enableEncryptionAtHost": false,
+			"osDisk": {
+				"diskStorageAccountType": "Premium_LRS",
+				"sizeGiB": 64
+			},
+			"vmSize": "large"
+		},
+		"provisioningState": "Accepted",
+		"taints": [
+			{
+				"effect": "NoExecute",
+				"key": "foo.com/key",
+				"value": "other"
+			}
+		],
+		"version": {
+			"channelGroup": "stable"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/08-httpGet-nodepool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/08-httpGet-nodepool/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/08-httpGet-nodepool/basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/08-httpGet-nodepool/basic-node-pool.json
@@ -1,0 +1,39 @@
+{
+	"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+	"location": "fake-location",
+	"name": "basic-node-pool",
+	"properties": {
+		"autoRepair": true,
+		"autoScaling": {
+			"max": 5,
+			"min": 1
+		},
+		"labels": [
+			{
+				"key": "label-ky",
+				"value": "label-value"
+			}
+		],
+		"nodeDrainTimeoutMinutes": 2,
+		"platform": {
+			"enableEncryptionAtHost": false,
+			"osDisk": {
+				"diskStorageAccountType": "Premium_LRS",
+				"sizeGiB": 64
+			},
+			"vmSize": "large"
+		},
+		"provisioningState": "Accepted",
+		"taints": [
+			{
+				"effect": "NoExecute",
+				"key": "foo.com/key",
+				"value": "other"
+			}
+		],
+		"version": {
+			"channelGroup": "stable"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
@@ -1,0 +1,83 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"00000000-0000-0000-80da-b38be40501dc\"",
+	"_rid": "NNYoALQEciYBAAAAAAAAAA==",
+	"_self": "dbs/NNYoAA==/colls/NNYoALQEciY=/docs/NNYoALQEciYBAAAAAAAAAA==/",
+	"_ts": 1767902971,
+	"id": "c893be2c-80b0-497f-8490-e3e5fd2b2cc4",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
+		"identity": {
+			"type": "UserAssigned"
+		},
+		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
+		"internalState": {
+			"internalAPI": {
+				"customerProperties": {
+					"api": {
+						"visibility": "Public"
+					},
+					"autoscaling": {
+						"maxNodeProvisionTimeSeconds": 900,
+						"maxPodGracePeriodSeconds": 600,
+						"podPriorityThreshold": -10
+					},
+					"clusterImageRegistry": {
+						"state": "Disabled"
+					},
+					"dns": {},
+					"etcd": {
+						"dataEncryption": {
+							"customerManaged": {
+								"encryptionType": "KMS",
+								"kms": {
+									"activeKey": {
+										"name": "encryptionKeyName",
+										"vaultName": "keyVaultName",
+										"version": "2024-12-01-preview"
+									}
+								}
+							},
+							"keyManagementMode": "CustomerManaged"
+						}
+					},
+					"network": {
+						"hostPrefix": 23,
+						"machineCidr": "10.0.0.0/16",
+						"networkType": "OVNKubernetes",
+						"podCidr": "10.128.0.0/14",
+						"serviceCidr": "172.30.0.0/16"
+					},
+					"platform": {
+						"managedResourceGroup": "managed-resource-group-name",
+						"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+						"operatorsAuthentication": {
+							"userAssignedIdentities": {}
+						},
+						"outboundType": "LoadBalancer",
+						"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+					},
+					"version": {
+						"channelGroup": "stable"
+					}
+				},
+				"location": "fake-location",
+				"serviceProviderProperties": {
+					"api": {},
+					"clusterServiceID": "",
+					"console": {},
+					"dns": {},
+					"platform": {}
+				}
+			}
+		},
+		"provisioningState": "Succeeded",
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
+		"systemData": {},
+		"tags": {
+			"one": "apple"
+		}
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-02.json
@@ -1,0 +1,54 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"00000000-0000-0000-80da-b390d80501dc\"",
+	"_rid": "NNYoALQEciYDAAAAAAAAAA==",
+	"_self": "dbs/NNYoAA==/colls/NNYoALQEciY=/docs/NNYoALQEciYDAAAAAAAAAA==/",
+	"_ts": 1767902971,
+	"id": "405f85e0-9528-458d-abbf-b16e2319c833",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
+		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+		"internalState": {
+			"internalAPI": {
+				"location": "fake-location",
+				"properties": {
+					"autoRepair": true,
+					"autoScaling": {
+						"max": 5,
+						"min": 1
+					},
+					"labels": {
+						"label-ky": "label-value"
+					},
+					"nodeDrainTimeoutMinutes": 2,
+					"platform": {
+						"enableEncryptionAtHost": false,
+						"osDisk": {
+							"diskStorageAccountType": "Premium_LRS",
+							"sizeGiB": 64
+						},
+						"vmSize": "large"
+					},
+					"taints": [
+						{
+							"effect": "NoExecute",
+							"key": "foo.com/key",
+							"value": "valid"
+						}
+					],
+					"version": {
+						"channelGroup": "stable"
+					}
+				},
+				"serviceProviderProperties": {
+					"clusterServiceID": ""
+				}
+			}
+		},
+		"provisioningState": "Accepted",
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
+		"systemData": {}
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-basic-node-pool.json
@@ -1,0 +1,54 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"00000000-0000-0000-80da-b404ec0501dc\"",
+	"_rid": "NNYoALQEciYCAAAAAAAAAA==",
+	"_self": "dbs/NNYoAA==/colls/NNYoALQEciY=/docs/NNYoALQEciYCAAAAAAAAAA==/",
+	"_ts": 1767902972,
+	"id": "23bd08bc-2ed3-40be-8c9e-7e005f8a421f",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"activeOperationId": "50c1a0ba-3bc4-48fb-857e-eb0974df1e1c",
+		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+		"internalState": {
+			"internalAPI": {
+				"location": "fake-location",
+				"properties": {
+					"autoRepair": true,
+					"autoScaling": {
+						"max": 5,
+						"min": 1
+					},
+					"labels": {
+						"label-ky": "label-value"
+					},
+					"nodeDrainTimeoutMinutes": 2,
+					"platform": {
+						"enableEncryptionAtHost": false,
+						"osDisk": {
+							"diskStorageAccountType": "Premium_LRS",
+							"sizeGiB": 64
+						},
+						"vmSize": "large"
+					},
+					"taints": [
+						{
+							"effect": "NoExecute",
+							"key": "foo.com/key",
+							"value": "other"
+						}
+					],
+					"version": {
+						"channelGroup": "stable"
+					}
+				},
+				"serviceProviderProperties": {
+					"clusterServiceID": ""
+				}
+			}
+		},
+		"provisioningState": "Accepted",
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+		"systemData": {}
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-cluster.json
@@ -1,0 +1,22 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"00000000-0000-0000-80da-b392b40501dc\"",
+	"_rid": "NNYoALQEciYEAAAAAAAAAA==",
+	"_self": "dbs/NNYoAA==/colls/NNYoALQEciY=/docs/NNYoALQEciYEAAAAAAAAAA==/",
+	"_ts": 1767902971,
+	"id": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
+		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
+		"lastTransitionTime": "2025-12-19T19:59:30.714826736Z",
+		"operationId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/locations/fake-location/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
+		"request": "Create",
+		"resourceId": null,
+		"startTime": "2025-12-19T19:59:30.714826736Z",
+		"status": "Succeeded",
+		"tenantId": "00000000-0000-0000-0000-000000000000"
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
+	"ttl": 604800
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-02.json
@@ -1,0 +1,22 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"00000000-0000-0000-80da-b395300501dc\"",
+	"_rid": "NNYoALQEciYGAAAAAAAAAA==",
+	"_self": "dbs/NNYoAA==/colls/NNYoALQEciY=/docs/NNYoALQEciYGAAAAAAAAAA==/",
+	"_ts": 1767902971,
+	"id": "4067756a-fcc1-4732-a211-d785d888203c",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
+		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+		"lastTransitionTime": "2026-01-08T20:04:05.330050272Z",
+		"operationId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/locations/fake-location/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
+		"request": "Create",
+		"resourceId": null,
+		"startTime": "2026-01-08T20:04:05.330050272Z",
+		"status": "Accepted",
+		"tenantId": "00000000-0000-0000-0000-000000000000"
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
+	"ttl": 604800
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-basic.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-basic.json
@@ -1,0 +1,22 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"00000000-0000-0000-80da-b3c8140501dc\"",
+	"_rid": "NNYoALQEciYFAAAAAAAAAA==",
+	"_self": "dbs/NNYoAA==/colls/NNYoALQEciY=/docs/NNYoALQEciYFAAAAAAAAAA==/",
+	"_ts": 1767902972,
+	"id": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+		"lastTransitionTime": "2026-01-08T15:09:32.172766239-05:00",
+		"operationId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/locations/fake-location/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+		"request": "Create",
+		"resourceId": null,
+		"startTime": "2026-01-08T20:04:05.054190978Z",
+		"status": "Succeeded",
+		"tenantId": "00000000-0000-0000-0000-000000000000"
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
+	"ttl": 604800
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-update-nodepool-basic.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-update-nodepool-basic.json
@@ -1,0 +1,22 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"00000000-0000-0000-80da-b404ec0501dc\"",
+	"_rid": "NNYoALQEciYIAAAAAAAAAA==",
+	"_self": "dbs/NNYoAA==/colls/NNYoALQEciY=/docs/NNYoALQEciYIAAAAAAAAAA==/",
+	"_ts": 1767902972,
+	"id": "50c1a0ba-3bc4-48fb-857e-eb0974df1e1c",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+		"lastTransitionTime": "2026-01-08T20:09:32.571015378Z",
+		"operationId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/locations/fake-location/hcpOperationStatuses/50c1a0ba-3bc4-48fb-857e-eb0974df1e1c",
+		"request": "Update",
+		"resourceId": null,
+		"startTime": "2026-01-08T20:09:32.571015378Z",
+		"status": "Accepted",
+		"tenantId": "00000000-0000-0000-0000-000000000000"
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
+	"ttl": 604800
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/subscription.json
@@ -1,0 +1,16 @@
+{
+    "_attachments": "attachments/",
+    "_etag": "\"00000000-0000-0000-80da-b3970c0501dc\"",
+    "_rid": "NNYoALQEciYHAAAAAAAAAA==",
+    "_self": "dbs/NNYoAA==/colls/NNYoALQEciY=/docs/NNYoALQEciYHAAAAAAAAAA==/",
+    "_ts": 1767902971,
+    "id": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+    "partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+    "properties": {
+        "properties": null,
+        "registrationDate": "2025-12-19T19:53:15+00:00",
+        "resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+        "state": "Registered"
+    },
+    "resourceType": "Microsoft.Resources/subscriptions"
+}

--- a/test-integration/utils/databasemutationhelpers/per_resource_http.go
+++ b/test-integration/utils/databasemutationhelpers/per_resource_http.go
@@ -73,15 +73,15 @@ func (c frontendHTTPTestAccessor) Get(ctx context.Context, resourceIDString stri
 	}
 }
 
-func (c frontendHTTPTestAccessor) List(ctx context.Context, parentResourceIDString string) ([]any, error) {
-	parentResourceID, err := azcorearm.ParseResourceID(parentResourceIDString)
+func (c frontendHTTPTestAccessor) List(ctx context.Context, exemplarResourceIDString string) ([]any, error) {
+	exemplarResourceID, err := azcorearm.ParseResourceID(exemplarResourceIDString)
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
 
-	switch strings.ToLower(parentResourceID.ResourceType.String()) {
+	switch strings.ToLower(exemplarResourceID.ResourceType.String()) {
 	case strings.ToLower(api.ClusterResourceType.String()):
-		pager := c.frontendClient.NewHcpOpenShiftClustersClient().NewListByResourceGroupPager(parentResourceID.ResourceGroupName, nil)
+		pager := c.frontendClient.NewHcpOpenShiftClustersClient().NewListByResourceGroupPager(exemplarResourceID.ResourceGroupName, nil)
 		ret := []any{}
 		for pager.More() {
 			page, err := pager.NextPage(ctx)
@@ -95,7 +95,7 @@ func (c frontendHTTPTestAccessor) List(ctx context.Context, parentResourceIDStri
 		return ret, nil
 
 	case strings.ToLower(api.NodePoolResourceType.String()):
-		pager := c.frontendClient.NewNodePoolsClient().NewListByParentPager(parentResourceID.ResourceGroupName, parentResourceID.Name, nil)
+		pager := c.frontendClient.NewNodePoolsClient().NewListByParentPager(exemplarResourceID.ResourceGroupName, exemplarResourceID.Parent.Name, nil)
 		ret := []any{}
 		for pager.More() {
 			page, err := pager.NextPage(ctx)
@@ -109,7 +109,7 @@ func (c frontendHTTPTestAccessor) List(ctx context.Context, parentResourceIDStri
 		return ret, nil
 
 	case strings.ToLower(api.ExternalAuthResourceType.String()):
-		pager := c.frontendClient.NewExternalAuthsClient().NewListByParentPager(parentResourceID.ResourceGroupName, parentResourceID.Name, nil)
+		pager := c.frontendClient.NewExternalAuthsClient().NewListByParentPager(exemplarResourceID.ResourceGroupName, exemplarResourceID.Parent.Name, nil)
 		ret := []any{}
 		for pager.More() {
 			page, err := pager.NextPage(ctx)
@@ -123,7 +123,7 @@ func (c frontendHTTPTestAccessor) List(ctx context.Context, parentResourceIDStri
 		return ret, nil
 
 	default:
-		return nil, utils.TrackError(fmt.Errorf("unknown resource type: %s", parentResourceID.ResourceType.String()))
+		return nil, utils.TrackError(fmt.Errorf("unknown resource type: %s", exemplarResourceID.ResourceType.String()))
 	}
 }
 

--- a/test-integration/utils/integrationutils/mutation_test_utils.go
+++ b/test-integration/utils/integrationutils/mutation_test_utils.go
@@ -78,7 +78,7 @@ func TrivialPassThroughClusterServiceMock(t *testing.T, testInfo *FrontendIntegr
 				}
 				internalIDToCluster[obj.HREF()] = []any{obj}
 
-			case strings.HasSuffix(dirEntry.Name(), "-external-auth.json"):
+			case strings.HasSuffix(dirEntry.Name(), "-externalauth.json"):
 				obj, err := arohcpv1alpha1.UnmarshalExternalAuth(fileContent)
 				if err != nil {
 					return fmt.Errorf("failed to unmarshal nodepool: %w", err)
@@ -88,7 +88,7 @@ func TrivialPassThroughClusterServiceMock(t *testing.T, testInfo *FrontendIntegr
 				}
 				internalIDToExternalAuth[obj.HREF()] = []any{obj}
 
-			case strings.HasSuffix(dirEntry.Name(), "-node-pool.json"):
+			case strings.HasSuffix(dirEntry.Name(), "-nodepool.json"):
 				obj, err := arohcpv1alpha1.UnmarshalNodePool(fileContent)
 				if err != nil {
 					return fmt.Errorf("failed to unmarshal nodepool: %w", err)


### PR DESCRIPTION
needed so that we can be sure what we're able to read old node data before the migration.