### PR TITLE
E2e add poll timeout to clusters_sharing_resgroup PollUntilDone calls

### DIFF
--- a/test/e2e/clusters_sharing_resgroup.go
+++ b/test/e2e/clusters_sharing_resgroup.go
@@ -131,7 +131,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("waiting for second cluster to complete creation")
-			defer pollCancel()
+
 			_, err = poller2.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
 				Frequency: framework.StandardPollInterval,
 			})

--- a/test/e2e/clusters_sharing_resgroup.go
+++ b/test/e2e/clusters_sharing_resgroup.go
@@ -123,13 +123,16 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("waiting for first cluster to complete creation")
-			_, err = poller1.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
+			pollCtx, pollCancel := context.WithTimeout(ctx, 45*time.Minute)
+			defer pollCancel()
+			_, err = poller1.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
 				Frequency: framework.StandardPollInterval,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("waiting for second cluster to complete creation")
-			_, err = poller2.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
+			defer pollCancel()
+			_, err = poller2.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
 				Frequency: framework.StandardPollInterval,
 			})
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### What

Add 45-minute timeout to cluster creation polling in e2e test.
Prevents indefinite polling in the clusters_sharing_resgroup e2e test by using a context with a 45-minute timeout for PollUntilDone calls.

### Why

The PollUntilDone calls in the e2e tests have no context timeout.
When cluster provisioning stalls for any reason, the test blocks indefinitely until CI's external hard kill terminates the process before it can write output, producing a misleading "deserialization error" instead of a clear timeout message.