### PR TITLE
 Image override pattern for personal dev deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -382,8 +382,9 @@ record-services-override: $(YQ) $(ORAS)
 # One-Step Personal Dev Environment
 #
 ifeq ($(DEPLOY_ENV),$(filter $(DEPLOY_ENV),pers swft))
-personal-dev-env: install-tools build-services record-services-override infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing infra.cosmos.access
+personal-dev-env: install-tools build-services record-services-override
 	$(MAKE) entrypoint/Region OVERRIDE_CONFIG_FILE=$(PERS_OVERRIDE_FILE)
+	$(MAKE) infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing infra.cosmos.access
 else
 personal-dev-env:
 	$(error personal-dev-env: DEPLOY_ENV must be set to "pers" or "swft", not "$(DEPLOY_ENV)")

--- a/Makefile
+++ b/Makefile
@@ -354,10 +354,36 @@ generate-kiota:
 .PHONY: generate-kiota
 
 #
+# Build and push all in-repo service images, then record a combined override config
+#
+PERS_OVERRIDE_FILE ?= /tmp/personal-dev-override.yaml
+
+build-services:
+	$(MAKE) -C frontend build-and-push
+	$(MAKE) -C backend build-and-push
+	$(MAKE) -C admin build-and-push
+	$(MAKE) -C sessiongate build-and-push
+.PHONY: build-services
+
+record-services-override: $(YQ) $(ORAS)
+	$(MAKE) -C frontend record-override OVERRIDE_CONFIG_FILE=/tmp/_frontend-override.yaml
+	$(MAKE) -C backend record-override OVERRIDE_CONFIG_FILE=/tmp/_backend-override.yaml
+	$(MAKE) -C admin record-override OVERRIDE_CONFIG_FILE=/tmp/_admin-override.yaml
+	$(MAKE) -C sessiongate record-override OVERRIDE_CONFIG_FILE=/tmp/_sessiongate-override.yaml
+	$(YQ) eval-all '. as $$item ireduce ({}; . * $$item)' \
+	  /tmp/_frontend-override.yaml \
+	  /tmp/_backend-override.yaml \
+	  /tmp/_admin-override.yaml \
+	  /tmp/_sessiongate-override.yaml \
+	  > $(PERS_OVERRIDE_FILE)
+.PHONY: record-services-override
+
+#
 # One-Step Personal Dev Environment
 #
 ifeq ($(DEPLOY_ENV),$(filter $(DEPLOY_ENV),pers swft))
-personal-dev-env: install-tools entrypoint/Region infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing infra.cosmos.access
+personal-dev-env: OVERRIDE_CONFIG_FILE = $(PERS_OVERRIDE_FILE)
+personal-dev-env: install-tools build-services record-services-override entrypoint/Region infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing infra.cosmos.access
 else
 personal-dev-env:
 	$(error personal-dev-env: DEPLOY_ENV must be set to "pers" or "swft", not "$(DEPLOY_ENV)")

--- a/Makefile
+++ b/Makefile
@@ -382,8 +382,8 @@ record-services-override: $(YQ) $(ORAS)
 # One-Step Personal Dev Environment
 #
 ifeq ($(DEPLOY_ENV),$(filter $(DEPLOY_ENV),pers swft))
-personal-dev-env: OVERRIDE_CONFIG_FILE = $(PERS_OVERRIDE_FILE)
-personal-dev-env: install-tools build-services record-services-override entrypoint/Region infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing infra.cosmos.access
+personal-dev-env: install-tools build-services record-services-override infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing infra.cosmos.access
+	$(MAKE) entrypoint/Region OVERRIDE_CONFIG_FILE=$(PERS_OVERRIDE_FILE)
 else
 personal-dev-env:
 	$(error personal-dev-env: DEPLOY_ENV must be set to "pers" or "swft", not "$(DEPLOY_ENV)")

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -88,6 +88,7 @@ record-override: $(YQ) $(ORAS)
 
 	@DIGEST=$$($(ORAS) manifest fetch --descriptor ${ADMIN_API_TAGGED_IMAGE} | $(YQ) .digest); \
 	$(YQ) eval -n "\
+		.clouds.dev.environments.$(DEPLOY_ENV).defaults.adminApi.image.registry = \"$(ARO_HCP_IMAGE_REGISTRY)\" | \
 		.clouds.dev.environments.$(DEPLOY_ENV).defaults.adminApi.image.repository = \"$(ADMIN_API_GENERATED_IMAGE_REPOSITORY)\" | \
 		.clouds.dev.environments.$(DEPLOY_ENV).defaults.adminApi.image.digest = \"$$DIGEST\" \
 	" > $(OVERRIDE_CONFIG_FILE)

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -70,6 +70,7 @@ record-override: $(YQ) $(ORAS)
 
 	@DIGEST=$$($(ORAS) manifest fetch --descriptor ${BACKEND_TAGGED_IMAGE} | $(YQ) .digest); \
 	$(YQ) eval -n "\
+		.clouds.dev.environments.$(DEPLOY_ENV).defaults.backend.image.registry = \"$(ARO_HCP_IMAGE_REGISTRY)\" | \
 		.clouds.dev.environments.$(DEPLOY_ENV).defaults.backend.image.repository = \"$(BACKEND_GENERATED_IMAGE_REPOSITORY)\" | \
 		.clouds.dev.environments.$(DEPLOY_ENV).defaults.backend.image.digest = \"$$DIGEST\" \
 	" > $(OVERRIDE_CONFIG_FILE)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -618,7 +618,7 @@ defaults:
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: arohcpbackend
-      digest: sha256:1ea55edf35052e5cf1cd84aa6e877ecee49324b7b2c7ee2fa70827e79edce8f8 # 6324ed1 (2026-04-10 21:21)
+      digest: ""
     tracing:
       address: ""
       exporter: ""
@@ -647,7 +647,7 @@ defaults:
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: arohcpadminapi
-      digest: sha256:2670a25858771691403ec47ff1af8504e517a52f95505dad9ed323d889361ded # 6324ed1 (2026-04-10 21:20)
+      digest: ""
     managedIdentityName: admin-api
     k8s:
       replicas: 2
@@ -666,7 +666,7 @@ defaults:
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: arohcpsessiongate
-      digest: sha256:1a0e007fa4c774e176e1638257206126699b557b5530733c898bf2367384830c # 6324ed1 (2026-04-10 21:20)
+      digest: ""
     managedIdentityName: sessiongate
     k8s:
       replicas: 2
@@ -691,7 +691,7 @@ defaults:
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: arohcpfrontend
-      digest: sha256:63d30656f797993d4f757aee9da4166986b17bcb7b5d983747b2596e8a775166 # 6324ed1 (2026-04-10 21:19)
+      digest: ""
     tracing:
       address: ""
       exporter: ""

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -35,7 +35,7 @@ adminApi:
     issuer: Self
     name: admin-api-cert-cspr-usw3
   image:
-    digest: sha256:2670a25858771691403ec47ff1af8504e517a52f95505dad9ed323d889361ded
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpadminapi
   k8s:
@@ -102,7 +102,7 @@ backend:
     roleSetName: dev
   exitOnPanic: true
   image:
-    digest: sha256:1ea55edf35052e5cf1cd84aa6e877ecee49324b7b2c7ee2fa70827e79edce8f8
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpbackend
   k8s:
@@ -285,7 +285,7 @@ frontend:
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:
-    digest: sha256:63d30656f797993d4f757aee9da4166986b17bcb7b5d983747b2596e8a775166
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   k8s:
@@ -837,7 +837,7 @@ sessiongate:
     issuer: Self
     name: sessiongate-cert-cspr-usw3
   image:
-    digest: sha256:1a0e007fa4c774e176e1638257206126699b557b5530733c898bf2367384830c
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpsessiongate
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -35,7 +35,7 @@ adminApi:
     issuer: Self
     name: admin-api-cert-dev-usw3
   image:
-    digest: sha256:2670a25858771691403ec47ff1af8504e517a52f95505dad9ed323d889361ded
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpadminapi
   k8s:
@@ -102,7 +102,7 @@ backend:
     roleSetName: dev
   exitOnPanic: true
   image:
-    digest: sha256:1ea55edf35052e5cf1cd84aa6e877ecee49324b7b2c7ee2fa70827e79edce8f8
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpbackend
   k8s:
@@ -285,7 +285,7 @@ frontend:
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:
-    digest: sha256:63d30656f797993d4f757aee9da4166986b17bcb7b5d983747b2596e8a775166
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   k8s:
@@ -837,7 +837,7 @@ sessiongate:
     issuer: Self
     name: sessiongate-cert-dev-usw3
   image:
-    digest: sha256:1a0e007fa4c774e176e1638257206126699b557b5530733c898bf2367384830c
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpsessiongate
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -35,7 +35,7 @@ adminApi:
     issuer: Self
     name: admin-api-cert-perf-usw3ptest
   image:
-    digest: sha256:2670a25858771691403ec47ff1af8504e517a52f95505dad9ed323d889361ded
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpadminapi
   k8s:
@@ -102,7 +102,7 @@ backend:
     roleSetName: dev
   exitOnPanic: true
   image:
-    digest: sha256:1ea55edf35052e5cf1cd84aa6e877ecee49324b7b2c7ee2fa70827e79edce8f8
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpbackend
   k8s:
@@ -285,7 +285,7 @@ frontend:
     zoneRedundantMode: Auto
   exitOnPanic: true
   image:
-    digest: sha256:63d30656f797993d4f757aee9da4166986b17bcb7b5d983747b2596e8a775166
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   k8s:
@@ -837,7 +837,7 @@ sessiongate:
     issuer: Self
     name: sessiongate-cert-perf-usw3ptest
   image:
-    digest: sha256:1a0e007fa4c774e176e1638257206126699b557b5530733c898bf2367384830c
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpsessiongate
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -35,7 +35,7 @@ adminApi:
     issuer: Self
     name: admin-api-cert-pers-usw3test
   image:
-    digest: sha256:2670a25858771691403ec47ff1af8504e517a52f95505dad9ed323d889361ded
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpadminapi
   k8s:
@@ -102,7 +102,7 @@ backend:
     roleSetName: dev
   exitOnPanic: true
   image:
-    digest: sha256:1ea55edf35052e5cf1cd84aa6e877ecee49324b7b2c7ee2fa70827e79edce8f8
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpbackend
   k8s:
@@ -285,7 +285,7 @@ frontend:
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:
-    digest: sha256:63d30656f797993d4f757aee9da4166986b17bcb7b5d983747b2596e8a775166
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   k8s:
@@ -839,7 +839,7 @@ sessiongate:
     issuer: Self
     name: sessiongate-cert-pers-usw3test
   image:
-    digest: sha256:1a0e007fa4c774e176e1638257206126699b557b5530733c898bf2367384830c
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpsessiongate
   k8s:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -35,7 +35,7 @@ adminApi:
     issuer: Self
     name: admin-api-cert-prow-j7654321
   image:
-    digest: sha256:2670a25858771691403ec47ff1af8504e517a52f95505dad9ed323d889361ded
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpadminapi
   k8s:
@@ -102,7 +102,7 @@ backend:
     roleSetName: dev
   exitOnPanic: true
   image:
-    digest: sha256:1ea55edf35052e5cf1cd84aa6e877ecee49324b7b2c7ee2fa70827e79edce8f8
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpbackend
   k8s:
@@ -285,7 +285,7 @@ frontend:
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:
-    digest: sha256:63d30656f797993d4f757aee9da4166986b17bcb7b5d983747b2596e8a775166
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   k8s:
@@ -839,7 +839,7 @@ sessiongate:
     issuer: Self
     name: sessiongate-cert-prow-j7654321
   image:
-    digest: sha256:1a0e007fa4c774e176e1638257206126699b557b5530733c898bf2367384830c
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpsessiongate
   k8s:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -35,7 +35,7 @@ adminApi:
     issuer: Self
     name: admin-api-cert-swft-lnstest
   image:
-    digest: sha256:2670a25858771691403ec47ff1af8504e517a52f95505dad9ed323d889361ded
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpadminapi
   k8s:
@@ -102,7 +102,7 @@ backend:
     roleSetName: dev
   exitOnPanic: true
   image:
-    digest: sha256:1ea55edf35052e5cf1cd84aa6e877ecee49324b7b2c7ee2fa70827e79edce8f8
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpbackend
   k8s:
@@ -285,7 +285,7 @@ frontend:
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:
-    digest: sha256:63d30656f797993d4f757aee9da4166986b17bcb7b5d983747b2596e8a775166
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpfrontend
   k8s:
@@ -839,7 +839,7 @@ sessiongate:
     issuer: Self
     name: sessiongate-cert-swft-lnstest
   image:
-    digest: sha256:1a0e007fa4c774e176e1638257206126699b557b5530733c898bf2367384830c
+    digest: ""
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpsessiongate
   k8s:

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -67,6 +67,7 @@ record-override: $(YQ) $(ORAS)
 
 	@DIGEST=$$($(ORAS) manifest fetch --descriptor ${FRONTEND_TAGGED_IMAGE} | $(YQ) .digest); \
 	$(YQ) eval -n "\
+		.clouds.dev.environments.$(DEPLOY_ENV).defaults.frontend.image.registry = \"$(ARO_HCP_IMAGE_REGISTRY)\" | \
 		.clouds.dev.environments.$(DEPLOY_ENV).defaults.frontend.image.repository = \"$(FRONTEND_GENERATED_IMAGE_REPOSITORY)\" | \
 		.clouds.dev.environments.$(DEPLOY_ENV).defaults.frontend.image.digest = \"$$DIGEST\" \
 	" > $(OVERRIDE_CONFIG_FILE)

--- a/sessiongate/Makefile
+++ b/sessiongate/Makefile
@@ -70,6 +70,7 @@ record-override: $(YQ) $(ORAS)
 
 	@DIGEST=$$($(ORAS) manifest fetch --descriptor ${SESSION_GATE_TAGGED_IMAGE} | $(YQ) .digest); \
 	$(YQ) eval -n "\
+		.clouds.dev.environments.$(DEPLOY_ENV).defaults.sessiongate.image.registry = \"$(ARO_HCP_IMAGE_REGISTRY)\" | \
 		.clouds.dev.environments.$(DEPLOY_ENV).defaults.sessiongate.image.repository = \"$(SESSION_GATE_GENERATED_IMAGE_REPOSITORY)\" | \
 		.clouds.dev.environments.$(DEPLOY_ENV).defaults.sessiongate.image.digest = \"$$DIGEST\" \
 	" > $(OVERRIDE_CONFIG_FILE)


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-592

### What
 Image override pattern for personal dev deployments
### Why
 Align personal dev with the Prow pattern using Image override pattern  . 



```shell
kubectl get po -n aro-hcp -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{range .spec.containers[*]}  {.name}:{.image}{"\n"}{end}{end}'
aro-hcp-backend-8488b68454-7mv5m
  aro-hcp-backend:arohcpsvcdev.azurecr.io/test-ves-arohcpbackend@sha256:e73185fb4aa165924d4fe0dfddcae1cce5a3a741ff07755ef373360d7139cf8f
aro-hcp-backend-8488b68454-q7gkv
  aro-hcp-backend:arohcpsvcdev.azurecr.io/test-ves-arohcpbackend@sha256:e73185fb4aa165924d4fe0dfddcae1cce5a3a741ff07755ef373360d7139cf8f
aro-hcp-frontend-669d5bd9c9-46bcd
  aro-hcp-frontend:arohcpsvcdev.azurecr.io/test-ves-arohcpfrontend@sha256:ff935981909b884c0e52616ef135f6905e6156904f4e4ef297390bc2512a2bc2
aro-hcp-frontend-669d5bd9c9-hcmh8
  aro-hcp-frontend:arohcpsvcdev.azurecr.io/test-ves-arohcpfrontend@sha256:ff935981909b884c0e52616ef135f6905e6156904f4e4ef297390bc2512a2bc2
[ves@ves-thinkpadp1gen4i ARO-HCP ]$

kubectl get po -n aro-hcp-admin-api -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{range .spec.containers[*]}  {.name}:{.image}{"\n"}{end}{end}'
admin-api-58f68887bd-59b4z
  service:arohcpsvcdev.azurecr.io/test-ves-arohcpadminapi@sha256:161591d2c93b8d1c125d50e614bfe4d480bfaf2e6daec93a0673704a44d47d13
admin-api-58f68887bd-pvhjp
  service:arohcpsvcdev.azurecr.io/test-ves-arohcpadminapi@sha256:161591d2c93b8d1c125d50e614bfe4d480bfaf2e6daec93a0673704a44d47d13


 kubectl get po -n aro-hcp
NAME                                READY   STATUS    RESTARTS   AGE
aro-hcp-backend-8488b68454-7mv5m    2/2     Running   0          71m
aro-hcp-backend-8488b68454-q7gkv    2/2     Running   0          71m
aro-hcp-frontend-669d5bd9c9-46bcd   2/2     Running   0          71m
aro-hcp-frontend-669d5bd9c9-hcmh8   2/2     Running   0          71m
[ves@ves-thinkpadp1gen4i ARO-HCP ]$ kubectl get po -n aro-hcp-admin-api
NAME                         READY   STATUS    RESTARTS   AGE
admin-api-58f68887bd-59b4z   2/2     Running   0          70m
admin-api-58f68887bd-pvhjp   2/2     Running   0          70m


kubectl get po -n sessiongate
NAME                           READY   STATUS    RESTARTS   AGE
sessiongate-5f96c9f589-9pjlt   2/2     Running   0          71m
sessiongate-5f96c9f589-mw6kg   2/2     Running   0          71m

``` 
