### PR TITLE
test: update serving_app verifier

### DIFF
--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -17,6 +17,7 @@ package verifiers
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"embed"
 	"fmt"
 	"net/http"
@@ -36,8 +37,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-
-	"github.com/Azure/ARO-HCP/test/util/framework"
 )
 
 //go:embed artifacts
@@ -164,15 +163,18 @@ func (v verifySimpleWebApp) Verify(ctx context.Context, adminRESTConfig *rest.Co
 	lastErr = nil
 	url := "https://" + host
 
-	// Create HTTP client with TLS skip for development environments
 	client := &http.Client{}
-	if framework.IsDevelopmentEnvironment() {
+	CAData := adminRESTConfig.CAData
+	if len(CAData) > 0 {
+		tlsConfig := &tls.Config{
+			RootCAs: x509.NewCertPool(),
+		}
+		tlsConfig.RootCAs.AppendCertsFromPEM(CAData)
 		client.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
+			TLSClientConfig: tlsConfig,
 		}
 	}
+
 	startTime := time.Now()
 	logged5Min := false
 	logged10Min := false


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-21125 
### What

Configure the route availability HTTP client to trust the cluster CA from adminRESTConfig.CAData, so HTTPS checks against the OpenShift route succeed when the route uses a private/cluster-issued certificate

### Why

<!-- Briefly explain why this change is needed -->

To mitigate error scenario in e2e for route created by testing app. - "tls: failed to verify certificate: x509: certificate signed by unknown authority"
