### PR TITLE
add env var for skipping add-grafana-datasource

### DIFF
--- a/dev-infrastructure/scripts/add-grafana-datasource.sh
+++ b/dev-infrastructure/scripts/add-grafana-datasource.sh
@@ -26,7 +26,7 @@ then
     exit 0
 fi
 
-if [ "${SKIP_GRAFANA_DATASOURCE}" = "true" ]; then
+if [ "${SKIP_GRAFANA_DATASOURCE:-false}" = "true" ]; then
     echo "Skipping Grafana datasource setup (SKIP_GRAFANA_DATASOURCE=true)"
     exit 0
 fi

--- a/dev-infrastructure/scripts/add-grafana-datasource.sh
+++ b/dev-infrastructure/scripts/add-grafana-datasource.sh
@@ -26,6 +26,11 @@ then
     exit 0
 fi
 
+if [ "${SKIP_GRAFANA_DATASOURCE}" = "true" ]; then
+    echo "Skipping Grafana datasource setup (SKIP_GRAFANA_DATASOURCE=true)"
+    exit 0
+fi
+
 # parse resource IDs
 IFS='/'
 read -ra ADDR <<< "$GRAFANA_RESOURCE_ID"


### PR DESCRIPTION
<!-- Link to Jira issue -->

Add ability to skip add-grafana-datasource.sh

<!-- Briefly describe what this PR does -->

When deploying a personal-dev-env this step adds several minutes.  This allows you to skip that step if you dont need it.

<!-- Briefly explain why this change is needed -->

### Special notes for your reviewer

<!-- optional -->
