### PR TITLE
refactor(e2e) rename the test name of the automated control plane z-stream upgrade to be more user story oriented

### DIFF
--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -38,8 +38,8 @@ import (
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
 )
 
-var _ = Describe("Control plane automated z-stream upgrade with candidate channel", func() {
-	DescribeTable("should perform an automated control plane z-stream upgrade",
+var _ = Describe("Service Provider", func() {
+	DescribeTable("should upgrade the control plane z-stream automatically on behalf of the customer",
 		func(ctx context.Context, minorVersion string, baseInstallVersion string) {
 			const (
 				customerNetworkSecurityGroupName = "customer-nsg-zstream-"
@@ -71,8 +71,12 @@ var _ = Describe("Control plane automated z-stream upgrade with candidate channe
 			clusterName := customerClusterNamePrefix + versionLabel + "-" + suffix
 			clusterParams := framework.NewDefaultClusterParams()
 			clusterParams.ClusterName = clusterName
-			clusterParams.ChannelGroup = "candidate"
 			clusterParams.OpenshiftVersionId = installVersion
+
+			// We use the candidate channel to potentially catch early z-stream upgrades.
+			// issues before they reach stable.
+			By("using the candidate channel")
+			clusterParams.ChannelGroup = "candidate"
 
 			By("creating resource group")
 			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-zstream-upgrade-"+versionLabel, tc.Location())

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -14,11 +14,11 @@ Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PA
 Customer should be able to create an HCP cluster with back-level version 4.19
 Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 Customer should be able to create an HCP cluster
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.19
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.20
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.21
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.22
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.23
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
 Engineering should be able to retrieve expected metrics from the /metrics endpoint
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -16,11 +16,11 @@ Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PA
 Customer should be able to create an HCP cluster with back-level version 4.19
 Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 Customer should be able to create an HCP cluster
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.19
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.20
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.21
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.22
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.23
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster
 HCP Nodepools GPU instances creates and deletes vm type NC4asT4v3 in a single cluster

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -16,11 +16,11 @@ Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PA
 Customer should be able to create an HCP cluster with back-level version 4.19
 Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 Customer should be able to create an HCP cluster
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.19
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.20
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.21
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.22
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.23
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -15,11 +15,11 @@ Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PA
 Customer should be able to create an HCP cluster with back-level version 4.19
 Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 Customer should be able to create an HCP cluster
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.19
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.20
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.21
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.22
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.23
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
 Engineering should be able to retrieve expected metrics from the /metrics endpoint
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -14,11 +14,11 @@ Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PA
 Customer should be able to create an HCP cluster with back-level version 4.19
 Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 Customer should be able to create an HCP cluster
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.19
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.20
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.21
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.22
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.23
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -16,11 +16,11 @@ Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PA
 Customer should be able to create an HCP cluster with back-level version 4.19
 Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 Customer should be able to create an HCP cluster
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.19
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.20
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.21
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.22
-Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.23
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors


### PR DESCRIPTION

### What

refactor(e2e) rename the test name of the automated control plane z-stream upgrade to be more user story oriented

### Why

To make it consistent with how we name our test specs.
Previously the same test read like
```
Control plane automated z-stream upgrade with candidate channel should perform an automated control plane z-stream upgrade for 4.19
```

now it reads like
```
Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
```
### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
