### PR TITLE
test: Add kubeconfig CA validation and remove insecure TLS workaround

### DIFF
--- a/test/e2e/admin_credential_lifecycle.go
+++ b/test/e2e/admin_credential_lifecycle.go
@@ -16,6 +16,8 @@ package e2e
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"net/http"
@@ -33,8 +35,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 
 	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 
@@ -164,15 +168,64 @@ var _ = Describe("Customer", func() {
 			By(fmt.Sprintf("creating %d admin credentials for the ready cluster", credentialCount))
 			for i := range credentialCount {
 				By(fmt.Sprintf("requesting admin credential %d", i+1))
-				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
-					ctx,
-					clusterClient,
+				validationTimeout := 10 * time.Minute
+				validationCtx, validationCancel := context.WithTimeoutCause(ctx, validationTimeout, fmt.Errorf(
+					"timeout exceeded (%v) while requesting admin credential %d",
+					validationTimeout, i+1))
+				defer validationCancel()
+
+				// request admin credential without using the helper function to ensure we can validate
+				// the raw kubeconfig returned by the API. The helper function returns a rest.Config
+				// that omits certain information that is required for validation (e.g. config.Clusters).
+				adminCredentialRequestPoller, err := clusterClient.BeginRequestAdminCredential(
+					validationCtx,
 					*resourceGroup.Name,
 					clusterName,
-					10*time.Minute,
+					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
+
+				credResp, err := adminCredentialRequestPoller.PollUntilDone(validationCtx, &runtime.PollUntilDoneOptions{
+					Frequency: framework.StandardPollInterval,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(credResp.Kubeconfig).NotTo(BeNil())
+
+				By("validating kubeconfig returned by the API is valid")
+				kubeconfigData := []byte(*credResp.Kubeconfig)
+				config, err := clientcmd.Load(kubeconfigData)
+				Expect(err).NotTo(HaveOccurred(), "kubeconfig must be valid YAML")
+
+				By("validating exactly one cluster in kubeconfig")
+				Expect(config.Clusters).To(HaveLen(1), "kubeconfig must contain exactly one cluster")
+				Expect(config.Clusters["cluster"]).NotTo(BeNil())
+				cluster := config.Clusters["cluster"]
+
+				By("validating cluster has CertificateAuthorityData")
+				Expect(cluster.CertificateAuthorityData).NotTo(BeEmpty(), "cluster must have CertificateAuthorityData")
+
+				By("validating cluster CA data is valid PEM")
+				pemBlock, rest := pem.Decode(cluster.CertificateAuthorityData)
+				Expect(pemBlock).NotTo(BeNil(), "cluster CA data must contain a valid PEM block")
+				Expect(pemBlock.Type).To(Equal("CERTIFICATE"), "cluster CA PEM block must be of type CERTIFICATE")
+				Expect(rest).To(BeEmpty(), "cluster CA data must contain exactly one PEM block")
+
+				// the certificate-authority-data is always presented as a self signed certificate where
+				// the subject and issuer are identical
+				// https://learn.microsoft.com/en-us/archive/technet-wiki/3147.pki-certificate-chaining-engine-cce#Building_the_Certificate_Chain
+				By("validating certificate authority data content uses the correct certificate")
+				cert, err := x509.ParseCertificate(pemBlock.Bytes)
+				Expect(err).NotTo(HaveOccurred(), "cluster CA data must contain a valid certificate")
+				Expect(cert.Issuer).To(Equal(cert.Subject), "root CA data must be self-signed")
+
+				By("validating cluster does not use InsecureSkipTLSVerify")
+				Expect(cluster.InsecureSkipTLSVerify).To(BeFalse(), "cluster must not use InsecureSkipTLSVerify")
+
+				By("converting validated kubeconfig to rest.Config")
+				adminRESTConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(adminRESTConfig).NotTo(BeNil(), "adminRESTConfig was nil for credential %d", i+1)
+
 				credentials = append(credentials, adminRESTConfig)
 
 				By(fmt.Sprintf("validating admin credential %d works", i+1))

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -113,31 +113,15 @@ func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster(
 
 	switch m := any(operationResult).(type) {
 	case hcpsdk20240610preview.HcpOpenShiftClustersClientRequestAdminCredentialResponse:
-		return readStaticRESTConfig(m.Kubeconfig)
+		return clientcmd.BuildConfigFromKubeconfigGetter("", func() (*clientcmdapi.Config, error) {
+			if m.Kubeconfig == nil {
+				return nil, fmt.Errorf("kubeconfig content is nil")
+			}
+			return clientcmd.Load([]byte(*m.Kubeconfig))
+		})
 	default:
 		return nil, fmt.Errorf("unknown type %T", m)
 	}
-}
-
-func readStaticRESTConfig(kubeconfigContent *string) (*rest.Config, error) {
-	ret, err := clientcmd.BuildConfigFromKubeconfigGetter("", func() (*clientcmdapi.Config, error) {
-		if kubeconfigContent == nil {
-			return nil, fmt.Errorf("kubeconfig content is nil")
-		}
-		return clientcmd.Load([]byte(*kubeconfigContent))
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Skip TLS verification for development environments with self-signed certificates
-	if IsDevelopmentEnvironment() {
-		ret.Insecure = true
-		ret.CAData = nil
-		ret.CAFile = ""
-	}
-
-	return ret, nil
 }
 
 func (tc *perItOrDescribeTestContext) RevokeCredentialsAndWait(


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/ARO-24888

Extend admin_credential_lifecycle E2E test to validate that kubeconfigs returned by RequestAdminCredential include valid CertificateAuthorityData and do not use InsecureSkipTLSVerify. Remove development environment workarounds that stripped CA data and forced insecure connections, as even self-signed certificates should include their CA data.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

Remove any branching test code that forces insecure kubeconfigs to ensure all environments ship with correctly secured data.


### Why

<!-- Briefly explain why this change is needed -->

[ARO-24888](https://issues.redhat.com/browse/ARO-24888) reports that ARO HCP kubeconfigs are missing `certificate-authority-data` and instead use `insecure-skip-tls-verify: true`, which blocks secure integration and is flagged by security tooling.

Investigation confirmed this is **not an RP problem** — the Frontend RP is a passthrough layer ([`internal/ocm/convert.go`](https://github.com/Azure/ARO-HCP/blob/d32080c45d3fdc201cbaed9e993aab4177d9f128/internal/ocm/convert.go#L1086-L1092)). The kubeconfig is generated by cluster-service/hypershift/CAPZ and returned unchanged. The fix must happen upstream in kubeconfig generation.

However, the test framework here had workarounds in `readStaticRESTConfig()` that stripped CA data and set `Insecure=true` for development environments. These workarounds potentially masked the underlying issue — even self-signed certificates should include their CA certificate in `certificate-authority-data`. 

TL;DR - even in testing envs, assuming this bug/customer request, there is no legitimate reason to use `insecure-skip-tls-verify` anymore. This E2E update will allow us to confirm this bug is real or not and also validate when it's implemented correctly.

Note that the changes made for [ARO-24888](https://issues.redhat.com/browse/ARO-24888) is only applicable for customer admin credentials. The SRE admin credentials must keep using the InsecureSkipTLSVerify as that is retrieved from another API endpoint that does not return the certificate-authority-data in its kubeconfig. 

### Special notes for your reviewer

Once the CS changes is rolled out, the new assertions in the e2e tests should pass. The e2e tests should also start using the certificate-authority-data within the kubeconfig instead of skipping tls verification or using system cert pools
