### PR TITLE
custom-link-tools: add cluster/kusto args

### DIFF
--- a/test/cmd/aro-hcp-tests/custom-link-tools/cmd_test.go
+++ b/test/cmd/aro-hcp-tests/custom-link-tools/cmd_test.go
@@ -40,6 +40,7 @@ func TestGeneratedHTML(t *testing.T) {
 	opts := Options{
 		completedOptions: &completedOptions{
 			TimingInputDir: "../testdata/output",
+			ADXClusterName: defaultADXClusterName,
 			Steps: []pipeline.NodeInfo{
 				{
 					Identifier: pipeline.Identifier{
@@ -56,6 +57,27 @@ func TestGeneratedHTML(t *testing.T) {
 										ResourceType:  "Microsoft.ContainerService/managedClusters",
 										Name:          "hcp-underlay-prow-usw3j688-svc-1",
 										ResourceGroup: "hcp-underlay-prow-usw3j688-svc-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Identifier: pipeline.Identifier{
+						ServiceGroup:  "Microsoft.Azure.ARO.HCP.Management.Infra",
+						ResourceGroup: "management",
+						Step:          "cluster",
+					},
+					Details: &pipeline.ExecutionDetails{
+						ARM: &pipeline.ARMExecutionDetails{
+							Operations: []pipeline.Operation{
+								{
+									OperationType: "Create",
+									Resource: &pipeline.Resource{
+										ResourceType:  "Microsoft.ContainerService/managedClusters",
+										Name:          "hcp-underlay-prow-usw3j688-mgmt-1",
+										ResourceGroup: "hcp-underlay-prow-usw3j688-mgmt-1",
 									},
 								},
 							},

--- a/test/cmd/testdata/zz_fixture_TestGeneratedHTMLcustom_link_tools.html
+++ b/test/cmd/testdata/zz_fixture_TestGeneratedHTMLcustom_link_tools.html
@@ -56,13 +56,13 @@
         </li>
     
         <li>
-          <a target="_blank" href="https://dataexplorer.azure.com/clusters/hcp-dev-us.westus3/databases/ServiceLogs?query=H4sIAAAAAAAA%2F3zOwWqDQBDG8btPMXjRQFZWhTak%2BAa9Nadewrh%2BjQbdXXbHSCAPX5KCyam3YeD38R8hdIzCQQ7DBGqoY4EME%2FK00lWldK3K90NZ77Xea%2F2dbj6SB4Ht%2FgOVfgEdC7cckWdfCJfB4NOdYrYphNsReWacFR4swt87udHSI4Duo1F48tRCFsBS%2FlJaFGvEk5hxjoJATUNZb7yabYcw8lX54BY1x6U%2Bv%2B12Kl6MKrNVWZ4QPRsc7xf1HCntrx4h9sOPpMmNfHBnGHkmbWmtfqAtje6U%2FAYAAP%2F%2FksoGJU0BAAA%3D" title="Hypershift Logs">
+          <a target="_blank" href="https://dataexplorer.azure.com/clusters/hcp-dev-us.westus3/databases/ServiceLogs?query=H4sIAAAAAAAA%2F3zOQWuzQBDG8bufYvCigaysCu8bUvwGvTWnXsK4PlWDuy67YyWQD1%2BSgsmpt2Hg9%2FCfIHSOwkFOowU11LFARos8rXRVKV2r8v%2BprI9aH7X%2BTHdvyYPAdX%2BBSr%2BAjoVbjsizD4Tv0eB97mO2K4TbCXlmZic8OoTfd3KjdUAA3UejsPXUQlbAUf5SWhRbxJOYaYmCQE1D2WC8WlyHMPFV%2BTCvaolrffl3OCjbW1FltjHHFtGzwfl%2B0cCR0uHqEeIwfkma3MiH%2BQIjz6Y9bdkPtKdp7pOfAAAA%2F%2F%2B6W1AxTgEAAA%3D%3D" title="Hypershift Logs">
               Hypershift Logs
           </a>
         </li>
     
         <li>
-          <a target="_blank" href="https://dataexplorer.azure.com/clusters/hcp-dev-us.westus3/databases/ServiceLogs?query=H4sIAAAAAAAA%2F3yPzYqrQBBG9z5F4UYD6dBRuDdk8A1mN1nNJpTthxrsH7rLyEAefkhmMFnNrig4h%2FNNEDon4Sin0YIa6lggo0WZV7qqlK7V%2Fv9pXx%2B1Pmr9mW%2FesgcC1%2F0FVPoF6Fi45YSy%2BEC8jgbvvk%2FFZifcTigL453w6BB%2F3tmNlgERdJcmYRuohSyAo%2FKldLdbI56ImeYkiNQ0VAwmqNl1iBN%2FqRD9oua01Jd%2Fh4NKV6P2xUo5tkiBDc73iwZOlPsAp351yrLjHhZOFPdwkmc3CtFfYORZuaV1yMOzpcn32XcAAAD%2F%2F2Mo9%2BhgAQAA" title="ACM Logs">
+          <a target="_blank" href="https://dataexplorer.azure.com/clusters/hcp-dev-us.westus3/databases/ServiceLogs?query=H4sIAAAAAAAA%2F3yPzWqDQBRG9z7FxY0GMmGi0IYU36C7ZtVNuI4fanB%2BmLlWCnn4krSYrLq7XDiH800QOifhKKfRghrqWCCjRZlXuqqUrtX%2B9bSvj1oftf7MN2%2FZHYHr%2FgMq%2FQR0LNxyQll8IH6NBu%2B%2BT8VmJ9xOKAvjnfDoEH%2Ff2ZWWARF0kyZhG6iFLICj8ql0t1sjHoiZ5iSI1DRUDCao2XWIE3%2BrEP2i5rTUl5fDQdneitoXK%2BbYIgU2ON8uGjhR7gOc%2BvMpy457WDhR3MNJnl0pRH%2BBkUfmltYld8%2BWJt9nPwEAAP%2F%2FEnZ9d2EBAAA%3D" title="ACM Logs">
               ACM Logs
           </a>
         </li>


### PR DESCRIPTION
* Add CLI arguments to be able to derive cluster names and kusto url in persistent environments where steps.yaml is not available.
* Add discovery of mgmt cluster name from steps.yaml