### PR TITLE
Warn on subscription document missing from cosmosdb

### DIFF
--- a/frontend/pkg/frontend/middleware_validatesubscription.go
+++ b/frontend/pkg/frontend/middleware_validatesubscription.go
@@ -63,6 +63,7 @@ func (h *middlewareValidateSubscriptionState) handleRequest(w http.ResponseWrite
 	if err != nil {
 		// subscription not found, treat as unregistered
 		if database.IsResponseError(err, http.StatusNotFound) {
+			logger.Warn("subscription document not found", "subscriptionId", subscriptionId)
 			arm.WriteError(
 				w, http.StatusBadRequest,
 				arm.CloudErrorCodeInvalidSubscriptionState, "",


### PR DESCRIPTION
Ideal state is to update the dump_data controller to include this, but it's not omnipresent since it's periodic, so this will at least tell us that we're missing the subscription from cosmosdb.  