### PR TITLE
 Cilium Connectivity Check Verifier into E2E tests using Cilium CNI plugin

### DIFF
--- a/test/e2e/cluster_create_cni_cilium.go
+++ b/test/e2e/cluster_create_cni_cilium.go
@@ -166,9 +166,9 @@ var _ = Describe("Customer", func() {
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodesReady(), verifiers.VerifyCiliumOperational(ciliumNamespace, "k8s-app=cilium"))
 			Expect(errors.Join(err, nodePoolErr)).NotTo(HaveOccurred(), "failed to verify cilium is running and nodes are Ready for cluster %q", customerClusterName)
 
-			By("verifying a simple web app can run with cilium")
-			err = verifiers.VerifySimpleWebApp().Verify(ctx, adminRESTConfig)
-			Expect(err).NotTo(HaveOccurred(), "failed to verify simple web app runs with cilium CNI")
+			By("checking that network works via a simple web app and connectivity checks")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifySimpleWebApp(), verifiers.VerifyCiliumConnectivityChecks("1.19.2"))
+			Expect(err).NotTo(HaveOccurred(), "failed to run simple web app and connectivity check app with cilium CNI")
 		},
 	)
 })

--- a/test/e2e/cluster_create_complex_cilium_kv.go
+++ b/test/e2e/cluster_create_complex_cilium_kv.go
@@ -206,9 +206,9 @@ var _ = Describe("Customer", func() {
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodesReady(), verifiers.VerifyCiliumOperational("kube-system", "k8s-app=cilium"))
 			Expect(errors.Join(err, nodePoolErr, consoleLogErr)).NotTo(HaveOccurred(), "failed to verify nodes are Ready with Cilium CNI for cluster %q", customerClusterName)
 
-			By("verifying a simple web app can run with cilium")
-			err = verifiers.VerifySimpleWebApp().Verify(ctx, adminRESTConfig)
-			Expect(err).NotTo(HaveOccurred(), "failed to verify simple web app runs with cilium CNI")
+			By("checking that network works via a simple web app and connectivity checks")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifySimpleWebApp(), verifiers.VerifyCiliumConnectivityChecks("1.19.2"))
+			Expect(err).NotTo(HaveOccurred(), "failed to run simple web app and connectivity check with cilium CNI")
 		},
 	)
 })

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0000.scc.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0000.scc.yaml
@@ -1,0 +1,25 @@
+# from https://github.com/openshift/hypershift/blob/dc7b179/docs/content/how-to/sdn/other-sdn-providers.md
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: cilium-test
+allowHostPorts: true
+allowHostNetwork: true
+users:
+  - system:serviceaccount:cilium-test:default
+priority: null
+readOnlyRootFilesystem: false
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+volumes: null
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostPID: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+requiredDropCapabilities: null
+groups: null

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0000.scc.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0000.scc.yaml
@@ -6,7 +6,7 @@ metadata:
 allowHostPorts: true
 allowHostNetwork: true
 users:
-  - system:serviceaccount:cilium-connectivity-check:default
+- system:serviceaccount:cilium-connectivity-check:default
 priority: null
 readOnlyRootFilesystem: false
 runAsUser:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0000.scc.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0000.scc.yaml
@@ -2,11 +2,11 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: cilium-test
+  name: cilium-connectivity-check
 allowHostPorts: true
 allowHostNetwork: true
 users:
-  - system:serviceaccount:cilium-test:default
+  - system:serviceaccount:cilium-connectivity-check:default
 priority: null
 readOnlyRootFilesystem: false
 runAsUser:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0001.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0001.yaml
@@ -1,0 +1,57 @@
+---
+metadata:
+  name: echo-a
+  labels:
+    name: echo-a
+    topology: any
+    component: network-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: echo-a
+    spec:
+      hostNetwork: false
+      containers:
+      - name: echo-a-container
+        env:
+        - name: PORT
+          value: "8080"
+        ports:
+        - containerPort: 8080
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:8080
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:8080
+  selector:
+    matchLabels:
+      name: echo-a
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0001.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0001.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-a
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0002.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0002.yaml
@@ -1,0 +1,58 @@
+---
+metadata:
+  name: echo-b
+  labels:
+    name: echo-b
+    topology: any
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: echo-b
+    spec:
+      hostNetwork: false
+      containers:
+      - name: echo-b-container
+        env:
+        - name: PORT
+          value: "8080"
+        ports:
+        - containerPort: 8080
+          hostPort: 40000
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:8080
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:8080
+  selector:
+    matchLabels:
+      name: echo-b
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0002.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0002.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-b
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0003.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0003.yaml
@@ -1,0 +1,66 @@
+---
+metadata:
+  name: echo-b-host
+  labels:
+    name: echo-b-host
+    topology: any
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: echo-b-host
+    spec:
+      hostNetwork: true
+      containers:
+      - name: echo-b-host-container
+        env:
+        - name: PORT
+          value: "21000"
+        ports: []
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:21000
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:21000
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: echo-b-host
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0003.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0003.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-b-host
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0004.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0004.yaml
@@ -1,0 +1,57 @@
+---
+metadata:
+  name: pod-to-a
+  labels:
+    name: pod-to-a
+    topology: any
+    component: network-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-a
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-a-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-a:8080/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-a:8080/public
+  selector:
+    matchLabels:
+      name: pod-to-a
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0004.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0004.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-a
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0005.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0005.yaml
@@ -1,0 +1,47 @@
+---
+metadata:
+  name: pod-to-a-denied-cnp
+  labels:
+    name: pod-to-a-denied-cnp
+    topology: any
+    component: policy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-a-denied-cnp
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-a-denied-cnp-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - ash
+            - -c
+            - '! curl -s --fail --connect-timeout 5 -o /dev/null echo-a:8080/private'
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - ash
+            - -c
+            - '! curl -s --fail --connect-timeout 5 -o /dev/null echo-a:8080/private'
+  selector:
+    matchLabels:
+      name: pod-to-a-denied-cnp
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0005.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0005.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-a-denied-cnp
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0006.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0006.yaml
@@ -1,0 +1,57 @@
+---
+metadata:
+  name: pod-to-a-allowed-cnp
+  labels:
+    name: pod-to-a-allowed-cnp
+    topology: any
+    component: policy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-a-allowed-cnp
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-a-allowed-cnp-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-a:8080/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-a:8080/public
+  selector:
+    matchLabels:
+      name: pod-to-a-allowed-cnp
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0006.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0006.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-a-allowed-cnp
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0007.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0007.yaml
@@ -1,0 +1,67 @@
+---
+metadata:
+  name: pod-to-b-multi-node-clusterip
+  labels:
+    name: pod-to-b-multi-node-clusterip
+    topology: multi-node
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-clusterip
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-b-multi-node-clusterip-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b:8080/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b:8080/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-clusterip
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0007.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0007.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-b-multi-node-clusterip
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0008.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0008.yaml
@@ -1,0 +1,67 @@
+---
+metadata:
+  name: pod-to-b-multi-node-headless
+  labels:
+    name: pod-to-b-multi-node-headless
+    topology: multi-node
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-headless
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-b-multi-node-headless-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-headless:8080/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-headless:8080/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-headless
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0008.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0008.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-b-multi-node-headless
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0009.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0009.yaml
@@ -1,0 +1,68 @@
+---
+metadata:
+  name: host-to-b-multi-node-clusterip
+  labels:
+    name: host-to-b-multi-node-clusterip
+    topology: multi-node
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: host-to-b-multi-node-clusterip
+    spec:
+      hostNetwork: true
+      containers:
+      - name: host-to-b-multi-node-clusterip-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b:8080/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b:8080/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      dnsPolicy: ClusterFirstWithHostNet
+  selector:
+    matchLabels:
+      name: host-to-b-multi-node-clusterip
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0009.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0009.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: host-to-b-multi-node-clusterip
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0010.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0010.yaml
@@ -1,0 +1,68 @@
+---
+metadata:
+  name: host-to-b-multi-node-headless
+  labels:
+    name: host-to-b-multi-node-headless
+    topology: multi-node
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: host-to-b-multi-node-headless
+    spec:
+      hostNetwork: true
+      containers:
+      - name: host-to-b-multi-node-headless-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-headless:8080/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-headless:8080/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      dnsPolicy: ClusterFirstWithHostNet
+  selector:
+    matchLabels:
+      name: host-to-b-multi-node-headless
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0010.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0010.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: host-to-b-multi-node-headless
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0011.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0011.yaml
@@ -1,0 +1,67 @@
+---
+metadata:
+  name: pod-to-b-multi-node-nodeport
+  labels:
+    name: pod-to-b-multi-node-nodeport
+    topology: multi-node
+    component: nodeport-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-nodeport
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-b-multi-node-nodeport-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-host-headless:31414/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-host-headless:31414/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-nodeport
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0011.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0011.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-b-multi-node-nodeport
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0012.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0012.yaml
@@ -1,0 +1,67 @@
+---
+metadata:
+  name: pod-to-b-intra-node-nodeport
+  labels:
+    name: pod-to-b-intra-node-nodeport
+    topology: intra-node
+    component: nodeport-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-intra-node-nodeport
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-b-intra-node-nodeport-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-host-headless:31414/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-host-headless:31414/public
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: pod-to-b-intra-node-nodeport
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0012.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0012.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-b-intra-node-nodeport
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0013.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0013.yaml
@@ -1,0 +1,19 @@
+---
+metadata:
+  name: echo-a
+  labels:
+    name: echo-a
+    topology: any
+    component: network-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports:
+  - name: http
+    port: 8080
+  type: ClusterIP
+  selector:
+    name: echo-a
+apiVersion: v1
+kind: Service

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0013.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0013.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-a
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0014.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0014.yaml
@@ -1,0 +1,20 @@
+---
+metadata:
+  name: echo-b
+  labels:
+    name: echo-b
+    topology: any
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports:
+  - name: http
+    port: 8080
+    nodePort: 31414
+  type: NodePort
+  selector:
+    name: echo-b
+apiVersion: v1
+kind: Service

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0014.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0014.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-b
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0015.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0015.yaml
@@ -1,0 +1,20 @@
+---
+metadata:
+  name: echo-b-headless
+  labels:
+    name: echo-b-headless
+    topology: any
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports:
+  - name: http
+    port: 8080
+  type: ClusterIP
+  selector:
+    name: echo-b
+  clusterIP: None
+apiVersion: v1
+kind: Service

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0015.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0015.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-b-headless
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0016.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0016.yaml
@@ -1,0 +1,18 @@
+---
+metadata:
+  name: echo-b-host-headless
+  labels:
+    name: echo-b-host-headless
+    topology: any
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports: []
+  type: ClusterIP
+  selector:
+    name: echo-b-host
+  clusterIP: None
+apiVersion: v1
+kind: Service

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0016.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0016.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-b-host-headless
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0017.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0017.yaml
@@ -1,0 +1,36 @@
+---
+metadata:
+  name: pod-to-a-denied-cnp
+  labels:
+    name: pod-to-a-denied-cnp
+    topology: any
+    component: policy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  endpointSelector:
+    matchLabels:
+      name: pod-to-a-denied-cnp
+  egress:
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
+  - toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: openshift-dns
+        k8s:dns.operator.openshift.io/daemonset-dns: default
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0017.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0017.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-a-denied-cnp
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0018.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0018.yaml
@@ -1,0 +1,43 @@
+---
+metadata:
+  name: pod-to-a-allowed-cnp
+  labels:
+    name: pod-to-a-allowed-cnp
+    topology: any
+    component: policy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  endpointSelector:
+    matchLabels:
+      name: pod-to-a-allowed-cnp
+  egress:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        name: echo-a
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
+  - toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: openshift-dns
+        k8s:dns.operator.openshift.io/daemonset-dns: default
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0018.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0018.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-a-allowed-cnp
   labels:

--- a/test/util/verifiers/cilium.go
+++ b/test/util/verifiers/cilium.go
@@ -14,16 +14,26 @@
 
 package verifiers
 
+// NOTE: This file depends on the staticFiles embed.FS variable defined in
+// serving_app.go, which embeds the artifacts directory containing the
+// cilium-connectivity-check YAML files.
+
 import (
 	"context"
 	"fmt"
+	"io/fs"
+	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -119,4 +129,244 @@ func (v verifyCiliumOperational) Verify(ctx context.Context, adminRESTConfig *re
 // Verifies that all Cilium pods are running in given namespace.
 func VerifyCiliumOperational(ciliumNamespace string, ciliumLabelSelector string) HostedClusterVerifier {
 	return verifyCiliumOperational{ciliumNamespace: ciliumNamespace, ciliumLabelSelector: ciliumLabelSelector}
+}
+
+type verifyCiliumConnectivityChecks struct {
+	ciliumVersion string
+}
+
+func (v verifyCiliumConnectivityChecks) Name() string {
+	return "VerifyCiliumConnectivityChecks"
+}
+
+func (v verifyCiliumConnectivityChecks) Verify(ctx context.Context, adminRESTConfig *rest.Config) error {
+	logger := ginkgo.GinkgoLogr
+
+	kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	// Create namespace for the connectivity check
+	namespaceName := "cilium-connectivity-check"
+	namespace, err := kubeClient.CoreV1().Namespaces().Create(
+		ctx,
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespaceName,
+			},
+		},
+		metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create test namespace: %w", err)
+	}
+	logger.Info("namespace for connectivity check was created", "namespace", namespaceName)
+
+	// Ensure namespace and SCCs cleanup on exit, SCCs are cluster-scoped so
+	// must be deleted explicitly
+	sccNames := []string{}
+	sccGVR := schema.GroupVersionResource{Group: "security.openshift.io", Version: "v1", Resource: "securitycontextconstraints"}
+	defer func() {
+		deleteCtx := context.Background()
+		for _, sccName := range sccNames {
+			err := dynamicClient.Resource(sccGVR).Delete(deleteCtx, sccName, metav1.DeleteOptions{})
+			if err != nil {
+				logger.Error(err, "failed to delete SCC", "name", sccName)
+			}
+		}
+		err := kubeClient.CoreV1().Namespaces().Delete(deleteCtx, namespaceName, metav1.DeleteOptions{})
+		if err != nil {
+			logger.Error(err, "failed to delete test namespace", "namespace", namespaceName)
+		}
+	}()
+
+	// Deploy all YAML files from the connectivity check directory
+	expectedPodCount := 0
+	checkDir := fmt.Sprintf("artifacts/cilium-connectivity-check-%s", v.ciliumVersion)
+	entries, err := fs.ReadDir(staticFiles, checkDir)
+	if err != nil {
+		return fmt.Errorf("failed to read connectivity check artifacts directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+
+		filePath := filepath.Join(checkDir, entry.Name())
+		deploymentYAML, err := staticFiles.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", filePath, err)
+		}
+
+		resource, err := createArbitraryResource(ctx, dynamicClient, namespace.Name, deploymentYAML)
+		if err != nil {
+			return fmt.Errorf("failed to create test resource from %s: %w", filePath, err)
+		}
+		if resource.GetKind() == "SecurityContextConstraints" {
+			sccNames = append(sccNames, resource.GetName())
+		}
+		if resource.GetKind() == "Deployment" {
+			replicas := int64(1)
+			if spec, ok := resource.Object["spec"].(map[string]interface{}); ok {
+				if r, ok := spec["replicas"].(int64); ok {
+					replicas = r
+				}
+			}
+			expectedPodCount += int(replicas)
+		}
+
+		logger.Info("created resource",
+			"file", entry.Name(),
+			"kind", resource.GetKind(),
+			"name", resource.GetName(),
+			"namespace", resource.GetNamespace(),
+		)
+
+	}
+
+	// Wait for all test pods to be running and ready. Any unhealthy pod
+	// indicates a failed connectivity check.
+	var lastErr error
+	logger.Info("expecting pods from deployed Deployments", "count", expectedPodCount)
+	var lastNotReadyPods []string
+	err = wait.PollUntilContextTimeout(ctx, 30*time.Second, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pods, err := kubeClient.CoreV1().Pods(namespaceName).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("failed to list pods in %s namespace: %w", namespaceName, err)
+			return false, nil
+		}
+
+		if len(pods.Items) < expectedPodCount {
+			lastErr = fmt.Errorf("expected %d pods in %s namespace, found %d", expectedPodCount, namespaceName, len(pods.Items))
+			return false, nil
+		}
+
+		notReadyPods := []string{}
+		for _, pod := range pods.Items {
+			// Check if the pod is running, any other state (including
+			// succeeded) indicates an error reported by a connectivity check
+			if pod.Status.Phase != corev1.PodRunning {
+				notReadyPods = append(notReadyPods, fmt.Sprintf("%s (phase: %s)", pod.Name, pod.Status.Phase))
+				continue
+			}
+
+			// Check if pod is ready - this is critical for connectivity checks
+			// as readiness probes are used to indicate test success/failure
+			podReady := false
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == corev1.PodReady {
+					if condition.Status == corev1.ConditionTrue {
+						podReady = true
+					}
+					break
+				}
+			}
+
+			// Detect liveness probe failures: a failing liveness probe kills
+			// and restarts the container, leaving it in Waiting state
+			// (e.g. CrashLoopBackOff) while the pod phase stays Running.
+			livenessFailure := ""
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
+					livenessFailure = fmt.Sprintf("container %s waiting: %s", cs.Name, cs.State.Waiting.Reason)
+					podReady = false
+					break
+				}
+			}
+
+			if !podReady {
+				if livenessFailure != "" {
+					notReadyPods = append(notReadyPods, fmt.Sprintf("%s (%s)", pod.Name, livenessFailure))
+				} else {
+					notReadyPods = append(notReadyPods, fmt.Sprintf("%s (running but not ready)", pod.Name))
+				}
+			}
+		}
+
+		if len(notReadyPods) > 0 {
+			// We are logging only status changes
+			slices.Sort(notReadyPods)
+			if !slices.Equal(notReadyPods, lastNotReadyPods) {
+				logger.Info("waiting for test pods to be ready", "notReady", notReadyPods)
+			}
+			lastErr = fmt.Errorf("test pods not yet ready: %v", notReadyPods)
+			lastNotReadyPods = notReadyPods
+			return false, nil
+		}
+
+		logger.Info("all connectivity check test pods are ready")
+
+		lastNotReadyPods = []string{}
+		return true, nil
+	})
+
+	// If the waiting failed on a timeout, some connectivity check pod must
+	// have failed, so we need to report what failed exactly.
+	if err != nil {
+		// Log all events in the test namespace to help with debugging, as
+		// failures in liveness or readiness probes will be visible there
+		events, eventsErr := kubeClient.CoreV1().Events(namespaceName).List(ctx, metav1.ListOptions{})
+		if eventsErr != nil {
+			logger.Error(eventsErr, "failed to list k8s events", "namespace", namespaceName)
+		} else {
+			logger.Info("listing k8s events", "namespace", namespaceName, "eventCount", len(events.Items))
+			for _, event := range events.Items {
+				logger.Info("event",
+					"type", event.Type,
+					"reason", event.Reason,
+					"message", event.Message,
+					"object", fmt.Sprintf("%s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Name),
+					"count", event.Count,
+					"firstTimestamp", event.FirstTimestamp,
+					"lastTimestamp", event.LastTimestamp,
+				)
+			}
+		}
+		// The pods use "terminationMessagePolicy: FallbackToLogsOnError"
+		// to report errors, so we log termination messages
+		pods, podsErr := kubeClient.CoreV1().Pods(namespaceName).List(ctx, metav1.ListOptions{})
+		if podsErr != nil {
+			logger.Error(podsErr, "failed to list pods for error reporting purposes", "namespace", namespaceName)
+		} else {
+			for _, pod := range pods.Items {
+				for _, cs := range pod.Status.ContainerStatuses {
+					if t := cs.State.Terminated; t != nil {
+						logger.Info("terminated container",
+							"pod", pod.Name,
+							"container", cs.Name,
+							"exitCode", t.ExitCode,
+							"message", t.Message,
+						)
+					}
+					if t := cs.LastTerminationState.Terminated; t != nil {
+						logger.Info("last terminated container",
+							"pod", pod.Name,
+							"container", cs.Name,
+							"exitCode", t.ExitCode,
+							"message", t.Message,
+						)
+					}
+				}
+			}
+		}
+		if lastErr != nil {
+			return fmt.Errorf("connectivity check failed, not all pods in %s namespace are ready: %w", namespaceName, lastErr)
+		}
+		return fmt.Errorf("connectivity check failed waiting for pods in %s namespace: %w", namespaceName, err)
+	}
+
+	return nil
+}
+
+// Deploy and run Cilium Connectivity Checks, set of deployments that will
+// perform a series of connectivity checks via liveness and readiness checks.
+// An unhealthy/unready pod indicates a problem.
+func VerifyCiliumConnectivityChecks(ciliumVersion string) HostedClusterVerifier {
+	return verifyCiliumConnectivityChecks{ciliumVersion: ciliumVersion}
 }

--- a/test/util/verifiers/helper.go
+++ b/test/util/verifiers/helper.go
@@ -124,6 +124,16 @@ var defaultRESTMappings = []meta.RESTMapping{
 		Scope:            meta.RESTScopeRoot,
 		Resource:         schema.GroupVersionResource{Group: "security.openshift.io", Version: "v1", Resource: "securitycontextconstraints"},
 	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "cilium.io", Version: "v1alpha1", Kind: "CiliumConfig"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "cilium.io", Version: "v1alpha1", Resource: "ciliumconfigs"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "cilium.io", Version: "v2", Kind: "CiliumNetworkPolicy"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "cilium.io", Version: "v2", Resource: "ciliumnetworkpolicies"},
+	},
 }
 
 var localRESTMapper = newHardcodedRESTMapper()


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-25876

### What

- Implement Cilium Connectivity Check Verifier, using cilium's [connectivity-check](https://github.com/cilium/cilium/tree/main/examples/kubernetes/connectivity-check) workload
- In case of any issued detected, the verifier reports all events in the connectivity check namespace, as well as termination messages (since the workload uses `terminationMessagePolicy: FallbackToLogsOnError`.
- Use this new verifier in E2E test cases where Cilium CNI plugin is used.

### Why

To make sure Cilium CNI fully works, covering more networking use cases as well as cilium network policies.

### Testing

We need to inject some errors during test development to make sure the verifier will detect and report them. In all these cases, error should be detected and reported.

- [X] make some pod fail to start
- [X] make some pod fail on readiness probe
- [X] make some pod fail on liveliness probe
- [X] misconfigure ~cilium networking policy~ security context constraint of the workload (so that we observe the check failing when network connection can't be made)

Since I accidentally break the check in commit [1782c97201f3ffc](https://github.com/Azure/ARO-HCP/pull/4812/changes/1782c97201f3ffc4481ab5d2f6c623504ab9ea44) by using different namespace name in the code as compared to the scc, half of the checks failed and we could observe all the conditions above, via [2055762089024163840](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/4812/pull-ci-Azure-ARO-HCP-main-integration-e2e-parallel/2055762089024163840).

We can see all details in the k8s events logged when failure of the verifier happens. Root cause (error to start a pod because of scc):

```
"ts"="2026-05-16 22:11:16.613064" "level"=0 "msg"="event" "type"="Warning" "reason"="FailedCreate" "message"="Error creating: pods \"echo-b-db89d9c95-\" is forbidden: unable to validate against any security context constraint: [provider \"anyuid\": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .containers[0].containers[0].hostPort: Invalid value: 40000: Host ports are not allowed to be used, provider \"restricted-v3\": Forbidden: not usable by user or serviceaccount, provider \"restricted\": Forbidden: not usable by user or serviceaccount, provider \"nested-container\": Forbidden: not usable by user or serviceaccount, provider \"nonroot-v2\": Forbidden: not usable by user or serviceaccount, provider \"nonroot\": Forbidden: not usable by user or serviceaccount, provider \"hostmount-anyuid\": Forbidden: not usable by user or serviceaccount, provider \"hostmount-anyuid-v2\": Forbidden: not usable by user or serviceaccount, provider \"hostnetwork-v2\": Forbidden: not usable by user or serviceaccount, provider \"hostnetwork\": Forbidden: not usable by user or serviceaccount, provider \"cilium-test\": Forbidden: not usable by user or serviceaccount, provider \"hostaccess\": Forbidden: not usable by user or serviceaccount, provider \"insights-runtime-extractor-scc\": Forbidden: not usable by user or serviceaccount, provider \"privileged\": Forbidden: not usable by user or serviceaccount]" "object"="ReplicaSet/echo-b-db89d9c95" "count"=12 "firstTimestamp"="2026-05-16 22:01:14 +0000 UTC" "lastTimestamp"="2026-05-16 22:01:24 +0000 UTC"
```

Liveness probe fail:

```
"ts"="2026-05-16 22:11:16.613346" "level"=0 "msg"="event" "type"="Warning" "reason"="Unhealthy" "message"="Liveness probe failed: curl: (7) Failed to connect to echo-a port 8080 after 1 ms: Connection refused\n" "object"="Pod/pod-to-a-5f56dc8c9b-94kmb" "count"=1 "firstTimestamp"="2026-05-16 22:01:25 +0000 UTC" "lastTimestamp"="2026-05-16 22:01:25 +0000 UTC"
```

Readiness probe fail

```
"ts"="2026-05-16 22:11:16.613337" "level"=0 "msg"="event" "type"="Warning" "reason"="Unhealthy" "message"="Readiness probe failed: curl: (7) Failed to connect to echo-a port 8080 after 1 ms: Connection refused\n" "object"="Pod/pod-to-a-5f56dc8c9b-94kmb" "count"=1 "firstTimestamp"="2026-05-16 22:01:20 +0000 UTC" "lastTimestamp"="2026-05-16 22:01:20 +0000 UTC"
```

### Special notes for your reviewer

This is a follow up for [ARO-20529](https://redhat.atlassian.net/browse/ARO-20529) (implemented via https://github.com/Azure/ARO-HCP/pull/4518).

See [cilium/examples/kubernetes/connectivity-check](https://github.com/cilium/cilium/tree/main/examples/kubernetes/connectivity-check):

* Set of deployments that will perform a series of connectivity checks via liveness and readiness checks.
* An unhealthy/unready pod indicates a problem.
* Suggested in [validation](https://hypershift-docs.netlify.app/how-to/aws/other-sdn-providers/#validation) section of HyperShift notes about cilium (with example of SCC for OCP)
