### PR TITLE
clusters-service: bump liveness and readiness probe timeouts

### DIFF
--- a/cluster-service/helm-charts/cluster-service/templates/deployment.yaml
+++ b/cluster-service/helm-charts/cluster-service/templates/deployment.yaml
@@ -241,7 +241,7 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         readinessProbe:
           httpGet:
             path: /healthcheck
@@ -252,6 +252,7 @@ spec:
               value: Probe
           initialDelaySeconds: 20
           periodSeconds: 10
+          timeoutSeconds: 10
         resources:
           requests:
             memory: '{{ .Values.memoryRequest }}'


### PR DESCRIPTION
We see p95 latencies for clusters-service under load often getting close to 10 seconds, and we see chronic probe failures for clusters-service during end-to-end tests. We need to give these queries more time so the service is less likely to be killed during a run from lack of liveness or readiness.
