### PR TITLE
e2e-setup: add size-override: Minimal tag

### DIFF
--- a/test/e2e-setup/bicep/modules/cluster.bicep
+++ b/test/e2e-setup/bicep/modules/cluster.bicep
@@ -38,7 +38,9 @@ param keyVaultName string
 param etcdEncryptionKeyName string
 
 @description('Tags that should be added to the ARO HCP cluster')
-param tags object = {}
+param tags object = {
+  'aro-hcp.experimental.cluster.size-override': 'Minimal'
+}
 
 @description('List of authorized IP ranges for API server access')
 param authorizedCidrs array?


### PR DESCRIPTION
### What

Quick followup for https://github.com/Azure/ARO-HCP/pull/4378

Align the defaults for E2E bicep based setup with recent changes in 86cf6cad462793f76f68b676a94a68faefbc1672.

### Why

We don't use the bicep file to deploy hosted clusters right now, but this doesn't mean we don't want to keep the defaults up to date.

### Special notes for your reviewer


