### PR TITLE
remove old resourceID serialization

### DIFF
--- a/backend/pkg/controllers/controllerutils/management_cluster_content_controller.go
+++ b/backend/pkg/controllers/controllerutils/management_cluster_content_controller.go
@@ -30,7 +30,6 @@ func NewInitialManagementClusterContent(managementClusterContentResourceID *azco
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: managementClusterContentResourceID,
 		},
-		ResourceID: *managementClusterContentResourceID,
 	}
 }
 

--- a/backend/pkg/controllers/controllerutils/needs_update_test.go
+++ b/backend/pkg/controllers/controllerutils/needs_update_test.go
@@ -108,7 +108,6 @@ func TestNeedsUpdate_ManagementClusterContent_RoundTripUnchanged(t *testing.T) {
 	rid := mustParseRID(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/c/managementClusterContents/readonlyHypershiftHostedCluster")
 	desired := &api.ManagementClusterContent{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: rid},
-		ResourceID:     *rid,
 		Status: api.ManagementClusterContentStatus{
 			Conditions: []metav1.Condition{
 				{

--- a/backend/pkg/controllers/controllerutils/util.go
+++ b/backend/pkg/controllers/controllerutils/util.go
@@ -80,7 +80,7 @@ func (k OperationKey) InitialController(controllerName string) *api.Controller {
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID: resourceID, ExternalID: k.GetParentResourceID(),
+		ExternalID: k.GetParentResourceID(),
 		Status: api.ControllerStatus{
 			Conditions: []metav1.Condition{},
 		},
@@ -110,7 +110,6 @@ func (k HCPClusterKey) InitialController(controllerName string) *api.Controller 
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID: resourceID,
 		ExternalID: k.GetResourceID(),
 		Status: api.ControllerStatus{
 			Conditions: []metav1.Condition{},
@@ -141,7 +140,6 @@ func (k HCPNodePoolKey) InitialController(controllerName string) *api.Controller
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID: resourceID,
 		ExternalID: k.GetResourceID(),
 		Status: api.ControllerStatus{
 			Conditions: []metav1.Condition{},
@@ -185,7 +183,6 @@ func (k *HCPExternalAuthKey) InitialController(controllerName string) *api.Contr
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID: resourceID,
 		ExternalID: k.GetResourceID(),
 		Status: api.ControllerStatus{
 			Conditions: []metav1.Condition{},

--- a/backend/pkg/controllers/controllerutils/util_test.go
+++ b/backend/pkg/controllers/controllerutils/util_test.go
@@ -98,7 +98,6 @@ func TestDegradedControllerPanicHandler(t *testing.T) {
 			CosmosMetadata: api.CosmosMetadata{
 				ResourceID: resourceID,
 			},
-			ResourceID: resourceID,
 			ExternalID: clusterResourceID,
 			Status: api.ControllerStatus{
 				Conditions: []metav1.Condition{},

--- a/backend/pkg/controllers/create_cluster_scoped_maestro_readonly_bundles_controller_test.go
+++ b/backend/pkg/controllers/create_cluster_scoped_maestro_readonly_bundles_controller_test.go
@@ -186,7 +186,6 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *te
 			name: "existing reference but no ID - sets new ID and preserves name",
 			initialSPC: &api.ServiceProviderCluster{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-				ResourceID:     *spcResourceID,
 				Status: api.ServiceProviderClusterStatus{
 					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 						{
@@ -220,7 +219,6 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *te
 			name: "complete bundle reference - ID unchanged",
 			initialSPC: &api.ServiceProviderCluster{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-				ResourceID:     *spcResourceID,
 				Status: api.ServiceProviderClusterStatus{
 					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 						{
@@ -253,7 +251,6 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *te
 			name: "multiple refs - only synced ref is updated, other refs unchanged",
 			initialSPC: &api.ServiceProviderCluster{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-				ResourceID:     *spcResourceID,
 				Status: api.ServiceProviderClusterStatus{
 					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 						{
@@ -297,7 +294,6 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *te
 			name: "maestro get or create error - returns last persisted SPC",
 			initialSPC: &api.ServiceProviderCluster{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-				ResourceID:     *spcResourceID,
 				Status: api.ServiceProviderClusterStatus{
 					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 						{
@@ -329,7 +325,6 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *te
 			name: "no bundle reference initially - creates ref with deterministic UUID name and new ID",
 			initialSPC: &api.ServiceProviderCluster{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-				ResourceID:     *spcResourceID,
 				Status: api.ServiceProviderClusterStatus{
 					MaestroReadonlyBundles: api.MaestroBundleReferenceList{},
 				},
@@ -367,7 +362,6 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *te
 			name: "no bundle ref initially - bundle name persisted then getOrCreate fails - returns SPC with name set, no ID",
 			initialSPC: &api.ServiceProviderCluster{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-				ResourceID:     *spcResourceID,
 				Status: api.ServiceProviderClusterStatus{
 					MaestroReadonlyBundles: api.MaestroBundleReferenceList{},
 				},
@@ -609,7 +603,6 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_SyncOnce_AllBundlesAlre
 	spcResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/serviceProviderClusters/default"))
 	spc := &api.ServiceProviderCluster{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-		ResourceID:     *spcResourceID,
 		Status: api.ServiceProviderClusterStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 				{
@@ -684,7 +677,6 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_SyncOnce_SyncLoopExecut
 		CosmosMetadata: arm.CosmosMetadata{
 			ResourceID: spcResourceID,
 		},
-		ResourceID: *spcResourceID,
 		Status: api.ServiceProviderClusterStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{},
 		},
@@ -793,7 +785,6 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_SyncOnce_ProcessesParti
 	spcResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/serviceProviderClusters/default"))
 	spc := &api.ServiceProviderCluster{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-		ResourceID:     *spcResourceID,
 		Status: api.ServiceProviderClusterStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 				{

--- a/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller_test.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller_test.go
@@ -208,7 +208,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *t
 			name: "existing reference but no ID - sets new ID and preserves name",
 			initialSPNP: &api.ServiceProviderNodePool{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-				ResourceID:     *spnpResourceID,
 				Status: api.ServiceProviderNodePoolStatus{
 					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 						{
@@ -242,7 +241,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *t
 			name: "complete bundle reference - ID unchanged",
 			initialSPNP: &api.ServiceProviderNodePool{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-				ResourceID:     *spnpResourceID,
 				Status: api.ServiceProviderNodePoolStatus{
 					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 						{
@@ -275,7 +273,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *t
 			name: "multiple refs - only synced ref is updated, other refs unchanged",
 			initialSPNP: &api.ServiceProviderNodePool{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-				ResourceID:     *spnpResourceID,
 				Status: api.ServiceProviderNodePoolStatus{
 					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 						{
@@ -319,7 +316,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *t
 			name: "maestro get or create error - returns last persisted SPNP",
 			initialSPNP: &api.ServiceProviderNodePool{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-				ResourceID:     *spnpResourceID,
 				Status: api.ServiceProviderNodePoolStatus{
 					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 						{
@@ -351,7 +347,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *t
 			name: "no bundle reference initially - creates ref with deterministic UUID name and new ID",
 			initialSPNP: &api.ServiceProviderNodePool{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-				ResourceID:     *spnpResourceID,
 				Status: api.ServiceProviderNodePoolStatus{
 					MaestroReadonlyBundles: api.MaestroBundleReferenceList{},
 				},
@@ -389,7 +384,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *t
 			name: "no bundle ref initially - bundle name persisted then getOrCreate fails - returns SPNP with name set, no ID",
 			initialSPNP: &api.ServiceProviderNodePool{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-				ResourceID:     *spnpResourceID,
 				Status: api.ServiceProviderNodePoolStatus{
 					MaestroReadonlyBundles: api.MaestroBundleReferenceList{},
 				},
@@ -538,7 +532,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_EmptyClusterS
 	spnpResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool/serviceProviderNodePools/default"))
 	spnp := &api.ServiceProviderNodePool{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-		ResourceID:     *spnpResourceID,
 		Status: api.ServiceProviderNodePoolStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{},
 		},
@@ -645,7 +638,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_AllBundlesAlr
 	spnpResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool/serviceProviderNodePools/default"))
 	spnp := &api.ServiceProviderNodePool{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-		ResourceID:     *spnpResourceID,
 		Status: api.ServiceProviderNodePoolStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 				{
@@ -710,7 +702,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_SyncLoopExecu
 	spnpResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool/serviceProviderNodePools/default"))
 	spnp := &api.ServiceProviderNodePool{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-		ResourceID:     *spnpResourceID,
 		Status: api.ServiceProviderNodePoolStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{},
 		},
@@ -811,7 +802,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_ProcessesPart
 	spnpResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool/serviceProviderNodePools/default"))
 	spnp := &api.ServiceProviderNodePool{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-		ResourceID:     *spnpResourceID,
 		Status: api.ServiceProviderNodePoolStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 				{

--- a/backend/pkg/controllers/delete_orphaned_maestro_readonly_bundles_controller_test.go
+++ b/backend/pkg/controllers/delete_orphaned_maestro_readonly_bundles_controller_test.go
@@ -58,7 +58,7 @@ func TestBuildClusterScopedMaestroAPIMaestroBundleNamesByShard(t *testing.T) {
 			spcsByShard: map[string][]*api.ServiceProviderCluster{
 				"shard1": {
 					{
-						ResourceID: *spcRID,
+						CosmosMetadata: arm.CosmosMetadata{ResourceID: spcRID},
 						Status: api.ServiceProviderClusterStatus{
 							MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 								{Name: "logical-name", MaestroAPIMaestroBundleName: ""},
@@ -75,7 +75,7 @@ func TestBuildClusterScopedMaestroAPIMaestroBundleNamesByShard(t *testing.T) {
 			spcsByShard: map[string][]*api.ServiceProviderCluster{
 				"shard1": {
 					{
-						ResourceID: *spcRID,
+						CosmosMetadata: arm.CosmosMetadata{ResourceID: spcRID},
 						Status: api.ServiceProviderClusterStatus{
 							MaestroReadonlyBundles: api.MaestroBundleReferenceList{nil},
 						},
@@ -98,7 +98,7 @@ func TestBuildClusterScopedMaestroAPIMaestroBundleNamesByShard(t *testing.T) {
 			spcsByShard: map[string][]*api.ServiceProviderCluster{
 				"s": {
 					{
-						ResourceID: *spcRID,
+						CosmosMetadata: arm.CosmosMetadata{ResourceID: spcRID},
 						Status: api.ServiceProviderClusterStatus{
 							MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 								{MaestroAPIMaestroBundleName: "bundle-one"},
@@ -145,7 +145,7 @@ func TestBuildNodePoolScopedMaestroAPIMaestroBundleNamesByShard(t *testing.T) {
 			spnpsByShard: map[string][]*api.ServiceProviderNodePool{
 				"shard1": {
 					{
-						ResourceID: *spnpRID,
+						CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpRID},
 						Status: api.ServiceProviderNodePoolStatus{
 							MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 								{Name: "logical-name", MaestroAPIMaestroBundleName: ""},
@@ -162,7 +162,7 @@ func TestBuildNodePoolScopedMaestroAPIMaestroBundleNamesByShard(t *testing.T) {
 			spnpsByShard: map[string][]*api.ServiceProviderNodePool{
 				"shard1": {
 					{
-						ResourceID: *spnpRID,
+						CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpRID},
 						Status: api.ServiceProviderNodePoolStatus{
 							MaestroReadonlyBundles: api.MaestroBundleReferenceList{nil},
 						},
@@ -185,7 +185,7 @@ func TestBuildNodePoolScopedMaestroAPIMaestroBundleNamesByShard(t *testing.T) {
 			spnpsByShard: map[string][]*api.ServiceProviderNodePool{
 				"s": {
 					{
-						ResourceID: *spnpRID,
+						CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpRID},
 						Status: api.ServiceProviderNodePoolStatus{
 							MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 								{MaestroAPIMaestroBundleName: "bundle-np"},
@@ -309,7 +309,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_getAllServiceProviderClusters(t *t
 			setupDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 				spc := &api.ServiceProviderCluster{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-					ResourceID:     *spcResourceID,
 				}
 				spcCRUD := mockResourcesDBClient.ServiceProviderClusters(clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName, clusterResourceID.Name)
 				_, err := spcCRUD.Create(ctx, spc, nil)
@@ -359,7 +358,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_getAllServiceProviderNodePools(t *
 			setupDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 				spnp := &api.ServiceProviderNodePool{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-					ResourceID:     *spnpResourceID,
 				}
 				spnpCRUD := mockResourcesDBClient.ServiceProviderNodePools(clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName, clusterResourceID.Name, "worker")
 				_, err := spnpCRUD.Create(ctx, spnp, nil)
@@ -774,7 +772,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderClustersByProvis
 				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 				spc := &api.ServiceProviderCluster{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-					ResourceID:     *spcResourceID,
 				}
 				return &deleteOrphanedMaestroReadonlyBundles{resourcesDBClient: mockResourcesDBClient, clusterServiceClient: mockCS},
 					map[string]*shardMaestroClient{"unused-shard": noopMaestroShardClient},
@@ -790,7 +787,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderClustersByProvis
 				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 				spc := &api.ServiceProviderCluster{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-					ResourceID:     *spcResourceID,
 				}
 				return &deleteOrphanedMaestroReadonlyBundles{resourcesDBClient: mockResourcesDBClient, clusterServiceClient: mockCS},
 					map[string]*shardMaestroClient{"unused-shard": noopMaestroShardClient},
@@ -815,7 +811,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderClustersByProvis
 				require.NoError(t, err)
 				spc := &api.ServiceProviderCluster{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-					ResourceID:     *spcResourceID,
 				}
 				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), *cluster.ServiceProviderProperties.ClusterServiceID).Return(nil, fmt.Errorf("provision shard error"))
 				return &deleteOrphanedMaestroReadonlyBundles{resourcesDBClient: mockResourcesDBClient, clusterServiceClient: mockCS},
@@ -840,7 +835,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderClustersByProvis
 				require.NoError(t, err)
 				spc := &api.ServiceProviderCluster{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-					ResourceID:     *spcResourceID,
 				}
 				shardInClientsMap := buildTestProvisionShard("consumer-in-list")
 				shard2ID := "33333333333333333333333333333333"
@@ -878,7 +872,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderClustersByProvis
 				require.NoError(t, err)
 				spc := &api.ServiceProviderCluster{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-					ResourceID:     *spcResourceID,
 				}
 				provisionShard := buildTestProvisionShard("test-consumer")
 				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), *cluster.ServiceProviderProperties.ClusterServiceID).Return(provisionShard, nil)
@@ -922,11 +915,9 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderClustersByProvis
 				spc2ResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub2/resourceGroups/rg2/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster2/serviceProviderClusters/default"))
 				spc1 := &api.ServiceProviderCluster{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spc1ResourceID},
-					ResourceID:     *spc1ResourceID,
 				}
 				spc2 := &api.ServiceProviderCluster{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spc2ResourceID},
-					ResourceID:     *spc2ResourceID,
 				}
 
 				shard1 := buildTestProvisionShard("consumer1")
@@ -1048,7 +1039,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderNodePoolsByProvi
 				broken.Parent = nil
 				spnp := &api.ServiceProviderNodePool{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: &broken},
-					ResourceID:     broken,
 				}
 				return &deleteOrphanedMaestroReadonlyBundles{resourcesDBClient: mockResourcesDBClient, clusterServiceClient: mockCS},
 					map[string]*shardMaestroClient{"unused-shard": noopMaestroShardClient},
@@ -1068,7 +1058,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderNodePoolsByProvi
 				noGrand.Parent = &npOnly
 				spnp := &api.ServiceProviderNodePool{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: &noGrand},
-					ResourceID:     noGrand,
 				}
 				return &deleteOrphanedMaestroReadonlyBundles{resourcesDBClient: mockResourcesDBClient, clusterServiceClient: mockCS},
 					map[string]*shardMaestroClient{"unused-shard": noopMaestroShardClient},
@@ -1087,7 +1076,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderNodePoolsByProvi
 				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 				spnp := &api.ServiceProviderNodePool{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-					ResourceID:     *spnpResourceID,
 				}
 				return &deleteOrphanedMaestroReadonlyBundles{resourcesDBClient: mockResourcesDBClient, clusterServiceClient: mockCS},
 					map[string]*shardMaestroClient{"unused-shard": noopMaestroShardClient},
@@ -1103,7 +1091,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderNodePoolsByProvi
 				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 				spnp := &api.ServiceProviderNodePool{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-					ResourceID:     *spnpResourceID,
 				}
 				return &deleteOrphanedMaestroReadonlyBundles{resourcesDBClient: mockResourcesDBClient, clusterServiceClient: mockCS},
 					map[string]*shardMaestroClient{"unused-shard": noopMaestroShardClient},
@@ -1128,7 +1115,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderNodePoolsByProvi
 				require.NoError(t, err)
 				spnp := &api.ServiceProviderNodePool{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-					ResourceID:     *spnpResourceID,
 				}
 				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), *cluster.ServiceProviderProperties.ClusterServiceID).Return(nil, fmt.Errorf("provision shard error"))
 				return &deleteOrphanedMaestroReadonlyBundles{resourcesDBClient: mockResourcesDBClient, clusterServiceClient: mockCS},
@@ -1153,7 +1139,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderNodePoolsByProvi
 				require.NoError(t, err)
 				spnp := &api.ServiceProviderNodePool{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-					ResourceID:     *spnpResourceID,
 				}
 				shardInClientsMap := buildTestProvisionShard("consumer-in-list")
 				shard2ID := "33333333333333333333333333333333"
@@ -1191,7 +1176,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderNodePoolsByProvi
 				require.NoError(t, err)
 				spnp := &api.ServiceProviderNodePool{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-					ResourceID:     *spnpResourceID,
 				}
 				provisionShard := buildTestProvisionShard("test-consumer")
 				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), *cluster.ServiceProviderProperties.ClusterServiceID).Return(provisionShard, nil)
@@ -1235,11 +1219,9 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderNodePoolsByProvi
 				spnp2ResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub2/resourceGroups/rg2/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster2/nodePools/worker/serviceProviderNodePools/default"))
 				spnp1 := &api.ServiceProviderNodePool{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnp1ResourceID},
-					ResourceID:     *spnp1ResourceID,
 				}
 				spnp2 := &api.ServiceProviderNodePool{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnp2ResourceID},
-					ResourceID:     *spnp2ResourceID,
 				}
 
 				shard1 := buildTestProvisionShard("consumer1")
@@ -1374,7 +1356,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_ensureClusterScopedOrphanedMaestro
 				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), *cluster.ServiceProviderProperties.ClusterServiceID).Return(shard, nil).AnyTimes()
 				spc := &api.ServiceProviderCluster{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-					ResourceID:     *spcResourceID,
 					Status: api.ServiceProviderClusterStatus{
 						MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 							{MaestroAPIMaestroBundleName: "referenced-bundle"},
@@ -1415,7 +1396,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_ensureClusterScopedOrphanedMaestro
 				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), *cluster.ServiceProviderProperties.ClusterServiceID).Return(shard, nil).AnyTimes()
 				spc := &api.ServiceProviderCluster{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-					ResourceID:     *spcResourceID,
 					Status: api.ServiceProviderClusterStatus{
 						MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 							{MaestroAPIMaestroBundleName: "referenced-bundle"},
@@ -1597,7 +1577,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedNodePoolScopedMaestr
 				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), *cluster.ServiceProviderProperties.ClusterServiceID).Return(shard, nil).AnyTimes()
 				spnp := &api.ServiceProviderNodePool{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-					ResourceID:     *spnpResourceID,
 					Status: api.ServiceProviderNodePoolStatus{
 						MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 							{MaestroAPIMaestroBundleName: "referenced-np-bundle"},
@@ -1638,7 +1617,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedNodePoolScopedMaestr
 				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), *cluster.ServiceProviderProperties.ClusterServiceID).Return(shard, nil).AnyTimes()
 				spnp := &api.ServiceProviderNodePool{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-					ResourceID:     *spnpResourceID,
 					Status: api.ServiceProviderNodePoolStatus{
 						MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 							{MaestroAPIMaestroBundleName: "kept-np-bundle"},
@@ -1728,7 +1706,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_ensureClusterScopedOrphanedMaestro
 
 	spcOnShard1 := &api.ServiceProviderCluster{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcOnShard1ResourceID},
-		ResourceID:     *spcOnShard1ResourceID,
 		Status: api.ServiceProviderClusterStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 				{MaestroAPIMaestroBundleName: "bundle-X"},
@@ -1811,7 +1788,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_ensureClusterScopedOrphanedMaestro
 
 	spc := &api.ServiceProviderCluster{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-		ResourceID:     *spcResourceID,
 		Status: api.ServiceProviderClusterStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 				{MaestroAPIMaestroBundleName: "bundle-N"},
@@ -1869,7 +1845,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_ensureClusterScopedOrphanedMaestro
 
 	spc := &api.ServiceProviderCluster{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-		ResourceID:     *spcResourceID,
 		Status: api.ServiceProviderClusterStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 				{MaestroAPIMaestroBundleName: "only-in-global-list"},
@@ -1928,7 +1903,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_SyncOnce_FullFlow_DeletesOrphanedB
 	spcResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/serviceProviderClusters/default"))
 	spc := &api.ServiceProviderCluster{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-		ResourceID:     *spcResourceID,
 		Status: api.ServiceProviderClusterStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 				{MaestroAPIMaestroBundleName: "kept-bundle"},

--- a/backend/pkg/controllers/maestro_readonly_bundle_helpers.go
+++ b/backend/pkg/controllers/maestro_readonly_bundle_helpers.go
@@ -274,7 +274,7 @@ func readAndPersistMaestroReadonlyBundleContent(
 		return utils.TrackError(fmt.Errorf("failed to calculate ManagementClusterContent from Maestro Bundle: %w", err))
 	}
 
-	existing, err := managementClusterContentsDBClient.Get(ctx, desired.CosmosMetadata.ResourceID.Name)
+	existing, err := managementClusterContentsDBClient.Get(ctx, desired.ResourceID.Name)
 	if err != nil && !database.IsNotFoundError(err) {
 		return utils.TrackError(fmt.Errorf("failed to get ManagementClusterContent: %w", err))
 	}

--- a/backend/pkg/controllers/maestro_readonly_bundle_helpers_test.go
+++ b/backend/pkg/controllers/maestro_readonly_bundle_helpers_test.go
@@ -482,7 +482,6 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		existingRID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/managementClusterContents/readonlyHypershiftHostedCluster"))
 		existing := &api.ManagementClusterContent{
 			CosmosMetadata: api.CosmosMetadata{ResourceID: existingRID},
-			ResourceID:     *existingRID,
 			Status:         api.ManagementClusterContentStatus{KubeContent: &metav1.List{Items: []runtime.RawExtension{}}},
 		}
 		_, err := mccCRUD.Create(ctx, existing, nil)
@@ -518,7 +517,6 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		existingContent := &metav1.List{Items: []runtime.RawExtension{{Raw: []byte(`{}`)}}}
 		existing := &api.ManagementClusterContent{
 			CosmosMetadata: api.CosmosMetadata{ResourceID: existingRID},
-			ResourceID:     *existingRID,
 			Status:         api.ManagementClusterContentStatus{KubeContent: existingContent},
 		}
 		_, err := mccCRUD.Create(ctx, existing, nil)
@@ -551,7 +549,6 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		require.NotNil(t, desired)
 		existing := &api.ManagementClusterContent{
 			CosmosMetadata: api.CosmosMetadata{ResourceID: existingRID},
-			ResourceID:     *existingRID,
 			Status:         desired.Status,
 		}
 		_, err = mccCRUD.Create(ctx, existing, nil)
@@ -608,7 +605,6 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		existingRID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/managementClusterContents/readonlyHypershiftHostedCluster"))
 		existingDoc := &api.ManagementClusterContent{
 			CosmosMetadata: api.CosmosMetadata{ResourceID: existingRID},
-			ResourceID:     *existingRID,
 			Status:         api.ManagementClusterContentStatus{KubeContent: &metav1.List{Items: []runtime.RawExtension{{Raw: []byte(validHCJSON)}}}},
 		}
 
@@ -663,7 +659,6 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		historicLTT := metav1.Time{Time: time.Date(2020, 6, 15, 12, 0, 0, 0, time.UTC)}
 		existing := &api.ManagementClusterContent{
 			CosmosMetadata: api.CosmosMetadata{ResourceID: existingRID},
-			ResourceID:     *existingRID,
 			Status: api.ManagementClusterContentStatus{
 				KubeContent: &metav1.List{
 					Items: []runtime.RawExtension{{Object: u}},

--- a/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller_test.go
+++ b/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller_test.go
@@ -143,7 +143,6 @@ func newTestOperation(t *testing.T, opName string, request api.OperationRequest,
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID:         resourceID,
 		OperationID:        operationID,
 		Request:            request,
 		Status:             status,
@@ -309,7 +308,6 @@ func TestOperationPhaseMetricsHandler_SkipsNilOperationID(t *testing.T) {
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID:         resourceID,
 		ExternalID:         api.Must(azcorearm.ParseResourceID("/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-1")),
 		Request:            api.OperationRequestCreate,
 		Status:             arm.ProvisioningStateAccepted,

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
@@ -218,7 +218,6 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 
 			_, err = mockResourcesDBClient.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, &api.ServiceProviderCluster{
 				CosmosMetadata: api.CosmosMetadata{ResourceID: resourceId},
-				ResourceID:     *resourceId,
 				Spec: api.ServiceProviderClusterSpec{
 					ControlPlaneVersion: api.ServiceProviderClusterSpecVersion{
 						DesiredVersion: ptr.To(semver.MustParse("4.19.0")),
@@ -235,7 +234,6 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			))
 			_, err = mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).Controllers(testClusterName).Create(ctx, &api.Controller{
 				CosmosMetadata: api.CosmosMetadata{ResourceID: rid},
-				ResourceID:     rid,
 				ExternalID:     fixture.clusterResourceID,
 				Status: api.ControllerStatus{
 					Conditions: tt.controlPlaneDesiredVersionControllerConditions,

--- a/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
+++ b/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
@@ -105,7 +105,6 @@ func (f *clusterTestFixture) newOperation(request database.OperationRequest) *ap
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: f.cosmosOperationResourceID,
 		},
-		ResourceID:  f.cosmosOperationResourceID,
 		TenantID:    testTenantID,
 		Status:      arm.ProvisioningStateAccepted,
 		Request:     request,

--- a/backend/pkg/controllers/read_and_persist_cluster_scoped_maestro_readonly_bundles_content_controller_test.go
+++ b/backend/pkg/controllers/read_and_persist_cluster_scoped_maestro_readonly_bundles_content_controller_test.go
@@ -124,7 +124,6 @@ func TestReadAndPersistClusterScopedMaestroReadonlyBundlesContentSyncer_SyncOnce
 	spcResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/serviceProviderClusters/default"))
 	spc := &api.ServiceProviderCluster{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-		ResourceID:     *spcResourceID,
 	}
 	spcCRUD := mockResourcesDBClient.ServiceProviderClusters(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
 	_, err = spcCRUD.Create(ctx, spc, nil)
@@ -167,7 +166,6 @@ func TestReadAndPersistClusterScopedMaestroReadonlyBundlesContentSyncer_SyncOnce
 	spcResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/serviceProviderClusters/default"))
 	spc := &api.ServiceProviderCluster{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-		ResourceID:     *spcResourceID,
 		Status: api.ServiceProviderClusterStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 				{Name: api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster, MaestroAPIMaestroBundleName: "bundle-name"},
@@ -224,7 +222,6 @@ func TestReadAndPersistClusterScopedMaestroReadonlyBundlesContentSyncer_SyncOnce
 	spcResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/serviceProviderClusters/default"))
 	spc := &api.ServiceProviderCluster{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
-		ResourceID:     *spcResourceID,
 		Status: api.ServiceProviderClusterStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 				{Name: api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster, MaestroAPIMaestroBundleName: "bundle-name"},

--- a/backend/pkg/controllers/read_and_persist_nodepool_scoped_maestro_readonly_bundles_content_controller_test.go
+++ b/backend/pkg/controllers/read_and_persist_nodepool_scoped_maestro_readonly_bundles_content_controller_test.go
@@ -124,7 +124,6 @@ func TestReadAndPersistNodePoolScopedMaestroReadonlyBundlesContentSyncer_SyncOnc
 	spnpResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool/serviceProviderNodePools/default"))
 	spnp := &api.ServiceProviderNodePool{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-		ResourceID:     *spnpResourceID,
 		Status: api.ServiceProviderNodePoolStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 				{Name: bundleInternalName, MaestroAPIMaestroBundleName: "bundle-name"},
@@ -221,7 +220,6 @@ func TestReadAndPersistNodePoolScopedMaestroReadonlyBundlesContentSyncer_SyncOnc
 	spnpResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool/serviceProviderNodePools/default"))
 	spnp := &api.ServiceProviderNodePool{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-		ResourceID:     *spnpResourceID,
 	}
 	spnpCRUD := mockResourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
 	_, err = spnpCRUD.Create(ctx, spnp, nil)
@@ -271,7 +269,6 @@ func TestReadAndPersistNodePoolScopedMaestroReadonlyBundlesContentSyncer_SyncOnc
 	spnpResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool/serviceProviderNodePools/default"))
 	spnp := &api.ServiceProviderNodePool{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-		ResourceID:     *spnpResourceID,
 		Status: api.ServiceProviderNodePoolStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 				{Name: bundleInternalName, MaestroAPIMaestroBundleName: "bundle-name"},
@@ -334,7 +331,6 @@ func TestReadAndPersistNodePoolScopedMaestroReadonlyBundlesContentSyncer_SyncOnc
 	spnpResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool/serviceProviderNodePools/default"))
 	spnp := &api.ServiceProviderNodePool{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-		ResourceID:     *spnpResourceID,
 		Status: api.ServiceProviderNodePoolStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 				{Name: api.MaestroBundleInternalNameReadonlyHypershiftNodePool, MaestroAPIMaestroBundleName: "bundle-name"},

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller_test.go
@@ -338,7 +338,6 @@ func createManagementClusterContentWithKubeContentItems(t *testing.T, ctx contex
 
 	managementClusterContent := &api.ManagementClusterContent{
 		CosmosMetadata: api.CosmosMetadata{ResourceID: managementClusterContentResourceID},
-		ResourceID:     *managementClusterContentResourceID,
 		Status: api.ManagementClusterContentStatus{
 			KubeContent: &metav1.List{
 				Items: items,

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
@@ -714,7 +714,6 @@ func createServiceProviderClusterWithVersion(t *testing.T, ctx context.Context, 
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: api.Must(azcorearm.ParseResourceID(spClusterResourceID)),
 		},
-		ResourceID: *api.Must(azcorearm.ParseResourceID(clusterResourceID)),
 		Status: api.ServiceProviderClusterStatus{
 			ControlPlaneVersion: api.ServiceProviderClusterStatusVersion{
 				ActiveVersions: []api.HCPClusterActiveVersion{
@@ -743,7 +742,6 @@ func createServiceProviderNodePoolWithVersion(t *testing.T, ctx context.Context,
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: api.Must(azcorearm.ParseResourceID(spNodePoolResourceID)),
 		},
-		ResourceID: *api.Must(azcorearm.ParseResourceID(nodePoolResourceID)),
 		Status: api.ServiceProviderNodePoolStatus{
 			NodePoolVersion: api.ServiceProviderNodePoolStatusVersion{
 				ActiveVersions: []api.HCPNodePoolActiveVersion{

--- a/backend/pkg/informers/informers_test.go
+++ b/backend/pkg/informers/informers_test.go
@@ -583,7 +583,6 @@ func activeOperationInformerTestCase() informerTestCase {
 			CosmosMetadata: api.CosmosMetadata{
 				ResourceID: resourceID,
 			},
-			ResourceID:         resourceID,
 			OperationID:        operationID,
 			ExternalID:         externalID,
 			Request:            api.OperationRequestCreate,

--- a/backend/pkg/informers/informers_test.go
+++ b/backend/pkg/informers/informers_test.go
@@ -665,7 +665,6 @@ func controllerInformerTestCase() informerTestCase {
 			CosmosMetadata: api.CosmosMetadata{
 				ResourceID: controllerResourceID,
 			},
-			ResourceID: controllerResourceID,
 		}
 	}
 
@@ -681,7 +680,6 @@ func controllerInformerTestCase() informerTestCase {
 			CosmosMetadata: api.CosmosMetadata{
 				ResourceID: controllerResourceID,
 			},
-			ResourceID: controllerResourceID,
 		}
 	}
 
@@ -697,7 +695,6 @@ func controllerInformerTestCase() informerTestCase {
 			CosmosMetadata: api.CosmosMetadata{
 				ResourceID: controllerResourceID,
 			},
-			ResourceID: controllerResourceID,
 		}
 	}
 

--- a/backend/pkg/listertesting/slice_listers_test.go
+++ b/backend/pkg/listertesting/slice_listers_test.go
@@ -410,7 +410,6 @@ func newTestClusterController(subscriptionID, resourceGroupName, clusterName, co
 		CosmosMetadata: arm.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID: resourceID,
 	}
 }
 
@@ -426,7 +425,6 @@ func newTestNodePoolController(subscriptionID, resourceGroupName, clusterName, n
 		CosmosMetadata: arm.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID: resourceID,
 	}
 }
 
@@ -442,7 +440,6 @@ func newTestExternalAuthController(subscriptionID, resourceGroupName, clusterNam
 		CosmosMetadata: arm.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID: resourceID,
 	}
 }
 

--- a/backend/pkg/listertesting/slice_listers_test.go
+++ b/backend/pkg/listertesting/slice_listers_test.go
@@ -396,7 +396,6 @@ func newTestServiceProviderCluster(subscriptionID, resourceGroupName, clusterNam
 		CosmosMetadata: arm.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID: *resourceID,
 	}
 }
 

--- a/backend/pkg/listertesting/slice_listers_test.go
+++ b/backend/pkg/listertesting/slice_listers_test.go
@@ -464,7 +464,6 @@ func newTestClusterScopedManagementClusterContent(subscriptionID, resourceGroupN
 	))
 	return &api.ManagementClusterContent{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
-		ResourceID:     *resourceID,
 	}
 }
 
@@ -478,6 +477,5 @@ func newTestNodePoolScopedManagementClusterContent(subscriptionID, resourceGroup
 	))
 	return &api.ManagementClusterContent{
 		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
-		ResourceID:     *resourceID,
 	}
 }

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -625,7 +625,6 @@ func TestRequestAdminCredential(t *testing.T) {
 					CosmosMetadata: api.CosmosMetadata{
 						ResourceID: resourceID,
 					},
-					ResourceID:  resourceID,
 					OperationID: operationID,
 					Request:     database.OperationRequestRevokeCredentials,
 					ExternalID:  clusterResourceID,
@@ -736,7 +735,6 @@ func TestRevokeCredentials(t *testing.T) {
 					CosmosMetadata: api.CosmosMetadata{
 						ResourceID: resourceID,
 					},
-					ResourceID:  resourceID,
 					OperationID: operationID,
 					Request:     database.OperationRequestRevokeCredentials,
 					ExternalID:  clusterResourceID,
@@ -755,7 +753,6 @@ func TestRevokeCredentials(t *testing.T) {
 					CosmosMetadata: api.CosmosMetadata{
 						ResourceID: resourceID,
 					},
-					ResourceID:  resourceID,
 					OperationID: operationID,
 					Request:     database.OperationRequestRequestCredential,
 					ExternalID:  clusterResourceID,

--- a/internal/admission/admit_cluster_test.go
+++ b/internal/admission/admit_cluster_test.go
@@ -273,7 +273,6 @@ func TestAdmitClusterOnUpdate(t *testing.T) {
 		}
 		return &api.ServiceProviderNodePool{
 			CosmosMetadata: api.CosmosMetadata{ResourceID: spResourceID},
-			ResourceID:     *spResourceID,
 			Status: api.ServiceProviderNodePoolStatus{
 				NodePoolVersion: api.ServiceProviderNodePoolStatusVersion{ActiveVersions: active},
 			},
@@ -527,7 +526,6 @@ func TestAdmitClusterOnUpdate(t *testing.T) {
 
 			serviceProviderCluster := &api.ServiceProviderCluster{
 				CosmosMetadata: api.CosmosMetadata{ResourceID: serviceProviderResourceID},
-				ResourceID:     *serviceProviderResourceID,
 				Status:         tt.serviceProviderClusterStatus,
 			}
 

--- a/internal/api/types_controller.go
+++ b/internal/api/types_controller.go
@@ -27,12 +27,6 @@ type Controller struct {
 	// it will be the ServiceProviderCluster type and the name default
 	CosmosMetadata `json:"cosmosMetadata"`
 
-	// this matches the resourcedocument and standard storage schema.
-	// we already store this field, but its currently done in conversion trickery.  Update to directly serialize it.
-	// all items previously stored will read out and have this filled in.
-	// we need to be sure that all new records have it too.
-	ResourceID *azcorearm.ResourceID `json:"resourceId,omitempty"`
-
 	// ExternalID is the Azure resource ID of the type this is associated with.
 	ExternalID *azcorearm.ResourceID `json:"externalId,omitempty"`
 

--- a/internal/api/types_management_cluster_content.go
+++ b/internal/api/types_management_cluster_content.go
@@ -16,8 +16,6 @@ package api
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 )
 
 // ManagementClusterContent represents K8s resources in the Management Cluster
@@ -25,10 +23,6 @@ import (
 type ManagementClusterContent struct {
 	// CosmosMetadata is nested under the corresponding resource type so that association and cleanup work as expected
 	CosmosMetadata `json:"cosmosMetadata"`
-
-	// resourceID exists to match cosmosMetadata.resourceID until we're able to transition all types to use cosmosMetadata,
-	// at which point we will stop using properties.resourceId in our queries. That will be about a month from now.
-	ResourceID azcorearm.ResourceID `json:"resourceId"`
 
 	// Status track the status of the Management Cluster Content.
 	Status ManagementClusterContentStatus `json:"status,omitempty"`

--- a/internal/api/types_operation.go
+++ b/internal/api/types_operation.go
@@ -40,10 +40,6 @@ const (
 type Operation struct {
 	CosmosMetadata `json:"cosmosMetadata"`
 
-	// ResourceID must be serialized exactly here for the generic CRUD to work.
-	// ResourceID here is NOT an ARM resourceID, it just parses like and one and is guarantee unique
-	ResourceID *azcorearm.ResourceID `json:"resourceId"`
-
 	// TenantID is the tenant ID of the client that requested the operation
 	TenantID string `json:"tenantId,omitempty"`
 	// ClientID is the object ID of the client that requested the operation

--- a/internal/api/types_serviceprovider_cluster.go
+++ b/internal/api/types_serviceprovider_cluster.go
@@ -43,10 +43,6 @@ type ServiceProviderCluster struct {
 	// it will be the ServiceProviderCluster type and the name default
 	CosmosMetadata `json:"cosmosMetadata"`
 
-	// resourceID exists to match cosmosMetadata.resourceID until we're able to transition all types to use cosmosMetadata,
-	// at which point we will stop using properties.resourceId in our queries. That will be about a month from now.
-	ResourceID azcorearm.ResourceID `json:"resourceId"`
-
 	LoadBalancerResourceID *azcorearm.ResourceID `json:"loadBalancerResourceID,omitempty"`
 
 	Spec ServiceProviderClusterSpec `json:"spec"`

--- a/internal/api/types_serviceprovider_nodepool.go
+++ b/internal/api/types_serviceprovider_nodepool.go
@@ -18,8 +18,6 @@ import (
 	"github.com/blang/semver/v4"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 )
 
 const (
@@ -35,10 +33,6 @@ type ServiceProviderNodePool struct {
 	// CosmosMetadata ResourceID is nested under the cluster so that association and cleanup work as expected
 	// it will be the ServiceProviderNodePool type and the name default
 	CosmosMetadata `json:"cosmosMetadata"`
-
-	// resourceID exists to match cosmosMetadata.resourceID until we're able to transition all types to use cosmosMetadata,
-	// at which point we will stop using properties.resourceId in our queries. That will be about a month from now.
-	ResourceID azcorearm.ResourceID `json:"resourceId"`
 
 	// Spec contains the desired state of the nodepool
 	Spec ServiceProviderNodePoolSpec `json:"spec,omitempty"`

--- a/internal/api/zz_generated.deepcopy.go
+++ b/internal/api/zz_generated.deepcopy.go
@@ -65,10 +65,6 @@ func (in *ClusterImageRegistryProfile) DeepCopy() *ClusterImageRegistryProfile {
 func (in *Controller) DeepCopyInto(out *Controller) {
 	*out = *in
 	in.CosmosMetadata.DeepCopyInto(&out.CosmosMetadata)
-	if in.ResourceID != nil {
-		in, out := &in.ResourceID, &out.ResourceID
-		*out = arm.DeepCopyResourceID(*in)
-	}
 	if in.ExternalID != nil {
 		in, out := &in.ExternalID, &out.ExternalID
 		*out = arm.DeepCopyResourceID(*in)

--- a/internal/api/zz_generated.deepcopy.go
+++ b/internal/api/zz_generated.deepcopy.go
@@ -1146,10 +1146,6 @@ func (in *OSDiskProfile) DeepCopy() *OSDiskProfile {
 func (in *Operation) DeepCopyInto(out *Operation) {
 	*out = *in
 	in.CosmosMetadata.DeepCopyInto(&out.CosmosMetadata)
-	if in.ResourceID != nil {
-		in, out := &in.ResourceID, &out.ResourceID
-		*out = arm.DeepCopyResourceID(*in)
-	}
 	if in.ExternalID != nil {
 		in, out := &in.ExternalID, &out.ExternalID
 		*out = arm.DeepCopyResourceID(*in)
@@ -1257,7 +1253,6 @@ func (in *ServiceProviderAPIProfile) DeepCopy() *ServiceProviderAPIProfile {
 func (in *ServiceProviderCluster) DeepCopyInto(out *ServiceProviderCluster) {
 	*out = *in
 	in.CosmosMetadata.DeepCopyInto(&out.CosmosMetadata)
-	out.ResourceID = *arm.DeepCopyResourceID(&in.ResourceID)
 	if in.LoadBalancerResourceID != nil {
 		in, out := &in.LoadBalancerResourceID, &out.LoadBalancerResourceID
 		*out = arm.DeepCopyResourceID(*in)
@@ -1462,7 +1457,6 @@ func (in *ServiceProviderDNSProfile) DeepCopy() *ServiceProviderDNSProfile {
 func (in *ServiceProviderNodePool) DeepCopyInto(out *ServiceProviderNodePool) {
 	*out = *in
 	in.CosmosMetadata.DeepCopyInto(&out.CosmosMetadata)
-	out.ResourceID = *arm.DeepCopyResourceID(&in.ResourceID)
 	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
 	return

--- a/internal/api/zz_generated.deepcopy.go
+++ b/internal/api/zz_generated.deepcopy.go
@@ -960,7 +960,6 @@ func (in MaestroBundleReferenceList) DeepCopy() MaestroBundleReferenceList {
 func (in *ManagementClusterContent) DeepCopyInto(out *ManagementClusterContent) {
 	*out = *in
 	in.CosmosMetadata.DeepCopyInto(&out.CosmosMetadata)
-	out.ResourceID = *arm.DeepCopyResourceID(&in.ResourceID)
 	in.Status.DeepCopyInto(&out.Status)
 	return
 }

--- a/internal/database/service_provider_cluster.go
+++ b/internal/database/service_provider_cluster.go
@@ -35,7 +35,6 @@ func newInitialServiceProviderCluster(clusterResourceID *azcorearm.ResourceID) *
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID: *resourceID,
 	}
 }
 

--- a/internal/database/service_provider_nodepool.go
+++ b/internal/database/service_provider_nodepool.go
@@ -35,7 +35,6 @@ func newInitialServiceProviderNodePool(npResourceID *azcorearm.ResourceID) *api.
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID: *resourceID,
 	}
 }
 

--- a/internal/database/types_operation.go
+++ b/internal/database/types_operation.go
@@ -71,12 +71,11 @@ func NewOperation(
 	// Microsoft.RedHatOpenShift/locations/hcpOperationStatuses.  This type is not compatible with the current cosmos storage and
 	// nests in a way that doesn't match other types. Since our operationID.Name is a UID, this is still a globally unique
 	// resourceID.
-	operation.CosmosMetadata.ResourceID = api.Must(azcorearm.ParseResourceID(path.Join("/",
+	operation.ResourceID = api.Must(azcorearm.ParseResourceID(path.Join("/",
 		"subscriptions", operation.ExternalID.SubscriptionID,
 		"providers", api.ProviderNamespace,
 		api.OperationStatusResourceTypeName, operation.OperationID.Name,
 	)))
-	operation.ResourceID = operation.CosmosMetadata.ResourceID
 
 	if correlationData != nil {
 		operation.ClientRequestID = correlationData.ClientRequestID

--- a/internal/databasetesting/mock_dbclient_test.go
+++ b/internal/databasetesting/mock_dbclient_test.go
@@ -243,7 +243,6 @@ func TestMockResourcesDBClient_CRUD_Operation(t *testing.T) {
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID:         resourceID,
 		OperationID:        operationID,
 		ExternalID:         externalID,
 		Request:            api.OperationRequestCreate,
@@ -574,7 +573,6 @@ func TestMockResourcesDBClient_ServiceProviderCluster_ETagConditionalReplace(t *
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: serviceProviderClusterResourceID,
 		},
-		ResourceID: *serviceProviderClusterResourceID,
 	}
 
 	spClusterCRUD := mock.ServiceProviderClusters(subscriptionID, resourceGroupName, clusterName)

--- a/internal/databasetesting/mock_dbclient_test.go
+++ b/internal/databasetesting/mock_dbclient_test.go
@@ -666,7 +666,6 @@ func TestMockResourcesDBClient_Controller_ETagConditionalReplace(t *testing.T) {
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: controllerResourceID,
 		},
-		ResourceID: controllerResourceID,
 		ExternalID: clusterResourceID,
 		Status: api.ControllerStatus{
 			Conditions: []metav1.Condition{

--- a/test-integration/backend/controllers/do_nothing/artifacts/sync_cluster/99-cosmosCompare-end-state/do-nothing-success.json
+++ b/test-integration/backend/controllers/do_nothing/artifacts/sync_cluster/99-cosmosCompare-end-state/do-nothing-success.json
@@ -11,7 +11,6 @@
 			"resourceID": "/subscriptions/4fa75980-6637-4157-9726-84d878a62e83/resourceGroups/shrilleffectiveness/providers/microsoft.redhatopenshift/hcpopenshiftclusters/lavishunhappiness/hcpOpenShiftControllers/DoNothingExample"
 		},
 		"externalId": "/subscriptions/4fa75980-6637-4157-9726-84d878a62e83/resourceGroups/shrilleffectiveness/providers/microsoft.redhatopenshift/hcpopenshiftclusters/lavishunhappiness",
-		"resourceId": "/subscriptions/4fa75980-6637-4157-9726-84d878a62e83/resourceGroups/shrilleffectiveness/providers/microsoft.redhatopenshift/hcpopenshiftclusters/lavishunhappiness/hcpOpenShiftControllers/DoNothingExample",
 		"status": {
 			"conditions": [
 				{

--- a/test-integration/backend/launch/metrics_test.go
+++ b/test-integration/backend/launch/metrics_test.go
@@ -171,7 +171,6 @@ func newMetricsTestOperation(t *testing.T, subscriptionID, name string, external
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: resourceID,
 		},
-		ResourceID:         resourceID,
 		OperationID:        operationID,
 		ExternalID:         externalID,
 		Request:            request,

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/01-create-01/01-01.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/01-create-01/01-01.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/first-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/first-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/01-create-01/01-02.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/01-create-01/01-02.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/second-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/second-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/01-create-01/02-01.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/01-create-01/02-01.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/second-node-pool/hcpOpenShiftControllers/first-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/second-node-pool",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/second-node-pool/hcpOpenShiftControllers/first-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/01-create-01/02-02.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/01-create-01/02-02.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/second-node-pool/hcpOpenShiftControllers/second-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/second-node-pool",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/second-node-pool/hcpOpenShiftControllers/second-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/02-list-first-nodepool/first.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/02-list-first-nodepool/first.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/first-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/first-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/02-list-first-nodepool/second.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/02-list-first-nodepool/second.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/second-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/second-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/02-list-second-nodepool/first.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/02-list-second-nodepool/first.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/second-node-pool/hcpOpenShiftControllers/first-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/second-node-pool",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/second-node-pool/hcpOpenShiftControllers/first-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/02-list-second-nodepool/second.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/02-list-second-nodepool/second.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/second-node-pool/hcpOpenShiftControllers/second-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/second-node-pool",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/second-node-pool/hcpOpenShiftControllers/second-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/03-replace-update-01/instance.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/03-replace-update-01/instance.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/first-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/first-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/04-list-first-nodepool/first.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/04-list-first-nodepool/first.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/first-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/first-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/04-list-first-nodepool/second.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/04-list-first-nodepool/second.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/second-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/second-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/06-list-first-nodepool/second.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic-nodepool/06-list-first-nodepool/second.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/second-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic/nodePools/first-node-pool/hcpOpenShiftControllers/second-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/02-get-initial/test-controller.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/02-get-initial/test-controller.json
@@ -3,7 +3,6 @@
 		"resourceID": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/test-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/test-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/03-list-another/test-controller.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/03-list-another/test-controller.json
@@ -3,7 +3,6 @@
 		"resourceID": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/test-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/test-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/04-create-another/second-controller.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/04-create-another/second-controller.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/second-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/second-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/05-get-new-instance/second-controller.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/05-get-new-instance/second-controller.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/second-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/second-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/06-list-both-instances/second-controller.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/06-list-both-instances/second-controller.json
@@ -3,7 +3,6 @@
 		"resourceId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/second-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/second-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/06-list-both-instances/test-controller.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/06-list-both-instances/test-controller.json
@@ -3,7 +3,6 @@
 		"resourceID": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/test-controller"
 	},
 	"externalId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster",
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/test-controller",
 	"status": {
 		"conditions": [
 			{

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/07-get-other-resource-group/second-controller.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/07-get-other-resource-group/second-controller.json
@@ -1,3 +1,1 @@
-{
-	"resourceId": "/subscriptions/subscriptionID/resourceGroups/otherResourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/second-controller"
-}
+{}

--- a/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/99-cosmosCompare-end-state/do-nothing-success.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/ControllerCRUD/basic/99-cosmosCompare-end-state/do-nothing-success.json
@@ -11,7 +11,6 @@
 			"resourceID": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/second-controller"
 		},
 		"externalId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster",
-		"resourceId": "/subscriptions/subscriptionID/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/parentCluster/hcpOpenShiftControllers/second-controller",
 		"status": {
 			"conditions": [
 				{

--- a/test-integration/frontend/informer_test.go
+++ b/test-integration/frontend/informer_test.go
@@ -585,7 +585,6 @@ func activeOperationInformerIntegrationTestCase() informerIntegrationTestCase {
 			CosmosMetadata: api.CosmosMetadata{
 				ResourceID: resourceID,
 			},
-			ResourceID:         resourceID,
 			OperationID:        operationID,
 			ExternalID:         externalID,
 			Request:            api.OperationRequestCreate,


### PR DESCRIPTION
After https://github.com/Azure/ARO-HCP/pull/5113 gets to production we can do this.  We need to be sure the backend doesn't rely on the field we're removing before we remove it.