### PR TITLE
Validate Azure-AsyncNotificationUri header to prevent SSRF

### DIFF
--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -806,7 +806,10 @@ func (f *Frontend) addDeleteClusterToTransaction(ctx context.Context, writer htt
 		// deletion request containing these headers so these operations cannot be directly tracked.
 		operationDoc.TenantID = request.Header.Get(arm.HeaderNameHomeTenantID)
 		operationDoc.ClientID = request.Header.Get(arm.HeaderNameClientObjectID)
-		operationDoc.NotificationURI = request.Header.Get(arm.HeaderNameAsyncNotificationURI)
+		notificationURI := request.Header.Get(arm.HeaderNameAsyncNotificationURI)
+		if err := arm.ValidateNotificationURI(notificationURI); err == nil {
+			operationDoc.NotificationURI = notificationURI
+		}
 		transaction.OnSuccess(addOperationResponseHeaders(writer, request, operationDoc.NotificationURI, operationDoc.OperationID))
 	}
 	_, err = f.dbClient.Operations(operationDoc.OperationID.SubscriptionID).AddCreateToTransaction(ctx, transaction, operationDoc, nil)

--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -659,7 +659,10 @@ func (f *Frontend) addDeleteExternalAuthToTransaction(ctx context.Context, write
 		// deletion request containing these headers so these operations cannot be directly tracked.
 		operationDoc.TenantID = request.Header.Get(arm.HeaderNameHomeTenantID)
 		operationDoc.ClientID = request.Header.Get(arm.HeaderNameClientObjectID)
-		operationDoc.NotificationURI = request.Header.Get(arm.HeaderNameAsyncNotificationURI)
+		notificationURI := request.Header.Get(arm.HeaderNameAsyncNotificationURI)
+		if err := arm.ValidateNotificationURI(notificationURI); err == nil {
+			operationDoc.NotificationURI = notificationURI
+		}
 		transaction.OnSuccess(addOperationResponseHeaders(writer, request, operationDoc.NotificationURI, operationDoc.OperationID))
 	}
 	_, err = f.dbClient.Operations(operationDoc.OperationID.SubscriptionID).AddCreateToTransaction(ctx, transaction, operationDoc, nil)

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -751,7 +751,10 @@ func (f *Frontend) addDeleteNodePoolToTransaction(ctx context.Context, writer ht
 		// deletion request containing these headers so these operations cannot be directly tracked.
 		operationDoc.TenantID = request.Header.Get(arm.HeaderNameHomeTenantID)
 		operationDoc.ClientID = request.Header.Get(arm.HeaderNameClientObjectID)
-		operationDoc.NotificationURI = request.Header.Get(arm.HeaderNameAsyncNotificationURI)
+		notificationURI := request.Header.Get(arm.HeaderNameAsyncNotificationURI)
+		if err := arm.ValidateNotificationURI(notificationURI); err == nil {
+			operationDoc.NotificationURI = notificationURI
+		}
 		transaction.OnSuccess(addOperationResponseHeaders(writer, request, operationDoc.NotificationURI, operationDoc.OperationID))
 	}
 	_, err = f.dbClient.Operations(operationDoc.OperationID.SubscriptionID).AddCreateToTransaction(ctx, transaction, operationDoc, nil)

--- a/internal/api/arm/notification.go
+++ b/internal/api/arm/notification.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arm
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// allowedNotificationHosts lists known Azure Resource Manager management
+// endpoints that are permitted as notification callback targets.
+// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/control-plane-and-data-plane#control-plane
+var allowedNotificationHosts = []string{
+	"management.azure.com",
+	"management.usgovcloudapi.net",
+}
+
+// ValidateNotificationURI validates that an Azure-AsyncNotificationUri
+// header value is safe to use as a callback target. An empty string is
+// considered valid (no notification). A non-empty URI must be HTTPS and
+// target a known ARM management endpoint to prevent SSRF attacks.
+func ValidateNotificationURI(uri string) error {
+	if uri == "" {
+		return nil
+	}
+
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return fmt.Errorf("invalid notification URI: %w", err)
+	}
+
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return fmt.Errorf("notification URI scheme must be HTTPS, got %q", parsed.Scheme)
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	for _, allowed := range allowedNotificationHosts {
+		if host == allowed {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("notification URI host %q is not a known ARM management endpoint", host)
+}

--- a/internal/api/arm/notification_test.go
+++ b/internal/api/arm/notification_test.go
@@ -1,0 +1,97 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arm
+
+import (
+	"testing"
+)
+
+func TestValidateNotificationURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr bool
+	}{
+		{
+			name:    "empty string is valid",
+			uri:     "",
+			wantErr: false,
+		},
+		{
+			name:    "valid ARM public endpoint",
+			uri:     "https://management.azure.com/providers/Microsoft.Resources/operationResults/abc123",
+			wantErr: false,
+		},
+		{
+			name:    "valid ARM US Gov endpoint",
+			uri:     "https://management.usgovcloudapi.net/providers/Microsoft.Resources/operationResults/abc123",
+			wantErr: false,
+		},
+		{
+			name:    "case insensitive URI",
+			uri:     "HTTPS://Management.azure.com/providers/Microsoft.Resources/operationResults/abc123",
+			wantErr: false,
+		},
+		{
+			name:    "HTTP scheme rejected",
+			uri:     "http://management.azure.com/providers/Microsoft.Resources/operationResults/abc123",
+			wantErr: true,
+		},
+		{
+			name:    "unknown host rejected",
+			uri:     "https://evil.example.com/callback",
+			wantErr: true,
+		},
+		{
+			name:    "subdomain of allowed host rejected",
+			uri:     "https://foo.management.azure.com/callback",
+			wantErr: true,
+		},
+		{
+			name:    "no scheme rejected",
+			uri:     "management.azure.com/callback",
+			wantErr: true,
+		},
+		{
+			name:    "javascript scheme rejected",
+			uri:     "javascript:alert(1)",
+			wantErr: true,
+		},
+		{
+			name:    "file scheme rejected",
+			uri:     "file:///etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "localhost rejected",
+			uri:     "https://localhost/callback",
+			wantErr: true,
+		},
+		{
+			name:    "IP address rejected",
+			uri:     "https://169.254.169.254/latest/meta-data",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNotificationURI(tt.uri)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateNotificationURI(%q) error = %v, wantErr %v", tt.uri, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/database/types_operation.go
+++ b/internal/database/types_operation.go
@@ -47,6 +47,14 @@ func NewOperation(
 	correlationData *arm.CorrelationData,
 ) *api.Operation {
 
+	// Validate the notification URI to prevent SSRF attacks.
+	// Drop invalid URIs silently since this header is injected
+	// by ARM, not by the end user, so we should not fail the
+	// user's request if ARM sends something unexpected.
+	if err := arm.ValidateNotificationURI(notificationURI); err != nil {
+		notificationURI = ""
+	}
+
 	now := time.Now().UTC()
 
 	operation := &api.Operation{


### PR DESCRIPTION
### What
Add `ValidateNotificationURI()` which enforces HTTPS and restricts the host to known ARM management endpoints (management.azure.com, management.usgovcloudapi.net).

Validation is applied in `NewOperation()` and in the delete handlers for clusters, node pools, and external auth configs where the header value is set directly on the operation document. Invalid URIs are silently dropped since this header is injected by ARM, not by end users.

### Why
We were [alerted](https://portal.microsofticm.com/imp/v5/incidents/details/31000000578371/summary) by a MSFT internal security team about a potential security vulnerability in our source code.

The `NotificationURI` from the `Azure-AsyncNotificationUri` header is used by the backend to make outbound HTTP POST requests when async operations complete. Without validation, a crafted URI could be used to target internal services or attacker-controlled endpoints.

### Testing
unit testing
