### PR TITLE
feat: enable azure db for postgresql enhanced metrics for cs and maestro dbs in some envs

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -862,6 +862,10 @@
           "type": "boolean",
           "description": "Enable geo-redundant backups for the PostgreSQL server."
         },
+        "enhancedMetricsEnabled": {
+          "type": "boolean",
+          "description": "Enable enhanced metrics for the PostgreSQL server."
+        },
         "containerizedDb": {
           "type": "object",
           "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -842,6 +842,7 @@ defaults:
       zoneRedundantMode: 'Auto'
       backupRetentionDays: 7
       geoRedundantBackup: false
+      enhancedMetricsEnabled: false
       containerizedDb:
         image: ""
         pvcCapacity: ""
@@ -911,6 +912,7 @@ defaults:
       zoneRedundantMode: 'Auto'
       backupRetentionDays: 7
       geoRedundantBackup: false
+      enhancedMetricsEnabled: false
       containerizedDb:
         image: ""
         pvcCapacity: ""
@@ -1103,12 +1105,16 @@ clouds:
       maestro:
         certDomain: selfsigned.maestro.keyvault.azure.com
         certIssuer: Self
+        postgres:
+          enhancedMetricsEnabled: true
       # Cluster Service
       clustersService:
         azureOperatorsManagedIdentities:
           roleSetName: dev
         azureRuntimeConfig:
           tlsCertificatesIssuer: Self
+        postgres:
+          enhancedMetricsEnabled: true
       # Hypershift Operator
       hypershift:
         limitClusterSizes: true

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -205,6 +205,7 @@ clustersService:
       pvcCapacity: ""
     databaseName: clusters-service
     deploy: true
+    enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
     name: arohcp-cspr-dbcs-usw3
@@ -505,6 +506,7 @@ maestro:
       pvcCapacity: ""
     databaseName: maestro
     deploy: true
+    enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
     name: arohcp-cspr-dbmaestro-usw3

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -205,6 +205,7 @@ clustersService:
       pvcCapacity: ""
     databaseName: clusters-service
     deploy: true
+    enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
     name: arohcp-dev-dbcs-usw3
@@ -505,6 +506,7 @@ maestro:
       pvcCapacity: ""
     databaseName: maestro
     deploy: true
+    enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
     name: arohcp-dev-dbmaestro-usw3

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -205,6 +205,7 @@ clustersService:
       pvcCapacity: ""
     databaseName: clusters-service
     deploy: true
+    enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
     name: arohcp-perf-dbcs-usw3ptest
@@ -505,6 +506,7 @@ maestro:
       pvcCapacity: ""
     databaseName: maestro
     deploy: true
+    enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
     name: arohcp-perf-dbmaestro-usw3ptest

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -205,6 +205,7 @@ clustersService:
       pvcCapacity: 512Mi
     databaseName: clusters-service
     deploy: false
+    enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
     name: arohcp-pers-dbcs-usw3test
@@ -505,6 +506,7 @@ maestro:
       pvcCapacity: 512Mi
     databaseName: maestro
     deploy: false
+    enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
     name: arohcp-pers-dbmaestro-usw3test

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -205,6 +205,7 @@ clustersService:
       pvcCapacity: 512Mi
     databaseName: clusters-service
     deploy: false
+    enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
     name: arohcp-prow-dbcs-j7654321
@@ -505,6 +506,7 @@ maestro:
       pvcCapacity: 512Mi
     databaseName: maestro
     deploy: false
+    enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
     name: arohcp-prow-dbmaestro-j7654321

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -205,6 +205,7 @@ clustersService:
       pvcCapacity: 512Mi
     databaseName: clusters-service
     deploy: false
+    enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
     name: arohcp-swft-dbcs-lnstest
@@ -505,6 +506,7 @@ maestro:
       pvcCapacity: 512Mi
     databaseName: maestro
     deploy: false
+    enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
     name: arohcp-swft-dbmaestro-lnstest

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -78,6 +78,7 @@ param maestroPostgresZoneRedundantMode = '{{ .maestro.postgres.zoneRedundantMode
 param maestroPostgresBackupRetentionDays = {{ .maestro.postgres.backupRetentionDays }}
 param maestroPostgresGeoRedundantBackup = {{ .maestro.postgres.geoRedundantBackup }}
 param maestroPostgresPrivate = {{ .maestro.postgres.private }}
+param maestroPostgresEnhancedMetricsEnabled = {{ .maestro.postgres.enhancedMetricsEnabled }}
 
 param csPostgresDeploy = {{ .clustersService.postgres.deploy }}
 param csPostgresZoneRedundantMode = '{{ .clustersService.postgres.zoneRedundantMode }}'
@@ -88,6 +89,7 @@ param csPostgresServerMinTLSVersion = '{{ .clustersService.postgres.minTLSVersio
 param csPostgresServerVersion = '{{ .clustersService.postgres.serverVersion }}'
 param csPostgresServerStorageSizeGB = {{ .clustersService.postgres.serverStorageSizeGB }}
 param csPostgresDatabaseName = '{{ .clustersService.postgres.databaseName }}'
+param csPostgresEnhancedMetricsEnabled = {{ .clustersService.postgres.enhancedMetricsEnabled }}
 param clusterServicePostgresPrivate = {{ .clustersService.postgres.private }}
 param csMIName = '{{ .clustersService.managedIdentityName }}'
 param csNamespace = '{{ .clustersService.k8s.namespace }}'

--- a/dev-infrastructure/modules/cluster-service.bicep
+++ b/dev-infrastructure/modules/cluster-service.bicep
@@ -77,11 +77,42 @@ param postgresBackupRetentionDays int
 @description('Enable geo-redundant backups for the PostgreSQL server.')
 param postgresGeoRedundantBackup bool
 
+@description('Enable enhanced metrics for the PostgreSQL server.')
+param postgresEnhancedMetricsEnabled bool
+
 //
 //   P O S T G R E S
 //
 
 import * as res from 'resource.bicep'
+
+// Base log_* settings taken from the CS RDS instance (legacy parameter group).
+// https://gitlab.cee.redhat.com/service/app-interface/-/blob/fc95453b1e0eaf162089525f5b94b6dc1e6a091f/resources/terraform/resources/ocm/clusters-service-production-rds-parameter-group-pg12.yml
+var baseDBConfigurations = [
+  {
+    source: 'log_min_duration_statement'
+    value: '3000'
+  }
+  {
+    source: 'log_statement'
+    value: 'all'
+  }
+]
+
+var dbEnhancedMetricsConfiguration = [
+  {
+    // Related to Postgres Enhanced Metrics.
+    // https://learn.microsoft.com/en-us/azure/postgresql/monitor/concepts-monitoring#enhanced-metrics
+    // Required to be able to have additional postgres metrics available.
+    source: 'metrics.collector_database_activity'
+    value: 'on'
+  }
+]
+
+var dbConfigurations = concat(
+  baseDBConfigurations,
+  postgresEnhancedMetricsEnabled ? dbEnhancedMetricsConfiguration : []
+)
 
 module csPostgres 'postgres/postgres.bicep' = if (deployPostgres) {
   name: 'cs-postgres-deployment'
@@ -98,18 +129,7 @@ module csPostgres 'postgres/postgres.bicep' = if (deployPostgres) {
     ]
     version: postgresServerVersion
     minTLSVersion: postgresServerMinTLSVersion
-    configurations: [
-      // some configs taked over from the CS RDS instance
-      // https://gitlab.cee.redhat.com/service/app-interface/-/blob/fc95453b1e0eaf162089525f5b94b6dc1e6a091f/resources/terraform/resources/ocm/clusters-service-production-rds-parameter-group-pg12.yml
-      {
-        source: 'log_min_duration_statement'
-        value: '3000'
-      }
-      {
-        source: 'log_statement'
-        value: 'all'
-      }
-    ]
+    configurations: dbConfigurations
     databases: [
       {
         name: csDatabaseName

--- a/dev-infrastructure/modules/maestro/maestro-server.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-server.bicep
@@ -75,12 +75,41 @@ param postgresBackupRetentionDays int
 @description('Enable geo-redundant backups for the PostgreSQL server.')
 param postgresGeoRedundantBackup bool
 
+@description('Enable enhanced metrics for the PostgreSQL server.')
+param postgresEnhancedMetricsEnabled bool
+
 @description('The regional resource group')
 param regionalResourceGroup string
 
 //
 //   P O S T G R E S
 //
+
+var baseDBConfigurations = [
+  {
+    source: 'log_min_duration_statement'
+    value: '3000'
+  }
+  {
+    source: 'log_statement'
+    value: 'all'
+  }
+]
+
+var dbEnhancedMetricsConfiguration = [
+  {
+    // Related to Postgres Enhanced Metrics.
+    // https://learn.microsoft.com/en-us/azure/postgresql/monitor/concepts-monitoring#enhanced-metrics
+    // Required to be able to have additional postgres metrics available.
+    source: 'metrics.collector_database_activity'
+    value: 'on'
+  }
+]
+
+var dbConfigurations = concat(
+  baseDBConfigurations,
+  postgresEnhancedMetricsEnabled ? dbEnhancedMetricsConfiguration : []
+)
 
 import * as res from '../resource.bicep'
 
@@ -101,16 +130,7 @@ module maestroPostgres '../postgres/postgres.bicep' = if (deployPostgres) {
       }
     ]
     version: postgresServerVersion
-    configurations: [
-      {
-        source: 'log_min_duration_statement'
-        value: '3000'
-      }
-      {
-        source: 'log_statement'
-        value: 'all'
-      }
-    ]
+    configurations: dbConfigurations
     databases: [
       {
         name: maestroDatabaseName

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -200,6 +200,9 @@ param csPostgresServerVersion string
 @description('The size of the Postgres server for CS')
 param csPostgresServerStorageSizeGB int
 
+@description('Enable enhanced metrics for the CS PostgreSQL server')
+param csPostgresEnhancedMetricsEnabled bool
+
 @description('If true, make the CS Postgres instance private')
 param clusterServicePostgresPrivate bool = true
 
@@ -236,6 +239,9 @@ param maestroPostgresDatabaseName string
 
 @description('The name of Maestro Server MQTT client')
 param maestroServerMqttClientName string
+
+@description('Enable enhanced metrics for the Maestro PostgreSQL server')
+param maestroPostgresEnhancedMetricsEnabled bool
 
 @description('The name of the maestro managed identity')
 param maestroMIName string
@@ -805,6 +811,7 @@ module maestroServer '../modules/maestro/maestro-server.bicep' = {
     maestroDatabaseName: maestroPostgresDatabaseName
     postgresServerPrivate: maestroPostgresPrivate
     postgresAdministrationManagedIdentityId: globalMSIId
+    postgresEnhancedMetricsEnabled: maestroPostgresEnhancedMetricsEnabled
     maestroServerManagedIdentityPrincipalId: mi.getManagedIdentityByName(
       managedIdentities.outputs.managedIdentities,
       maestroMIName
@@ -829,6 +836,7 @@ module cs '../modules/cluster-service.bicep' = {
     postgresServerMinTLSVersion: csPostgresServerMinTLSVersion
     postgresServerVersion: csPostgresServerVersion
     postgresServerStorageSizeGB: csPostgresServerStorageSizeGB
+    postgresEnhancedMetricsEnabled: csPostgresEnhancedMetricsEnabled
     csDatabaseName: csPostgresDatabaseName
     privateEndpointSubnetId: nodeSubnetCreation.outputs.subnetId
     privateEndpointVnetId: vnetCreation.outputs.vnetId


### PR DESCRIPTION
We add the ability to enable enhanced metrics when using azure database for postgresql as the maestro and cs dbs. We set it as disabled by default and we enable it for all aro-hcp dev derivated environments like personal, cspr, prow.

More info about enhanced metrics available in:
https://learn.microsoft.com/en-us/azure/postgresql/monitor/concepts-monitoring#enhanced-metrics.

Aside from dev derivated envs the next step will be to enable it in ARO-HCP Integration via sdp-pipelines repo.