### PR TITLE
[WIP] Validate control plane operators permissions on user provided infra

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -385,6 +385,12 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.CosmosDBClient,
 		backendInformers,
 	)
+	controlPlaneIdentitiesPermissionValidationController := validationcontrollers.NewClusterValidationController(
+		validations.NewControlPlaneIdentitiesPermissionValidation(b.options.FPAMIDataplaneClientBuilder),
+		activeOperationLister,
+		b.options.CosmosDBClient,
+		backendInformers,
+	)
 
 	nodePoolVersionController := upgradecontrollers.NewNodePoolVersionController(
 		b.options.CosmosDBClient,
@@ -428,6 +434,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go azureRPRegistrationValidationController.Run(ctx, 20)
 				go azureClusterResourceGroupExistenceValidationController.Run(ctx, 20)
 				go azureClusterManagedIdentitiesExistenceValidationController.Run(ctx, 20)
+				go controlPlaneIdentitiesPermissionValidationController.Run(ctx, 20)
 				go nodePoolVersionController.Run(ctx, 20)
 			},
 			OnStoppedLeading: func() {

--- a/backend/pkg/controllers/validationcontrollers/validations/control_plane_identities_permission_validation.go
+++ b/backend/pkg/controllers/validationcontrollers/validations/control_plane_identities_permission_validation.go
@@ -1,0 +1,63 @@
+package validations
+
+import (
+	"context"
+
+	azureclient "github.com/Azure/ARO-HCP/backend/pkg/azure/client"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/go-errors/errors"
+)
+
+// ControlPlaneIdentitiesPermissionValidation validates that the control plane identities have the necessary permissions.
+type ControlPlaneIdentitiesPermissionValidation struct {
+	fpamiDataplaneClientBuilder azureclient.FPAMIDataplaneClientBuilder
+}
+
+func NewControlPlaneIdentitiesPermissionValidation(fpamiDataplaneClientBuilder azureclient.FPAMIDataplaneClientBuilder) *ControlPlaneIdentitiesPermissionValidation {
+	return &ControlPlaneIdentitiesPermissionValidation{
+		fpamiDataplaneClientBuilder: fpamiDataplaneClientBuilder,
+	}
+}
+
+func (v *ControlPlaneIdentitiesPermissionValidation) Name() string {
+	return "ControlPlaneIdentitiesPermissionValidation"
+}
+
+func (v *ControlPlaneIdentitiesPermissionValidation) Validate(ctx context.Context, clusterSubscription *arm.Subscription, cluster *api.HCPOpenShiftCluster) error {
+	logger := utils.LoggerFromContext(ctx)
+	logger.Info("Validating control plane identities permissions")
+
+	controlPlaneMissingActions := make(map[string][]string)
+	for operatorName, identity := range cluster.CustomerProperties.Platform.OperatorsAuthentication.UserAssignedIdentities.ControlPlaneOperators {
+		missingActions, err := v.findMissingActionsForIdentity(ctx, cluster, identity)
+		if err != nil {
+			return err
+		}
+		controlPlaneMissingActions[operatorName] = missingActions
+	}
+
+	if len(controlPlaneMissingActions) > 0 {
+		return errors.Errorf("control plane operators missing required permissions: %v",
+			controlPlaneMissingActions)
+	}
+
+	return nil
+}
+
+func (v *ControlPlaneIdentitiesPermissionValidation) findMissingActionsForIdentity(ctx context.Context, cluster *api.HCPOpenShiftCluster, identity *azcorearm.ResourceID) ([]string, error) {
+	// Get roleDefinitionResourceId from operators managed identities configuration
+	// https://github.com/Azure/ARO-HCP/pull/
+
+	// Get the role definitions(actions and data actions) for the identity
+	// https://github.com/Azure/ARO-HCP/pull/4403
+
+	// Use the CheckAccessV2 client to check if the identity has the necessary permissions
+	// https://github.com/Azure/ARO-HCP/pull/3907
+	// If the identity does not have the necessary permissions, return the missing actions
+	// If the identity has the necessary permissions, return nil
+
+	return nil, nil
+}


### PR DESCRIPTION
[ARO-25131](https://redhat.atlassian.net/browse/ARO-25131)

When creating an ARO-HCP Cluster, the end-users creating those Clusters need to pre-create a set of Azure Managed Identities which are then used by k8s control plane operators in the clusters.

This is the controller which validates the roles and permissions assigned to the managed identity provided by the user. 

