### PR TITLE
Add 20251223 to testsdk.md

### DIFF
--- a/api/testsdk.md
+++ b/api/testsdk.md
@@ -34,6 +34,17 @@ go:
   module-name: sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp
 ```
 
+### Tag: v20251223preview
+
+These settings apply only when `--tag=v20251223preview` is specified on the command line.
+
+``` yaml $(tag) == 'v20251223preview'
+input-file:
+  - redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/openapi.json
+go:
+  module-name: sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp
+```
+
 ### Code Generation
 
 Other Go SDK generation settings.


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Update to `api/testsdk.md`, adding section for the `v20251223preview` tag.

<!-- Briefly describe what this PR does -->

### Why

So that we can now run `make testsdk`.

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
