### PR TITLE
chore: bump cluster install versions to latest for 4.20, 4.21

### DIFF
--- a/internal/ocm/client.go
+++ b/internal/ocm/client.go
@@ -805,7 +805,7 @@ func NewOpenShiftVersionXYZ(v, cg string) string {
 		if len(parts) == 2 {
 			// Patch version is managed by Red Hat. This will be computed automatically to the latest
 			// as part of https://github.com/Azure/ARO-HCP/pull/4477
-			if patch, ok := map[string]string{"4.19": "25", "4.20": "16", "4.21": "5"}[v]; ok {
+			if patch, ok := map[string]string{"4.19": "27", "4.20": "17", "4.21": "8"}[v]; ok {
 				parts = append(parts, patch)
 			} else {
 				parts = append(parts, "0")

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -259,7 +259,7 @@ func TestConvertCStoHCPOpenShiftCluster(t *testing.T) {
 			name: "converts stable version from CS to RP (X.Y.Z to X.Y)",
 			ocmClusterTweaks: arohcpv1alpha1.NewCluster().
 				Version(arohcpv1alpha1.NewVersion().
-					ID("openshift-v4.20.16").
+					ID("openshift-v4.20.17").
 					ChannelGroup("stable")),
 			hcpClusterTweaks: &api.HCPOpenShiftCluster{
 				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
@@ -455,7 +455,7 @@ func TestWithImmutableAttributes(t *testing.T) {
 			},
 			want: ocmCluster(t, ocmClusterDefaults(api.TestLocation).
 				Version(arohcpv1alpha1.NewVersion().
-					ID("openshift-v4.20.16").
+					ID("openshift-v4.20.17").
 					ChannelGroup("stable"))),
 		},
 		{
@@ -496,7 +496,7 @@ func TestWithImmutableAttributes(t *testing.T) {
 				},
 			},
 			want: ocmCluster(t, ocmClusterDefaults(api.TestLocation).Version(
-				arohcpv1alpha1.NewVersion().ID("openshift-v4.19.25").ChannelGroup("stable"))),
+				arohcpv1alpha1.NewVersion().ID("openshift-v4.19.27").ChannelGroup("stable"))),
 		},
 		{
 			name: "with version 4.21",
@@ -506,7 +506,7 @@ func TestWithImmutableAttributes(t *testing.T) {
 				},
 			},
 			want: ocmCluster(t, ocmClusterDefaults(api.TestLocation).Version(
-				arohcpv1alpha1.NewVersion().ID("openshift-v4.21.5").ChannelGroup("stable"))),
+				arohcpv1alpha1.NewVersion().ID("openshift-v4.21.8").ChannelGroup("stable"))),
 		},
 	}
 
@@ -612,7 +612,7 @@ func ocmClusterDefaults(azureLocation string) *arohcpv1alpha1.ClusterBuilder {
 		Region(arohcpv1alpha1.NewCloudRegion().
 			ID(azureLocation)).
 		Version(arohcpv1alpha1.NewVersion().
-			ID("openshift-v4.20.16").
+			ID("openshift-v4.20.17").
 			ChannelGroup("stable")).
 		ImageRegistry(arohcpv1alpha1.NewClusterImageRegistry().
 			State(csImageRegistryStateEnabled)).
@@ -713,7 +713,7 @@ func TestBuildCSNodePool(t *testing.T) {
 			),
 			expectedCSNodePool: getBaseCSNodePoolBuilder().
 				Version(arohcpv1alpha1.NewVersion().
-					ID("openshift-v4.20.16").
+					ID("openshift-v4.20.17").
 					ChannelGroup("stable")),
 		},
 		{


### PR DESCRIPTION
### What

chore: bump cluster install versions to latest for 4.20, 4.21

### Why
chore: bump cluster install versions to latest for 4.20, 4.21

This also bumps it for 4.19 as it is still around.

This is interim bump until https://github.com/Azure/ARO-HCP/pull/4821 is merged that will allow us to automatically pick the latest

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
