### PR TITLE
Export image tags for prow image mirror

### DIFF
--- a/admin/Makefile
+++ b/admin/Makefile
@@ -78,6 +78,14 @@ build-and-push: image $(ORAS)
 	$(CONTAINER_ENGINE) push ${ADMIN_API_TAGGED_IMAGE}
 .PHONY: build-and-push
 
+export-image-vars:
+ifndef IMAGE_VARS_FILE
+	$(error IMAGE_VARS_FILE is not set)
+endif
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REF=${ADMIN_API_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
+.PHONY: export-image-vars
+
 OVERRIDE_CONFIG_FILE ?= /tmp/amin-api-override-config-$(date +%s).yaml
 
 record-override: $(YQ) $(ORAS)

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -82,7 +82,7 @@ export-image-vars:
 ifndef IMAGE_VARS_FILE
 	$(error IMAGE_VARS_FILE is not set)
 endif
-	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF=${ADMIN_API_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
 .PHONY: export-image-vars
 

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -82,7 +82,7 @@ export-image-vars:
 ifndef IMAGE_VARS_FILE
 	$(error IMAGE_VARS_FILE is not set)
 endif
-	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}" > $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF=${ADMIN_API_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
 .PHONY: export-image-vars
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -62,7 +62,7 @@ export-image-vars:
 ifndef IMAGE_VARS_FILE
 	$(error IMAGE_VARS_FILE is not set)
 endif
-	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}" > $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF=${BACKEND_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
 .PHONY: export-image-vars
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -62,7 +62,7 @@ export-image-vars:
 ifndef IMAGE_VARS_FILE
 	$(error IMAGE_VARS_FILE is not set)
 endif
-	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF=${BACKEND_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
 .PHONY: export-image-vars
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -58,6 +58,14 @@ build-and-push: image $(ORAS)
 	$(CONTAINER_ENGINE) push ${BACKEND_TAGGED_IMAGE}
 .PHONY: build-and-push
 
+export-image-vars:
+ifndef IMAGE_VARS_FILE
+	$(error IMAGE_VARS_FILE is not set)
+endif
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REF=${BACKEND_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
+.PHONY: export-image-vars
+
 # Unix timestamp for this make run; computed once so multiple targets see the same value.
 MAKE_RUN_TS := $(shell date +%s)
 OVERRIDE_CONFIG_FILE ?= /tmp/backend-override-config-$(MAKE_RUN_TS).yaml

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -57,6 +57,14 @@ build-and-push: image $(ORAS)
 	$(CONTAINER_ENGINE) push ${FRONTEND_TAGGED_IMAGE}
 .PHONY: build-and-push
 
+export-image-vars:
+ifndef IMAGE_VARS_FILE
+	$(error IMAGE_VARS_FILE is not set)
+endif
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REF=${FRONTEND_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
+.PHONY: export-image-vars
+
 OVERRIDE_CONFIG_FILE ?= /tmp/frontend-override-config-$(date +%s).yaml
 
 record-override: $(YQ) $(ORAS)

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -61,7 +61,7 @@ export-image-vars:
 ifndef IMAGE_VARS_FILE
 	$(error IMAGE_VARS_FILE is not set)
 endif
-	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}" > $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF=${FRONTEND_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
 .PHONY: export-image-vars
 

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -61,7 +61,7 @@ export-image-vars:
 ifndef IMAGE_VARS_FILE
 	$(error IMAGE_VARS_FILE is not set)
 endif
-	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF=${FRONTEND_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
 .PHONY: export-image-vars
 

--- a/image-sync/oc-mirror/Makefile
+++ b/image-sync/oc-mirror/Makefile
@@ -26,7 +26,7 @@ export-image-vars:
 ifndef IMAGE_VARS_FILE
 	$(error IMAGE_VARS_FILE is not set)
 endif
-	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR_URL}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}" > $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF=${OC_MIRROR_IMAGE_TAGGED}" >> $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF_LATEST=${OC_MIRROR_IMAGE}:latest" >> $(IMAGE_VARS_FILE)
 .PHONY: export-image-vars

--- a/image-sync/oc-mirror/Makefile
+++ b/image-sync/oc-mirror/Makefile
@@ -5,6 +5,8 @@ COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcela
 
 include ../../setup-templatize-env.mk
 
+ARO_HCP_IMAGE_REGISTRY ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
+
 ifeq ($(shell uname), Darwin)
 	AUTH_FILE = ${HOME}/.config/containers/auth.json
 else

--- a/image-sync/oc-mirror/Makefile
+++ b/image-sync/oc-mirror/Makefile
@@ -26,7 +26,7 @@ export-image-vars:
 ifndef IMAGE_VARS_FILE
 	$(error IMAGE_VARS_FILE is not set)
 endif
-	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF=${OC_MIRROR_IMAGE_TAGGED}" >> $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF_LATEST=${OC_MIRROR_IMAGE}:latest" >> $(IMAGE_VARS_FILE)
 .PHONY: export-image-vars

--- a/image-sync/oc-mirror/Makefile
+++ b/image-sync/oc-mirror/Makefile
@@ -22,6 +22,15 @@ build-and-push: image
 	$(CONTAINER_ENGINE) push ${OC_MIRROR_IMAGE}:latest
 .PHONY: build-and-push
 
+export-image-vars:
+ifndef IMAGE_VARS_FILE
+	$(error IMAGE_VARS_FILE is not set)
+endif
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR_URL}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REF=${OC_MIRROR_IMAGE_TAGGED}" >> $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REF_LATEST=${OC_MIRROR_IMAGE}:latest" >> $(IMAGE_VARS_FILE)
+.PHONY: export-image-vars
+
 acm-dry-run: image
 	@$(CONTAINER_ENGINE) run -it --rm --tmpfs /oc-mirror-workspace \
 		-e XDG_RUNTIME_DIR=/ \

--- a/sessiongate/Makefile
+++ b/sessiongate/Makefile
@@ -64,7 +64,7 @@ export-image-vars:
 ifndef IMAGE_VARS_FILE
 	$(error IMAGE_VARS_FILE is not set)
 endif
-	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}" > $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF=${SESSION_GATE_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
 .PHONY: export-image-vars
 

--- a/sessiongate/Makefile
+++ b/sessiongate/Makefile
@@ -60,6 +60,14 @@ build-and-push: image
 	$(CONTAINER_ENGINE) push ${SESSION_GATE_TAGGED_IMAGE}
 .PHONY: build-and-push
 
+export-image-vars:
+ifndef IMAGE_VARS_FILE
+	$(error IMAGE_VARS_FILE is not set)
+endif
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REF=${SESSION_GATE_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
+.PHONY: export-image-vars
+
 OVERRIDE_CONFIG_FILE ?= /tmp/sessiongate-override-config-$(date +%s).yaml
 
 record-override: $(YQ) $(ORAS)

--- a/sessiongate/Makefile
+++ b/sessiongate/Makefile
@@ -7,6 +7,7 @@ SESSIONGATE_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 -include ../tooling/hcpctl/Variables.mk
 
 # Image
+ARO_HCP_IMAGE_REGISTRY ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
 ARO_HCP_REVISION ?= $(shell git rev-parse HEAD)
 ARO_HCP_COMMIT_TIME := $(shell TZ=UTC git show -s --format=%cd --date=iso-strict-local ${ARO_HCP_REVISION})
 SESSION_GATE_IMAGE_TAG ?= $(shell DETECT_DIRTY_GIT_WORKTREE=${DETECT_DIRTY_GIT_WORKTREE} DEPLOY_ENV=${DEPLOY_ENV} ../generate-tag.sh)

--- a/sessiongate/Makefile
+++ b/sessiongate/Makefile
@@ -64,7 +64,7 @@ export-image-vars:
 ifndef IMAGE_VARS_FILE
 	$(error IMAGE_VARS_FILE is not set)
 endif
-	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF=${SESSION_GATE_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
 .PHONY: export-image-vars
 

--- a/tooling/aro-hcp-exporter/Makefile
+++ b/tooling/aro-hcp-exporter/Makefile
@@ -50,3 +50,11 @@ build-and-push: image
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
 	$(CONTAINER_ENGINE) push ${ARO_HCP_EXPORTER_TAGGED_IMAGE}
 .PHONY: build-and-push
+
+export-image-vars:
+ifndef IMAGE_VARS_FILE
+	$(error IMAGE_VARS_FILE is not set)
+endif
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REF=${ARO_HCP_EXPORTER_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
+.PHONY: export-image-vars

--- a/tooling/aro-hcp-exporter/Makefile
+++ b/tooling/aro-hcp-exporter/Makefile
@@ -55,6 +55,6 @@ export-image-vars:
 ifndef IMAGE_VARS_FILE
 	$(error IMAGE_VARS_FILE is not set)
 endif
-	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}" > $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF=${ARO_HCP_EXPORTER_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
 .PHONY: export-image-vars

--- a/tooling/aro-hcp-exporter/Makefile
+++ b/tooling/aro-hcp-exporter/Makefile
@@ -55,6 +55,6 @@ export-image-vars:
 ifndef IMAGE_VARS_FILE
 	$(error IMAGE_VARS_FILE is not set)
 endif
-	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_ACR}" > $(IMAGE_VARS_FILE)
+	@echo "IMAGE_REGISTRY=${ARO_HCP_IMAGE_REGISTRY}" > $(IMAGE_VARS_FILE)
 	@echo "IMAGE_REF=${ARO_HCP_EXPORTER_TAGGED_IMAGE}" >> $(IMAGE_VARS_FILE)
 .PHONY: export-image-vars


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-523

### What

Export image registry variables so that prow job can use it to push the images using `oc image mirror <src> <dest>`

### Why

Podman build and push is not supported in prow. Hence we need to rely on the images which are built by ci-operator and use `oc image mirror` to push images to ACR. For which prow job needs the acr image registry and image name with tag

### Testing

Tested locally by running `make export-image-vars`

### Special notes for your reviewer

Example usage in prow: https://github.com/openshift/release/pull/76898
