### PR TITLE
test: add E2E for MI role assignment recovery (ARO-25805)

### DIFF
--- a/test/e2e/cluster_delayed_role_assignments.go
+++ b/test/e2e/cluster_delayed_role_assignments.go
@@ -1,0 +1,215 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+var _ = Describe("ARO HCP Service", func() {
+	It("should successfully provision cluster when MI role assignments are added after cluster creation",
+		labels.RequireNothing,
+		labels.High,
+		labels.Positive,
+		labels.AroRpApiCompatible,
+		func(ctx context.Context) {
+			const (
+				customerNsgName        = "customer-nsg-name"
+				customerVnetName       = "customer-vnet-name"
+				customerVnetSubnetName = "customer-vnet-subnet1"
+				customerClusterName    = "delayed-rbac-cluster"
+
+				clusterCreationTimeout   = 45 * time.Minute
+				consistentlyLoopDuration = 3 * time.Minute
+			)
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
+			}
+
+			By("creating a resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "delayed-rbac", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group")
+
+			By("creating cluster parameters")
+			clusterParams := framework.NewDefaultClusterParams20251223()
+			clusterParams.ClusterName = customerClusterName
+			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+
+			By("deploying customer infrastructure (NSG, VNet, subnet, KeyVault)")
+			suffix := rand.String(6)
+			customerInfraResult, err := tc.CreateBicepTemplateAndWait(ctx,
+				framework.WithTemplateFromFS(TestArtifactsFS, "test-artifacts/generated-test-artifacts/modules/customer-infra.json"),
+				framework.WithDeploymentName("customer-infra-"+customerClusterName),
+				framework.WithScope(framework.BicepDeploymentScopeResourceGroup),
+				framework.WithClusterResourceGroup(*resourceGroup.Name),
+				framework.WithParameters(map[string]any{
+					"customerNsgName":        customerNsgName,
+					"customerVnetName":       customerVnetName,
+					"customerVnetSubnetName": customerVnetSubnetName,
+					"clusterName":            customerClusterName,
+				}),
+				framework.WithTimeout(10*time.Minute),
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to deploy customer infrastructure")
+
+			clusterParams, err = framework.PopulateClusterParamsFromCustomerInfraDeployment20251223(clusterParams, customerInfraResult)
+			Expect(err).NotTo(HaveOccurred(), "failed to populate cluster params from customer infra deployment")
+
+			// Determine MI resource group and identity names. In pooled mode,
+			// the pool already created MIs without role assignments. In
+			// non-pooled mode, we create MIs explicitly via cluster-identities.
+			// Either way, MIs exist but lack role assignments — CS's MI
+			// permission validation will fail and retry (ARO-25805).
+			By("ensuring managed identities exist WITHOUT role assignments")
+			subscriptionID, err := tc.SubscriptionID(ctx)
+			Expect(err).NotTo(HaveOccurred(), "failed to get subscription ID")
+
+			var msiResourceGroupName string
+			var identities framework.Identities
+			var leasedPool *framework.LeasedIdentityPool
+
+			if tc.UsePooledIdentities() {
+				pool, err := tc.NextLeasedIdentityPool()
+				Expect(err).NotTo(HaveOccurred(), "failed to lease identity pool")
+				leasedPool = &pool
+				msiResourceGroupName = pool.ResourceGroupName
+				identities = pool.Identities
+			} else {
+				msiResourceGroupName = *resourceGroup.Name
+				identities = framework.NewDefaultIdentitiesWithSuffix(customerClusterName)
+				_, err = tc.CreateBicepTemplateAndWait(ctx,
+					framework.WithTemplateFromFS(TestArtifactsFS, "test-artifacts/generated-test-artifacts/modules/cluster-identities.json"),
+					framework.WithDeploymentName("mi-identities-only-"+customerClusterName),
+					framework.WithScope(framework.BicepDeploymentScopeResourceGroup),
+					framework.WithClusterResourceGroup(*resourceGroup.Name),
+					framework.WithParameters(map[string]any{
+						"identities": identities,
+					}),
+					framework.WithTimeout(10*time.Minute),
+				)
+				Expect(err).NotTo(HaveOccurred(), "failed to deploy identity-only bicep template")
+			}
+
+			uamis, msi := framework.BuildIdentityParamsFromNames(subscriptionID, msiResourceGroupName, identities)
+
+			By("starting HCP cluster creation (MIs exist but lack role assignments)")
+			hcpClient := tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			cluster, err := framework.BuildHCPClusterFromParams20251223(clusterParams, tc.Location(), nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to build HCP cluster spec")
+			cluster.Identity = msi
+			cluster.Properties.Platform.OperatorsAuthentication.UserAssignedIdentities = uamis
+			_, err = hcpClient.BeginCreateOrUpdate(ctx, *resourceGroup.Name, customerClusterName, cluster, nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to start cluster creation")
+
+			By("waiting for cluster resource to become visible")
+			Eventually(func(g Gomega) {
+				_, err := hcpClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+				g.Expect(err).NotTo(HaveOccurred(), "GET cluster failed — RP may not have registered the resource yet")
+			}, 2*time.Minute, 10*time.Second).Should(Succeed(),
+				"timed out waiting for cluster resource to become visible after BeginCreateOrUpdate")
+
+			By("verifying cluster does not enter terminal Failed state while role assignments are missing")
+			Consistently(func(g Gomega) {
+				resp, err := hcpClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+				if err != nil {
+					GinkgoLogr.Info("GET cluster returned error, skipping poll iteration", "error", err)
+					return
+				}
+				g.Expect(resp.Properties).NotTo(BeNil(), "cluster response has nil Properties")
+				g.Expect(resp.Properties.ProvisioningState).NotTo(BeNil(), "cluster response has nil ProvisioningState")
+				state := *resp.Properties.ProvisioningState
+				GinkgoLogr.Info("cluster provisioning state", "state", state)
+				g.Expect(state).NotTo(Equal(hcpsdk20251223preview.ProvisioningStateFailed),
+					"cluster entered terminal Failed state — CS inflight validation should retry, not fail terminally (ARO-25805)")
+			}, consistentlyLoopDuration, 30*time.Second).Should(Succeed())
+
+			By("deploying role assignments for managed identities")
+			deployMIOpts := []framework.BicepDeploymentOption{
+				framework.WithTemplateFromFS(TestArtifactsFS, "test-artifacts/generated-test-artifacts/modules/managed-identities.json"),
+				framework.WithDeploymentName("mi-assignments-" + customerClusterName + "-" + suffix),
+				framework.WithClusterResourceGroup(*resourceGroup.Name),
+				framework.WithTimeout(10 * time.Minute),
+				framework.WithParameters(map[string]any{
+					"nsgName":      clusterParams.NsgName,
+					"vnetName":     clusterParams.VnetName,
+					"subnetName":   clusterParams.SubnetName,
+					"keyVaultName": clusterParams.KeyVaultName,
+				}),
+			}
+			if leasedPool != nil {
+				deployMIOpts = append(deployMIOpts, framework.WithIdentityPool(leasedPool))
+			}
+			_, err = tc.DeployManagedIdentities(ctx,
+				customerClusterName,
+				framework.RBACScopeResourceGroup,
+				deployMIOpts...,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to deploy role assignments for managed identities")
+
+			By("waiting for cluster to reach Succeeded state")
+			Eventually(func(g Gomega) {
+				resp, err := hcpClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+				if err != nil {
+					var respErr *azcore.ResponseError
+					if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+						g.Expect(err).NotTo(HaveOccurred(), "cluster returned 404 — resource disappeared after role assignment deployment")
+						return
+					}
+					GinkgoLogr.Info("GET cluster returned error, retrying", "error", err)
+					g.Expect(err).NotTo(HaveOccurred(), "GET cluster failed — RP returned an unexpected error")
+				}
+				g.Expect(resp.Properties).NotTo(BeNil(), "cluster response has nil Properties")
+				g.Expect(resp.Properties.ProvisioningState).NotTo(BeNil(), "cluster response has nil ProvisioningState")
+				state := *resp.Properties.ProvisioningState
+				GinkgoLogr.Info("cluster provisioning state", "state", state)
+				g.Expect(state).NotTo(Equal(hcpsdk20251223preview.ProvisioningStateFailed),
+					"cluster entered terminal Failed state after role assignment deployment")
+				g.Expect(state).To(Equal(hcpsdk20251223preview.ProvisioningStateSucceeded),
+					"cluster has not yet reached Succeeded state")
+			}, clusterCreationTimeout-consistentlyLoopDuration, 30*time.Second).Should(Succeed(),
+				"cluster should eventually succeed after role assignments are created")
+
+			By("verifying cluster is viable")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				customerClusterName,
+				10*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for HCP cluster")
+
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster viability")
+		})
+})

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -10,6 +10,7 @@ Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
+ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -9,6 +9,7 @@ Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
+ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -9,6 +9,7 @@ Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
+ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -12,6 +12,7 @@ Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
+ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -9,6 +9,7 @@ Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
+ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -9,6 +9,7 @@ Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
+ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates

--- a/test/util/framework/deployment_helper.go
+++ b/test/util/framework/deployment_helper.go
@@ -105,6 +105,7 @@ type bicepDeploymentConfig struct {
 	debugDetailLevel string
 	location         string
 	template         []byte
+	identityPool     *LeasedIdentityPool
 }
 
 type BicepDeploymentOption func(*bicepDeploymentConfig)
@@ -160,6 +161,12 @@ func WithTemplateFromFS(fs embed.FS, path string) BicepDeploymentOption {
 func WithTemplateFromBytes(template []byte) BicepDeploymentOption {
 	return func(cfg *bicepDeploymentConfig) {
 		cfg.template = template
+	}
+}
+
+func WithIdentityPool(pool *LeasedIdentityPool) BicepDeploymentOption {
+	return func(cfg *bicepDeploymentConfig) {
+		cfg.identityPool = pool
 	}
 }
 

--- a/test/util/framework/deployment_params.go
+++ b/test/util/framework/deployment_params.go
@@ -662,4 +662,62 @@ func (tc *perItOrDescribeTestContext) CreateClusterCustomerResources20251223(ctx
 	return clusterParams, nil
 }
 
+// BuildIdentityParamsFromNames constructs the UserAssignedIdentitiesProfile and
+// ManagedServiceIdentity from identity names and resource group, without
+// requiring a Bicep deployment. This produces the same structure as the outputs
+// of non-msi-scoped-assignments.bicep.
+func BuildIdentityParamsFromNames(
+	subscriptionID string,
+	msiResourceGroupName string,
+	identities Identities,
+) (*hcpsdk20251223preview.UserAssignedIdentitiesProfile, *hcpsdk20251223preview.ManagedServiceIdentity) {
+	idFmt := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s"
+	id := func(name string) *string {
+		return to.Ptr(fmt.Sprintf(idFmt, subscriptionID, msiResourceGroupName, name))
+	}
+
+	uamis := &hcpsdk20251223preview.UserAssignedIdentitiesProfile{
+		ControlPlaneOperators: map[string]*string{
+			"cluster-api-azure":        id(identities.ClusterApiAzureMiName),
+			"control-plane":            id(identities.ControlPlaneMiName),
+			"cloud-controller-manager": id(identities.CloudControllerManagerMiName),
+			"ingress":                  id(identities.IngressMiName),
+			"disk-csi-driver":          id(identities.DiskCsiDriverMiName),
+			"file-csi-driver":          id(identities.FileCsiDriverMiName),
+			"image-registry":           id(identities.ImageRegistryMiName),
+			"cloud-network-config":     id(identities.CloudNetworkConfigMiName),
+			"kms":                      id(identities.KmsMiName),
+		},
+		DataPlaneOperators: map[string]*string{
+			"disk-csi-driver": id(identities.DpDiskCsiDriverMiName),
+			"file-csi-driver": id(identities.DpFileCsiDriverMiName),
+			"image-registry":  id(identities.DpImageRegistryMiName),
+		},
+		ServiceManagedIdentity: id(identities.ServiceManagedIdentityName),
+	}
+
+	azureAttachedIDs := []*string{
+		id(identities.ServiceManagedIdentityName),
+		id(identities.ClusterApiAzureMiName),
+		id(identities.ControlPlaneMiName),
+		id(identities.CloudControllerManagerMiName),
+		id(identities.IngressMiName),
+		id(identities.DiskCsiDriverMiName),
+		id(identities.FileCsiDriverMiName),
+		id(identities.ImageRegistryMiName),
+		id(identities.CloudNetworkConfigMiName),
+		id(identities.KmsMiName),
+	}
+	userAssigned := make(map[string]*hcpsdk20251223preview.UserAssignedIdentity, len(azureAttachedIDs))
+	for _, armID := range azureAttachedIDs {
+		userAssigned[*armID] = &hcpsdk20251223preview.UserAssignedIdentity{}
+	}
+	msi := &hcpsdk20251223preview.ManagedServiceIdentity{
+		Type:                   to.Ptr(hcpsdk20251223preview.ManagedServiceIdentityTypeUserAssigned),
+		UserAssignedIdentities: userAssigned,
+	}
+
+	return uamis, msi
+}
+
 // ClusterParamsV20251223 contains parameters for v20251223preview cluster creation

--- a/test/util/framework/identities_helper.go
+++ b/test/util/framework/identities_helper.go
@@ -206,11 +206,16 @@ func (tc *perItOrDescribeTestContext) DeployManagedIdentities(
 		cfg.deploymentName = fmt.Sprintf("mi-%s", cfg.resourceGroup)
 	}
 
-	usePooled := tc.UsePooledIdentities()
 	msiRGName := cfg.resourceGroup
 	var identities Identities
+	usePooled := false
 
-	if usePooled {
+	if cfg.identityPool != nil {
+		usePooled = true
+		msiRGName = cfg.identityPool.ResourceGroupName
+		identities = cfg.identityPool.Identities
+	} else if tc.UsePooledIdentities() {
+		usePooled = true
 		msiPool, err := tc.getLeasedIdentities()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get leased MSIs: %w", err)
@@ -316,6 +321,13 @@ func (tc *perItOrDescribeTestContext) getLeasedIdentities() (LeasedIdentityPool,
 		ResourceGroupName: leasedRG,
 		Identities:        NewDefaultIdentities(),
 	}, nil
+}
+
+// NextLeasedIdentityPool leases the next assigned identity container for the
+// calling test spec. Each call consumes a new container — callers should
+// store the result and reuse it rather than calling this multiple times.
+func (tc *perItOrDescribeTestContext) NextLeasedIdentityPool() (LeasedIdentityPool, error) {
+	return tc.getLeasedIdentities()
 }
 
 // leasedIdentityContainers returns the list of resource groups that are currently leased


### PR DESCRIPTION
Adds an E2E test that creates a cluster without MI role assignments, verifies it does not enter terminal error state, then adds role assignments and confirms the cluster eventually succeeds.
