### PR TITLE
Enable testing of versions > 4.20 and calculate latest z-stream for non-stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ report.json
 _artifacts
 must-gather-*
 /hcpctl
+timing-metadata-*

--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -55,36 +55,32 @@ var _ = Describe("ARO-HCP", func() {
 			customerVnetSubnetName := "customer-vnet-subnet-" + channelGroup + "-"
 			customerClusterNamePrefix := "cluster-" + channelGroup + "-"
 
-			tc := framework.NewTestContext()
-			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
-				Expect(err).NotTo(HaveOccurred())
-			}
-
 			versionLabel := strings.ReplaceAll(version, ".", "-") // e.g. "4.20" -> "4-20"
 			suffix := rand.String(6)
 			clusterName := customerClusterNamePrefix + versionLabel + "-" + suffix
 			clusterParams := framework.NewDefaultClusterParams()
 			clusterParams.ClusterName = clusterName
 			clusterParams.OpenshiftVersionId = version
-			// For nightly channel, calculate the latest version for the default Y stream
-			if clusterParams.ChannelGroup == "nightly" {
-				var err error
-				clusterParams.OpenshiftVersionId, err = framework.GetLatestInstallVersionForNightlyChannel(version)
-				if err != nil {
-					if errors.Is(err, framework.ErrNightlyReleaseStreamNotFound) || errors.Is(err, framework.ErrNoAcceptedNightlyTags) {
-						Skip(fmt.Sprintf("No node pool install version found for %s in nightly channel (%s)", version, err.Error()))
-					} else {
-						Fail(fmt.Sprintf("failed to get latest node pool install version for nightly channel: %s", err.Error()))
-					}
+			openShiftControlPlaneVersion, err := framework.GetLatestInstallVersion(ctx, clusterParams.ChannelGroup, version)
+			if err != nil {
+				if errors.Is(err, framework.ErrNightlyReleaseStreamNotFound) || errors.Is(err, framework.ErrNoAcceptedNightlyTags) || errors.Is(err, framework.ErrVersionNotFound) {
+					Skip(fmt.Sprintf("No install version found for %s in %s channel (%s)", version, clusterParams.ChannelGroup, err.Error()))
+				} else {
+					Fail(fmt.Sprintf("failed to get latest install version for %s channel: %s", clusterParams.ChannelGroup, err.Error()))
 				}
 			}
-
-			// TODO: remove this filter when https://redhat.atlassian.net/browse/ARO-25490 and https://redhat.atlassian.net/browse/ARO-24955 are closed
+			// TODO: remove this filter when https://redhat.atlassian.net/browse/OCPBUGS-83564 is fixed
 			calculatedControlPlaneSemver, err := semver.ParseTolerant(clusterParams.OpenshiftVersionId)
 			Expect(err).NotTo(HaveOccurred(), "calculated control plane version was not semver parseable")
-			if calculatedControlPlaneSemver.Major > 4 || (calculatedControlPlaneSemver.Major == 4 && calculatedControlPlaneSemver.Minor >= 21) {
-				Skip(fmt.Sprintf("Skipping test for control plane version %s: versions >= 4.21 are not supported by this test", clusterParams.OpenshiftVersionId))
+			if calculatedControlPlaneSemver.Major == 5 {
+				Skip(fmt.Sprintf("Skipping test for control plane version %s: versions >= 5.0 are not yet supported by this test", clusterParams.OpenshiftVersionId))
+			}
+			clusterParams.OpenshiftVersionId = openShiftControlPlaneVersion
+
+			tc := framework.NewTestContext()
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				Expect(err).NotTo(HaveOccurred())
 			}
 
 			By("creating resource group")

--- a/test/util/framework/deployment_params.go
+++ b/test/util/framework/deployment_params.go
@@ -40,10 +40,9 @@ const (
 	RBACScopeResourceGroup RBACScope = "resourceGroup"
 	RBACScopeResource      RBACScope = "resource"
 
-	// Default OpenShift channel group, version, and node pool version for the E2E test
+	// Default OpenShift channel group and version for the E2E tests
 	DefaultOCPChannelGroup         = "candidate"
 	DefaultOCPVersionId            = "4.20"
-	DefaultOCPNodePoolVersionId    = "4.20.15"
 	DefaultOCPNodePoolChannelGroup = "candidate"
 
 	DefaultPodCIDR      = "10.128.0.0/14"
@@ -90,15 +89,15 @@ func DefaultOpenshiftControlPlaneVersionId() string {
 	version := os.Getenv("ARO_HCP_OPENSHIFT_CONTROLPLANE_VERSION")
 	if len(version) == 0 {
 		version = DefaultOCPVersionId
-		// For nightly channel, calculate the latest version for the default Y stream
-		if DefaultOpenshiftChannelGroup() == "nightly" {
+		channelGroup := DefaultOpenshiftChannelGroup()
+		if channelGroup != "stable" {
 			var err error
-			version, err = GetLatestInstallVersionForNightlyChannel(version)
+			version, err = GetLatestInstallVersion(context.Background(), channelGroup, version)
 			if err != nil {
-				if errors.Is(err, ErrNightlyReleaseStreamNotFound) || errors.Is(err, ErrNoAcceptedNightlyTags) {
-					Skip(fmt.Sprintf("No install version found for %s in nightly channel (%s)", version, err.Error()))
+				if errors.Is(err, ErrNightlyReleaseStreamNotFound) || errors.Is(err, ErrNoAcceptedNightlyTags) || errors.Is(err, ErrVersionNotFound) {
+					Skip(fmt.Sprintf("No install version found for %s in %s channel (%s)", version, channelGroup, err.Error()))
 				} else {
-					Fail(fmt.Sprintf("failed to get latest install version for nightly channel: %s", err.Error()))
+					Fail(fmt.Sprintf("failed to get latest install version for %s channel: %s", channelGroup, err.Error()))
 				}
 			}
 		}
@@ -117,16 +116,15 @@ func DefaultOpenshiftChannelGroup() string {
 func DefaultOpenshiftNodePoolVersionId() string {
 	version := os.Getenv("ARO_HCP_OPENSHIFT_NODEPOOL_VERSION")
 	if len(version) == 0 {
-		version = DefaultOCPNodePoolVersionId
-		// For nightly channel, calculate the latest version for the default Y stream (it's the same as the control plane version)
-		if DefaultOpenshiftNodePoolChannelGroup() == "nightly" {
+		channelGroup := DefaultOpenshiftNodePoolChannelGroup()
+		if channelGroup != "stable" {
 			var err error
-			version, err = GetLatestInstallVersionForNightlyChannel(DefaultOCPVersionId)
+			version, err = GetLatestInstallVersion(context.Background(), channelGroup, DefaultOCPVersionId)
 			if err != nil {
-				if errors.Is(err, ErrNightlyReleaseStreamNotFound) || errors.Is(err, ErrNoAcceptedNightlyTags) {
-					Skip(fmt.Sprintf("No node pool install version found for %s in nightly channel (%s)", version, err.Error()))
+				if errors.Is(err, ErrNightlyReleaseStreamNotFound) || errors.Is(err, ErrNoAcceptedNightlyTags) || errors.Is(err, ErrVersionNotFound) {
+					Skip(fmt.Sprintf("No install version found for %s in %s channel (%s)", version, channelGroup, err.Error()))
 				} else {
-					Fail(fmt.Sprintf("failed to get latest node pool install version for nightly channel: %s", err.Error()))
+					Fail(fmt.Sprintf("failed to get latest install version for %s channel: %s", channelGroup, err.Error()))
 				}
 			}
 		}

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -765,7 +765,7 @@ func CreateHCPClusterAndWait(
 		defer cancel()
 	}
 
-	logger.Info("Starting HCP cluster creation", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName)
+	logger.Info("Starting HCP cluster creation", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName, "version", cluster.Properties.Version.ID, "channelGroup", cluster.Properties.Version.ChannelGroup)
 	poller, err := hcpClient.BeginCreateOrUpdate(ctx, resourceGroupName, hcpClusterName, cluster, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed starting cluster creation %q in resourcegroup=%q: %w", hcpClusterName, resourceGroupName, err)

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
@@ -38,7 +39,10 @@ var (
 	ErrNightlyReleaseStreamNotFound = errors.New("nightly release stream not found")
 	ErrNoAcceptedNightlyTags        = errors.New("no accepted nightly tags found")
 	ErrNoParseableNightlyTags       = errors.New("no parseable nightly tags found")
+	ErrVersionNotFound              = errors.New("no graph nodes found")
 )
+
+const graphAPIRequestTimeout = 30 * time.Second
 
 // GetInstallVersionForZStreamUpgrade returns the version to install the cluster with when testing
 // a z-stream upgrade, and whether that version has an available z-stream upgrade path. It uses
@@ -196,6 +200,81 @@ func GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx context.Context, channelGr
 		return out[i].LT(out[j])
 	})
 	return out, nil
+}
+
+// GetLatestInstallVersion returns the latest install version for the given channel group and version
+// For nightly channels, it returns the latest accepted nightly tag.
+// For all other channels, it returns the latest version in the minor.
+func GetLatestInstallVersion(ctx context.Context, channelGroup string, version string) (string, error) {
+	if channelGroup == "nightly" {
+		return GetLatestInstallVersionForNightlyChannel(version)
+	}
+	return GetLatestInstallVersionForGraphChannel(ctx, channelGroup, version)
+}
+
+// Note that this function is different from GetLatestVersionInMinor because it will return also engineering candidate versions.
+func GetLatestInstallVersionForGraphChannel(ctx context.Context, channelGroup string, version string) (string, error) {
+	channel := fmt.Sprintf("%s-%s", channelGroup, version)
+	graphURL := fmt.Sprintf("https://api.openshift.com/api/upgrades_info/v1/graph?channel=%s", url.QueryEscape(channel))
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, graphURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("create %s graph request for %s: %w", channelGroup, channel, err)
+	}
+
+	client := &http.Client{Timeout: graphAPIRequestTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("query %s graph for %s: %w", channelGroup, channel, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("query %s graph for %s returned %s: %s", channelGroup, channel, resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var payload struct {
+		Nodes []struct {
+			Version string `json:"version"`
+		} `json:"nodes"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decode %s graph response for %s: %w", channelGroup, channel, err)
+	}
+	if len(payload.Nodes) == 0 {
+		return "", fmt.Errorf("%w for %s", ErrVersionNotFound, channel)
+	}
+
+	requestedMinor, err := semver.ParseTolerant(version)
+	if err != nil {
+		return "", fmt.Errorf("parse requested %s minor %q: %w", channelGroup, version, err)
+	}
+
+	var latestVersion semver.Version
+	latestVersionID := ""
+	for _, node := range payload.Nodes {
+		nodeVersion, parseErr := semver.ParseTolerant(node.Version)
+		if parseErr != nil {
+			continue
+		}
+		if nodeVersion.Major != requestedMinor.Major || nodeVersion.Minor != requestedMinor.Minor {
+			continue
+		}
+		if latestVersionID == "" || nodeVersion.GT(latestVersion) {
+			latestVersion = nodeVersion
+			latestVersionID = node.Version
+		}
+	}
+
+	if latestVersionID == "" {
+		return "", fmt.Errorf("no %s versions found in %s for requested minor %s", channelGroup, channel, version)
+	}
+
+	return latestVersionID, nil
 }
 
 // GetLatestInstallVersionForNightlyChannel returns the latest accepted nightly tag for the given minor version


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Remove the filter that prevents testing cluster install for OCP versions greater than 4.20

Note there's a new filter to skip candidate builds of OCP 5.0 until https://redhat.atlassian.net/browse/OCPBUGS-83564 is fixed.

We are also calculating the latest z-stream version of OCP when using non-stable channels.

### Why

This filter was added because of 2 issues breaking versions greater than 4.20. 

- https://redhat.atlassian.net/browse/ARO-25490
- https://redhat.atlassian.net/browse/ARO-24955

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
