### PR TITLE
Followup the e2e for cluster minor upgrade by adding an additional verifier around KAS version

### DIFF
--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -26,6 +26,7 @@ import (
 	"github.com/blang/semver/v4"
 
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
@@ -41,7 +42,6 @@ var _ = Describe("Customer", func() {
 	DescribeTable("should be able to successfully upgrade control plane minor version",
 		func(ctx context.Context, targetMinor string) {
 			channelGroup := framework.DefaultOpenshiftChannelGroup()
-
 			targetVer := api.Must(semver.ParseTolerant(targetMinor))
 
 			var previousMinor semver.Version
@@ -140,6 +140,12 @@ var _ = Describe("Customer", func() {
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred())
 
+			Expect(ctx.Err()).NotTo(HaveOccurred())
+			kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred())
+			preUpgradeKubeAPIServerVersion, err := kubeClient.Discovery().ServerVersion()
+			Expect(err).NotTo(HaveOccurred())
+
 			By(fmt.Sprintf("triggering control plane y-stream upgrade to %s (target minor %s)", desiredVersion,
 				targetVer.String()))
 			update := hcpsdk20240610preview.HcpOpenShiftClusterUpdate{
@@ -156,6 +162,7 @@ var _ = Describe("Customer", func() {
 			By("verifying control plane reached desired version and cluster remains viable")
 			Eventually(func() error {
 				return verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
+					verifiers.VerifyKubeAPIServerServerVersionUpgraded(preUpgradeKubeAPIServerVersion),
 					verifiers.VerifyHostedControlPlaneYStreamUpgrade(
 						previousMinor.String(),
 						targetVer.String()))

--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/blang/semver/v4"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/cincinatti"
+	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+var _ = Describe("Customer", func() {
+	DescribeTable("should be able to successfully upgrade control plane minor version",
+		func(ctx context.Context, targetMinor string) {
+			channelGroup := framework.DefaultOpenshiftChannelGroup()
+
+			targetVer := api.Must(semver.ParseTolerant(targetMinor))
+
+			var previousMinor semver.Version
+			if targetMinor == "5.0" {
+				previousMinor = api.Must(semver.ParseTolerant("4.22"))
+			} else {
+				previousMinor = semver.MustParse(fmt.Sprintf("%d.%d.0", targetVer.Major, targetVer.Minor-1))
+			}
+
+			installVersion, hasUpgradePath, err := framework.GetLatestVersionInMinorWithUpgradePathTo(ctx, channelGroup,
+				previousMinor.String(),
+				targetVer.String())
+			if cincinatti.IsCincinnatiVersionNotFoundError(err) {
+				Skip(fmt.Sprintf("Cincinnati returned version not found for previous minor %s or target minor %s on channel %s: %v",
+					previousMinor.String(),
+					targetVer.String(),
+					channelGroup, err))
+			}
+			Expect(err).NotTo(HaveOccurred())
+			if !hasUpgradePath {
+				Skip(fmt.Sprintf("no y-stream upgrade path from minor %s to %s on channel %s",
+					previousMinor.String(),
+					targetVer.String(),
+					channelGroup))
+			}
+
+			maxTarget, err := framework.GetLatestVersionInMinor(ctx, channelGroup, targetVer.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			candidates, err := framework.GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx, channelGroup, maxTarget, installVersion)
+			Expect(err).NotTo(HaveOccurred())
+			if len(candidates) == 0 {
+				Skip(fmt.Sprintf("no Cincinnati upgrade candidates from install %s within target minor %s; cannot exercise control plane y-stream upgrade",
+					installVersion, targetVer.String()))
+			}
+			desiredVersion := candidates[len(candidates)-1].String()
+
+			tc := framework.NewTestContext()
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			versionLabel := strings.ReplaceAll(targetMinor, ".", "-")
+			suffix := rand.String(6)
+			clusterName := "cp-ystream-upgrade-" + versionLabel + "-" + suffix
+
+			By("creating resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-cp-ystream-upgrade-"+versionLabel, tc.Location())
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating cluster parameters at install (previous minor) version")
+			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams.ClusterName = clusterName
+			clusterParams.OpenshiftVersionId = installVersion
+			clusterParams.ChannelGroup = channelGroup
+			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name+"-cp-ystream-"+suffix, "-managed", 64)
+
+			By("creating customer resources")
+			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{
+					"customerNsgName":        "customer-nsg-cp-ystream-" + suffix,
+					"customerVnetName":       "customer-vnet-cp-ystream-" + suffix,
+					"customerVnetSubnetName": "customer-vnet-subnet-cp-ystream-" + suffix,
+				},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("creating the HCP cluster with install version %s (previous minor %s)", installVersion,
+				previousMinor.String()))
+			err = tc.CreateHCPClusterFromParam(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				45*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("getting admin credentials")
+			hcpClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+				ctx,
+				hcpClient,
+				*resourceGroup.Name,
+				clusterName,
+				10*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the cluster is viable before upgrade")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("triggering control plane y-stream upgrade to %s (target minor %s)", desiredVersion,
+				targetVer.String()))
+			update := hcpsdk20240610preview.HcpOpenShiftClusterUpdate{
+				Properties: &hcpsdk20240610preview.HcpOpenShiftClusterPropertiesUpdate{
+					Version: &hcpsdk20240610preview.VersionProfile{
+						ID:           to.Ptr(desiredVersion),
+						ChannelGroup: to.Ptr(channelGroup),
+					},
+				},
+			}
+			_, err = framework.UpdateHCPCluster(ctx, hcpClient, *resourceGroup.Name, clusterName, update, 45*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying control plane reached desired version and cluster remains viable")
+			Eventually(func() error {
+				return verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
+					verifiers.VerifyHostedControlPlaneYStreamUpgrade(
+						previousMinor.String(),
+						targetVer.String()))
+			}, 45*time.Minute, 2*time.Minute).Should(Succeed())
+		},
+		Entry("from 4.20 minor to 4.21 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.21"),
+		Entry("from 4.21 minor to 4.22 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.22"),
+		Entry("from 4.22 minor to 4.23 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.23"),
+		Entry("from 4.22 minor to 5.0 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "5.0"),
+		Entry("from 5.0 minor to 5.1 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "5.1"),
+		Entry("from 5.1 minor to 5.2 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "5.2"),
+		Entry("from 5.2 minor to 5.3 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "5.3"),
+		Entry("from 5.3 minor to 5.4 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "5.4"),
+		Entry("from 5.4 minor to 5.5 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "5.5"),
+		Entry("from 5.5 minor to 5.6 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "5.6"),
+		Entry("from 5.6 minor to 5.7 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "5.7"),
+		Entry("from 5.7 minor to 5.8 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "5.8"),
+		Entry("from 5.8 minor to 5.9 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "5.9"),
+		Entry("from 5.9 minor to 5.10 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "5.10"),
+		Entry("from 5.10 minor to 5.11 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "5.11"),
+		Entry("from 5.11 minor to 5.12 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "5.12"),
+	)
+})

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -19,6 +19,22 @@ Service Provider should upgrade the control plane z-stream automatically on beha
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
+Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
+Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
+Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
+Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 5.0 minor
+Customer should be able to successfully upgrade control plane minor version from 5.0 minor to 5.1 minor
+Customer should be able to successfully upgrade control plane minor version from 5.1 minor to 5.2 minor
+Customer should be able to successfully upgrade control plane minor version from 5.2 minor to 5.3 minor
+Customer should be able to successfully upgrade control plane minor version from 5.3 minor to 5.4 minor
+Customer should be able to successfully upgrade control plane minor version from 5.4 minor to 5.5 minor
+Customer should be able to successfully upgrade control plane minor version from 5.5 minor to 5.6 minor
+Customer should be able to successfully upgrade control plane minor version from 5.6 minor to 5.7 minor
+Customer should be able to successfully upgrade control plane minor version from 5.7 minor to 5.8 minor
+Customer should be able to successfully upgrade control plane minor version from 5.8 minor to 5.9 minor
+Customer should be able to successfully upgrade control plane minor version from 5.9 minor to 5.10 minor
+Customer should be able to successfully upgrade control plane minor version from 5.10 minor to 5.11 minor
+Customer should be able to successfully upgrade control plane minor version from 5.11 minor to 5.12 minor
 Engineering should be able to retrieve expected metrics from the /metrics endpoint
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -21,6 +21,22 @@ Service Provider should upgrade the control plane z-stream automatically on beha
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
+Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
+Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
+Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
+Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 5.0 minor
+Customer should be able to successfully upgrade control plane minor version from 5.0 minor to 5.1 minor
+Customer should be able to successfully upgrade control plane minor version from 5.1 minor to 5.2 minor
+Customer should be able to successfully upgrade control plane minor version from 5.2 minor to 5.3 minor
+Customer should be able to successfully upgrade control plane minor version from 5.3 minor to 5.4 minor
+Customer should be able to successfully upgrade control plane minor version from 5.4 minor to 5.5 minor
+Customer should be able to successfully upgrade control plane minor version from 5.5 minor to 5.6 minor
+Customer should be able to successfully upgrade control plane minor version from 5.6 minor to 5.7 minor
+Customer should be able to successfully upgrade control plane minor version from 5.7 minor to 5.8 minor
+Customer should be able to successfully upgrade control plane minor version from 5.8 minor to 5.9 minor
+Customer should be able to successfully upgrade control plane minor version from 5.9 minor to 5.10 minor
+Customer should be able to successfully upgrade control plane minor version from 5.10 minor to 5.11 minor
+Customer should be able to successfully upgrade control plane minor version from 5.11 minor to 5.12 minor
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster
 HCP Nodepools GPU instances creates and deletes vm type NC4asT4v3 in a single cluster

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -21,6 +21,22 @@ Service Provider should upgrade the control plane z-stream automatically on beha
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
+Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
+Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
+Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
+Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 5.0 minor
+Customer should be able to successfully upgrade control plane minor version from 5.0 minor to 5.1 minor
+Customer should be able to successfully upgrade control plane minor version from 5.1 minor to 5.2 minor
+Customer should be able to successfully upgrade control plane minor version from 5.2 minor to 5.3 minor
+Customer should be able to successfully upgrade control plane minor version from 5.3 minor to 5.4 minor
+Customer should be able to successfully upgrade control plane minor version from 5.4 minor to 5.5 minor
+Customer should be able to successfully upgrade control plane minor version from 5.5 minor to 5.6 minor
+Customer should be able to successfully upgrade control plane minor version from 5.6 minor to 5.7 minor
+Customer should be able to successfully upgrade control plane minor version from 5.7 minor to 5.8 minor
+Customer should be able to successfully upgrade control plane minor version from 5.8 minor to 5.9 minor
+Customer should be able to successfully upgrade control plane minor version from 5.9 minor to 5.10 minor
+Customer should be able to successfully upgrade control plane minor version from 5.10 minor to 5.11 minor
+Customer should be able to successfully upgrade control plane minor version from 5.11 minor to 5.12 minor
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -20,6 +20,22 @@ Service Provider should upgrade the control plane z-stream automatically on beha
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
+Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
+Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
+Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
+Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 5.0 minor
+Customer should be able to successfully upgrade control plane minor version from 5.0 minor to 5.1 minor
+Customer should be able to successfully upgrade control plane minor version from 5.1 minor to 5.2 minor
+Customer should be able to successfully upgrade control plane minor version from 5.2 minor to 5.3 minor
+Customer should be able to successfully upgrade control plane minor version from 5.3 minor to 5.4 minor
+Customer should be able to successfully upgrade control plane minor version from 5.4 minor to 5.5 minor
+Customer should be able to successfully upgrade control plane minor version from 5.5 minor to 5.6 minor
+Customer should be able to successfully upgrade control plane minor version from 5.6 minor to 5.7 minor
+Customer should be able to successfully upgrade control plane minor version from 5.7 minor to 5.8 minor
+Customer should be able to successfully upgrade control plane minor version from 5.8 minor to 5.9 minor
+Customer should be able to successfully upgrade control plane minor version from 5.9 minor to 5.10 minor
+Customer should be able to successfully upgrade control plane minor version from 5.10 minor to 5.11 minor
+Customer should be able to successfully upgrade control plane minor version from 5.11 minor to 5.12 minor
 Engineering should be able to retrieve expected metrics from the /metrics endpoint
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -19,6 +19,22 @@ Service Provider should upgrade the control plane z-stream automatically on beha
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
+Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
+Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
+Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
+Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 5.0 minor
+Customer should be able to successfully upgrade control plane minor version from 5.0 minor to 5.1 minor
+Customer should be able to successfully upgrade control plane minor version from 5.1 minor to 5.2 minor
+Customer should be able to successfully upgrade control plane minor version from 5.2 minor to 5.3 minor
+Customer should be able to successfully upgrade control plane minor version from 5.3 minor to 5.4 minor
+Customer should be able to successfully upgrade control plane minor version from 5.4 minor to 5.5 minor
+Customer should be able to successfully upgrade control plane minor version from 5.5 minor to 5.6 minor
+Customer should be able to successfully upgrade control plane minor version from 5.6 minor to 5.7 minor
+Customer should be able to successfully upgrade control plane minor version from 5.7 minor to 5.8 minor
+Customer should be able to successfully upgrade control plane minor version from 5.8 minor to 5.9 minor
+Customer should be able to successfully upgrade control plane minor version from 5.9 minor to 5.10 minor
+Customer should be able to successfully upgrade control plane minor version from 5.10 minor to 5.11 minor
+Customer should be able to successfully upgrade control plane minor version from 5.11 minor to 5.12 minor
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -21,6 +21,22 @@ Service Provider should upgrade the control plane z-stream automatically on beha
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
+Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
+Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
+Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
+Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 5.0 minor
+Customer should be able to successfully upgrade control plane minor version from 5.0 minor to 5.1 minor
+Customer should be able to successfully upgrade control plane minor version from 5.1 minor to 5.2 minor
+Customer should be able to successfully upgrade control plane minor version from 5.2 minor to 5.3 minor
+Customer should be able to successfully upgrade control plane minor version from 5.3 minor to 5.4 minor
+Customer should be able to successfully upgrade control plane minor version from 5.4 minor to 5.5 minor
+Customer should be able to successfully upgrade control plane minor version from 5.5 minor to 5.6 minor
+Customer should be able to successfully upgrade control plane minor version from 5.6 minor to 5.7 minor
+Customer should be able to successfully upgrade control plane minor version from 5.7 minor to 5.8 minor
+Customer should be able to successfully upgrade control plane minor version from 5.8 minor to 5.9 minor
+Customer should be able to successfully upgrade control plane minor version from 5.9 minor to 5.10 minor
+Customer should be able to successfully upgrade control plane minor version from 5.10 minor to 5.11 minor
+Customer should be able to successfully upgrade control plane minor version from 5.11 minor to 5.12 minor
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors

--- a/test/util/framework/cluster_version_history_summary.go
+++ b/test/util/framework/cluster_version_history_summary.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import configv1 "github.com/openshift/api/config/v1"
+
+// ClusterVersionHistoryEntrySummary is a compact view of one ClusterVersion status.history entry.
+// Prefer SummarizeClusterVersionHistory over using raw []UpdateHistory where values are formatted
+// for output (see SummarizeClusterVersionHistory).
+type ClusterVersionHistoryEntrySummary struct {
+	Version string `json:"version"`
+	State   string `json:"state"`
+	Image   string `json:"image"`
+}
+
+// SummarizeClusterVersionHistory returns a representation of ClusterVersion status.history entries
+// that omits *metav1.Time fields from configv1.UpdateHistory, avoiding nil pointer panics when the
+// result is logged (for example CompletionTime is nil when state is "Partial") that the GinkgoLogr
+// formatter would hit when logging raw history in test output.
+func SummarizeClusterVersionHistory(history []configv1.UpdateHistory) []ClusterVersionHistoryEntrySummary {
+	out := make([]ClusterVersionHistoryEntrySummary, 0, len(history))
+	for _, h := range history {
+		out = append(out, ClusterVersionHistoryEntrySummary{
+			Version: h.Version,
+			State:   string(h.State),
+			Image:   h.Image,
+		})
+	}
+	return out
+}

--- a/test/util/verifiers/hosted_control_plane_version.go
+++ b/test/util/verifiers/hosted_control_plane_version.go
@@ -17,11 +17,14 @@ package verifiers
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/blang/semver/v4"
 	"github.com/onsi/ginkgo/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -143,4 +146,35 @@ func (v verifyHostedControlPlaneYStreamUpgrade) Verify(ctx context.Context, admi
 // contains at least one parseable version in previousMinor and at least one in targetMinor.
 func VerifyHostedControlPlaneYStreamUpgrade(previousMinor, targetMinor string) HostedClusterVerifier {
 	return verifyHostedControlPlaneYStreamUpgrade{previousMinor: previousMinor, targetMinor: targetMinor}
+}
+
+type verifyKubeAPIServerServerVersionUpgraded struct {
+	preUpgrade *version.Info
+}
+
+func (v verifyKubeAPIServerServerVersionUpgraded) Name() string {
+	return "VerifyKubeAPIServerServerVersionUpgraded"
+}
+
+func (v verifyKubeAPIServerServerVersionUpgraded) Verify(ctx context.Context, adminRESTConfig *rest.Config) error {
+	clientset, err := kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("create kubernetes clientset: %w", err)
+	}
+	postUpgrade, err := clientset.Discovery().ServerVersion()
+	if err != nil {
+		return fmt.Errorf("get kube-apiserver ServerVersion: %w", err)
+	}
+	if reflect.DeepEqual(v.preUpgrade, postUpgrade) {
+		ginkgo.GinkgoLogr.Info("kube-apiserver ServerVersion unchanged from pre-upgrade",
+			"preUpgrade", v.preUpgrade, "postUpgrade", postUpgrade)
+		return fmt.Errorf("kube-apiserver ServerVersion not updated (unchanged from pre-upgrade)")
+	}
+	return nil
+}
+
+// VerifyKubeAPIServerServerVersionUpgraded fails if the kube-apiserver version is the same as before the upgrade.
+// preUpgrade is the kubernetes discovery ServerVersion (/version) read from the cluster before upgrading.
+func VerifyKubeAPIServerServerVersionUpgraded(preUpgrade *version.Info) HostedClusterVerifier {
+	return verifyKubeAPIServerServerVersionUpgraded{preUpgrade: preUpgrade}
 }

--- a/test/util/verifiers/hosted_control_plane_version.go
+++ b/test/util/verifiers/hosted_control_plane_version.go
@@ -25,6 +25,9 @@ import (
 	"k8s.io/client-go/rest"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/test/util/framework"
 )
 
 type verifyHostedControlPlaneZStreamUpgradeOnly struct {
@@ -51,7 +54,8 @@ func (v verifyHostedControlPlaneZStreamUpgradeOnly) Verify(ctx context.Context, 
 		return fmt.Errorf("failed to get clusterversion %q: %w", "version", err)
 	}
 
-	ginkgo.GinkgoLogr.Info("Retrieved openshift cluster version history", "ocp version history", clusterVersion.Status.History)
+	ginkgo.GinkgoLogr.Info("Retrieved openshift cluster version history",
+		"history", framework.SummarizeClusterVersionHistory(clusterVersion.Status.History))
 
 	var sawUpgrade bool
 	for _, history := range clusterVersion.Status.History {
@@ -82,4 +86,61 @@ func (v verifyHostedControlPlaneZStreamUpgradeOnly) Verify(ctx context.Context, 
 // major.minor as initialVersion.
 func VerifyHostedControlPlaneZStreamUpgradeOnly(initialVersion string) HostedClusterVerifier {
 	return verifyHostedControlPlaneZStreamUpgradeOnly{initialVersion: initialVersion}
+}
+
+type verifyHostedControlPlaneYStreamUpgrade struct {
+	targetMinor   string
+	previousMinor string
+}
+
+func (v verifyHostedControlPlaneYStreamUpgrade) Name() string {
+	return fmt.Sprintf("VerifyHostedControlPlaneYStreamUpgrade(previousMinor=%s, targetMinor=%s)", v.previousMinor, v.targetMinor)
+}
+
+func (v verifyHostedControlPlaneYStreamUpgrade) Verify(ctx context.Context, adminRESTConfig *rest.Config) error {
+	configClient, err := configv1client.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create config client: %w", err)
+	}
+
+	clusterVersion, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get clusterversion %q: %w", "version", err)
+	}
+
+	ginkgo.GinkgoLogr.Info("clusterversion status after y-stream upgrade",
+		"history", framework.SummarizeClusterVersionHistory(clusterVersion.Status.History))
+
+	parsedPreviousMinor := api.Must(semver.ParseTolerant(v.previousMinor))
+	parsedTargetMinor := api.Must(semver.ParseTolerant(v.targetMinor))
+
+	var previousMinorFound, targetMinorFound bool
+	for _, historyEntry := range clusterVersion.Status.History {
+		if len(historyEntry.Version) == 0 {
+			continue
+		}
+		version, err := semver.ParseTolerant(historyEntry.Version)
+		if err != nil {
+			return fmt.Errorf("parse clusterversion history version %q: %w", historyEntry.Version, err)
+		}
+		if version.Major == parsedPreviousMinor.Major && version.Minor == parsedPreviousMinor.Minor {
+			previousMinorFound = true
+		}
+		if version.Major == parsedTargetMinor.Major && version.Minor == parsedTargetMinor.Minor {
+			targetMinorFound = true
+		}
+	}
+	if !previousMinorFound {
+		return fmt.Errorf("clusterversion status.history has no version in previous minor %q", v.previousMinor)
+	}
+	if !targetMinorFound {
+		return fmt.Errorf("clusterversion status.history has no version in target minor %q", v.targetMinor)
+	}
+	return nil
+}
+
+// VerifyHostedControlPlaneYStreamUpgrade returns a verifier that clusterversion status.history
+// contains at least one parseable version in previousMinor and at least one in targetMinor.
+func VerifyHostedControlPlaneYStreamUpgrade(previousMinor, targetMinor string) HostedClusterVerifier {
+	return verifyHostedControlPlaneYStreamUpgrade{previousMinor: previousMinor, targetMinor: targetMinor}
 }


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Followup the e2e for cluster minor upgrade by adding an additional verifier around KAS version

### Why

Adds an additional verifier that verifies that the kube-api server version has been upgraded
    
Follows up https://github.com/Azure/ARO-HCP/pull/4652#discussion_r3022458946

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

Intentionally separated from https://github.com/Azure/ARO-HCP/pull/4652 and to be merged after it.

