### PR TITLE
feat: add ManifestWork redaction function

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -30,6 +30,7 @@ require (
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
 	go.uber.org/mock v0.6.0
+	k8s.io/api v0.34.3
 	k8s.io/apimachinery v0.34.3
 	k8s.io/client-go v0.34.3
 	k8s.io/component-base v0.34.3
@@ -143,7 +144,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.34.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/backend/pkg/manifestwork/redact_manifestwork.go
+++ b/backend/pkg/manifestwork/redact_manifestwork.go
@@ -1,0 +1,307 @@
+package manifestwork
+
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"encoding/json"
+	"fmt"
+
+	workv1 "open-cluster-management.io/api/work/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// redactedValue is the placeholder value used when redacting sensitive data.
+const redactedValue = "[REDACTED]"
+
+// RedactManifestWork returns a deep copy of the given ManifestWork with sensitive
+// data redacted. It handles:
+//   - Kubernetes Secrets embedded as manifests (redacts Data and StringData fields)
+//   - Nested ManifestWorks that may themselves contain Secrets or further
+//     ManifestWorks (applied recursively)
+//   - Status feedback JsonRaw values that may contain serialized sensitive K8s
+//     resources (e.g. a full Secret returned via a feedback rule)
+//
+// Resources whose GVK cannot be determined from their raw JSON (e.g. partial
+// status objects without apiVersion/kind) are left unchanged, as their type
+// cannot be reliably inferred.
+//
+// NOTE on the output representation of each manifest's runtime.RawExtension:
+// the returned deep copy preserves only Object or only Raw, but not both: Manifests
+// that entered with a typed recognized Object (*corev1.Secret, *workv1.ManifestWork) will
+// have Object set and Raw nil. Manifests that entered with only Raw, or with
+// an unrecognized Object type (e.g. *unstructured.Unstructured or any other CR type), will have Raw
+// set and Object nil. Both states are valid for runtime.RawExtension. MarshalJSON
+// handles either correctly, but callers should not assume a specific field is populated.
+func RedactManifestWork(mw *workv1.ManifestWork) (*workv1.ManifestWork, error) {
+	redacted := mw.DeepCopy()
+	if err := redactManifestWorkInPlace(redacted); err != nil {
+		return nil, err
+	}
+	return redacted, nil
+}
+
+// redactManifestWorkInPlace modifies the ManifestWork in-place, redacting
+// sensitive data from its spec manifests and status feedbacks. Callers must
+// ensure this is called on a deep copy to avoid mutating the original.
+func redactManifestWorkInPlace(mw *workv1.ManifestWork) error {
+	for i := range mw.Spec.Workload.Manifests {
+		if err := redactManifestInPlace(&mw.Spec.Workload.Manifests[i]); err != nil {
+			return utils.TrackError(fmt.Errorf("redacting spec manifest at index %d: %w", i, err))
+		}
+	}
+
+	for i := range mw.Status.ResourceStatus.Manifests {
+		if err := redactManifestConditionFeedbacksInPlace(&mw.Status.ResourceStatus.Manifests[i]); err != nil {
+			return utils.TrackError(fmt.Errorf("redacting status feedback at manifest condition index %d: %w", i, err))
+		}
+	}
+
+	return nil
+}
+
+// redactManifestInPlace inspects the embedded resource within a workv1.Manifest
+// and redacts sensitive data in-place.
+//
+// A runtime.RawExtension (embedded in workv1.Manifest) can have three states:
+//  1. Object is set, Raw is nil
+//  2. Raw is set, Object is nil
+//  3. Both Object and Raw are set
+
+// This function prioritizes Object when it is set, using Go type assertions for
+// maximum type safety. In every branch of the Object-is-set path, Raw is either
+// nilled out or overwritten to ensure that any pre-existing Raw bytes (which may
+// contain unredacted sensitive data) are never left intact. When Object is nil,
+// we fall through to the Raw-only path.
+
+// ASSUMPTION: when both Object and Raw are set, they represent the same resource.
+// If this invariant were ever violated (e.g. Object is a ConfigMap but Raw contains a
+// Secret), we would redact based on Object's type and discard Raw. Since Raw is
+// always nilled out or overwritten in the Object-is-set path, sensitive data
+// that may have been present in Raw can never be logged. The only consequence
+// of the invariant being violated would be an incomplete redacted representation
+// of the manifest (missing whatever Raw contained), not a sensitive data leak.
+func redactManifestInPlace(m *workv1.Manifest) error {
+	if m.Object != nil {
+		switch obj := m.Object.(type) {
+		case *corev1.Secret:
+			redactSecretFieldsInPlace(obj)
+			// Nil out Raw to prevent leaking unredacted sensitive data that
+			// may be present in pre-existing raw bytes. After this, callers
+			// serializing the manifest will use the redacted Object.
+			m.Raw = nil
+			return nil
+		case *workv1.ManifestWork:
+			if err := redactManifestWorkInPlace(obj); err != nil {
+				return utils.TrackError(fmt.Errorf("redacting nested typed ManifestWork: %w", err))
+			}
+			// Nil out Raw for the same reason as the Secret case above.
+			m.Raw = nil
+			return nil
+		default:
+			// Any other typed K8s object (e.g. *unstructured.Unstructured or a
+			// different CR type. Serialize to raw JSON overwriting any pre-existing Raw
+			// bytes and process via the raw path so we can still detect
+			// Secrets/ManifestWorks by GVK.
+			raw, err := json.Marshal(obj)
+			if err != nil {
+				return utils.TrackError(fmt.Errorf("marshaling typed object to JSON for redaction: %w", err))
+			}
+			m.Raw = raw
+			// Nil out Object to prevent leaking unredacted sensitive data that
+			// may be present in pre-existing Object. After this, callers
+			// serializing the manifest will use the redacted Raw.
+			m.Object = nil
+			return redactManifestFromRawInPlace(m)
+		}
+	}
+
+	// Object is nil - process the raw JSON bytes directly.
+	if len(m.Raw) > 0 {
+		return redactManifestFromRawInPlace(m)
+	}
+
+	return nil
+}
+
+// redactManifestFromRawInPlace detects the GVK of the embedded resource from
+// its raw JSON representation and applies type-specific redaction in-place for
+// Secrets and ManifestWorks.
+// The manifest's Object field is always nilled out when redaction is successful.
+// If the GVK cannot be determined, nothing is redacted.
+func redactManifestFromRawInPlace(m *workv1.Manifest) error {
+	gvk, ok := detectGVKFromRaw(m.Raw)
+	if !ok {
+		return nil // can't determine type; nothing to redact
+	}
+
+	switch {
+	case isSecretGK(gvk):
+		redactedRaw, err := redactSecretFromRawJSON(m.Raw)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("redacting raw Secret manifest: %w", err))
+		}
+		m.Raw = redactedRaw
+		m.Object = nil
+		return nil
+	case isManifestWorkGK(gvk):
+		redactedRaw, err := redactManifestWorkFromRawJSON(m.Raw)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("redacting raw nested ManifestWork manifest: %w", err))
+		}
+		m.Raw = redactedRaw
+		m.Object = nil
+		return nil
+	default:
+		return nil
+	}
+}
+
+// --- Secret redaction ---
+
+// redactSecretFieldsInPlace zeroes out the Data and StringData fields on a
+// typed corev1.Secret in-place, replacing each value with the redacted placeholder.
+func redactSecretFieldsInPlace(secret *corev1.Secret) {
+	for k := range secret.Data {
+		secret.Data[k] = []byte(redactedValue)
+	}
+	for k := range secret.StringData {
+		secret.StringData[k] = redactedValue
+	}
+}
+
+// redactSecretFromRawJSON deserializes raw JSON into a corev1.Secret, redacts its
+// sensitive fields, and returns the re-serialized JSON.
+func redactSecretFromRawJSON(raw []byte) ([]byte, error) {
+	var secret corev1.Secret
+	if err := json.Unmarshal(raw, &secret); err != nil {
+		return nil, utils.TrackError(fmt.Errorf("unmarshaling Secret: %w", err))
+	}
+
+	redactSecretFieldsInPlace(&secret)
+
+	redacted, err := json.Marshal(&secret)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("marshaling redacted Secret: %w", err))
+	}
+	return redacted, nil
+}
+
+// --- Nested ManifestWork redaction ---
+
+// redactManifestWorkFromRawJSON deserializes raw JSON into a workv1.ManifestWork,
+// recursively redacts sensitive data, and returns the re-serialized JSON.
+func redactManifestWorkFromRawJSON(raw []byte) ([]byte, error) {
+	var mw workv1.ManifestWork
+	if err := json.Unmarshal(raw, &mw); err != nil {
+		return nil, utils.TrackError(fmt.Errorf("unmarshaling nested ManifestWork: %w", err))
+	}
+
+	if err := redactManifestWorkInPlace(&mw); err != nil {
+		return nil, utils.TrackError(fmt.Errorf("redacting nested ManifestWork: %w", err))
+	}
+
+	redacted, err := json.Marshal(&mw)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("marshaling redacted ManifestWork: %w", err))
+	}
+	return redacted, nil
+}
+
+// --- Status feedback redaction ---
+
+// redactManifestConditionFeedbacksInPlace redacts JsonRaw values within status
+// feedback entries in-place that may contain serialized sensitive K8s resources
+// (e.g. a full Secret returned via the "@" json path feedback rule).
+func redactManifestConditionFeedbacksInPlace(mc *workv1.ManifestCondition) error {
+	for i := range mc.StatusFeedbacks.Values {
+		if err := redactFeedbackValueInPlace(&mc.StatusFeedbacks.Values[i]); err != nil {
+			return utils.TrackError(fmt.Errorf("redacting feedback value %q: %w", mc.StatusFeedbacks.Values[i].Name, err))
+		}
+	}
+	return nil
+}
+
+// redactFeedbackValueInPlace checks a single FeedbackValue's JsonRaw field for
+// embedded sensitive K8s resources and redacts them in-place if found. Values
+// without JsonRaw (integer, string, boolean types) are left unchanged.
+func redactFeedbackValueInPlace(fv *workv1.FeedbackValue) error {
+	if fv.Value.JsonRaw == nil {
+		return nil
+	}
+
+	raw := []byte(*fv.Value.JsonRaw)
+
+	gvk, ok := detectGVKFromRaw(raw)
+	if !ok {
+		// Not a recognizable K8s resource (e.g. a partial status field
+		// without apiVersion/kind). Cannot determine sensitivity.
+		return nil
+	}
+
+	var (
+		redactedRaw []byte
+		err         error
+	)
+	switch {
+	case isSecretGK(gvk):
+		redactedRaw, err = redactSecretFromRawJSON(raw)
+	case isManifestWorkGK(gvk):
+		redactedRaw, err = redactManifestWorkFromRawJSON(raw)
+	default:
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	redacted := string(redactedRaw)
+	fv.Value.JsonRaw = &redacted
+	return nil
+}
+
+// --- GVK detection helpers ---
+
+// detectGVKFromRaw extracts the GroupVersionKind from raw JSON by reading only the
+// apiVersion and kind fields. Returns false if the JSON cannot be parsed or
+// does not contain a kind field.
+func detectGVKFromRaw(raw []byte) (schema.GroupVersionKind, bool) {
+	var typeMeta metav1.TypeMeta
+	err := json.Unmarshal(raw, &typeMeta)
+	if err != nil {
+		return schema.GroupVersionKind{}, false
+	}
+	if typeMeta.Kind == "" {
+		return schema.GroupVersionKind{}, false
+	}
+	return typeMeta.GroupVersionKind(), true
+}
+
+// isSecretGK returns true if the GVK represents a core Secret resource.
+// The version is intentionally not checked so that any API version is matched.
+func isSecretGK(gvk schema.GroupVersionKind) bool {
+	return gvk.Group == "" && gvk.Kind == "Secret"
+}
+
+// isManifestWorkGK returns true if the GVK represents an open-cluster-management
+// ManifestWork resource. The version is intentionally not checked so that any
+// API version is matched.
+func isManifestWorkGK(gvk schema.GroupVersionKind) bool {
+	return gvk.Group == workv1.GroupName && gvk.Kind == "ManifestWork"
+}

--- a/backend/pkg/manifestwork/redact_manifestwork_test.go
+++ b/backend/pkg/manifestwork/redact_manifestwork_test.go
@@ -1,0 +1,858 @@
+package manifestwork
+
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	workv1 "open-cluster-management.io/api/work/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestRedactManifestWork(t *testing.T) {
+	tests := []struct {
+		name   string
+		mw     *workv1.ManifestWork
+		verify func(t *testing.T, result *workv1.ManifestWork)
+	}{
+		{
+			name: "empty ManifestWork passes through unchanged",
+			mw:   &workv1.ManifestWork{},
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				require.Empty(t, result.Spec.Workload.Manifests)
+				require.Empty(t, result.Status.ResourceStatus.Manifests)
+			},
+		},
+		{
+			name: "a ConfigMap is left unchanged",
+			mw: &workv1.ManifestWork{
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							newRawManifest(t, newConfigMap("cm1", "default")),
+						},
+					},
+				},
+			},
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				require.Len(t, result.Spec.Workload.Manifests, 1)
+				// ConfigMap data should be intact
+				var cm corev1.ConfigMap
+				require.NoError(t, json.Unmarshal(result.Spec.Workload.Manifests[0].Raw, &cm))
+				require.Equal(t, "value", cm.Data["key"])
+			},
+		},
+		{
+			name: "raw Secret with Data and StringData is redacted",
+			mw: &workv1.ManifestWork{
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							newRawManifest(t, newSecret("my-secret", "default",
+								map[string][]byte{
+									"password":  []byte("super-secret"),
+									"api-token": []byte("tok-12345"),
+								},
+								map[string]string{
+									"username": "admin",
+								},
+							)),
+						},
+					},
+				},
+			},
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				require.Len(t, result.Spec.Workload.Manifests, 1)
+				secret := unmarshalSecretFromManifest(t, result.Spec.Workload.Manifests[0])
+				// Sensitive fields redacted
+				requireSecretRedacted(t, secret)
+				require.Len(t, secret.Data, 2, "keys should be preserved")
+				require.Len(t, secret.StringData, 1, "keys should be preserved")
+				// Non-sensitive metadata preserved
+				require.Equal(t, "my-secret", secret.Name)
+				require.Equal(t, "default", secret.Namespace)
+				require.Equal(t, corev1.SecretTypeOpaque, secret.Type)
+			},
+		},
+		{
+			name: "typed Secret Object is redacted",
+			mw: &workv1.ManifestWork{
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							newTypedManifest(newSecret("typed-secret", "ns1",
+								map[string][]byte{"token": []byte("secret-val")},
+								map[string]string{"conn": "host=db password=abc"},
+							)),
+						},
+					},
+				},
+			},
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				require.Len(t, result.Spec.Workload.Manifests, 1)
+				m := result.Spec.Workload.Manifests[0]
+				// Typed path: Object should be the modified Secret, Raw should be nil
+				require.NotNil(t, m.Object)
+				require.Nil(t, m.Raw)
+				secret, ok := m.Object.(*corev1.Secret)
+				require.True(t, ok, "Object should still be *corev1.Secret")
+				requireSecretRedacted(t, secret)
+				require.Equal(t, "typed-secret", secret.Name)
+			},
+		},
+		{
+			name: "typed Secret with nil Data and StringData does not panic",
+			mw: &workv1.ManifestWork{
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							newTypedManifest(newSecret("empty-secret", "default", nil, nil)),
+						},
+					},
+				},
+			},
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				secret := result.Spec.Workload.Manifests[0].Object.(*corev1.Secret)
+				require.Nil(t, secret.Data)
+				require.Nil(t, secret.StringData)
+			},
+		},
+		{
+			name: "raw nested ManifestWork containing a raw Secret",
+			mw: func() *workv1.ManifestWork {
+				innerSecretManifest := newRawManifest(t, newSecret("inner-secret", "default",
+					map[string][]byte{"key": []byte("sensitive-data")}, nil,
+				))
+				innerMW := &workv1.ManifestWork{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "work.open-cluster-management.io/v1", Kind: "ManifestWork"},
+					ObjectMeta: metav1.ObjectMeta{Name: "inner-mw"},
+					Spec: workv1.ManifestWorkSpec{
+						Workload: workv1.ManifestsTemplate{
+							Manifests: []workv1.Manifest{innerSecretManifest},
+						},
+					},
+				}
+				return &workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{Name: "outer-mw"},
+					Spec: workv1.ManifestWorkSpec{
+						Workload: workv1.ManifestsTemplate{
+							Manifests: []workv1.Manifest{
+								newRawManifest(t, innerMW),
+							},
+						},
+					},
+				}
+			}(),
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				require.Len(t, result.Spec.Workload.Manifests, 1)
+				innerMW := unmarshalManifestWorkFromManifest(t, result.Spec.Workload.Manifests[0])
+				require.Len(t, innerMW.Spec.Workload.Manifests, 1)
+				innerSecret := unmarshalSecretFromManifest(t, innerMW.Spec.Workload.Manifests[0])
+				requireSecretRedacted(t, innerSecret)
+				require.Contains(t, innerSecret.Data, "key", "key name should be preserved")
+			},
+		},
+		{
+			name: "typed nested ManifestWork containing a typed Secret",
+			mw: &workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{Name: "outer-mw"},
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							newTypedManifest(&workv1.ManifestWork{
+								TypeMeta:   metav1.TypeMeta{APIVersion: "work.open-cluster-management.io/v1", Kind: "ManifestWork"},
+								ObjectMeta: metav1.ObjectMeta{Name: "inner-mw"},
+								Spec: workv1.ManifestWorkSpec{
+									Workload: workv1.ManifestsTemplate{
+										Manifests: []workv1.Manifest{
+											newTypedManifest(newSecret("nested-secret", "default",
+												map[string][]byte{"db-pass": []byte("p4ssw0rd")}, nil,
+											)),
+										},
+									},
+								},
+							}),
+						},
+					},
+				},
+			},
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				innerMW := result.Spec.Workload.Manifests[0].Object.(*workv1.ManifestWork)
+				innerSecret := innerMW.Spec.Workload.Manifests[0].Object.(*corev1.Secret)
+				requireSecretRedacted(t, innerSecret)
+				require.Equal(t, "nested-secret", innerSecret.Name)
+			},
+		},
+		{
+			name: "3-level deep nesting (MW -> MW -> Secret)",
+			mw: func() *workv1.ManifestWork {
+				secretManifest := newRawManifest(t, newSecret("deep-secret", "default",
+					map[string][]byte{"deep-key": []byte("deep-value")}, nil,
+				))
+				level2MW := &workv1.ManifestWork{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "work.open-cluster-management.io/v1", Kind: "ManifestWork"},
+					ObjectMeta: metav1.ObjectMeta{Name: "level2-mw"},
+					Spec: workv1.ManifestWorkSpec{
+						Workload: workv1.ManifestsTemplate{
+							Manifests: []workv1.Manifest{secretManifest},
+						},
+					},
+				}
+				level1MW := &workv1.ManifestWork{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "work.open-cluster-management.io/v1", Kind: "ManifestWork"},
+					ObjectMeta: metav1.ObjectMeta{Name: "level1-mw"},
+					Spec: workv1.ManifestWorkSpec{
+						Workload: workv1.ManifestsTemplate{
+							Manifests: []workv1.Manifest{
+								newRawManifest(t, level2MW),
+							},
+						},
+					},
+				}
+				return &workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{Name: "root-mw"},
+					Spec: workv1.ManifestWorkSpec{
+						Workload: workv1.ManifestsTemplate{
+							Manifests: []workv1.Manifest{
+								newRawManifest(t, level1MW),
+							},
+						},
+					},
+				}
+			}(),
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				level1 := unmarshalManifestWorkFromManifest(t, result.Spec.Workload.Manifests[0])
+				level2 := unmarshalManifestWorkFromManifest(t, level1.Spec.Workload.Manifests[0])
+				deepSecret := unmarshalSecretFromManifest(t, level2.Spec.Workload.Manifests[0])
+				requireSecretRedacted(t, deepSecret)
+				require.Equal(t, "deep-secret", deepSecret.Name)
+			},
+		},
+		{
+			name: "unstructured Secret Object uses fallback raw path and is redacted",
+			mw: &workv1.ManifestWork{
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							newTypedManifest(&unstructured.Unstructured{
+								Object: map[string]interface{}{
+									"apiVersion": "v1",
+									"kind":       "Secret",
+									"metadata": map[string]interface{}{
+										"name":      "unstructured-secret",
+										"namespace": "default",
+									},
+									"data": map[string]interface{}{
+										// Value must be valid base64 because corev1.Secret.Data
+										// is map[string][]byte, and json.Unmarshal decodes JSON
+										// strings as base64 for []byte fields.
+										"akey": "YXZhbHVl", // base64("avalue")
+									},
+									"type": "Opaque",
+								},
+							}),
+						},
+					},
+				},
+			},
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				m := result.Spec.Workload.Manifests[0]
+				// The default path converts Object to Raw, so Raw should be set
+				require.NotEmpty(t, m.Raw)
+				secret := unmarshalSecretFromManifest(t, m)
+				requireSecretRedacted(t, secret)
+				require.Equal(t, "unstructured-secret", secret.Name)
+			},
+		},
+		{
+			name: "raw JSON without apiVersion/kind is left unchanged",
+			mw: &workv1.ManifestWork{
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							{RawExtension: runtime.RawExtension{
+								Raw: []byte(`{"name":"some-resource","data":{"key":"value"}}`),
+							}},
+						},
+					},
+				},
+			},
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				var parsed map[string]interface{}
+				require.NoError(t, json.Unmarshal(result.Spec.Workload.Manifests[0].Raw, &parsed))
+				data := parsed["data"].(map[string]interface{})
+				require.Equal(t, "value", data["key"], "data should be untouched without GVK")
+			},
+		},
+		{
+			name: "multiple manifests with mixed types - only Secret is redacted",
+			mw: &workv1.ManifestWork{
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							newRawManifest(t, newConfigMap("cm1", "default")),
+							newRawManifest(t, newSecret("secret1", "default",
+								map[string][]byte{"pw": []byte("s3cret")}, nil,
+							)),
+						},
+					},
+				},
+			},
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				require.Len(t, result.Spec.Workload.Manifests, 2)
+				// ConfigMap unchanged
+				var cm corev1.ConfigMap
+				require.NoError(t, json.Unmarshal(result.Spec.Workload.Manifests[0].Raw, &cm))
+				require.Equal(t, "value", cm.Data["key"])
+				// Secret redacted
+				secret := unmarshalSecretFromManifest(t, result.Spec.Workload.Manifests[1])
+				requireSecretRedacted(t, secret)
+			},
+		},
+		{
+			name: "status feedback with JsonRaw containing a Secret is redacted",
+			mw: func() *workv1.ManifestWork {
+				secretJSON, _ := json.Marshal(newSecret("feedback-secret", "default",
+					map[string][]byte{"asecretkey": []byte("asecretvalue")}, nil,
+				))
+				jsonRawStr := string(secretJSON)
+				return &workv1.ManifestWork{
+					Status: workv1.ManifestWorkStatus{
+						ResourceStatus: workv1.ManifestResourceStatus{
+							Manifests: []workv1.ManifestCondition{
+								{
+									StatusFeedbacks: workv1.StatusFeedbackResult{
+										Values: []workv1.FeedbackValue{
+											{
+												Name: "full-resource",
+												Value: workv1.FieldValue{
+													Type:    workv1.JsonRaw,
+													JsonRaw: &jsonRawStr,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			}(),
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				fv := result.Status.ResourceStatus.Manifests[0].StatusFeedbacks.Values[0]
+				require.NotNil(t, fv.Value.JsonRaw)
+				var secret corev1.Secret
+				require.NoError(t, json.Unmarshal([]byte(*fv.Value.JsonRaw), &secret))
+				requireSecretRedacted(t, &secret)
+				require.Equal(t, "feedback-secret", secret.Name)
+			},
+		},
+		{
+			name: "status feedback with JsonRaw ManifestWork containing Secret is redacted",
+			mw: func() *workv1.ManifestWork {
+				innerSecretManifest := newRawManifest(t, newSecret("inner-fb-secret", "default",
+					map[string][]byte{"api-key": []byte("key-123")}, nil,
+				))
+				innerMW := &workv1.ManifestWork{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "work.open-cluster-management.io/v1", Kind: "ManifestWork"},
+					ObjectMeta: metav1.ObjectMeta{Name: "feedback-mw"},
+					Spec: workv1.ManifestWorkSpec{
+						Workload: workv1.ManifestsTemplate{
+							Manifests: []workv1.Manifest{innerSecretManifest},
+						},
+					},
+				}
+				mwJSON, _ := json.Marshal(innerMW)
+				jsonRawStr := string(mwJSON)
+				return &workv1.ManifestWork{
+					Status: workv1.ManifestWorkStatus{
+						ResourceStatus: workv1.ManifestResourceStatus{
+							Manifests: []workv1.ManifestCondition{
+								{
+									StatusFeedbacks: workv1.StatusFeedbackResult{
+										Values: []workv1.FeedbackValue{
+											{
+												Name: "nested-mw-feedback",
+												Value: workv1.FieldValue{
+													Type:    workv1.JsonRaw,
+													JsonRaw: &jsonRawStr,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			}(),
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				fv := result.Status.ResourceStatus.Manifests[0].StatusFeedbacks.Values[0]
+				require.NotNil(t, fv.Value.JsonRaw)
+				var innerMW workv1.ManifestWork
+				require.NoError(t, json.Unmarshal([]byte(*fv.Value.JsonRaw), &innerMW))
+				innerSecret := unmarshalSecretFromManifest(t, innerMW.Spec.Workload.Manifests[0])
+				requireSecretRedacted(t, innerSecret)
+			},
+		},
+		{
+			name: "status feedback with non-K8s JsonRaw is left unchanged",
+			mw: func() *workv1.ManifestWork {
+				rawStatus := `{"replicas":3,"readyReplicas":2}`
+				return &workv1.ManifestWork{
+					Status: workv1.ManifestWorkStatus{
+						ResourceStatus: workv1.ManifestResourceStatus{
+							Manifests: []workv1.ManifestCondition{
+								{
+									StatusFeedbacks: workv1.StatusFeedbackResult{
+										Values: []workv1.FeedbackValue{
+											{
+												Name: "deployment-status",
+												Value: workv1.FieldValue{
+													Type:    workv1.JsonRaw,
+													JsonRaw: &rawStatus,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			}(),
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				fv := result.Status.ResourceStatus.Manifests[0].StatusFeedbacks.Values[0]
+				require.Equal(t, `{"replicas":3,"readyReplicas":2}`, *fv.Value.JsonRaw,
+					"non-K8s JsonRaw should be untouched")
+			},
+		},
+		{
+			name: "status feedback with non-JsonRaw value types are left unchanged",
+			mw: func() *workv1.ManifestWork {
+				intVal := int64(42)
+				boolVal := true
+				strVal := "healthy"
+				return &workv1.ManifestWork{
+					Status: workv1.ManifestWorkStatus{
+						ResourceStatus: workv1.ManifestResourceStatus{
+							Manifests: []workv1.ManifestCondition{
+								{
+									StatusFeedbacks: workv1.StatusFeedbackResult{
+										Values: []workv1.FeedbackValue{
+											{
+												Name:  "replicas",
+												Value: workv1.FieldValue{Type: workv1.Integer, Integer: &intVal},
+											},
+											{
+												Name:  "ready",
+												Value: workv1.FieldValue{Type: workv1.Boolean, Boolean: &boolVal},
+											},
+											{
+												Name:  "phase",
+												Value: workv1.FieldValue{Type: workv1.String, String: &strVal},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			}(),
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				values := result.Status.ResourceStatus.Manifests[0].StatusFeedbacks.Values
+				require.Equal(t, int64(42), *values[0].Value.Integer)
+				require.Equal(t, true, *values[1].Value.Boolean)
+				require.Equal(t, "healthy", *values[2].Value.String)
+			},
+		},
+		{
+			name: "both Object and Raw set: typed Secret Object - Raw is nilled out",
+			mw: func() *workv1.ManifestWork {
+				secret := newSecret("dual-secret", "default",
+					map[string][]byte{"password": []byte("typed-secret-value")}, nil,
+				)
+				rawSecret, _ := json.Marshal(newSecret("dual-secret", "default",
+					map[string][]byte{"password": []byte("raw-secret-value")}, nil,
+				))
+				return &workv1.ManifestWork{
+					Spec: workv1.ManifestWorkSpec{
+						Workload: workv1.ManifestsTemplate{
+							Manifests: []workv1.Manifest{
+								{RawExtension: runtime.RawExtension{
+									Object: secret,
+									Raw:    rawSecret,
+								}},
+							},
+						},
+					},
+				}
+			}(),
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				m := result.Spec.Workload.Manifests[0]
+				// Object should be the redacted Secret
+				require.NotNil(t, m.Object)
+				secret := m.Object.(*corev1.Secret)
+				requireSecretRedacted(t, secret)
+				// Raw must be nil - not left with unredacted content
+				require.Nil(t, m.Raw, "Raw must be nilled out to prevent leaking unredacted data")
+			},
+		},
+		{
+			name: "both Object and Raw set: typed ManifestWork Object - Raw is nilled out",
+			mw: func() *workv1.ManifestWork {
+				innerMW := &workv1.ManifestWork{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "work.open-cluster-management.io/v1", Kind: "ManifestWork"},
+					ObjectMeta: metav1.ObjectMeta{Name: "inner-mw"},
+					Spec: workv1.ManifestWorkSpec{
+						Workload: workv1.ManifestsTemplate{
+							Manifests: []workv1.Manifest{
+								newTypedManifest(newSecret("nested-secret", "default",
+									map[string][]byte{"key": []byte("nested-value")}, nil,
+								)),
+							},
+						},
+					},
+				}
+				// Simulate stale Raw containing unredacted data
+				rawMW, _ := json.Marshal(innerMW)
+				return &workv1.ManifestWork{
+					Spec: workv1.ManifestWorkSpec{
+						Workload: workv1.ManifestsTemplate{
+							Manifests: []workv1.Manifest{
+								{RawExtension: runtime.RawExtension{
+									Object: innerMW,
+									Raw:    rawMW,
+								}},
+							},
+						},
+					},
+				}
+			}(),
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				m := result.Spec.Workload.Manifests[0]
+				// Object should be the redacted ManifestWork
+				require.NotNil(t, m.Object)
+				innerMW := m.Object.(*workv1.ManifestWork)
+				innerSecret := innerMW.Spec.Workload.Manifests[0].Object.(*corev1.Secret)
+				requireSecretRedacted(t, innerSecret)
+				// Raw must be nil - not left with unredacted content
+				require.Nil(t, m.Raw, "Raw must be nilled out to prevent leaking unredacted data")
+			},
+		},
+		{
+			name: "both Object and Raw set: unrecognized Object type - Raw is overwritten and redacted",
+			mw: func() *workv1.ManifestWork {
+				// Object is an unstructured Secret (hits the default type-switch branch)
+				unstructuredSecret := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata": map[string]interface{}{
+							"name":      "unstructured-dual",
+							"namespace": "default",
+						},
+						"data": map[string]interface{}{
+							"token": "dW5zdHJ1Y3R1cmVkLXNlY3JldA==",
+						},
+					},
+				}
+				// Stale Raw with different sensitive content
+				staleRaw := []byte(`{"apiVersion":"v1","kind":"Secret","metadata":{"name":"stale"},"data":{"old-key":"c3RhbGUtZGF0YQ=="}}`)
+				return &workv1.ManifestWork{
+					Spec: workv1.ManifestWorkSpec{
+						Workload: workv1.ManifestsTemplate{
+							Manifests: []workv1.Manifest{
+								{RawExtension: runtime.RawExtension{
+									Object: unstructuredSecret,
+									Raw:    staleRaw,
+								}},
+							},
+						},
+					},
+				}
+			}(),
+			verify: func(t *testing.T, result *workv1.ManifestWork) {
+				m := result.Spec.Workload.Manifests[0]
+				// Object should be nil (default branch converts to Raw)
+				require.Nil(t, m.Object)
+				// Raw should contain the redacted Secret derived from Object, not the stale Raw
+				require.NotEmpty(t, m.Raw)
+				secret := unmarshalSecretFromManifest(t, m)
+				requireSecretRedacted(t, secret)
+				require.Equal(t, "unstructured-dual", secret.Name,
+					"should contain the Object's resource, not the stale Raw")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := RedactManifestWork(tt.mw)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			tt.verify(t, result)
+		})
+	}
+}
+
+func TestRedactManifestWorkDoesNotMutateOriginal(t *testing.T) {
+	t.Run("typed Secret path", func(t *testing.T) {
+		originalSecret := newSecret("original", "default",
+			map[string][]byte{"password": []byte("super-secret")},
+			map[string]string{"conn-string": "host=db password=abc"},
+		)
+		mw := &workv1.ManifestWork{
+			Spec: workv1.ManifestWorkSpec{
+				Workload: workv1.ManifestsTemplate{
+					Manifests: []workv1.Manifest{
+						newTypedManifest(originalSecret),
+					},
+				},
+			},
+		}
+
+		result, err := RedactManifestWork(mw)
+		require.NoError(t, err)
+
+		// Original Secret must be untouched
+		require.Equal(t, []byte("super-secret"), originalSecret.Data["password"],
+			"original Data should not be mutated")
+		require.Equal(t, "host=db password=abc", originalSecret.StringData["conn-string"],
+			"original StringData should not be mutated")
+
+		// Result must be redacted
+		redactedSecret := result.Spec.Workload.Manifests[0].Object.(*corev1.Secret)
+		requireSecretRedacted(t, redactedSecret)
+	})
+
+	t.Run("raw Secret path", func(t *testing.T) {
+		secretJSON, err := json.Marshal(newSecret("raw-original", "default",
+			map[string][]byte{"token": []byte("raw-secret-token")}, nil,
+		))
+		require.NoError(t, err)
+
+		originalRaw := make([]byte, len(secretJSON))
+		copy(originalRaw, secretJSON)
+
+		mw := &workv1.ManifestWork{
+			Spec: workv1.ManifestWorkSpec{
+				Workload: workv1.ManifestsTemplate{
+					Manifests: []workv1.Manifest{
+						{RawExtension: runtime.RawExtension{Raw: secretJSON}},
+					},
+				},
+			},
+		}
+
+		result, err := RedactManifestWork(mw)
+		require.NoError(t, err)
+
+		// Original Raw bytes must be untouched (DeepCopy creates a new slice)
+		require.Equal(t, originalRaw, mw.Spec.Workload.Manifests[0].Raw,
+			"original Raw bytes should not be mutated")
+
+		// Result must be redacted
+		redactedSecret := unmarshalSecretFromManifest(t, result.Spec.Workload.Manifests[0])
+		requireSecretRedacted(t, redactedSecret)
+	})
+
+	t.Run("status feedback JsonRaw path", func(t *testing.T) {
+		secretJSON, err := json.Marshal(newSecret("fb-original", "default",
+			map[string][]byte{"cert": []byte("original-cert")}, nil,
+		))
+		require.NoError(t, err)
+		originalStr := string(secretJSON)
+		jsonRawStr := string(secretJSON) // separate copy for the MW
+
+		mw := &workv1.ManifestWork{
+			Status: workv1.ManifestWorkStatus{
+				ResourceStatus: workv1.ManifestResourceStatus{
+					Manifests: []workv1.ManifestCondition{
+						{
+							StatusFeedbacks: workv1.StatusFeedbackResult{
+								Values: []workv1.FeedbackValue{
+									{
+										Name: "resource",
+										Value: workv1.FieldValue{
+											Type:    workv1.JsonRaw,
+											JsonRaw: &jsonRawStr,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result, err := RedactManifestWork(mw)
+		require.NoError(t, err)
+
+		// Original JsonRaw must be untouched
+		require.Equal(t, originalStr, *mw.Status.ResourceStatus.Manifests[0].StatusFeedbacks.Values[0].Value.JsonRaw,
+			"original JsonRaw should not be mutated")
+
+		// Result must be redacted
+		var redactedSecret corev1.Secret
+		require.NoError(t, json.Unmarshal(
+			[]byte(*result.Status.ResourceStatus.Manifests[0].StatusFeedbacks.Values[0].Value.JsonRaw),
+			&redactedSecret,
+		))
+		requireSecretRedacted(t, &redactedSecret) //nolint:gosec // pointer to local is fine in test
+	})
+}
+
+func TestDetectGVK(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     []byte
+		wantGVK schema.GroupVersionKind
+		wantOK  bool
+	}{
+		{
+			name:    "valid core/v1 Secret",
+			raw:     []byte(`{"apiVersion":"v1","kind":"Secret"}`),
+			wantGVK: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"},
+			wantOK:  true,
+		},
+		{
+			name:    "valid ManifestWork",
+			raw:     []byte(`{"apiVersion":"work.open-cluster-management.io/v1","kind":"ManifestWork"}`),
+			wantGVK: schema.GroupVersionKind{Group: "work.open-cluster-management.io", Version: "v1", Kind: "ManifestWork"},
+			wantOK:  true,
+		},
+		{
+			name:    "valid apps/v1 Deployment",
+			raw:     []byte(`{"apiVersion":"apps/v1","kind":"Deployment"}`),
+			wantGVK: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			wantOK:  true,
+		},
+		{
+			name:   "missing kind returns false",
+			raw:    []byte(`{"apiVersion":"v1"}`),
+			wantOK: false,
+		},
+		{
+			name:   "empty kind returns false",
+			raw:    []byte(`{"apiVersion":"v1","kind":""}`),
+			wantOK: false,
+		},
+		{
+			name:   "invalid JSON returns false",
+			raw:    []byte(`not json`),
+			wantOK: false,
+		},
+		{
+			name:   "empty bytes returns false",
+			raw:    []byte{},
+			wantOK: false,
+		},
+		{
+			name:   "JSON without K8s fields returns false",
+			raw:    []byte(`{"name":"foo","value":"bar"}`),
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gvk, ok := detectGVKFromRaw(tt.raw)
+			require.Equal(t, tt.wantOK, ok)
+			if ok {
+				require.Equal(t, tt.wantGVK, gvk)
+			}
+		})
+	}
+}
+
+// --- Test helpers ---
+
+func newRawManifest(t *testing.T, obj any) workv1.Manifest {
+	t.Helper()
+	raw, err := json.Marshal(obj)
+	require.NoError(t, err)
+	return workv1.Manifest{
+		RawExtension: runtime.RawExtension{Raw: raw},
+	}
+}
+
+func newTypedManifest(obj runtime.Object) workv1.Manifest {
+	return workv1.Manifest{
+		RawExtension: runtime.RawExtension{Object: obj},
+	}
+}
+
+func unmarshalSecretFromManifest(t *testing.T, m workv1.Manifest) *corev1.Secret {
+	t.Helper()
+	raw := manifestRaw(t, m)
+	var s corev1.Secret
+	require.NoError(t, json.Unmarshal(raw, &s))
+	return &s
+}
+
+func unmarshalManifestWorkFromManifest(t *testing.T, m workv1.Manifest) *workv1.ManifestWork {
+	t.Helper()
+	raw := manifestRaw(t, m)
+	var mw workv1.ManifestWork
+	require.NoError(t, json.Unmarshal(raw, &mw))
+	return &mw
+}
+
+func manifestRaw(t *testing.T, m workv1.Manifest) []byte {
+	t.Helper()
+	raw, err := m.MarshalJSON()
+	require.NoError(t, err)
+	return raw
+}
+
+func newSecret(name, namespace string, data map[string][]byte, stringData map[string]string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Data:       data,
+		StringData: stringData,
+		Type:       corev1.SecretTypeOpaque,
+	}
+}
+
+func newConfigMap(name, namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Data:       map[string]string{"key": "value"},
+	}
+}
+
+// requireSecretRedacted asserts that all Data values are the redacted placeholder
+// and all StringData values are the redacted placeholder.
+func requireSecretRedacted(t *testing.T, secret *corev1.Secret) {
+	t.Helper()
+	for k, v := range secret.Data {
+		require.Equal(t, []byte(redactedValue), v, "Data[%q] should be redacted", k)
+	}
+	for k, v := range secret.StringData {
+		require.Equal(t, redactedValue, v, "StringData[%q] should be redacted", k)
+	}
+}


### PR DESCRIPTION
We add a new manifestwork.RedactManifestWork function that returns a deep copy of a given ManifestWork with redacted sensitive data from Kubernetes Secrets that might be within it. It handles:
- Kubernetes Secrets embedded as manifests (redacts Data and StringData fields)
- Nested ManifestWorks that may themselves contain Secrets or further ManifestWorks (applied recursively)
- Status feedback JsonRaw values that may contain serialized sensitive K8s resources (e.g. a full Secret returned via a feedback rule)

Resources whose GVK cannot be determined from their raw JSON (e.g. partial status objects without apiVersion/kind) are left unchanged, as their type cannot be reliably inferred.

The function is useful for logging manifestworks content without showing the Kubernetes Secrets data values.