### PR TITLE
remove inlined resourceDocument to convert to common storage

### DIFF
--- a/internal/database/convert_cluster.go
+++ b/internal/database/convert_cluster.go
@@ -42,7 +42,7 @@ func InternalToCosmosCluster(internalObj *api.HCPOpenShiftCluster) (*HCPCluster,
 			CosmosMetadata: api.CosmosMetadata{
 				ResourceID: internalObj.ID,
 			},
-			ResourceDocument: &ResourceDocument{
+			IntermediateResourceDoc: &ResourceDocument{
 				ResourceID:        internalObj.ID,
 				InternalID:        ptr.Deref(internalObj.ServiceProviderProperties.ClusterServiceID, api.InternalID{}),
 				ActiveOperationID: internalObj.ServiceProviderProperties.ActiveOperationID,
@@ -56,7 +56,6 @@ func InternalToCosmosCluster(internalObj *api.HCPOpenShiftCluster) (*HCPCluster,
 			},
 		},
 	}
-	cosmosObj.IntermediateResourceDoc = cosmosObj.ResourceDocument
 
 	// some pieces of data in the internalCluster conflict with ResourceDocument fields.  We may evolve over time, but for
 	// now avoid persisting those.
@@ -71,12 +70,6 @@ func InternalToCosmosCluster(internalObj *api.HCPOpenShiftCluster) (*HCPCluster,
 	// on the reading side, we handle the pointer as expected.
 	cosmosObj.InternalState.InternalAPI.ServiceProviderProperties.ClusterServiceID = &api.InternalID{}
 	cosmosObj.InternalState.InternalAPI.ServiceProviderProperties.ActiveOperationID = ""
-
-	// This is not the place for validation, but during such a transition we need to ensure we fail quickly and certainly
-	// This flow will eventually be called when we replace the write path and we must always have a value.
-	if len(cosmosObj.InternalID.String()) == 0 {
-		panic("Developer Error: InternalID is required")
-	}
 
 	return cosmosObj, nil
 }
@@ -124,10 +117,7 @@ func CosmosToInternalCluster(cosmosObj *HCPCluster) (*api.HCPOpenShiftCluster, e
 	if cosmosObj == nil {
 		return nil, nil
 	}
-	resourceDoc := cosmosObj.ResourceDocument
-	if resourceDoc == nil {
-		resourceDoc = cosmosObj.IntermediateResourceDoc
-	}
+	resourceDoc := cosmosObj.IntermediateResourceDoc
 	if resourceDoc == nil {
 		return nil, fmt.Errorf("resource document cannot be nil")
 	}

--- a/internal/database/convert_cluster_test.go
+++ b/internal/database/convert_cluster_test.go
@@ -180,7 +180,7 @@ func TestCosmosToInternalClusterPreservesETag(t *testing.T) {
 			},
 		},
 		HCPClusterProperties: HCPClusterProperties{
-			ResourceDocument: &ResourceDocument{
+			IntermediateResourceDoc: &ResourceDocument{
 				ResourceID: resourceID,
 			},
 		},

--- a/internal/database/convert_defaults_consistency_test.go
+++ b/internal/database/convert_defaults_consistency_test.go
@@ -362,7 +362,7 @@ func TestPreExistingDataCluster(t *testing.T) {
 			ResourceID:   resourceID,
 		},
 		HCPClusterProperties: HCPClusterProperties{
-			ResourceDocument: &ResourceDocument{
+			IntermediateResourceDoc: &ResourceDocument{
 				ResourceID:        resourceID,
 				InternalID:        api.Must(api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/test-cluster")),
 				ProvisioningState: arm.ProvisioningStateSucceeded,
@@ -420,7 +420,7 @@ func TestKMSVisibilityDefaultsToPublic(t *testing.T) {
 			ResourceID:   resourceID,
 		},
 		HCPClusterProperties: HCPClusterProperties{
-			ResourceDocument: &ResourceDocument{
+			IntermediateResourceDoc: &ResourceDocument{
 				ResourceID:        resourceID,
 				InternalID:        api.Must(api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/test-cluster")),
 				ProvisioningState: arm.ProvisioningStateSucceeded,
@@ -485,7 +485,7 @@ func TestPreExistingDataNodePool(t *testing.T) {
 			ResourceID:   resourceID,
 		},
 		NodePoolProperties: NodePoolProperties{
-			ResourceDocument: &ResourceDocument{
+			IntermediateResourceDoc: &ResourceDocument{
 				ResourceID:        resourceID,
 				InternalID:        api.Must(api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/test-cluster/node_pools/test-np")),
 				ProvisioningState: arm.ProvisioningStateSucceeded,
@@ -649,7 +649,7 @@ func TestPreExistingDataExternalAuth(t *testing.T) {
 			ResourceID:   resourceID,
 		},
 		ExternalAuthProperties: ExternalAuthProperties{
-			ResourceDocument: &ResourceDocument{
+			IntermediateResourceDoc: &ResourceDocument{
 				ResourceID:        resourceID,
 				InternalID:        api.Must(api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/test-cluster/external_auth_config/external_auths/default")),
 				ProvisioningState: arm.ProvisioningStateSucceeded,

--- a/internal/database/convert_externalauth.go
+++ b/internal/database/convert_externalauth.go
@@ -41,7 +41,7 @@ func InternalToCosmosExternalAuth(internalObj *api.HCPOpenShiftClusterExternalAu
 			CosmosMetadata: api.CosmosMetadata{
 				ResourceID: internalObj.ID,
 			},
-			ResourceDocument: &ResourceDocument{
+			IntermediateResourceDoc: &ResourceDocument{
 				ResourceID:        internalObj.ID,
 				InternalID:        internalObj.ServiceProviderProperties.ClusterServiceID,
 				ActiveOperationID: internalObj.ServiceProviderProperties.ActiveOperationID,
@@ -56,7 +56,6 @@ func InternalToCosmosExternalAuth(internalObj *api.HCPOpenShiftClusterExternalAu
 			},
 		},
 	}
-	cosmosObj.IntermediateResourceDoc = cosmosObj.ResourceDocument
 
 	// some pieces of data in the internalExternalAuth conflict with ResourceDocument fields.  We may evolve over time, but for
 	// now avoid persisting those.
@@ -73,10 +72,7 @@ func CosmosToInternalExternalAuth(cosmosObj *ExternalAuth) (*api.HCPOpenShiftClu
 	if cosmosObj == nil {
 		return nil, nil
 	}
-	resourceDoc := cosmosObj.ResourceDocument
-	if resourceDoc == nil {
-		resourceDoc = cosmosObj.IntermediateResourceDoc
-	}
+	resourceDoc := cosmosObj.IntermediateResourceDoc
 	if resourceDoc == nil {
 		return nil, fmt.Errorf("resource document cannot be nil")
 	}

--- a/internal/database/convert_externalauth_test.go
+++ b/internal/database/convert_externalauth_test.go
@@ -87,7 +87,7 @@ func TestCosmosToInternalExternalAuthPreservesETag(t *testing.T) {
 			},
 		},
 		ExternalAuthProperties: ExternalAuthProperties{
-			ResourceDocument: &ResourceDocument{
+			IntermediateResourceDoc: &ResourceDocument{
 				ResourceID: resourceID,
 			},
 		},

--- a/internal/database/convert_nodepool.go
+++ b/internal/database/convert_nodepool.go
@@ -41,7 +41,7 @@ func InternalToCosmosNodePool(internalObj *api.HCPOpenShiftClusterNodePool) (*No
 			CosmosMetadata: api.CosmosMetadata{
 				ResourceID: internalObj.ID,
 			},
-			ResourceDocument: &ResourceDocument{
+			IntermediateResourceDoc: &ResourceDocument{
 				ResourceID:        internalObj.ID,
 				InternalID:        internalObj.ServiceProviderProperties.ClusterServiceID,
 				ActiveOperationID: internalObj.ServiceProviderProperties.ActiveOperationID,
@@ -55,7 +55,6 @@ func InternalToCosmosNodePool(internalObj *api.HCPOpenShiftClusterNodePool) (*No
 			},
 		},
 	}
-	cosmosObj.IntermediateResourceDoc = cosmosObj.ResourceDocument
 
 	// some pieces of data in the internalNodePool conflict with ResourceDocument fields.  We may evolve over time, but for
 	// now avoid persisting those.
@@ -76,10 +75,7 @@ func CosmosToInternalNodePool(cosmosObj *NodePool) (*api.HCPOpenShiftClusterNode
 	if cosmosObj == nil {
 		return nil, nil
 	}
-	resourceDoc := cosmosObj.ResourceDocument
-	if resourceDoc == nil {
-		resourceDoc = cosmosObj.IntermediateResourceDoc
-	}
+	resourceDoc := cosmosObj.IntermediateResourceDoc
 	if resourceDoc == nil {
 		return nil, fmt.Errorf("resource document cannot be nil")
 	}

--- a/internal/database/convert_nodepool_test.go
+++ b/internal/database/convert_nodepool_test.go
@@ -90,7 +90,7 @@ func TestCosmosToInternalNodePoolPreservesETag(t *testing.T) {
 			},
 		},
 		NodePoolProperties: NodePoolProperties{
-			ResourceDocument: &ResourceDocument{
+			IntermediateResourceDoc: &ResourceDocument{
 				ResourceID: resourceID,
 			},
 		},

--- a/internal/database/types_externalauth.go
+++ b/internal/database/types_externalauth.go
@@ -25,8 +25,6 @@ type ExternalAuth struct {
 }
 
 type ExternalAuthProperties struct {
-	*ResourceDocument `json:",inline"`
-
 	// when we switch to inlining the internalObj, this will be in the right spot.  We add it now so that we can switch our
 	// queries to select on cosmosMetata.ResourceID instead of resourceId
 	CosmosMetadata api.CosmosMetadata `json:"cosmosMetadata"`

--- a/internal/database/types_hcpcluster.go
+++ b/internal/database/types_hcpcluster.go
@@ -25,8 +25,6 @@ type HCPCluster struct {
 }
 
 type HCPClusterProperties struct {
-	*ResourceDocument `json:",inline"`
-
 	// when we switch to inlining the internalObj, this will be in the right spot.  We add it now so that we can switch our
 	// queries to select on cosmosMetata.ResourceID instead of resourceId
 	CosmosMetadata api.CosmosMetadata `json:"cosmosMetadata"`

--- a/internal/database/types_nodepool.go
+++ b/internal/database/types_nodepool.go
@@ -25,8 +25,6 @@ type NodePool struct {
 }
 
 type NodePoolProperties struct {
-	*ResourceDocument `json:",inline"`
-
 	// when we switch to inlining the internalObj, this will be in the right spot.  We add it now so that we can switch our
 	// queries to select on cosmosMetata.ResourceID instead of resourceId
 	CosmosMetadata api.CosmosMetadata `json:"cosmosMetadata"`

--- a/test-integration/admin/artifacts/AdminCRUD/HCP/breakglass/00-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/admin/artifacts/AdminCRUD/HCP/breakglass/00-load-initial-cosmos-state/01-cluster.json
@@ -2,10 +2,18 @@
 	"id": "68bc6026-a8a9-5706-92c5-25d3313bcabb",
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
+			"systemData": {},
+			"tags": {
+				"foo": "bar"
+			}
 		},
-		"internalId": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
 		"internalState": {
 			"internalAPI": {
 				"location": "eastus",
@@ -13,12 +21,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
-		"systemData": {},
-		"tags": {
-			"foo": "bar"
 		}
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"

--- a/test-integration/admin/artifacts/AdminCRUD/HCP/cosmosdump/00-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/admin/artifacts/AdminCRUD/HCP/cosmosdump/00-load-initial-cosmos-state/01-cluster.json
@@ -2,10 +2,23 @@
 	"id": "68bc6026-a8a9-5706-92c5-25d3313bcabb",
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			},
+			"tags": {
+				"foo": "bar"
+			}
 		},
-		"internalId": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
 		"internalState": {
 			"internalAPI": {
 				"location": "eastus",
@@ -13,17 +26,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"foo": "bar"
 		}
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",

--- a/test-integration/admin/artifacts/AdminCRUD/HCP/hello-world/00-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/admin/artifacts/AdminCRUD/HCP/hello-world/00-load-initial-cosmos-state/01-cluster.json
@@ -2,10 +2,23 @@
 	"id": "68bc6026-a8a9-5706-92c5-25d3313bcabb",
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			},
+			"tags": {
+				"foo": "bar"
+			}
 		},
-		"internalId": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
 		"internalState": {
 			"internalAPI": {
 				"location": "eastus",
@@ -13,17 +26,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"foo": "bar"
 		}
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",

--- a/test-integration/admin/artifacts/AdminCRUD/HCP/lowercase-middleware/00-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/admin/artifacts/AdminCRUD/HCP/lowercase-middleware/00-load-initial-cosmos-state/01-cluster.json
@@ -2,10 +2,23 @@
 	"id": "68bc6026-a8a9-5706-92c5-25d3313bcabb",
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			},
+			"tags": {
+				"foo": "bar"
+			}
 		},
-		"internalId": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
 		"internalState": {
 			"internalAPI": {
 				"location": "eastus",
@@ -13,17 +26,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"foo": "bar"
 		}
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",

--- a/test-integration/backend/controllers/do_nothing/artifacts/sync_cluster/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/do_nothing/artifacts/sync_cluster/00-load-initial-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "1efd180d-f929-5506-9e76-15ef4c14ca7b",
 	"partitionKey": "4fa75980-6637-4157-9726-84d878a62e83",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/4fa75980-6637-4157-9726-84d878a62e83/resourceGroups/shrillEffectiveness/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/lavishUnhappiness",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/4fa75980-6637-4157-9726-84d878a62e83/resourceGroups/shrillEffectiveness/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/lavishUnhappiness",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/4fa75980-6637-4157-9726-84d878a62e83/resourceGroups/shrillEffectiveness/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/lavishUnhappiness",

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/present_cluster/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/present_cluster/00-load-initial-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/present_cluster/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/present_cluster/99-cosmosCompare-end-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/cluster-safe.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/cluster-safe.json
@@ -2,11 +2,21 @@
 	"id": "1efd180d-f929-5506-9e76-15ef4c14ca7b",
 	"partitionKey": "4fa75980-6637-4157-9726-84d878a62e83",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/4fa75980-6637-4157-9726-84d878a62e83/resourceGroups/shrillEffectiveness/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/lavishUnhappiness",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/4fa75980-6637-4157-9726-84d878a62e83/resourceGroups/shrillEffectiveness/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/lavishUnhappiness",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/4fa75980-6637-4157-9726-84d878a62e83/resourceGroups/shrillEffectiveness/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/lavishUnhappiness",

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/externalauth-default.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/externalauth-default.json
@@ -7,8 +7,18 @@
 	"id": "9a361107-eb97-5b1b-bc2e-b9cfa961b5bc",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-		"internalId": "/api/clusters_mgmt/v1/clusters/swzpxg6nxn/external_auth_config/external_auths/5fghjjqxvd",
+		"intermediateResourceDoc": {
+			"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
+			"internalId": "/api/clusters_mgmt/v1/clusters/swzpxg6nxn/external_auth_config/external_auths/5fghjjqxvd",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"properties": {
@@ -59,14 +69,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/nodepool-basic.json
@@ -7,8 +7,18 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-		"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
+		"intermediateResourceDoc": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/99-cosmosCompare-end-state/cluster-safe.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/99-cosmosCompare-end-state/cluster-safe.json
@@ -2,11 +2,21 @@
 	"id": "1efd180d-f929-5506-9e76-15ef4c14ca7b",
 	"partitionKey": "4fa75980-6637-4157-9726-84d878a62e83",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/4fa75980-6637-4157-9726-84d878a62e83/resourceGroups/shrillEffectiveness/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/lavishUnhappiness",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/4fa75980-6637-4157-9726-84d878a62e83/resourceGroups/shrillEffectiveness/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/lavishUnhappiness",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/4fa75980-6637-4157-9726-84d878a62e83/resourceGroups/shrillEffectiveness/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/lavishUnhappiness",

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/00-load-initial-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -38,14 +48,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/00-load-initial-state/nodepool-basic.json
@@ -2,8 +2,18 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-		"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
+		"intermediateResourceDoc": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -20,14 +30,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/99-cosmosCompare-end-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -38,14 +48,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/99-cosmosCompare-end-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/99-cosmosCompare-end-state/nodepool-basic.json
@@ -2,8 +2,18 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-		"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
+		"intermediateResourceDoc": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -20,14 +30,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/controller_under_missing_nodepool_deleted/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/controller_under_missing_nodepool_deleted/00-load-initial-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -38,14 +48,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/controller_under_missing_nodepool_deleted/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/controller_under_missing_nodepool_deleted/99-cosmosCompare-end-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -38,14 +48,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/00-load-initial-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/00-load-initial-state/externalauth-default.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/00-load-initial-state/externalauth-default.json
@@ -7,8 +7,18 @@
 	"id": "9a361107-eb97-5b1b-bc2e-b9cfa961b5bc",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/external_auth_config/external_auths/5fghjjqxvd",
+		"intermediateResourceDoc": {
+			"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/external_auth_config/external_auths/5fghjjqxvd",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"properties": {
@@ -59,14 +69,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/99-cosmosCompare-end-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/99-cosmosCompare-end-state/externalauth-default.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/99-cosmosCompare-end-state/externalauth-default.json
@@ -7,8 +7,18 @@
 	"id": "9a361107-eb97-5b1b-bc2e-b9cfa961b5bc",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/external_auth_config/external_auths/5fghjjqxvd",
+		"intermediateResourceDoc": {
+			"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/external_auth_config/external_auths/5fghjjqxvd",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"properties": {
@@ -59,14 +69,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/externalauth-default.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/externalauth-default.json
@@ -7,8 +7,18 @@
 	"id": "9a361107-eb97-5b1b-bc2e-b9cfa961b5bc",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/external_auth_config/external_auths/5fghjjqxvd",
+		"intermediateResourceDoc": {
+			"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/external_auth_config/external_auths/5fghjjqxvd",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"properties": {
@@ -59,14 +69,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/nodepool-basic.json
@@ -7,8 +7,18 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2",
+		"intermediateResourceDoc": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/99-cosmosCompare-end-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/99-cosmosCompare-end-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/99-cosmosCompare-end-state/nodepool-basic.json
@@ -7,8 +7,18 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2",
+		"intermediateResourceDoc": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/00-load-initial-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/00-load-initial-state/nodepool-basic.json
@@ -7,8 +7,18 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2",
+		"intermediateResourceDoc": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/99-cosmosCompare-end-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/99-cosmosCompare-end-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/99-cosmosCompare-end-state/nodepool-basic.json
@@ -7,8 +7,18 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-		"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
+		"intermediateResourceDoc": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/externalauth-default.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/externalauth-default.json
@@ -7,8 +7,18 @@
 	"id": "9a361107-eb97-5b1b-bc2e-b9cfa961b5bc",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-		"internalId": "/api/clusters_mgmt/v1/clusters/swzpxg6nxn/external_auth_config/external_auths/5fghjjqxvd",
+		"intermediateResourceDoc": {
+			"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
+			"internalId": "/api/clusters_mgmt/v1/clusters/swzpxg6nxn/external_auth_config/external_auths/5fghjjqxvd",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"properties": {
@@ -59,14 +69,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/nodepool-basic.json
@@ -7,8 +7,18 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-		"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
+		"intermediateResourceDoc": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/99-cosmosCompare-end-state/cluster.json
@@ -2,11 +2,21 @@
 	"id": "f7583c84-ae03-56f3-b91d-55bbb849164d",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "6aeeebf8-f771-4d4e-9097-45b972cb96e4",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -68,14 +78,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/99-cosmosCompare-end-state/externalauth-default.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/99-cosmosCompare-end-state/externalauth-default.json
@@ -7,8 +7,18 @@
 	"id": "9a361107-eb97-5b1b-bc2e-b9cfa961b5bc",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
-		"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-		"internalId": "/api/clusters_mgmt/v1/clusters/swzpxg6nxn/external_auth_config/external_auths/5fghjjqxvd",
+		"intermediateResourceDoc": {
+			"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
+			"internalId": "/api/clusters_mgmt/v1/clusters/swzpxg6nxn/external_auth_config/external_auths/5fghjjqxvd",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"properties": {
@@ -59,14 +69,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/externalAuths/default",

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request-provisioning-conflict/01-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request-provisioning-conflict/01-load-initial-cosmos-state/01-cluster.json
@@ -2,9 +2,11 @@
 	"id": "68bc6026-a8a9-5706-92c5-25d3313bcabb",
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
-		"internalId": "/api/clusters_mgmt/v1/clusters/fixed-value",
-		"provisioningState": "Provisioning",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster"
+		"intermediateResourceDoc": {
+			"internalId": "/api/clusters_mgmt/v1/clusters/fixed-value",
+			"provisioningState": "Provisioning",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster"
+		}
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request/01-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request/01-load-initial-cosmos-state/01-cluster.json
@@ -2,9 +2,11 @@
 	"id": "68bc6026-a8a9-5706-92c5-25d3313bcabb",
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
-		"internalId": "/api/clusters_mgmt/v1/clusters/fixed-value",
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster"
+		"intermediateResourceDoc": {
+			"internalId": "/api/clusters_mgmt/v1/clusters/fixed-value",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster"
+		}
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke-forbidden-afec-missing/01-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke-forbidden-afec-missing/01-load-initial-cosmos-state/01-cluster.json
@@ -2,11 +2,13 @@
 	"id": "68bc6026-a8a9-5706-92c5-25d3313bcabb",
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
-		"internalId": "/api/clusters_mgmt/v1/clusters/fixed-value",
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
-		"tags": {
-			"foo": "bar"
+		"intermediateResourceDoc": {
+			"internalId": "/api/clusters_mgmt/v1/clusters/fixed-value",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
+			"tags": {
+				"foo": "bar"
+			}
 		}
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke-forbidden-afec-pending/01-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke-forbidden-afec-pending/01-load-initial-cosmos-state/01-cluster.json
@@ -2,11 +2,13 @@
 	"id": "68bc6026-a8a9-5706-92c5-25d3313bcabb",
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
-		"internalId": "/api/clusters_mgmt/v1/clusters/fixed-value",
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
-		"tags": {
-			"foo": "bar"
+		"intermediateResourceDoc": {
+			"internalId": "/api/clusters_mgmt/v1/clusters/fixed-value",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
+			"tags": {
+				"foo": "bar"
+			}
 		}
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke-provisioning-conflict/01-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke-provisioning-conflict/01-load-initial-cosmos-state/01-cluster.json
@@ -2,10 +2,23 @@
 	"id": "68bc6026-a8a9-5706-92c5-25d3313bcabb",
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/fixed-value",
+			"provisioningState": "Provisioning",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			},
+			"tags": {
+				"foo": "bar"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/fixed-value",
 		"internalState": {
 			"internalAPI": {
 				"location": "eastus",
@@ -13,17 +26,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Provisioning",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"foo": "bar"
 		}
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/01-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/01-load-initial-cosmos-state/01-cluster.json
@@ -2,11 +2,13 @@
 	"id": "68bc6026-a8a9-5706-92c5-25d3313bcabb",
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
-		"internalId": "/api/clusters_mgmt/v1/clusters/fixed-value",
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
-		"tags": {
-			"foo": "bar"
+		"intermediateResourceDoc": {
+			"internalId": "/api/clusters_mgmt/v1/clusters/fixed-value",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",
+			"tags": {
+				"foo": "bar"
+			}
 		}
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/02-cosmosCompare-confirm-content/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/02-cosmosCompare-confirm-content/cluster-create-with-tags.json
@@ -7,12 +7,8 @@
 	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "bb83a448-9eb0-431c-9fd3-9cec8699ea5f",
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags"
-		},
-		"identity": {
-			"type": "UserAssigned"
 		},
 		"intermediateResourceDoc": {
 			"activeOperationId": "bb83a448-9eb0-431c-9fd3-9cec8699ea5f",
@@ -32,7 +28,6 @@
 				"one": "apple"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/fhlllh5lkl",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -95,17 +90,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
@@ -7,12 +7,8 @@
 	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "bb83a448-9eb0-431c-9fd3-9cec8699ea5f",
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags"
-		},
-		"identity": {
-			"type": "UserAssigned"
 		},
 		"intermediateResourceDoc": {
 			"activeOperationId": "bb83a448-9eb0-431c-9fd3-9cec8699ea5f",
@@ -33,7 +29,6 @@
 				"two": "banana"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/fhlllh5lkl",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -96,18 +91,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple",
-			"two": "banana"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/cluster-test-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/cluster-test-cluster.json
@@ -5,9 +5,6 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster"
 		},
-		"identity": {
-			"type": "UserAssigned"
-		},
 		"intermediateResourceDoc": {
 			"identity": {
 				"type": "UserAssigned"
@@ -83,14 +80,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Deleting",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/cluster-test-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/cluster-test-cluster.json
@@ -5,9 +5,6 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster"
 		},
-		"identity": {
-			"type": "UserAssigned"
-		},
 		"intermediateResourceDoc": {
 			"identity": {
 				"type": "UserAssigned"
@@ -83,14 +80,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Deleting",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
@@ -52,14 +52,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Deleting",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/01-load-old-data/create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/01-load-old-data/create-with-tags.json
@@ -7,11 +7,24 @@
 	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "90b2322c-2c26-47ca-b6f9-d9b1a8385cbc",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "90b2322c-2c26-47ca-b6f9-d9b1a8385cbc",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			},
+			"tags": {
+				"one": "apple"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -72,17 +85,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
@@ -7,12 +7,8 @@
 	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "c01d4815-566a-4f10-ad8c-de1667682c5b",
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags"
-		},
-		"identity": {
-			"type": "UserAssigned"
 		},
 		"intermediateResourceDoc": {
 			"activeOperationId": "c01d4815-566a-4f10-ad8c-de1667682c5b",
@@ -33,7 +29,6 @@
 				"two": "banana"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -95,18 +90,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple",
-			"two": "banana"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/cluster-creating/02-loadCosmos-cluster/cosmos-01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/cluster-creating/02-loadCosmos-cluster/cosmos-01-cluster.json
@@ -3,18 +3,20 @@
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
 		"customerDesiredState": null,
-		"identity": {
-			"principalId": "the-principal",
-			"tenantId": "the-tenant",
-			"type": ""
+		"intermediateResourceDoc": {
+			"identity": {
+				"principalId": "the-principal",
+				"tenantId": "the-tenant",
+				"type": ""
+			},
+			"internalId": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-creating",
+			"provisioningState": "Provisioning",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-creating",
+			"tags": {
+				"foo": "bar"
+			}
 		},
-		"internalId": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-creating",
-		"provisioningState": "Provisioning",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-creating",
-		"serviceProviderState": null,
-		"tags": {
-			"foo": "bar"
-		}
+		"serviceProviderState": null
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-creating",
 	"resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters"

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/cluster-deleting/02-loadCosmos-cluster/cosmos-01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/cluster-deleting/02-loadCosmos-cluster/cosmos-01-cluster.json
@@ -3,18 +3,20 @@
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
 		"customerDesiredState": null,
-		"identity": {
-			"principalId": "the-principal",
-			"tenantId": "the-tenant",
-			"type": ""
+		"intermediateResourceDoc": {
+			"identity": {
+				"principalId": "the-principal",
+				"tenantId": "the-tenant",
+				"type": ""
+			},
+			"internalId": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-deleting",
+			"provisioningState": "Deleting",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-deleting",
+			"tags": {
+				"foo": "bar"
+			}
 		},
-		"internalId": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-deleting",
-		"provisioningState": "Deleting",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-deleting",
-		"serviceProviderState": null,
-		"tags": {
-			"foo": "bar"
-		}
+		"serviceProviderState": null
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-deleting",
 	"resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters"

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/cluster-create-with-tags.json
@@ -10,9 +10,6 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags"
 		},
-		"identity": {
-			"type": "UserAssigned"
-		},
 		"intermediateResourceDoc": {
 			"identity": {
 				"type": "UserAssigned"
@@ -30,7 +27,6 @@
 				"one": "apple"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/tqqtpctbpj",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -93,17 +89,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/externalauth-default.json
@@ -7,7 +7,6 @@
 	"id": "85dada74-03ca-5abf-9adc-218fbd0090c7",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "60df392c-42ba-4384-95b4-5e4601df2f3e",
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default"
 		},
@@ -23,7 +22,6 @@
 				"lastModifiedByType": "Application"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/tqqtpctbpj/external_auth_config/external_auths/88m6lb2bbv",
 		"internalState": {
 			"internalAPI": {
 				"properties": {
@@ -74,14 +72,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/cluster-create-with-tags.json
@@ -7,10 +7,23 @@
 	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			},
+			"tags": {
+				"one": "apple"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -71,17 +84,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/externalauth-default.json
@@ -7,8 +7,18 @@
 	"id": "85dada74-03ca-5abf-9adc-218fbd0090c7",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
-		"internalId": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b",
+		"intermediateResourceDoc": {
+			"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
+			"internalId": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"properties": {
@@ -59,14 +69,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
@@ -7,10 +7,23 @@
 	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			},
+			"tags": {
+				"one": "apple"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -71,17 +84,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/externalauth-default.json
@@ -7,7 +7,6 @@
 	"id": "85dada74-03ca-5abf-9adc-218fbd0090c7",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "d99a71e0-9237-4ae2-8617-e76035e2bcd4",
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default"
 		},
@@ -23,7 +22,6 @@
 				"lastModifiedByType": "Application"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b",
 		"internalState": {
 			"internalAPI": {
 				"properties": {
@@ -74,14 +72,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/cluster-create-with-tags.json
@@ -7,11 +7,24 @@
 	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			},
+			"tags": {
+				"one": "apple"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -72,17 +85,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/externalauth-default.json
@@ -7,8 +7,18 @@
 	"id": "85dada74-03ca-5abf-9adc-218fbd0090c7",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
-		"internalId": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b",
+		"intermediateResourceDoc": {
+			"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
+			"internalId": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"properties": {
@@ -59,14 +69,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-basic-node-pool.json
@@ -7,8 +7,18 @@
 	"id": "2b834a28-7e5b-50e2-9fb9-b6679cdd6a1b",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+		"intermediateResourceDoc": {
+			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-node-pool-02.json
@@ -7,8 +7,18 @@
 	"id": "9b74accf-0661-53d8-9741-b3aa39f9a53c",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+		"intermediateResourceDoc": {
+			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/cluster-create-with-tags.json
@@ -7,12 +7,8 @@
 	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags"
-		},
-		"identity": {
-			"type": "UserAssigned"
 		},
 		"intermediateResourceDoc": {
 			"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
@@ -32,7 +28,6 @@
 				"one": "apple"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -94,17 +89,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/externalauth-default.json
@@ -7,7 +7,6 @@
 	"id": "85dada74-03ca-5abf-9adc-218fbd0090c7",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default"
 		},
@@ -23,7 +22,6 @@
 				"lastModifiedByType": "Application"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b",
 		"internalState": {
 			"internalAPI": {
 				"properties": {
@@ -74,14 +72,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-basic-node-pool.json
@@ -7,7 +7,6 @@
 	"id": "2b834a28-7e5b-50e2-9fb9-b6679cdd6a1b",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool"
 		},
@@ -23,7 +22,6 @@
 				"lastModifiedByType": "Application"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -61,14 +59,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-node-pool-02.json
@@ -7,7 +7,6 @@
 	"id": "9b74accf-0661-53d8-9741-b3aa39f9a53c",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02"
 		},
@@ -23,7 +22,6 @@
 				"lastModifiedByType": "Application"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -61,14 +59,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/cluster-create-with-tags.json
@@ -7,11 +7,24 @@
 	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			},
+			"tags": {
+				"one": "apple"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -71,17 +84,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/externalauth-default.json
@@ -7,8 +7,18 @@
 	"id": "85dada74-03ca-5abf-9adc-218fbd0090c7",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/external_auth_config/external_auths/zt59xrx22b",
+		"intermediateResourceDoc": {
+			"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/external_auth_config/external_auths/zt59xrx22b",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"properties": {
@@ -59,14 +69,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-basic-node-pool.json
@@ -7,8 +7,18 @@
 	"id": "2b834a28-7e5b-50e2-9fb9-b6679cdd6a1b",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+		"intermediateResourceDoc": {
+			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-node-pool-02.json
@@ -7,8 +7,18 @@
 	"id": "9b74accf-0661-53d8-9741-b3aa39f9a53c",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+		"intermediateResourceDoc": {
+			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/cluster-create-with-tags.json
@@ -7,11 +7,24 @@
 	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			},
+			"tags": {
+				"one": "apple"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -71,17 +84,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/externalauth-default.json
@@ -3,7 +3,6 @@
 	"id": "85dada74-03ca-5abf-9adc-218fbd0090c7",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "117a9956-c10f-493d-a435-fcc43ab90896",
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default"
 		},
@@ -19,7 +18,6 @@
 				"lastModifiedByType": "Application"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/external_auth_config/external_auths/zt59xrx22b",
 		"internalState": {
 			"internalAPI": {
 				"properties": {
@@ -70,14 +68,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/externalAuths/default",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-basic-node-pool.json
@@ -7,8 +7,18 @@
 	"id": "2b834a28-7e5b-50e2-9fb9-b6679cdd6a1b",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+		"intermediateResourceDoc": {
+			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-node-pool-02.json
@@ -17,7 +17,6 @@
 				"lastModifiedByType": "Application"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -55,14 +54,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-creating/02-loadCosmos-cluster/cosmos-01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-creating/02-loadCosmos-cluster/cosmos-01-cluster.json
@@ -3,18 +3,20 @@
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
 		"customerDesiredState": null,
-		"identity": {
-			"principalId": "the-principal",
-			"tenantId": "the-tenant",
-			"type": ""
+		"intermediateResourceDoc": {
+			"identity": {
+				"principalId": "the-principal",
+				"tenantId": "the-tenant",
+				"type": ""
+			},
+			"internalId": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-creating",
+			"provisioningState": "Provisioning",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-creating",
+			"tags": {
+				"foo": "bar"
+			}
 		},
-		"internalId": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-creating",
-		"provisioningState": "Provisioning",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-creating",
-		"serviceProviderState": null,
-		"tags": {
-			"foo": "bar"
-		}
+		"serviceProviderState": null
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-creating",
 	"resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters"

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-deleting/02-loadCosmos-cluster/cosmos-01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-deleting/02-loadCosmos-cluster/cosmos-01-cluster.json
@@ -3,18 +3,20 @@
 	"partitionKey": "0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
 		"customerDesiredState": null,
-		"identity": {
-			"principalId": "the-principal",
-			"tenantId": "the-tenant",
-			"type": ""
+		"intermediateResourceDoc": {
+			"identity": {
+				"principalId": "the-principal",
+				"tenantId": "the-tenant",
+				"type": ""
+			},
+			"internalId": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-deleting",
+			"provisioningState": "Deleting",
+			"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-deleting",
+			"tags": {
+				"foo": "bar"
+			}
 		},
-		"internalId": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-deleting",
-		"provisioningState": "Deleting",
-		"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-deleting",
-		"serviceProviderState": null,
-		"tags": {
-			"foo": "bar"
-		}
+		"serviceProviderState": null
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-deleting",
 	"resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters"

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/cluster-create-with-tags.json
@@ -10,9 +10,6 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags"
 		},
-		"identity": {
-			"type": "UserAssigned"
-		},
 		"intermediateResourceDoc": {
 			"identity": {
 				"type": "UserAssigned"
@@ -30,7 +27,6 @@
 				"one": "apple"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/dl7f9px2f2",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -93,17 +89,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-basic-node-pool.json
@@ -7,7 +7,6 @@
 	"id": "2b834a28-7e5b-50e2-9fb9-b6679cdd6a1b",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "bf643e76-55fe-48a0-a752-f5c5a2db72ad",
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool"
 		},
@@ -23,7 +22,6 @@
 				"lastModifiedByType": "Application"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/dl7f9px2f2/node_pools/82npf9hxmk",
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -61,14 +59,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-node-pool-02.json
@@ -7,7 +7,6 @@
 	"id": "9b74accf-0661-53d8-9741-b3aa39f9a53c",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "25e4713b-44b5-4799-9e60-894a132c6674",
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02"
 		},
@@ -23,7 +22,6 @@
 				"lastModifiedByType": "Application"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/dl7f9px2f2/node_pools/5zdc9grtvf",
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -61,14 +59,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/cluster-create-with-tags.json
@@ -7,11 +7,24 @@
 	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			},
+			"tags": {
+				"one": "apple"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -72,17 +85,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-basic-node-pool.json
@@ -7,8 +7,18 @@
 	"id": "2b834a28-7e5b-50e2-9fb9-b6679cdd6a1b",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+		"intermediateResourceDoc": {
+			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-node-pool-02.json
@@ -7,8 +7,18 @@
 	"id": "9b74accf-0661-53d8-9741-b3aa39f9a53c",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+		"intermediateResourceDoc": {
+			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
@@ -7,11 +7,24 @@
 	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
-		"identity": {
-			"type": "UserAssigned"
+		"intermediateResourceDoc": {
+			"activeOperationId": "7a4ed07a-47a1-4efb-966a-93a6316522a0",
+			"identity": {
+				"type": "UserAssigned"
+			},
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
+			"provisioningState": "Succeeded",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			},
+			"tags": {
+				"one": "apple"
+			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj",
 		"internalState": {
 			"internalAPI": {
 				"customerProperties": {
@@ -72,17 +85,6 @@
 					"platform": {}
 				}
 			}
-		},
-		"provisioningState": "Succeeded",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
-		},
-		"tags": {
-			"one": "apple"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-02.json
@@ -7,8 +7,18 @@
 	"id": "9b74accf-0661-53d8-9741-b3aa39f9a53c",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+		"intermediateResourceDoc": {
+			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
+			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
+			"provisioningState": "Accepted",
+			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
+			"systemData": {
+				"createdBy": "Unknown-ARO-HCP-frontend",
+				"createdByType": "Application",
+				"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+				"lastModifiedByType": "Application"
+			}
+		},
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -45,14 +55,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-basic-node-pool.json
@@ -7,7 +7,6 @@
 	"id": "2b834a28-7e5b-50e2-9fb9-b6679cdd6a1b",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
-		"activeOperationId": "9e244879-591b-4693-823a-4412b4200f4d",
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool"
 		},
@@ -23,7 +22,6 @@
 				"lastModifiedByType": "Application"
 			}
 		},
-		"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
 		"internalState": {
 			"internalAPI": {
 				"location": "fake-location",
@@ -61,14 +59,6 @@
 					"clusterServiceID": ""
 				}
 			}
-		},
-		"provisioningState": "Accepted",
-		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
-		"systemData": {
-			"createdBy": "Unknown-ARO-HCP-frontend",
-			"createdByType": "Application",
-			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
-			"lastModifiedByType": "Application"
 		}
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",


### PR DESCRIPTION
after https://github.com/Azure/ARO-HCP/pull/4103 makes it to production, we can merge this PR. We cannot do it before because if revert from the level containing https://github.com/Azure/ARO-HCP/pull/4103 to the level just before, we need the old level to be able to understand new data that was written.