### PR TITLE
record cosmos resource counts and controller conditions as metrics

### DIFF
--- a/backend/alerts/backend-prometheusRule.yaml
+++ b/backend/alerts/backend-prometheusRule.yaml
@@ -25,3 +25,17 @@ spec:
         description: 'The Backend operation error rate is above 5% for the last hour. Current value: {{ $value | humanizePercentage }}.'
         runbook_url: 'TBD'
         summary: 'High Error Rate on Backend Operations'
+    - alert: BackendControllerDegraded
+      expr: |
+        (
+          sum by (cluster, controller_name) (backend_controller_status_conditions{condition="Degraded", status="True"})
+          /
+          sum by (cluster, controller_name) (backend_controller_status_conditions{condition="Degraded"})
+        ) > 0.05
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        description: 'Controller {{ $labels.controller_name }} is degraded for more than 5% of resources. Current degradation rate: {{ $value | humanizePercentage }}.'
+        runbook_url: 'TBD'
+        summary: 'Controller {{ $labels.controller_name }} degradation detected'

--- a/backend/alerts/backend-prometheusRule_test.yaml
+++ b/backend/alerts/backend-prometheusRule_test.yaml
@@ -30,3 +30,32 @@ tests:
   - eval_time: 10m # At this point, the condition has held for 10 minutes
     alertname: BackendOperationErrorRate
     exp_alerts: []
+# Test: BackendControllerDegraded above 5%
+- interval: 1m
+  input_series:
+  - series: 'backend_controller_status_conditions{controller_name="cluster-validation", condition="Degraded", status="True"}'
+    values: "2+0x10" # Constant 2 degraded
+  - series: 'backend_controller_status_conditions{controller_name="cluster-validation", condition="Degraded", status="False"}'
+    values: "18+0x10" # Constant 18 not degraded → 2/20 = 10%
+  alert_rule_test:
+  - eval_time: 5m
+    alertname: BackendControllerDegraded
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        controller_name: cluster-validation
+      exp_annotations:
+        description: 'Controller cluster-validation is degraded for more than 5% of resources. Current degradation rate: 10%.'
+        runbook_url: 'TBD'
+        summary: 'Controller cluster-validation degradation detected'
+# Test: BackendControllerDegraded below 5%
+- interval: 1m
+  input_series:
+  - series: 'backend_controller_status_conditions{controller_name="cluster-validation", condition="Degraded", status="True"}'
+    values: "4+0x10" # Constant 4 degraded
+  - series: 'backend_controller_status_conditions{controller_name="cluster-validation", condition="Degraded", status="False"}'
+    values: "96+0x10" # Constant 96 not degraded → 4/100 = 4%
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: BackendControllerDegraded
+    exp_alerts: []

--- a/backend/oldoperationscanner/operations_scanner.go
+++ b/backend/oldoperationscanner/operations_scanner.go
@@ -139,7 +139,7 @@ type OperationsScanner struct {
 	subscriptionsByState   *prometheus.GaugeVec
 }
 
-func NewOperationsScanner(dbClient database.DBClient, clustersServiceClient ocm.ClusterServiceClientSpec, azureLocation string, subscriptionLister listers.SubscriptionLister) *OperationsScanner {
+func NewOperationsScanner(dbClient database.DBClient, clustersServiceClient ocm.ClusterServiceClientSpec, azureLocation string, subscriptionLister listers.SubscriptionLister, registerer prometheus.Registerer) *OperationsScanner {
 	s := &OperationsScanner{
 		dbClient:            dbClient,
 		lockClient:          dbClient.GetLockClient(),
@@ -151,33 +151,33 @@ func NewOperationsScanner(dbClient database.DBClient, clustersServiceClient ocm.
 
 		newTimestamp: func() time.Time { return time.Now().UTC() },
 
-		LeaderGauge: promauto.With(prometheus.DefaultRegisterer).NewGauge(
+		LeaderGauge: promauto.With(registerer).NewGauge(
 			prometheus.GaugeOpts{
 				Name: "backend_leader_election_state",
 				Help: "Leader election state (1 when leader).",
 			},
 		),
-		workerGauge: promauto.With(prometheus.DefaultRegisterer).NewGauge(
+		workerGauge: promauto.With(registerer).NewGauge(
 			prometheus.GaugeOpts{
 				Name: "backend_workers",
 				Help: "Number of concurrent workers.",
 			},
 		),
-		operationsCount: promauto.With(prometheus.DefaultRegisterer).NewCounterVec(
+		operationsCount: promauto.With(registerer).NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "backend_operations_total",
 				Help: "Total count of operations.",
 			},
 			[]string{"type"},
 		),
-		operationsFailedCount: promauto.With(prometheus.DefaultRegisterer).NewCounterVec(
+		operationsFailedCount: promauto.With(registerer).NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "backend_failed_operations_total",
 				Help: "Total count of failed operations.",
 			},
 			[]string{"type"},
 		),
-		operationsDuration: promauto.With(prometheus.DefaultRegisterer).NewHistogramVec(
+		operationsDuration: promauto.With(registerer).NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name:                            "backend_operations_duration_seconds",
 				Help:                            "Histogram of operation latencies.",
@@ -188,14 +188,14 @@ func NewOperationsScanner(dbClient database.DBClient, clustersServiceClient ocm.
 			},
 			[]string{"type"},
 		),
-		lastOperationTimestamp: promauto.With(prometheus.DefaultRegisterer).NewGaugeVec(
+		lastOperationTimestamp: promauto.With(registerer).NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "backend_last_operation_timestamp_seconds",
 				Help: "Timestamp of the last operation.",
 			},
 			[]string{"type"},
 		),
-		subscriptionsByState: promauto.With(prometheus.DefaultRegisterer).NewGaugeVec(
+		subscriptionsByState: promauto.With(registerer).NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "backend_subscriptions",
 				Help: "Number of subscriptions by state.",

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -23,7 +23,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	// load all the prometheus client-go metrics
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -33,6 +32,7 @@ import (
 	k8sutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/component-base/metrics/legacyregistry"
 	utilsclock "k8s.io/utils/clock"
 
 	"github.com/Azure/ARO-HCP/backend/oldoperationscanner"
@@ -46,6 +46,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/validationcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/validationcontrollers/validations"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers/metrics"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -106,6 +107,9 @@ func (b *Backend) Run(ctx context.Context) error {
 	logger := utils.LoggerFromContext(ctx)
 	logger.Info("Running backend")
 
+	registerer := legacyregistry.Registerer()
+	controllerutils.RegisterControllerMetrics(registerer)
+
 	logger.Info(fmt.Sprintf(
 		"%s (%s) started in %s",
 		b.options.AppShortDescriptionName,
@@ -151,7 +155,7 @@ func (b *Backend) Run(ctx context.Context) error {
 
 	// Handle requests directly for /healthz endpoint
 	if b.options.HealthzServerListenAddress != "" {
-		backendHealthGauge := promauto.With(prometheus.DefaultRegisterer).NewGauge(prometheus.GaugeOpts{Name: "backend_health", Help: "backend_health is 1 when healthy"})
+		backendHealthGauge := promauto.With(registerer).NewGauge(prometheus.GaugeOpts{Name: "backend_health", Help: "backend_health is 1 when healthy"})
 
 		http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 
@@ -176,9 +180,9 @@ func (b *Backend) Run(ctx context.Context) error {
 
 	if b.options.MetricsServerListenAddress != "" {
 		http.Handle("/metrics", promhttp.InstrumentMetricHandler(
-			prometheus.DefaultRegisterer,
+			registerer,
 			promhttp.HandlerFor(
-				prometheus.DefaultGatherer,
+				prometheus.Gatherers{legacyregistry.DefaultGatherer},
 				promhttp.HandlerOpts{},
 			),
 		))
@@ -196,7 +200,7 @@ func (b *Backend) Run(ctx context.Context) error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := b.runBackendControllersUnderLeaderElection(ctx, electionChecker)
+		err := b.runBackendControllersUnderLeaderElection(ctx, electionChecker, registerer)
 		// When leader election exits (e.g. lost lease), cancel so Run() unblocks and performs shutdown.
 		cancel(fmt.Errorf("backend controllers leader election exited"))
 		errCh <- err
@@ -249,7 +253,7 @@ func (b *Backend) shutdownHTTPServer(ctx context.Context, server *http.Server, n
 
 // runBackendControllersUnderLeaderElection runs the backen controllers under
 // a leader election loop.
-func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, electionChecker *leaderelection.HealthzAdaptor) error {
+func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, electionChecker *leaderelection.HealthzAdaptor, registerer prometheus.Registerer) error {
 	backendInformers := informers.NewBackendInformers(ctx, b.options.CosmosDBClient.GlobalListers())
 
 	_, subscriptionLister := backendInformers.Subscriptions()
@@ -257,7 +261,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 
 	startedLeading := atomic.Bool{}
 	operationsScanner := oldoperationscanner.NewOperationsScanner(
-		b.options.CosmosDBClient, b.options.ClustersServiceClient, b.options.AzureLocation, subscriptionLister)
+		b.options.CosmosDBClient, b.options.ClustersServiceClient, b.options.AzureLocation, subscriptionLister, registerer)
 	dataDumpController := controllerutils.NewClusterWatchingController(
 		"DataDump", b.options.CosmosDBClient, backendInformers, 1*time.Minute, controllers.NewDataDumpController(activeOperationLister, b.options.CosmosDBClient))
 	doNothingController := controllers.NewDoNothingExampleController(b.options.CosmosDBClient, subscriptionLister)
@@ -386,6 +390,11 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		backendInformers,
 	)
 
+	storageMetricsObserver := metrics.NewStorageMetricsObserver(
+		registerer,
+		backendInformers,
+	)
+
 	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
 		Lock:          b.options.LeaderElectionLock,
 		LeaseDuration: leaderElectionLeaseDuration,
@@ -398,6 +407,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 
 				// start the SharedInformers
 				go backendInformers.RunWithContext(ctx)
+				go storageMetricsObserver.Run(ctx)
 
 				go operationsScanner.Run(ctx)
 				go dataDumpController.Run(ctx, 20)

--- a/backend/pkg/controllers/controllerutils/controller_metrics.go
+++ b/backend/pkg/controllers/controllerutils/controller_metrics.go
@@ -16,12 +16,11 @@ package controllerutils
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
 	// ReconcileTotal counts the total number of reconciliations per controller.
-	ReconcileTotal = promauto.NewCounterVec(
+	ReconcileTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "backend_controller_reconcile_total",
 			Help: "Total number of reconciliations per controller.",
@@ -29,3 +28,8 @@ var (
 		[]string{"controller"},
 	)
 )
+
+// RegisterControllerMetrics registers controller-level metrics with the given registerer.
+func RegisterControllerMetrics(registerer prometheus.Registerer) {
+	registerer.MustRegister(ReconcileTotal)
+}

--- a/backend/pkg/controllers/controllerutils/util.go
+++ b/backend/pkg/controllers/controllerutils/util.go
@@ -136,6 +136,9 @@ func (k *HCPNodePoolKey) InitialController(controllerName string) *api.Controlle
 // clock is used by helper functions for setting last transition time.  It is injectable for unit testing.
 var clock utilsclock.Clock = utilsclock.RealClock{}
 
+// ConditionTypeDegraded is the condition type used to report controller degradation.
+const ConditionTypeDegraded = "Degraded"
+
 // controllerMutationFunc is called when trying to write a controller. It gives a spot for computation of a value.
 // It should only perform short calls, not long lookups.  It must not fail. Think of it as a way to write information
 // that you have already precomputed.
@@ -145,7 +148,7 @@ func ReportSyncError(syncErr error) controllerMutationFunc {
 	return func(controller *api.Controller) {
 		if syncErr == nil {
 			SetCondition(&controller.Status.Conditions, api.Condition{
-				Type:    "Degraded",
+				Type:    ConditionTypeDegraded,
 				Status:  api.ConditionFalse,
 				Reason:  "NoErrors",
 				Message: "As expected.",
@@ -154,7 +157,7 @@ func ReportSyncError(syncErr error) controllerMutationFunc {
 		}
 
 		SetCondition(&controller.Status.Conditions, api.Condition{
-			Type:    "Degraded",
+			Type:    ConditionTypeDegraded,
 			Status:  api.ConditionTrue,
 			Reason:  "Failed",
 			Message: fmt.Sprintf("Had an error while syncing: %s", syncErr.Error()),

--- a/backend/pkg/controllers/controllerutils/util_test.go
+++ b/backend/pkg/controllers/controllerutils/util_test.go
@@ -33,19 +33,19 @@ func TestGetCondition(t *testing.T) {
 		{
 			name:          "returns nil for nil slice",
 			conditions:    nil,
-			conditionType: "Degraded",
+			conditionType: ConditionTypeDegraded,
 			wantFound:     false,
 		},
 		{
 			name:          "returns nil when type not found",
 			conditions:    []api.Condition{{Type: "Available", Status: api.ConditionTrue, Message: "Available"}},
-			conditionType: "Degraded",
+			conditionType: ConditionTypeDegraded,
 			wantFound:     false,
 		},
 		{
 			name:          "returns first match when multiple have same type",
-			conditions:    []api.Condition{{Type: "Degraded", Status: api.ConditionTrue, Message: "first"}, {Type: "Degraded", Status: api.ConditionFalse, Message: "second"}},
-			conditionType: "Degraded",
+			conditions:    []api.Condition{{Type: ConditionTypeDegraded, Status: api.ConditionTrue, Message: "first"}, {Type: ConditionTypeDegraded, Status: api.ConditionFalse, Message: "second"}},
+			conditionType: ConditionTypeDegraded,
 			wantFound:     true,
 			wantMessage:   "first",
 		},
@@ -67,11 +67,11 @@ func TestGetCondition(t *testing.T) {
 	t.Run("the returned reference should never point to the original item in the list", func(t *testing.T) {
 		conditions := []api.Condition{
 			{Type: "Available", Status: api.ConditionTrue, Message: "Available"},
-			{Type: "Degraded", Status: api.ConditionTrue, Reason: "NoErrors", Message: "As expected."},
+			{Type: ConditionTypeDegraded, Status: api.ConditionTrue, Reason: "NoErrors", Message: "As expected."},
 		}
 		unwantedCondition := &conditions[1]
 
-		res := GetCondition(conditions, "Degraded")
+		res := GetCondition(conditions, ConditionTypeDegraded)
 		// We intentionally perform a pointer comparison to check that the returned condition is a reference to the found one in the list.
 		if res == unwantedCondition {
 			t.Errorf("returned condition is a reference to the found one in the list")
@@ -90,21 +90,21 @@ func TestSetCondition(t *testing.T) {
 		{
 			name:                 "adds condition when slice is nil",
 			conditions:           nil,
-			toSet:                api.Condition{Type: "Degraded", Status: api.ConditionFalse, Reason: "NoErrors", Message: "As expected."},
+			toSet:                api.Condition{Type: ConditionTypeDegraded, Status: api.ConditionFalse, Reason: "NoErrors", Message: "As expected."},
 			wantLen:              1,
 			wantConditionMessage: "As expected.",
 		},
 		{
 			name:                 "adds condition when type not found",
 			conditions:           []api.Condition{{Type: "Available", Status: api.ConditionTrue}},
-			toSet:                api.Condition{Type: "Degraded", Status: api.ConditionFalse, Reason: "NoErrors", Message: "As expected."},
+			toSet:                api.Condition{Type: ConditionTypeDegraded, Status: api.ConditionFalse, Reason: "NoErrors", Message: "As expected."},
 			wantLen:              2,
 			wantConditionMessage: "As expected.",
 		},
 		{
 			name:                 "modifies existing condition when found",
-			conditions:           []api.Condition{{Type: "Degraded", Status: api.ConditionTrue, Reason: "Failed", Message: "Had an error"}},
-			toSet:                api.Condition{Type: "Degraded", Status: api.ConditionFalse, Reason: "NoErrors", Message: "As expected."},
+			conditions:           []api.Condition{{Type: ConditionTypeDegraded, Status: api.ConditionTrue, Reason: "Failed", Message: "Had an error"}},
+			toSet:                api.Condition{Type: ConditionTypeDegraded, Status: api.ConditionFalse, Reason: "NoErrors", Message: "As expected."},
 			wantLen:              1,
 			wantConditionMessage: "As expected.",
 		},
@@ -128,23 +128,23 @@ func TestIsConditionTrue(t *testing.T) {
 		conditionType string
 		want          bool
 	}{
-		{"returns false for nil conditions", nil, "Degraded", false},
+		{"returns false for nil conditions", nil, ConditionTypeDegraded, false},
 		{
 			name:          "returns false when condition not found",
 			conditions:    []api.Condition{{Type: "Available", Status: api.ConditionTrue}},
-			conditionType: "Degraded",
+			conditionType: ConditionTypeDegraded,
 			want:          false,
 		},
 		{
 			name:          "returns false when condition found and its status is False",
-			conditions:    []api.Condition{{Type: "Degraded", Status: api.ConditionFalse}},
-			conditionType: "Degraded",
+			conditions:    []api.Condition{{Type: ConditionTypeDegraded, Status: api.ConditionFalse}},
+			conditionType: ConditionTypeDegraded,
 			want:          false,
 		},
 		{
 			name:          "returns true when condition found and status is True",
-			conditions:    []api.Condition{{Type: "Degraded", Status: api.ConditionTrue}},
-			conditionType: "Degraded",
+			conditions:    []api.Condition{{Type: ConditionTypeDegraded, Status: api.ConditionTrue}},
+			conditionType: ConditionTypeDegraded,
 			want:          true,
 		},
 	}

--- a/backend/pkg/controllers/do_nothing.go
+++ b/backend/pkg/controllers/do_nothing.go
@@ -87,7 +87,7 @@ func (c *doNothingExample) synchronizeHCPCluster(ctx context.Context, key contro
 	} else {
 		logger.Info("starting work for item",
 			"provisioning_state", cosmosHCPCluster.ServiceProviderProperties.ProvisioningState,
-			"controller_degraded", controllerutils.GetCondition(existingController.Status.Conditions, "Degraded"),
+			"controller_degraded", controllerutils.GetCondition(existingController.Status.Conditions, controllerutils.ConditionTypeDegraded),
 		)
 	}
 

--- a/backend/pkg/informers/metrics/metrics.go
+++ b/backend/pkg/informers/metrics/metrics.go
@@ -1,0 +1,286 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	observationJitter = 0.2
+)
+
+// StorageMetricsObserver periodically observes informer caches and
+// updates Prometheus GaugeVec metrics. Each resource type is observed
+// independently in its own goroutine, following the pattern used by
+// the Kubernetes API server's Store.startObservingCount().
+type StorageMetricsObserver struct {
+	backendInformers informers.BackendInformers
+	pollPeriod       time.Duration
+
+	resourcesObjectCounts            *prometheus.GaugeVec
+	controllerConditionsObjectCounts *prometheus.GaugeVec
+}
+
+// NewStorageMetricsObserver creates a StorageMetricsObserver that periodically
+// polls backendInformers and emits statistics as metrics.
+func NewStorageMetricsObserver(registerer prometheus.Registerer, backendInformers informers.BackendInformers) *StorageMetricsObserver {
+	return &StorageMetricsObserver{
+		backendInformers: backendInformers,
+		pollPeriod:       1 * time.Minute,
+		resourcesObjectCounts: promauto.With(registerer).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "backend_resource_provider_objects",
+				Help: "Number of resource objects by provisioning state.",
+			},
+			[]string{"resource_type", "provisioning_state"},
+		),
+		controllerConditionsObjectCounts: promauto.With(registerer).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "backend_controller_status_conditions",
+				Help: "Number of controller resources by controller name, condition, and status.",
+			},
+			[]string{"controller_name", "condition", "status"},
+		),
+	}
+}
+
+// Run starts a periodic observation goroutine per resource type and
+// blocks until ctx is cancelled.
+func (o *StorageMetricsObserver) Run(ctx context.Context) {
+	logger := utils.LoggerFromContext(ctx)
+	logger.Info("starting storage metrics observer")
+	defer logger.Info("stopped storage metrics observer")
+
+	wg := sync.WaitGroup{}
+
+	startObservation := func(name string, observe func(context.Context)) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			observationCtx := utils.ContextWithLogger(ctx, logger.WithValues("resource_name", name))
+			wait.JitterUntilWithContext(observationCtx, observe, o.pollPeriod, observationJitter, true)
+		}()
+	}
+
+	startObservation("clusters", o.observeClusters)
+	startObservation("nodepools", o.observeNodePools)
+	startObservation("externalauths", o.observeExternalAuths)
+	startObservation("activeoperations", o.observeActiveOperations)
+	startObservation("subscriptions", o.observeSubscriptions)
+	startObservation("controllers", o.observeControllerConditions)
+
+	<-ctx.Done()
+	wg.Wait()
+}
+
+func (o *StorageMetricsObserver) observeClusters(ctx context.Context) {
+	logger := utils.LoggerFromContext(ctx)
+	informer, lister := o.backendInformers.Clusters()
+	if !informer.HasSynced() {
+		return
+	}
+	clusters, err := lister.List(ctx)
+	if err != nil {
+		logger.Error(err, "failed to list clusters for metrics")
+		return
+	}
+
+	o.updateStorageMetrics(
+		api.ClusterResourceType,
+		getStorageStatsByState(clusters, provisioningStates(), func(cluster *api.HCPOpenShiftCluster) string {
+			return string(cluster.ServiceProviderProperties.ProvisioningState)
+		}),
+	)
+}
+
+func (o *StorageMetricsObserver) observeNodePools(ctx context.Context) {
+	logger := utils.LoggerFromContext(ctx)
+	informer, lister := o.backendInformers.NodePools()
+	if !informer.HasSynced() {
+		return
+	}
+	nodePools, err := lister.List(ctx)
+	if err != nil {
+		logger.Error(err, "failed to list node pools for metrics")
+		return
+	}
+	o.updateStorageMetrics(
+		api.NodePoolResourceType,
+		getStorageStatsByState(nodePools, provisioningStates(), func(nodePool *api.HCPOpenShiftClusterNodePool) string {
+			return string(nodePool.Properties.ProvisioningState)
+		}),
+	)
+}
+
+func (o *StorageMetricsObserver) observeExternalAuths(ctx context.Context) {
+	logger := utils.LoggerFromContext(ctx)
+	informer, lister := o.backendInformers.ExternalAuths()
+	if !informer.HasSynced() {
+		return
+	}
+	externalAuths, err := lister.List(ctx)
+	if err != nil {
+		logger.Error(err, "failed to list external auths for metrics")
+		return
+	}
+
+	o.updateStorageMetrics(
+		api.ExternalAuthResourceType,
+		getStorageStatsByState(externalAuths, provisioningStates(), func(externalAuth *api.HCPOpenShiftClusterExternalAuth) string {
+			return string(externalAuth.Properties.ProvisioningState)
+		}),
+	)
+}
+
+func (o *StorageMetricsObserver) observeActiveOperations(ctx context.Context) {
+	logger := utils.LoggerFromContext(ctx)
+	informer, lister := o.backendInformers.ActiveOperations()
+	if !informer.HasSynced() {
+		return
+	}
+	operations, err := lister.List(ctx)
+	if err != nil {
+		logger.Error(err, "failed to list active operations for metrics")
+		return
+	}
+	o.updateStorageMetrics(
+		api.OperationStatusResourceType,
+		getStorageStatsByState(operations, provisioningStates(), func(operation *api.Operation) string {
+			return string(operation.Status)
+		}),
+	)
+}
+
+func (o *StorageMetricsObserver) observeSubscriptions(ctx context.Context) {
+	logger := utils.LoggerFromContext(ctx)
+	informer, lister := o.backendInformers.Subscriptions()
+	if !informer.HasSynced() {
+		return
+	}
+	subscriptions, err := lister.List(ctx)
+	if err != nil {
+		logger.Error(err, "failed to list subscriptions for metrics")
+		return
+	}
+	subscriptionStates := []string{}
+	for state := range arm.ListSubscriptionStates() {
+		subscriptionStates = append(subscriptionStates, string(state))
+	}
+	o.updateStorageMetrics(
+		azcorearm.SubscriptionResourceType,
+		getStorageStatsByState(subscriptions, subscriptionStates, func(subscription *arm.Subscription) string {
+			return string(subscription.State)
+		}),
+	)
+}
+
+// observeControllerConditions aggregates controller condition counts by controller name.
+// Unlike resource counts, controller names are not pre-initialized to zero because they
+// are derived from the data. This means that if a controller name were to disappear
+// entirely, its gauge values would become stale. In practice this is not a concern
+// because controller names only change with new software versions (process restart).
+func (o *StorageMetricsObserver) observeControllerConditions(ctx context.Context) {
+	logger := utils.LoggerFromContext(ctx)
+	informer, lister := o.backendInformers.Controllers()
+	if !informer.HasSynced() {
+		return
+	}
+	controllers, err := lister.List(ctx)
+	if err != nil {
+		logger.Error(err, "failed to list controllers for metrics")
+		return
+	}
+
+	controllerDegradedStats := make(map[string]controllerStats)
+	for _, controller := range controllers {
+		degradedCondition := controllerutils.GetCondition(controller.Status.Conditions, controllerutils.ConditionTypeDegraded)
+		if degradedCondition == nil {
+			continue
+		}
+		name := controller.GetResourceID().Name
+		stats := controllerDegradedStats[name]
+		switch degradedCondition.Status {
+		case api.ConditionTrue:
+			stats.DegradedTrue++
+		case api.ConditionFalse:
+			stats.DegradedFalse++
+		case api.ConditionUnknown:
+			stats.DegradedUnknown++
+		}
+		controllerDegradedStats[name] = stats
+	}
+	for controllerName, stats := range controllerDegradedStats {
+		o.updateControllerMetrics(controllerName, stats)
+	}
+}
+
+func getStorageStatsByState[T any](items []T, stateList []string, stateLabeler func(item T) string) resourceStats {
+	phaseCounts := make(map[string]int64)
+	for _, phase := range stateList {
+		phaseCounts[phase] = 0
+	}
+	for _, item := range items {
+		phaseCounts[stateLabeler(item)]++
+	}
+	return resourceStats{
+		CountsByPhase: phaseCounts,
+	}
+}
+
+type resourceStats struct {
+	CountsByPhase map[string]int64
+}
+
+func (o *StorageMetricsObserver) updateStorageMetrics(resourceType azcorearm.ResourceType, stats resourceStats) {
+	for phase, count := range stats.CountsByPhase {
+		o.resourcesObjectCounts.WithLabelValues(resourceType.String(), phase).Set(float64(count))
+	}
+}
+
+type controllerStats struct {
+	DegradedTrue    int64
+	DegradedFalse   int64
+	DegradedUnknown int64
+}
+
+func (o *StorageMetricsObserver) updateControllerMetrics(controllerName string, stats controllerStats) {
+	o.controllerConditionsObjectCounts.WithLabelValues(controllerName, controllerutils.ConditionTypeDegraded, string(api.ConditionTrue)).Set(float64(stats.DegradedTrue))
+	o.controllerConditionsObjectCounts.WithLabelValues(controllerName, controllerutils.ConditionTypeDegraded, string(api.ConditionFalse)).Set(float64(stats.DegradedFalse))
+	o.controllerConditionsObjectCounts.WithLabelValues(controllerName, controllerutils.ConditionTypeDegraded, string(api.ConditionUnknown)).Set(float64(stats.DegradedUnknown))
+}
+
+func provisioningStates() []string {
+	states := []string{}
+	for state := range arm.ListProvisioningStates() {
+		states = append(states, string(state))
+	}
+	return states
+}

--- a/backend/pkg/informers/metrics/metrics_test.go
+++ b/backend/pkg/informers/metrics/metrics_test.go
@@ -1,0 +1,511 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+type expectedMetric struct {
+	name   string
+	labels prometheus.Labels
+	value  float64
+}
+
+type metricsTestCase struct {
+	name        string
+	dbResources func(t *testing.T) []any
+	expected    []expectedMetric
+}
+
+func TestStorageMetrics(t *testing.T) {
+	testCases := []metricsTestCase{
+		clusterCountsTestCase(),
+		nodePoolCountsTestCase(),
+		externalAuthCountsTestCase(),
+		activeOperationCountsTestCase(),
+		subscriptionCountsTestCase(),
+		controllerConditionsTestCase(),
+		controllerWithoutDegradedConditionTestCase(),
+		emptyInformerCacheTestCase(),
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(t.Context(), logr.Discard())
+
+			mockDB, err := databasetesting.NewMockDBClientWithResources(ctx, tc.dbResources(t))
+			require.NoError(t, err)
+
+			backendInformers := informers.NewBackendInformersWithRelistDuration(ctx, mockDB.GlobalListers(), ptr.To(1*time.Second))
+			go backendInformers.RunWithContext(ctx)
+			waitForSync(t, ctx, backendInformers)
+
+			reg := prometheus.NewPedanticRegistry()
+			observer := NewStorageMetricsObserver(reg, backendInformers)
+			go observer.Run(ctx)
+
+			// eventually we want this to succeed while the observer goroutine is running
+			require.EventuallyWithT(t, func(ct *assert.CollectT) {
+				assertExpectedMetrics(ct, reg, tc.expected)
+			}, 3*time.Second, 200*time.Millisecond)
+		})
+	}
+}
+
+func assertExpectedMetrics(t require.TestingT, reg *prometheus.Registry, expected []expectedMetric) {
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, exp := range expected {
+		found := false
+		for _, mf := range families {
+			if mf.GetName() != exp.name {
+				continue
+			}
+			for _, m := range mf.GetMetric() {
+				match := true
+				for _, lp := range m.GetLabel() {
+					if v, ok := exp.labels[lp.GetName()]; ok {
+						if v != lp.GetValue() {
+							match = false
+							break
+						}
+					}
+				}
+				if match && len(m.GetLabel()) == len(exp.labels) {
+					require.Equal(t, exp.value, m.GetGauge().GetValue(),
+						"metric %s with labels %v", exp.name, exp.labels)
+					found = true
+				}
+			}
+		}
+		require.True(t, found, "metric %s with labels %v not found", exp.name, exp.labels)
+	}
+}
+
+func waitForSync(t *testing.T, ctx context.Context, bi informers.BackendInformers) {
+	t.Helper()
+	clusterInformer, _ := bi.Clusters()
+	nodePoolInformer, _ := bi.NodePools()
+	externalAuthInformer, _ := bi.ExternalAuths()
+	activeOperationInformer, _ := bi.ActiveOperations()
+	subscriptionInformer, _ := bi.Subscriptions()
+	controllerInformer, _ := bi.Controllers()
+	require.True(t, cache.WaitForCacheSync(ctx.Done(),
+		clusterInformer.HasSynced,
+		nodePoolInformer.HasSynced,
+		externalAuthInformer.HasSynced,
+		activeOperationInformer.HasSynced,
+		subscriptionInformer.HasSynced,
+		controllerInformer.HasSynced,
+	), "timed out waiting for caches to sync")
+}
+
+// ---- Cluster counts test case ----
+
+func clusterCountsTestCase() metricsTestCase {
+	const (
+		subscriptionID    = "sub-1"
+		resourceGroupName = "test-rg"
+	)
+	newCluster := func(t *testing.T, name string, state arm.ProvisioningState) *api.HCPOpenShiftCluster {
+		t.Helper()
+		clusterResourceID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + subscriptionID +
+				"/resourceGroups/" + resourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + name,
+		))
+		internalID, err := api.NewInternalID("/api/clusters_mgmt/v1/clusters/" + name)
+		require.NoError(t, err)
+		return &api.HCPOpenShiftCluster{
+			TrackedResource: arm.TrackedResource{
+				Resource: arm.Resource{
+					ID:   clusterResourceID,
+					Name: name,
+					Type: api.ClusterResourceType.String(),
+					SystemData: &arm.SystemData{
+						CreatedAt: ptr.To(time.Now()),
+					},
+				},
+				Location: "eastus",
+			},
+			ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+				ProvisioningState: state,
+				ClusterServiceID:  internalID,
+			},
+		}
+	}
+	return metricsTestCase{
+		name: "cluster counts by provisioning state",
+		dbResources: func(t *testing.T) []any {
+			return []any{
+				newCluster(t, "cluster-1", arm.ProvisioningStateSucceeded),
+				newCluster(t, "cluster-2", arm.ProvisioningStateSucceeded),
+				newCluster(t, "cluster-3", arm.ProvisioningStateDeleting),
+			}
+		},
+		expected: []expectedMetric{
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": api.ClusterResourceType.String(), "provisioning_state": "Succeeded"}, 2},
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": api.ClusterResourceType.String(), "provisioning_state": "Deleting"}, 1},
+		},
+	}
+}
+
+// ---- NodePool counts test case ----
+
+func nodePoolCountsTestCase() metricsTestCase {
+	const (
+		subscriptionID    = "sub-1"
+		resourceGroupName = "test-rg"
+		clusterName       = "cluster-1"
+	)
+	newNodePool := func(t *testing.T, name string, state arm.ProvisioningState) *api.HCPOpenShiftClusterNodePool {
+		t.Helper()
+		npResourceID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + subscriptionID +
+				"/resourceGroups/" + resourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + clusterName +
+				"/nodePools/" + name,
+		))
+		internalID, err := api.NewInternalID("/api/clusters_mgmt/v1/clusters/" + clusterName)
+		require.NoError(t, err)
+		return &api.HCPOpenShiftClusterNodePool{
+			TrackedResource: arm.TrackedResource{
+				Resource: arm.Resource{
+					ID:   npResourceID,
+					Name: name,
+					Type: api.NodePoolResourceType.String(),
+				},
+				Location: "eastus",
+			},
+			Properties: api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: state,
+				Replicas:          3,
+			},
+			ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+				ClusterServiceID: internalID,
+			},
+		}
+	}
+	return metricsTestCase{
+		name: "nodepool counts by provisioning state",
+		dbResources: func(t *testing.T) []any {
+			return []any{
+				newNodePool(t, "np-1", arm.ProvisioningStateSucceeded),
+				newNodePool(t, "np-2", arm.ProvisioningStateSucceeded),
+				newNodePool(t, "np-3", arm.ProvisioningStateDeleting),
+			}
+		},
+		expected: []expectedMetric{
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": api.NodePoolResourceType.String(), "provisioning_state": "Succeeded"}, 2},
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": api.NodePoolResourceType.String(), "provisioning_state": "Deleting"}, 1},
+		},
+	}
+}
+
+// ---- ExternalAuth counts test case ----
+
+func externalAuthCountsTestCase() metricsTestCase {
+	const (
+		subscriptionID    = "sub-1"
+		resourceGroupName = "test-rg"
+		clusterName       = "cluster-1"
+	)
+	newExternalAuth := func(t *testing.T, name string, state arm.ProvisioningState) *api.HCPOpenShiftClusterExternalAuth {
+		t.Helper()
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + subscriptionID +
+				"/resourceGroups/" + resourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + clusterName +
+				"/externalAuths/" + name,
+		))
+		return &api.HCPOpenShiftClusterExternalAuth{
+			ProxyResource: arm.NewProxyResource(resourceID),
+			Properties: api.HCPOpenShiftClusterExternalAuthProperties{
+				ProvisioningState: state,
+			},
+		}
+	}
+	return metricsTestCase{
+		name: "external auth counts by provisioning state",
+		dbResources: func(t *testing.T) []any {
+			return []any{
+				newExternalAuth(t, "ea-1", arm.ProvisioningStateSucceeded),
+				newExternalAuth(t, "ea-2", arm.ProvisioningStateSucceeded),
+				newExternalAuth(t, "ea-3", arm.ProvisioningStateAwaitingSecret),
+			}
+		},
+		expected: []expectedMetric{
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": api.ExternalAuthResourceType.String(), "provisioning_state": "Succeeded"}, 2},
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": api.ExternalAuthResourceType.String(), "provisioning_state": "AwaitingSecret"}, 1},
+			// Verify pre-initialization: states with zero items must be explicitly set to 0
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": api.ExternalAuthResourceType.String(), "provisioning_state": "Failed"}, 0},
+		},
+	}
+}
+
+// ---- Active operation counts test case ----
+
+func activeOperationCountsTestCase() metricsTestCase {
+	const subscriptionID = "sub-1"
+	newOperation := func(t *testing.T, opName string, status arm.ProvisioningState) *api.Operation {
+		t.Helper()
+		operationID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + subscriptionID +
+				"/providers/Microsoft.RedHatOpenShift/locations/eastus/hcpOperationStatuses/" + opName,
+		))
+		externalID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + subscriptionID +
+				"/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-1",
+		))
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + subscriptionID +
+				"/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/" + opName,
+		))
+		now := time.Now().UTC()
+		return &api.Operation{
+			CosmosMetadata: api.CosmosMetadata{
+				ResourceID: resourceID,
+			},
+			ResourceID:         resourceID,
+			OperationID:        operationID,
+			ExternalID:         externalID,
+			Request:            api.OperationRequestCreate,
+			Status:             status,
+			StartTime:          now,
+			LastTransitionTime: now,
+		}
+	}
+	return metricsTestCase{
+		name: "active operation counts by provisioning state",
+		dbResources: func(t *testing.T) []any {
+			t.Helper()
+			return []any{
+				newOperation(t, "op-1", arm.ProvisioningStateAccepted),
+				newOperation(t, "op-2", arm.ProvisioningStateAccepted),
+				newOperation(t, "op-3", arm.ProvisioningStateProvisioning),
+				newOperation(t, "op-4", arm.ProvisioningStateSucceeded),
+			}
+		},
+		expected: []expectedMetric{
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": api.OperationStatusResourceType.String(), "provisioning_state": "Accepted"}, 2},
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": api.OperationStatusResourceType.String(), "provisioning_state": "Provisioning"}, 1},
+		},
+	}
+}
+
+// ---- Subscription counts test case ----
+
+func subscriptionCountsTestCase() metricsTestCase {
+	newSubscription := func(t *testing.T, id string, state arm.SubscriptionState) *arm.Subscription {
+		t.Helper()
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + id,
+		))
+		return &arm.Subscription{
+			CosmosMetadata: arm.CosmosMetadata{
+				ResourceID: resourceID,
+			},
+			ResourceID: resourceID,
+			State:      state,
+		}
+	}
+	return metricsTestCase{
+		name: "subscription counts by state",
+		dbResources: func(t *testing.T) []any {
+			t.Helper()
+			return []any{
+				newSubscription(t, "sub-1", arm.SubscriptionStateRegistered),
+				newSubscription(t, "sub-2", arm.SubscriptionStateRegistered),
+				newSubscription(t, "sub-3", arm.SubscriptionStateWarned),
+			}
+		},
+		expected: []expectedMetric{
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": azcorearm.SubscriptionResourceType.String(), "provisioning_state": "Registered"}, 2},
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": azcorearm.SubscriptionResourceType.String(), "provisioning_state": "Warned"}, 1},
+		},
+	}
+}
+
+// ---- Controller conditions test case ----
+
+func controllerConditionsTestCase() metricsTestCase {
+	const (
+		subscriptionID    = "sub-1"
+		resourceGroupName = "test-rg"
+	)
+	newControllerClusterController := func(t *testing.T, clusterName string, name string, degradedStatus api.ConditionStatus) *api.Controller {
+		t.Helper()
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + subscriptionID +
+				"/resourceGroups/" + resourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + clusterName +
+				"/hcpOpenShiftControllers/" + name,
+		))
+
+		status := api.ControllerStatus{
+			Conditions: []api.Condition{
+				{
+					Type:               controllerutils.ConditionTypeDegraded,
+					Status:             degradedStatus,
+					Reason:             string(degradedStatus),
+					Message:            string(degradedStatus),
+					LastTransitionTime: time.Now(),
+				},
+			},
+		}
+
+		return &api.Controller{
+			CosmosMetadata: api.CosmosMetadata{
+				ResourceID: resourceID,
+			},
+			ResourceID: resourceID,
+			Status:     status,
+		}
+	}
+	return metricsTestCase{
+		name: "controller condition counts",
+		dbResources: func(t *testing.T) []any {
+			t.Helper()
+			return []any{
+				newControllerClusterController(t, "cluster-1", "cluster-validation", api.ConditionFalse),
+				newControllerClusterController(t, "cluster-1", "cluster-matching", api.ConditionTrue),
+				newControllerClusterController(t, "cluster-1", "nodepool-sync", api.ConditionFalse),
+
+				newControllerClusterController(t, "cluster-2", "cluster-validation", api.ConditionTrue),
+				newControllerClusterController(t, "cluster-2", "cluster-matching", api.ConditionTrue),
+				newControllerClusterController(t, "cluster-2", "nodepool-sync", api.ConditionTrue),
+
+				newControllerClusterController(t, "cluster-3", "cluster-validation", api.ConditionUnknown),
+				newControllerClusterController(t, "cluster-3", "cluster-matching", api.ConditionUnknown),
+				newControllerClusterController(t, "cluster-3", "nodepool-sync", api.ConditionUnknown),
+			}
+		},
+		expected: []expectedMetric{
+			{"backend_controller_status_conditions", prometheus.Labels{"controller_name": "cluster-validation", "condition": "Degraded", "status": "True"}, 1},
+			{"backend_controller_status_conditions", prometheus.Labels{"controller_name": "cluster-validation", "condition": "Degraded", "status": "False"}, 1},
+			{"backend_controller_status_conditions", prometheus.Labels{"controller_name": "cluster-validation", "condition": "Degraded", "status": "Unknown"}, 1},
+
+			{"backend_controller_status_conditions", prometheus.Labels{"controller_name": "cluster-matching", "condition": "Degraded", "status": "True"}, 2},
+			{"backend_controller_status_conditions", prometheus.Labels{"controller_name": "cluster-matching", "condition": "Degraded", "status": "Unknown"}, 1},
+
+			{"backend_controller_status_conditions", prometheus.Labels{"controller_name": "nodepool-sync", "condition": "Degraded", "status": "True"}, 1},
+			{"backend_controller_status_conditions", prometheus.Labels{"controller_name": "nodepool-sync", "condition": "Degraded", "status": "False"}, 1},
+			{"backend_controller_status_conditions", prometheus.Labels{"controller_name": "nodepool-sync", "condition": "Degraded", "status": "Unknown"}, 1},
+		},
+	}
+}
+
+// ---- Controller without Degraded condition test case ----
+
+func controllerWithoutDegradedConditionTestCase() metricsTestCase {
+	const (
+		subscriptionID    = "sub-1"
+		resourceGroupName = "test-rg"
+	)
+	newControllerClusterController := func(t *testing.T, clusterName string, name string, conditions []api.Condition) *api.Controller {
+		t.Helper()
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + subscriptionID +
+				"/resourceGroups/" + resourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + clusterName +
+				"/hcpOpenShiftControllers/" + name,
+		))
+
+		return &api.Controller{
+			CosmosMetadata: api.CosmosMetadata{
+				ResourceID: resourceID,
+			},
+			ResourceID: resourceID,
+			Status: api.ControllerStatus{
+				Conditions: conditions,
+			},
+		}
+	}
+	return metricsTestCase{
+		name: "controllers without degraded condition are skipped",
+		dbResources: func(t *testing.T) []any {
+			t.Helper()
+			return []any{
+				// Controller with no conditions at all
+				newControllerClusterController(t, "cluster-1", "no-conditions", nil),
+				// Controller with a non-Degraded condition only
+				newControllerClusterController(t, "cluster-1", "other-condition", []api.Condition{
+					{
+						Type:    "Ready",
+						Status:  api.ConditionTrue,
+						Reason:  "AllGood",
+						Message: "Ready",
+					},
+				}),
+				// Controller with a Degraded condition (should be counted)
+				newControllerClusterController(t, "cluster-1", "has-degraded", []api.Condition{
+					{
+						Type:    controllerutils.ConditionTypeDegraded,
+						Status:  api.ConditionFalse,
+						Reason:  "NoErrors",
+						Message: "As expected.",
+					},
+				}),
+			}
+		},
+		expected: []expectedMetric{
+			// Only "has-degraded" should appear in metrics
+			{"backend_controller_status_conditions", prometheus.Labels{"controller_name": "has-degraded", "condition": "Degraded", "status": "True"}, 0},
+			{"backend_controller_status_conditions", prometheus.Labels{"controller_name": "has-degraded", "condition": "Degraded", "status": "False"}, 1},
+			{"backend_controller_status_conditions", prometheus.Labels{"controller_name": "has-degraded", "condition": "Degraded", "status": "Unknown"}, 0},
+		},
+	}
+}
+
+// ---- Empty informer cache test case ----
+
+func emptyInformerCacheTestCase() metricsTestCase {
+	return metricsTestCase{
+		name: "empty informer cache produces zero counts",
+		dbResources: func(t *testing.T) []any {
+			t.Helper()
+			return []any{} // no resources at all
+		},
+		expected: []expectedMetric{
+			// Clusters: all provisioning states should be zero
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": api.ClusterResourceType.String(), "provisioning_state": "Succeeded"}, 0},
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": api.ClusterResourceType.String(), "provisioning_state": "Failed"}, 0},
+			// NodePools: zero
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": api.NodePoolResourceType.String(), "provisioning_state": "Succeeded"}, 0},
+			// Subscriptions: zero
+			{"backend_resource_provider_objects", prometheus.Labels{"resource_type": azcorearm.SubscriptionResourceType.String(), "provisioning_state": "Registered"}, 0},
+		},
+	}
+}

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -512,6 +512,33 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         for: 'PT5M'
         severity: 4
       }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'BackendControllerDegraded'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'BackendControllerDegraded/{{ $labels.cluster }}/{{ $labels.controller_name }}'
+          description: 'Controller {{ $labels.controller_name }} is degraded for more than 5% of resources. Current degradation rate: {{ $value | humanizePercentage }}.'
+          info: 'Controller {{ $labels.controller_name }} is degraded for more than 5% of resources. Current degradation rate: {{ $value | humanizePercentage }}.'
+          runbook_url: 'TBD'
+          summary: 'Controller {{ $labels.controller_name }} degradation detected'
+          title: 'Controller {{ $labels.controller_name }} degradation detected'
+        }
+        expression: '( sum by (cluster, controller_name) (backend_controller_status_conditions{condition="Degraded", status="True"}) / sum by (cluster, controller_name) (backend_controller_status_conditions{condition="Degraded"}) ) > 0.05'
+        for: 'PT5M'
+        severity: 3
+      }
     ]
     scopes: [
       azureMonitoring


### PR DESCRIPTION
### What

expose metrics for cosmos objects
    
* backend_resource_provider_objects (by provisioning_state)
* backend_controller_status_conditions (by resource_type, controller_name, condition, status)
    
add a BackendControllerDegraded alert that fires per controller_name and resource_type when >5% of instances report Degraded=True for 5m.

this PR also makes sure to bring direct backend metrics under one prometheus registry to enable proper testing.

### Why

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
