### PR TITLE
test: Timeout constants for resource creations

### DIFF
--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -13,7 +13,7 @@
   `framework.RBACScopeResource` is used in at least one test case in E2E
   test suite.
 * **Nodepool creation:** To create a nodepool, utilize the `CreateNodePoolFromParam` method. Beforehand, the default nodepool parameters should be prepared using the `NewDefaultNodePoolParams` method. Both of these methods are located within the `framework` module. Like cluster parameters, custom configurations can be assigned to the nodepool parameter values.
-* **Timeout of deployment:** To keep the timeout consistent with other test cases, use 45 minutes.
+* **Timeout of deployment:** Timeouts should be defined as named constants in `test/util/framework/constants.go` to ensure reusability and consistency across the test suite. Use the appropriate constant (e.g. `framework.ClusterCreationTimeout`, `framework.NodePoolCreationTimeout`, `framework.ExternalAuthCreationTimeout`) rather than hardcoding duration values. When a new timeout category is needed, add a constant to that file first.
 
 ## Resource naming \- Independence and Isolation
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -199,6 +199,35 @@ For instructions and best practices on creating ARO HCP E2E test cases, refer to
 
 Be sure to review these guidelines before creating or updating ARO HCP E2E test cases.
 
+## Updating Provisioning Timeouts
+Timeout constants are defined in [`test/util/framework/constants.go`](../util/framework/constants.go) and should be set to the **99th percentile** of observed provisioning durations. The decision should be based on results from all environments. To determine the appropriate values, run the following Kusto query which returns results grouped by `resource_type`. You can also adjust the `resourceType` or `controller_name` filter to narrow down to a specific resource type:
+
+```kql
+database('ServiceLogs').table('backendLogs')
+| where timestamp between (ago(7d) .. now())
+| where container_name == 'aro-hcp-backend'
+| where log.msg has 'new status'
+| where log.newStatus == 'Provisioning' or log.newStatus == 'Succeeded'
+| where log.controller_name endswith 'create'
+| project timestamp, resource_id = tostring(log.resource_id), status = tostring(log.newStatus), resource_type = tostring(log.resourceType), log.controller_name
+| summarize
+    provisioning_time = minif(timestamp, status == 'Provisioning'),
+    succeeded_time    = minif(timestamp, status == 'Succeeded')
+    by resource_id, resource_type
+| where isnotempty(provisioning_time) and isnotempty(succeeded_time)
+| extend duration = succeeded_time - provisioning_time
+| summarize
+    count  = count(),
+    avg    = avg(duration),
+    p50    = percentile(duration, 50),
+    p90    = percentile(duration, 90),
+    p95    = percentile(duration, 95),
+    p99    = percentile(duration, 99),
+    p999   = percentile(duration, 99.9),
+    p9999  = percentile(duration, 99.99)
+    by resource_type
+```
+
 ## General guidance to write E2E test with ginkgo
 
 Keep description of specs and tests informational and comprehensive so that it can be read and understood as a complete sentence, e.g. "Get HCPOpenShiftCluster: it fails to get a nonexistent cluster with a Not Found error by preparing an HCP clusters client (and) by sending a GET request for the nonexistent cluster".

--- a/test/e2e/admin_api.go
+++ b/test/e2e/admin_api.go
@@ -86,7 +86,7 @@ var _ = Describe("SRE", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/admin_api.go
+++ b/test/e2e/admin_api.go
@@ -301,7 +301,7 @@ var _ = Describe("SRE", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -315,7 +315,7 @@ var _ = Describe("SRE", func() {
 				*resourceGroup.Name,
 				engineeringClusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -408,7 +408,7 @@ var _ = Describe("SRE", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -422,7 +422,7 @@ var _ = Describe("SRE", func() {
 				*resourceGroup.Name,
 				engineeringClusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/admin_credential_lifecycle.go
+++ b/test/e2e/admin_credential_lifecycle.go
@@ -88,7 +88,7 @@ var _ = Describe("Customer", func() {
 
 			By("starting HCP cluster creation asynchronously")
 			clusterClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
-			timeout := 45 * time.Minute
+			timeout := framework.ClusterCreationTimeout
 			deploymentCtx, deploymentCancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during admin credential lifecycle test", timeout.Minutes()))
 			defer deploymentCancel()
 
@@ -159,7 +159,7 @@ var _ = Describe("Customer", func() {
 
 				// Continue waiting
 				return false
-			}, 45*time.Minute, 30*time.Second).Should(BeTrue(), "Cluster should become ready within 45 minutes")
+			}, framework.ClusterCreationTimeout, 30*time.Second).Should(BeTrue(), "Cluster should become ready within 45 minutes")
 
 			// Store all admin credentials for later validation
 			var credentials []*rest.Config

--- a/test/e2e/admin_credential_lifecycle.go
+++ b/test/e2e/admin_credential_lifecycle.go
@@ -159,7 +159,7 @@ var _ = Describe("Customer", func() {
 
 				// Continue waiting
 				return false
-			}, framework.ClusterCreationTimeout, 30*time.Second).Should(BeTrue(), "Cluster should become ready within 45 minutes")
+			}, framework.ClusterCreationTimeout, 30*time.Second).Should(BeTrue(), fmt.Sprintf("Cluster should become ready within '%f' minutes", framework.ClusterCreationTimeout.Minutes()))
 
 			// Store all admin credentials for later validation
 			var credentials []*rest.Config

--- a/test/e2e/arm64_nodepool.go
+++ b/test/e2e/arm64_nodepool.go
@@ -85,7 +85,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -104,7 +104,7 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -128,7 +128,7 @@ var _ = Describe("Authorized CIDRs", func() {
 					GinkgoLogr,
 					*resourceGroup.Name,
 					clusterParams,
-					45*time.Minute,
+					framework.ClusterCreationTimeout,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -237,7 +237,7 @@ var _ = Describe("Authorized CIDRs", func() {
 					*resourceGroup.Name,
 					clusterName,
 					nodePoolParams,
-					45*time.Minute,
+					framework.NodePoolCreationTimeout,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -290,7 +290,7 @@ var _ = Describe("Authorized CIDRs", func() {
 						},
 					},
 				}
-				_, err = framework.CreateOrUpdateExternalAuthAndWait(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, clusterName, customerExternalAuthName, extAuth, 15*time.Minute)
+				_, err = framework.CreateOrUpdateExternalAuthAndWait(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, clusterName, customerExternalAuthName, extAuth, framework.ExternalAuthCreationTimeout)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("verifying ExternalAuth is in a Succeeded state")

--- a/test/e2e/cluster_autoscaling.go
+++ b/test/e2e/cluster_autoscaling.go
@@ -92,7 +92,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -119,7 +119,7 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/cluster_create_cni_cilium.go
+++ b/test/e2e/cluster_create_cni_cilium.go
@@ -79,7 +79,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -154,7 +154,7 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			// We delay checking the error on purpose to get more details
 			// about the issue by running the verifiers.

--- a/test/e2e/cluster_create_complex_cilium_kv.go
+++ b/test/e2e/cluster_create_complex_cilium_kv.go
@@ -99,7 +99,7 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				clusterResource,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -183,7 +183,7 @@ var _ = Describe("Customer", func() {
 				customerClusterName,
 				customerNodePoolName,
 				nodePool,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			// We delay checking the error on purpose to get more details
 			// about the issue by running the verifiers.

--- a/test/e2e/cluster_create_nodepool_osdisk.go
+++ b/test/e2e/cluster_create_nodepool_osdisk.go
@@ -75,7 +75,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -89,7 +89,7 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/cluster_create_private_kv.go
+++ b/test/e2e/cluster_create_private_kv.go
@@ -97,7 +97,7 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				clusterResource,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			if isAPINotDeployedError(err) {
 				if time.Now().Before(timeBombDeadline) {
@@ -146,7 +146,7 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/cluster_delete_cx_rg.go
+++ b/test/e2e/cluster_delete_cx_rg.go
@@ -84,7 +84,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -120,7 +120,7 @@ var _ = Describe("Customer", func() {
 						*resourceGroup.Name,
 						customerClusterName,
 						nodePoolParams,
-						45*time.Minute,
+						framework.NodePoolCreationTimeout,
 					)
 					if createErr != nil {
 						errCh <- fmt.Errorf("nodepool %s: %w", nodePoolParams.NodePoolName, createErr)

--- a/test/e2e/cluster_nsg_subnet_reuse.go
+++ b/test/e2e/cluster_nsg_subnet_reuse.go
@@ -102,7 +102,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams1,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/cluster_pullsecret.go
+++ b/test/e2e/cluster_pullsecret.go
@@ -129,7 +129,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			By("Creating the node pool")
@@ -141,7 +141,7 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -89,7 +89,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -118,7 +118,7 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/cluster_update.go
+++ b/test/e2e/cluster_update.go
@@ -79,7 +79,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 					GinkgoLogr,
 					*resourceGroup.Name,
 					clusterParams,
-					45*time.Minute,
+					framework.ClusterCreationTimeout,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -155,7 +155,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 					GinkgoLogr,
 					*resourceGroup.Name,
 					clusterParams,
-					45*time.Minute,
+					framework.ClusterCreationTimeout,
 				)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/cluster_version_backlevel.go
+++ b/test/e2e/cluster_version_backlevel.go
@@ -143,7 +143,7 @@ var _ = Describe("Customer", func() {
 					*resourceGroup.Name,
 					clusterName,
 					cluster,
-					45*time.Minute,
+					framework.ClusterCreationTimeout,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -186,7 +186,7 @@ var _ = Describe("Customer", func() {
 						clusterName,
 						nodePoolName,
 						nodePool,
-						45*time.Minute,
+						framework.NodePoolCreationTimeout,
 					)
 					Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/clusters_sharing_resgroup.go
+++ b/test/e2e/clusters_sharing_resgroup.go
@@ -155,7 +155,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("attempting to create a third cluster using the same managed resource group as the second cluster")
-			err = tc.CreateHCPClusterFromParam(ctx, GinkgoLogr, *customerResourceGroup.Name, clusterParams3, 45*time.Minute)
+			err = tc.CreateHCPClusterFromParam(ctx, GinkgoLogr, *customerResourceGroup.Name, clusterParams3, framework.ClusterCreationTimeout)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(MatchRegexp("please provide a unique managed resource group name")))
 

--- a/test/e2e/clusters_sharing_resgroup.go
+++ b/test/e2e/clusters_sharing_resgroup.go
@@ -124,7 +124,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("waiting for first cluster to complete creation")
-			pollCtx, pollCancel := context.WithTimeout(ctx, 45*time.Minute)
+			pollCtx, pollCancel := context.WithTimeout(ctx, framework.ClusterCreationTimeout)
 			defer pollCancel()
 			_, err = poller1.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
 				Frequency: framework.StandardPollInterval,

--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -110,7 +110,7 @@ var _ = Describe("ARO-HCP", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -161,7 +161,7 @@ var _ = Describe("ARO-HCP", func() {
 				*resourceGroup.Name,
 				clusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -117,7 +117,7 @@ var _ = Describe("Service Provider", func() {
 					GinkgoLogr,
 					*resourceGroup.Name,
 					clusterParams,
-					45*time.Minute,
+					framework.ClusterCreationTimeout,
 				)
 				if createErr == nil {
 					return true, nil

--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -121,7 +121,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -88,7 +88,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -115,7 +115,7 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -168,7 +168,7 @@ var _ = Describe("Customer", func() {
 					},
 				},
 			}
-			_, err = framework.CreateOrUpdateExternalAuthAndWait(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, customerClusterName, customerExternalAuthName, extAuth, 15*time.Minute)
+			_, err = framework.CreateOrUpdateExternalAuthAndWait(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, customerClusterName, customerExternalAuthName, extAuth, framework.ExternalAuthCreationTimeout)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying ExternalAuth is in a Succeeded state")

--- a/test/e2e/external_auth_list_and_verify.go
+++ b/test/e2e/external_auth_list_and_verify.go
@@ -79,7 +79,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/external_auth_list_and_verify.go
+++ b/test/e2e/external_auth_list_and_verify.go
@@ -113,7 +113,7 @@ var _ = Describe("Customer", func() {
 				clusterName,
 				*expectedExternalAuth.Name,
 				expectedExternalAuth,
-				15*time.Minute,
+				framework.ExternalAuthCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -137,7 +137,7 @@ var _ = Describe("Customer", func() {
 				clusterName,
 				*anotherExternalAuth.Name,
 				anotherExternalAuth,
-				15*time.Minute,
+				framework.ExternalAuthCreationTimeout,
 			)
 			Expect(err).To(HaveOccurred())
 
@@ -185,7 +185,7 @@ var _ = Describe("Customer", func() {
 				clusterName,
 				*expectedExternalAuth.Name,
 				expectedExternalAuth,
-				15*time.Minute,
+				framework.ExternalAuthCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/gpu_nodepools_create_delete.go
+++ b/test/e2e/gpu_nodepools_create_delete.go
@@ -93,7 +93,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 					GinkgoLogr,
 					*resourceGroup.Name,
 					clusterParams,
-					45*time.Minute,
+					framework.ClusterCreationTimeout,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -124,7 +124,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 					*resourceGroup.Name,
 					customerClusterName,
 					defaultNodePoolParams,
-					45*time.Minute,
+					framework.NodePoolCreationTimeout,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -139,7 +139,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 					*resourceGroup.Name,
 					customerClusterName,
 					gpuNodePoolParams,
-					45*time.Minute,
+					framework.NodePoolCreationTimeout,
 				)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/idms_lifecycle.go
+++ b/test/e2e/idms_lifecycle.go
@@ -102,7 +102,7 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				clusterParams,
 				imageDigestMirrors,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 
 			var respErr *azcore.ResponseError

--- a/test/e2e/image_registry_cluster_create.go
+++ b/test/e2e/image_registry_cluster_create.go
@@ -84,7 +84,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/kusto_logs_present.go
+++ b/test/e2e/kusto_logs_present.go
@@ -82,7 +82,7 @@ var _ = Describe("Engineering", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			subscriptionID, err := tc.SubscriptionID(ctx)

--- a/test/e2e/nodepool_autoscaling.go
+++ b/test/e2e/nodepool_autoscaling.go
@@ -89,7 +89,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -138,7 +138,7 @@ var _ = Describe("Customer", func() {
 					*resourceGroup.Name,
 					customerClusterName,
 					azNodePoolParams,
-					45*time.Minute,
+					framework.NodePoolCreationTimeout,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -202,7 +202,7 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				noAZNodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -271,7 +271,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/nodepool_ephemeral_osdisk.go
+++ b/test/e2e/nodepool_ephemeral_osdisk.go
@@ -107,7 +107,7 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -128,7 +128,7 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 				customerClusterName,
 				customerNodePoolName,
 				nodePool,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			if isAPINotDeployedError(err) {
 				if time.Now().Before(timeBombDeadline) {

--- a/test/e2e/nodepool_labels_taints.go
+++ b/test/e2e/nodepool_labels_taints.go
@@ -86,7 +86,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -133,7 +133,7 @@ var _ = Describe("Customer", func() {
 				customerClusterName,
 				customerNodePoolName,
 				nodePool,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -220,7 +220,7 @@ var _ = Describe("Customer", func() {
 				customerClusterName,
 				customerNodePoolName,
 				update,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/nodepool_update_nodes.go
+++ b/test/e2e/nodepool_update_nodes.go
@@ -77,7 +77,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -112,7 +112,7 @@ var _ = Describe("Customer", func() {
 						*resourceGroup.Name,
 						customerClusterName,
 						nodePoolParams,
-						45*time.Minute,
+						framework.NodePoolCreationTimeout,
 					)
 					if createErr != nil {
 						errCh <- createErr

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -125,7 +125,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -142,7 +142,7 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				clusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/oidc_issuer_workload_identity.go
+++ b/test/e2e/oidc_issuer_workload_identity.go
@@ -211,7 +211,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -252,7 +252,7 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/shoebox_logs.go
+++ b/test/e2e/shoebox_logs.go
@@ -253,7 +253,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(ctx, GinkgoLogr, *resourceGroup.Name, clusterParams, 45*time.Minute)
+			err = tc.CreateHCPClusterFromParam(ctx, GinkgoLogr, *resourceGroup.Name, clusterParams, framework.ClusterCreationTimeout)
 			Expect(err).NotTo(HaveOccurred())
 
 			subscriptionID, err := tc.SubscriptionID(ctx)

--- a/test/e2e/simple_negative_cases.go
+++ b/test/e2e/simple_negative_cases.go
@@ -105,7 +105,7 @@ var _ = Describe("Customer", func() {
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				45*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -157,7 +157,7 @@ var _ = Describe("Customer", func() {
 				*resourceGroup.Name,
 				clusterParams.ClusterName,
 				nodePoolParams,
-				45*time.Minute,
+				framework.NodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -1,0 +1,22 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import "time"
+
+// Provisioning timeouts
+const ClusterCreationTimeout = 20 * time.Minute
+const NodePoolCreationTimeout = 45 * time.Minute
+const ExternalAuthCreationTimeout = 15 * time.Minute

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -18,5 +18,5 @@ import "time"
 
 // Provisioning timeouts
 const ClusterCreationTimeout = 20 * time.Minute
-const NodePoolCreationTimeout = 45 * time.Minute
+const NodePoolCreationTimeout = 20 * time.Minute
 const ExternalAuthCreationTimeout = 15 * time.Minute

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -16,6 +16,7 @@ package framework
 
 import "time"
 
+// When updating timeouts, please refer to test/e2e/README.md for instructions.
 // Provisioning timeouts
 const ClusterCreationTimeout = 20 * time.Minute
 const NodePoolCreationTimeout = 20 * time.Minute

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -18,6 +18,8 @@ import "time"
 
 // When updating timeouts, please refer to test/e2e/README.md for instructions.
 // Provisioning timeouts
-const ClusterCreationTimeout = 20 * time.Minute
-const NodePoolCreationTimeout = 20 * time.Minute
-const ExternalAuthCreationTimeout = 15 * time.Minute
+const (
+	ClusterCreationTimeout      = 20 * time.Minute
+	NodePoolCreationTimeout     = 20 * time.Minute
+	ExternalAuthCreationTimeout = 15 * time.Minute
+)


### PR DESCRIPTION
[ARO-24922](https://redhat.atlassian.net/browse/ARO-24922), [ARO-24505](https://redhat.atlassian.net/browse/ARO-24505)

### What

Add constants for default timeout period for cluster, nodepool and external-auth.
Change timeouts for cluster and nodepool creation from 45 minutes to 20 minutes.

### Why

Unify the timeouts between tests. Update timeouts to reflect SLOs

### Special notes for your reviewer