### PR TITLE
Parameterize cross-cluster Kusto scripts

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1891,6 +1891,12 @@
         "viewerGroups": {
           "type": "string"
         },
+        "crossClusterServiceLogsScript": {
+          "type": "string"
+        },
+        "crossClusterHostedControlPlaneLogsScript": {
+          "type": "string"
+        },
         "enableAutoScale": {
           "type": "boolean"
         },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -254,6 +254,8 @@ defaults:
     hostedControlPlaneLogsDatabase: "HostedControlPlaneLogs"
     adminGroups: ""
     viewerGroups: ""
+    crossClusterServiceLogsScript: ""
+    crossClusterHostedControlPlaneLogsScript: ""
     sku: ""
     tier: ""
   auditLogsEventHub:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -433,6 +433,8 @@ kusto:
   adminGroups: ""
   autoScaleMax: 10
   autoScaleMin: 2
+  crossClusterHostedControlPlaneLogsScript: ""
+  crossClusterServiceLogsScript: ""
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -433,6 +433,8 @@ kusto:
   adminGroups: ""
   autoScaleMax: 10
   autoScaleMin: 2
+  crossClusterHostedControlPlaneLogsScript: ""
+  crossClusterServiceLogsScript: ""
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -433,6 +433,8 @@ kusto:
   adminGroups: ""
   autoScaleMax: 10
   autoScaleMin: 2
+  crossClusterHostedControlPlaneLogsScript: ""
+  crossClusterServiceLogsScript: ""
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -433,6 +433,8 @@ kusto:
   adminGroups: ""
   autoScaleMax: 10
   autoScaleMin: 2
+  crossClusterHostedControlPlaneLogsScript: ""
+  crossClusterServiceLogsScript: ""
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -433,6 +433,8 @@ kusto:
   adminGroups: ""
   autoScaleMax: 10
   autoScaleMin: 2
+  crossClusterHostedControlPlaneLogsScript: ""
+  crossClusterServiceLogsScript: ""
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -433,6 +433,8 @@ kusto:
   adminGroups: ""
   autoScaleMax: 10
   autoScaleMin: 2
+  crossClusterHostedControlPlaneLogsScript: ""
+  crossClusterServiceLogsScript: ""
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2

--- a/dev-infrastructure/configurations/kusto.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/kusto.tmpl.bicepparam
@@ -21,3 +21,7 @@ param autoScaleMin = {{ .kusto.autoScaleMin }}
 param autoScaleMax = {{ .kusto.autoScaleMax }}
 
 param enableAutoScale = {{ .kusto.enableAutoScale }}
+
+param crossClusterServiceLogsScript = {{ if .kusto.crossClusterServiceLogsScript }}'''{{ .kusto.crossClusterServiceLogsScript }}'''{{ else }}''{{ end }}
+
+param crossClusterHostedControlPlaneLogsScript = {{ if .kusto.crossClusterHostedControlPlaneLogsScript }}'''{{ .kusto.crossClusterHostedControlPlaneLogsScript }}'''{{ else }}''{{ end }}

--- a/dev-infrastructure/modules/logs/kusto/main.bicep
+++ b/dev-infrastructure/modules/logs/kusto/main.bicep
@@ -31,6 +31,13 @@ param autoScaleMax int
 @description('Toggle if autoscale should be enabled')
 param enableAutoScale bool
 
+@description('Optional cross-cluster ServiceLogs Kusto script content.')
+@secure()
+param crossClusterServiceLogsScript string = ''
+
+@description('Optional cross-cluster HostedControlPlaneLogs Kusto script content.')
+@secure()
+param crossClusterHostedControlPlaneLogsScript string = ''
 var db = {
   serviceLogs: serviceLogsDatabase
   hostedControlPlaneLogs: hostedControlPlaneLogsDatabase
@@ -54,6 +61,9 @@ var allCustomerLogsTablesKQL = {
   containerlogs: loadTextContent('tables/containerLogs.kql')
   kubernetesEvents: loadTextContent('tables/kubernetesEvents.kql')
 }
+
+var deployCrossClusterServiceLogsScript = !empty(crossClusterServiceLogsScript)
+var deployCrossClusterHostedControlPlaneLogsScript = !empty(crossClusterHostedControlPlaneLogsScript)
 
 // 1. Cluster
 module cluster 'cluster.bicep' = {
@@ -138,7 +148,42 @@ module databaseUserScripts 'database-users.bicep' = [
   }
 ]
 
-// 5. Remove the caller principal
+// 5. Cross-cluster query scripts (executed when their script content is provided)
+module crossClusterServiceLogsQueryScript 'script.bicep' = if (deployCrossClusterServiceLogsScript) {
+  name: 'crossClusterServiceLogsScript'
+  params: {
+    kustoName: kustoName
+    databaseName: db.serviceLogs
+    scriptName: 'crossClusterQueries'
+    scriptContent: crossClusterServiceLogsScript
+    principalPermissionsAction: 'RetainPermissionOnScriptCompletion'
+    continueOnErrors: false
+  }
+  dependsOn: [
+    databaseUserScripts
+    serviceLogsTables
+    hostedControlPlaneLogsTables
+  ]
+}
+
+module crossClusterHostedControlPlaneLogsQueryScript 'script.bicep' = if (deployCrossClusterHostedControlPlaneLogsScript) {
+  name: 'crossClusterHostedControlPlaneLogsScript'
+  params: {
+    kustoName: kustoName
+    databaseName: db.hostedControlPlaneLogs
+    scriptName: 'crossClusterQueries'
+    scriptContent: crossClusterHostedControlPlaneLogsScript
+    principalPermissionsAction: 'RetainPermissionOnScriptCompletion'
+    continueOnErrors: false
+  }
+  dependsOn: [
+    databaseUserScripts
+    serviceLogsTables
+    hostedControlPlaneLogsTables
+  ]
+}
+
+// 6. Remove the caller principal
 // THIS MUST BE THE LAST SCRIPT TO RUN
 module removePermission 'script.bicep' = [
   for (database, i) in databases: {
@@ -155,6 +200,8 @@ module removePermission 'script.bicep' = [
       databaseUserScripts
       serviceLogsTables
       hostedControlPlaneLogsTables
+      crossClusterServiceLogsQueryScript
+      crossClusterHostedControlPlaneLogsQueryScript
     ]
   }
 ]

--- a/dev-infrastructure/templates/kusto.bicep
+++ b/dev-infrastructure/templates/kusto.bicep
@@ -34,6 +34,13 @@ param autoScaleMax int
 @description('Toggle if autoscale should be enabled')
 param enableAutoScale bool
 
+@description('Optional cross-cluster ServiceLogs Kusto script content.')
+@secure()
+param crossClusterServiceLogsScript string = ''
+
+@description('Optional cross-cluster HostedControlPlaneLogs Kusto script content.')
+@secure()
+param crossClusterHostedControlPlaneLogsScript string = ''
 module kusto '../modules/logs/kusto/main.bicep' = if (manageInstance) {
   name: 'kusto-${location}'
   params: {
@@ -48,5 +55,7 @@ module kusto '../modules/logs/kusto/main.bicep' = if (manageInstance) {
     autoScaleMin: autoScaleMin
     autoScaleMax: autoScaleMax
     enableAutoScale: enableAutoScale
+    crossClusterServiceLogsScript: crossClusterServiceLogsScript
+    crossClusterHostedControlPlaneLogsScript: crossClusterHostedControlPlaneLogsScript
   }
 }


### PR DESCRIPTION
[ARO-25331](https://redhat.atlassian.net/browse/ARO-25331)

### What
Parameterizes the normal Kusto Bicep path with two optional string parameters for cross-cluster script content, one for `ServiceLogs` and one for `HostedControlPlaneLogs`. The script deployment remains in the existing Kusto rollout, but the script text is no longer loaded from checked-in generated `.kql` files. Instead, the deployment consumes pre-generated script content supplied by the caller, and only deploys those scripts when the provided strings are non-empty.

### Why
The rollout-specific cluster list belongs to private `sdp-pipelines`, not public `ARO-HCP`. This keeps `ARO-HCP` generic and repo-self-contained while still allowing the normal Kusto deployment path to deploy cross-cluster entity groups and functions. It also avoids introducing a separate rollout path just for these scripts.

ref: [sdp-pipelines/pullrequest/15050727](https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/sdp-pipelines/pullrequest/15050727)