### PR TITLE
Trigger icm alert for container oom kills

### DIFF
--- a/dev-infrastructure/configurations/kusto-alerting.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/kusto-alerting.tmpl.bicepparam
@@ -1,0 +1,8 @@
+using '../templates/kusto-alerting.bicep'
+
+param kustoClusterId = '__kustoClusterId__'
+param kustoUri = '__kustoUri__'
+param kustoName = '{{ .kusto.kustoName }}'
+param slActionGroupId = '__slActionGroupId__'
+param serviceLogsDatabase = '{{ .kusto.serviceLogsDatabase }}'
+param hostedControlPlaneLogsDatabase = '{{ .kusto.hostedControlPlaneLogsDatabase }}'

--- a/dev-infrastructure/modules/kusto-alerts/alert-rule.bicep
+++ b/dev-infrastructure/modules/kusto-alerts/alert-rule.bicep
@@ -1,0 +1,91 @@
+@description('Name of the alert rule')
+param alertName string
+
+@description('Azure region')
+param location string
+
+@description('Resource ID of the ADX cluster to query')
+param kustoClusterId string
+
+@description('KQL query to evaluate')
+param query string
+
+@description('Alert severity: 0=Critical, 1=Error, 2=Warning, 3=Informational')
+@allowed([0, 1, 2, 3])
+param severity int
+
+@description('Threshold value for the alert condition')
+param threshold int
+
+@description('Comparison operator for the alert condition')
+@allowed(['GreaterThan', 'GreaterThanOrEqual', 'LessThan', 'LessThanOrEqual', 'Equal'])
+param operator string
+
+@description('How often the query is evaluated (ISO 8601 duration, e.g. PT5M)')
+param evaluationFrequency string
+
+@description('Time window for the query (ISO 8601 duration, e.g. PT15M)')
+param windowSize string
+
+@description('Aggregation type for the query result')
+@allowed(['Count', 'Average', 'Minimum', 'Maximum', 'Total'])
+param timeAggregation string
+
+@description('Resource IDs of the action groups to notify')
+param actionGroupIds array
+
+@description('Whether the alert rule is enabled')
+param enabled bool
+
+@description('Resource ID of the user-assigned managed identity for ADX access')
+param identityId string
+
+@description('Auto-resolve when condition clears')
+param autoMitigate bool = true
+
+@sys.description('Description of the alert rule')
+param alertDescription string = ''
+
+@description('Dimensions to split alerts by (e.g. cluster, name)')
+param dimensions array = []
+
+resource alertRule 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview' = {
+  name: alertName
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${identityId}': {}
+    }
+  }
+  properties: {
+    actions: {
+      actionGroups: actionGroupIds
+    }
+    autoMitigate: autoMitigate
+    criteria: {
+      allOf: [
+        {
+          dimensions: dimensions
+          failingPeriods: {
+            minFailingPeriodsToAlert: 1
+            numberOfEvaluationPeriods: 1
+          }
+          operator: operator
+          query: query
+          resourceIdColumn: ''
+          threshold: threshold
+          timeAggregation: timeAggregation
+        }
+      ]
+    }
+    description: alertDescription
+    displayName: alertName
+    enabled: enabled
+    evaluationFrequency: evaluationFrequency
+    scopes: [kustoClusterId]
+    severity: severity
+    targetResourceTypes: ['Microsoft.Kusto/clusters']
+    windowSize: windowSize
+  }
+}

--- a/dev-infrastructure/modules/kusto-alerts/alert-rules.bicep
+++ b/dev-infrastructure/modules/kusto-alerts/alert-rules.bicep
@@ -1,0 +1,67 @@
+// Kusto (ADX) alert rule definitions.
+// Add new alerts here — no changes to shared infrastructure (main.bicep) needed.
+//
+// To add a new alert:
+//   1. Define a query template variable using triple-quoted KQL
+//      - Use adx('{0}').tableName and replace '{0}' with adxServiceLogs or adxHcpLogs
+//      - Add explicit time filters: | where timestamp >= ago(5m) and timestamp <= now()
+//      - Project the columns needed for dimensions and context
+//   2. Create a module block referencing 'alert-rule.bicep'
+//      - Use replace() to inject adxServiceLogs or adxHcpLogs into the query
+//      - Set dimensions to split alerts (e.g. by cluster)
+
+@description('Azure region')
+param location string
+
+@description('Resource ID of the ADX cluster')
+param kustoClusterId string
+
+@description('Resource IDs of the action groups to notify')
+param actionGroupIds array
+
+@description('Resource ID of the user-assigned managed identity')
+param identityId string
+
+@description('Pre-built adx() URI for ServiceLogs database')
+param adxServiceLogs string
+
+@description('Pre-built adx() URI for HostedControlPlaneLogs database')
+param adxHcpLogs string
+
+// --- Fluent-bit OOM killing alert ---
+
+var oomKillingQueryTemplate = '''
+adx('{0}').kubernetesEvents
+| where timestamp >= ago(5m) and timestamp <= now()
+| where reason == 'OOMKilling'
+| extend name = extract(@"\d+ \(([^)]+)\)", 1, message)
+| where name == 'fluent-bit'
+| project timestamp, cluster, name, message
+'''
+
+module oomKillingAlert 'alert-rule.bicep' = {
+  name: 'oom-killing-alert'
+  params: {
+    alertName: 'FluentBitOOMKilling'
+    location: location
+    kustoClusterId: kustoClusterId
+    query: replace(oomKillingQueryTemplate, '{0}', adxServiceLogs)
+    severity: 2
+    threshold: 0
+    operator: 'GreaterThan'
+    timeAggregation: 'Count'
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT5M'
+    actionGroupIds: actionGroupIds
+    identityId: identityId
+    enabled: true
+    alertDescription: 'Fluent-bit container is being OOM killed'
+    dimensions: [
+      {
+        name: 'cluster'
+        operator: 'Include'
+        values: ['*']
+      }
+    ]
+  }
+}

--- a/dev-infrastructure/modules/kusto-alerts/alert-rules.bicep
+++ b/dev-infrastructure/modules/kusto-alerts/alert-rules.bicep
@@ -7,7 +7,7 @@
 //      - Add explicit time filters: | where timestamp >= ago(5m) and timestamp <= now()
 //      - Project the columns needed for dimensions and context
 //   2. Create a module block referencing 'alert-rule.bicep'
-//      - Use replace() to inject adxServiceLogs or adxHcpLogs into the query
+//      - Use replace() to inject adxServiceLogs into the query
 //      - Set dimensions to split alerts (e.g. by cluster)
 
 @description('Azure region')
@@ -25,21 +25,21 @@ param identityId string
 @description('Pre-built adx() URI for ServiceLogs database')
 param adxServiceLogs string
 
-// --- Fluent-bit OOM killing alert ---
+// --- Critical container OOM killing alert ---
 
 var oomKillingQueryTemplate = '''
 adx('{0}').kubernetesEvents
 | where timestamp >= ago(5m) and timestamp <= now()
 | where reason == 'OOMKilling'
 | extend name = extract(@"\d+ \(([^)]+)\)", 1, message)
-| where name == 'fluent-bit'
+| where name in ('fluent-bit', 'mdsd', 'maestro', 'aro-hcp-frontend', 'aro-hcp-backend', 'clusters-service', 'hypershift')
 | project timestamp, cluster, name, message
 '''
 
 module oomKillingAlert 'alert-rule.bicep' = {
   name: 'oom-killing-alert'
   params: {
-    alertName: 'FluentBitOOMKilling'
+    alertName: 'CriticalContainerOOMKilling'
     location: location
     kustoClusterId: kustoClusterId
     query: replace(oomKillingQueryTemplate, '{0}', adxServiceLogs)
@@ -52,10 +52,15 @@ module oomKillingAlert 'alert-rule.bicep' = {
     actionGroupIds: actionGroupIds
     identityId: identityId
     enabled: true
-    alertDescription: 'Fluent-bit container is being OOM killed'
+    alertDescription: 'A critical container is being OOM killed'
     dimensions: [
       {
         name: 'cluster'
+        operator: 'Include'
+        values: ['*']
+      }
+      {
+        name: 'name'
         operator: 'Include'
         values: ['*']
       }

--- a/dev-infrastructure/modules/kusto-alerts/alert-rules.bicep
+++ b/dev-infrastructure/modules/kusto-alerts/alert-rules.bicep
@@ -25,25 +25,24 @@ param identityId string
 @description('Pre-built adx() URI for ServiceLogs database')
 param adxServiceLogs string
 
-// --- Critical container OOM killing alert ---
+// --- Container OOM killing alert ---
 
 var oomKillingQueryTemplate = '''
 adx('{0}').kubernetesEvents
 | where timestamp >= ago(5m) and timestamp <= now()
 | where reason == 'OOMKilling'
 | extend name = extract(@"\d+ \(([^)]+)\)", 1, message)
-| where name in ('fluent-bit', 'mdsd', 'maestro', 'aro-hcp-frontend', 'aro-hcp-backend', 'clusters-service', 'hypershift')
 | project timestamp, cluster, name, message
 '''
 
 module oomKillingAlert 'alert-rule.bicep' = {
   name: 'oom-killing-alert'
   params: {
-    alertName: 'CriticalContainerOOMKilling'
+    alertName: 'ContainerOOMKilling'
     location: location
     kustoClusterId: kustoClusterId
     query: replace(oomKillingQueryTemplate, '{0}', adxServiceLogs)
-    severity: 2
+    severity: 3
     threshold: 0
     operator: 'GreaterThan'
     timeAggregation: 'Count'
@@ -52,7 +51,7 @@ module oomKillingAlert 'alert-rule.bicep' = {
     actionGroupIds: actionGroupIds
     identityId: identityId
     enabled: true
-    alertDescription: 'A critical container is being OOM killed'
+    alertDescription: 'A container is being OOM killed'
     dimensions: [
       {
         name: 'cluster'

--- a/dev-infrastructure/modules/kusto-alerts/alert-rules.bicep
+++ b/dev-infrastructure/modules/kusto-alerts/alert-rules.bicep
@@ -3,7 +3,7 @@
 //
 // To add a new alert:
 //   1. Define a query template variable using triple-quoted KQL
-//      - Use adx('{0}').tableName and replace '{0}' with adxServiceLogs or adxHcpLogs
+//      - Use adx('{0}').tableName and replace '{0}' with adxServiceLogs
 //      - Add explicit time filters: | where timestamp >= ago(5m) and timestamp <= now()
 //      - Project the columns needed for dimensions and context
 //   2. Create a module block referencing 'alert-rule.bicep'
@@ -24,9 +24,6 @@ param identityId string
 
 @description('Pre-built adx() URI for ServiceLogs database')
 param adxServiceLogs string
-
-@description('Pre-built adx() URI for HostedControlPlaneLogs database')
-param adxHcpLogs string
 
 // --- Fluent-bit OOM killing alert ---
 

--- a/dev-infrastructure/modules/kusto-alerts/main.bicep
+++ b/dev-infrastructure/modules/kusto-alerts/main.bicep
@@ -1,0 +1,85 @@
+// Kusto (ADX) log search alerting infrastructure.
+// Creates shared resources (identity, permissions) and delegates
+// alert definitions to alert-rules.bicep.
+// ICM action group is provided by the monitoring pipeline (SL action group).
+// Deployed as part of the Kusto infrastructure in the kusto RG.
+
+@description('Resource ID of the ADX cluster')
+param kustoClusterId string
+
+@description('Resource ID of the SL ICM action group (empty string if not available)')
+param slActionGroupId string
+
+@description('Name of the service logs database')
+param serviceLogsDatabase string
+
+@description('Name of the hosted control plane logs database')
+param hostedControlPlaneLogsDatabase string
+
+@description('Name of the Kusto cluster')
+param kustoName string
+
+@description('URI of the ADX cluster (e.g. https://cluster.region.kusto.windows.net)')
+param kustoUri string
+
+@description('Azure region')
+param location string = resourceGroup().location
+
+// 1. User-assigned managed identity (shared by all Kusto alert rules)
+resource alertIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'kusto-alerts-identity'
+  location: location
+}
+
+// 2. Azure RBAC Reader on ADX cluster (required by scheduledQueryRules to validate access)
+resource kustoCluster 'Microsoft.Kusto/clusters@2024-04-13' existing = {
+  name: kustoName
+}
+
+var readerRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+
+resource kustoReaderRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(kustoCluster.id, alertIdentity.id, readerRoleId)
+  scope: kustoCluster
+  properties: {
+    principalId: alertIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: readerRoleId
+  }
+}
+
+// 3. Grant Viewer access on ADX databases for the alert identity (for KQL query execution)
+module serviceLogsAccess '../logs/kusto/grant-access.bicep' = {
+  name: 'kusto-alerts-servicelogs-access'
+  params: {
+    kustoName: kustoName
+    databaseName: serviceLogsDatabase
+    readAccessPrincipalIds: [alertIdentity.properties.principalId]
+  }
+}
+
+module hcpLogsAccess '../logs/kusto/grant-access.bicep' = {
+  name: 'kusto-alerts-hcplogs-access'
+  params: {
+    kustoName: kustoName
+    databaseName: hostedControlPlaneLogsDatabase
+    readAccessPrincipalIds: [alertIdentity.properties.principalId]
+  }
+}
+
+// 4. Action group IDs — reuse ICM SL action group from monitoring pipeline
+var actionGroupIds = slActionGroupId != '' ? [slActionGroupId] : []
+
+// 5. Alert rules — add new alerts in alert-rules.bicep
+module alertRules 'alert-rules.bicep' = {
+  name: 'kusto-alert-rules'
+  params: {
+    location: location
+    kustoClusterId: kustoClusterId
+    actionGroupIds: actionGroupIds
+    identityId: alertIdentity.id
+    adxServiceLogs: '${kustoUri}/${serviceLogsDatabase}'
+    adxHcpLogs: '${kustoUri}/${hostedControlPlaneLogsDatabase}'
+  }
+  dependsOn: [serviceLogsAccess, hcpLogsAccess, kustoReaderRole]
+}

--- a/dev-infrastructure/modules/kusto-alerts/main.bicep
+++ b/dev-infrastructure/modules/kusto-alerts/main.bicep
@@ -36,7 +36,10 @@ resource kustoCluster 'Microsoft.Kusto/clusters@2024-04-13' existing = {
   name: kustoName
 }
 
-var readerRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+var readerRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  'acdd72a7-3385-48ef-bd42-f606fba81ae7'
+)
 
 resource kustoReaderRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(kustoCluster.id, alertIdentity.id, readerRoleId)
@@ -79,7 +82,6 @@ module alertRules 'alert-rules.bicep' = {
     actionGroupIds: actionGroupIds
     identityId: alertIdentity.id
     adxServiceLogs: '${kustoUri}/${serviceLogsDatabase}'
-    adxHcpLogs: '${kustoUri}/${hostedControlPlaneLogsDatabase}'
   }
   dependsOn: [serviceLogsAccess, hcpLogsAccess, kustoReaderRole]
 }

--- a/dev-infrastructure/monitoring-pipeline.yaml
+++ b/dev-infrastructure/monitoring-pipeline.yaml
@@ -4,6 +4,7 @@
 # * Azure Monitor Metrics resources for services
 # * Azure Monitor Metrics resources for hosted control planes
 # * Action Groups & Prometheus alerting rules
+# * Kusto (ADX) log search alerting rules
 #
 $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Monitoring
@@ -35,3 +36,39 @@ resourceGroups:
         resourceGroup: regional
         step: output
         name: hcpAzureMonitoringWorkspaceId
+- name: kusto
+  resourceGroup: '{{ .kusto.rg }}'
+  subscription: '{{ .svc.subscription.key }}'
+  steps:
+  - name: kusto-lookup
+    action: ARM
+    template: templates/kusto-lookup.bicep
+    parameters: configurations/kusto-lookup.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
+  - name: kusto-alerting
+    action: ARM
+    template: templates/kusto-alerting.bicep
+    parameters: configurations/kusto-alerting.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    variables:
+    - name: kustoClusterId
+      input:
+        resourceGroup: kusto
+        step: kusto-lookup
+        name: kustoResourceId
+    - name: kustoUri
+      input:
+        resourceGroup: kusto
+        step: kusto-lookup
+        name: kustoUri
+    - name: slActionGroupId
+      input:
+        resourceGroup: regional
+        step: monitoring
+        name: slActionGroupId
+    dependsOn:
+    - resourceGroup: kusto
+      step: kusto-lookup
+    - resourceGroup: regional
+      step: monitoring

--- a/dev-infrastructure/templates/kusto-alerting.bicep
+++ b/dev-infrastructure/templates/kusto-alerting.bicep
@@ -1,0 +1,29 @@
+@description('Resource ID of the ADX cluster (empty string if kusto is not enabled)')
+param kustoClusterId string
+
+@description('Name of the Kusto cluster')
+param kustoName string
+
+@description('URI of the ADX cluster')
+param kustoUri string
+
+@description('Resource ID of the SL ICM action group (empty string if not available)')
+param slActionGroupId string
+
+@description('Name of the service logs database')
+param serviceLogsDatabase string
+
+@description('Name of the hosted control plane logs database')
+param hostedControlPlaneLogsDatabase string
+
+module kustoAlerting '../modules/kusto-alerts/main.bicep' = if (kustoClusterId != '') {
+  name: 'kusto-alerting'
+  params: {
+    kustoClusterId: kustoClusterId
+    slActionGroupId: slActionGroupId
+    serviceLogsDatabase: serviceLogsDatabase
+    hostedControlPlaneLogsDatabase: hostedControlPlaneLogsDatabase
+    kustoName: kustoName
+    kustoUri: kustoUri
+  }
+}

--- a/dev-infrastructure/templates/monitoring.bicep
+++ b/dev-infrastructure/templates/monitoring.bicep
@@ -104,3 +104,5 @@ module msftAlerts '../modules/metrics/msft-rules.bicep' = {
     actionGroups: msftActionGroups
   }
 }
+
+output slActionGroupId string = manageConnection ? actionGroups.outputs.actionGroupsSL : ''


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-607

### What

Enables kusto log based alerts. Creates kusto alert rules, managed identity with role assignments.
Adds ICM alert for container OOM kills

### Why

To alert on container OOM kills through ICM

### Testing

Tested in personal dev by routing the alerts to gmail