### PR TITLE
Add targeted retries for regional infra ARM deployment

### DIFF
--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -150,6 +150,13 @@ resourceGroups:
     template: templates/region.bicep
     parameters: configurations/region.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    automatedRetry:
+      errorContainsAny:
+      - "providers/Microsoft.Resources/deployments/svc-monitor"
+      - "providers/Microsoft.Resources/deployments/hcp-monitor"
+      - "providers/Microsoft.Resources/deployments/maestro-infra-deployment"
+      maximumRetryCount: 3
+      durationBetweenRetries: 2m
     variables:
     - name: globalMSIId
       input:


### PR DESCRIPTION
Retry the regional/infra ARM step when failures come from svc-monitor, hcp-monitor, or maestro-infra-deployment nested deployments. The returned error messages are extremely generic so we try to match by deployment name.

Example error

```
      {
        "code": "Conflict",
        "message": {
          "status": "Failed",
          "error": {
            "code": "ResourceDeploymentFailure",
            "message": "The resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'.",
            "details": [
              {
                "code": "DeploymentFailed",
                "target": "/subscriptions/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/resourceGroups/hcp-underlay-prow-j4277248/providers/Microsoft.Resources/deployments/svc-monitor",
                "message": "At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.",
                "details": [
                  {
                    "code": "ResourceDeploymentFailure",
                    "target": "/subscriptions/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/resourceGroups/hcp-underlay-prow-j4277248/providers/Microsoft.Monitor/accounts/services-j4277248/providers/Microsoft.Authorization/roleAssignments/377c405e-8948-5cfe-b6a5-d9d917defab9",
                    "message": "Encountered internal server error. Diagnostic information: timestamp '20260303T011640Z', subscription id 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', tracking id '7ecd3fb0-d9ea-4f95-b0f0-7665a6b78546', request correlation id 'f88c8346-6f16-4ebb-a7d7-9fbd36b5743a'."
                  }
                ]
              }
            ]
          }
        }
      },
```