### PR TITLE
Allow node pool major upgrades

### DIFF
--- a/backend/pkg/controllers/controllerutils/generic_watching_controller.go
+++ b/backend/pkg/controllers/controllerutils/generic_watching_controller.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/utils"
-	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
+	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 )
 
 type GenericSyncer[T comparable] interface {
@@ -164,7 +164,7 @@ func (c *genericWatchingController[T]) EnqueueResourceIDAdd(resourceID *azcorear
 	if resourceID == nil {
 		return
 	}
-	if !apihelpers.ResourceTypeEqual(resourceID.ResourceType, c.resourceType) {
+	if !armhelpers.ResourceTypeEqual(resourceID.ResourceType, c.resourceType) {
 		c.EnqueueResourceIDAdd(resourceID.Parent, changed)
 		return
 	}

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
@@ -26,16 +26,21 @@ import (
 	"github.com/golang/groupcache/lru"
 	"github.com/google/uuid"
 
+	"k8s.io/apimachinery/pkg/api/operation"
+
 	"github.com/openshift/cluster-version-operator/pkg/cincinnati"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/cincinatti"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
+	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
+	"github.com/Azure/ARO-HCP/internal/validation"
 )
 
 // nodePoolVersionSyncer is a nodePool syncer that synchronizes cluster information
@@ -200,8 +205,13 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 		return nil
 	}
 
+	subscription, err := c.cosmosClient.Subscriptions().Get(ctx, cluster.ID.SubscriptionID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get subscription: %w", err))
+	}
+
 	// Validate the customer's desired version before setting it
-	if err := c.validateDesiredNodePoolVersion(ctx, &customerDesiredVersion, existingServiceProviderNodePool, existingServiceProviderCluster, nodePool.Properties.Version.ChannelGroup, clusterKey, clusterUUID); err != nil {
+	if err := c.validateDesiredNodePoolVersion(ctx, &customerDesiredVersion, existingServiceProviderNodePool, existingServiceProviderCluster, subscription, nodePool.Properties.Version.ChannelGroup, clusterKey, clusterUUID); err != nil {
 		return utils.TrackError(fmt.Errorf("invalid desired version: %w", err))
 	}
 
@@ -243,6 +253,7 @@ func prependActiveVersionIfChanged(currentVersions []api.HCPNodePoolActiveVersio
 // It validates:
 //   - The desired version is not less than the highest active node pool version (no downgrades)
 //   - The desired version is not greater than the lowest control plane version
+//   - No major version changes (unless FeatureExperimentalReleaseFeatures is registered)
 //   - No minor versions are skipped
 //   - An upgrade path exists from the current version (all the activeVersions) to the desired version (via Cincinnati)
 //
@@ -252,6 +263,7 @@ func (c *nodePoolVersionSyncer) validateDesiredNodePoolVersion(
 	desiredVersion *semver.Version,
 	spNodePool *api.ServiceProviderNodePool,
 	spCluster *api.ServiceProviderCluster,
+	subscription *arm.Subscription,
 	channelGroup string,
 	clusterKey controllerutils.HCPClusterKey,
 	clusterUUID uuid.UUID,
@@ -265,53 +277,16 @@ func (c *nodePoolVersionSyncer) validateDesiredNodePoolVersion(
 
 	// Get all active versions from ServiceProviderNodePool
 	nodePoolActiveVersions := spNodePool.Status.NodePoolVersion.ActiveVersions
+	lowestCPVersion, _ := apihelpers.FindLowestAndHighestClusterVersion(spCluster.Status.ControlPlaneVersion.ActiveVersions)
 
-	// If desired version is already among active versions, validation passes (upgrade already in progress or complete)
-	if isVersionInActiveVersions(desiredVersion, nodePoolActiveVersions) {
-		return nil
+	// This operation is added to normalize the use for the validations so they are shared
+	// between the frontend and the backend
+	op := operation.Operation{
+		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
 	}
 
-	// Get the lowest and highest node pool active versions
-	lowestNodePoolVersion, highestNodePoolVersion := api.FindNodePoolVersionBounds(nodePoolActiveVersions)
-
-	// Get the lowest control plane version (most restrictive upper bound)
-	lowestControlPlaneVersion := api.FindLowestClusterVersion(spCluster.Status.ControlPlaneVersion.ActiveVersions)
-
-	// Node pool version >= highest active version (no partial downgrades)
-	if highestNodePoolVersion != nil && desiredVersion.LT(*highestNodePoolVersion) {
-		return fmt.Errorf(
-			"invalid node pool version %s: cannot downgrade from current version %s",
-			desiredVersion.String(), highestNodePoolVersion.String(),
-		)
-	}
-
-	// Node pool version <= control plane version (check against lowest CP version)
-	// TODO: We may relax this constraint in the future
-	if lowestControlPlaneVersion != nil && desiredVersion.GT(*lowestControlPlaneVersion) {
-		return fmt.Errorf(
-			"invalid node pool version %s: cannot exceed control plane version %s",
-			desiredVersion.String(), lowestControlPlaneVersion.String(),
-		)
-	}
-
-	if lowestNodePoolVersion != nil {
-		// TODO: Add support for major version upgrades (e.g., 4.20 → 5.0) when needed
-		// No major version upgrades implemented
-		if desiredVersion.Major != lowestNodePoolVersion.Major {
-			return fmt.Errorf(
-				"invalid upgrade path from %s to %s: major version changes are not supported",
-				lowestNodePoolVersion.String(), desiredVersion.String(),
-			)
-		}
-		// Allow same minor (z-stream upgrade) or next minor (y-stream upgrade)
-		// Cannot skip minor versions (check against lowest node pool version)
-		// TODO: We will relax this constraint in the future to allow skipping minor versions
-		if desiredVersion.Minor > lowestNodePoolVersion.Minor+1 {
-			return fmt.Errorf(
-				"invalid upgrade path from %s to %s: skipping minor versions is not allowed",
-				lowestNodePoolVersion.String(), desiredVersion.String(),
-			)
-		}
+	if err := validation.ValidateNodePoolUpgrade(*desiredVersion, nodePoolActiveVersions, lowestCPVersion, op.HasOption(api.FeatureExperimentalReleaseFeatures)); err != nil {
+		return err
 	}
 
 	// Validate upgrade path exists in Cincinnati for ALL active node pool versions
@@ -324,19 +299,6 @@ func (c *nodePoolVersionSyncer) validateDesiredNodePoolVersion(
 	}
 
 	return nil
-}
-
-// isVersionInActiveVersions checks if the given version is already in the list of active versions.
-func isVersionInActiveVersions(version *semver.Version, activeVersions []api.HCPNodePoolActiveVersion) bool {
-	if version == nil {
-		return false
-	}
-	for _, av := range activeVersions {
-		if av.Version != nil && av.Version.EQ(*version) {
-			return true
-		}
-	}
-	return false
 }
 
 // validateUpgradePathAvailable checks that an upgrade path exists from current to desired version.

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"k8s.io/utils/ptr"
+
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
@@ -59,9 +61,31 @@ func (a *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
 
 var _ controllerutils.CooldownChecker = &alwaysSyncCooldownChecker{}
 
+// createTestSubscription creates a subscription in the mock database.
+func createTestSubscription(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient) {
+	t.Helper()
+
+	subResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscriptionID))
+	subscription := &arm.Subscription{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID: subResourceID,
+		},
+		ResourceID: subResourceID,
+		State:      arm.SubscriptionStateRegistered,
+		Properties: &arm.SubscriptionProperties{
+			TenantId: ptr.To("test-tenant-id"),
+		},
+	}
+	_, err := mockDB.Subscriptions().Create(ctx, subscription, nil)
+	require.NoError(t, err)
+}
+
 // createTestNodePoolWithVersion creates a parent cluster and a node pool in the mock database.
 func createTestNodePoolWithVersion(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient, desiredVersion string) {
 	t.Helper()
+
+	// Create subscription first
+	createTestSubscription(t, ctx, mockDB)
 
 	// Create parent cluster first (required by mock DB structure).
 	clusterResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscriptionID +
@@ -278,6 +302,7 @@ func TestNodePoolVersionSyncer_ValidateDesiredNodePoolVersion(t *testing.T) {
 		desiredVersion       string
 		activeVersions       []string
 		controlPlaneVersions []string
+		allowMajorUpgrades   bool
 		expectError          bool
 		errorContains        string
 	}{
@@ -336,12 +361,55 @@ func TestNodePoolVersionSyncer_ValidateDesiredNodePoolVersion(t *testing.T) {
 			errorContains:        "skipping minor versions is not allowed",
 		},
 		{
-			name:                 "major version change - fail",
-			desiredVersion:       "5.19.10",
-			activeVersions:       []string{"4.19.10"},
-			controlPlaneVersions: []string{"5.19.10"},
+			name:                 "major version change - fail by default",
+			desiredVersion:       "5.0.0",
+			activeVersions:       []string{"4.22.0"},
+			controlPlaneVersions: []string{"5.0.0"},
 			expectError:          true,
 			errorContains:        "major version changes are not supported",
+		},
+		{
+			name:                 "valid major upgrade 4.22 to 5.0",
+			desiredVersion:       "5.0.0",
+			activeVersions:       []string{"4.22.0"},
+			controlPlaneVersions: []string{"5.0.0"},
+			allowMajorUpgrades:   true,
+			expectError:          false,
+		},
+		{
+			name:                 "valid major upgrade 4.23 to 5.1",
+			desiredVersion:       "5.1.0",
+			activeVersions:       []string{"4.23.0"},
+			controlPlaneVersions: []string{"5.1.0"},
+			allowMajorUpgrades:   true,
+			expectError:          false,
+		},
+		{
+			name:                 "invalid major upgrade 4.22 to 5.1",
+			desiredVersion:       "5.1.0",
+			activeVersions:       []string{"4.22.0"},
+			controlPlaneVersions: []string{"5.1.0"},
+			allowMajorUpgrades:   true,
+			expectError:          true,
+			errorContains:        "4.22 can only upgrade to 5.0",
+		},
+		{
+			name:                 "invalid major upgrade 4.23 to 5.0",
+			desiredVersion:       "5.0.0",
+			activeVersions:       []string{"4.23.0"},
+			controlPlaneVersions: []string{"5.0.0"},
+			allowMajorUpgrades:   true,
+			expectError:          true,
+			errorContains:        "4.23 can only upgrade to 5.1",
+		},
+		{
+			name:                 "invalid major upgrade 4.20 not supported",
+			desiredVersion:       "5.0.0",
+			activeVersions:       []string{"4.20.0"},
+			controlPlaneVersions: []string{"5.0.0"},
+			allowMajorUpgrades:   true,
+			expectError:          true,
+			errorContains:        "major version upgrades are not supported",
 		},
 		// Downgrade tests
 		{
@@ -432,11 +500,24 @@ func TestNodePoolVersionSyncer_ValidateDesiredNodePoolVersion(t *testing.T) {
 			}
 			syncer.clusterToCincinnatiClient.Add(clusterKey, mockCincinnatiClient)
 
+			// Create subscription based on allowMajorUpgrades flag
+			subscription := &arm.Subscription{
+				Properties: &arm.SubscriptionProperties{},
+			}
+
+			if tt.allowMajorUpgrades {
+				subscription.Properties.RegisteredFeatures = &[]arm.Feature{{
+					Name:  ptr.To(api.FeatureExperimentalReleaseFeatures),
+					State: ptr.To("Registered"),
+				}}
+			}
+
 			err := syncer.validateDesiredNodePoolVersion(
 				ctx,
 				&desiredVersion,
 				spNodePool,
 				spCluster,
+				subscription,
 				"stable",
 				clusterKey,
 				[16]byte{}, // dummy UUID
@@ -448,59 +529,6 @@ func TestNodePoolVersionSyncer_ValidateDesiredNodePoolVersion(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-		})
-	}
-}
-
-func TestNodePoolVersionSyncer_IsVersionInActiveVersions(t *testing.T) {
-	tests := []struct {
-		name           string
-		version        string
-		activeVersions []string
-		expected       bool
-	}{
-		{
-			name:           "empty active versions",
-			version:        "4.19.10",
-			activeVersions: []string{},
-			expected:       false,
-		},
-		{
-			name:           "version found in single active version",
-			version:        "4.19.10",
-			activeVersions: []string{"4.19.10"},
-			expected:       true,
-		},
-		{
-			name:           "version not found in single active version",
-			version:        "4.20.5",
-			activeVersions: []string{"4.19.10"},
-			expected:       false,
-		},
-		{
-			name:           "version found in multiple active versions",
-			version:        "4.19.5",
-			activeVersions: []string{"4.19.10", "4.19.5"},
-			expected:       true,
-		},
-		{
-			name:           "version not found in multiple active versions",
-			version:        "4.20.5",
-			activeVersions: []string{"4.19.10", "4.19.5"},
-			expected:       false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			version := semver.MustParse(tt.version)
-			var activeVersions []api.HCPNodePoolActiveVersion
-			for _, v := range tt.activeVersions {
-				version := semver.MustParse(v)
-				activeVersions = append(activeVersions, api.HCPNodePoolActiveVersion{Version: &version})
-			}
-			result := isVersionInActiveVersions(&version, activeVersions)
-			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/backend/pkg/informers/informers.go
+++ b/backend/pkg/informers/informers.go
@@ -32,7 +32,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/utils"
-	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
+	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 )
 
 const (
@@ -554,7 +554,7 @@ func findAncestorResourceID(resourceType azcorearm.ResourceType, resourceID *azc
 	if resourceID == nil {
 		return nil, nil
 	}
-	if apihelpers.ResourceTypeEqual(resourceID.ResourceType, resourceType) {
+	if armhelpers.ResourceTypeEqual(resourceID.ResourceType, resourceType) {
 		return []string{strings.ToLower(resourceID.String())}, nil
 	}
 	if resourceID.Parent == nil {

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -531,6 +531,11 @@ func (f *Frontend) patchNodePool(writer http.ResponseWriter, request *http.Reque
 func (f *Frontend) updateNodePoolInCosmos(ctx context.Context, writer http.ResponseWriter, request *http.Request, httpStatusCode int, newInternalNodePool, oldInternalNodePool *api.HCPOpenShiftClusterNodePool) error {
 	logger := utils.LoggerFromContext(ctx)
 
+	subscription, err := f.dbClient.Subscriptions().Get(ctx, oldInternalNodePool.ID.SubscriptionID)
+	if err != nil {
+		return err
+	}
+
 	versionedInterface, err := VersionFromContext(ctx)
 	if err != nil {
 		return utils.TrackError(err)
@@ -538,14 +543,6 @@ func (f *Frontend) updateNodePoolInCosmos(ctx context.Context, writer http.Respo
 	correlationData, err := CorrelationDataFromContext(ctx)
 	if err != nil {
 		return utils.TrackError(err)
-	}
-	resourceID, err := utils.ResourceIDFromContext(ctx)
-	if err != nil {
-		return utils.TrackError(err)
-	}
-	subscription, err := f.dbClient.Subscriptions().Get(ctx, resourceID.SubscriptionID)
-	if err != nil {
-		return err
 	}
 	// Node pool validation checks some fields against the parent cluster
 	// so we have to request the cluster from Cluster Service.
@@ -565,6 +562,7 @@ func (f *Frontend) updateNodePoolInCosmos(ctx context.Context, writer http.Respo
 	if err != nil {
 		return utils.TrackError(err)
 	}
+
 	validationOp := operation.Operation{
 		Type:    operation.Update,
 		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
@@ -573,7 +571,7 @@ func (f *Frontend) updateNodePoolInCosmos(ctx context.Context, writer http.Respo
 	validationErrs := validation.ValidateNodePool(ctx, validationOp, newInternalNodePool, oldInternalNodePool)
 	// in addition to static validation, we have validation based on the state of the hcp cluster
 	// AdmitNodePoolUpdate includes AdmitNodePool checks plus version upgrade validation
-	validationErrs = append(validationErrs, admission.AdmitNodePoolUpdate(newInternalNodePool, oldInternalNodePool, cluster, spNodePool, spCluster)...)
+	validationErrs = append(validationErrs, admission.AdmitNodePoolUpdate(newInternalNodePool, oldInternalNodePool, cluster, spNodePool, spCluster, validationOp)...)
 	if err := arm.CloudErrorFromFieldErrors(validationErrs); err != nil {
 		return utils.TrackError(err)
 	}

--- a/internal/admission/admit_nodepool.go
+++ b/internal/admission/admit_nodepool.go
@@ -16,14 +16,16 @@ package admission
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/blang/semver/v4"
 
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
+	"github.com/Azure/ARO-HCP/internal/validation"
 )
 
 // AdmitNodePool performs non-static checks of nodepool.  Checks that require more information than is contained inside of
@@ -62,14 +64,14 @@ func AdmitNodePool(newNodePool, oldNodePool *api.HCPOpenShiftClusterNodePool, cl
 // It includes all validations from AdmitNodePool plus version upgrade constraints.
 // The spNodePool and spCluster parameters provide the service provider state for version validation.
 func AdmitNodePoolUpdate(newNodePool, oldNodePool *api.HCPOpenShiftClusterNodePool, cluster *api.HCPOpenShiftCluster,
-	spNodePool *api.ServiceProviderNodePool, spCluster *api.ServiceProviderCluster) field.ErrorList {
+	spNodePool *api.ServiceProviderNodePool, spCluster *api.ServiceProviderCluster, op operation.Operation) field.ErrorList {
 	errs := field.ErrorList{}
 
 	// Include all standard node pool admission checks
 	errs = append(errs, AdmitNodePool(newNodePool, oldNodePool, cluster)...)
 
 	// Add update-specific version upgrade validation
-	errs = append(errs, validateNodePoolVersionUpgrade(newNodePool, oldNodePool, spNodePool, spCluster)...)
+	errs = append(errs, validateNodePoolVersionUpgrade(newNodePool, oldNodePool, spNodePool, spCluster, op)...)
 
 	return errs
 }
@@ -77,10 +79,10 @@ func AdmitNodePoolUpdate(newNodePool, oldNodePool *api.HCPOpenShiftClusterNodePo
 // validateNodePoolVersionUpgrade validates that a node pool version change is a valid upgrade.
 // It checks:
 //   - No downgrade: new version >= old version
-//   - No major version change: new major == old major
+//   - No major version change: new major == old major (unless FeatureExperimentalReleaseFeatures is registered)
 //   - No skipping minor versions: new minor <= old minor + 1
 //   - Cannot exceed cluster version: new version <= cluster version
-func validateNodePoolVersionUpgrade(newNodePool, oldNodePool *api.HCPOpenShiftClusterNodePool, spNodePool *api.ServiceProviderNodePool, spCluster *api.ServiceProviderCluster) field.ErrorList {
+func validateNodePoolVersionUpgrade(newNodePool, oldNodePool *api.HCPOpenShiftClusterNodePool, spNodePool *api.ServiceProviderNodePool, spCluster *api.ServiceProviderCluster, op operation.Operation) field.ErrorList {
 
 	// Skip validation if no version is specified or version didn't change
 	if len(newNodePool.Properties.Version.ID) == 0 || newNodePool.Properties.Version.ID == oldNodePool.Properties.Version.ID {
@@ -92,11 +94,9 @@ func validateNodePoolVersionUpgrade(newNodePool, oldNodePool *api.HCPOpenShiftCl
 
 	newVersion, err := semver.Parse(newNodePool.Properties.Version.ID)
 	if err != nil {
-		errs = append(errs, field.Invalid(
-			fldPath,
-			newNodePool.Properties.Version.ID,
-			fmt.Sprintf("invalid node pool version format: %s", err.Error()),
-		))
+		errs = append(errs, field.Invalid(fldPath, newNodePool.Properties.Version.ID, fmt.Sprintf("invalid node pool version format: %s", err.Error())))
+		// Return early, it cannot validate an unparseable version
+		return errs
 	}
 	// Skip validation if the newVersion hasn't changed from the desired Version
 	if spNodePool.Spec.NodePoolVersion.DesiredVersion != nil &&
@@ -104,75 +104,13 @@ func validateNodePoolVersionUpgrade(newNodePool, oldNodePool *api.HCPOpenShiftCl
 		return nil
 	}
 
-	nodePoolActiveVersions := spNodePool.Status.NodePoolVersion.ActiveVersions
-
-	// Check if the newVersion is already in the activeVersions
-	if isVersionInActiveVersions(newVersion, nodePoolActiveVersions) {
-		return nil
+	lowestCPVersion, _ := apihelpers.FindLowestAndHighestClusterVersion(spCluster.Status.ControlPlaneVersion.ActiveVersions)
+	if err := validation.ValidateNodePoolUpgrade(newVersion, spNodePool.Status.NodePoolVersion.ActiveVersions, lowestCPVersion, op.HasOption(api.FeatureExperimentalReleaseFeatures)); err != nil {
+		errs = append(errs, field.Invalid(fldPath, newNodePool.Properties.Version.ID, err.Error()))
 	}
 
-	// Check if the newVersion <= control plane versions
-	// TODO: We may relax this constraint in the future
-	clusterActiveVersions := spCluster.Status.ControlPlaneVersion.ActiveVersions
-	if len(clusterActiveVersions) > 0 {
-		lowestControlPlane := api.FindLowestClusterVersion(clusterActiveVersions)
-		if lowestControlPlane != nil && newVersion.GT(*lowestControlPlane) {
-			errs = append(errs, field.Invalid(
-				fldPath,
-				newNodePool.Properties.Version.ID,
-				fmt.Sprintf("invalid node pool version %s: cannot exceed control plane version %s",
-					newVersion.String(), lowestControlPlane.String()),
-			))
-		}
+	if spNodePool.Spec.NodePoolVersion.DesiredVersion != nil && newVersion.LE(*spNodePool.Spec.NodePoolVersion.DesiredVersion) {
+		errs = append(errs, field.Invalid(fldPath, newNodePool.Properties.Version.ID, fmt.Sprintf("cannot downgrade from version %s to %s", spNodePool.Spec.NodePoolVersion.DesiredVersion.String(), newVersion.String())))
 	}
-
-	if len(nodePoolActiveVersions) > 0 {
-		lowestActive, highestActive := api.FindNodePoolVersionBounds(nodePoolActiveVersions)
-		// No partial downgrades: Node pool version >= highest active version
-		if highestActive != nil && newVersion.LT(*highestActive) {
-			errs = append(errs, field.Invalid(
-				fldPath,
-				newNodePool.Properties.Version.ID,
-				fmt.Sprintf("cannot downgrade from version %s to %s", highestActive.String(), newVersion.String()),
-			))
-		}
-
-		if newVersion.LE(*spNodePool.Spec.NodePoolVersion.DesiredVersion) {
-			errs = append(errs, field.Invalid(
-				fldPath,
-				newNodePool.Properties.Version.ID,
-				fmt.Sprintf("cannot downgrade from version %s to %s", spNodePool.Spec.NodePoolVersion.DesiredVersion.String(), newVersion.String()),
-			))
-		}
-		// No major version change
-		// TODO: Add support for major version upgrades (e.g., 4.20 → 5.0) when needed
-		if newVersion.Major != lowestActive.Major {
-			errs = append(errs, field.Invalid(
-				fldPath,
-				newNodePool.Properties.Version.ID,
-				fmt.Sprintf("invalid upgrade path from %s to %s: major version changes are not supported",
-					lowestActive.String(), newVersion.String()),
-			))
-		}
-		//Don't skip minor
-		// TODO: We will relax this constraint in the future to allow skipping minor versions
-		if newVersion.Minor > lowestActive.Minor+1 {
-			errs = append(errs, field.Invalid(
-				fldPath,
-				newNodePool.Properties.Version.ID,
-				fmt.Sprintf("invalid upgrade path from %s to %s: skipping minor versions is not allowed",
-					lowestActive.String(), newVersion.String()),
-			))
-		}
-
-	}
-
 	return errs
-}
-
-// isVersionInActiveVersions checks if the given version is already in the list of active versions.
-func isVersionInActiveVersions(version semver.Version, activeVersions []api.HCPNodePoolActiveVersion) bool {
-	return slices.ContainsFunc(activeVersions, func(av api.HCPNodePoolActiveVersion) bool {
-		return av.Version != nil && av.Version.EQ(version)
-	})
 }

--- a/internal/admission/admit_nodepool_test.go
+++ b/internal/admission/admit_nodepool_test.go
@@ -20,18 +20,24 @@ import (
 
 	"github.com/blang/semver/v4"
 
+	"k8s.io/apimachinery/pkg/api/operation"
+	"k8s.io/utils/ptr"
+
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/validation"
 )
 
 func TestAdmitNodePoolUpdate_VersionValidation(t *testing.T) {
 	tests := []struct {
-		name             string
-		newVersion       string
-		activeVersions   []string // current active versions in ServiceProviderNodePool (first is highest)
-		clusterVersions  []string // active versions in ServiceProviderCluster (first is highest)
-		desiredVersion   string   // desired version in ServiceProviderNodePool.Spec
-		expectError      string
-		expectErrorCount int
+		name               string
+		newVersion         string
+		activeVersions     []string // current active versions in ServiceProviderNodePool (first is highest)
+		clusterVersions    []string // active versions in ServiceProviderCluster (first is highest)
+		desiredVersion     string   // desired version in ServiceProviderNodePool.Spec
+		allowMajorUpgrades bool     // experimental feature flag
+		expectError        string
+		expectErrorCount   int
 	}{
 		{
 			name:            "valid z-stream upgrade",
@@ -63,12 +69,55 @@ func TestAdmitNodePoolUpdate_VersionValidation(t *testing.T) {
 			expectError:     "cannot downgrade",
 		},
 		{
-			name:            "major version change not allowed",
-			activeVersions:  []string{"4.17.0"},
+			name:            "major version change not allowed by default",
+			activeVersions:  []string{"4.22.0"},
 			newVersion:      "5.0.0",
 			clusterVersions: []string{"5.0.0"},
-			desiredVersion:  "4.17.0",
+			desiredVersion:  "4.22.0",
 			expectError:     "major version changes are not supported",
+		},
+		{
+			name:               "valid major upgrade 4.22 to 5.0",
+			activeVersions:     []string{"4.22.0"},
+			newVersion:         "5.0.0",
+			clusterVersions:    []string{"5.0.0"},
+			desiredVersion:     "4.22.0",
+			allowMajorUpgrades: true,
+		},
+		{
+			name:               "valid major upgrade 4.23 to 5.1",
+			activeVersions:     []string{"4.23.0"},
+			newVersion:         "5.1.0",
+			clusterVersions:    []string{"5.1.0"},
+			desiredVersion:     "4.23.0",
+			allowMajorUpgrades: true,
+		},
+		{
+			name:               "invalid major upgrade 4.22 to 5.1",
+			activeVersions:     []string{"4.22.0"},
+			newVersion:         "5.1.0",
+			clusterVersions:    []string{"5.1.0"},
+			desiredVersion:     "4.22.0",
+			allowMajorUpgrades: true,
+			expectError:        "4.22 can only upgrade to 5.0",
+		},
+		{
+			name:               "invalid major upgrade 4.23 to 5.0",
+			activeVersions:     []string{"4.23.0"},
+			newVersion:         "5.0.0",
+			clusterVersions:    []string{"5.0.0"},
+			desiredVersion:     "4.23.0",
+			allowMajorUpgrades: true,
+			expectError:        "4.23 can only upgrade to 5.1",
+		},
+		{
+			name:               "invalid major upgrade 4.20 not supported",
+			activeVersions:     []string{"4.20.0"},
+			newVersion:         "5.0.0",
+			clusterVersions:    []string{"5.0.0"},
+			desiredVersion:     "4.20.0",
+			allowMajorUpgrades: true,
+			expectError:        "major version upgrades are not supported",
 		},
 		{
 			name:            "skipping minor versions not allowed",
@@ -120,7 +169,7 @@ func TestAdmitNodePoolUpdate_VersionValidation(t *testing.T) {
 		{
 			name:            "version already in active versions skips validation",
 			activeVersions:  []string{"4.18.0", "4.17.0"},
-			newVersion:      "4.17.0",
+			newVersion:      "4.18.0",
 			clusterVersions: []string{"4.18.0"},
 			desiredVersion:  "4.18.0",
 		},
@@ -180,6 +229,20 @@ func TestAdmitNodePoolUpdate_VersionValidation(t *testing.T) {
 				},
 			}
 
+			// Create operation based on allowMajorUpgrades flag
+			var op operation.Operation
+			if tt.allowMajorUpgrades {
+				op = operation.Operation{
+					Type: operation.Update,
+					Options: validation.AFECsToValidationOptions([]arm.Feature{{
+						Name:  ptr.To(api.FeatureExperimentalReleaseFeatures),
+						State: ptr.To("Registered"),
+					}}),
+				}
+			} else {
+				op = operation.Operation{Type: operation.Update}
+			}
+
 			// Build ServiceProviderNodePool with active versions
 			var activeVersions []api.HCPNodePoolActiveVersion
 			for _, v := range tt.activeVersions {
@@ -218,7 +281,7 @@ func TestAdmitNodePoolUpdate_VersionValidation(t *testing.T) {
 				},
 			}
 
-			errs := AdmitNodePoolUpdate(newNodePool, oldNodePool, cluster, spNodePool, spCluster)
+			errs := AdmitNodePoolUpdate(newNodePool, oldNodePool, cluster, spNodePool, spCluster, op)
 
 			if tt.expectError != "" {
 				if len(errs) == 0 {
@@ -298,7 +361,10 @@ func TestAdmitNodePoolUpdate_IncludesAdmitNodePoolChecks(t *testing.T) {
 		},
 	}
 
-	errs := AdmitNodePoolUpdate(newNodePool, oldNodePool, cluster, spNodePool, spCluster)
+	// Empty update operation (no experimental features)
+	op := operation.Operation{Type: operation.Update}
+
+	errs := AdmitNodePoolUpdate(newNodePool, oldNodePool, cluster, spNodePool, spCluster, op)
 
 	if len(errs) == 0 {
 		t.Fatal("expected error for channel group mismatch, got none")

--- a/internal/api/arm/error.go
+++ b/internal/api/arm/error.go
@@ -23,7 +23,7 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
-	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
+	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 )
 
 // CloudError codes
@@ -247,12 +247,12 @@ func NewResourceNotFoundError(resourceID *azcorearm.ResourceID) *CloudError {
 	var message string
 
 	switch {
-	case apihelpers.ResourceTypeEqual(resourceID.ResourceType, azcorearm.SubscriptionResourceType):
+	case armhelpers.ResourceTypeEqual(resourceID.ResourceType, azcorearm.SubscriptionResourceType):
 		code = CloudErrorCodeSubscriptionNotFound
 		message = fmt.Sprintf(
 			"The subscription '%s' was not found.",
 			resourceID.SubscriptionID)
-	case apihelpers.ResourceTypeEqual(resourceID.ResourceType, azcorearm.ResourceGroupResourceType):
+	case armhelpers.ResourceTypeEqual(resourceID.ResourceType, azcorearm.ResourceGroupResourceType):
 		code = CloudErrorCodeResourceGroupNotFound
 		message = fmt.Sprintf(
 			"The resource group '%s' under subscription '%s' was not found.",

--- a/internal/api/types_serviceprovider_cluster.go
+++ b/internal/api/types_serviceprovider_cluster.go
@@ -217,15 +217,3 @@ const (
 	// the Cluster's Hypershift's HostedCluster K8s resource.
 	MaestroBundleInternalNameReadonlyHypershiftHostedCluster MaestroBundleInternalName = "readonlyHypershiftHostedCluster"
 )
-
-// FindLowestClusterVersion returns the lowest version from the list of control plane active versions.
-// ActiveVersions can be in any order, so we iterate to find the actual minimum.
-func FindLowestClusterVersion(activeVersions []HCPClusterActiveVersion) *semver.Version {
-	var lowest *semver.Version
-	for _, av := range activeVersions {
-		if lowest == nil || av.Version.LT(*lowest) {
-			lowest = av.Version
-		}
-	}
-	return lowest
-}

--- a/internal/api/types_serviceprovider_nodepool.go
+++ b/internal/api/types_serviceprovider_nodepool.go
@@ -116,18 +116,3 @@ type HCPNodePoolActiveVersion struct {
 	// Version is the full version in x.y.z format (e.g., "4.19.2")
 	Version *semver.Version `json:"version,omitempty"`
 }
-
-// FindNodePoolVersionBounds returns the lowest and highest versions from the node pool active versions.
-// ActiveVersions can be in any order, so we iterate to find the actual minimum and maximum.
-func FindNodePoolVersionBounds(activeVersions []HCPNodePoolActiveVersion) (*semver.Version, *semver.Version) {
-	var lowest, highest *semver.Version
-	for _, av := range activeVersions {
-		if lowest == nil || av.Version.LT(*lowest) {
-			lowest = av.Version
-		}
-		if highest == nil || av.Version.GT(*highest) {
-			highest = av.Version
-		}
-	}
-	return lowest, highest
-}

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -38,6 +38,15 @@ const (
 	OpenShiftVersionPrefix = "openshift-v"
 )
 
+// AllowedMajorUpgrades is for OpenShift cross-major upgrades (one major at a time, e.g. 4 to 5). Keys and values
+// are major.minor lines ("x.y"): the key is the current version's line, the value is the only allowed line for
+// the desired version. Used when validating version on clusters and node pools.
+// Add entries when new cross-major paths are supported.
+var AllowMajorUpgradePaths = map[string]string{
+	"4.22": "5.0",
+	"4.23": "5.1",
+}
+
 // Ptr returns a pointer to p.
 func Ptr[T any](p T) *T {
 	return &p

--- a/internal/database/service_provider_cluster.go
+++ b/internal/database/service_provider_cluster.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/utils"
-	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
+	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 )
 
 // newInitialServiceProviderCluster returns a new ServiceProviderCluster with
@@ -46,7 +46,7 @@ func newInitialServiceProviderCluster(clusterResourceID *azcorearm.ResourceID) *
 func GetOrCreateServiceProviderCluster(
 	ctx context.Context, dbClient DBClient, clusterResourceID *azcorearm.ResourceID,
 ) (*api.ServiceProviderCluster, error) {
-	if !apihelpers.ResourceTypeEqual(clusterResourceID.ResourceType, api.ClusterResourceType) {
+	if !armhelpers.ResourceTypeEqual(clusterResourceID.ResourceType, api.ClusterResourceType) {
 		return nil, utils.TrackError(fmt.Errorf("expected resource type %s, got %s", api.ClusterResourceType, clusterResourceID.ResourceType))
 	}
 

--- a/internal/database/service_provider_nodepool.go
+++ b/internal/database/service_provider_nodepool.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/utils"
-	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
+	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 )
 
 // newInitialServiceProviderNodePool returns a new ServiceProviderNodePool with
@@ -46,7 +46,7 @@ func newInitialServiceProviderNodePool(npResourceID *azcorearm.ResourceID) *api.
 func GetOrCreateServiceProviderNodePool(
 	ctx context.Context, dbClient DBClient, nodePoolResourceID *azcorearm.ResourceID,
 ) (*api.ServiceProviderNodePool, error) {
-	if !apihelpers.ResourceTypeEqual(nodePoolResourceID.ResourceType, api.NodePoolResourceType) {
+	if !armhelpers.ResourceTypeEqual(nodePoolResourceID.ResourceType, api.NodePoolResourceType) {
 		return nil, utils.TrackError(fmt.Errorf("expected resource type %s, got %s", api.NodePoolResourceType, nodePoolResourceID.ResourceType))
 	}
 

--- a/internal/databasetesting/mock_dbclient_test.go
+++ b/internal/databasetesting/mock_dbclient_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
-	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
+	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 )
 
 func TestMockDBClient_LoadFromDirectory(t *testing.T) {
@@ -62,13 +62,13 @@ func TestMockDBClient_LoadFromDirectory(t *testing.T) {
 		}
 
 		switch {
-		case apihelpers.ResourceTypeStringEqual(typedDoc.ResourceType, api.ClusterResourceType):
+		case armhelpers.ResourceTypeStringEqual(typedDoc.ResourceType, api.ClusterResourceType):
 			foundCluster = true
-		case apihelpers.ResourceTypeStringEqual(typedDoc.ResourceType, api.NodePoolResourceType):
+		case armhelpers.ResourceTypeStringEqual(typedDoc.ResourceType, api.NodePoolResourceType):
 			foundNodePool = true
-		case apihelpers.ResourceTypeStringEqual(typedDoc.ResourceType, azcorearm.SubscriptionResourceType):
+		case armhelpers.ResourceTypeStringEqual(typedDoc.ResourceType, azcorearm.SubscriptionResourceType):
 			foundSubscription = true
-		case apihelpers.ResourceTypeStringEqual(typedDoc.ResourceType, api.OperationStatusResourceType):
+		case armhelpers.ResourceTypeStringEqual(typedDoc.ResourceType, api.OperationStatusResourceType):
 			foundOperation = true
 		}
 	}
@@ -479,7 +479,7 @@ func TestMockDBClient_UntypedCRUD(t *testing.T) {
 		t.Fatalf("Failed to get cluster via untyped CRUD: %v", err)
 	}
 
-	if !apihelpers.ResourceTypeStringEqual(retrieved.ResourceType, api.ClusterResourceType) {
+	if !armhelpers.ResourceTypeStringEqual(retrieved.ResourceType, api.ClusterResourceType) {
 		t.Errorf("Expected resource type %s, got %s", api.ClusterResourceType.String(), retrieved.ResourceType)
 	}
 }

--- a/internal/databasetesting/mock_init.go
+++ b/internal/databasetesting/mock_init.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
+	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 )
 
 // NewMockDBClientWithResources creates a new MockDBClient and populates it with the given resources.
@@ -146,12 +146,12 @@ func (m *MockDBClient) addController(ctx context.Context, controller *api.Contro
 	}
 	parentType := resourceID.Parent.ResourceType
 	switch {
-	case apihelpers.ResourceTypeEqual(parentType, api.ClusterResourceType):
+	case armhelpers.ResourceTypeEqual(parentType, api.ClusterResourceType):
 		clusterName := resourceID.Parent.Name
 		controllerCRUD := m.HCPClusters(resourceID.SubscriptionID, resourceID.ResourceGroupName).Controllers(clusterName)
 		_, err := controllerCRUD.Create(ctx, controller, nil)
 		return err
-	case apihelpers.ResourceTypeEqual(parentType, api.NodePoolResourceType):
+	case armhelpers.ResourceTypeEqual(parentType, api.NodePoolResourceType):
 		if resourceID.Parent.Parent == nil {
 			return fmt.Errorf("nodepool controller is missing grandparent cluster ID")
 		}
@@ -160,7 +160,7 @@ func (m *MockDBClient) addController(ctx context.Context, controller *api.Contro
 		controllerCRUD := m.HCPClusters(resourceID.SubscriptionID, resourceID.ResourceGroupName).NodePools(clusterName).Controllers(nodePoolName)
 		_, err := controllerCRUD.Create(ctx, controller, nil)
 		return err
-	case apihelpers.ResourceTypeEqual(parentType, api.ExternalAuthResourceType):
+	case armhelpers.ResourceTypeEqual(parentType, api.ExternalAuthResourceType):
 		if resourceID.Parent.Parent == nil {
 			return fmt.Errorf("externalauth controller is missing grandparent cluster ID")
 		}

--- a/internal/utils/apihelpers/version.go
+++ b/internal/utils/apihelpers/version.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apihelpers
+
+import (
+	"github.com/blang/semver/v4"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+// FindLowestAndHighestClusterVersion returns (lowest, highest) *semver.Version from activeVersions.
+// When activeVersions is empty, it returns (nil, nil).
+func FindLowestAndHighestClusterVersion(activeVersions []api.HCPClusterActiveVersion) (*semver.Version, *semver.Version) {
+	var low, high *semver.Version
+	for _, activeVersion := range activeVersions {
+		if low == nil || activeVersion.Version.LT(*low) {
+			low = activeVersion.Version
+		}
+		if high == nil || activeVersion.Version.GT(*high) {
+			high = activeVersion.Version
+		}
+	}
+	return low, high
+}
+
+// FindLowestAndHighestNodePoolVersion returns the lowest and highest versions from the node pool active versions.
+// ActiveVersions can be in any order, so we iterate to find the actual minimum and maximum.
+func FindLowestAndHighestNodePoolVersion(activeVersions []api.HCPNodePoolActiveVersion) (*semver.Version, *semver.Version) {
+	var lowest, highest *semver.Version
+	for _, av := range activeVersions {
+		if lowest == nil || av.Version.LT(*lowest) {
+			lowest = av.Version
+		}
+		if highest == nil || av.Version.GT(*highest) {
+			highest = av.Version
+		}
+	}
+	return lowest, highest
+}

--- a/internal/utils/apihelpers/version_test.go
+++ b/internal/utils/apihelpers/version_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apihelpers
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+func TestFindLowestAndHighestClusterVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		versions   []api.HCPClusterActiveVersion
+		wantLowest *semver.Version
+		wantHigh   *semver.Version
+	}{
+		{
+			name:       "nil ActiveVersions returns nil",
+			versions:   nil,
+			wantLowest: nil,
+			wantHigh:   nil,
+		},
+		{
+			name:       "empty ActiveVersions returns nil",
+			versions:   []api.HCPClusterActiveVersion{},
+			wantLowest: nil,
+			wantHigh:   nil,
+		},
+		{
+			name:       "single entry returns that control plane version for both bounds",
+			versions:   []api.HCPClusterActiveVersion{{Version: api.Ptr(semver.MustParse("4.22.0"))}},
+			wantLowest: api.Ptr(semver.MustParse("4.22.0")),
+			wantHigh:   api.Ptr(semver.MustParse("4.22.0")),
+		},
+		{
+			name: "unsorted active versions return semantic min and max",
+			versions: []api.HCPClusterActiveVersion{
+				{Version: api.Ptr(semver.MustParse("4.20.0"))},
+				{Version: api.Ptr(semver.MustParse("4.23.0"))},
+				{Version: api.Ptr(semver.MustParse("4.22.0"))},
+			},
+			wantLowest: api.Ptr(semver.MustParse("4.20.0")),
+			wantHigh:   api.Ptr(semver.MustParse("4.23.0")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotLow, gotHigh := FindLowestAndHighestClusterVersion(tt.versions)
+			if tt.wantLowest == nil || tt.wantHigh == nil {
+				assert.Nil(t, gotLow)
+				assert.Nil(t, gotHigh)
+			} else {
+				assert.NotNil(t, gotLow)
+				assert.NotNil(t, gotHigh)
+				assert.Equal(t, *tt.wantLowest, *gotLow)
+				assert.Equal(t, *tt.wantHigh, *gotHigh)
+			}
+		})
+	}
+}
+
+func TestFindLowestAndHighestNodePoolVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		versions   []api.HCPNodePoolActiveVersion
+		wantLowest *semver.Version
+		wantHigh   *semver.Version
+	}{
+		{
+			name:       "nil ActiveVersions returns nil",
+			versions:   nil,
+			wantLowest: nil,
+			wantHigh:   nil,
+		},
+		{
+			name:       "empty ActiveVersions returns nil",
+			versions:   []api.HCPNodePoolActiveVersion{},
+			wantLowest: nil,
+			wantHigh:   nil,
+		},
+		{
+			name:       "single entry returns that version for both bounds",
+			versions:   []api.HCPNodePoolActiveVersion{{Version: api.Ptr(semver.MustParse("4.22.0"))}},
+			wantLowest: api.Ptr(semver.MustParse("4.22.0")),
+			wantHigh:   api.Ptr(semver.MustParse("4.22.0")),
+		},
+		{
+			name: "unsorted active versions return semantic min and max",
+			versions: []api.HCPNodePoolActiveVersion{
+				{Version: api.Ptr(semver.MustParse("4.20.0"))},
+				{Version: api.Ptr(semver.MustParse("4.23.0"))},
+				{Version: api.Ptr(semver.MustParse("4.22.0"))},
+			},
+			wantLowest: api.Ptr(semver.MustParse("4.20.0")),
+			wantHigh:   api.Ptr(semver.MustParse("4.23.0")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotLow, gotHigh := FindLowestAndHighestNodePoolVersion(tt.versions)
+			if tt.wantLowest == nil || tt.wantHigh == nil {
+				assert.Nil(t, gotLow)
+				assert.Nil(t, gotHigh)
+			} else {
+				assert.NotNil(t, gotLow)
+				assert.NotNil(t, gotHigh)
+				assert.Equal(t, *tt.wantLowest, *gotLow)
+				assert.Equal(t, *tt.wantHigh, *gotHigh)
+			}
+		})
+	}
+}

--- a/internal/utils/armhelpers/equalities.go
+++ b/internal/utils/armhelpers/equalities.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package apihelpers
+package armhelpers
 
 import (
 	"strings"

--- a/internal/validation/validators.go
+++ b/internal/validation/validators.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/blang/semver/v4"
@@ -33,6 +34,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
 )
 
 func NoExtraWhitespace(_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *string) field.ErrorList {
@@ -741,4 +745,76 @@ func MaximumIfNoAZ[T constraints.Integer](ctx context.Context, op operation.Oper
 
 	// If availability zone is NOT set, enforce the max limit using the existing Maximum validator
 	return Maximum(ctx, op, fldPath, value, oldValue, max)
+}
+
+// ValidateMajorUpgrade validates that a cross-major version upgrade follows the allowed upgrade paths.
+// Returns an error if the upgrade path is not allowed, nil otherwise.
+// Use the n-1 skew
+func ValidateMajorUpgrade(fromVersion, toVersion semver.Version) error {
+	sourceKey := fmt.Sprintf("%d.%d", fromVersion.Major, fromVersion.Minor)
+	targetKey := fmt.Sprintf("%d.%d", toVersion.Major, toVersion.Minor)
+
+	allowedTargets, exists := api.AllowMajorUpgradePaths[sourceKey]
+	if !exists {
+		return fmt.Errorf("invalid upgrade path from %s to %s: major version upgrades are not supported",
+			fromVersion.String(), toVersion.String())
+	}
+
+	if allowedTargets != targetKey {
+		return fmt.Errorf("invalid upgrade path from %s to %s: %s can only upgrade to %s",
+			fromVersion.String(), toVersion.String(), sourceKey, allowedTargets)
+	}
+
+	return nil
+}
+
+// ValidateNodePoolUpgrade performs common node pool version upgrade validation:
+// - No downgrades from highest active version
+// - Cannot exceed lowest control plane version
+// - No major version changes without AFEC (uses existing ValidateMajorUpgrade)
+// - No minor version skipping
+func ValidateNodePoolUpgrade(desiredVersion semver.Version, activeVersions []api.HCPNodePoolActiveVersion, lowestCPVersion *semver.Version, allowMajorUpgrade bool) error {
+	// Skip if already in active versions
+	if slices.ContainsFunc(activeVersions, func(av api.HCPNodePoolActiveVersion) bool {
+		return av.Version != nil && av.Version.EQ(desiredVersion)
+	}) {
+		return nil
+	}
+
+	lowest, highest := apihelpers.FindLowestAndHighestNodePoolVersion(activeVersions)
+
+	// No partial downgrades: desiredVersion >= highest active version
+	if highest != nil && desiredVersion.LT(*highest) {
+		return fmt.Errorf(
+			"invalid node pool version %s: cannot downgrade from current version %s",
+			desiredVersion.String(), highest.String(),
+		)
+	}
+
+	// Check if the desiredVersion <= control plane versions
+	// TODO: We may relax this constraint in the future
+	if lowestCPVersion != nil && desiredVersion.GT(*lowestCPVersion) {
+		return fmt.Errorf(
+			"invalid node pool version %s: cannot exceed control plane version %s",
+			desiredVersion.String(), lowestCPVersion.String(),
+		)
+	}
+
+	// No major version change unless FeatureExperimentalReleaseFeatures is registered
+	if lowest != nil && desiredVersion.Major > lowest.Major {
+		if !allowMajorUpgrade {
+			return fmt.Errorf("major version changes are not supported")
+		}
+		return ValidateMajorUpgrade(*lowest, desiredVersion)
+	}
+
+	// Minor skip validation
+	if lowest != nil && desiredVersion.Minor > lowest.Minor+1 {
+		return fmt.Errorf(
+			"invalid upgrade path from %s to %s: skipping minor versions is not allowed",
+			lowest.String(), desiredVersion.String(),
+		)
+	}
+
+	return nil
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-version-update/09-httpReplace-nodepool-version-higher-than-cp-version/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-version-update/09-httpReplace-nodepool-version-higher-than-cp-version/expected-error.txt
@@ -1,5 +1,3 @@
-      {
-        "code": "InvalidRequestContent",
-        "message": "Invalid value: \"4.22.5\": invalid node pool version 4.22.5: cannot exceed control plane version 4.22.0",
-        "target": "properties.version.id"
-      }
+    "code": "InvalidRequestContent",
+    "message": "Invalid value: \"4.22.5\": invalid node pool version 4.22.5: cannot exceed control plane version 4.22.0",
+    "target": "properties.version.id"

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-version-update/10-httpReplace-nodepool-skip-minor-version/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-version-update/10-httpReplace-nodepool-skip-minor-version/expected-error.txt
@@ -1,5 +1,3 @@
-  {
     "code": "InvalidRequestContent",
     "message": "Invalid value: \"4.22.0\": invalid upgrade path from 4.20.8 to 4.22.0: skipping minor versions is not allowed",
     "target": "properties.version.id"
-  }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/00-httpCreate-subscription/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/00-httpCreate-subscription/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/00-httpCreate-subscription/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/00-httpCreate-subscription/subscription.json
@@ -1,0 +1,13 @@
+{
+	"properties": {
+		"registeredFeatures": [
+			{
+				"name": "Microsoft.RedHatOpenShift/ExperimentalReleaseFeatures",
+				"state": "Registered"
+			}
+		]
+	},
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,57 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {
+			"/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/different-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service-managed-identity": {}
+		}
+	},
+	"name": "major-upgrade",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"operatorsAuthentication": {
+				"userAssignedIdentities": {
+					"serviceManagedIdentity": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/different-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service-managed-identity"
+				}
+			},
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "5.0"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/02-completeOperation-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/02-completeOperation-cluster/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/03-loadCosmos-serviceProviderCluster/serviceProviderCluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/03-loadCosmos-serviceProviderCluster/serviceProviderCluster.json
@@ -1,0 +1,23 @@
+{
+	"id": "|subscriptions|6b690bec-0c16-4ecb-8f67-781caf40bba7|resourcegroups|resourcegroupname|providers|microsoft.redhatopenshift|hcpopenshiftclusters|major-upgrade|serviceproviderclusters|default",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade/serviceProviderClusters/default",
+		"spec": {
+			"control_plane_version": {
+				"desired_version": "5.0.0"
+			}
+		},
+		"status": {
+			"control_plane_version": {
+				"active_versions": [
+					{
+						"version": "5.0.0"
+					}
+				]
+			}
+		}
+	},
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade/serviceProviderClusters/default",
+	"resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters/serviceproviderclusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/04-httpCreate-nodepool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/04-httpCreate-nodepool/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade/nodePools/np421"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/04-httpCreate-nodepool/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/04-httpCreate-nodepool/nodepool.json
@@ -1,0 +1,14 @@
+{
+	"name": "np421",
+	"properties": {
+		"autoRepair": true,
+		"platform": {
+			"vmSize": "large"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.21.0"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/05-completeOperation-nodepool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/05-completeOperation-nodepool/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade/nodePools/np421"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/06-loadCosmos-serviceProviderNodePool/serviceProviderNodePool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/06-loadCosmos-serviceProviderNodePool/serviceProviderNodePool.json
@@ -1,0 +1,23 @@
+{
+	"id": "|subscriptions|6b690bec-0c16-4ecb-8f67-781caf40bba7|resourcegroups|resourcegroupname|providers|microsoft.redhatopenshift|hcpopenshiftclusters|major-upgrade|nodepools|np421|serviceprovidernodepools|default",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade/nodePools/np421/serviceProviderNodePools/default",
+		"spec": {
+			"nodePoolVersion": {
+				"desiredVersion": "4.21.0"
+			}
+		},
+		"status": {
+			"nodePoolVersion": {
+				"activeVersions": [
+					{
+						"version": "4.21.0"
+					}
+				]
+			}
+		}
+	},
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade/nodePools/np421/serviceProviderNodePools/default",
+	"resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools/serviceprovidernodepools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/07-httpReplace-nodepool-major-upgrade/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/07-httpReplace-nodepool-major-upgrade/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade/nodePools/np421"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/07-httpReplace-nodepool-major-upgrade/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/07-httpReplace-nodepool-major-upgrade/expected-error.txt
@@ -1,0 +1,1 @@
+major version upgrades are not supported

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/07-httpReplace-nodepool-major-upgrade/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-invalid-source/07-httpReplace-nodepool-major-upgrade/nodepool.json
@@ -1,0 +1,9 @@
+{
+	"name": "np421",
+	"properties": {
+		"version": {
+			"id": "5.0.0"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/00-httpCreate-subscription/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/00-httpCreate-subscription/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/00-httpCreate-subscription/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/00-httpCreate-subscription/subscription.json
@@ -1,0 +1,13 @@
+{
+	"properties": {
+		"registeredFeatures": [
+			{
+				"name": "Microsoft.RedHatOpenShift/ExperimentalReleaseFeatures",
+				"state": "Registered"
+			}
+		]
+	},
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade-valid"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,57 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {
+			"/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/different-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service-managed-identity": {}
+		}
+	},
+	"name": "major-upgrade-valid",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"operatorsAuthentication": {
+				"userAssignedIdentities": {
+					"serviceManagedIdentity": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/different-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service-managed-identity"
+				}
+			},
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "5.0"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/02-completeOperation-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/02-completeOperation-cluster/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade-valid"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/03-loadCosmos-serviceProviderCluster/serviceProviderCluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/03-loadCosmos-serviceProviderCluster/serviceProviderCluster.json
@@ -1,0 +1,23 @@
+{
+	"id": "|subscriptions|6b690bec-0c16-4ecb-8f67-781caf40bba7|resourcegroups|resourcegroupname|providers|microsoft.redhatopenshift|hcpopenshiftclusters|major-upgrade-valid|serviceproviderclusters|default",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade-valid/serviceProviderClusters/default",
+		"spec": {
+			"control_plane_version": {
+				"desired_version": "5.0.0"
+			}
+		},
+		"status": {
+			"control_plane_version": {
+				"active_versions": [
+					{
+						"version": "5.0.0"
+					}
+				]
+			}
+		}
+	},
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade-valid/serviceProviderClusters/default",
+	"resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters/serviceproviderclusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/04-httpCreate-nodepool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/04-httpCreate-nodepool/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade-valid/nodePools/np422"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/04-httpCreate-nodepool/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/04-httpCreate-nodepool/nodepool.json
@@ -1,0 +1,14 @@
+{
+	"name": "np422",
+	"properties": {
+		"autoRepair": true,
+		"platform": {
+			"vmSize": "large"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.22.0"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/05-completeOperation-nodepool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/05-completeOperation-nodepool/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade-valid/nodePools/np422"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/06-loadCosmos-serviceProviderNodePool/serviceProviderNodePool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/06-loadCosmos-serviceProviderNodePool/serviceProviderNodePool.json
@@ -1,0 +1,23 @@
+{
+	"id": "|subscriptions|6b690bec-0c16-4ecb-8f67-781caf40bba7|resourcegroups|resourcegroupname|providers|microsoft.redhatopenshift|hcpopenshiftclusters|major-upgrade-valid|nodepools|np422|serviceprovidernodepools|default",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade-valid/nodePools/np422/serviceProviderNodePools/default",
+		"spec": {
+			"nodePoolVersion": {
+				"desiredVersion": "4.22.0"
+			}
+		},
+		"status": {
+			"nodePoolVersion": {
+				"activeVersions": [
+					{
+						"version": "4.22.0"
+					}
+				]
+			}
+		}
+	},
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade-valid/nodePools/np422/serviceProviderNodePools/default",
+	"resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools/serviceprovidernodepools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/07-httpReplace-nodepool-major-upgrade/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/07-httpReplace-nodepool-major-upgrade/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/major-upgrade-valid/nodePools/np422"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/07-httpReplace-nodepool-major-upgrade/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/major-upgrade-valid/07-httpReplace-nodepool-major-upgrade/nodepool.json
@@ -1,0 +1,14 @@
+{
+	"name": "np422",
+	"properties": {
+		"autoRepair": true,
+		"platform": {
+			"vmSize": "large"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "5.0.0"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/utils/integrationutils/cosmos_testinfo.go
+++ b/test-integration/utils/integrationutils/cosmos_testinfo.go
@@ -38,7 +38,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/utils"
-	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
+	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 )
 
 type CosmosIntegrationTestInfo struct {
@@ -114,19 +114,19 @@ func LoadCosmosContent(ctx context.Context, cosmosContainer *azcosmos.ContainerC
 
 	var err error
 	switch {
-	case apihelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.OperationStatusResourceType),
-		apihelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.ClusterResourceType),
-		apihelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.NodePoolResourceType),
-		apihelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.ExternalAuthResourceType),
-		apihelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.ClusterControllerResourceType),
-		apihelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.NodePoolControllerResourceType),
-		apihelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.ExternalAuthControllerResourceType),
-		apihelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.ServiceProviderClusterResourceType),
-		apihelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.ServiceProviderNodePoolResourceType):
+	case armhelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.OperationStatusResourceType),
+		armhelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.ClusterResourceType),
+		armhelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.NodePoolResourceType),
+		armhelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.ExternalAuthResourceType),
+		armhelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.ClusterControllerResourceType),
+		armhelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.NodePoolControllerResourceType),
+		armhelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.ExternalAuthControllerResourceType),
+		armhelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.ServiceProviderClusterResourceType),
+		armhelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), api.ServiceProviderNodePoolResourceType):
 		partitionKey := azcosmos.NewPartitionKeyString(contentMap["partitionKey"].(string))
 		_, err = cosmosContainer.CreateItem(ctx, partitionKey, content, nil)
 
-	case apihelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), azcorearm.SubscriptionResourceType):
+	case armhelpers.ResourceTypeStringEqual(contentMap["resourceType"].(string), azcorearm.SubscriptionResourceType):
 		partitionKey := azcosmos.NewPartitionKeyString(contentMap["partitionKey"].(string))
 		_, err = cosmosContainer.CreateItem(ctx, partitionKey, content, nil)
 
@@ -281,12 +281,12 @@ func saveContainerContent(ctx context.Context, documentLister DocumentLister, ou
 				armResourceID.Name+".json",
 			)
 
-		case apihelpers.ResourceTypeStringEqual(resourceType.(string), azcorearm.SubscriptionResourceType):
+		case armhelpers.ResourceTypeStringEqual(resourceType.(string), azcorearm.SubscriptionResourceType):
 			filename = filepath.Join(
 				"subscriptions",
 				fmt.Sprintf("subscription_%s.json", docMap["id"].(string)))
 
-		case apihelpers.ResourceTypeStringEqual(resourceType.(string), api.OperationStatusResourceType):
+		case armhelpers.ResourceTypeStringEqual(resourceType.(string), api.OperationStatusResourceType):
 			externalID := properties["externalId"].(string)
 			if clusterResourceID, _ := azcorearm.ParseResourceID(externalID); clusterResourceID != nil {
 				clusterDir := resourceIDToDir(clusterResourceID)

--- a/test-integration/utils/integrationutils/frontend_testinfo.go
+++ b/test-integration/utils/integrationutils/frontend_testinfo.go
@@ -32,7 +32,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
-	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
+	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 )
 
@@ -158,7 +158,7 @@ func resourceIDToDir(resourceID *azcorearm.ResourceID) string {
 		)
 
 	default:
-		if apihelpers.ResourceTypeEqual(resourceID.Parent.ResourceType, azcorearm.ResourceGroupResourceType) {
+		if armhelpers.ResourceTypeEqual(resourceID.Parent.ResourceType, azcorearm.ResourceGroupResourceType) {
 			return filepath.Join(
 				startingDir,
 				resourceID.ResourceType.String(),


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Create a new feature tag AllowMajorUpgrades that will allow node pool major upgrades. This PR only adds support to allow the change. However, cluster .y and .x upgrades are not yet in place, and CS requires more changes to this upgrade be complete.

### Why

Adding initial support for node pools major upgrades, to start working on this feature sooner.

### Special notes for your reviewer

Refactors and tests in different commits, once it is approved/lgtm I will squash them. Addressing also some related comments from https://github.com/Azure/ARO-HCP/pull/4720 and https://github.com/Azure/ARO-HCP/pull/4566