### PR TITLE
Bring back nodepool version upgrade e2e with a revisited timeout

### DIFF
--- a/test/e2e/nodepool_ephemeral_osdisk.go
+++ b/test/e2e/nodepool_ephemeral_osdisk.go
@@ -218,7 +218,8 @@ func buildNodePoolWithDiskType(
 				ID:           to.Ptr(params.OpenshiftVersionId),
 				ChannelGroup: to.Ptr(params.ChannelGroup),
 			},
-			Replicas: to.Ptr(params.Replicas),
+			NodeDrainTimeoutMinutes: params.NodeDrainTimeoutMinutes,
+			Replicas:                to.Ptr(params.Replicas),
 			Platform: &hcpsdk20251223preview.NodePoolPlatformProfile{
 				VMSize: to.Ptr(params.VMSize),
 				OSDisk: &hcpsdk20251223preview.OsDiskProfile{

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/blang/semver/v4"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/cincinatti"
+	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+var _ = Describe("Customer", func() {
+	DescribeTable("should upgrade a nodepool",
+		func(ctx context.Context, nodePoolMinor string, targetMinor string) {
+			// ARO-25490 (https://redhat.atlassian.net/browse/ARO-25490): remove after 2026-04-07 UTC or when fixed in CS.
+			// Node pools on minor 4.21 fail during install (Azure marketplace image missing in CS).
+			if nodePoolMinor == "4.21" && time.Now().Before(time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC)) {
+				Skip("skipped until ARO-25490 fixed in CS or after 2026-04-07: 4.21 node pool install fails — " +
+					"Failed to process pending node pool 'npupgrade-4-21' for cluster '…': " +
+					"failed to retrieve azure marketplace image for nodepool 'npupgrade-4-21': azure marketplace image '4.21-gen2' not found")
+			}
+
+			channelGroup := framework.DefaultOpenshiftChannelGroup()
+			targetMinorVersion := api.Must(semver.ParseTolerant(targetMinor))
+			nodePoolMinorVersion := api.Must(semver.ParseTolerant(nodePoolMinor))
+
+			var (
+				nodePoolInitialVersion string
+				hasUpgradePath         bool
+				err                    error
+			)
+			if nodePoolMinorVersion.EQ(targetMinorVersion) {
+				// z-stream: same y.z line — older patch on node pool, cluster on latest patch.
+				nodePoolInitialVersion, hasUpgradePath, err = framework.GetInstallVersionForZStreamUpgrade(ctx, channelGroup, targetMinor)
+				if cincinatti.IsCincinnatiVersionNotFoundError(err) {
+					Skip(fmt.Sprintf("Cincinnati returned version not found for target minor %s on channel %s", targetMinor, channelGroup))
+				}
+				Expect(err).NotTo(HaveOccurred())
+				if !hasUpgradePath {
+					Skip(fmt.Sprintf("no z-stream upgrade path for minor %s on channel %s", targetMinor, channelGroup))
+				}
+			} else {
+				// y-stream: node pool on an older minor than the cluster (target minor).
+				Expect(nodePoolMinorVersion.LT(targetMinorVersion)).To(BeTrue(),
+					"when nodePoolMinor and targetMinor differ, node pool minor must be less than target minor (y-stream)")
+				nodePoolInitialVersion, hasUpgradePath, err = framework.GetLatestVersionInMinorWithUpgradePathTo(ctx, channelGroup, nodePoolMinor, targetMinor)
+				if cincinatti.IsCincinnatiVersionNotFoundError(err) {
+					Skip(fmt.Sprintf("Cincinnati returned version not found for node pool minor %s on channel %s", nodePoolMinor, channelGroup))
+				}
+				Expect(err).NotTo(HaveOccurred())
+				if !hasUpgradePath {
+					Skip(fmt.Sprintf("no version in %s with upgrade path to target minor %s", nodePoolMinor, targetMinor))
+				}
+			}
+
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			suffix := rand.String(6)
+			clusterName := "np-version-upgrade-cluster-" + suffix
+
+			By("creating resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-np-version-upgrade-"+suffix, tc.Location())
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating cluster parameters at control plane version")
+			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams.ClusterName = clusterName
+			clusterParams.OpenshiftVersionId = targetMinor
+			clusterParams.ChannelGroup = channelGroup
+			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name+"-np-upgrade-"+suffix, "-managed", 64)
+
+			By("creating customer resources")
+			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{
+					"customerNsgName":        "customer-nsg-np-upgrade-" + suffix,
+					"customerVnetName":       "customer-vnet-np-upgrade-" + suffix,
+					"customerVnetSubnetName": "customer-vnet-subnet-np-upgrade-" + suffix,
+				},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("creating the HCP cluster with version %s", targetMinor))
+			err = tc.CreateHCPClusterFromParam(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				45*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("creating nodepool with version %s (behind control plane; upgrade path validated via Cincinnati)", nodePoolInitialVersion))
+			// Node pool name must be a DNS label (no '.'); encode minor as e.g. 4.20 -> npupgrade-4-20.
+			customerNodePoolName := fmt.Sprintf("npupgrade-%s", strings.ReplaceAll(nodePoolMinor, ".", "-"))
+			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams.NodePoolName = customerNodePoolName
+			nodePoolParams.OpenshiftVersionId = nodePoolInitialVersion
+			nodePoolParams.ChannelGroup = channelGroup
+
+			err = tc.CreateNodePoolFromParam(
+				ctx,
+				*resourceGroup.Name,
+				clusterName,
+				nodePoolParams,
+				45*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("getting admin credentials and lowest control plane version from OpenShift version history")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				clusterName,
+				10*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			configClient, err := configv1client.NewForConfig(adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred())
+			clusterVersion, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			var parseableVersions []string
+			for _, h := range clusterVersion.Status.History {
+				if _, err := semver.ParseTolerant(h.Version); err != nil {
+					continue
+				}
+				parseableVersions = append(parseableVersions, h.Version)
+				if h.State == configv1.CompletedUpdate {
+					break
+				}
+			}
+			sort.Slice(parseableVersions, func(i, j int) bool {
+				vi, _ := semver.ParseTolerant(parseableVersions[i])
+				vj, _ := semver.ParseTolerant(parseableVersions[j])
+				return vi.LT(vj)
+			})
+			Expect(parseableVersions).NotTo(BeEmpty(), "no clusterversion status.history entry with valid parseable version")
+
+			By("computing nodepool desired version from Cincinnati (lowest <= lowest control plane version with upgrade path from nodepool)")
+			candidates, err := framework.GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx,
+				channelGroup, parseableVersions[0], nodePoolInitialVersion)
+			Expect(err).NotTo(HaveOccurred())
+			if len(candidates) == 0 {
+				Skip(fmt.Sprintf("skipping: no Cincinnati upgrade path from nodepool version %s to any version <= %s (lowest control plane version in history); cannot exercise nodepool upgrade", nodePoolInitialVersion, parseableVersions[0]))
+			}
+			nodePoolDesiredVersion := candidates[len(candidates)-1].String()
+
+			By("capturing node release images before upgrade")
+			previousReleaseImages, err := framework.NodePoolReleaseImages(ctx, adminRESTConfig, customerNodePoolName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(previousReleaseImages).NotTo(BeEmpty(), "expected node pool nodes to report at least one release image ref before upgrade")
+
+			By(fmt.Sprintf("triggering nodepool upgrade to version %s", nodePoolDesiredVersion))
+			nodePoolsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
+			update := hcpsdk20240610preview.NodePoolUpdate{
+				Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
+					Version: &hcpsdk20240610preview.NodePoolVersionProfile{
+						ID:           to.Ptr(nodePoolDesiredVersion),
+						ChannelGroup: to.Ptr(channelGroup),
+					},
+				},
+			}
+			_, err = framework.UpdateNodePoolAndWait(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName, update, 45*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying nodes are ready, updated to expected version, and release images differ from pre-upgrade")
+			// Node pool upgrades typically finish in on the order of a dozen minutes; the Eventually timeout below
+			// adds buffer on the safe side for this initial E2E. TODO: tighten to align with the node pool upgrade
+			// SLO once determined.
+			Eventually(func() error {
+				return verifiers.VerifyNodePoolUpgrade(nodePoolDesiredVersion, customerNodePoolName, previousReleaseImages).Verify(ctx, adminRESTConfig)
+			}, 30*time.Minute, 2*time.Minute).Should(Succeed())
+
+			By("verifying node pool GET still reflects the new version")
+			npGetResponse, err := framework.GetNodePool(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(npGetResponse.Properties).NotTo(BeNil())
+			Expect(npGetResponse.Properties.Version).NotTo(BeNil())
+			Expect(npGetResponse.Properties.Version.ID).NotTo(BeNil())
+			Expect(*npGetResponse.Properties.Version.ID).To(Equal(nodePoolDesiredVersion))
+		},
+		Entry("from 4.20.z to 4.21.zLatest",
+			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible,
+			"4.20", "4.21"),
+		Entry("from 4.21.z to 4.21.zLatest",
+			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible,
+			"4.21", "4.21"),
+		Entry("from 4.20.z to 4.20.zLatest",
+			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible,
+			"4.20", "4.20"),
+	)
+})

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -138,7 +138,7 @@ var _ = Describe("Customer", func() {
 			nodePoolParams.NodePoolName = customerNodePoolName
 			nodePoolParams.OpenshiftVersionId = nodePoolInitialVersion
 			nodePoolParams.ChannelGroup = channelGroup
-
+			nodePoolParams.NodeDrainTimeoutMinutes = to.Ptr(int32(10))
 			err = tc.CreateNodePoolFromParam(
 				ctx,
 				*resourceGroup.Name,

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -206,12 +206,14 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying nodes are ready, updated to expected version, and release images differ from pre-upgrade")
-			// Node pool upgrades typically finish in on the order of a dozen minutes; the Eventually timeout below
-			// adds buffer on the safe side for this initial E2E. TODO: tighten to align with the node pool upgrade
-			// SLO once determined.
+			// We have seen the backend take on the order of ~8 minutes to trigger the upgrade in CS; from there
+			// the upgrade proceeds on its usual ~15–20 minute course. A 30 minute window left the test on the
+			// edge of failing, so we use 45 minutes while investigating backend delay. Leads under discussion:
+			// - Increase backend memory: https://github.com/Azure/ARO-HCP/pull/4581 , https://github.com/Azure/ARO-HCP/pull/4641
+			// - Fire controllers sooner when Cosmos documents change: https://github.com/Azure/ARO-HCP/pull/4485 , https://github.com/Azure/ARO-HCP/pull/3913
 			Eventually(func() error {
 				return verifiers.VerifyNodePoolUpgrade(nodePoolDesiredVersion, customerNodePoolName, previousReleaseImages).Verify(ctx, adminRESTConfig)
-			}, 30*time.Minute, 2*time.Minute).Should(Succeed())
+			}, 45*time.Minute, 2*time.Minute).Should(Succeed())
 
 			By("verifying node pool GET still reflects the new version")
 			npGetResponse, err := framework.GetNodePool(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)

--- a/test/go.mod
+++ b/test/go.mod
@@ -29,8 +29,10 @@ require (
 	github.com/openshift/api v0.0.0-20260130140113-71e91db96ffc
 	github.com/openshift/client-go v0.0.0-20260108185524-48f4ccfc4e13
 	github.com/openshift/cluster-version-operator v1.0.1-0.20260202115537-557510ea0603
+	github.com/openshift/hypershift/api v0.0.0-20260226113135-8ab86680f975
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
 	go.yaml.in/yaml/v2 v2.4.4
 	golang.org/x/crypto v0.49.0
 	golang.org/x/sync v0.20.0
@@ -214,7 +216,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/openshift-online/ocm-api-model/clientapi v0.0.453 // indirect
 	github.com/openshift-online/ocm-sdk-go v0.1.498 // indirect
-	github.com/openshift/hypershift/api v0.0.0-20260226113135-8ab86680f975 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -241,7 +242,6 @@ require (
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.3 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tektoncd/pipeline v1.6.0 // indirect
 	github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 // indirect
 	github.com/tetratelabs/wazero v1.9.0 // indirect

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -29,4 +29,7 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
 Customer should be able to update nodepool replicas and autoscaling
+Customer should upgrade a nodepool from 4.20.z to 4.21.zLatest
+Customer should upgrade a nodepool from 4.21.z to 4.21.zLatest
+Customer should upgrade a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -30,5 +30,8 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
+Customer should upgrade a nodepool from 4.20.z to 4.21.zLatest
+Customer should upgrade a nodepool from 4.21.z to 4.21.zLatest
+Customer should upgrade a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -29,5 +29,8 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
+Customer should upgrade a nodepool from 4.20.z to 4.21.zLatest
+Customer should upgrade a nodepool from 4.21.z to 4.21.zLatest
+Customer should upgrade a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -31,5 +31,8 @@ Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
 Customer should be able to update nodepool replicas and autoscaling
+Customer should upgrade a nodepool from 4.20.z to 4.21.zLatest
+Customer should upgrade a nodepool from 4.21.z to 4.21.zLatest
+Customer should upgrade a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -27,5 +27,8 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
+Customer should upgrade a nodepool from 4.20.z to 4.21.zLatest
+Customer should upgrade a nodepool from 4.21.z to 4.21.zLatest
+Customer should upgrade a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -29,5 +29,8 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
+Customer should upgrade a nodepool from 4.20.z to 4.21.zLatest
+Customer should upgrade a nodepool from 4.21.z to 4.21.zLatest
+Customer should upgrade a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources

--- a/test/util/framework/deployment_params.go
+++ b/test/util/framework/deployment_params.go
@@ -154,6 +154,10 @@ type NodePoolParams struct {
 	OSDiskSizeGiB          int32
 	DiskStorageAccountType string
 	ChannelGroup           string
+	// NodeDrainTimeoutMinutes: how long (in minutes) to respect Pod Disruption Budgets when draining
+	// nodes in this pool (e.g. upgrades, scale-in). Valid: 0 to 10080. 0 = no time limit for that phase.
+	// When omitted from the create payload or nil here, the cluster-configured global nodeDrainTimeoutMinutes kicks in.
+	NodeDrainTimeoutMinutes *int32
 	// AutoScaling enables nodepool autoscaling. When set, Replicas is ignored.
 	AutoScaling *NodePoolAutoScalingParams
 }

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -850,7 +850,8 @@ func BuildNodePoolFromParams(
 				ID:           to.Ptr(parameters.OpenshiftVersionId),
 				ChannelGroup: to.Ptr(parameters.ChannelGroup),
 			},
-			Replicas: to.Ptr(parameters.Replicas),
+			NodeDrainTimeoutMinutes: parameters.NodeDrainTimeoutMinutes,
+			Replicas:                to.Ptr(parameters.Replicas),
 			Platform: &hcpsdk20240610preview.NodePoolPlatformProfile{
 				VMSize: to.Ptr(parameters.VMSize),
 				OSDisk: &hcpsdk20240610preview.OsDiskProfile{

--- a/test/util/framework/nodes_helper.go
+++ b/test/util/framework/nodes_helper.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/set"
+
+	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+// SelectNodesBelongingToNodePool groups nodes by the HyperShift node label (hypershift/v1beta1.NodePoolLabel).
+//
+// HyperShift sets that label to "<HostedCluster prefix>-<nodePoolName>" (hyphen-separated), e.g. label
+// "e2e-cluster-np-init-0" for customer node pool name "np-init-0". A node matches when the label value ends
+// with "-<nodePoolName>" (the pool name is the final segment, not a prefix of the whole label).
+//
+// A Kubernetes LabelSelector is not enough here: it only matches on the full label value (equality / set-based),
+// not on a suffix or substring. Tests and callers typically know only the ARM node pool name, not the
+// HostedCluster-specific prefix, so the complete label value is unknown until nodes are listed and inspected.
+//
+// If several distinct label values match (e.g. one nodePoolName is a suffix of another pool’s name so both
+// match HasSuffix), it returns the nodes for the label with the shortest length (tightest match). Under one
+// HostedCluster the prefix is shared, so the real pool label is a single map key; same-length ties for
+// different strings do not occur in that case.
+//
+// nodePoolName must be non-empty (otherwise returns an error).
+func SelectNodesBelongingToNodePool(nodes []corev1.Node, nodePoolName string) ([]corev1.Node, error) {
+	if len(nodePoolName) == 0 {
+		return nil, errors.New("nodePoolName is required")
+	}
+	byLabel := make(map[string][]corev1.Node)
+	for i := range nodes {
+		lv, ok := nodes[i].Labels[hypershiftv1beta1.NodePoolLabel]
+		if !ok {
+			continue
+		}
+		if !strings.HasSuffix(lv, "-"+nodePoolName) {
+			continue
+		}
+		byLabel[lv] = append(byLabel[lv], nodes[i])
+	}
+	if len(byLabel) == 0 {
+		return nil, nil
+	}
+	// Shortest label is the tightest suffix match when multiple label values matched.
+	shortestLabelValue := ""
+	for labelValue := range byLabel {
+		if len(shortestLabelValue) == 0 || len(labelValue) < len(shortestLabelValue) {
+			shortestLabelValue = labelValue
+		}
+	}
+	return byLabel[shortestLabelValue], nil
+}
+
+// NodePoolReleaseImages returns release image refs from node.Status.Images for nodes in the given pool
+// (lists nodes, then SelectNodesBelongingToNodePool). nodePoolName must be non-empty.
+func NodePoolReleaseImages(ctx context.Context, adminRESTConfig *rest.Config, nodePoolName string) (set.Set[string], error) {
+	kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+	list, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list nodes (nodePool=%s): %w", nodePoolName, err)
+	}
+	nodes, err := SelectNodesBelongingToNodePool(list.Items, nodePoolName)
+	if err != nil {
+		return nil, err
+	}
+	images := set.Set[string]{}
+	for i := range nodes {
+		for _, img := range nodes[i].Status.Images {
+			for _, name := range img.Names {
+				images.Insert(name)
+			}
+		}
+	}
+	return images, nil
+}

--- a/test/util/framework/nodes_helper_test.go
+++ b/test/util/framework/nodes_helper_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+func TestSelectNodesBelongingToNodePool(t *testing.T) {
+	t.Parallel()
+
+	nodeWithNodePoolLabel := func(labelValue string) corev1.Node {
+		return corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: labelValue + "-" + uuid.NewString(),
+				Labels: map[string]string{
+					v1beta1.NodePoolLabel: labelValue,
+				},
+			},
+		}
+	}
+
+	node1 := nodeWithNodePoolLabel("e2e-cluster-np")
+	node2 := nodeWithNodePoolLabel("e2e-cluster-np")
+	node3 := nodeWithNodePoolLabel("e2e-cluster-worker-np")
+	node4 := nodeWithNodePoolLabel("e2e-cluster-infra-worker-np")
+
+	tests := []struct {
+		name                  string
+		nodes                 []corev1.Node
+		pool                  string
+		expectError           bool
+		expectedErrorContains string
+		wantNodes             []corev1.Node
+	}{
+		{
+			name:                  "empty nodePoolName",
+			pool:                  "",
+			expectError:           true,
+			expectedErrorContains: "nodePoolName is required",
+		},
+		{
+			name:      "empty node list",
+			nodes:     nil,
+			pool:      "np",
+			wantNodes: nil,
+		},
+		{
+			name: "missing label", // this should never happen
+			nodes: []corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Labels: map[string]string{"other": "v"}}},
+			},
+			pool:      "np",
+			wantNodes: nil,
+		},
+		{
+			name:      "suffix does not match",
+			nodes:     []corev1.Node{node4, node3, node2, node1},
+			pool:      "other-pool",
+			wantNodes: nil,
+		},
+		{
+			name:      "nodePoolName full hypershift label does not match suffix rule",
+			nodes:     []corev1.Node{node1, node2},
+			pool:      "e2e-cluster-np",
+			wantNodes: nil,
+		},
+		{
+			name:      "shortest matching label wins when suffix overlaps",
+			nodes:     []corev1.Node{node4, node3, node1, node2},
+			pool:      "np",
+			wantNodes: []corev1.Node{node1, node2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			nodes, err := SelectNodesBelongingToNodePool(tt.nodes, tt.pool)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.NotEmpty(t, tt.expectedErrorContains, "expectedErrorContains should be set when expectError is true")
+				assert.ErrorContains(t, err, tt.expectedErrorContains)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantNodes, nodes, "returned nodes must match")
+		})
+	}
+}

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -18,9 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"sort"
-	"strings"
 
 	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
@@ -38,88 +36,153 @@ import (
 // caller can install and optionally skip upgrade assertions.
 func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string, configuredVersionID string) (installVersion string, hasUpgradePath bool, err error) {
 	configuredVersion := api.Must(semver.ParseTolerant(configuredVersionID))
+	candidates, err := GetAllVersionsInMinorStartingWith(ctx, channelGroup, configuredVersionID)
+	if err != nil {
+		return "", false, err
+	}
+	if len(candidates) == 1 {
+		return configuredVersion.String(), false, nil
+	}
+
+	nextMinorStr := fmt.Sprintf("%d.%d", configuredVersion.Major, configuredVersion.Minor+1)
+	maxVersion, err := GetLatestVersionInMinor(ctx, channelGroup, nextMinorStr)
+	if err != nil {
+		if !cincinatti.IsCincinnatiVersionNotFoundError(err) {
+			return "", false, err
+		}
+		// we don't have the next minor, use the max version in the current minor
+		maxVersion = candidates[0].String()
+	}
+
+	for i := 0; i < len(candidates)-1; i++ {
+		upgradeTargets, err := GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx, channelGroup, maxVersion, candidates[i].String())
+		if err != nil {
+			return "", false, err
+		}
+		if len(upgradeTargets) > 0 {
+			return candidates[i+1].String(), true, nil
+		}
+	}
+	return candidates[0].String(), false, nil
+}
+
+// GetAllVersionsInMinorStartingWith returns all OpenShift versions in the same major.minor as the given version,
+// including that version, from Cincinnati for the given channelGroup. The version string is parse-tolerant
+// (e.g. "4.20", "4.20.0", "4.20.1"). Results are sorted descending (latest first).
+func GetAllVersionsInMinorStartingWith(ctx context.Context, channelGroup string, version string) ([]semver.Version, error) {
+	fromVersion, err := semver.ParseTolerant(version)
+	if err != nil {
+		return nil, fmt.Errorf("parse version %q: %w", version, err)
+	}
 
 	cincinnatiURI, err := cincinatti.GetCincinnatiURI(channelGroup)
 	if err != nil {
-		return "", false, fmt.Errorf("get Cincinnati URI: %w", err)
+		return nil, fmt.Errorf("get Cincinnati URI: %w", err)
 	}
-
 	transport, _ := http.DefaultTransport.(*http.Transport)
 	if transport == nil {
 		transport = &http.Transport{}
 	}
 	client := cvocincinnati.NewClient(uuid.NameSpaceDNS, transport, "ARO-HCP", cincinatti.NewAlwaysConditionRegistry())
-	channel := fmt.Sprintf("%s-%d.%d", channelGroup, configuredVersion.Major, configuredVersion.Minor)
+	channel := fmt.Sprintf("%s-%d.%d", channelGroup, fromVersion.Major, fromVersion.Minor)
 
-	_, possibleUpgradeCandidates, _, err := client.GetUpdates(ctx, cincinnatiURI, "multi", "multi", channel, configuredVersion)
+	_, possibleUpgradeCandidates, _, err := client.GetUpdates(ctx, cincinnatiURI, "multi", "multi", channel, fromVersion)
 	if err != nil {
-		return "", false, fmt.Errorf("get Cincinnati updates for %s in %s: %w", configuredVersion.String(), channel, err)
+		return nil, err
 	}
 
-	// Restrict to versions in the same major.minor (z-stream only).
-	candidates := []semver.Version{configuredVersion}
+	candidates := []semver.Version{fromVersion}
 	for _, release := range possibleUpgradeCandidates {
 		candidateVersion := api.Must(semver.ParseTolerant(release.Version))
-		if candidateVersion.Major != configuredVersion.Major || candidateVersion.Minor != configuredVersion.Minor {
+		if candidateVersion.Major != fromVersion.Major || candidateVersion.Minor != fromVersion.Minor {
 			continue
 		}
 		candidates = append(candidates, candidateVersion)
 	}
-
 	sort.Slice(candidates, func(i, j int) bool {
 		return candidates[j].LT(candidates[i])
 	})
-
-	if len(candidates) == 1 {
-		return configuredVersion.String(), false, nil
-	}
-
-	return pickInstallVersionWithNextMinorPreference(ctx, client, cincinnatiURI, channelGroup, configuredVersion, candidates)
+	return candidates, nil
 }
 
-// pickInstallVersionWithNextMinorPreference chooses an install version from versionsInSameMinor (sorted descending, latest first).
-// When the next minor exists, it prefers a version whose upgrade target has an upgrade path to the next minor; otherwise it returns the version just before latest.
-// The second return value is true only when an install version with an upgrade path was found.
-func pickInstallVersionWithNextMinorPreference(ctx context.Context, client cincinatti.Client, cincinnatiURI *url.URL, channelGroup string, configuredVersion semver.Version, versionsInSameMinor []semver.Version) (string, bool, error) {
-	installTarget := versionsInSameMinor[1] // latest is first, so second is the default install (upgrade to latest)
-	nextMinorStr := fmt.Sprintf("%d.%d", configuredVersion.Major, configuredVersion.Minor+1)
-	nextMinorChannel := fmt.Sprintf("%s-%s", channelGroup, nextMinorStr)
-	_, _, _, nextMinorErr := client.GetUpdates(ctx, cincinnatiURI, "multi", "multi", nextMinorChannel, installTarget)
-	if nextMinorErr != nil && !cincinatti.IsCincinnatiVersionNotFoundError(nextMinorErr) {
-		return "", false, fmt.Errorf("checking next minor %s: %w", nextMinorStr, nextMinorErr)
+// GetLatestVersionInMinor returns the latest OpenShift version for the given major.minor (e.g. "4.20")
+// from Cincinnati for the given channelGroup (e.g. "candidate", "stable").
+func GetLatestVersionInMinor(ctx context.Context, channelGroup string, minorVersion string) (string, error) {
+	versions, err := GetAllVersionsInMinorStartingWith(ctx, channelGroup, minorVersion)
+	if err != nil {
+		return "", err
 	}
-	if nextMinorErr != nil {
-		// Next minor not available; use default (version just before latest). Upgrade path exists (z-stream to latest).
-		return installTarget.String(), true, nil
+	if len(versions) == 0 {
+		return "", &cvocincinnati.Error{Reason: "VersionNotFound", Message: fmt.Sprintf("no versions found for minor %s", minorVersion)}
 	}
-	// Find the latest upgrade target that has path to next minor; install is the version next to it (one step older).
-	for i := 0; i < len(versionsInSameMinor)-1; i++ {
-		hasPath, err := hasUpgradePathToNextMinor(ctx, client, cincinnatiURI, nextMinorChannel, nextMinorStr, versionsInSameMinor[i])
+	return versions[0].String(), nil
+}
+
+// GetLatestVersionInMinorWithUpgradePathTo returns the latest OpenShift version for fromMinor (e.g. "4.20")
+// that has a Cincinnati upgrade path to toMinor (e.g. "4.21"), for the given channelGroup.
+// hasUpgradePath is false when no version in fromMinor has an upgrade path to toMinor.
+func GetLatestVersionInMinorWithUpgradePathTo(ctx context.Context, channelGroup string, fromMinor string, toMinor string) (version string, hasUpgradePath bool, err error) {
+	versionsInFromMinor, err := GetAllVersionsInMinorStartingWith(ctx, channelGroup, fromMinor)
+	if err != nil {
+		return "", false, err
+	}
+	maxInToMinor, err := GetLatestVersionInMinor(ctx, channelGroup, toMinor)
+	if err != nil {
+		return "", false, err
+	}
+	for _, v := range versionsInFromMinor {
+		candidates, err := GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx, channelGroup, maxInToMinor, v.String())
 		if err != nil {
 			return "", false, err
 		}
-		if hasPath {
-			return versionsInSameMinor[i+1].String(), true, nil
+		if len(candidates) > 0 {
+			return v.String(), true, nil
 		}
 	}
-	// No version has path to next minor; install the latest in same minor (no upgrade path to verify).
-	return versionsInSameMinor[0].String(), false, nil
+	return "", false, nil
 }
 
-// hasUpgradePathToNextMinor returns true if the given version has an upgrade path to the next minor.
-// nextMinorChannel is the Cincinnati channel for the next minor (e.g. "candidate-4.21"); nextMinor is the version prefix (e.g. "4.21").
-func hasUpgradePathToNextMinor(ctx context.Context, cincinnatiClient cincinatti.Client, uri *url.URL, nextMinorChannel, nextMinor string, ver semver.Version) (bool, error) {
-	_, updates, _, err := cincinnatiClient.GetUpdates(ctx, uri, "multi", "multi", nextMinorChannel, ver)
-	if err != nil && !cincinatti.IsCincinnatiVersionNotFoundError(err) {
-		return false, err
-	}
+// GetUpgradeCandidatesInMaxMinorFromCincinnati returns all versions in the same major.minor as maxVersion
+// that are <= maxVersion and have a Cincinnati upgrade path from fromVersion, for the given channelGroup.
+// Results are sorted from lowest to highest. Use for possible upgrade targets (e.g. node pool y-stream upgrade).
+func GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx context.Context, channelGroup string, maxVersion string, fromVersion string) (candidates []semver.Version, err error) {
+	maxVer, err := semver.ParseTolerant(maxVersion)
 	if err != nil {
-		return false, nil
+		return nil, fmt.Errorf("parse maxVersion %q: %w", maxVersion, err)
 	}
-	for _, r := range updates {
-		if strings.Contains(r.Version, nextMinor+".") {
-			return true, nil
+	fromVer, err := semver.ParseTolerant(fromVersion)
+	if err != nil {
+		return nil, fmt.Errorf("parse fromVersion %q: %w", fromVersion, err)
+	}
+	channel := fmt.Sprintf("%s-%d.%d", channelGroup, maxVer.Major, maxVer.Minor)
+
+	cincinnatiURI, err := cincinatti.GetCincinnatiURI(channelGroup)
+	if err != nil {
+		return nil, fmt.Errorf("get Cincinnati URI: %w", err)
+	}
+	transport, _ := http.DefaultTransport.(*http.Transport)
+	if transport == nil {
+		transport = &http.Transport{}
+	}
+	client := cvocincinnati.NewClient(uuid.NameSpaceDNS, transport, "ARO-HCP", cincinatti.NewAlwaysConditionRegistry())
+
+	_, possibleCandidates, _, err := client.GetUpdates(ctx, cincinnatiURI, "multi", "multi", channel, fromVer)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []semver.Version
+	for _, release := range possibleCandidates {
+		candidateVersion := api.Must(semver.ParseTolerant(release.Version))
+		if candidateVersion.Major != maxVer.Major || candidateVersion.Minor != maxVer.Minor {
+			continue
+		}
+		if !candidateVersion.GT(maxVer) {
+			out = append(out, candidateVersion)
 		}
 	}
-	return false, nil
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].LT(out[j])
+	})
+	return out, nil
 }

--- a/test/util/verifiers/nodes.go
+++ b/test/util/verifiers/nodes.go
@@ -16,11 +16,22 @@ package verifiers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"regexp"
+	"strings"
 
+	"github.com/blang/semver/v4"
+
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/set"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
+	"github.com/Azure/ARO-HCP/test/util/framework"
 )
 
 type verifyNodesReady struct{}
@@ -46,13 +57,7 @@ func (v verifyNodesReady) Verify(ctx context.Context, adminRESTConfig *rest.Conf
 
 	var notReadyNodes []string
 	for _, node := range nodes.Items {
-		var nodeIsReady = false
-		for _, condition := range node.Status.Conditions {
-			if condition.Type == "Ready" && condition.Status == "True" {
-				nodeIsReady = true
-			}
-		}
-		if !nodeIsReady {
+		if !nodeReady(&node) {
 			notReadyNodes = append(notReadyNodes, node.Name)
 		}
 	}
@@ -97,4 +102,147 @@ func VerifyNodeCount(expected int) HostedClusterVerifier {
 	return verifyNodeCount{
 		expected: expected,
 	}
+}
+
+type verifyNodePoolUpgrade struct {
+	expectedVersion       string
+	nodePoolName          string
+	previousReleaseImages set.Set[string]
+}
+
+// nodeSummary is a compact representation of a node for error messages.
+// Full node objects can be 10KB+ due to annotations and are too large for error output.
+type nodeSummary struct {
+	Name                    string   `json:"name"`
+	Ready                   bool     `json:"ready"`
+	ContainerRuntimeVersion string   `json:"containerRuntimeVersion"`
+	ReleaseImages           []string `json:"releaseImages,omitempty"`
+}
+
+func summarizeNodes(nodes []corev1.Node) []nodeSummary {
+	summaries := make([]nodeSummary, len(nodes))
+	for i, node := range nodes {
+		var releaseImages []string
+		for _, img := range node.Status.Images {
+			releaseImages = append(releaseImages, img.Names...)
+		}
+		summaries[i] = nodeSummary{
+			Name:                    node.Name,
+			Ready:                   nodeReady(to.Ptr(node)),
+			ContainerRuntimeVersion: node.Status.NodeInfo.ContainerRuntimeVersion,
+			ReleaseImages:           releaseImages,
+		}
+	}
+	return summaries
+}
+
+func (v verifyNodePoolUpgrade) Name() string {
+	return fmt.Sprintf("VerifyNodePoolUpgrade(expected=%s, nodePool=%s)", v.expectedVersion, v.nodePoolName)
+}
+
+func (v verifyNodePoolUpgrade) Verify(ctx context.Context, adminRESTConfig *rest.Config) error {
+	expectedSemver, err := semver.ParseTolerant(v.expectedVersion)
+	if err != nil {
+		return fmt.Errorf("parse expected version %q: %w", v.expectedVersion, err)
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+	nodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list nodes (nodePool=%s): %w", v.nodePoolName, err)
+	}
+	matchingNodes, err := framework.SelectNodesBelongingToNodePool(nodes.Items, v.nodePoolName)
+	if err != nil {
+		return err
+	}
+	var reasons []string
+	for i := range matchingNodes {
+		node := &matchingNodes[i]
+		if !nodeReady(node) {
+			reasons = append(reasons, fmt.Sprintf("%s (not ready)", node.Name))
+			continue
+		}
+		if reason := v.nodeVersionInMinor(node, expectedSemver); len(reason) > 0 {
+			reasons = append(reasons, reason)
+			continue
+		}
+		if reason := v.nodeReleaseImagesUpdated(node); len(reason) > 0 {
+			reasons = append(reasons, reason)
+		}
+	}
+	if len(matchingNodes) == 0 {
+		return fmt.Errorf("no nodes found in node pool %q", v.nodePoolName)
+	}
+	if len(reasons) == 0 {
+		return nil
+	}
+
+	msg := fmt.Sprintf("node pool upgrade verification failed: %s", strings.Join(reasons, "; "))
+	nodeSummaries := summarizeNodes(matchingNodes)
+	nodeSummariesJSON, err := json.Marshal(nodeSummaries)
+	if err != nil {
+		return fmt.Errorf("%s; marshal node summaries: %w", msg, err)
+	}
+	return fmt.Errorf("%s; nodes=%s", msg, string(nodeSummariesJSON))
+}
+
+// VerifyNodePoolUpgrade verifies after a node pool upgrade (y-stream or z-stream) for nodes in the
+// given node pool only: (1) all those nodes are ready, (2) they report a version in the same
+// major.minor as expectedVersion, and (3) each node's release images differ from previousReleaseImages.
+// nodePoolName must be non-empty. Nodes are selected with
+// framework.SelectNodesBelongingToNodePool (hypershift nodePool label ends with -<nodePoolName>; shortest label wins).
+func VerifyNodePoolUpgrade(expectedVersion string, nodePoolName string, previousReleaseImages set.Set[string]) HostedClusterVerifier {
+	return verifyNodePoolUpgrade{
+		expectedVersion:       expectedVersion,
+		nodePoolName:          nodePoolName,
+		previousReleaseImages: previousReleaseImages,
+	}
+}
+
+// nodeReady returns true if the node has NodeReady condition status True.
+func nodeReady(node *corev1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// nodeVersionInMinor returns a non-empty reason if the node's version is not in the same major.minor as expectedSemver.
+func (v verifyNodePoolUpgrade) nodeVersionInMinor(node *corev1.Node, expectedSemver semver.Version) string {
+	cri := node.Status.NodeInfo.ContainerRuntimeVersion
+	m := regexp.MustCompile(`rhaos(\d+)\.(\d+)`).FindStringSubmatch(cri)
+	nodeVerStr := ""
+	if len(m) == 3 {
+		nodeVerStr = m[1] + "." + m[2]
+	}
+	if len(nodeVerStr) == 0 {
+		return fmt.Sprintf("%s (no version in containerRuntimeVersion %q)", node.Name, node.Status.NodeInfo.ContainerRuntimeVersion)
+	}
+	nodeVer, err := semver.ParseTolerant(nodeVerStr)
+	if err != nil {
+		return fmt.Sprintf("%s (invalid version %q)", node.Name, nodeVerStr)
+	}
+	if nodeVer.Major != expectedSemver.Major || nodeVer.Minor != expectedSemver.Minor {
+		return fmt.Sprintf("%s (version %s not in same minor as expected %s)", node.Name, nodeVerStr, v.expectedVersion)
+	}
+	return ""
+}
+
+// nodeReleaseImagesUpdated returns a non-empty reason if no release image on the node differs from previous.
+func (v verifyNodePoolUpgrade) nodeReleaseImagesUpdated(node *corev1.Node) string {
+	var currentImgs []string
+	for _, img := range node.Status.Images {
+		currentImgs = append(currentImgs, img.Names...)
+	}
+	for _, name := range currentImgs {
+		if !v.previousReleaseImages.Has(name) {
+			return "" // at least one new image differs from previous
+		}
+	}
+	return fmt.Sprintf("%s (release images unchanged: %v)", node.Name, currentImgs)
 }


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Bring back nodepool version upgrade e2e with a revisited timeout.

Follows up https://github.com/Azure/ARO-HCP/pull/4654

### Why

Node pool upgrade E2E sometimes left too little headroom: the ARM update is
quick, but backend → CS → node reconciliation can stretch past 30 minutes.

Example run (2026-03-26, node pool upgrade to 4.21.5):

- Frontend (test STEP): triggering nodepool upgrade to version 4.21.5 @ 03/26/26 23:18:20.218

- Backend nodepoolversion — ServiceProviderNodePool updated with desired version:
```json
{
  "timestamp": "2026-03-26T23:21:50.754Z",
  "log": {
    "time": "2026-03-26T23:21:50.7542969Z",
    "level": "INFO",
    "source": {
      "function": "github.com/Azure/ARO-HCP/backend/pkg/controllers/upgradecontrollers.(*nodePoolVersionSyncer).SyncOnce",
      "file": "/app/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go",
      "line": 215
    },
    "msg": "Updated ServiceProviderNodePool with new desired version",
    "controller_name": "nodepoolversion",
    "subscription_id": "<redacted>",
    "resource_group": "rg-np-version-upgrade-fkrtl9-qz4x7z",
    "resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools",
    "resource_name": "npupgrade-4-20",
    "resource_id": "/subscriptions/<redacted>/resourcegroups/rg-np-version-upgrade-fkrtl9-qz4x7z/providers/microsoft.redhatopenshift/hcpopenshiftclusters/np-version-upgrade-cluster-fkrtl9/nodepools/npupgrade-4-20",
    "hcp_cluster_name": "/subscriptions/<redacted>/resourcegroups/rg-np-version-upgrade-fkrtl9-qz4x7z/providers/microsoft.redhatopenshift/hcpopenshiftclusters/np-version-upgrade-cluster-fkrtl9",
    "desiredVersion": "4.21.5"
  }
}
```
- Backend triggernodepoolupgrade — upgrade policy created in CS:
```json
{
  "timestamp": "2026-03-26T23:26:55.579Z",
  "log": {
    "time": "2026-03-26T23:26:55.5798526Z",
    "level": "INFO",
    "source": {
      "function": "github.com/Azure/ARO-HCP/backend/pkg/controllers/upgradecontrollers.(*triggerNodePoolUpgradeSyncer).createUpgradePolicyIfNeeded",
      "file": "/app/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go",
      "line": 151
    },
    "msg": "Successfully created node pool upgrade policy",
    "controller_name": "triggernodepoolupgrade",
    "subscription_id": "<redacted>",
    "resource_group": "rg-np-version-upgrade-fkrtl9-qz4x7z",
    "resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools",
    "resource_name": "npupgrade-4-20",
    "resource_id": "/subscriptions/<redacted>/resourcegroups/rg-np-version-upgrade-fkrtl9-qz4x7z/providers/microsoft.redhatopenshift/hcpopenshiftclusters/np-version-upgrade-cluster-fkrtl9/nodepools/npupgrade-4-20",
    "hcp_cluster_name": "/subscriptions/<redacted>/resourcegroups/rg-np-version-upgrade-fkrtl9-qz4x7z/providers/microsoft.redhatopenshift/hcpopenshiftclusters/np-version-upgrade-cluster-fkrtl9",
    "desiredVersion": "4.21.5"
  }
}
```

The processing the backend took roughly 8 minutes which is something that needs to be improved as we want upgrades to happen within the timeframe of the user making the request i.e "immediate" execution.
 
See the special notes section about possible such improvements.

- CS — worker processing the upgrade policy:
```json
{
  "timestamp": "2026-03-26T23:27:21.687Z",
  "log": {
    "level": "info",
    "ts": "2026-03-26T23:27:21.6868506Z",
    "caller": "azure/aro_hcp_node_pool_upgrade_policy_worker.go:133",
    "msg": "Processing ARO-HCP upgrade policy '470f43d6-296b-11f1-93f3-6ec4d9d4bffa' for node pool 'npupgrade-4-20' in cluster '2p9mms86qteb3c81et0sd49s39aqithg'",
    "opid": "49abdf17-3143-440f-8018-3f6d84d0a597"
  }
}
```
- CS — node pool reached target version (upgrade complete):
```json
{
  "timestamp": "2026-03-26T23:48:30.126Z",
  "log": {
    "level": "info",
    "ts": "2026-03-26T23:48:30.1263341Z",
    "caller": "manifestwork/aro_hcp_node_pool_status.go:277",
    "msg": "ARO-HCP node pool 'npupgrade-4-20' in cluster '2p9mms86qteb3c81et0sd49s39aqithg' reached target version '4.21.5', updating version and deleting upgrade policy '470f43d6-296b-11f1-93f3-6ec4d9d4bffa'",
    "opid": "9359c38e-3dc2-4a76-96e7-8ac960d9c283",
    "cid": "2p9mms86qteb3c81et0sd49s39aqithg",
    "aro_hcp_cluster_resource_id": "/subscriptions/<redacted>/resourceGroups/rg-np-version-upgrade-fkrtl9-qz4x7z/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/np-version-upgrade-cluster-fkrtl9",
    "aro_hcp_node_pool_resource_id": "/subscriptions/<redacted>/resourceGroups/rg-np-version-upgrade-fkrtl9-qz4x7z/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/np-version-upgrade-cluster-fkrtl9/nodePools/npupgrade-4-20"
  }
}
```
So upgrade was completed at around 23:48 at around the same timelines the test timed out `[FAILED] in [It] - /opt/app-root/src/github.com/Azure/ARO-HCP/test/e2e/nodepool_version_upgrade.go:214 @ 03/26/26 23:49:24.783`


### Testing



### Special notes for your reviewer

We bump the Eventually that waits for VerifyNodePoolUpgrade from 30m to 45m while
backend/CS timing is investigated and improved in two angles:

- Resource management:
https://github.com/Azure/ARO-HCP/pull/4581
https://github.com/Azure/ARO-HCP/pull/4641

- fire controllers quickly when there is a change
https://github.com/Azure/ARO-HCP/pull/4485
https://github.com/Azure/ARO-HCP/pull/3913
