### PR TITLE
validation: Require tenantId in subscriptions

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -562,6 +562,20 @@ func (f *Frontend) ArmSubscriptionPut(writer http.ResponseWriter, request *http.
 	}
 	requestSubscription.ResourceID = requestSubscription.CosmosMetadata.ResourceID
 
+	// Ensure a tenant ID value is present in SubscriptionProperties. If it was omitted
+	// in the request body then get it from the request headers. The tenant ID field is
+	// optional according to the Resource Provider Contract, but the backend depends on
+	// it for cluster creation so it's effectively a required field for ARO-HCP.
+	if requestSubscription.Properties == nil {
+		requestSubscription.Properties = &arm.SubscriptionProperties{}
+	}
+	if requestSubscription.Properties.TenantId == nil || len(*requestSubscription.Properties.TenantId) == 0 {
+		tenantID := request.Header.Get(arm.HeaderNameHomeTenantID)
+		if len(tenantID) > 0 {
+			requestSubscription.Properties.TenantId = api.Ptr(tenantID)
+		}
+	}
+
 	validationErrs := validation.ValidateSubscriptionCreate(ctx, &requestSubscription)
 	if err := arm.CloudErrorFromFieldErrors(validationErrs); err != nil {
 		return utils.TrackError(err)

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -270,6 +270,7 @@ func TestSubscriptionsPUT(t *testing.T) {
 			req, err := http.NewRequest(http.MethodPut, ts.URL+urlPath, bytes.NewReader(body))
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set(arm.HeaderNameHomeTenantID, api.TestTenantID)
 
 			rs, err := ts.Client().Do(req)
 			require.NoError(t, err)

--- a/internal/validation/validate_subscription.go
+++ b/internal/validation/validate_subscription.go
@@ -18,12 +18,17 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/api/operation"
+	"k8s.io/apimachinery/pkg/api/safe"
 	"k8s.io/apimachinery/pkg/api/validate"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+var (
+	toSubscriptionProperties = func(oldObj *arm.Subscription) *arm.SubscriptionProperties { return oldObj.Properties }
 )
 
 func ValidateSubscriptionCreate(ctx context.Context, newObj *arm.Subscription) field.ErrorList {
@@ -50,7 +55,20 @@ func validateSubscription(ctx context.Context, op operation.Operation, newObj, o
 	}
 
 	//Properties       *SubscriptionProperties `json:"properties"`
+	errs = append(errs, validateSubscriptionProperties(ctx, op, field.NewPath("properties"), newObj.Properties, safe.Field(oldObj, toSubscriptionProperties))...)
+
 	//LastUpdated int `json:"-"`
+
+	return errs
+}
+
+func validateSubscriptionProperties(ctx context.Context, op operation.Operation, fldPath *field.Path, newObj, oldObj *arm.SubscriptionProperties) field.ErrorList {
+	errs := field.ErrorList{}
+
+	// TenantId is optional according to the Resource Provider Contract but the
+	// ARO-HCP backend relies on it for cluster creation. The frontend tries to
+	// ensure its presence, cherry-picking from request headers if necessary.
+	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("tenantId"), &newObj.TenantId, nil)...)
 
 	return errs
 }

--- a/internal/validation/validate_subscription_comprehensive_test.go
+++ b/internal/validation/validate_subscription_comprehensive_test.go
@@ -275,7 +275,7 @@ func createValidSubscription() *arm.Subscription {
 		ResourceID:       api.Must(azcorearm.ParseResourceID("/subscriptions/12345678-1234-1234-1234-123456789012")),
 		State:            arm.SubscriptionStateRegistered,
 		RegistrationDate: ptr.To("2023-01-01T00:00:00Z"),
-		Properties:       nil, // Properties are optional
+		Properties:       &arm.SubscriptionProperties{TenantId: api.Ptr(api.TestTenantID)},
 	}
 }
 

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/02-cosmosCompare-confirm-content/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/02-cosmosCompare-confirm-content/subscription.json
@@ -9,7 +9,9 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
 		},
-		"properties": null,
+		"properties": {
+			"tenantId": "00000000-0000-0000-0000-000000000000"
+		},
 		"registrationDate": "2025-12-19T19:53:15+00:00",
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
 		"state": "Registered"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/subscription.json
@@ -4,7 +4,9 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
 		},
-		"properties": null,
+		"properties": {
+			"tenantId": "00000000-0000-0000-0000-000000000000"
+		},
 		"registrationDate": "2025-12-19T19:53:15+00:00",
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
 		"state": "Registered"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/subscription.json
@@ -4,7 +4,9 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
 		},
-		"properties": null,
+		"properties": {
+			"tenantId": "00000000-0000-0000-0000-000000000000"
+		},
 		"registrationDate": "2025-12-19T19:53:15+00:00",
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
 		"state": "Registered"

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/subscription.json
@@ -9,7 +9,9 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
 		},
-		"properties": null,
+		"properties": {
+			"tenantId": "00000000-0000-0000-0000-000000000000"
+		},
 		"registrationDate": "2025-12-19T19:53:15+00:00",
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
 		"state": "Registered"

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/subscription.json
@@ -9,7 +9,9 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
 		},
-		"properties": null,
+		"properties": {
+			"tenantId": "00000000-0000-0000-0000-000000000000"
+		},
 		"registrationDate": "2025-12-19T19:53:15+00:00",
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
 		"state": "Registered"


### PR DESCRIPTION
Followup to [a comment in #4784](https://github.com/Azure/ARO-HCP/pull/4784#discussion_r3051165754) 

### What

This changes subscription validation to require the `TenantId` field.

### Why

In a subscription PUT request, the `TenantId` field is optional according to the [Resource Provider Contract](https://github.com/cloud-and-ai-microsoft/resource-provider-contract/blob/master/v1.0/subscription-lifecycle-api-reference.md) but the ARO-HCP backend relies on it for cluster creation. Therefore we want to make sure we never write a subscription document to Cosmos without a `TenantId` value.  The frontend tries to ensure its presence before validating, filling it in from the `X-Ms-Home-Tenant-Id` request header if necessary.

It's unclear whether a subscription registration without a `TenantId` value would ever actually occur outside of test environments.  This may be purely academic, but it ensures an invariant in our Cosmos DB data.

### Testing

Several existing integration tests were updated to reflect the automatic addition of a tenant ID value from request headers.
