### PR TITLE
[FSI] Override HyperShift shared ingress HAProxy image to pull from ACR

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -2222,6 +2222,9 @@
         },
         "limitClusterSizes": {
           "type": "boolean"
+        },
+        "sharedIngressImage": {
+          "$ref": "#/definitions/containerImage"
         }
       },
       "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -287,6 +287,9 @@ defaults:
     # By default we set it to empty as this tag is only required for msft environments. We override
     # this value in sdp pipelines for msft environments.
     sharedIngressIPTag: ''
+    sharedIngressImage:
+      repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+      digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
     limitClusterSizes: false
   # Log settings
   logs:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -288,7 +288,8 @@ defaults:
     # this value in sdp pipelines for msft environments.
     sharedIngressIPTag: ''
     sharedIngressImage:
-      repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+      registry: quay.io
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
       digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
     limitClusterSizes: false
   # Log settings

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -411,7 +411,8 @@ hypershift:
   sharedIngressIPTag: ""
   sharedIngressImage:
     digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
-    repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -409,6 +409,9 @@ hypershift:
   limitClusterSizes: true
   namespace: hypershift
   sharedIngressIPTag: ""
+  sharedIngressImage:
+    digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
+    repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -411,7 +411,8 @@ hypershift:
   sharedIngressIPTag: ""
   sharedIngressImage:
     digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
-    repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -409,6 +409,9 @@ hypershift:
   limitClusterSizes: true
   namespace: hypershift
   sharedIngressIPTag: ""
+  sharedIngressImage:
+    digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
+    repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -411,7 +411,8 @@ hypershift:
   sharedIngressIPTag: ""
   sharedIngressImage:
     digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
-    repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -409,6 +409,9 @@ hypershift:
   limitClusterSizes: true
   namespace: hypershift
   sharedIngressIPTag: ""
+  sharedIngressImage:
+    digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
+    repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -411,7 +411,8 @@ hypershift:
   sharedIngressIPTag: ""
   sharedIngressImage:
     digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
-    repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -409,6 +409,9 @@ hypershift:
   limitClusterSizes: true
   namespace: hypershift
   sharedIngressIPTag: ""
+  sharedIngressImage:
+    digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
+    repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -411,7 +411,8 @@ hypershift:
   sharedIngressIPTag: ""
   sharedIngressImage:
     digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
-    repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -409,6 +409,9 @@ hypershift:
   limitClusterSizes: true
   namespace: hypershift
   sharedIngressIPTag: ""
+  sharedIngressImage:
+    digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
+    repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -411,7 +411,8 @@ hypershift:
   sharedIngressIPTag: ""
   sharedIngressImage:
     digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
-    repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -409,6 +409,9 @@ hypershift:
   limitClusterSizes: true
   namespace: hypershift
   sharedIngressIPTag: ""
+  sharedIngressImage:
+    digest: sha256:1af59b7a29432314bde54e8977fa45fa92dc48885efbf0df601418ec0912f472
+    repository: quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -160,3 +160,16 @@ module globalMSISvcAcrAccess '../modules/acr/acr-permissions.bicep' = {
     svcAcr
   ]
 }
+
+module globalMSIOcpAcrAccess '../modules/acr/acr-permissions.bicep' = {
+  name: '${globalMSIName}-ocp-acr-access'
+  params: {
+    principalIds: [globalMSI.properties.principalId]
+    grantPushAccess: true
+    grantPullAccess: true
+    acrName: ocpAcrName
+  }
+  dependsOn: [
+    ocpAcr
+  ]
+}

--- a/hypershiftoperator/deploy/templates/installer.job.yaml
+++ b/hypershiftoperator/deploy/templates/installer.job.yaml
@@ -32,6 +32,9 @@ spec:
             {{- if .Values.operatorEnvVars.sharedIngressIPTag }}
             --additional-operator-env-vars SHARED_INGRESS_AZURE_PIP_IP_TAGS={{ .Values.operatorEnvVars.sharedIngressIPTag }} \
             {{- end }}
+            {{- if .Values.operatorEnvVars.sharedIngressImage }}
+            --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY={{ .Values.operatorEnvVars.sharedIngressImage }} \
+            {{- end }}
             {{ .Values.additionalArgs }}
       restartPolicy: Never
       serviceAccountName: hypershift-installer

--- a/hypershiftoperator/pipeline.yaml
+++ b/hypershiftoperator/pipeline.yaml
@@ -41,7 +41,7 @@ resourceGroups:
   - name: mirror-shared-ingress-image
     action: ImageMirror
     targetACR:
-      configRef: 'acr.svc.name'
+      configRef: 'acr.ocp.name'
     sourceRegistry:
       configRef: hypershift.sharedIngressImage.registry
     repository:

--- a/hypershiftoperator/pipeline.yaml
+++ b/hypershiftoperator/pipeline.yaml
@@ -38,6 +38,32 @@ resourceGroups:
       - "unauthorized: authentication required"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
+  - name: mirror-shared-ingress-image
+    action: ImageMirror
+    targetACR:
+      configRef: 'acr.svc.name'
+    sourceRegistry:
+      configRef: hypershift.sharedIngressImage.registry
+    repository:
+      configRef: hypershift.sharedIngressImage.repository
+    digest:
+      configRef: hypershift.sharedIngressImage.digest
+    pullSecretKeyVault:
+      configRef: global.keyVault.name
+    pullSecretName:
+      configRef: imageSync.ondemandSync.pullSecretName
+    shellIdentity:
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    automatedRetry:
+      errorContainsAny:
+      - "unknown_storage_failure"
+      - "unexpected EOF"
+      - "unauthorized: authentication required"
+      maximumRetryCount: 5
+      durationBetweenRetries: 1m
 - name: kusto
   resourceGroup: '{{ .kusto.rg }}'
   subscription: '{{ .global.subscription.key }}'
@@ -79,6 +105,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: global
       step: mirror-image
+    - resourceGroup: global
+      step: mirror-shared-ingress-image
     identityFrom:
       resourceGroup: global
       step: output

--- a/hypershiftoperator/values.yaml
+++ b/hypershiftoperator/values.yaml
@@ -9,5 +9,5 @@ azureKeyVaultClientId: "__csiSecretStoreClientId__"
 additionalArgs: "{{ .hypershift.additionalInstallArg }}"
 operatorEnvVars:
   sharedIngressIPTag: "{{ .hypershift.sharedIngressIPTag }}"
-  sharedIngressImage: "{{ .acr.svc.name }}.{{ .acrDNSSuffix }}/{{ .hypershift.sharedIngressImage.repository }}@{{ .hypershift.sharedIngressImage.digest }}"
+  sharedIngressImage: "{{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/{{ .hypershift.sharedIngressImage.repository }}@{{ .hypershift.sharedIngressImage.digest }}"
 limitClusterSizes: {{ .hypershift.limitClusterSizes }}

--- a/hypershiftoperator/values.yaml
+++ b/hypershiftoperator/values.yaml
@@ -9,4 +9,5 @@ azureKeyVaultClientId: "__csiSecretStoreClientId__"
 additionalArgs: "{{ .hypershift.additionalInstallArg }}"
 operatorEnvVars:
   sharedIngressIPTag: "{{ .hypershift.sharedIngressIPTag }}"
+  sharedIngressImage: "{{ .acr.svc.name }}.{{ .acrDNSSuffix }}/{{ .hypershift.sharedIngressImage.repository }}@{{ .hypershift.sharedIngressImage.digest }}"
 limitClusterSizes: {{ .hypershift.limitClusterSizes }}

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -692,7 +692,7 @@ spec:
             --platform-monitoring=None \
             --enable-size-tagging=true \
             --limit-crd-install=Azure \
-            --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=arohcpsvcdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890 \
+            --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890 \
             --enable-cpo-overrides
       restartPolicy: Never
       serviceAccountName: hypershift-installer

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -692,6 +692,7 @@ spec:
             --platform-monitoring=None \
             --enable-size-tagging=true \
             --limit-crd-install=Azure \
+            --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=arohcpsvcdev.azurecr.io/quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890 \
             --enable-cpo-overrides
       restartPolicy: Never
       serviceAccountName: hypershift-installer

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -692,7 +692,7 @@ spec:
             --platform-monitoring=None \
             --enable-size-tagging=true \
             --limit-crd-install=Azure \
-            --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=arohcpsvcdev.azurecr.io/quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890 \
+            --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=arohcpsvcdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890 \
             --enable-cpo-overrides
       restartPolicy: Never
       serviceAccountName: hypershift-installer

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -32,6 +32,15 @@ images:
     targets:
     - jsonPath: defaults.hypershift.image.digest
       filePath: ../../config/config.yaml
+  # HyperShift shared ingress HAProxy image
+  hypershift-shared-ingress:
+    group: hypershift-stack
+    source:
+      image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+      tagPattern: "^[a-f0-9]{40}$"
+    targets:
+    - jsonPath: defaults.hypershift.sharedIngressImage.digest
+      filePath: ../../config/config.yaml
   # Clusters Service image
   clusters-service:
     group: cs


### PR DESCRIPTION
## Summary

- Override the HyperShift shared ingress HAProxy image to pull from ACR via `--additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=...` instead of the hardcoded `quay.io` default, for FSI/SFI compliance
- Use ORAS on-demand mirror (ImageMirror pipeline step) instead of pull-through cache, consistent with how all other service images are sourced

## Context

The upstream HyperShift `GetSharedIngressHAProxyImage()` in `support/images/envvars.go` reads the `IMAGE_SHARED_INGRESS_HAPROXY` env var directly and falls back to a hardcoded `quay.io/redhat-user-workloads/...` default. This code path does **not** go through `--registry-overrides` string substitution, so the only way to override it is via the env var.

### Changes

- `config/config.yaml` — `sharedIngressImage` block under `hypershift:` with `registry`, `repository`, and `digest` fields for ORAS mirroring
- `config/config.schema.json` — `sharedIngressImage` property added to `hypershift` definition (optional, references `containerImage`)
- `hypershiftoperator/pipeline.yaml` — `mirror-shared-ingress-image` ImageMirror step added (copies image from quay.io to SVC ACR at deploy time), deploy step depends on both mirror steps
- `hypershiftoperator/values.yaml` — `sharedIngressImage` templatized value under `operatorEnvVars`
- `hypershiftoperator/deploy/templates/installer.job.yaml` — conditional `--additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=...` block
- `tooling/image-updater/config.yaml` — `hypershift-shared-ingress` entry for automated digest updates

### Why ORAS mirror instead of pull-through cache?

Pull-through cache (`quay-cache/...` prefix) has drawbacks for FSI compliance:
- Cached images can be evicted by the ACR retention policy
- Cache availability depends on upstream registry being reachable at pull time
- ORAS mirror copies the image into the ACR as a first-class artifact, pinned by digest, at deploy time — the same mechanism used for 22 other service images

### Follow-up required

A corresponding change in `sdp-pipelines/hcp/` is needed to add the `sharedIngressImage` field to the higher-environment config and schema (which has `additionalProperties: false`).

## Related

- JIRA: ARO-22152, [ARO-24834](https://redhat.atlassian.net/browse/ARO-24834)
- PR #4687 — ACR pull-through cache rules (this PR no longer depends on `quay-redhat-user-workloads` cache rule)

## Test plan

- [x] `make -C config materialize` passes (schema validation, config render, 42 helm template tests, 11 ACR value tests)
- [x] Fixture shows `--additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=arohcpsvcdev.azurecr.io/redhat-user-workloads/...` in rendered output
- [x] ORAS mirror step copies image from `quay.io` to `arohcpsvcdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1af59b7a...`
- [x] Deploy to personal dev — hypershift operator env var `IMAGE_SHARED_INGRESS_HAPROXY` set correctly
- [x] Shared ingress router pods (`hypershift-sharedingress` namespace) use ACR-mirrored image path (not `quay-cache/`)
- [x] Image registry policy E2E tests pass on both SVC (3/3) and MGMT (3/3) clusters