### PR TITLE
Upgrade to aks 1.33.8

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -406,7 +406,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.33.7
+      kubernetesVersion: 1.33.8
       networkDataplane: "cilium"
       networkPolicy: "cilium"
       systemAgentPool:
@@ -530,7 +530,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.33.7
+      kubernetesVersion: 1.33.8
       networkDataplane: "azure"
       networkPolicy: "azure"
       etcd:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -406,7 +406,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.32.5
+      kubernetesVersion: 1.33.7
       networkDataplane: "cilium"
       networkPolicy: "cilium"
       systemAgentPool:
@@ -530,7 +530,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.32.5
+      kubernetesVersion: 1.33.7
       networkDataplane: "azure"
       networkPolicy: "azure"
       etcd:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -551,7 +551,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.32.5
+    kubernetesVersion: 1.33.7
     name: cspr-westus3-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -858,7 +858,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.32.5
+    kubernetesVersion: 1.33.7
     name: cspr-westus3-svc-1
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -551,7 +551,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.7
+    kubernetesVersion: 1.33.8
     name: cspr-westus3-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -858,7 +858,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.7
+    kubernetesVersion: 1.33.8
     name: cspr-westus3-svc-1
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -551,7 +551,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.32.5
+    kubernetesVersion: 1.33.7
     name: dev-westus3-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -858,7 +858,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.32.5
+    kubernetesVersion: 1.33.7
     name: dev-westus3-svc-1
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -551,7 +551,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.7
+    kubernetesVersion: 1.33.8
     name: dev-westus3-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -858,7 +858,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.7
+    kubernetesVersion: 1.33.8
     name: dev-westus3-svc-1
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -551,7 +551,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.7
+    kubernetesVersion: 1.33.8
     name: perf-usw3ptest-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -858,7 +858,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.7
+    kubernetesVersion: 1.33.8
     name: perf-usw3ptest-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -551,7 +551,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.32.5
+    kubernetesVersion: 1.33.7
     name: perf-usw3ptest-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -858,7 +858,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.32.5
+    kubernetesVersion: 1.33.7
     name: perf-usw3ptest-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -551,7 +551,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.7
+    kubernetesVersion: 1.33.8
     name: pers-usw3test-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -860,7 +860,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.7
+    kubernetesVersion: 1.33.8
     name: pers-usw3test-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -551,7 +551,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.32.5
+    kubernetesVersion: 1.33.7
     name: pers-usw3test-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -860,7 +860,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.32.5
+    kubernetesVersion: 1.33.7
     name: pers-usw3test-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -551,7 +551,7 @@ mgmt:
       vmSize: Standard_D4ds_v5
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.32.5
+    kubernetesVersion: 1.33.7
     name: prow-j7654321-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -860,7 +860,7 @@ svc:
       vmSize: Standard_D4ds_v5
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.32.5
+    kubernetesVersion: 1.33.7
     name: prow-j7654321-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -551,7 +551,7 @@ mgmt:
       vmSize: Standard_D4ds_v5
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.7
+    kubernetesVersion: 1.33.8
     name: prow-j7654321-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -860,7 +860,7 @@ svc:
       vmSize: Standard_D4ds_v5
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.7
+    kubernetesVersion: 1.33.8
     name: prow-j7654321-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -551,7 +551,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.7
+    kubernetesVersion: 1.33.8
     name: swft-lnstest-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -860,7 +860,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.7
+    kubernetesVersion: 1.33.8
     name: swft-lnstest-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -551,7 +551,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.32.5
+    kubernetesVersion: 1.33.7
     name: swft-lnstest-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -860,7 +860,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.32.5
+    kubernetesVersion: 1.33.7
     name: swft-lnstest-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -271,10 +271,10 @@ resourceGroups:
     variables:
     - name: CLUSTER_NAME
       configRef: mgmt.aks.name
-    - name: KUBERNETES_VERSION
-      configRef: mgmt.aks.kubernetesVersion
     - name: RESOURCE_GROUP
       configRef: mgmt.rg
+    - name: KUBERNETES_VERSION
+      configRef: mgmt.aks.kubernetesVersion
     dependsOn:
     - resourceGroup: management
       step: delete-non-swift-user-nodepools

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -260,7 +260,6 @@ resourceGroups:
     - resourceGroup: management
       step: cluster
   - name: upgrade-aks-cluster
-    aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell
     command: ./upgrade-aks-cluster.sh
     workingDir: ./scripts

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -259,6 +259,26 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: cluster
+  - name: upgrade-aks-cluster
+    aksCluster: '{{ .mgmt.aks.name }}'
+    action: Shell
+    command: ./upgrade-aks-cluster.sh
+    workingDir: ./scripts
+    shellIdentity:
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    variables:
+    - name: CLUSTER_NAME
+      configRef: mgmt.aks.name
+    - name: KUBERNETES_VERSION
+      configRef: mgmt.aks.kubernetesVersion
+    - name: RESOURCE_GROUP
+      configRef: mgmt.rg
+    dependsOn:
+    - resourceGroup: service
+      step: delete-non-swift-user-nodepools
   - name: nsp
     action: ARM
     omitFromServiceGroupCompletion: true

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -277,7 +277,7 @@ resourceGroups:
     - name: RESOURCE_GROUP
       configRef: mgmt.rg
     dependsOn:
-    - resourceGroup: service
+    - resourceGroup: management
       step: delete-non-swift-user-nodepools
   - name: nsp
     action: ARM

--- a/dev-infrastructure/scripts/upgrade-aks-cluster.sh
+++ b/dev-infrastructure/scripts/upgrade-aks-cluster.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# Inputs via environment variables:
+#   CLUSTER_NAME   - AKS cluster name
+#   KUBERNETES_VERSION - Kubernetes Version
+#   RESOURCE_GROUP - Resource group containing the cluster
+
+echo " Upgrading cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' to '${KUBERNETES_VERSION}'..."
+
+az aks upgrade \
+    --resource-group ${CLUSTER_NAME} \
+    --name ${RESOURCE_GROUP} \
+    --kubernetes-version ${KUBERNETES_VERSION} \
+    --yes
+

--- a/dev-infrastructure/scripts/upgrade-aks-cluster.sh
+++ b/dev-infrastructure/scripts/upgrade-aks-cluster.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 echo " Upgrading cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' to '${KUBERNETES_VERSION}'..."
 
 az aks upgrade \
-    --resource-group ${CLUSTER_NAME} \
-    --name ${RESOURCE_GROUP} \
+    --resource-group ${RESOURCE_GROUP} \
+    --name ${CLUSTER_NAME} \
     --kubernetes-version ${KUBERNETES_VERSION} \
     --yes
 

--- a/dev-infrastructure/scripts/upgrade-aks-cluster.sh
+++ b/dev-infrastructure/scripts/upgrade-aks-cluster.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 # Inputs via environment variables:
 #   CLUSTER_NAME   - AKS cluster name
-#   KUBERNETES_VERSION - Kubernetes Version
 #   RESOURCE_GROUP - Resource group containing the cluster
+#   KUBERNETES_VERSION - Kubernetes Version
 
-echo " Upgrading cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' to '${KUBERNETES_VERSION}'..."
+echo "Upgrading cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' to '${KUBERNETES_VERSION}'..."
 
 az aks upgrade \
     --resource-group ${RESOURCE_GROUP} \

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -204,10 +204,10 @@ resourceGroups:
     variables:
     - name: CLUSTER_NAME
       configRef: svc.aks.name
-    - name: KUBERNETES_VERSION
-      configRef: svc.aks.kubernetesVersion
     - name: RESOURCE_GROUP
       configRef: svc.rg
+    - name: KUBERNETES_VERSION
+      configRef: svc.aks.kubernetesVersion
     dependsOn:
     - resourceGroup: service
       step: delete-old-user-nodepools

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -193,7 +193,6 @@ resourceGroups:
     - resourceGroup: service
       step: cluster
   - name: upgrade-aks-cluster
-    aksCluster: '{{ .svc.aks.name }}'
     action: Shell
     command: ./upgrade-aks-cluster.sh
     workingDir: ./scripts

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -192,6 +192,26 @@ resourceGroups:
     dependsOn:
     - resourceGroup: service
       step: cluster
+  - name: upgrade-aks-cluster
+    aksCluster: '{{ .svc.aks.name }}'
+    action: Shell
+    command: ./upgrade-aks-cluster.sh
+    workingDir: ./scripts
+    shellIdentity:
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    variables:
+    - name: CLUSTER_NAME
+      configRef: svc.aks.name
+    - name: KUBERNETES_VERSION
+      configRef: svc.aks.kubernetesVersion
+    - name: RESOURCE_GROUP
+      configRef: svc.rg
+    dependsOn:
+    - resourceGroup: service
+      step: delete-old-user-nodepools
   - name: cluster-output
     action: ARM
     template: templates/output-svc-cluster.bicep


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-25883

### What

Upgrade AKS version to 1.33.8 for svc and mgmt.
Our current approach was not upgrading nodepool, but this PR adresses it with the `az aks upgrade` step in both mgmt and svc pipeline. This is a preliminary solution until we have AKS Fleet in place.

### Why

We want to upgrade to AKS 1.35 to close possible gaps to the latest version - and we need to do it step by step.
1.33.x (x>8) will have a fix we need for swift

### Testing

manual tests confirmed the functionality works.
prow E2E tests will not trigger real upgrades because the install version matches already the target version enforced by the upgrade script. in any case it is a noop

### Special notes for your reviewer

<!-- optional -->
