### PR TITLE
frontend: Stash arm.Subscription from middleware

### DIFF
--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -305,12 +305,7 @@ func (f *Frontend) createHCPCluster(writer http.ResponseWriter, request *http.Re
 	ctx := request.Context()
 	logger := utils.LoggerFromContext(ctx)
 
-	resourceID, err := utils.ResourceIDFromContext(ctx)
-	if err != nil {
-		return err
-	}
-
-	subscription, err := f.dbClient.Subscriptions().Get(ctx, resourceID.SubscriptionID)
+	subscription, err := SubscriptionFromContext(ctx)
 	if err != nil {
 		return err
 	}

--- a/frontend/pkg/frontend/context.go
+++ b/frontend/pkg/frontend/context.go
@@ -53,6 +53,8 @@ func (c contextKey) String() string {
 		return "systemData"
 	case contextKeyPattern:
 		return "pattern"
+	case contextKeySubscription:
+		return "subscription"
 	}
 	return "<unknown>"
 }
@@ -67,6 +69,7 @@ const (
 	contextKeyCorrelationData
 	contextKeySystemData
 	contextKeyPattern
+	contextKeySubscription
 )
 
 func ContextWithOriginalPath(ctx context.Context, originalPath string) context.Context {
@@ -156,4 +159,21 @@ func ContextWithPattern(ctx context.Context, pattern *string) context.Context {
 func PatternFromContext(ctx context.Context) *string {
 	pattern, _ := ctx.Value(contextKeyPattern).(*string)
 	return pattern
+}
+
+func ContextWithSubscription(ctx context.Context, subscription *arm.Subscription) context.Context {
+	return context.WithValue(ctx, contextKeySubscription, subscription)
+}
+
+func SubscriptionFromContext(ctx context.Context) (*arm.Subscription, error) {
+	rawValue := ctx.Value(contextKeySubscription)
+	subscription, ok := rawValue.(*arm.Subscription)
+	if !ok {
+		err := &ContextError{
+			got: rawValue,
+			key: contextKeySubscription,
+		}
+		return subscription, err
+	}
+	return subscription, nil
 }

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -622,7 +622,7 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 	ctx := request.Context()
 	logger := utils.LoggerFromContext(ctx)
 
-	subscription, err := f.dbClient.Subscriptions().Get(ctx, subscriptionID)
+	subscription, err := SubscriptionFromContext(ctx)
 	if err != nil {
 		return err
 	}

--- a/frontend/pkg/frontend/middleware_validatesubscription.go
+++ b/frontend/pkg/frontend/middleware_validatesubscription.go
@@ -57,8 +57,6 @@ func (h *middlewareValidateSubscriptionState) handleRequest(w http.ResponseWrite
 		return
 	}
 
-	// TODO: Ideally, we don't want to have to hit the database in this middleware
-	// Currently, we are using the database to retrieve the subscription's tenantID and state
 	subscription, err := h.dbClient.Subscriptions().Get(ctx, subscriptionId)
 	if err != nil {
 		logger.Error(err, "failed to get subscription document", "subscriptionId", subscriptionId)
@@ -94,6 +92,10 @@ func (h *middlewareValidateSubscriptionState) handleRequest(w http.ResponseWrite
 	span.SetAttributes(
 		tracing.SubscriptionStateKey.String(string(subscription.State)),
 	)
+
+	// Stash the subscription for REST handlers.
+	ctx = ContextWithSubscription(ctx, subscription)
+	r = r.WithContext(ctx)
 
 	switch subscription.State {
 	case arm.SubscriptionStateRegistered:

--- a/frontend/pkg/frontend/middleware_validatesubscription_test.go
+++ b/frontend/pkg/frontend/middleware_validatesubscription_test.go
@@ -235,6 +235,11 @@ func TestMiddlewareValidateSubscription(t *testing.T) {
 
 			assert.Equal(t, tt.expectedState, subscription.State)
 
+			// Verify the subscription was stashed in the request context.
+			stashedSubscription, err := SubscriptionFromContext(request.Context())
+			assert.NoError(t, err)
+			assert.Equal(t, subscription.ResourceID, stashedSubscription.ResourceID)
+
 			// Check that the attributes have been added to the span too.
 			ss := sr.collect()
 			require.Len(t, ss, 1)


### PR DESCRIPTION
### What

Small optimization to avoid a redundant Cosmos DB lookup for a couple routes.

### Why

Most routes use `newMiddlewareValidateSubscriptionState` to verify the subscription is registered before proceeding. This involves fetching the subscription document from Cosmos DB.

A couple REST handlers now check for registered subscription features, which also requires the subscription document from Cosmos DB.

Instead of refetching the document from Cosmos DB, have the middleware stash the subscription document in the `http.Request` context.
