### PR TITLE
Changing functions to have non-pointer method receievers

### DIFF
--- a/backend/pkg/controllers/controllerutils/cluster_watching_controller_test.go
+++ b/backend/pkg/controllers/controllerutils/cluster_watching_controller_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerutils
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/funcr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+type mockClusterSyncer struct {
+	syncOnceFunc func(ctx context.Context, key HCPClusterKey) error
+	cooldown     CooldownChecker
+}
+
+func (m *mockClusterSyncer) SyncOnce(ctx context.Context, key HCPClusterKey) error {
+	if m.syncOnceFunc != nil {
+		return m.syncOnceFunc(ctx, key)
+	}
+	return nil
+}
+
+func (m *mockClusterSyncer) CooldownChecker() CooldownChecker {
+	if m.cooldown != nil {
+		return m.cooldown
+	}
+	return NewTimeBasedCooldownChecker(time.Minute)
+}
+
+func TestClusterWatchingControllerSyncHasLoggerContextValues(t *testing.T) {
+	subscriptionID := "00000000-0000-0000-0000-000000000000"
+	resourceGroup := "test-rg"
+	clusterName := "test-cluster"
+
+	var capturedCtx context.Context
+	mockSyncer := &mockClusterSyncer{
+		syncOnceFunc: func(ctx context.Context, key HCPClusterKey) error {
+			capturedCtx = ctx
+			return nil
+		},
+	}
+
+	mockDB := databasetesting.NewMockDBClient()
+	controller := NewClusterWatchingController(
+		"test-controller",
+		mockDB,
+		nil, // nil informers for unit testing
+		time.Minute,
+		mockSyncer,
+	)
+
+	gwc := controller.(*genericWatchingController[HCPClusterKey])
+	gwc.queue.Add(HCPClusterKey{
+		SubscriptionID:    subscriptionID,
+		ResourceGroupName: resourceGroup,
+		HCPClusterName:    clusterName,
+	})
+
+	var logOutput strings.Builder
+	logger := funcr.New(func(prefix, args string) {
+		logOutput.WriteString(prefix)
+		logOutput.WriteString(args)
+	}, funcr.Options{})
+	ctx := utils.ContextWithLogger(context.Background(), logger)
+
+	gwc.processNextWorkItem(ctx)
+
+	require.NotNil(t, capturedCtx, "syncer should have been called")
+
+	// Log a message using the captured logger to verify its values
+	capturedLogger := utils.LoggerFromContext(capturedCtx)
+	capturedLogger.Info("test")
+
+	output := logOutput.String()
+	require.Contains(t, output, ` "subscription_id"="00000000-0000-0000-0000-000000000000" `, "logger should contain subscription_id")
+	require.Contains(t, output, ` "resource_group"="test-rg" `, "logger should contain resource_group")
+	require.Contains(t, output, ` "resource_name"="test-cluster" `, "logger should contain cluster name")
+	require.Contains(t, output, `"hcp_cluster_name"="/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster"`)
+
+}

--- a/backend/pkg/controllers/controllerutils/util.go
+++ b/backend/pkg/controllers/controllerutils/util.go
@@ -60,18 +60,18 @@ type OperationKey struct {
 	ParentResourceID string `json:"parentResourceID"`
 }
 
-func (k *OperationKey) GetParentResourceID() *azcorearm.ResourceID {
+func (k OperationKey) GetParentResourceID() *azcorearm.ResourceID {
 	return api.Must(azcorearm.ParseResourceID(k.ParentResourceID))
 }
 
-func (k *OperationKey) AddLoggerValues(logger logr.Logger) logr.Logger {
+func (k OperationKey) AddLoggerValues(logger logr.Logger) logr.Logger {
 	return logger.WithValues(
 		utils.LogValues{}.
 			AddLogValuesForResourceID(k.GetParentResourceID()).
 			AddOperationID(k.OperationName)...)
 }
 
-func (k *OperationKey) InitialController(controllerName string) *api.Controller {
+func (k OperationKey) InitialController(controllerName string) *api.Controller {
 	// TODO, this structure only allows one status per operation controller even if there are multiple instances of the operation
 	// TODO, this may or may not age well. Nesting is possible or we could actually separate controllers that way (probably useful).
 	// TODO, leaving this as a thing open to change in the future.
@@ -94,17 +94,17 @@ type HCPClusterKey struct {
 	HCPClusterName    string `json:"hcpClusterName"`
 }
 
-func (k *HCPClusterKey) GetResourceID() *azcorearm.ResourceID {
+func (k HCPClusterKey) GetResourceID() *azcorearm.ResourceID {
 	return api.Must(api.ToClusterResourceID(k.SubscriptionID, k.ResourceGroupName, k.HCPClusterName))
 }
 
-func (k *HCPClusterKey) AddLoggerValues(logger logr.Logger) logr.Logger {
+func (k HCPClusterKey) AddLoggerValues(logger logr.Logger) logr.Logger {
 	return logger.WithValues(
 		utils.LogValues{}.
 			AddLogValuesForResourceID(k.GetResourceID())...)
 }
 
-func (k *HCPClusterKey) InitialController(controllerName string) *api.Controller {
+func (k HCPClusterKey) InitialController(controllerName string) *api.Controller {
 	resourceID := api.Must(azcorearm.ParseResourceID(k.GetResourceID().String() + "/" + api.ControllerResourceTypeName + "/" + controllerName))
 	return &api.Controller{
 		CosmosMetadata: api.CosmosMetadata{
@@ -126,16 +126,16 @@ type HCPNodePoolKey struct {
 	HCPNodePoolName   string `json:"hcpNodePoolName"`
 }
 
-func (k *HCPNodePoolKey) GetResourceID() *azcorearm.ResourceID {
+func (k HCPNodePoolKey) GetResourceID() *azcorearm.ResourceID {
 	return api.Must(api.ToNodePoolResourceID(k.SubscriptionID, k.ResourceGroupName, k.HCPClusterName, k.HCPNodePoolName))
 }
 
-func (k *HCPNodePoolKey) AddLoggerValues(logger logr.Logger) logr.Logger {
+func (k HCPNodePoolKey) AddLoggerValues(logger logr.Logger) logr.Logger {
 	return logger.WithValues(
 		utils.LogValues{}.AddLogValuesForResourceID(k.GetResourceID())...)
 }
 
-func (k *HCPNodePoolKey) InitialController(controllerName string) *api.Controller {
+func (k HCPNodePoolKey) InitialController(controllerName string) *api.Controller {
 	resourceID := api.Must(azcorearm.ParseResourceID(k.GetResourceID().String() + "/" + api.ControllerResourceTypeName + "/" + controllerName))
 	return &api.Controller{
 		CosmosMetadata: api.CosmosMetadata{
@@ -154,11 +154,11 @@ type SubscriptionKey struct {
 	SubscriptionID string `json:"subscriptionID"`
 }
 
-func (k *SubscriptionKey) GetResourceID() *azcorearm.ResourceID {
+func (k SubscriptionKey) GetResourceID() *azcorearm.ResourceID {
 	return api.Must(arm.ToSubscriptionResourceID(k.SubscriptionID))
 }
 
-func (k *SubscriptionKey) AddLoggerValues(logger logr.Logger) logr.Logger {
+func (k SubscriptionKey) AddLoggerValues(logger logr.Logger) logr.Logger {
 	return logger.WithValues(
 		utils.LogValues{}.
 			AddLogValuesForResourceID(k.GetResourceID())...)


### PR DESCRIPTION
This caused an interface check to fail, which caused us to lose our logging context.  Added a unit test to be sure we dont' lose it again for at least the value.
