### PR TITLE
add control plane minor upgrade validation

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -470,6 +470,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ClustersServiceClient,
 		activeOperationLister,
 		backendInformers,
+		subscriptionLister,
 	)
 	triggerControlPlaneUpgradeController := upgradecontrollers.NewTriggerControlPlaneUpgradeController(
 		b.options.CosmosDBClient,

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -16,6 +16,7 @@ package upgradecontrollers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -26,16 +27,22 @@ import (
 	"github.com/golang/groupcache/lru"
 	"github.com/google/uuid"
 
+	"k8s.io/apimachinery/pkg/api/operation"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
 	"github.com/openshift/cluster-version-operator/pkg/cincinnati"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/admission"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/cincinatti"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
+	"github.com/Azure/ARO-HCP/internal/validation"
 )
 
 // controlPlaneDesiredVersionSyncer is a Cluster syncer that manages control plane desired version.
@@ -45,6 +52,7 @@ type controlPlaneDesiredVersionSyncer struct {
 	cooldownChecker      controllerutils.CooldownChecker
 	cosmosClient         database.DBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
+	subscriptionLister   listers.SubscriptionLister
 
 	cincinnatiClientLock      sync.RWMutex
 	clusterToCincinnatiClient *lru.Cache
@@ -61,6 +69,7 @@ func NewControlPlaneDesiredVersionController(
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
+	subscriptionLister listers.SubscriptionLister,
 ) controllerutils.Controller {
 
 	syncer := &controlPlaneDesiredVersionSyncer{
@@ -68,6 +77,7 @@ func NewControlPlaneDesiredVersionController(
 		cosmosClient:              cosmosClient,
 		clusterToCincinnatiClient: lru.New(100000),
 		clusterServiceClient:      clusterServiceClient,
+		subscriptionLister:        subscriptionLister,
 	}
 
 	controller := controllerutils.NewClusterWatchingController(
@@ -124,7 +134,16 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 	customerDesiredMinor := existingCluster.CustomerProperties.Version.ID
 	channelGroup := existingCluster.CustomerProperties.Version.ChannelGroup
 	activeVersions := existingServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions
-	desiredVersion, err := c.desiredControlPlaneZVersion(ctx, cincinnatiClient, customerDesiredMinor, channelGroup, activeVersions)
+	subscription, err := c.subscriptionLister.Get(ctx, key.SubscriptionID)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	operation := operation.Operation{
+		Type:    operation.Update,
+		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
+	}
+	desiredVersion, err := c.desiredControlPlaneZVersion(ctx, cincinnatiClient, key.GetResourceID(), customerDesiredMinor, channelGroup, activeVersions,
+		operation.HasOption(api.FeatureExperimentalReleaseFeatures))
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to determine desired control plane version: %w", err))
 	}
@@ -192,11 +211,8 @@ func (c *controlPlaneDesiredVersionSyncer) getCincinnatiClient(key controlleruti
 //
 // customerDesiredMinor and channelGroup are required. If they are not specified, no version is returned.
 // Returns nil if no upgrade is needed.
-func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(
-	ctx context.Context, cincinnatiClient cincinatti.Client,
-	customerDesiredMinor string, channelGroup string,
-	activeVersions []api.HCPClusterActiveVersion,
-) (*semver.Version, error) {
+func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx context.Context, cincinnatiClient cincinatti.Client, clusterResourceID *azcorearm.ResourceID,
+	customerDesiredMinor string, channelGroup string, activeVersions []api.HCPClusterActiveVersion, allowExperimentalReleaseFeatures bool) (*semver.Version, error) {
 	logger := utils.LoggerFromContext(ctx)
 
 	if len(customerDesiredMinor) == 0 {
@@ -237,62 +253,54 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(
 	// Use the most recent version to determine the minor version
 	actualLatestVersion := activeVersions[0].Version
 
-	actualMinorVersion := semver.MustParse(fmt.Sprintf("%d.%d.0", actualLatestVersion.Major, actualLatestVersion.Minor))
+	actualLatestMinorVersion := semver.MustParse(fmt.Sprintf("%d.%d.0", actualLatestVersion.Major, actualLatestVersion.Minor))
 
 	// ParseTolerant handles both "4.19", "4.19.0" and full versions like "4.20.15". Normalize to major.minor.0
 	// so that same-minor z-stream (e.g. 4.20.0 -> 4.20.15) is not mistaken for a y-stream upgrade.
 	parsedDesired := api.Must(semver.ParseTolerant(customerDesiredMinor))
 	desiredMinorVersion := semver.MustParse(fmt.Sprintf("%d.%d.0", parsedDesired.Major, parsedDesired.Minor))
 
-	if desiredMinorVersion.LT(actualMinorVersion) {
+	if desiredMinorVersion.LT(actualLatestMinorVersion) {
 		return nil, utils.TrackError(fmt.Errorf(
 			"invalid next y-stream upgrade path from %s to %s: only upgrades to the next minor version are allowed, no downgrades",
-			actualMinorVersion.String(), desiredMinorVersion.String(),
+			actualLatestMinorVersion.String(), desiredMinorVersion.String(),
 		))
 	}
 
-	if desiredMinorVersion.GT(actualMinorVersion) {
-		// TODO: Add support for major version upgrades (e.g., 4.20 → 5.0) when needed
-		if desiredMinorVersion.Major != actualMinorVersion.Major {
-			return nil, utils.TrackError(fmt.Errorf(
-				"invalid next y-stream upgrade path from %s to %s: major version changes are not supported",
-				actualMinorVersion.String(), desiredMinorVersion.String(),
-			))
+	if desiredMinorVersion.GT(actualLatestMinorVersion) {
+		if desiredMinorVersion.Major >= 5 && !allowExperimentalReleaseFeatures {
+			return nil, utils.TrackError(errors.New("OpenShift v5 and above is not supported"))
 		}
-		if desiredMinorVersion.Minor != actualMinorVersion.Minor+1 {
-			return nil, utils.TrackError(fmt.Errorf(
-				"invalid next y-stream upgrade path from %s to %s: only upgrades to the next minor version are allowed, no skipping minor versions",
-				actualMinorVersion.String(), desiredMinorVersion.String(),
-			))
+		if err := validation.OpenshiftVersionAtMostOneMinorSkew(actualLatestMinorVersion.String(), desiredMinorVersion.String()); err != nil {
+			return nil, utils.TrackError(err)
+		}
+		if err := admission.ValidateClusterNodePoolsMinorVersionSkew(ctx, c.cosmosClient, clusterResourceID, desiredMinorVersion); err != nil {
+			return nil, utils.TrackError(err)
 		}
 	}
-
-	targetMinorVersion := desiredMinorVersion
 
 	activeVersionList := make([]semver.Version, 0, len(activeVersions))
 	for _, av := range activeVersions {
 		activeVersionList = append(activeVersionList, *av.Version)
 	}
 
-	if desiredMinorVersion.Minor == actualMinorVersion.Minor+1 {
-		logger.Info("Resolving next Y-stream upgrade", "actualMinor", actualMinorVersion.String(), "activeVersions", activeVersions, "channelGroup", channelGroup,
-			"targetMinor", desiredMinorVersion.String())
-
-		latestVersion, err := c.findLatestVersionInMinor(ctx, cincinnatiClient, channelGroup, desiredMinorVersion, activeVersionList)
-		if err != nil {
-			return nil, utils.TrackError(err)
-		}
-
-		if latestVersion != nil {
-			return latestVersion, nil
-		}
-
-		// If no upgrade path to target minor, fall back to Z-stream upgrade in current minor
-		// This helps the cluster reach a gateway version that may enable the Y-stream upgrade later
-		targetMinorVersion = actualMinorVersion
+	if desiredMinorVersion.EQ(actualLatestMinorVersion) {
+		return c.findLatestVersionInMinor(ctx, cincinnatiClient, channelGroup, desiredMinorVersion, activeVersionList)
 	}
 
-	return c.findLatestVersionInMinor(ctx, cincinnatiClient, channelGroup, targetMinorVersion, activeVersionList)
+	logger.Info("Resolving user-initiated upgrade desired version", "actualMinor", actualLatestMinorVersion.String(), "activeVersions", activeVersions,
+		"channelGroup", channelGroup, "targetMinor", desiredMinorVersion.String())
+
+	latestVersion, err := c.findLatestVersionInMinor(ctx, cincinnatiClient, channelGroup, desiredMinorVersion, activeVersionList)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	if latestVersion != nil {
+		return latestVersion, nil
+	}
+
+	// User-requested control plane minor has no path yet; advance to latest patch on the current minor toward a gateway for a later user-initiated upgrade.
+	return c.findLatestVersionInMinor(ctx, cincinnatiClient, channelGroup, actualLatestMinorVersion, activeVersionList)
 }
 
 // findLatestVersionInMinor queries Cincinnati and finds the latest version within the specified target minor.

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -20,15 +20,20 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-version-operator/pkg/cincinnati"
 
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
 	cincinatti "github.com/Azure/ARO-HCP/internal/cincinatti"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
 )
 
 func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
@@ -271,10 +276,10 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 			mockCincinnatiClient := cincinatti.NewMockClient(ctrl)
 			tt.mockSetup(mockCincinnatiClient)
 
-			syncer := &controlPlaneDesiredVersionSyncer{}
+			syncer := &controlPlaneDesiredVersionSyncer{cosmosClient: databasetesting.NewMockDBClient()}
 
 			ctx := context.Background()
-			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions)
+			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions, false)
 
 			assertVersionResult(t, result, err, tt.expectedVersion, tt.expectedError, tt.expectedErrorContains)
 		})
@@ -288,6 +293,7 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 		customerDesiredMinor  string
 		channelGroup          string
 		mockSetup             func(*cincinatti.MockClient)
+		cosmosResources       []any
 		expectedVersion       *semver.Version
 		expectedError         bool
 		expectedErrorContains string
@@ -324,6 +330,42 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 					nil,
 				)
 			},
+			expectedVersion: ptr.To(semver.MustParse("4.20.10")),
+			expectedError:   false,
+		},
+		{
+			name:                 "Y-stream upgrade - succeeds with node pool within skew versus desired minor",
+			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.22")), State: configv1.CompletedUpdate}},
+			customerDesiredMinor: "4.20",
+			channelGroup:         "stable",
+			mockSetup: func(mc *cincinatti.MockClient) {
+				// Query for 4.20 versions from 4.19.22
+				// Cincinnati may return versions from other minors which should be filtered out
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinatti.GetCincinnatiURI("stable")), "multi", "multi", "stable-4.20", semver.MustParse("4.19.22")).Return(
+					configv1.Release{Version: "4.19.22"},
+					[]configv1.Release{{Version: "4.20.15"}, {Version: "4.20.10"}, {Version: "4.19.25"}}, // 4.19.25 should be filtered out
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+
+				// Check if 4.20.15 (latest candidate) has gateway to 4.21
+				// This is called twice: once to check if next minor exists, once to check gateway
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinatti.GetCincinnatiURI("stable")), "multi", "multi", "stable-4.21", semver.MustParse("4.20.15")).Return(
+					configv1.Release{Version: "4.20.15"},
+					[]configv1.Release{}, // No path to 4.21
+					[]configv1.ConditionalUpdate{},
+					nil,
+				).Times(2)
+
+				// Check if 4.20.10 has gateway to 4.21 - it does
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinatti.GetCincinnatiURI("stable")), "multi", "multi", "stable-4.21", semver.MustParse("4.20.10")).Return(
+					configv1.Release{Version: "4.20.10"},
+					[]configv1.Release{{Version: "4.21.0"}},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+			},
+			cosmosResources: testCosmosClusterWithWorkersNodePoolAtVersion("4.18.0"),
 			expectedVersion: ptr.To(semver.MustParse("4.20.10")),
 			expectedError:   false,
 		},
@@ -450,26 +492,61 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 			mockCincinnatiClient := cincinatti.NewMockClient(ctrl)
 			tt.mockSetup(mockCincinnatiClient)
 
-			syncer := &controlPlaneDesiredVersionSyncer{}
-
 			ctx := context.Background()
-			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions)
+			mockDB, err := databasetesting.NewMockDBClientWithResources(ctx, tt.cosmosResources)
+			require.NoError(t, err)
+			syncer := &controlPlaneDesiredVersionSyncer{cosmosClient: mockDB}
+
+			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions, false)
 
 			assertVersionResult(t, result, err, tt.expectedVersion, tt.expectedError, tt.expectedErrorContains)
 		})
 	}
 }
 
+// testCosmosClusterWithWorkersNodePoolAtVersion returns a cluster and workers node pool for the subscription, resource group,
+// and cluster name shared by desiredControlPlaneZVersion tests. nodePoolVersionId is properties.version.id on the pool.
+func testCosmosClusterWithWorkersNodePoolAtVersion(nodePoolVersionId string) []any {
+	clusterResourceId := api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster"))
+	cluster := &api.HCPOpenShiftCluster{
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   clusterResourceId,
+				Name: clusterResourceId.Name,
+				Type: clusterResourceId.ResourceType.String(),
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: api.Must(api.NewInternalID("/api/clusters_mgmt/v1/clusters/test-cluster")),
+		},
+	}
+	nodePoolResourceId := api.Must(azcorearm.ParseResourceID(clusterResourceId.String() + "/nodePools/workers"))
+	return []any{
+		cluster,
+		&api.HCPOpenShiftClusterNodePool{
+			TrackedResource: arm.NewTrackedResource(nodePoolResourceId, "eastus"),
+			Properties: api.HCPOpenShiftClusterNodePoolProperties{
+				Version: api.NodePoolVersionProfile{ID: nodePoolVersionId},
+			},
+			ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+				ClusterServiceID: api.Must(api.NewInternalID("/api/clusters_mgmt/v1/clusters/test-cluster/node_pools/workers")),
+			},
+		},
+	}
+}
+
 func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 	tests := []struct {
-		name                  string
-		activeVersions        []api.HCPClusterActiveVersion
-		customerDesiredMinor  string
-		channelGroup          string
-		mockSetup             func(*cincinatti.MockClient)
-		expectedVersion       *semver.Version
-		expectedError         bool
-		expectedErrorContains string
+		name                        string
+		activeVersions              []api.HCPClusterActiveVersion
+		customerDesiredMinor        string
+		channelGroup                string
+		mockSetup                   func(*cincinatti.MockClient)
+		cosmosResources             []any
+		experimentalReleaseFeatures bool
+		expectedVersion             *semver.Version
+		expectedError               bool
+		expectedErrorContains       string
 	}{
 		{
 			name:                  "Validation - downgrade not allowed (4.20 -> 4.19)",
@@ -482,14 +559,25 @@ func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 			expectedErrorContains: "only upgrades to the next minor version are allowed, no downgrades",
 		},
 		{
-			name:                  "Validation - major version change not supported (4.20 -> 5.0)",
+			name:                  "Validation - OpenShift 5.x requires AFEC (4.20 -> 5.0)",
 			activeVersions:        []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.15")), State: configv1.CompletedUpdate}},
 			customerDesiredMinor:  "5.0",
 			channelGroup:          "stable",
 			mockSetup:             func(mc *cincinatti.MockClient) {},
 			expectedVersion:       nil,
 			expectedError:         true,
-			expectedErrorContains: "major version changes are not supported",
+			expectedErrorContains: "OpenShift v5 and above is not supported",
+		},
+		{
+			name:                        "Validation - unsupported cross-major (4.20 -> 5.0, not a supported 4→5 landing) when AFEC registered",
+			activeVersions:              []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.15")), State: configv1.CompletedUpdate}},
+			customerDesiredMinor:        "5.0",
+			channelGroup:                "stable",
+			mockSetup:                   func(mc *cincinatti.MockClient) {},
+			experimentalReleaseFeatures: true,
+			expectedVersion:             nil,
+			expectedError:               true,
+			expectedErrorContains:       "cross-major upgrade from 4.20 is only allowed to",
 		},
 		{
 			name:                  "Validation - skip minor version not allowed (4.19 -> 4.21)",
@@ -499,7 +587,7 @@ func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 			mockSetup:             func(mc *cincinatti.MockClient) {},
 			expectedVersion:       nil,
 			expectedError:         true,
-			expectedErrorContains: "only upgrades to the next minor version are allowed, no skipping minor versions",
+			expectedErrorContains: "only upgrade to the next minor is allowed",
 		},
 		{
 			name:                  "Validation - major version downgrade not allowed (5.1 -> 4.20)",
@@ -511,6 +599,18 @@ func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 			expectedError:         true,
 			expectedErrorContains: "only upgrades to the next minor version are allowed, no downgrades",
 		},
+		{
+			name:                        "Validation - node pool minor skew blocks supported cross-major desired minor",
+			activeVersions:              []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.22.0")), State: configv1.CompletedUpdate}},
+			customerDesiredMinor:        "5.0",
+			channelGroup:                "stable",
+			mockSetup:                   func(mc *cincinatti.MockClient) {},
+			cosmosResources:             testCosmosClusterWithWorkersNodePoolAtVersion("4.20.0"),
+			experimentalReleaseFeatures: true,
+			expectedVersion:             nil,
+			expectedError:               true,
+			expectedErrorContains:       "incompatible with node pool",
+		},
 	}
 
 	for _, tt := range tests {
@@ -520,10 +620,112 @@ func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 			mockCincinnatiClient := cincinatti.NewMockClient(ctrl)
 			tt.mockSetup(mockCincinnatiClient)
 
-			syncer := &controlPlaneDesiredVersionSyncer{}
+			ctx := context.Background()
+			mockDB, err := databasetesting.NewMockDBClientWithResources(ctx, tt.cosmosResources)
+			require.NoError(t, err)
+			syncer := &controlPlaneDesiredVersionSyncer{cosmosClient: mockDB}
+
+			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions, tt.experimentalReleaseFeatures)
+
+			assertVersionResult(t, result, err, tt.expectedVersion, tt.expectedError, tt.expectedErrorContains)
+		})
+	}
+}
+
+func TestDesiredControlPlaneZVersion_CrossMajorUpgrade(t *testing.T) {
+	tests := []struct {
+		name                        string
+		activeVersions              []api.HCPClusterActiveVersion
+		customerDesiredMinor        string
+		channelGroup                string
+		mockSetup                   func(*cincinatti.MockClient)
+		cosmosResources             []any
+		experimentalReleaseFeatures bool
+		expectedVersion             *semver.Version
+		expectedError               bool
+		expectedErrorContains       string
+	}{
+		{
+			name:                        "Cross-major allowed — 4.22 to 5.0 with experimental release features and compatible node pools",
+			activeVersions:              []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.22.0")), State: configv1.CompletedUpdate}},
+			customerDesiredMinor:        "5.0",
+			channelGroup:                "stable",
+			cosmosResources:             testCosmosClusterWithWorkersNodePoolAtVersion("4.22.0"),
+			experimentalReleaseFeatures: true,
+			mockSetup: func(mc *cincinatti.MockClient) {
+				stableURI := api.Must(cincinatti.GetCincinnatiURI("stable"))
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), stableURI, "multi", "multi", "stable-5.0", semver.MustParse("4.22.0")).Return(
+					configv1.Release{Version: "4.22.0"},
+					[]configv1.Release{{Version: "5.0.15"}, {Version: "5.0.10"}, {Version: "4.22.5"}},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), stableURI, "multi", "multi", "stable-5.1", semver.MustParse("5.0.15")).Times(2).Return(
+					configv1.Release{Version: "5.0.15"},
+					[]configv1.Release{},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), stableURI, "multi", "multi", "stable-5.1", semver.MustParse("5.0.10")).Return(
+					configv1.Release{Version: "5.0.10"},
+					[]configv1.Release{{Version: "5.1.0"}},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+			},
+			expectedVersion: ptr.To(semver.MustParse("5.0.10")),
+			expectedError:   false,
+		},
+		{
+			name:                        "Cross-major not allowed — 4.22 to 5.0 without experimental release features",
+			activeVersions:              []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.22.0")), State: configv1.CompletedUpdate}},
+			customerDesiredMinor:        "5.0",
+			channelGroup:                "stable",
+			mockSetup:                   func(mc *cincinatti.MockClient) {},
+			experimentalReleaseFeatures: false,
+			expectedVersion:             nil,
+			expectedError:               true,
+			expectedErrorContains:       "OpenShift v5 and above is not supported",
+		},
+		{
+			name:                        "Cross-major not allowed — 4.21 to 5.0 is not a supported landing even with experimental release features",
+			activeVersions:              []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.21.10")), State: configv1.CompletedUpdate}},
+			customerDesiredMinor:        "5.0",
+			channelGroup:                "stable",
+			cosmosResources:             testCosmosClusterWithWorkersNodePoolAtVersion("4.21.0"),
+			mockSetup:                   func(mc *cincinatti.MockClient) {},
+			experimentalReleaseFeatures: true,
+			expectedVersion:             nil,
+			expectedError:               true,
+			expectedErrorContains:       "cross-major upgrade from 4.21 is only allowed to",
+		},
+		{
+			name:                        "Cross-major not allowed — 4.22 to 5.1 skips the supported 4.22 to 5.0 path",
+			activeVersions:              []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.22.0")), State: configv1.CompletedUpdate}},
+			customerDesiredMinor:        "5.1",
+			channelGroup:                "stable",
+			cosmosResources:             testCosmosClusterWithWorkersNodePoolAtVersion("4.22.0"),
+			mockSetup:                   func(mc *cincinatti.MockClient) {},
+			experimentalReleaseFeatures: true,
+			expectedVersion:             nil,
+			expectedError:               true,
+			expectedErrorContains:       "cross-major upgrade from 4.22 is only allowed to",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			mockCincinnatiClient := cincinatti.NewMockClient(ctrl)
+			tt.mockSetup(mockCincinnatiClient)
 
 			ctx := context.Background()
-			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions)
+			mockDB, err := databasetesting.NewMockDBClientWithResources(ctx, tt.cosmosResources)
+			require.NoError(t, err)
+			syncer := &controlPlaneDesiredVersionSyncer{cosmosClient: mockDB}
+
+			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions, tt.experimentalReleaseFeatures)
 
 			assertVersionResult(t, result, err, tt.expectedVersion, tt.expectedError, tt.expectedErrorContains)
 		})
@@ -661,13 +863,13 @@ func TestDesiredControlPlaneZVersion_InitialVersionSelection(t *testing.T) {
 			mockCincinnatiClient := cincinatti.NewMockClient(ctrl)
 			tt.mockSetup(mockCincinnatiClient)
 
-			syncer := &controlPlaneDesiredVersionSyncer{}
+			syncer := &controlPlaneDesiredVersionSyncer{cosmosClient: databasetesting.NewMockDBClient()}
 
 			// Empty active versions - simulating a new cluster
 			activeVersions := []api.HCPClusterActiveVersion{}
 
 			ctx := context.Background()
-			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, tt.customerDesiredMinor, tt.channelGroup, activeVersions)
+			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, activeVersions, false)
 
 			assertVersionResult(t, result, err, tt.expectedVersion, tt.expectedError, tt.expectedErrorContains)
 		})

--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -616,15 +616,16 @@ func (f *Frontend) updateHCPClusterInCosmos(ctx context.Context, writer http.Res
 	if mutationErrs := admission.MutateCluster(newInternalCluster, subscription); len(mutationErrs) > 0 {
 		return utils.TrackError(arm.CloudErrorFromFieldErrors(mutationErrs))
 	}
+
 	validationOp := operation.Operation{
 		Type:    operation.Update,
 		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
 	}
 	validationErrs := validation.ValidateCluster(ctx, validationOp, newInternalCluster, oldInternalCluster, api.Must(versionedInterface.ValidationPathRewriter(&api.HCPOpenShiftCluster{})))
+	validationErrs = append(validationErrs, admission.AdmitClusterOnUpdate(ctx, validationOp, f.dbClient, oldInternalCluster, newInternalCluster)...)
 	if err := arm.CloudErrorFromFieldErrors(validationErrs); err != nil {
 		return utils.TrackError(err)
 	}
-
 	// Now that validation is done we clear the user-assigned identities map since that is reconstructed from Cluster Service data
 	// TODO this is bad, see above TODOs. We want to validate what we store.
 	newInternalCluster.Identity.UserAssignedIdentities = nil

--- a/internal/admission/admit_cluster.go
+++ b/internal/admission/admit_cluster.go
@@ -16,16 +16,23 @@ package admission
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
 
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
+	"github.com/Azure/ARO-HCP/internal/validation"
 )
 
 // MutateCluster sets internal cluster state derived from subscription features
@@ -111,6 +118,59 @@ func MutateClusterCreate(cluster *api.HCPOpenShiftCluster) {
 func AdmitClusterOnCreate(ctx context.Context, newVersion *api.HCPOpenShiftCluster, subscription *arm.Subscription) field.ErrorList {
 	// to be filled in
 	errs := field.ErrorList{}
+
+	return errs
+}
+
+// AdmitClusterOnUpdate performs non-static checks of cluster. Checks that
+// require more information than is contained inside of the cluster instance itself.
+func AdmitClusterOnUpdate(ctx context.Context, op operation.Operation, dbClient database.DBClient, oldCluster, newCluster *api.HCPOpenShiftCluster) field.ErrorList {
+	var errs field.ErrorList
+
+	// Version                 VersionProfile              `json:"version,omitempty"`
+	errs = append(errs, admitVersionProfileOnClusterUpdate(ctx, op, dbClient, oldCluster, newCluster)...)
+
+	return errs
+}
+
+// admitVersionProfileOnClusterUpdate runs admission checks when properties.version changes
+// (skew against active control-plane versions and existing node pool minor skew).
+func admitVersionProfileOnClusterUpdate(ctx context.Context, op operation.Operation, dbClient database.DBClient, oldCluster, newCluster *api.HCPOpenShiftCluster) field.ErrorList {
+	if len(newCluster.CustomerProperties.Version.ID) == 0 ||
+		oldCluster.CustomerProperties.Version.ID == newCluster.CustomerProperties.Version.ID {
+		return nil
+	}
+	versionPath := field.NewPath("properties", "version", "id")
+	var errs field.ErrorList
+
+	oldVersion, oldParseErr := semver.ParseTolerant(oldCluster.CustomerProperties.Version.ID)
+	if oldParseErr != nil {
+		return field.ErrorList{field.Invalid(versionPath, oldCluster.CustomerProperties.Version.ID, oldParseErr.Error())}
+	}
+
+	serviceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, dbClient, oldCluster.ID)
+	if err != nil {
+		errs = append(errs, field.InternalError(versionPath, errors.New("cannot validate cluster version skew")))
+	} else {
+		lowest, highest := apihelpers.FindLowestAndHighestClusterVersion(serviceProviderCluster.Status.ControlPlaneVersion.ActiveVersions)
+		if lowest != nil && highest != nil {
+			// When the customer's current release line matches the lowest active CP, static validation
+			// already enforced skew from the old cluster version; do not duplicate against lowest.
+			if oldVersion.Major != lowest.Major || oldVersion.Minor != lowest.Minor {
+				if skewErr := validation.OpenshiftVersionAtMostOneMinorSkew(lowest.String(), newCluster.CustomerProperties.Version.ID); skewErr != nil {
+					errs = append(errs, field.Invalid(versionPath, newCluster.CustomerProperties.Version.ID, skewErr.Error()))
+				}
+			}
+			errs = append(errs, validation.VersionMustBeAtLeast(ctx, op, versionPath, ptr.To(newCluster.CustomerProperties.Version.ID), nil, highest.String())...)
+		}
+	}
+
+	clusterVersion, parseErr := semver.ParseTolerant(newCluster.CustomerProperties.Version.ID)
+	if parseErr != nil {
+		errs = append(errs, field.Invalid(versionPath, newCluster.CustomerProperties.Version.ID, parseErr.Error()))
+	} else if npErr := ValidateClusterNodePoolsMinorVersionSkew(ctx, dbClient, oldCluster.ID, clusterVersion); npErr != nil {
+		errs = append(errs, field.Invalid(versionPath, newCluster.CustomerProperties.Version.ID, npErr.Error()))
+	}
 
 	return errs
 }

--- a/internal/admission/admit_cluster_test.go
+++ b/internal/admission/admit_cluster_test.go
@@ -15,13 +15,22 @@
 package admission
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
 )
 
 func TestMutateCluster(t *testing.T) {
@@ -202,6 +211,358 @@ func TestMutateCluster(t *testing.T) {
 				t.Errorf("expected ControlPlanePodSizing %q, got %q",
 					tt.expectedControlPlanePodSizing, cluster.ServiceProviderProperties.ExperimentalFeatures.ControlPlanePodSizing)
 			}
+		})
+	}
+}
+
+func TestAdmitClusterOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	const (
+		subscriptionID    = "6b690bec-0c16-4ecb-8f67-781caf40bba7"
+		resourceGroupName = "test-rg"
+		clusterName       = "test-cluster"
+	)
+
+	clusterResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + subscriptionID +
+			"/resourceGroups/" + resourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + clusterName))
+
+	serviceProviderResourceID := api.Must(azcorearm.ParseResourceID(
+		clusterResourceID.String() + "/serviceProviderClusters/default"))
+
+	serviceProviderClusterStatusWithActiveControlPlaneVersion := func(fullVersion string) api.ServiceProviderClusterStatus {
+		return api.ServiceProviderClusterStatus{
+			ControlPlaneVersion: api.ServiceProviderClusterStatusVersion{
+				ActiveVersions: []api.HCPClusterActiveVersion{{Version: ptr.To(api.Must(semver.ParseTolerant(fullVersion)))}},
+			},
+		}
+	}
+
+	serviceProviderClusterStatusWithActiveControlPlaneVersions := func(fullVersions ...string) api.ServiceProviderClusterStatus {
+		active := make([]api.HCPClusterActiveVersion, 0, len(fullVersions))
+		for _, v := range fullVersions {
+			active = append(active, api.HCPClusterActiveVersion{Version: ptr.To(api.Must(semver.ParseTolerant(v)))})
+		}
+		return api.ServiceProviderClusterStatus{
+			ControlPlaneVersion: api.ServiceProviderClusterStatusVersion{ActiveVersions: active},
+		}
+	}
+
+	makeTestNodePool := func(name, versionID string) *api.HCPOpenShiftClusterNodePool {
+		nodePoolResourceID := api.Must(azcorearm.ParseResourceID(
+			clusterResourceID.String() + "/nodePools/" + name))
+		return &api.HCPOpenShiftClusterNodePool{
+			TrackedResource: arm.NewTrackedResource(nodePoolResourceID, "eastus"),
+			Properties: api.HCPOpenShiftClusterNodePoolProperties{
+				Version: api.NodePoolVersionProfile{ID: versionID},
+			},
+		}
+	}
+
+	makeServiceProviderNodePool := func(nodePoolName string, activeFullVersions ...string) *api.ServiceProviderNodePool {
+		npResourceID := api.Must(azcorearm.ParseResourceID(clusterResourceID.String() + "/nodePools/" + nodePoolName))
+		spResourceID := api.Must(azcorearm.ParseResourceID(fmt.Sprintf("%s/%s/%s",
+			npResourceID.String(), api.ServiceProviderNodePoolResourceTypeName, api.ServiceProviderNodePoolResourceName)))
+		active := make([]api.HCPNodePoolActiveVersion, 0, len(activeFullVersions))
+		for _, v := range activeFullVersions {
+			active = append(active, api.HCPNodePoolActiveVersion{Version: ptr.To(api.Must(semver.ParseTolerant(v)))})
+		}
+		return &api.ServiceProviderNodePool{
+			CosmosMetadata: api.CosmosMetadata{ResourceID: spResourceID},
+			ResourceID:     *spResourceID,
+			Status: api.ServiceProviderNodePoolStatus{
+				NodePoolVersion: api.ServiceProviderNodePoolStatusVersion{ActiveVersions: active},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                         string
+		oldClusterVersionID          string
+		clusterVersionID             string
+		serviceProviderClusterStatus api.ServiceProviderClusterStatus
+		nodePools                    []*api.HCPOpenShiftClusterNodePool
+		serviceProviderNodePools     []*api.ServiceProviderNodePool
+		wantError                    bool
+		expectError                  string
+	}{
+		{
+			name:                         "empty desired version skips admission",
+			oldClusterVersionID:          "4.10",
+			clusterVersionID:             "",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("np1", "4.10.0")},
+			wantError:                    false,
+		},
+		{
+			name:                         "unchanged version skips admission",
+			oldClusterVersionID:          "5.0",
+			clusterVersionID:             "5.0",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.20.0")},
+			wantError:                    false,
+		},
+		{
+			name:                         "unparsable old version id",
+			oldClusterVersionID:          "4.x",
+			clusterVersionID:             "4.22",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    nil,
+			wantError:                    true,
+			expectError:                  "Invalid character(s) found in minor number",
+		},
+		{
+			name:                         "skips skew vs lowest when old minor matches lowest active cluster version",
+			oldClusterVersionID:          "4.21",
+			clusterVersionID:             "4.23",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.21"),
+			nodePools:                    nil,
+			wantError:                    false,
+		},
+		{
+			name:                         "allows 4.22 to 5.0 with active cluster version 4.22",
+			oldClusterVersionID:          "4.22",
+			clusterVersionID:             "5.0",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    nil,
+			wantError:                    false,
+		},
+		{
+			name:                         "rejects 5.1 when old minor below lowest active cluster version",
+			oldClusterVersionID:          "4.21",
+			clusterVersionID:             "5.1",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    nil,
+			wantError:                    true,
+			expectError:                  "invalid upgrade path",
+		},
+		{
+			name:                         "rejects 4.24 when old minor below lowest active cluster version",
+			oldClusterVersionID:          "4.21",
+			clusterVersionID:             "4.24",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    nil,
+			wantError:                    true,
+			expectError:                  "only upgrade to the next minor is allowed",
+		},
+		{
+			name:                         "rejects version below highest active cluster version",
+			oldClusterVersionID:          "4.22",
+			clusterVersionID:             "4.21",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    nil,
+			wantError:                    true,
+			expectError:                  "must be at least",
+		},
+		{
+			name:                         "allows upgrade across adjacent active cluster minors",
+			oldClusterVersionID:          "4.21",
+			clusterVersionID:             "4.22",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersions("4.22", "4.21"),
+			nodePools:                    nil,
+			wantError:                    false,
+		},
+		{
+			name:                         "rejects skip minor vs lowest when fleet spans minors",
+			oldClusterVersionID:          "4.21",
+			clusterVersionID:             "4.22",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersions("4.20", "4.22"),
+			nodePools:                    nil,
+			wantError:                    true,
+			expectError:                  "only upgrade to the next minor is allowed",
+		},
+		{
+			name:                         "rejects when node pool over two minors behind",
+			oldClusterVersionID:          "4.20",
+			clusterVersionID:             "4.21",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.20"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.17.0")},
+			wantError:                    true,
+			expectError:                  "must not be more than two minor versions ahead",
+		},
+		{
+			name:                         "allows no-op version with node pools in skew",
+			oldClusterVersionID:          "4.20",
+			clusterVersionID:             "4.20",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.20"),
+			nodePools: []*api.HCPOpenShiftClusterNodePool{
+				makeTestNodePool("workers", "4.18.0"),
+				makeTestNodePool("infra", "4.20.3"),
+				makeTestNodePool("spot", "4.20.1"),
+			},
+			wantError: false,
+		},
+		{
+			name:                         "allows 4.22 to 5.0 node pool 4.22",
+			oldClusterVersionID:          "4.22",
+			clusterVersionID:             "5.0",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.22.0")},
+			wantError:                    false,
+		},
+		{
+			name:                         "allows 4.22 to 5.0 node pool 4.21",
+			oldClusterVersionID:          "4.22",
+			clusterVersionID:             "5.0",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.21.0")},
+			wantError:                    false,
+		},
+		{
+			name:                         "allows 4.23 to 5.1 node pool 4.22",
+			oldClusterVersionID:          "4.23",
+			clusterVersionID:             "5.1",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.23"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.22.0")},
+			wantError:                    false,
+		},
+		{
+			name:                         "allows 4.23 to 5.1 node pool 4.23",
+			oldClusterVersionID:          "4.23",
+			clusterVersionID:             "5.1",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.23"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.23.0")},
+			wantError:                    false,
+		},
+		{
+			name:                         "allows 5.1 to 5.2 node pool 4.23",
+			oldClusterVersionID:          "5.1",
+			clusterVersionID:             "5.2",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("5.1"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.23.0")},
+			wantError:                    false,
+		},
+		{
+			name:                         "rejects 4.22 to 5.0 node pool 4.20",
+			oldClusterVersionID:          "4.22",
+			clusterVersionID:             "5.0",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.20.0")},
+			wantError:                    true,
+			expectError:                  "incompatible with node pool",
+		},
+		{
+			name:                         "rejects 4.23 to 5.1 node pool 4.21",
+			oldClusterVersionID:          "4.23",
+			clusterVersionID:             "5.1",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.23"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.21.0")},
+			wantError:                    true,
+			expectError:                  "incompatible with node pool",
+		},
+		{
+			name:                         "rejects 4.22 to 5.0 node pool 4.23",
+			oldClusterVersionID:          "4.22",
+			clusterVersionID:             "5.0",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.23.0")},
+			wantError:                    true,
+			expectError:                  "incompatible with node pool",
+		},
+		{
+			name:                         "rejects 4.22 to 5.0 mixed node pool minors",
+			oldClusterVersionID:          "4.22",
+			clusterVersionID:             "5.0",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools: []*api.HCPOpenShiftClusterNodePool{
+				makeTestNodePool("workers", "4.22.0"),
+				makeTestNodePool("legacy", "4.20.0"),
+			},
+			wantError:   true,
+			expectError: "incompatible with node pool",
+		},
+		{
+			name:                         "rejects 4.22 to 5.0 sp node pool behind customer minor",
+			oldClusterVersionID:          "4.22",
+			clusterVersionID:             "5.0",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.22.0")},
+			serviceProviderNodePools:     []*api.ServiceProviderNodePool{makeServiceProviderNodePool("workers", "4.17.0")},
+			wantError:                    true,
+			expectError:                  "incompatible with node pool",
+		},
+		{
+			name:                         "rejects minor upgrade sp node pool two minors behind",
+			oldClusterVersionID:          "4.20",
+			clusterVersionID:             "4.21",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.20"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.20.0")},
+			serviceProviderNodePools:     []*api.ServiceProviderNodePool{makeServiceProviderNodePool("workers", "4.17.0")},
+			wantError:                    true,
+			expectError:                  "must not be more than two minor versions ahead",
+		},
+		{
+			name:                         "rejects 4.22 to 5.0 incompatible lowest active cluster version",
+			oldClusterVersionID:          "4.22",
+			clusterVersionID:             "5.0",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.22.0")},
+			serviceProviderNodePools:     []*api.ServiceProviderNodePool{makeServiceProviderNodePool("workers", "4.22.0", "4.17.0")},
+			wantError:                    true,
+			expectError:                  "incompatible with node pool",
+		},
+		{
+			name:                         "allows 4.22 to 5.0 compatible active cluster versions",
+			oldClusterVersionID:          "4.22",
+			clusterVersionID:             "5.0",
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
+			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.22.0")},
+			serviceProviderNodePools:     []*api.ServiceProviderNodePool{makeServiceProviderNodePool("workers", "4.22.1", "4.22.0")},
+			wantError:                    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.wantError {
+				assert.NotEmpty(t, tt.expectError, "wantError is true but expectError is empty; set a non-empty substring to match admission errors")
+			} else {
+				assert.Empty(t, tt.expectError, "wantError is false but expectError is set (%q); clear expectError for success cases", tt.expectError)
+			}
+
+			serviceProviderCluster := &api.ServiceProviderCluster{
+				CosmosMetadata: api.CosmosMetadata{ResourceID: serviceProviderResourceID},
+				ResourceID:     *serviceProviderResourceID,
+				Status:         tt.serviceProviderClusterStatus,
+			}
+
+			resources := []any{serviceProviderCluster}
+			for _, nodePool := range tt.nodePools {
+				resources = append(resources, nodePool)
+			}
+			for _, serviceProviderNodePool := range tt.serviceProviderNodePools {
+				resources = append(resources, serviceProviderNodePool)
+			}
+			mockDB, err := databasetesting.NewMockDBClientWithResources(ctx, resources)
+			assert.NoError(t, err)
+
+			oldCluster := &api.HCPOpenShiftCluster{
+				TrackedResource: arm.NewTrackedResource(clusterResourceID, "eastus"),
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					Version: api.VersionProfile{ID: tt.oldClusterVersionID},
+				},
+			}
+			newCluster := &api.HCPOpenShiftCluster{
+				TrackedResource: oldCluster.TrackedResource,
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					Version: api.VersionProfile{ID: tt.clusterVersionID},
+				},
+			}
+
+			errs := AdmitClusterOnUpdate(ctx, operation.Operation{Type: operation.Update}, mockDB, oldCluster, newCluster)
+
+			if tt.wantError {
+				assert.NotEmpty(t, errs, "expected field errors containing %q", tt.expectError)
+				assert.Contains(t, errs.ToAggregate().Error(), tt.expectError, "aggregated field errors should contain %q", tt.expectError)
+				return
+			}
+
+			assert.Empty(t, errs)
 		})
 	}
 }

--- a/internal/admission/utils.go
+++ b/internal/admission/utils.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admission
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/blang/semver/v4"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
+)
+
+// ValidateClusterNodePoolsMinorVersionSkew lists all node pools for the cluster in Cosmos and checks clusterVersion against each pool
+// using the same skew rules (n-2 minor, cross-major allowlist) for:
+//   - the customer node pool properties.version.id (when non-empty),
+//   - the service provider node pool lowest and highest active versions when they exist.
+func ValidateClusterNodePoolsMinorVersionSkew(ctx context.Context, dbClient database.DBClient, clusterResourceID *azcorearm.ResourceID, clusterVersion semver.Version) error {
+	nodePoolIterator, err := dbClient.HCPClusters(clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName).NodePools(clusterResourceID.Name).List(ctx, nil)
+	if err != nil {
+		return errors.New("cannot validate node pool skew")
+	}
+	var errs []error
+	for _, nodePool := range nodePoolIterator.Items(ctx) {
+		serviceProviderNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, dbClient, nodePool.ID)
+		if err != nil {
+			errs = append(errs, errors.New("cannot validate node pool skew"))
+			continue
+		}
+		lowest, highest := apihelpers.FindLowestAndHighestNodePoolVersion(serviceProviderNodePool.Status.NodePoolVersion.ActiveVersions)
+
+		if len(nodePool.Properties.Version.ID) > 0 {
+			parsed, err := semver.ParseTolerant(nodePool.Properties.Version.ID)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("cannot validate skew for node pool %q: invalid version %q: %w", nodePool.Name, nodePool.Properties.Version.ID, err))
+			} else if err := clusterVersionSkewVersusNodePool(nodePool.Name, parsed, clusterVersion); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		if lowest != nil && highest != nil {
+			if err := clusterVersionSkewVersusNodePool(nodePool.Name, *lowest, clusterVersion); err != nil {
+				errs = append(errs, err)
+			}
+			if err := clusterVersionSkewVersusNodePool(nodePool.Name, *highest, clusterVersion); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	if err := nodePoolIterator.GetError(); err != nil {
+		return errors.New("cannot validate node pool skew")
+	}
+	return errors.Join(errs...)
+}
+
+func clusterVersionSkewVersusNodePool(nodePoolName string, nodePoolVer, parsedClusterVersion semver.Version) error {
+
+	nodePoolMinorReleaseLine := fmt.Sprintf("%d.%d", nodePoolVer.Major, nodePoolVer.Minor)
+	clusterMinorReleaseLine := fmt.Sprintf("%d.%d", parsedClusterVersion.Major, parsedClusterVersion.Minor)
+	nodePoolMinorReleaseVersion := api.Must(semver.ParseTolerant(nodePoolMinorReleaseLine))
+	clusterMinorReleaseVersion := api.Must(semver.ParseTolerant(clusterMinorReleaseLine))
+
+	if nodePoolMinorReleaseVersion.EQ(clusterMinorReleaseVersion) {
+		return nil
+	}
+
+	if nodePoolVer.Major == parsedClusterVersion.Major {
+		if int64(nodePoolVer.Minor) >= int64(parsedClusterVersion.Minor)-2 {
+			return nil
+		}
+		return fmt.Errorf(
+			"cluster minor %s must not be more than two minor versions ahead of node pool %q (minor %s)",
+			clusterMinorReleaseLine, nodePoolName, nodePoolMinorReleaseLine,
+		)
+	}
+
+	allowedClusterVersions := api.AllowControlPlaneNodePoolMajorVersionSkew[nodePoolMinorReleaseLine]
+	if slices.Contains(allowedClusterVersions, clusterMinorReleaseLine) {
+		return nil
+	}
+	return fmt.Errorf(
+		"cluster minor %s incompatible with node pool %q minor %s",
+		clusterMinorReleaseLine, nodePoolName, nodePoolMinorReleaseLine,
+	)
+}

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -47,6 +47,17 @@ var AllowMajorUpgradePaths = map[string]string{
 	"4.23": "5.1",
 }
 
+// AllowControlPlaneNodePoolMajorVersionSkew maps node pool OpenShift minor release lines (x.y) to allowed
+// control-plane minor release lines when the node pool major differs from the cluster major. Values are
+// sorted from strictest to most permissive allowed skew. See the HyperShift control plane version status
+// enhancement for node pool skews against cluster version:
+// https://github.com/openshift/enhancements/blob/master/enhancements/hypershift/hypershift-control-plane-version-status.md
+var AllowControlPlaneNodePoolMajorVersionSkew = map[string][]string{
+	"4.21": {"5.0"},
+	"4.22": {"5.0", "5.1"},
+	"4.23": {"5.1", "5.2"},
+}
+
 // Ptr returns a pointer to p.
 func Ptr[T any](p T) *T {
 	return &p

--- a/internal/databasetesting/mock_init.go
+++ b/internal/databasetesting/mock_init.go
@@ -30,6 +30,7 @@ import (
 //   - *api.Operation
 //   - *api.HCPOpenShiftClusterExternalAuth
 //   - *api.ServiceProviderCluster
+//   - *api.ServiceProviderNodePool
 //   - *arm.Subscription
 //   - *api.Controller
 //
@@ -59,6 +60,8 @@ func (m *MockDBClient) addResource(ctx context.Context, resource any) error {
 		return m.addExternalAuth(ctx, r)
 	case *api.ServiceProviderCluster:
 		return m.addServiceProviderCluster(ctx, r)
+	case *api.ServiceProviderNodePool:
+		return m.addServiceProviderNodePool(ctx, r)
 	case *arm.Subscription:
 		return m.addSubscription(ctx, r)
 	case *api.Controller:
@@ -123,6 +126,24 @@ func (m *MockDBClient) addServiceProviderCluster(ctx context.Context, spc *api.S
 	clusterName := resourceID.Parent.Name
 	spcCRUD := m.ServiceProviderClusters(resourceID.SubscriptionID, resourceID.ResourceGroupName, clusterName)
 	_, err := spcCRUD.Create(ctx, spc, nil)
+	return err
+}
+
+func (m *MockDBClient) addServiceProviderNodePool(ctx context.Context, spnp *api.ServiceProviderNodePool) error {
+	resourceID := spnp.GetResourceID()
+	if resourceID == nil {
+		return fmt.Errorf("service provider node pool is missing resource ID")
+	}
+	if resourceID.Parent == nil {
+		return fmt.Errorf("service provider node pool is missing parent node pool ID")
+	}
+	if resourceID.Parent.Parent == nil {
+		return fmt.Errorf("service provider node pool is missing grandparent cluster ID")
+	}
+	clusterName := resourceID.Parent.Parent.Name
+	nodePoolName := resourceID.Parent.Name
+	serviceProviderNodePoolCRUD := m.ServiceProviderNodePools(resourceID.SubscriptionID, resourceID.ResourceGroupName, clusterName, nodePoolName)
+	_, err := serviceProviderNodePoolCRUD.Create(ctx, spnp, nil)
 	return err
 }
 

--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -350,10 +350,10 @@ func validateVersionProfile(ctx context.Context, op operation.Operation, fldPath
 		errs = append(errs, OpenshiftVersionAtMostOneMinorSkewWithField(ctx, op, fldPath.Child("id"), &newObj.ID, safe.Field(oldObj, toVersionID))...)
 	}
 	if !op.HasOption(api.FeatureExperimentalReleaseFeatures) {
-		// only allow our subscription to change versions for now until we add validation protecting the change
-		errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath.Child("id"), &newObj.ID, safe.Field(oldObj, toVersionID))...)
 		// we never allow micro to any cluster that might live longer than a couple days.  We cannot allow it because it might install naughty things
 		errs = append(errs, OpenshiftVersionWithoutMicro(ctx, op, fldPath.Child("id"), &newObj.ID, nil)...)
+		// only allow OpenShift v5 and above for subscriptions that have the experimental feature registered for now
+		// remove this together with the matching check in the control plane desired version controller when we are ready
 		if v, err := semver.ParseTolerant(newObj.ID); err == nil && v.Major >= 5 {
 			errs = append(errs, field.Invalid(fldPath.Child("id"), newObj.ID, "OpenShift v5 and above is not supported"))
 		}

--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"strings"
 
+	"github.com/blang/semver/v4"
+
 	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/api/safe"
 	"k8s.io/apimachinery/pkg/api/validate"
@@ -330,8 +332,7 @@ var (
 func validateVersionProfile(ctx context.Context, op operation.Operation, fldPath *field.Path, newObj, oldObj *api.VersionProfile) field.ErrorList {
 	errs := field.ErrorList{}
 
-	// Version should be immutable once is created
-	// additional validations may depend on the subscription, hence they will be done in the admission package
+	// Version should be immutable once is created.
 	// ID           string `json:"id,omitempty"
 	// Version ID is required, but some records may not have had it originally, so don't fail them yet.
 	if oldObj == nil || len(oldObj.ID) > 0 {
@@ -346,12 +347,16 @@ func validateVersionProfile(ctx context.Context, op operation.Operation, fldPath
 		}
 
 		errs = append(errs, VersionMayNotDecrease(ctx, op, fldPath.Child("id"), &newObj.ID, safe.Field(oldObj, toVersionID))...)
+		errs = append(errs, OpenshiftVersionAtMostOneMinorSkewWithField(ctx, op, fldPath.Child("id"), &newObj.ID, safe.Field(oldObj, toVersionID))...)
 	}
 	if !op.HasOption(api.FeatureExperimentalReleaseFeatures) {
 		// only allow our subscription to change versions for now until we add validation protecting the change
 		errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath.Child("id"), &newObj.ID, safe.Field(oldObj, toVersionID))...)
 		// we never allow micro to any cluster that might live longer than a couple days.  We cannot allow it because it might install naughty things
 		errs = append(errs, OpenshiftVersionWithoutMicro(ctx, op, fldPath.Child("id"), &newObj.ID, nil)...)
+		if v, err := semver.ParseTolerant(newObj.ID); err == nil && v.Major >= 5 {
+			errs = append(errs, field.Invalid(fldPath.Child("id"), newObj.ID, "OpenShift v5 and above is not supported"))
+		}
 	} else {
 		// For our CI clusters, let us install anything: allow full semver format (X.Y.Z-prerelease)
 		errs = append(errs, OpenshiftVersionWithOptionalMicro(ctx, op, fldPath.Child("id"), &newObj.ID, nil)...)

--- a/internal/validation/validate_cluster_comprehensive_test.go
+++ b/internal/validation/validate_cluster_comprehensive_test.go
@@ -68,6 +68,27 @@ func TestValidateClusterCreate(t *testing.T) {
 			expectErrors: []expectedError{},
 		},
 		{
+			name: "OpenShift 5 rejected on create without experimental release features (no prior version id)",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "5.0"
+				return c
+			}(),
+			expectErrors: []expectedError{
+				{message: "OpenShift v5 and above is not supported", fieldPath: "customerProperties.version.id"},
+			},
+		},
+		{
+			name: "OpenShift 5 allowed with experimental release features - create",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "5.0"
+				return c
+			}(),
+			opOptions:    testFeatureOptions(api.FeatureExperimentalReleaseFeatures),
+			expectErrors: []expectedError{},
+		},
+		{
 			name: "invalid DNS prefix - create",
 			cluster: func() *api.HCPOpenShiftCluster {
 				c := createValidCluster()
@@ -2087,6 +2108,138 @@ func TestValidateClusterUpdate(t *testing.T) {
 			}(),
 			opOptions:    testFeatureOptions(api.FeatureExperimentalReleaseFeatures),
 			expectErrors: []expectedError{},
+		},
+		{
+			name: "update: version may not skip minor within same major (4.20 to 4.22)",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "4.22"
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "4.20"
+				return c
+			}(),
+			opOptions: testFeatureOptions(api.FeatureExperimentalReleaseFeatures),
+			expectErrors: []expectedError{
+				{message: "only upgrade to the next minor is allowed", fieldPath: "customerProperties.version.id"},
+			},
+		},
+		{
+			name: "update: cross-major 4.22 to 5.0 rejected without experimental release features",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "5.0"
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "4.22"
+				return c
+			}(),
+			expectErrors: []expectedError{
+				{message: "OpenShift v5 and above is not supported", fieldPath: "customerProperties.version.id"},
+				{message: "field is immutable", fieldPath: "customerProperties.version.id"},
+			},
+		},
+		{
+			name: "update: cross-major 4.20 to 5.0 rejected (4.20 not in 4→5 pairing map)",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "5.0"
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "4.20"
+				return c
+			}(),
+			opOptions: testFeatureOptions(api.FeatureExperimentalReleaseFeatures),
+			expectErrors: []expectedError{
+				{message: "cross-major upgrade from 4.20 is only allowed to", fieldPath: "customerProperties.version.id"},
+			},
+		},
+		{
+			name: "update: cross-major 4.22 to 5.0 allowed",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "5.0"
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "4.22"
+				return c
+			}(),
+			opOptions:    testFeatureOptions(api.FeatureExperimentalReleaseFeatures),
+			expectErrors: []expectedError{},
+		},
+		{
+			name: "update: cross-major 4.23 to 5.1 allowed",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "5.1"
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "4.23"
+				return c
+			}(),
+			opOptions:    testFeatureOptions(api.FeatureExperimentalReleaseFeatures),
+			expectErrors: []expectedError{},
+		},
+		{
+			name: "update: cross-major 4.22 to 5.1 rejected (wrong paired minor)",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "5.1"
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "4.22"
+				return c
+			}(),
+			opOptions: testFeatureOptions(api.FeatureExperimentalReleaseFeatures),
+			expectErrors: []expectedError{
+				{message: "cross-major upgrade from 4.22 is only allowed to 5.0", fieldPath: "customerProperties.version.id"},
+			},
+		},
+		{
+			name: "update: cross-major 4.23 to 5.0 rejected (wrong paired minor)",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "5.0"
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "4.23"
+				return c
+			}(),
+			opOptions: testFeatureOptions(api.FeatureExperimentalReleaseFeatures),
+			expectErrors: []expectedError{
+				{message: "cross-major upgrade from 4.23 is only allowed to 5.1", fieldPath: "customerProperties.version.id"},
+			},
+		},
+		{
+			name: "update: upgrade 4 to 6 major rejected (unsupported cross-major skew)",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "6.0"
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Version.ID = "4.22"
+				return c
+			}(),
+			opOptions: testFeatureOptions(api.FeatureExperimentalReleaseFeatures),
+			expectErrors: []expectedError{
+				{message: "skipping major versions is not allowed", fieldPath: "customerProperties.version.id"},
+			},
 		},
 		{
 			name: "update: version must still be at least 4.20 even if old cluster had lower version without experimental flag",

--- a/internal/validation/validate_cluster_comprehensive_test.go
+++ b/internal/validation/validate_cluster_comprehensive_test.go
@@ -1989,9 +1989,8 @@ func TestValidateClusterUpdate(t *testing.T) {
 				c.ServiceProviderProperties.ManagedIdentitiesDataPlaneIdentityURL = "https://oldhost.identity.azure.net"
 				return c
 			}(),
-			// channelGroup is mutable, but version.id, dns.baseDomainPrefix and api.visibility are immutable without experimental flag
+			// channelGroup and version.id are mutable; dns.baseDomainPrefix, api.visibility and managedIdentitiesDataPlaneIdentityURL are immutable without experimental flag
 			expectErrors: []expectedError{
-				{message: "field is immutable", fieldPath: "customerProperties.version.id"},
 				{message: "field is immutable", fieldPath: "customerProperties.dns.baseDomainPrefix"},
 				{message: "field is immutable", fieldPath: "customerProperties.api.visibility"},
 				{message: "field is immutable", fieldPath: "serviceProviderProperties.managedIdentitiesDataPlaneIdentityURL"},
@@ -2140,7 +2139,6 @@ func TestValidateClusterUpdate(t *testing.T) {
 			}(),
 			expectErrors: []expectedError{
 				{message: "OpenShift v5 and above is not supported", fieldPath: "customerProperties.version.id"},
-				{message: "field is immutable", fieldPath: "customerProperties.version.id"},
 			},
 		},
 		{

--- a/internal/validation/validators.go
+++ b/internal/validation/validators.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/validate/constraints"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
@@ -103,6 +104,58 @@ func VersionMayNotDecrease(_ context.Context, op operation.Operation, fldPath *f
 		return field.ErrorList{field.Invalid(fldPath, value, fmt.Sprintf("may not decrease from %s", *oldValue))}
 	}
 
+	return nil
+}
+
+// OpenshiftVersionAtMostOneMinorSkew returns nil if newVersionID is an allowed skew from previousVersionID
+// (same rules as ARM validation: at most one minor within a major; cross-major only 4→5 via the supported pairings).
+// Empty previous or new id is a no-op (nil). Parse failures return an error from semver.
+func OpenshiftVersionAtMostOneMinorSkew(previousVersionID, newVersionID string) error {
+	if len(previousVersionID) == 0 || len(newVersionID) == 0 {
+		return nil
+	}
+
+	parsedDesiredVersion, err := semver.ParseTolerant(newVersionID)
+	if err != nil {
+		return err
+	}
+	parsedPreviousVersion, err := semver.ParseTolerant(previousVersionID)
+	if err != nil {
+		return err
+	}
+
+	if parsedDesiredVersion.Major != parsedPreviousVersion.Major {
+		// Only a single major bump is considered; +2 or more (e.g. 4→6) is not supported.
+		if parsedDesiredVersion.Major != parsedPreviousVersion.Major+1 {
+			return fmt.Errorf("invalid upgrade path from %s to %s: skipping major versions is not allowed", previousVersionID, newVersionID)
+		}
+		previousVersionReleaseLine := fmt.Sprintf("%d.%d", parsedPreviousVersion.Major, parsedPreviousVersion.Minor)
+		desiredVersionReleaseLine := fmt.Sprintf("%d.%d", parsedDesiredVersion.Major, parsedDesiredVersion.Minor)
+		allowedTargetReleaseLine := api.AllowMajorUpgradePaths[previousVersionReleaseLine]
+		if desiredVersionReleaseLine != allowedTargetReleaseLine {
+			return fmt.Errorf("invalid upgrade path from %s to %s: cross-major upgrade from %s is only allowed to %s", previousVersionID, newVersionID, previousVersionReleaseLine, allowedTargetReleaseLine)
+		}
+		return nil
+	}
+
+	if parsedDesiredVersion.Minor > parsedPreviousVersion.Minor+1 {
+		return fmt.Errorf("only upgrade to the next minor is allowed: expected %d.%d after %d.%d", parsedPreviousVersion.Major, parsedPreviousVersion.Minor+1, parsedPreviousVersion.Major, parsedPreviousVersion.Minor)
+	}
+
+	return nil
+}
+
+// OpenshiftVersionAtMostOneMinorSkewWithField reports OpenshiftVersionAtMostOneMinorSkew failures as field errors on newVersionID.
+func OpenshiftVersionAtMostOneMinorSkewWithField(_ context.Context, _ operation.Operation, fldPath *field.Path, newVersionID, previousVersionID *string) field.ErrorList {
+	newVersionIDString := ptr.Deref(newVersionID, "")
+	previousVersionIDString := ptr.Deref(previousVersionID, "")
+	if len(newVersionIDString) == 0 || len(previousVersionIDString) == 0 {
+		return nil
+	}
+
+	if err := OpenshiftVersionAtMostOneMinorSkew(previousVersionIDString, newVersionIDString); err != nil {
+		return field.ErrorList{field.Invalid(fldPath, newVersionID, err.Error())}
+	}
 	return nil
 }
 

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-cluster-v5-without-experimental-on-create/00-httpCreate-subscription-without-afec/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-cluster-v5-without-experimental-on-create/00-httpCreate-subscription-without-afec/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-cluster-v5-without-experimental-on-create/00-httpCreate-subscription-without-afec/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-cluster-v5-without-experimental-on-create/00-httpCreate-subscription-without-afec/subscription.json
@@ -1,0 +1,6 @@
+{
+	"properties": null,
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-cluster-v5-without-experimental-on-create/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-cluster-v5-without-experimental-on-create/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-reject-cluster-v5-without-experimental"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-cluster-v5-without-experimental-on-create/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-cluster-v5-without-experimental-on-create/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,60 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {
+			"/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service-managed-identity": {
+				"clientId": "the-service-managed-client",
+				"principalId": "the-service-managed-principal"
+			}
+		}
+	},
+	"name": "create-reject-cluster-v5-without-experimental",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"operatorsAuthentication": {
+				"userAssignedIdentities": {
+					"serviceManagedIdentity": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service-managed-identity"
+				}
+			},
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "5.0"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-cluster-v5-without-experimental-on-create/01-httpCreate-cluster/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-cluster-v5-without-experimental-on-create/01-httpCreate-cluster/expected-error.txt
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "InvalidRequestContent",
+    "message": "Invalid value: \"5.0\": OpenShift v5 and above is not supported",
+    "target": "properties.version.id"
+  }
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/00-httpCreate-subscription-with-afec/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/00-httpCreate-subscription-with-afec/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/00-httpCreate-subscription-with-afec/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/00-httpCreate-subscription-with-afec/subscription.json
@@ -1,0 +1,13 @@
+{
+	"properties": {
+		"registeredFeatures": [
+			{
+				"name": "Microsoft.RedHatOpenShift/ExperimentalReleaseFeatures",
+				"state": "Registered"
+			}
+		]
+	},
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-reject-cluster-version-skew"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,60 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {
+			"/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service-managed-identity": {
+				"clientId": "the-service-managed-client",
+				"principalId": "the-service-managed-principal"
+			}
+		}
+	},
+	"name": "update-reject-cluster-version-skew",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"operatorsAuthentication": {
+				"userAssignedIdentities": {
+					"serviceManagedIdentity": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service-managed-identity"
+				}
+			},
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.21"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/02-completeOperation-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/02-completeOperation-cluster/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-reject-cluster-version-skew"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/03-loadCosmos-serviceProviderCluster/serviceProviderCluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/03-loadCosmos-serviceProviderCluster/serviceProviderCluster.json
@@ -1,0 +1,26 @@
+{
+	"id": "|subscriptions|6b690bec-0c16-4ecb-8f67-781caf40bba7|resourcegroups|resourcegroupname|providers|microsoft.redhatopenshift|hcpopenshiftclusters|update-reject-cluster-version-skew|serviceproviderclusters|default",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-reject-cluster-version-skew/serviceProviderClusters/default",
+		"spec": {
+			"control_plane_version": {
+				"desired_version": "4.21.12"
+			}
+		},
+		"status": {
+			"control_plane_version": {
+				"active_versions": [
+					{
+						"version": "4.20.9"
+					},
+					{
+						"version": "4.21.12"
+					}
+				]
+			}
+		}
+	},
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-reject-cluster-version-skew/serviceProviderClusters/default",
+	"resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters/serviceproviderclusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/04-httpCreate-nodepool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/04-httpCreate-nodepool/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-reject-cluster-version-skew/nodePools/workers"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/04-httpCreate-nodepool/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/04-httpCreate-nodepool/nodepool.json
@@ -1,0 +1,32 @@
+{
+	"name": "workers",
+	"properties": {
+		"autoRepair": true,
+		"autoScaling": {
+			"max": 5,
+			"min": 1
+		},
+		"labels": [
+			{
+				"key": "label-key",
+				"value": "label-value"
+			}
+		],
+		"nodeDrainTimeoutMinutes": 2,
+		"platform": {
+			"vmSize": "large"
+		},
+		"taints": [
+			{
+				"effect": "NoExecute",
+				"key": "foo.com/key",
+				"value": "valid"
+			}
+		],
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20.0"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/05-completeOperation-nodepool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/05-completeOperation-nodepool/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-reject-cluster-version-skew/nodePools/workers"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/06-httpPatch-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/06-httpPatch-cluster/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-reject-cluster-version-skew"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/06-httpPatch-cluster/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/06-httpPatch-cluster/expected-error.txt
@@ -1,0 +1,23 @@
+{
+  "error": {
+    "code": "MultipleErrorsOccurred",
+    "message": "3 errors occurred",
+    "details": [
+      {
+        "code": "InvalidRequestContent",
+        "message": "Invalid value: \"4.23\": only upgrade to the next minor is allowed: expected 4.22 after 4.21",
+        "target": "properties.version.id"
+      },
+      {
+        "code": "InvalidRequestContent",
+        "message": "Invalid value: \"4.23\": only upgrade to the next minor is allowed: expected 4.21 after 4.20",
+        "target": "properties.version.id"
+      },
+      {
+        "code": "InvalidRequestContent",
+        "message": "Invalid value: \"4.23\": cluster minor 4.23 must not be more than two minor versions ahead of node pool \"workers\" (minor 4.20)",
+        "target": "properties.version.id"
+      }
+    ]
+  }
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/06-httpPatch-cluster/patch.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-reject-cluster-version-skew-patch/06-httpPatch-cluster/patch.json
@@ -1,0 +1,8 @@
+{
+	"properties": {
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.23"
+		}
+	}
+}


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

add control plane minor upgrade validation

### Why

The validation were missing and the following validations have been added

[feat: add frontend validation during version update](https://github.com/Azure/ARO-HCP/commit/f73339d50759d33d21abf0b99f8e7a5241940b3f) 

- checks that v5 is only allowed under a feature flag
- checks for node skew for all existing node pools against the desired version
- checks for non allowed minor skip against the highest control plane active version

[feat: validate that new cluster version is at most one minor skew to the old one](https://github.com/Azure/ARO-HCP/commit/0e5c34794506848690ca17e2e78c56d26c8f71dd) 

With the validations added, we also allowed the version.id to be mutable so that we can open the feature to wider customer

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

Integration test added

### Special notes for your reviewer

<!-- optional -->
