### PR TITLE
Use fqdn of ingest service to avoid DNS server issues at cluster creation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1080,7 +1080,7 @@ clouds:
             server:
               mqttClientName: 'maestro-server-{{ .ctx.regionShort }}-dev'
               tracing:
-                address: "http://ingest.observability:4318"
+                address: "http://ingest.observability.svc.cluster.local:4318"
                 exporter: "otlp"
           # Frontend
           frontend:
@@ -1177,7 +1177,7 @@ clouds:
                 image: "docker.io/library/postgres:14.2"
                 pvcCapacity: 512Mi
             tracing:
-              address: "http://ingest.observability:4318"
+              address: "http://ingest.observability.svc.cluster.local:4318"
               exporter: "otlp"
           # Geneva
           geneva:
@@ -1197,12 +1197,12 @@ clouds:
             server:
               mqttClientName: 'maestro-server-{{ .ctx.regionShort }}'
               tracing:
-                address: "http://ingest.observability:4318"
+                address: "http://ingest.observability.svc.cluster.local:4318"
                 exporter: "otlp"
           # Backend
           backend:
             tracing:
-              address: "http://ingest.observability:4318"
+              address: "http://ingest.observability.svc.cluster.local:4318"
               exporter: "otlp"
           # Frontend
           frontend:
@@ -1212,7 +1212,7 @@ clouds:
               private: false
               zoneRedundantMode: 'Disabled'
             tracing:
-              address: "http://ingest.observability:4318"
+              address: "http://ingest.observability.svc.cluster.local:4318"
               exporter: "otlp"
           # MC
           mgmt:
@@ -1326,7 +1326,7 @@ clouds:
                 image: "docker.io/library/postgres:14.2"
                 pvcCapacity: 512Mi
             tracing:
-              address: "http://ingest.observability:4318"
+              address: "http://ingest.observability.svc.cluster.local:4318"
               exporter: "otlp"
           # Geneva
           geneva:
@@ -1346,12 +1346,12 @@ clouds:
             server:
               mqttClientName: 'maestro-server-{{ .ctx.regionShort }}'
               tracing:
-                address: "http://ingest.observability:4318"
+                address: "http://ingest.observability.svc.cluster.local:4318"
                 exporter: "otlp"
           # Backend
           backend:
             tracing:
-              address: "http://ingest.observability:4318"
+              address: "http://ingest.observability.svc.cluster.local:4318"
               exporter: "otlp"
           # Frontend
           frontend:
@@ -1361,7 +1361,7 @@ clouds:
               private: false
               zoneRedundantMode: 'Disabled'
             tracing:
-              address: "http://ingest.observability:4318"
+              address: "http://ingest.observability.svc.cluster.local:4318"
               exporter: "otlp"
           # MC
           mgmt:

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -6,16 +6,16 @@ clouds:
           westus3: 01cf9a0611b7603976b25b7495213a1cc9a3d153107a781d3b4925051fe28003
       dev:
         regions:
-          westus3: 43876241e14ea9d3501029d45d88b61f21ac24568107cd67ea3c4b129e561aa3
+          westus3: 0442afddd50de286ec469f964bb73f9a7ca9be805db5087a21dc5b0a3b75ac0d
       perf:
         regions:
           westus3: 0f793798c5b06a465004413f95ccfb07da932bd1721d6739441423887cfd0ca4
       pers:
         regions:
-          westus3: 27ce5832adce50279b3e64c96be2e53383bf79fba1a305167512302e81e58272
+          westus3: 45b58cca8bacd4175502faa3190ff8c396b3ffbd689fe1f60c2dfe23f1ec1a9e
       prow:
         regions:
-          westus3: 29c719050ba5e926470ac443c9beffb3cb03f61a407a5181cb3ce3a29b33ecc6
+          westus3: 2f38ae9774f077a56d4b4edb9c713ac28fcf1e9d71cf535a56b3ec54201a5f7a
       swft:
         regions:
           uksouth: 77fc8618ddd4988f4d8e47ac8a7490ff333914fed130490c67b0ea1998ca6192

--- a/config/dev.digests.yaml
+++ b/config/dev.digests.yaml
@@ -6,16 +6,16 @@ clouds:
           westus3: 01cf9a0611b7603976b25b7495213a1cc9a3d153107a781d3b4925051fe28003
       dev:
         regions:
-          westus3: e143cc6651f96a80e3787b3c0c9bf12ad348ae70762a5d6f43908702b8fe818c
+          westus3: 43876241e14ea9d3501029d45d88b61f21ac24568107cd67ea3c4b129e561aa3
       perf:
         regions:
           westus3: 0f793798c5b06a465004413f95ccfb07da932bd1721d6739441423887cfd0ca4
       pers:
         regions:
-          westus3: 30debee1c5e419eddd4d7c35fa1ac4f65a5f33eabe053108f57f1d7a6b072be0
+          westus3: 27ce5832adce50279b3e64c96be2e53383bf79fba1a305167512302e81e58272
       prow:
         regions:
-          westus3: 5d74cb2c30493625cb222469e365baa0c58fd77a35b664d3b4c49588eee3e3f8
+          westus3: 29c719050ba5e926470ac443c9beffb3cb03f61a407a5181cb3ce3a29b33ecc6
       swft:
         regions:
           uksouth: 77fc8618ddd4988f4d8e47ac8a7490ff333914fed130490c67b0ea1998ca6192

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -418,7 +418,7 @@ maestro:
     managedIdentityName: maestro-server
     mqttClientName: maestro-server-usw3-dev
     tracing:
-      address: http://ingest.observability:4318
+      address: http://ingest.observability.svc.cluster.local:4318
       exporter: otlp
 mgmt:
   aks:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -76,7 +76,7 @@ backend:
     serviceAccountName: backend
   managedIdentityName: backend
   tracing:
-    address: http://ingest.observability:4318
+    address: http://ingest.observability.svc.cluster.local:4318
     exporter: otlp
 backplaneAPI:
   image:
@@ -165,7 +165,7 @@ clustersService:
     zoneRedundantMode: Auto
   provisionShardClusterLimit: 100
   tracing:
-    address: http://ingest.observability:4318
+    address: http://ingest.observability.svc.cluster.local:4318
     exporter: otlp
 cxKeyVault:
   name: ah-pers-cx-usw3test-1
@@ -221,7 +221,7 @@ frontend:
     serviceAccountName: frontend
   managedIdentityName: frontend
   tracing:
-    address: http://ingest.observability:4318
+    address: http://ingest.observability.svc.cluster.local:4318
     exporter: otlp
 geneva:
   actions:
@@ -418,7 +418,7 @@ maestro:
     managedIdentityName: maestro-server
     mqttClientName: maestro-server-usw3test
     tracing:
-      address: http://ingest.observability:4318
+      address: http://ingest.observability.svc.cluster.local:4318
       exporter: otlp
 mgmt:
   aks:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -76,7 +76,7 @@ backend:
     serviceAccountName: backend
   managedIdentityName: backend
   tracing:
-    address: http://ingest.observability:4318
+    address: http://ingest.observability.svc.cluster.local:4318
     exporter: otlp
 backplaneAPI:
   image:
@@ -165,7 +165,7 @@ clustersService:
     zoneRedundantMode: Auto
   provisionShardClusterLimit: 100
   tracing:
-    address: http://ingest.observability:4318
+    address: http://ingest.observability.svc.cluster.local:4318
     exporter: otlp
 cxKeyVault:
   name: ah-prow-cx-usw3j234-1
@@ -221,7 +221,7 @@ frontend:
     serviceAccountName: frontend
   managedIdentityName: frontend
   tracing:
-    address: http://ingest.observability:4318
+    address: http://ingest.observability.svc.cluster.local:4318
     exporter: otlp
 geneva:
   actions:
@@ -418,7 +418,7 @@ maestro:
     managedIdentityName: maestro-server
     mqttClientName: maestro-server-usw3j234
     tracing:
-      address: http://ingest.observability:4318
+      address: http://ingest.observability.svc.cluster.local:4318
       exporter: otlp
 mgmt:
   aks:

--- a/maestro/server/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_maestro_server.yaml
+++ b/maestro/server/testdata/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_maestro_server.yaml
@@ -197,7 +197,7 @@ spec:
           readOnly: true
         env:
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: 'http://ingest.observability:4318'
+          value: 'http://ingest.observability.svc.cluster.local:4318'
         - name: OTEL_TRACES_EXPORTER
           value: 'otlp'
         - name: "AMS_ENV"


### PR DESCRIPTION
### What

This PR updates the config to use ingest fqdn.

### Why

During cluster creation in my personal dev, I consistently encountered the following error. The DNS server isn't yet reachable at that stage and therefore the cluster creation fails. Using the fqdn avoids the DNS resolution.

```
{"time":"2026-01-15T02:01:42.426118882Z","level":"ERROR","source":{"function":"github.com/Azure/ARO-HCP/internal/tracing.ConfigureOpenTelemetryTracer.func2","file":"/app/internal/tracing/otel_sdk.go","line":88},"msg":"OpenTelemetry.ErrorHandler: traces export: Post \"http://ingest.observability:4318/v1/traces\": dial tcp: lookup ingest.observability on 10.130.0.10:53: no such host"}
```

### Special notes for your reviewer

