### PR TITLE
feat: update azure operator managed identities min ocp version to 4.20

### DIFF
--- a/cluster-service/helm-charts/cluster-service/templates/azure-operators-managed-identities-config.configmap.yaml
+++ b/cluster-service/helm-charts/cluster-service/templates/azure-operators-managed-identities-config.configmap.yaml
@@ -8,7 +8,7 @@ data:
   azure-operators-managed-identities-config.yaml: |
     controlPlaneOperatorsIdentities:
       cluster-api-azure:
-        minOpenShiftVersion: 4.19
+        minOpenShiftVersion: 4.20
         roleDefinitions:
         {{- range $azureOperatorsMI.clusterApiAzure.roleDefinitions }}
           - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
@@ -16,7 +16,7 @@ data:
         {{- end }}
         optional: false
       control-plane:
-        minOpenShiftVersion: 4.19
+        minOpenShiftVersion: 4.20
         roleDefinitions:
         {{- range $azureOperatorsMI.controlPlane.roleDefinitions }}
           - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
@@ -24,7 +24,7 @@ data:
         {{- end }}
         optional: false
       cloud-controller-manager:
-        minOpenShiftVersion: 4.19
+        minOpenShiftVersion: 4.20
         roleDefinitions:
         {{- range $azureOperatorsMI.cloudControllerManager.roleDefinitions }}
           - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
@@ -32,7 +32,7 @@ data:
         {{- end }}
         optional: false
       ingress:
-        minOpenShiftVersion: 4.19
+        minOpenShiftVersion: 4.20
         roleDefinitions:
         {{- range $azureOperatorsMI.ingress.roleDefinitions }}
           - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
@@ -40,7 +40,7 @@ data:
         {{- end }}
         optional: false
       disk-csi-driver:
-        minOpenShiftVersion: 4.19
+        minOpenShiftVersion: 4.20
         roleDefinitions:
         {{- range $azureOperatorsMI.diskCsiDriver.roleDefinitions }}
           - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
@@ -48,7 +48,7 @@ data:
         {{- end }}
         optional: false
       file-csi-driver:
-        minOpenShiftVersion: 4.19
+        minOpenShiftVersion: 4.20
         roleDefinitions:
         {{- range $azureOperatorsMI.fileCsiDriver.roleDefinitions }}
           - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
@@ -56,7 +56,7 @@ data:
         {{- end }}
         optional: false
       image-registry:
-        minOpenShiftVersion: 4.19
+        minOpenShiftVersion: 4.20
         roleDefinitions:
         {{- range $azureOperatorsMI.imageRegistry.roleDefinitions }}
           - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
@@ -64,7 +64,7 @@ data:
         {{- end }}
         optional: false
       cloud-network-config:
-        minOpenShiftVersion: 4.19
+        minOpenShiftVersion: 4.20
         roleDefinitions:
         {{- range $azureOperatorsMI.cloudNetworkConfig.roleDefinitions }}
           - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
@@ -72,7 +72,7 @@ data:
         {{- end }}
         optional: false
       kms:
-        minOpenShiftVersion: 4.19
+        minOpenShiftVersion: 4.20
         roleDefinitions:
         {{- range $azureOperatorsMI.kms.roleDefinitions }}
           - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
@@ -81,7 +81,7 @@ data:
         optional: true
     dataPlaneOperatorsIdentities:
       disk-csi-driver:
-        minOpenShiftVersion: 4.19
+        minOpenShiftVersion: 4.20
         roleDefinitions:
         {{- range $azureOperatorsMI.diskCsiDriver.roleDefinitions }}
           - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
@@ -94,7 +94,7 @@ data:
             namespace: 'openshift-cluster-csi-drivers'
         optional: false
       image-registry:
-        minOpenShiftVersion: 4.19
+        minOpenShiftVersion: 4.20
         roleDefinitions:
         {{- range $azureOperatorsMI.imageRegistry.roleDefinitions }}
           - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'
@@ -107,7 +107,7 @@ data:
             namespace: 'openshift-image-registry'
         optional: false
       file-csi-driver:
-        minOpenShiftVersion: 4.19
+        minOpenShiftVersion: 4.20
         roleDefinitions:
         {{- range $azureOperatorsMI.fileCsiDriver.roleDefinitions }}
           - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/{{ .id }}'


### PR DESCRIPTION
### What
Update the minimum openshift version for the azure operators managed identities to the next available minor version '4.20'. 

https://redhat.atlassian.net/browse/ARO-25651

### Why
Support for 4.19 is being removed (see https://github.com/Azure/ARO-HCP/pull/4710)

### Testing
No additional tests required, existing test should catch any failures caused by this configuration change.

### Special notes for your reviewer
Blocked by:
- https://github.com/Azure/ARO-HCP/pull/4711
- https://github.com/Azure/ARO-HCP/pull/4715

Blocks: 
- https://github.com/Azure/ARO-HCP/pull/4710
