### PR TITLE
Add fipsEnabled property: the cluster would be using fips validated libs

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -123,6 +123,10 @@ model HcpOpenShiftClusterProperties {
   /** OpenShift internal image registry */
   @visibility(Lifecycle.Read, Lifecycle.Create)
   clusterImageRegistry?: ClusterImageRegistryProfile;
+
+  /** Cluster uses FIPS validated cryptographic libraries */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  fipsEnabled?: boolean = false;
 }
 
 /** The resource provisioning state. */

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
@@ -84,7 +84,8 @@
         "nodeDrainTimeoutMinutes": 20,
         "clusterImageRegistry": {
           "state": "Enabled"
-        }
+        },
+        "fipsEnabled": false
       },
       "identity": {
         "type": "UserAssigned",
@@ -180,7 +181,8 @@
           "nodeDrainTimeoutMinutes": 20,
           "clusterImageRegistry": {
             "state": "Enabled"
-          }
+          },
+          "fipsEnabled": false
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",
@@ -294,7 +296,8 @@
           "nodeDrainTimeoutMinutes": 20,
           "clusterImageRegistry": {
             "state": "Enabled"
-          }
+          },
+          "fipsEnabled": false
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
@@ -93,7 +93,8 @@
           "nodeDrainTimeoutMinutes": 20,
           "clusterImageRegistry": {
             "state": "Enabled"
-          }
+          },
+          "fipsEnabled": false
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
@@ -90,7 +90,8 @@
               "nodeDrainTimeoutMinutes": 20,
               "clusterImageRegistry": {
                 "state": "Enabled"
-              }
+              },
+              "fipsEnabled": false
             },
             "identity": {
               "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
@@ -104,7 +104,8 @@
           "nodeDrainTimeoutMinutes": 20,
           "clusterImageRegistry": {
             "state": "Enabled"
-          }
+          },
+          "fipsEnabled": false
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/openapi.json
@@ -2317,6 +2317,15 @@
             "read",
             "create"
           ]
+        },
+        "fipsEnabled": {
+          "type": "boolean",
+          "description": "Cluster uses FIPS validated cryptographic libraries",
+          "default": false,
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         }
       },
       "required": [

--- a/internal/api/types_cluster.go
+++ b/internal/api/types_cluster.go
@@ -60,6 +60,7 @@ type HCPOpenShiftClusterCustomerProperties struct {
 	Etcd                    EtcdProfile                 `json:"etcd,omitempty"`
 	ClusterImageRegistry    ClusterImageRegistryProfile `json:"clusterImageRegistry,omitempty"`
 	ImageDigestMirrors      []ImageDigestMirror         `json:"imageDigestMirrors,omitempty"`
+	FipsEnabled             bool                        `json:"fipsEnabled,omitempty"`
 }
 
 // HCPOpenShiftClusterCustomerProperties represents the property bag of a HCPOpenShiftCluster resource.
@@ -270,6 +271,7 @@ func NewDefaultHCPOpenShiftCluster(resourceID *azcorearm.ResourceID, azureLocati
 			ClusterImageRegistry: ClusterImageRegistryProfile{
 				State: ClusterImageRegistryStateEnabled,
 			},
+			FipsEnabled: false,
 		},
 	}
 }

--- a/internal/api/v20251223preview/generated/models.go
+++ b/internal/api/v20251223preview/generated/models.go
@@ -347,6 +347,9 @@ type HcpOpenShiftClusterProperties struct {
 	// imageDigestMirrors is a set of rules to allow pulling images from a mirrored registry by using digest specifications.
 	ImageDigestMirrors []*ImageDigestMirror
 
+	// Cluster uses FIPS validated cryptographic libraries
+	FipsEnabled *bool
+
 	// Cluster network configuration
 	Network *NetworkProfile
 

--- a/internal/api/v20251223preview/generated/models_serde.go
+++ b/internal/api/v20251223preview/generated/models_serde.go
@@ -898,6 +898,7 @@ func (h HcpOpenShiftClusterProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "dns", h.DNS)
 	populate(objectMap, "etcd", h.Etcd)
 	populate(objectMap, "imageDigestMirrors", h.ImageDigestMirrors)
+	populate(objectMap, "fipsEnabled", h.FipsEnabled)
 	populate(objectMap, "network", h.Network)
 	populate(objectMap, "nodeDrainTimeoutMinutes", h.NodeDrainTimeoutMinutes)
 	populate(objectMap, "platform", h.Platform)
@@ -935,6 +936,9 @@ func (h *HcpOpenShiftClusterProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "imageDigestMirrors":
 			err = unpopulate(val, "ImageDigestMirrors", &h.ImageDigestMirrors)
+			delete(rawMsg, key)
+		case "fipsEnabled":
+			err = unpopulate(val, "FipsEnabled", &h.FipsEnabled)
 			delete(rawMsg, key)
 		case "network":
 			err = unpopulate(val, "Network", &h.Network)

--- a/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
@@ -115,6 +115,9 @@ func SetDefaultValuesCluster(obj *HcpOpenShiftCluster) {
 	if obj.Properties.ClusterImageRegistry.State == nil {
 		obj.Properties.ClusterImageRegistry.State = ptr.To(generated.ClusterImageRegistryStateEnabled)
 	}
+	if obj.Properties.FipsEnabled == nil {
+		obj.Properties.FipsEnabled = ptr.To(false)
+	}
 }
 
 func newVersionProfile(from *api.VersionProfile) generated.VersionProfile {
@@ -352,6 +355,7 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 				ClusterImageRegistry:    api.PtrOrNil(newClusterImageRegistryProfile(&from.CustomerProperties.ClusterImageRegistry)),
 				Etcd:                    api.PtrOrNil(newEtcdProfile(&from.CustomerProperties.Etcd)),
 				ImageDigestMirrors:      newImageDigestMirrors(from.CustomerProperties.ImageDigestMirrors),
+				FipsEnabled:             api.PtrOrNil(from.CustomerProperties.FipsEnabled),
 			},
 			Identity: newManagedServiceIdentity(from.Identity),
 		},
@@ -476,6 +480,9 @@ func (c *HcpOpenShiftCluster) ConvertToInternal(existing *api.HCPOpenShiftCluste
 		}
 		if c.Properties.ImageDigestMirrors != nil {
 			normalizeImageDigestMirrors(c.Properties.ImageDigestMirrors, &out.CustomerProperties.ImageDigestMirrors)
+		}
+		if c.Properties.FipsEnabled != nil {
+			out.CustomerProperties.FipsEnabled = *c.Properties.FipsEnabled
 		}
 	}
 

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -901,7 +901,8 @@ func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpC
 			MachineCIDR(hcpCluster.CustomerProperties.Network.MachineCIDR).
 			HostPrefix(int(hcpCluster.CustomerProperties.Network.HostPrefix))).
 		ImageRegistry(arohcpv1alpha1.NewClusterImageRegistry().
-			State(clusterImageRegistryState))
+			State(clusterImageRegistryState)).
+		FIPS(hcpCluster.CustomerProperties.FipsEnabled)
 	azureBuilder := arohcpv1alpha1.NewAzure().
 		TenantID(tenantID).
 		SubscriptionID(strings.ToLower(subscriptionID)).

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -617,7 +617,8 @@ func ocmClusterDefaults(azureLocation string) *arohcpv1alpha1.ClusterBuilder {
 		ImageRegistry(arohcpv1alpha1.NewClusterImageRegistry().
 			State(csImageRegistryStateEnabled)).
 		RegistryConfig(arohcpv1alpha1.NewClusterRegistryConfig().
-			ImageDigestMirrors())
+			ImageDigestMirrors()).
+		FIPS(false)
 }
 
 func getHCPNodePoolResource(opts ...func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-17753

### What

This PR adds `fipsEnabled` property to ARO-HCP API specs.

### Why

This change is for the ARO-HCP product is to support scenarios and use cases where the control plane and its workers need to be fips enabled (i.e. running on systems using FIPS-enabled cryptographic libraries).

### Special notes for your reviewer

<!-- optional -->
