### PR TITLE
add logging for every database mutation

### DIFF
--- a/internal/database/crud_helpers.go
+++ b/internal/database/crud_helpers.go
@@ -241,6 +241,8 @@ func serializeItem[InternalAPIType, CosmosAPIType any](newObj *InternalAPIType) 
 }
 
 func addCreateToTransaction[InternalAPIType, CosmosAPIType any](ctx context.Context, transaction DBTransaction, newObj *InternalAPIType, opts *azcosmos.TransactionalBatchItemOptions) (string, error) {
+	logger := utils.LoggerFromContext(ctx)
+
 	partitionKeyString := transaction.GetPartitionKey()
 	if strings.ToLower(partitionKeyString) != partitionKeyString {
 		return "", fmt.Errorf("partitionKeyString must be lowercase, not: %q", partitionKeyString)
@@ -259,6 +261,11 @@ func addCreateToTransaction[InternalAPIType, CosmosAPIType any](ctx context.Cont
 		ResourceID: cosmosMetadata.ResourceID.String(),
 	}
 
+	logger.Info("db mutation: transaction create",
+		"resourceID", cosmosMetadata.ResourceID.String(),
+		"content", newObj,
+	)
+
 	transaction.AddStep(
 		transactionDetails,
 		func(b *azcosmos.TransactionalBatch) (string, error) {
@@ -271,6 +278,8 @@ func addCreateToTransaction[InternalAPIType, CosmosAPIType any](ctx context.Cont
 }
 
 func addReplaceToTransaction[InternalAPIType, CosmosAPIType any](ctx context.Context, containerClient *azcosmos.ContainerClient, transaction DBTransaction, newObj *InternalAPIType, opts *azcosmos.TransactionalBatchItemOptions) (string, error) {
+	logger := utils.LoggerFromContext(ctx)
+
 	partitionKeyString := transaction.GetPartitionKey()
 
 	// do a get first to ensure the ID is migrated
@@ -299,6 +308,11 @@ func addReplaceToTransaction[InternalAPIType, CosmosAPIType any](ctx context.Con
 		Etag:       cosmosMetadata.CosmosETag,
 	}
 
+	logger.Info("db mutation: transaction replace",
+		"resourceID", cosmosMetadata.ResourceID.String(),
+		"content", newObj,
+	)
+
 	if opts == nil {
 		opts = &azcosmos.TransactionalBatchItemOptions{}
 	}
@@ -319,6 +333,8 @@ func addReplaceToTransaction[InternalAPIType, CosmosAPIType any](ctx context.Con
 }
 
 func create[InternalAPIType, CosmosAPIType any](ctx context.Context, containerClient *azcosmos.ContainerClient, partitionKeyString string, newObj *InternalAPIType, opts *azcosmos.ItemOptions) (*InternalAPIType, error) {
+	logger := utils.LoggerFromContext(ctx)
+
 	if strings.ToLower(partitionKeyString) != partitionKeyString {
 		return nil, fmt.Errorf("partitionKeyString must be lowercase, not: %q", partitionKeyString)
 	}
@@ -349,10 +365,17 @@ func create[InternalAPIType, CosmosAPIType any](ctx context.Context, containerCl
 		return nil, fmt.Errorf("failed to convert Cosmos object to internal type: %w", err)
 	}
 
+	logger.Info("db mutation: create",
+		"resourceID", cosmosMetadata.ResourceID.String(),
+		"content", internalObj,
+	)
+
 	return internalObj, nil
 }
 
 func replace[InternalAPIType, CosmosAPIType any](ctx context.Context, containerClient *azcosmos.ContainerClient, partitionKeyString string, newObj *InternalAPIType, opts *azcosmos.ItemOptions) (*InternalAPIType, error) {
+	logger := utils.LoggerFromContext(ctx)
+
 	cosmosPersistable, ok := any(newObj).(arm.CosmosPersistable)
 	if !ok {
 		return nil, fmt.Errorf("type %T does not implement CosmosPersistable interface", newObj)
@@ -396,10 +419,17 @@ func replace[InternalAPIType, CosmosAPIType any](ctx context.Context, containerC
 		return nil, fmt.Errorf("failed to convert Cosmos object to internal type: %w", err)
 	}
 
+	logger.Info("db mutation: replace",
+		"resourceID", cosmosMetadata.ResourceID.String(),
+		"content", internalObj,
+	)
+
 	return internalObj, nil
 }
 
 func deleteResource(ctx context.Context, containerClient *azcosmos.ContainerClient, partitionKeyString string, resourceID *azcorearm.ResourceID) error {
+	logger := utils.LoggerFromContext(ctx)
+
 	typedObj, err := get[TypedDocument, TypedDocument](ctx, containerClient, partitionKeyString, resourceID)
 	if IsResponseError(err, http.StatusNotFound) {
 		return nil
@@ -407,6 +437,11 @@ func deleteResource(ctx context.Context, containerClient *azcosmos.ContainerClie
 	if err != nil {
 		return utils.TrackError(err)
 	}
+
+	logger.Info("db mutation: delete",
+		"resourceID", resourceID.String(),
+		"content", typedObj,
+	)
 
 	_, err = containerClient.DeleteItem(ctx, azcosmos.NewPartitionKeyString(partitionKeyString), typedObj.ID, nil)
 	if err != nil {
@@ -416,6 +451,12 @@ func deleteResource(ctx context.Context, containerClient *azcosmos.ContainerClie
 }
 
 func deleteByCosmosID(ctx context.Context, containerClient *azcosmos.ContainerClient, partitionKeyString, cosmosID string) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	logger.Info("db mutation: delete",
+		"cosmosID", cosmosID,
+	)
+
 	_, err := containerClient.DeleteItem(ctx, azcosmos.NewPartitionKeyString(partitionKeyString), cosmosID, nil)
 	if err != nil {
 		return utils.TrackError(err)

--- a/internal/databasetesting/mock_crud.go
+++ b/internal/databasetesting/mock_crud.go
@@ -250,6 +250,8 @@ func (m *mockResourceCRUD[InternalAPIType, CosmosAPIType]) List(ctx context.Cont
 }
 
 func (m *mockResourceCRUD[InternalAPIType, CosmosAPIType]) Create(ctx context.Context, newObj *InternalAPIType, options *azcosmos.ItemOptions) (*InternalAPIType, error) {
+	logger := utils.LoggerFromContext(ctx)
+
 	cosmosObj, err := database.InternalToCosmos[InternalAPIType, CosmosAPIType](newObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert to cosmos type: %w", err)
@@ -282,10 +284,22 @@ func (m *mockResourceCRUD[InternalAPIType, CosmosAPIType]) Create(ctx context.Co
 	m.client.StoreDocument(cosmosID, dataWithETag)
 
 	// Read back the stored object
-	return m.GetByID(ctx, cosmosID)
+	result, err := m.GetByID(ctx, cosmosID)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("db mutation: create",
+		"resourceID", cosmosData.ResourceID.String(),
+		"content", result,
+	)
+
+	return result, nil
 }
 
 func (m *mockResourceCRUD[InternalAPIType, CosmosAPIType]) Replace(ctx context.Context, newObj *InternalAPIType, options *azcosmos.ItemOptions) (*InternalAPIType, error) {
+	logger := utils.LoggerFromContext(ctx)
+
 	cosmosObj, err := database.InternalToCosmos[InternalAPIType, CosmosAPIType](newObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert to cosmos type: %w", err)
@@ -330,21 +344,42 @@ func (m *mockResourceCRUD[InternalAPIType, CosmosAPIType]) Replace(ctx context.C
 	m.client.StoreDocument(existingCosmosID, dataWithETag)
 
 	// Read back the stored object
-	return m.Get(ctx, cosmosPersistable.GetCosmosData().GetResourceID().Name)
+	result, err := m.Get(ctx, cosmosPersistable.GetCosmosData().GetResourceID().Name)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("db mutation: replace",
+		"resourceID", cosmosData.ResourceID.String(),
+		"content", result,
+	)
+
+	return result, nil
 }
 
 func (m *mockResourceCRUD[InternalAPIType, CosmosAPIType]) Delete(ctx context.Context, resourceID string) error {
+	logger := utils.LoggerFromContext(ctx)
+
 	curr, err := m.Get(ctx, resourceID)
 	if err != nil {
 		return err
 	}
 
-	cosmosUID := any(curr).(arm.CosmosPersistable).GetCosmosData().GetCosmosUID()
+	cosmosData := any(curr).(arm.CosmosPersistable).GetCosmosData()
+	cosmosUID := cosmosData.GetCosmosUID()
+
+	logger.Info("db mutation: delete",
+		"resourceID", cosmosData.ResourceID.String(),
+		"content", curr,
+	)
+
 	m.client.DeleteDocument(cosmosUID)
 	return nil
 }
 
 func (m *mockResourceCRUD[InternalAPIType, CosmosAPIType]) AddCreateToTransaction(ctx context.Context, transaction database.DBTransaction, newObj *InternalAPIType, opts *azcosmos.TransactionalBatchItemOptions) (string, error) {
+	logger := utils.LoggerFromContext(ctx)
+
 	cosmosObj, err := database.InternalToCosmos[InternalAPIType, CosmosAPIType](newObj)
 	if err != nil {
 		return "", fmt.Errorf("failed to convert to cosmos type: %w", err)
@@ -374,6 +409,11 @@ func (m *mockResourceCRUD[InternalAPIType, CosmosAPIType]) AddCreateToTransactio
 		CosmosID:   cosmosID,
 	}
 
+	logger.Info("db mutation: transaction create",
+		"resourceID", cosmosData.ResourceID.String(),
+		"content", newObj,
+	)
+
 	mockTx.steps = append(mockTx.steps, mockTransactionStep{
 		details: transactionDetails,
 		execute: func() (string, json.RawMessage, error) {
@@ -391,6 +431,8 @@ func (m *mockResourceCRUD[InternalAPIType, CosmosAPIType]) AddCreateToTransactio
 }
 
 func (m *mockResourceCRUD[InternalAPIType, CosmosAPIType]) AddReplaceToTransaction(ctx context.Context, transaction database.DBTransaction, newObj *InternalAPIType, opts *azcosmos.TransactionalBatchItemOptions) (string, error) {
+	logger := utils.LoggerFromContext(ctx)
+
 	cosmosPersistable, ok := any(newObj).(arm.CosmosPersistable)
 	if !ok {
 		return "", fmt.Errorf("type %T does not implement CosmosPersistable", newObj)
@@ -425,6 +467,11 @@ func (m *mockResourceCRUD[InternalAPIType, CosmosAPIType]) AddReplaceToTransacti
 		GoType:     fmt.Sprintf("%T", newObj),
 		CosmosID:   cosmosID,
 	}
+
+	logger.Info("db mutation: transaction replace",
+		"resourceID", cosmosData.ResourceID.String(),
+		"content", newObj,
+	)
 
 	mockTx.steps = append(mockTx.steps, mockTransactionStep{
 		details: transactionDetails,
@@ -819,10 +866,17 @@ func (m *mockUntypedCRUD) listInternal(ctx context.Context, opts *database.DBCli
 }
 
 func (m *mockUntypedCRUD) Delete(ctx context.Context, resourceID *azcorearm.ResourceID) error {
+	logger := utils.LoggerFromContext(ctx)
+
 	curr, err := m.Get(ctx, resourceID)
 	if err != nil {
 		return err
 	}
+
+	logger.Info("db mutation: delete",
+		"resourceID", resourceID.String(),
+		"content", curr,
+	)
 
 	cosmosUID := curr.ID
 	m.client.DeleteDocument(cosmosUID)
@@ -830,6 +884,12 @@ func (m *mockUntypedCRUD) Delete(ctx context.Context, resourceID *azcorearm.Reso
 }
 
 func (m *mockUntypedCRUD) DeleteByCosmosID(ctx context.Context, partitionKey, cosmosID string) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	logger.Info("db mutation: delete",
+		"cosmosID", cosmosID,
+	)
+
 	m.client.DeleteDocument(cosmosID)
 	return nil
 }


### PR DESCRIPTION
This is NOT a replacement for the datadumper.  recall that transactions can fail and that other entities may  have cosmos credentials. This does however give strong hints as to what we're trying to do.