### PR TITLE
API spec: add vnet integration subnet

### DIFF
--- a/internal/api/types_cluster.go
+++ b/internal/api/types_cluster.go
@@ -125,6 +125,7 @@ type ServiceProviderAPIProfile struct {
 type CustomerPlatformProfile struct {
 	ManagedResourceGroup    string                         `json:"managedResourceGroup,omitempty"`
 	SubnetID                *azcorearm.ResourceID          `json:"subnetId,omitempty"`
+	VnetIntegrationSubnetID *azcorearm.ResourceID          `json:"vnetIntegrationSubnetId,omitempty"`
 	OutboundType            OutboundType                   `json:"outboundType,omitempty"`
 	NetworkSecurityGroupID  *azcorearm.ResourceID          `json:"networkSecurityGroupId,omitempty"`
 	OperatorsAuthentication OperatorsAuthenticationProfile `json:"operatorsAuthentication,omitempty"`

--- a/internal/api/v20240610preview/conversion_fuzz_test.go
+++ b/internal/api/v20240610preview/conversion_fuzz_test.go
@@ -67,6 +67,11 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 			j.ClusterServiceID = ocm.InternalID{}
 			j.ExistingCosmosUID = ""
 		},
+		func(j *api.HCPOpenShiftClusterCustomerProperties, c randfill.Continue) {
+			c.FillNoCustom(j)
+			// VnetIntegrationSubnetID is introduced in a future API version and will not roundtrip
+			j.Platform.VnetIntegrationSubnetID = nil
+		},
 		func(j *api.CustomerManagedEncryptionProfile, c randfill.Continue) {
 			c.FillNoCustom(j)
 			// we cannot properly roundtrip a zero value here, so nil when that happens

--- a/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
@@ -188,6 +188,7 @@ func newPlatformProfile(from *api.CustomerPlatformProfile, from2 *api.ServicePro
 	return generated.PlatformProfile{
 		ManagedResourceGroup:    api.PtrOrNil(from.ManagedResourceGroup),
 		SubnetID:                api.ResourceIDToStringPtr(from.SubnetID),
+		VnetIntegrationSubnetID: api.ResourceIDToStringPtr(from.VnetIntegrationSubnetID),
 		OutboundType:            api.PtrOrNil(generated.OutboundType(from.OutboundType)),
 		NetworkSecurityGroupID:  api.ResourceIDToStringPtr(from.NetworkSecurityGroupID),
 		OperatorsAuthentication: api.PtrOrNil(newOperatorsAuthenticationProfile(&from.OperatorsAuthentication)),
@@ -519,6 +520,13 @@ func normalizePlatform(fldPath *field.Path, p *generated.PlatformProfile, out *a
 			errs = append(errs, field.Invalid(fldPath.Child("subnetID"), *p.SubnetID, err.Error()))
 		} else {
 			out.SubnetID = resourceID
+		}
+	}
+	if p.VnetIntegrationSubnetID != nil && len(*p.VnetIntegrationSubnetID) > 0 {
+		if resourceID, err := azcorearm.ParseResourceID(*p.VnetIntegrationSubnetID); err != nil {
+			errs = append(errs, field.Invalid(fldPath.Child("vnetIntegrationSubnetId"), *p.VnetIntegrationSubnetID, err.Error()))
+		} else {
+			out.VnetIntegrationSubnetID = resourceID
 		}
 	}
 	if p.OutboundType != nil {

--- a/internal/api/zz_generated.deepcopy.go
+++ b/internal/api/zz_generated.deepcopy.go
@@ -232,6 +232,10 @@ func (in *CustomerPlatformProfile) DeepCopyInto(out *CustomerPlatformProfile) {
 		in, out := &in.SubnetID, &out.SubnetID
 		*out = arm.DeepCopyResourceID(*in)
 	}
+	if in.VnetIntegrationSubnetID != nil {
+		in, out := &in.VnetIntegrationSubnetID, &out.VnetIntegrationSubnetID
+		*out = arm.DeepCopyResourceID(*in)
+	}
 	if in.NetworkSecurityGroupID != nil {
 		in, out := &in.NetworkSecurityGroupID, &out.NetworkSecurityGroupID
 		*out = arm.DeepCopyResourceID(*in)


### PR DESCRIPTION
[ARO-17758](https://issues.redhat.com/browse/ARO-17758)

### What

Adds a dedicated `vnetIntegrationSubnetId` field to HCPOpenShiftCluster's PlatformProfile. This field is required, and will thus be a breaking change to the API spec. It is implemented exclusively on the v20251223preview API. 

### Why

This field will be used for vnet injection, in order to run control plane components in user vnets via SWIFT. 

### Special notes for your reviewer

<!-- optional -->
