### PR TITLE
docs: add 'Running pipelines locally' section to cspr.md

### DIFF
--- a/docs/cspr.md
+++ b/docs/cspr.md
@@ -48,28 +48,24 @@ To access the service and management cluster of CS PR, make sure you have an act
 > [!CAUTION]
 > Infrastructure and service changes to the CS PR environment should be deployed through the [CI/CD pipeline](#cicd) by merging PRs. Running pipelines locally should only be done in emergency situations, e.g. to unblock a broken environment or to debug deployment failures that cannot be reproduced through CI/CD.
 
-If you need to run a deployment locally, make sure you have an active Azure session with your Red Hat account. Prefer using the **entrypoint** command, which runs the full region deployment including all dependent service groups:
+If you need to run a deployment locally, make sure you have an active Azure session with your Red Hat account and run:
 
   ```sh
-  # full region deployment (preferred)
   DEPLOY_ENV=cspr make entrypoint/Region
   ```
 
-Only use individual pipeline commands if you need to target a specific service group in isolation:
-
-  ```sh
-  # deploy management cluster infrastructure only
-  DEPLOY_ENV=cspr make pipeline/Management.Infra
-
-  # deploy service cluster infrastructure only
-  DEPLOY_ENV=cspr make pipeline/Service.Infra
-
-  # delete the management cluster resource group itself and all resources within it
-  DEPLOY_ENV=cspr make pipeline/Management.Delete
-  ```
-
-To perform a dry-run (no actual changes) first, add `DRY_RUN=true`:
+This runs the full region deployment including all dependent service groups in the correct order. To perform a dry-run (no actual changes) first, add `DRY_RUN=true`:
 
   ```sh
   DEPLOY_ENV=cspr DRY_RUN=true make entrypoint/Region
+  ```
+
+If the environment is broken beyond repair and needs to be rebuilt from scratch, you can delete all resources in the management cluster resource group first, then redeploy:
+
+  ```sh
+  # delete all resources in the management cluster resource group (destructive!)
+  DEPLOY_ENV=cspr make pipeline/Management.Delete
+
+  # then redeploy
+  DEPLOY_ENV=cspr make entrypoint/Region
   ```

--- a/docs/cspr.md
+++ b/docs/cspr.md
@@ -64,7 +64,7 @@ Only use individual pipeline commands if you need to target a specific service g
   # deploy service cluster infrastructure only
   DEPLOY_ENV=cspr make pipeline/Service.Infra
 
-  # delete all resources in the management cluster resource group
+  # delete the management cluster resource group itself and all resources within it
   DEPLOY_ENV=cspr make pipeline/Management.Delete
   ```
 

--- a/docs/cspr.md
+++ b/docs/cspr.md
@@ -42,3 +42,34 @@ To access the service and management cluster of CS PR, make sure you have an act
   DEPLOY_ENV=cspr make infra.mgmt.aks.kubeconfig
   export KUBECONFIG=$(DEPLOY_ENV=cspr make infra.mgmt.aks.kubeconfigfile)
   ```
+
+## Running pipelines locally
+
+> [!CAUTION]
+> Infrastructure and service changes to the CS PR environment should be deployed through the [CI/CD pipeline](#cicd) by merging PRs. Running pipelines locally should only be done in emergency situations, e.g. to unblock a broken environment or to debug deployment failures that cannot be reproduced through CI/CD.
+
+If you need to run a deployment locally, make sure you have an active Azure session with your Red Hat account. Prefer using the **entrypoint** command, which runs the full region deployment including all dependent service groups:
+
+  ```sh
+  # full region deployment (preferred)
+  DEPLOY_ENV=cspr make entrypoint/Region
+  ```
+
+Only use individual pipeline commands if you need to target a specific service group in isolation:
+
+  ```sh
+  # deploy management cluster infrastructure only
+  DEPLOY_ENV=cspr make pipeline/Management.Infra
+
+  # deploy service cluster infrastructure only
+  DEPLOY_ENV=cspr make pipeline/Service.Infra
+
+  # delete all resources in the management cluster resource group
+  DEPLOY_ENV=cspr make pipeline/Management.Delete
+  ```
+
+To perform a dry-run (no actual changes) first, add `DRY_RUN=true`:
+
+  ```sh
+  DEPLOY_ENV=cspr DRY_RUN=true make entrypoint/Region
+  ```


### PR DESCRIPTION
Adds a new "Running pipelines locally" section to the CSPR environment documentation with:

- A caution callout noting that CI/CD is the primary deployment path and local runs should only be used in emergencies
- `entrypoint/Region` as the command for full region deployment
- Dry-run usage example with `DRY_RUN=true`
- Nuke-and-rebuild workflow using `pipeline/Management.Delete` followed by `entrypoint/Region` for broken environments