### PR TITLE
feat: create clusters service control plane in backend

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -38,6 +38,7 @@ import (
 	azureclient "github.com/Azure/ARO-HCP/backend/pkg/azure/client"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/billingcontrollers"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clustercreation"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterdeletion"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterpropertiescontroller"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
@@ -774,6 +775,13 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		backendInformers,
 	)
 
+	clusterClusterServiceCreateController := clustercreation.NewClusterClusterServiceCreateController(
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
+
 	clusterDeletionClusterServiceDeleteDispatchController := clusterdeletion.NewClusterClusterServiceDeleteDispatchController(
 		utilsclock.RealClock{},
 		b.options.ResourcesDBClient,
@@ -829,6 +837,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go doNothingController.Run(ctx, 20)
 				go dispatchRequestCredentialController.Run(ctx, 20)
 				go dispatchRevokeCredentialsController.Run(ctx, 20)
+				go clusterClusterServiceCreateController.Run(ctx, 20)
 				go nodePoolClusterServiceCreateController.Run(ctx, 20)
 				go externalAuthClusterServiceCreateController.Run(ctx, 20)
 				go operationClusterCreateController.Run(ctx, 20)

--- a/backend/pkg/controllers/clustercreation/cluster_cluster_service_create_controller.go
+++ b/backend/pkg/controllers/clustercreation/cluster_cluster_service_create_controller.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustercreation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+type clusterClusterServiceCreateSyncer struct {
+	cooldownChecker       controllerutil.CooldownChecker
+	resourcesDBClient     database.ResourcesDBClient
+	clusterLister         listers.ClusterLister
+	subscriptionLister    listers.SubscriptionLister
+	clustersServiceClient ocm.ClusterServiceClientSpec
+}
+
+var _ controllerutils.ClusterSyncer = (*clusterClusterServiceCreateSyncer)(nil)
+
+func NewClusterClusterServiceCreateController(
+	resourcesDBClient database.ResourcesDBClient,
+	clustersServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	backendInformers informers.BackendInformers,
+) controllerutils.Controller {
+	_, clusterLister := backendInformers.Clusters()
+	_, subscriptionLister := backendInformers.Subscriptions()
+	syncer := &clusterClusterServiceCreateSyncer{
+		cooldownChecker:       controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient:     resourcesDBClient,
+		clusterLister:         clusterLister,
+		subscriptionLister:    subscriptionLister,
+		clustersServiceClient: clustersServiceClient,
+	}
+
+	return controllerutils.NewClusterWatchingController(
+		"ClusterClusterServiceCreate",
+		resourcesDBClient,
+		backendInformers,
+		nil,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *clusterClusterServiceCreateSyncer) needsWork(cluster *api.HCPOpenShiftCluster) bool {
+	return cluster.ServiceProviderProperties.DeletionTimestamp == nil &&
+		(cluster.ServiceProviderProperties.ClusterServiceID == nil ||
+			len(cluster.ServiceProviderProperties.ClusterServiceID.String()) == 0)
+}
+
+func (c *clusterClusterServiceCreateSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	// Quick cache lookup first to see if work is needed
+	cluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	if !c.needsWork(cluster) {
+		return nil
+	}
+
+	// Confirm against the live document to make sure the cluster hasn't been deleted or modified since we last checked
+	cluster, err = c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	if !c.needsWork(cluster) {
+		return nil
+	}
+
+	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, cluster.ID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+	}
+
+	ready, err := c.createPreconditionDesiredVersionResolved(ctx, existingServiceProviderCluster)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	if !ready {
+		return nil
+	}
+
+	subscription, err := c.subscriptionLister.Get(ctx, key.SubscriptionID)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	if subscription.Properties == nil || subscription.Properties.TenantId == nil {
+		return utils.TrackError(fmt.Errorf("subscription %s has no tenantId", key.SubscriptionID))
+	}
+	tenantID := *subscription.Properties.TenantId
+	mrg := cluster.CustomerProperties.Platform.ManagedResourceGroup
+
+	csCluster, err := c.findAROHCPClusterByAzureInfo(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, tenantID, mrg)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	if csCluster == nil {
+		csCluster, err = c.createClusterServiceCluster(ctx, cluster, existingServiceProviderCluster, tenantID)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("failed to create cluster in CS: %w", err))
+		}
+	}
+
+	csInternalID, err := api.NewInternalID(csCluster.HREF())
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	logger.Info("Storing ClusterServiceID on cluster document", "clusterServiceID", csInternalID.String())
+	cluster.ServiceProviderProperties.ClusterServiceID = &csInternalID
+	_, err = c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Replace(ctx, cluster, nil)
+	if database.IsPreconditionFailedError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to replace Cluster: %w", err))
+	}
+
+	return nil
+}
+
+// createPreconditionDesiredVersionResolved reports whether the ControlPlaneDesiredVersion
+// controller has written the Cincinnati-resolved desired version to the ServiceProviderCluster.
+// Returns (false, nil) when this controller should wait and retry.
+func (c *clusterClusterServiceCreateSyncer) createPreconditionDesiredVersionResolved(ctx context.Context, serviceProviderCluster *api.ServiceProviderCluster) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	if serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion != nil {
+		return true, nil
+	}
+	logger.Info("DesiredVersion not yet set, waiting for ControlPlaneDesiredVersion controller")
+	return false, nil
+}
+
+// findAROHCPClusterByAzureInfo returns the Cluster Service cluster whose Azure
+// metadata matches the given subscription, resource group, ARM resource name,
+// tenant ID, and managed resource group name (MRG).
+// It returns (nil, nil) when no such cluster exists.
+// An error is returned if more than one cluster is returned matching the Azure metadata, as it should be unique.
+func (c *clusterClusterServiceCreateSyncer) findAROHCPClusterByAzureInfo(ctx context.Context, subscriptionID, resourceGroupName, resourceName, tenantID, managedResourceGroupName string) (*arohcpv1alpha1.Cluster, error) {
+	// Subscription ID, resource group, and cluster name are lowercased when building the Cluster Service
+	// cluster (see withImmutableAttributes in convert.go).
+	wantSub := strings.ToLower(subscriptionID)
+	wantRG := strings.ToLower(resourceGroupName)
+	wantName := strings.ToLower(resourceName)
+	// Tenant ID and managed resource group are not lowercased in the OCM CS
+	// builder (see withImmutableAttributes in convert.go), we keep the casing as it is.
+	wantTenant := tenantID
+	wantMRG := managedResourceGroupName
+	search := c.clustersServiceClusterByAzureInfoSearchString(wantSub, wantRG, wantName, wantTenant, wantMRG)
+	matches, err := c.csClustersMatchingClusterByAzureInfo(ctx, c.clustersServiceClient.ListClusters(search), wantSub, wantRG, wantName, wantTenant, wantMRG)
+	if err != nil {
+		return nil, err
+	}
+	if len(matches) > 1 {
+		return nil, fmt.Errorf(
+			"cluster service returned %d clusters for one Azure resource (expected exactly 1): "+
+				"subscription_id=%q resource_group=%q resource_name=%q tenant_id=%q managed_resource_group=%q",
+			len(matches), wantSub, wantRG, wantName, wantTenant, wantMRG,
+		)
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	return nil, nil
+}
+
+func (c *clusterClusterServiceCreateSyncer) clustersServiceClusterByAzureInfoSearchString(wantSub, wantRG, wantName, wantTenant, wantMRG string) string {
+	return fmt.Sprintf(
+		"azure.subscription_id = '%s' and azure.resource_group_name = '%s' and azure.resource_name = '%s' and "+
+			"azure.tenant_id = '%s' and azure.managed_resource_group_name = '%s'",
+		wantSub, wantRG, wantName, wantTenant, wantMRG,
+	)
+}
+
+func (c *clusterClusterServiceCreateSyncer) csClustersMatchingClusterByAzureInfo(ctx context.Context, it ocm.ClusterListIterator, wantSub, wantRG, wantName, wantTenant, wantMRG string) ([]*arohcpv1alpha1.Cluster, error) {
+	var res []*arohcpv1alpha1.Cluster
+	for csCluster := range it.Items(ctx) {
+		az := csCluster.Azure()
+		if az == nil {
+			continue
+		}
+		if az.SubscriptionID() != wantSub ||
+			az.ResourceGroupName() != wantRG ||
+			az.ResourceName() != wantName ||
+			az.TenantID() != wantTenant ||
+			az.ManagedResourceGroupName() != wantMRG {
+			continue
+		}
+		res = append(res, csCluster)
+	}
+	if err := it.GetError(); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (c *clusterClusterServiceCreateSyncer) createClusterServiceCluster(ctx context.Context, cluster *api.HCPOpenShiftCluster, serviceProviderCluster *api.ServiceProviderCluster, tenantID string) (*arohcpv1alpha1.Cluster, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	csClusterBuilder, csAutoscalerBuilder, err := ocm.BuildCSCluster(cluster.ID, tenantID, cluster, nil, nil, serviceProviderCluster)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to build CS cluster: %w", err))
+	}
+
+	logger.Info("Creating cluster in Cluster Service", "version", serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion.String())
+	result, err := c.clustersServiceClient.PostCluster(ctx, csClusterBuilder, csAutoscalerBuilder)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("PostCluster failed: %w", err))
+	}
+
+	return result, nil
+}
+
+func (c *clusterClusterServiceCreateSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}

--- a/backend/pkg/controllers/clustercreation/cluster_cluster_service_create_controller_test.go
+++ b/backend/pkg/controllers/clustercreation/cluster_cluster_service_create_controller_test.go
@@ -1,0 +1,514 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustercreation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// Test constants
+const (
+	testSubscriptionID      = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName   = "test-rg"
+	testClusterName         = "test-cluster"
+	testClusterServiceIDStr = "/api/aro_hcp/v1alpha1/clusters/abc123"
+	testTenantID            = "11111111-1111-1111-1111-111111111111"
+	testClusterUID          = "00000000-0000-0000-0000-000000000000"
+	// testManagedResourceGroup must match what api.MinimumValidClusterTestCase() sets.
+	testManagedResourceGroup = "testManagedResourceGroup"
+)
+
+// testClusterResourceID builds the ARM resource ID for the test cluster.
+func testClusterResourceID() *azcorearm.ResourceID {
+	return api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName,
+	))
+}
+
+// newTestCluster returns an HCPOpenShiftCluster based on MinimumValidClusterTestCase with
+// test-constant IDs. Callers can further customize it via functional opts.
+// MinimumValidClusterTestCase is used as the base because createClusterServiceCluster
+// calls ocm.BuildCSCluster, which requires a fully-populated cluster (version, DNS, subnet, etc.).
+func newTestCluster(opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
+	rid := testClusterResourceID()
+	cluster := api.MinimumValidClusterTestCase()
+	cluster.CosmosMetadata = arm.CosmosMetadata{
+		ResourceID:   rid,
+		PartitionKey: strings.ToLower(rid.SubscriptionID),
+	}
+	cluster.ID = rid
+	cluster.Name = testClusterName
+	cluster.Type = rid.ResourceType.String()
+	cluster.ServiceProviderProperties.ClusterServiceID = nil
+	cluster.ServiceProviderProperties.ClusterUID = testClusterUID
+	for _, opt := range opts {
+		opt(cluster)
+	}
+	return cluster
+}
+
+// newTestSubscription returns a minimal Subscription with tenant ID set.
+func newTestSubscription() *arm.Subscription {
+	rid := api.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscriptionID))
+	return &arm.Subscription{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID:   rid,
+			PartitionKey: strings.ToLower(rid.SubscriptionID),
+		},
+		ResourceID: rid,
+		Properties: &arm.SubscriptionProperties{TenantId: ptr.To(testTenantID)},
+	}
+}
+
+// newTestSPC returns a ServiceProviderCluster for the test cluster.
+// Callers can customize it via functional opts.
+func newTestSPC(opts ...func(*api.ServiceProviderCluster)) *api.ServiceProviderCluster {
+	resourceID := api.Must(azcorearm.ParseResourceID(fmt.Sprintf("%s/%s/%s",
+		testClusterResourceID().String(),
+		api.ServiceProviderClusterResourceTypeName,
+		api.ServiceProviderClusterResourceName,
+	)))
+	spc := &api.ServiceProviderCluster{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+		Spec:           api.ServiceProviderClusterSpec{},
+	}
+	spc.SetPartitionKey(testSubscriptionID)
+	for _, opt := range opts {
+		opt(spc)
+	}
+	return spc
+}
+
+func TestClusterClusterServiceCreate_SyncOnce(t *testing.T) {
+	desiredVersion := ptr.To(semver.MustParse("4.20.0"))
+	clusterInternalID := api.Must(api.NewInternalID(testClusterServiceIDStr))
+
+	tests := []struct {
+		name                           string
+		listCluster                    *api.HCPOpenShiftCluster    // cluster seeded into the lister (nil = not found)
+		dbCluster                      *api.HCPOpenShiftCluster    // cluster stored in the DB
+		existingServiceProviderCluster *api.ServiceProviderCluster // nil = not pre-seeded; controller get-or-creates
+		setupMockCS                    func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec
+		expectError                    bool
+		verifyDB                       func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:        "successful sync records cluster service ID on cluster",
+			listCluster: newTestCluster(),
+			dbCluster:   newTestCluster(),
+			existingServiceProviderCluster: newTestSPC(func(spc *api.ServiceProviderCluster) {
+				spc.Spec.ControlPlaneVersion.DesiredVersion = desiredVersion
+			}),
+			setupMockCS: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mockCS.EXPECT().
+					ListClusters(gomock.Any()).
+					Return(ocm.NewSimpleClusterListIterator(nil, nil))
+				csCluster, err := arohcpv1alpha1.NewCluster().
+					HREF(testClusterServiceIDStr).
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().
+					PostCluster(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(csCluster, nil)
+				return mockCS
+			},
+			expectError: false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				require.NotNil(t, cluster.ServiceProviderProperties.ClusterServiceID)
+				assert.Equal(t, testClusterServiceIDStr, cluster.ServiceProviderProperties.ClusterServiceID.String())
+			},
+		},
+		{
+			name: "skip when cluster already has ClusterServiceID",
+			listCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.ClusterServiceID = &clusterInternalID
+			}),
+			dbCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.ClusterServiceID = &clusterInternalID
+			}),
+			setupMockCS: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				return ocm.NewMockClusterServiceClientSpec(ctrl)
+			},
+			expectError: false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				require.NotNil(t, cluster.ServiceProviderProperties.ClusterServiceID)
+				assert.Equal(t, testClusterServiceIDStr, cluster.ServiceProviderProperties.ClusterServiceID.String())
+			},
+		},
+		{
+			name:        "desired version not set waits without dispatching",
+			listCluster: newTestCluster(),
+			dbCluster:   newTestCluster(),
+			setupMockCS: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				return ocm.NewMockClusterServiceClientSpec(ctrl)
+			},
+			expectError: false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.Nil(t, cluster.ServiceProviderProperties.ClusterServiceID)
+			},
+		},
+		{
+			name:        "adopts existing Cluster Service cluster for Azure resource",
+			listCluster: newTestCluster(),
+			dbCluster:   newTestCluster(),
+			existingServiceProviderCluster: newTestSPC(func(spc *api.ServiceProviderCluster) {
+				spc.Spec.ControlPlaneVersion.DesiredVersion = desiredVersion
+			}),
+			setupMockCS: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+				// Build the CS cluster with Azure fields matching the test cluster so it
+				// passes the csClustersMatchingClusterByAzureInfo filter.
+				csCluster, err := arohcpv1alpha1.NewCluster().
+					HREF(testClusterServiceIDStr).
+					Azure(arohcpv1alpha1.NewAzure().
+						SubscriptionID(strings.ToLower(testSubscriptionID)).
+						ResourceGroupName(strings.ToLower(testResourceGroupName)).
+						ResourceName(strings.ToLower(testClusterName)).
+						TenantID(testTenantID).
+						ManagedResourceGroupName(testManagedResourceGroup)).
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().
+					ListClusters(gomock.Any()).
+					Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{csCluster}, nil))
+				return mockCS
+			},
+			expectError: false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				require.NotNil(t, cluster.ServiceProviderProperties.ClusterServiceID)
+				assert.Equal(t, testClusterServiceIDStr, cluster.ServiceProviderProperties.ClusterServiceID.String())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = utils.ContextWithLogger(ctx, testr.New(t))
+			ctrl := gomock.NewController(t)
+
+			subscription := newTestSubscription()
+			mockDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{subscription, tt.dbCluster})
+			require.NoError(t, err)
+
+			if tt.existingServiceProviderCluster != nil {
+				_, err := mockDB.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, tt.existingServiceProviderCluster, nil)
+				require.NoError(t, err)
+			}
+
+			mockCS := tt.setupMockCS(ctrl)
+
+			var listerClusters []*api.HCPOpenShiftCluster
+			if tt.listCluster != nil {
+				listerClusters = []*api.HCPOpenShiftCluster{tt.listCluster}
+			}
+			syncer := &clusterClusterServiceCreateSyncer{
+				resourcesDBClient:     mockDB,
+				clusterLister:         &listertesting.SliceClusterLister{Clusters: listerClusters},
+				subscriptionLister:    &listertesting.SliceSubscriptionLister{Subscriptions: []*arm.Subscription{subscription}},
+				clustersServiceClient: mockCS,
+			}
+
+			key := controllerutils.HCPClusterKey{
+				SubscriptionID:    testSubscriptionID,
+				ResourceGroupName: testResourceGroupName,
+				HCPClusterName:    testClusterName,
+			}
+
+			err = syncer.SyncOnce(ctx, key)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tt.verifyDB != nil {
+				tt.verifyDB(t, ctx, mockDB)
+			}
+		})
+	}
+}
+
+func TestClusterClusterServiceCreate_findAROHCPClusterByAzureInfo(t *testing.T) {
+	azureTestCluster := func(t *testing.T, sub, rg, name, tenant, mrg string) *arohcpv1alpha1.Cluster {
+		t.Helper()
+		c, err := arohcpv1alpha1.NewCluster().
+			Name(name).
+			Azure(arohcpv1alpha1.NewAzure().
+				SubscriptionID(sub).
+				ResourceGroupName(rg).
+				ResourceName(name).
+				TenantID(tenant).
+				ManagedResourceGroupName(mrg)).
+			Build()
+		require.NoError(t, err)
+		return c
+	}
+
+	ctx := context.Background()
+	defaultSub := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	defaultRG := "my-rg"
+	defaultResName := "MyCluster"
+	defaultTenant := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	defaultMRG := "arohcp-mycluster-uuid"
+
+	searchString := func(sub, rg, name, tenant, mrg string) string {
+		return (&clusterClusterServiceCreateSyncer{}).clustersServiceClusterByAzureInfoSearchString(
+			strings.ToLower(sub), strings.ToLower(rg), strings.ToLower(name), tenant, mrg,
+		)
+	}
+
+	tests := []struct {
+		name        string
+		sub         string
+		rg          string
+		resName     string
+		tenant      string
+		mrg         string
+		setupMockCS func(t *testing.T, ctrl *gomock.Controller, wantSearch string) (ocm.ClusterServiceClientSpec, *arohcpv1alpha1.Cluster)
+		wantErr     bool
+	}{
+		{
+			name: "found on primary search",
+			setupMockCS: func(t *testing.T, ctrl *gomock.Controller, wantSearch string) (ocm.ClusterServiceClientSpec, *arohcpv1alpha1.Cluster) {
+				wantSub := strings.ToLower(defaultSub)
+				wantRG := strings.ToLower(defaultRG)
+				wantName := strings.ToLower(defaultResName)
+				match := azureTestCluster(t, wantSub, wantRG, wantName, defaultTenant, defaultMRG)
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					ListClusters(wantSearch).
+					Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{match}, nil))
+				return mock, match
+			},
+		},
+		{
+			name: "found with uppercase subscription id",
+			sub:  strings.ToUpper(defaultSub),
+			setupMockCS: func(t *testing.T, ctrl *gomock.Controller, wantSearch string) (ocm.ClusterServiceClientSpec, *arohcpv1alpha1.Cluster) {
+				wantSub := strings.ToLower(defaultSub)
+				wantRG := strings.ToLower(defaultRG)
+				wantName := strings.ToLower(defaultResName)
+				match := azureTestCluster(t, wantSub, wantRG, wantName, defaultTenant, defaultMRG)
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					ListClusters(wantSearch).
+					Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{match}, nil))
+				return mock, match
+			},
+		},
+		{
+			name: "found with uppercase resource group",
+			rg:   strings.ToUpper(defaultRG),
+			setupMockCS: func(t *testing.T, ctrl *gomock.Controller, wantSearch string) (ocm.ClusterServiceClientSpec, *arohcpv1alpha1.Cluster) {
+				wantSub := strings.ToLower(defaultSub)
+				wantRG := strings.ToLower(defaultRG)
+				wantName := strings.ToLower(defaultResName)
+				match := azureTestCluster(t, wantSub, wantRG, wantName, defaultTenant, defaultMRG)
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					ListClusters(wantSearch).
+					Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{match}, nil))
+				return mock, match
+			},
+		},
+		{
+			name:    "found with uppercase resource name",
+			resName: strings.ToUpper(defaultResName),
+			setupMockCS: func(t *testing.T, ctrl *gomock.Controller, wantSearch string) (ocm.ClusterServiceClientSpec, *arohcpv1alpha1.Cluster) {
+				wantSub := strings.ToLower(defaultSub)
+				wantRG := strings.ToLower(defaultRG)
+				wantName := strings.ToLower(defaultResName)
+				match := azureTestCluster(t, wantSub, wantRG, wantName, defaultTenant, defaultMRG)
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					ListClusters(wantSearch).
+					Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{match}, nil))
+				return mock, match
+			},
+		},
+		{
+			name: "not found when list is empty",
+			setupMockCS: func(t *testing.T, ctrl *gomock.Controller, wantSearch string) (ocm.ClusterServiceClientSpec, *arohcpv1alpha1.Cluster) {
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					ListClusters(wantSearch).
+					Return(ocm.NewSimpleClusterListIterator(nil, nil))
+				return mock, nil
+			},
+		},
+		{
+			name: "not found when cs returns cluster with different resource name",
+			setupMockCS: func(t *testing.T, ctrl *gomock.Controller, wantSearch string) (ocm.ClusterServiceClientSpec, *arohcpv1alpha1.Cluster) {
+				wantSub := strings.ToLower(defaultSub)
+				wantRG := strings.ToLower(defaultRG)
+				mismatch := azureTestCluster(t, wantSub, wantRG, "other-name", defaultTenant, defaultMRG)
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					ListClusters(wantSearch).
+					Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{mismatch}, nil))
+				return mock, nil
+			},
+		},
+		{
+			name: "not found when cs returns cluster with different resource group",
+			setupMockCS: func(t *testing.T, ctrl *gomock.Controller, wantSearch string) (ocm.ClusterServiceClientSpec, *arohcpv1alpha1.Cluster) {
+				wantSub := strings.ToLower(defaultSub)
+				wantName := strings.ToLower(defaultResName)
+				mismatch := azureTestCluster(t, wantSub, "other-rg", wantName, defaultTenant, defaultMRG)
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					ListClusters(wantSearch).
+					Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{mismatch}, nil))
+				return mock, nil
+			},
+		},
+		{
+			name: "not found when cs returns cluster with different subscription",
+			setupMockCS: func(t *testing.T, ctrl *gomock.Controller, wantSearch string) (ocm.ClusterServiceClientSpec, *arohcpv1alpha1.Cluster) {
+				wantRG := strings.ToLower(defaultRG)
+				wantName := strings.ToLower(defaultResName)
+				mismatch := azureTestCluster(t, "00000000-0000-0000-0000-000000000001", wantRG, wantName, defaultTenant, defaultMRG)
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					ListClusters(wantSearch).
+					Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{mismatch}, nil))
+				return mock, nil
+			},
+		},
+		{
+			name: "not found when cs returns cluster with different tenant",
+			setupMockCS: func(t *testing.T, ctrl *gomock.Controller, wantSearch string) (ocm.ClusterServiceClientSpec, *arohcpv1alpha1.Cluster) {
+				wantSub := strings.ToLower(defaultSub)
+				wantRG := strings.ToLower(defaultRG)
+				wantName := strings.ToLower(defaultResName)
+				mismatch := azureTestCluster(t, wantSub, wantRG, wantName, "cccccccc-cccc-cccc-cccc-cccccccccccc", defaultMRG)
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					ListClusters(wantSearch).
+					Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{mismatch}, nil))
+				return mock, nil
+			},
+		},
+		{
+			name: "not found when cs returns cluster with different managed resource group",
+			setupMockCS: func(t *testing.T, ctrl *gomock.Controller, wantSearch string) (ocm.ClusterServiceClientSpec, *arohcpv1alpha1.Cluster) {
+				wantSub := strings.ToLower(defaultSub)
+				wantRG := strings.ToLower(defaultRG)
+				wantName := strings.ToLower(defaultResName)
+				mismatch := azureTestCluster(t, wantSub, wantRG, wantName, defaultTenant, "arohcp-other-mrg")
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					ListClusters(wantSearch).
+					Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{mismatch}, nil))
+				return mock, nil
+			},
+		},
+		{
+			name: "multiple matches error",
+			setupMockCS: func(t *testing.T, ctrl *gomock.Controller, wantSearch string) (ocm.ClusterServiceClientSpec, *arohcpv1alpha1.Cluster) {
+				wantSub := strings.ToLower(defaultSub)
+				wantRG := strings.ToLower(defaultRG)
+				wantName := strings.ToLower(defaultResName)
+				a := azureTestCluster(t, wantSub, wantRG, wantName, defaultTenant, defaultMRG)
+				b := azureTestCluster(t, wantSub, wantRG, wantName, defaultTenant, defaultMRG)
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					ListClusters(wantSearch).
+					Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{a, b}, nil))
+				return mock, nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub := defaultSub
+			if tt.sub != "" {
+				sub = tt.sub
+			}
+			rg := defaultRG
+			if tt.rg != "" {
+				rg = tt.rg
+			}
+			resName := defaultResName
+			if tt.resName != "" {
+				resName = tt.resName
+			}
+			tenant := defaultTenant
+			if tt.tenant != "" {
+				tenant = tt.tenant
+			}
+			mrg := defaultMRG
+			if tt.mrg != "" {
+				mrg = tt.mrg
+			}
+			wantSearch := searchString(sub, rg, resName, tenant, mrg)
+
+			ctrl := gomock.NewController(t)
+			mockCS, want := tt.setupMockCS(t, ctrl, wantSearch)
+
+			s := &clusterClusterServiceCreateSyncer{clustersServiceClient: mockCS}
+			got, err := s.findAROHCPClusterByAzureInfo(ctx, sub, rg, resName, tenant, mrg)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if want != nil {
+				require.Same(t, want, got)
+			} else {
+				require.Nil(t, got)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -49,6 +49,7 @@ import (
 
 type operationClusterCreate struct {
 	clock                                 utilsclock.PassiveClock
+	activeOperationLister                 listers.ActiveOperationLister
 	clusterLister                         listers.ClusterLister
 	clusterManagementClusterContentLister listers.ManagementClusterContentLister
 	readDesireLister                      dblisters.ReadDesireLister
@@ -80,10 +81,12 @@ func NewOperationClusterCreateController(
 	informers informers.BackendInformers,
 	readDesireLister dblisters.ReadDesireLister,
 ) controllerutils.Controller {
+	_, activeOperationLister := informers.ActiveOperations()
 	_, clusterLister := informers.Clusters()
 	_, clusterManagementClusterContentLister := informers.ManagementClusterContents()
 	syncer := &operationClusterCreate{
 		clock:                                 clock,
+		activeOperationLister:                 activeOperationLister,
 		clusterLister:                         clusterLister,
 		clusterManagementClusterContentLister: clusterManagementClusterContentLister,
 		readDesireLister:                      readDesireLister,
@@ -120,7 +123,7 @@ func (c *operationClusterCreate) SynchronizeOperation(ctx context.Context, key c
 	logger := utils.LoggerFromContext(ctx)
 	logger.Info("checking operation")
 
-	operation, err := c.resourcesDBClient.Operations(key.SubscriptionID).Get(ctx, key.OperationName)
+	operation, err := c.activeOperationLister.Get(ctx, key.SubscriptionID, key.OperationName)
 	if database.IsNotFoundError(err) {
 		return nil // no work to do
 	}
@@ -131,13 +134,26 @@ func (c *operationClusterCreate) SynchronizeOperation(ctx context.Context, key c
 		return nil // no work to do
 	}
 
-	if len(operation.InternalID.String()) == 0 {
-		// we cannot proceed: yet.
-		// TODO when we update to make clusterserice creation async, we need https://github.com/Azure/ARO-HCP/pull/4695 or similar
-		// and we need to wire up a fail-safe where if we have no ID and we time out, we report the best failure we can.
+	cluster, err := c.clusterLister.Get(ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Name)
+	if database.IsNotFoundError(err) {
+		logger.Info("cluster not found in cache, waiting")
 		return nil
 	}
-	clusterStatus, err := c.clusterServiceClient.GetClusterStatus(ctx, operation.InternalID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster to resolve ClusterServiceID: %w", err))
+	}
+	if operation.OperationID.Name != cluster.ServiceProviderProperties.ActiveOperationID {
+		logger.Info("cluster active operation id mismatch, returning early",
+			"synchronizedActiveOperationID", operation.OperationID.Name,
+			"clusterActiveOperationID", cluster.ServiceProviderProperties.ActiveOperationID)
+		return nil
+	}
+	if !c.shouldReconcileOperationAndResourceStatus(cluster) {
+		return nil
+	}
+	clusterServiceID := *cluster.ServiceProviderProperties.ClusterServiceID
+
+	clusterStatus, err := c.clusterServiceClient.GetClusterStatus(ctx, clusterServiceID)
 	if err != nil {
 		return utils.TrackError(err)
 	}
@@ -148,7 +164,7 @@ func (c *operationClusterCreate) SynchronizeOperation(ctx context.Context, key c
 	}
 	logger.Info("new status via cosmos", "newStatus", cosmosNewOperationState.provisioningState, "newOperationMessage", cosmosNewOperationState.message)
 
-	newOperationStatus, opError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus)
+	newOperationStatus, opError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus, clusterServiceID)
 	if err != nil {
 		return utils.TrackError(err)
 	}
@@ -163,6 +179,9 @@ func (c *operationClusterCreate) SynchronizeOperation(ctx context.Context, key c
 
 	logger.Info("updating status")
 	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, newOperationStatus, opError, postAsyncNotificationFn(c.notificationClient))
+	if database.IsPreconditionFailedError(err) {
+		return nil
+	}
 	if err != nil {
 		return utils.TrackError(err)
 	}
@@ -318,6 +337,11 @@ func (c *operationClusterCreate) hostedClusterOperationStatus(ctx context.Contex
 	// 2. the hosted cluster has successfully installed at least one version
 	// 3. the hosted cluster has a control plane endpoint host and port
 	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+}
+
+func (c *operationClusterCreate) shouldReconcileOperationAndResourceStatus(cluster *api.HCPOpenShiftCluster) bool {
+	return cluster.ServiceProviderProperties.DeletionTimestamp == nil &&
+		cluster.ServiceProviderProperties.ClusterServiceID != nil
 }
 
 // withDegradedSuffix appends the HostedCluster Degraded condition's reason and

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
@@ -53,104 +53,178 @@ import (
 
 func TestOperationClusterCreate_SynchronizeOperation(t *testing.T) {
 	createdAt := mustParseTime("2025-01-15T10:30:00Z")
+	fixture := newClusterTestFixture()
 
-	tests := []struct {
-		name         string
-		clusterState arohcpv1alpha1.ClusterState
-		createdAt    *time.Time
-		expectError  bool
-		verify       func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture)
+	succeededDesire := func(t *testing.T) *kubeapplier.ReadDesire {
+		return newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+			Status: v1beta1.HostedClusterStatus{
+				Conditions: []metav1.Condition{
+					{Type: string(v1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue},
+				},
+				ControlPlaneVersion: v1beta1.ControlPlaneVersionStatus{
+					History: []v1beta1.ControlPlaneUpdateHistory{
+						{Version: "4.17.3", State: configv1.CompletedUpdate},
+					},
+				},
+				ControlPlaneEndpoint: v1beta1.APIEndpoint{
+					Host: "api.example.com",
+					Port: 6443,
+				},
+			},
+		})
+	}
+
+	testCases := []struct {
+		name              string
+		existingCluster   *api.HCPOpenShiftCluster
+		existingOperation *api.Operation
+		setupCSMock       func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec
+		wantErr           bool
+		verifyDB          func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
 	}{
 		{
-			name:         "successful create updates operation to succeeded",
-			clusterState: arohcpv1alpha1.ClusterStateReady,
-			createdAt:    &createdAt,
-			expectError:  false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+			name:              "successful create updates operation to succeeded",
+			existingCluster:   newClusterWithAPIURL("https://api.example.com", &createdAt),
+			existingOperation: fixture.newOperation(database.OperationRequestCreate),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				clusterStatus, err := arohcpv1alpha1.NewClusterStatus().
+					State(arohcpv1alpha1.ClusterStateReady).
+					Build()
+				require.NoError(t, err)
+				mockCSClient.EXPECT().
+					GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
+					Return(clusterStatus, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
 			},
 		},
 		{
-			name:         "non-terminal cluster state updates to provisioning",
-			clusterState: arohcpv1alpha1.ClusterStateInstalling,
-			createdAt:    nil,
-			expectError:  false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+			name:              "non-terminal cluster state updates to provisioning",
+			existingCluster:   newClusterWithAPIURL("https://api.example.com", nil),
+			existingOperation: fixture.newOperation(database.OperationRequestCreate),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				clusterStatus, err := arohcpv1alpha1.NewClusterStatus().
+					State(arohcpv1alpha1.ClusterStateInstalling).
+					Build()
+				require.NoError(t, err)
+				mockCSClient.EXPECT().
+					GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
+					Return(clusterStatus, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateProvisioning, op.Status)
 			},
 		},
+		{
+			name:            "polls cluster service when operation InternalID is empty",
+			existingCluster: newClusterWithAPIURL("https://api.example.com", &createdAt),
+			existingOperation: func() *api.Operation {
+				op := fixture.newOperation(database.OperationRequestCreate)
+				op.InternalID = api.InternalID{}
+				return op
+			}(),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				clusterStatus, err := arohcpv1alpha1.NewClusterStatus().
+					State(arohcpv1alpha1.ClusterStateReady).
+					Build()
+				require.NoError(t, err)
+				mockCSClient.EXPECT().
+					GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
+					Return(clusterStatus, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
+			},
+		},
+		{
+			name: "waits when cluster ClusterServiceID is unset",
+			existingCluster: func() *api.HCPOpenShiftCluster {
+				cluster := newClusterWithAPIURL("https://api.example.com", &createdAt)
+				cluster.ServiceProviderProperties.ClusterServiceID = nil
+				return cluster
+			}(),
+			existingOperation: fixture.newOperation(database.OperationRequestCreate),
+			setupCSMock: func(ctrl *gomock.Controller, _ *clusterTestFixture) ocm.ClusterServiceClientSpec {
+				return ocm.NewMockClusterServiceClientSpec(ctrl)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name: "returns early when cluster active operation id mismatches",
+			existingCluster: func() *api.HCPOpenShiftCluster {
+				cluster := newClusterWithAPIURL("https://api.example.com", &createdAt)
+				cluster.ServiceProviderProperties.ActiveOperationID = "other-operation"
+				return cluster
+			}(),
+			existingOperation: fixture.newOperation(database.OperationRequestCreate),
+			setupCSMock: func(ctrl *gomock.Controller, _ *clusterTestFixture) ocm.ClusterServiceClientSpec {
+				return ocm.NewMockClusterServiceClientSpec(ctrl)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = utils.ContextWithLogger(ctx, testr.New(t))
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			fixture := newClusterTestFixture()
-			cluster := fixture.newCluster(tt.createdAt)
-			operation := fixture.newOperation(database.OperationRequestCreate)
-
-			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, operation})
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{tc.existingCluster, tc.existingOperation})
 			require.NoError(t, err)
 
-			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-			clusterStatus, err := arohcpv1alpha1.NewClusterStatus().
-				State(tt.clusterState).
-				Build()
+			listerOperation, err := mockResourcesDBClient.Operations(testSubscriptionID).Get(ctx, testOperationName)
 			require.NoError(t, err)
 
-			mockCSClient.EXPECT().
-				GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
-				Return(clusterStatus, nil)
-
-			// Provide listers so that determineOperationStatus can check cluster
-			// and hosted cluster state from cosmos.
-			succeededDesire := newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
-				Status: v1beta1.HostedClusterStatus{
-					Conditions: []metav1.Condition{
-						{Type: string(v1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue},
-					},
-					ControlPlaneVersion: v1beta1.ControlPlaneVersionStatus{
-						History: []v1beta1.ControlPlaneUpdateHistory{
-							{Version: "4.17.3", State: configv1.CompletedUpdate},
-						},
-					},
-					ControlPlaneEndpoint: v1beta1.APIEndpoint{
-						Host: "api.example.com",
-						Port: 6443,
-					},
-				},
-			})
+			mockCSClient := tc.setupCSMock(ctrl, fixture)
 
 			controller := &operationClusterCreate{
-				clock:                utilsclock.RealClock{},
+				clock: utilsclock.RealClock{},
+				activeOperationLister: &listertesting.SliceActiveOperationLister{
+					Operations: []*api.Operation{listerOperation},
+				},
 				resourcesDBClient:    mockResourcesDBClient,
 				clusterServiceClient: mockCSClient,
 				notificationClient:   nil,
 				clusterLister: &listertesting.SliceClusterLister{
-					Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
+					Clusters: []*api.HCPOpenShiftCluster{tc.existingCluster},
 				},
 				readDesireLister: &internallistertesting.SliceReadDesireLister{
-					Desires: []*kubeapplier.ReadDesire{succeededDesire},
+					Desires: []*kubeapplier.ReadDesire{succeededDesire(t)},
 				},
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
-
-			if tt.expectError {
+			if tc.wantErr {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+				return
 			}
+			require.NoError(t, err)
 
-			if tt.verify != nil {
-				tt.verify(t, ctx, mockResourcesDBClient, fixture)
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
 			}
 		})
 	}
@@ -226,9 +300,9 @@ func newHostedClusterReadDesire(t *testing.T, hostedCluster *v1beta1.HostedClust
 	}
 }
 
-func newClusterWithAPIURL(url string) *api.HCPOpenShiftCluster {
+func newClusterWithAPIURL(url string, createdAt *time.Time) *api.HCPOpenShiftCluster {
 	fixture := newClusterTestFixture()
-	cluster := fixture.newCluster(nil)
+	cluster := fixture.newCluster(createdAt)
 	cluster.ServiceProviderProperties.API = api.ServiceProviderAPIProfile{URL: url}
 	return cluster
 }
@@ -249,7 +323,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 		{
 			name: "both checks succeed → Succeeded",
 			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
+				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com", nil)},
 			},
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
@@ -277,7 +351,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 		{
 			name: "cluster API URL empty → Provisioning (lowest priority wins)",
 			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("")},
+				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("", nil)},
 			},
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
@@ -305,7 +379,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 		{
 			name: "hosted cluster not found → Provisioning",
 			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
+				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com", nil)},
 			},
 			readDesireLister: &internallistertesting.SliceReadDesireLister{},
 			expectedState:    arm.ProvisioningStateProvisioning,
@@ -339,7 +413,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 		{
 			name: "read desire lister non-404 error → error propagated",
 			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
+				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com", nil)},
 			},
 			readDesireLister: &errorReadDesireLister{err: fmt.Errorf("maestro error")},
 			expectError:      true,
@@ -355,7 +429,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 		{
 			name: "read desire not yet successful → Provisioning",
 			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
+				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com", nil)},
 			},
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
@@ -369,7 +443,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 		{
 			name: "hosted cluster not available → Provisioning",
 			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
+				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com", nil)},
 			},
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
@@ -393,7 +467,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 		{
 			name: "no control plane endpoint host → Provisioning",
 			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
+				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com", nil)},
 			},
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
@@ -417,7 +491,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 		{
 			name: "no control plane endpoint port → Provisioning",
 			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
+				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com", nil)},
 			},
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
@@ -444,7 +518,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 		{
 			name: "version with valid success condition but not installed → Provisioning",
 			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
+				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com", nil)},
 			},
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
@@ -183,7 +183,7 @@ func (c *operationClusterDelete) reconcileOperationAndResourceStatus(ctx context
 		return nil
 	}
 
-	newOperationStatus, newOperationError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, csClusterStatus)
+	newOperationStatus, newOperationError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, csClusterStatus, *clusterCSID)
 	if err != nil {
 		return utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete_legacy.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete_legacy.go
@@ -115,7 +115,7 @@ func (c *operationClusterDelete) legacySynchronizeOperation(ctx context.Context,
 		return utils.TrackError(err)
 	}
 
-	newOperationStatus, newOperationError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus)
+	newOperationStatus, newOperationError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus, operation.InternalID)
 	if err != nil {
 		return utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
@@ -247,7 +247,7 @@ func (c *operationClusterUpdate) clusterServiceUpdateOperationState(ctx context.
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
-	newOperationStatus, opError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus)
+	newOperationStatus, opError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus, operation.InternalID)
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/operationcontrollers/utils.go
+++ b/backend/pkg/controllers/operationcontrollers/utils.go
@@ -431,7 +431,7 @@ func PostAsyncNotification(ctx context.Context, notificationClient *http.Client,
 // convertClusterStatus attempts to translate a ClusterStatus object from
 // Cluster Service into an ARM provisioning state and, if necessary, a
 // structured OData error.
-func convertClusterStatus(ctx context.Context, clusterServiceClient ocm.ClusterServiceClientSpec, operation *api.Operation, clusterStatus *arohcpv1alpha1.ClusterStatus) (arm.ProvisioningState, *arm.CloudErrorBody, error) {
+func convertClusterStatus(ctx context.Context, clusterServiceClient ocm.ClusterServiceClientSpec, operation *api.Operation, clusterStatus *arohcpv1alpha1.ClusterStatus, clusterServiceID api.InternalID) (arm.ProvisioningState, *arm.CloudErrorBody, error) {
 	var newOperationStatus = operation.Status
 	var opError *arm.CloudErrorBody
 	var err error
@@ -452,7 +452,7 @@ func convertClusterStatus(ctx context.Context, clusterServiceClient ocm.ClusterS
 		// Construct the cloud error code depending on the provision error code.
 		switch code {
 		case InflightChecksFailedProvisionErrorCode:
-			opError, err = convertInflightChecks(ctx, clusterServiceClient, operation.InternalID)
+			opError, err = convertInflightChecks(ctx, clusterServiceClient, clusterServiceID)
 			if err != nil {
 				return newOperationStatus, opError, err
 			}

--- a/backend/pkg/controllers/operationcontrollers/utils_test.go
+++ b/backend/pkg/controllers/operationcontrollers/utils_test.go
@@ -187,7 +187,7 @@ func TestConvertClusterStatus(t *testing.T) {
 				Status:     tt.currentProvisioningState,
 			}
 
-			opState, opError, err := convertClusterStatus(ctx, nil, op, clusterStatus)
+			opState, opError, err := convertClusterStatus(ctx, nil, op, clusterStatus, tt.internalId)
 
 			assert.Equal(t, tt.updatedProvisioningState, opState)
 

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -139,11 +139,6 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 	if existingCluster.ServiceProviderProperties.DeletionTimestamp != nil {
 		return nil
 	}
-	if existingCluster.ServiceProviderProperties.ClusterServiceID == nil {
-		// Currently, this is correct.  We will likely refactor and change this to separate the read of active versions from the determination
-		// of the next desired version: we'll need to choose a desired version even if there are no active versions.
-		return nil
-	}
 
 	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
 	if err != nil {
@@ -162,7 +157,7 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 	}
 
 	// Resolve the cluster UUID from the cached HostedCluster so we can build the Cincinnati client.
-	// Use it as best effort.  If we cannot find use, use an empty value to make progress without a specific value.
+	// Use it as best effort. If we cannot find it, use an empty value to make progress without a specific value.
 	clusterUUID, found, err := maestrohelpers.GetCachedHostedClusterUUIDForCluster(ctx, c.readDesireLister, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
 	if err != nil {
 		logger.Info("error getting cluster UUID, continuing with empty", "err", err.Error())

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -372,12 +372,14 @@ func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluste
 
 	// These attributes cannot be updated after cluster creation.
 	if oldClusterServiceCluster == nil {
+		csVersionID := clusterCSVersionID(serviceProviderCluster, hcpCluster)
 		// Add attributes that cannot be updated after cluster creation.
 		clusterBuilder, err = withImmutableAttributes(clusterBuilder, hcpCluster,
 			resourceID.SubscriptionID,
 			resourceID.ResourceGroupName,
 			tenantID,
 			hcpCluster.ServiceProviderProperties.ManagedIdentitiesDataPlaneIdentityURL,
+			csVersionID,
 		)
 		if err != nil {
 			return nil, nil, err
@@ -449,6 +451,21 @@ func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluste
 	return clusterBuilder, clusterAutoscalerBuilder, nil
 }
 
+// clusterCSVersionID returns the OpenShift version ID for a new Cluster Service cluster.
+// ServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion is authoritative when set.
+// When unset (e.g. frontend install before ControlPlaneDesiredVersion runs), the customer
+// version on the HCP cluster document is used.
+// Once cluster install is migrated to backend, we can expect the desiredVersion field to always
+// be set on the ServiceProviderCluster.
+func clusterCSVersionID(serviceProviderCluster *api.ServiceProviderCluster, hcpCluster *api.HCPOpenShiftCluster) string {
+	channelGroup := hcpCluster.CustomerProperties.Version.ChannelGroup
+	if serviceProviderCluster != nil && serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion != nil {
+		return NewOpenShiftVersionXYZ(serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion.String(), channelGroup)
+	}
+	// Remove this once cluster install is migrated to backend
+	return NewOpenShiftVersionXYZ(hcpCluster.CustomerProperties.Version.ID, channelGroup)
+}
+
 // DesiredHostedClusterSizeOverride returns the value the CSPropertySizeOverride
 // entry should have for a given (ServiceProviderCluster, HCP cluster) pair,
 // and whether the property should be present at all. This is the single
@@ -476,7 +493,7 @@ func DesiredHostedClusterSizeOverride(serviceProviderCluster *api.ServiceProvide
 	return "", false
 }
 
-func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpCluster *api.HCPOpenShiftCluster, subscriptionID, resourceGroupName, tenantID, identityURL string) (*arohcpv1alpha1.ClusterBuilder, error) {
+func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpCluster *api.HCPOpenShiftCluster, subscriptionID, resourceGroupName, tenantID, identityURL, csVersionID string) (*arohcpv1alpha1.ClusterBuilder, error) {
 	clusterImageRegistryState, err := convertClusterImageRegistryStateRPToCS(hcpCluster.CustomerProperties.ClusterImageRegistry)
 	if err != nil {
 		return nil, err
@@ -498,7 +515,7 @@ func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpC
 			Enabled(csHypershifEnabled)).
 		CCS(arohcpv1alpha1.NewCCS().Enabled(csCCSEnabled)).
 		Version(arohcpv1alpha1.NewVersion().
-			ID(NewOpenShiftVersionXYZ(hcpCluster.CustomerProperties.Version.ID, hcpCluster.CustomerProperties.Version.ChannelGroup)).
+			ID(csVersionID).
 			ChannelGroup(hcpCluster.CustomerProperties.Version.ChannelGroup)).
 		Network(arohcpv1alpha1.NewNetwork().
 			Type(string(hcpCluster.CustomerProperties.Network.NetworkType)).

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"dario.cat/mergo"
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -166,13 +167,15 @@ func TestWithImmutableAttributes(t *testing.T) {
 			var buf bytes.Buffer
 			require.NoError(t, arohcpv1alpha1.MarshalCluster(tc.want, &buf))
 			want := buf.String()
+			hcpCluster := api.ClusterTestCase(t, tc.hcpCluster)
 			builder, err := withImmutableAttributes(
 				ocmClusterDefaults(api.TestLocation),
-				api.ClusterTestCase(t, tc.hcpCluster),
+				hcpCluster,
 				api.TestSubscriptionID,
 				api.TestResourceGroupName,
 				api.TestTenantID,
 				api.TestManagedIdentitiesDataPlaneIdentityURL,
+				clusterCSVersionID(nil, hcpCluster),
 			)
 			require.NoError(t, err)
 			result, err := builder.Build()
@@ -1185,6 +1188,56 @@ func TestBuildCSCluster(t *testing.T) {
 
 			// Compare
 			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+func TestClusterCSVersionID(t *testing.T) {
+	hcpCluster := func(versionID string) *api.HCPOpenShiftCluster {
+		c := &api.HCPOpenShiftCluster{}
+		c.CustomerProperties.Version.ID = versionID
+		c.CustomerProperties.Version.ChannelGroup = "stable"
+		return c
+	}
+	spcWithDesired := func(v string) *api.ServiceProviderCluster {
+		return &api.ServiceProviderCluster{
+			Spec: api.ServiceProviderClusterSpec{
+				ControlPlaneVersion: api.ServiceProviderClusterSpecVersion{
+					DesiredVersion: ptr.To(semver.MustParse(v)),
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		spc        *api.ServiceProviderCluster
+		hcpCluster *api.HCPOpenShiftCluster
+		want       string
+	}{
+		{
+			name:       "customer version when SPC is nil",
+			spc:        nil,
+			hcpCluster: hcpCluster("4.20"),
+			want:       "openshift-v4.20.25",
+		},
+		{
+			name:       "customer version when SPC has no DesiredVersion",
+			spc:        &api.ServiceProviderCluster{},
+			hcpCluster: hcpCluster("4.20"),
+			want:       "openshift-v4.20.25",
+		},
+		{
+			name:       "SPC DesiredVersion wins over customer minor",
+			spc:        spcWithDesired("4.20.8"),
+			hcpCluster: hcpCluster("4.20"),
+			want:       "openshift-v4.20.8",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, clusterCSVersionID(tc.spc, tc.hcpCluster))
 		})
 	}
 }


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Move CS cluster creation out of OperationClusterCreate into a dedicated
ClusterClusterServiceCreate controller. The new controller waits for
ControlPlaneDesiredVersion to resolve the install version, creates the CS
cluster (or reuses one matched by Azure metadata), and persists
ClusterServiceID on the cluster document.

OperationClusterCreate now polls CS provisioning status via that stored ID
instead of operation.InternalID. BuildCSCluster prefers the resolved
DesiredVersion from ServiceProviderCluster when building the CS cluster.

Async cluster installation will not take affect until cluster creation
is removed from the frontend.

### Why

The clusters service control plane is currently created synchronously during the create flow and uses hard coded versions derived from the customer desired version. By moving to an asynchronous approach we reduce create time and have clusters service deployment managed in the background. This will also allow us time to lookup the desired version from Cincinnati.

### Testing

Includes unit tests. Integration and end-to-end testing with the controller functional is done in https://github.com/Azure/ARO-HCP/pull/5709.
<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer
