### PR TITLE
fix: avoid mistaken Maestro readonly bundle deletes from stale Cosmos

### DIFF
--- a/backend/pkg/controllers/delete_orphaned_maestro_readonly_bundles_controller.go
+++ b/backend/pkg/controllers/delete_orphaned_maestro_readonly_bundles_controller.go
@@ -18,8 +18,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"time"
+
+	workv1 "open-cluster-management.io/api/work/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -73,45 +74,54 @@ func NewDeleteOrphanedMaestroReadonlyBundlesController(cosmosClient database.DBC
 }
 
 // SyncOnce current algorithm is:
-//  1. List all ServiceProviderClusters
-//  2. Build a map that contains an association between the CS Provision Shard ID and the ServiceProviderClusters that
-//     are allocated to that shard. IMPORTANT NOTE: This assumes that the maestro server associated to the provision shard
-//     has resources with always the same source ID. If it turns out we cannot have this assumption this logic would not
-//     be good enough. In that case it might be necessary to store to what source ID a Maestro Bundle/set of Maestro Bundles
-//     belongs to but then the instantiation of the Maestro client needs to be done differently as its scoped to
-//     Maestro Consumer Name + Maestro Source ID. We know for example that in the CSPR environment different CS instances
-//     have different Maestro source IDs using the same Maestro Server.
-//  3. For each shard in the map previously built, we use the Maestro API to list all the Maestro Bundles, and for each
-//     Maestro Bundle we check if its Maestro API Maestro Bundle Name matches any of the MaestroBundleReferences in any
-//     of the ServiceProviderClusters allocated to that shard. If it does not match, we delete the Maestro Bundle. If it
-//     matches we leave it alone
+//  1. List all ServiceProviderClusters (initial snapshot).
+//  2. Build a map from Cluster Service provision shard ID to Maestro client (one client per registered provision shard).
+//  3. Build initialShardToSPCs: map provision shard ID to the ServiceProviderClusters on that shard (from the initial list).
+//     This assumes the Maestro server for a provision shard uses a single Maestro source ID for resources we list; if not,
+//     client construction would need to change (Maestro Consumer Name + Maestro Source ID scope).
+//  4. For each shard, list Maestro bundles (paginated, same label selector as today). A bundle is a delete candidate if
+//     it passes the readonly managed-by label filter and its name is not referenced by any SPC on that shard in initialShardToSPCs.
+//     Each candidate records the provision shard id and a pointer to the listed ManifestWork.
+//  5. List all ServiceProviderClusters again (fresh snapshot), rebuild freshShardToSPCs the same way as (3).
+//  6. For each candidate, if the bundle name is still not referenced on that shard in the fresh snapshot, delete it via Maestro
 //
-// We considered using the Maestro API Maestro UID which is globally unique but it's possible that there's a scenario
-// where the cluster scoped maestro readonly bundles controller creates a bundle reference in the ServiceProviderClass, created the bundle
-// using the Maestro API but failed to persist it in the database for some reason and the cluster ended up being deleted.
-// In that scenario we would not have the Maestro UID to identify the Maestro Bundle and we would not be able to delete it. Furthermore
-// we should not use the fact of the UID being empty as the trigger to delete because it could be that it's being created
-// and not yet persisted in Cosmos.
+// Cross-store: The fresh SPC list and per-shard reference set (steps 5-6) prevent deleting a bundle that is already referenced
+// in committed Cosmos documents by the time that snapshot is built, so a stale initial list alone does not cause accidental
+// delete.
+
+// IMPORTANT NOTE: This assumes that the maestro server associated to the provision shard
+// has resources with always the same source ID. If it turns out we cannot have this assumption this logic would not
+// be good enough. In that case it might be necessary to store to what source ID a Maestro Bundle/set of Maestro Bundles
+// belongs to but then the instantiation of the Maestro client needs to be done differently as its scoped to
+// Maestro Consumer Name + Maestro Source ID. We know for example that in the CSPR environment different CS instances
+// have different Maestro source IDs using the same Maestro Server.
 func (c *deleteOrphanedMaestroReadonlyBundles) SyncOnce(ctx context.Context, _ any) error {
 	logger := utils.LoggerFromContext(ctx)
 	logger.Info("Syncing orphaned Maestro Readonly Bundles")
-	allServiceProviderClusters, err := c.getAllServiceProviderClusters(ctx)
+	initialServiceProviderClusters, err := c.getAllServiceProviderClusters(ctx)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get all ServiceProviderClusters: %w", err))
 	}
-	logger.Info(fmt.Sprintf("Found %d ServiceProviderClusters", len(allServiceProviderClusters)))
+	logger.Info(fmt.Sprintf("Found %d ServiceProviderClusters (initial)", len(initialServiceProviderClusters)))
 
-	logger.Info("Building Provision Shard to ServiceProviderClusters index")
-	provisionShardsToServiceProviderClustersIndex, err := c.buildProvisionShardToServiceProviderClustersIndex(ctx, allServiceProviderClusters)
-	// We cancel the Maestro clients when the sync is done. This is important to avoid leaking resources when the sync is done.
-	defer cancelMaestroClientsInIndex(provisionShardsToServiceProviderClustersIndex) // close on success or error (index may be partial on error)
+	logger.Info("Building Maestro clients per Cluster Service provision shard")
+	maestroClientsByShard, err := c.buildMaestroClientsByProvisionShard(ctx)
+	// Cancel Maestro clients when the sync is done to avoid leaking resources (map may be partial on error).
+	defer cancelMaestroClientsByProvisionShard(maestroClientsByShard)
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to build Provision Shard to ServiceProviderClusters index: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to build Maestro clients by provision shard: %w", err))
 	}
-	logger.Info(fmt.Sprintf("Built Provision Shard to ServiceProviderClusters index with %d keys", len(provisionShardsToServiceProviderClustersIndex)))
+	logger.Info(fmt.Sprintf("Built Maestro clients for %d provision shards", len(maestroClientsByShard)))
+
+	logger.Info("Mapping initial ServiceProviderClusters to provision shards")
+	initialShardToSPCs, err := c.mapServiceProviderClustersByProvisionShard(ctx, initialServiceProviderClusters, maestroClientsByShard)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to map ServiceProviderClusters to provision shards: %w", err))
+	}
+	logger.Info(fmt.Sprintf("Initial ServiceProviderClusters mapped to %d provision shards", len(initialShardToSPCs)))
 
 	logger.Info("Ensuring orphaned Maestro Readonly Bundles are deleted")
-	err = c.ensureOrphanedMaestroReadonlyBundlesAreDeleted(ctx, provisionShardsToServiceProviderClustersIndex)
+	err = c.ensureOrphanedMaestroReadonlyBundlesAreDeleted(ctx, maestroClientsByShard, initialShardToSPCs)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to ensure orphaned Maestro Bundles are deleted: %w", err))
 	}
@@ -154,148 +164,120 @@ func (c *deleteOrphanedMaestroReadonlyBundles) getAllServiceProviderClusters(ctx
 	return allServiceProviderClusters, nil
 }
 
-// provisionShardServiceProviderClusters represents the set of ServiceProviderClusters whose Maestro bundles
-// are associated to a Provision Shard (Management Cluster)
-type provisionShardServiceProviderClusters struct {
-	// maestroClient is the Maestro client to communicate with the Maestro server
-	// associated to the provision shard. IMPORTANT NOTE: This assumes that
-	// all the resources in the Maestro server associated to the provision shard
-	// have the same source ID. If it turns out we cannot have this assumption
-	// this logic would not be good enough.
-	maestroClient maestro.Client
-	// maestroClientCancelFunc is the cancel function to cancel the Maestro client.
-	// Calling this function is important when the client is not needed anymore to avoid leaking resources when the sync is done.
+// shardMaestroClient holds a Maestro API client for one Cluster Service provision shard and its teardown cancel func.
+type shardMaestroClient struct {
+	maestroClient           maestro.Client
 	maestroClientCancelFunc context.CancelFunc
-	// serviceProviderClusters is the list of ServiceProviderClusters that are allocated to the shard.
-	// IMPORTANT NOTE: This assumes that all the resources in the Maestro server associated to the provision shard
-	// have the same source ID. If it turns out we cannot have this assumption
-	// this logic would not be good enough.
-	serviceProviderClusters []*api.ServiceProviderCluster
 }
 
-// cancelMaestroClientsInIndex runs the cancel function for each entry in the index.
-// The caller of buildProvisionShardToServiceProviderClustersIndex should defer this so the index is cancelled on success or error (on error the index may be partial).
-func cancelMaestroClientsInIndex(index map[string]*provisionShardServiceProviderClusters) {
-	for _, shardToSPCs := range index {
-		shardToSPCs.maestroClientCancelFunc()
+// cancelMaestroClientsByProvisionShard runs the cancel function for each Maestro client entry in maestroClientsByProvisionShard.
+func cancelMaestroClientsByProvisionShard(maestroClientsByProvisionShard map[string]*shardMaestroClient) {
+	for _, entry := range maestroClientsByProvisionShard {
+		entry.maestroClientCancelFunc()
 	}
 }
 
-// buildProvisionShardServiceProviderClustersIndex builds an index of Provision Shard ID to provisionShardServiceProviderClusters.
-// The key is the Cluster Service Provision Shard ID. To achieve that the following steps are followed:
-//  1. List all the registered provision shards (currently using the Clusters Service API)
-//  2. For each provision shard, create a Maestro client.
-//  3. For each ServiceProviderCluster, get the Cluster Service Provision Shard ID associated to it (currently using the Clusters Service API) and
-//     add the ServiceProviderCluster to the corresponding provisionShardServiceProviderClusters entry in the index.
+// buildMaestroClientsByProvisionShard lists registered provision shards from Cluster Service and builds a map of
+// provision shard ID to Maestro client. The key of the map is the CS provision shard ID.
 //
-// On error the returned index may be partial (clients created before the error). The caller must close the index in all cases (e.g. defer closeMaestroClientsInIndex).
-func (c *deleteOrphanedMaestroReadonlyBundles) buildProvisionShardToServiceProviderClustersIndex(ctx context.Context, allServiceProviderClusters []*api.ServiceProviderCluster) (map[string]*provisionShardServiceProviderClusters, error) {
-	provisionShardsToServiceProviderClustersIndex := map[string]*provisionShardServiceProviderClusters{}
+// On error the returned map may be partial (clients created before the error). The caller must defer cancelMaestroClientsByProvisionShard unconditionally.
+func (c *deleteOrphanedMaestroReadonlyBundles) buildMaestroClientsByProvisionShard(ctx context.Context) (map[string]*shardMaestroClient, error) {
+	maestroClientsByProvisionShard := map[string]*shardMaestroClient{}
 
 	// TODO we list the provision shards from CS but at some point we should have
 	// the information in Cosmos and this should be changed to use that instead.
 	// TODO should we take into account the provision shard status on what to consider (active, maintenance, offline, ...)?
 	// for now we consider all provision shards independently of their status.
-	provisionShardsIterator := c.clusterServiceClient.ListProvisionShards()
-	for provisionShard := range provisionShardsIterator.Items(ctx) {
+	for provisionShard := range c.clusterServiceClient.ListProvisionShards().Items(ctx) {
 		// We create a new context with a cancel function so we can cancel the Maestro client when the sync is done.
 		// This is important to avoid leaking resources when the sync is done.
 		maestroClientCtx, cancel := context.WithCancel(ctx)
 		maestroClient, err := c.createMaestroClientFromProvisionShard(maestroClientCtx, provisionShard)
 		if err != nil {
-			cancel() // on error creating the Maestro client we ensure we cancel the just created context too
-			return provisionShardsToServiceProviderClustersIndex, utils.TrackError(fmt.Errorf("failed to create Maestro client: %w", err))
+			cancel() // on error creating the Maestro client we ensure we cancel the context that we just created too
+			return maestroClientsByProvisionShard, utils.TrackError(fmt.Errorf("failed to create Maestro client: %w", err))
 		}
-		provisionShardsToServiceProviderClustersIndex[provisionShard.ID()] = &provisionShardServiceProviderClusters{
+		maestroClientsByProvisionShard[provisionShard.ID()] = &shardMaestroClient{
 			maestroClient:           maestroClient,
 			maestroClientCancelFunc: cancel,
-			serviceProviderClusters: []*api.ServiceProviderCluster{},
 		}
 	}
 
-	for _, spc := range allServiceProviderClusters {
-		clusterResourceID := spc.ResourceID.Parent
-		cluster, err := c.cosmosClient.HCPClusters(clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName).Get(ctx, clusterResourceID.Name)
-		if err != nil {
-			return provisionShardsToServiceProviderClustersIndex, utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
-		}
-		// TODO we should store the provision shard ID somewhere so we don't need to fetch it from cluster service repeatedly
-		// TODO should we take into account that at some point in the future we will implement migration between management
-		// clusters, where a cluster could have bundles allocated to different provision shards at the same time?
-		clusterCSShard, err := c.clusterServiceClient.GetClusterProvisionShard(ctx, cluster.ServiceProviderProperties.ClusterServiceID)
-		if err != nil {
-			return provisionShardsToServiceProviderClustersIndex, utils.TrackError(fmt.Errorf("failed to get Cluster Provision Shard: %w", err))
-		}
-
-		currentProvisionShardServiceProviderClusters, ok := provisionShardsToServiceProviderClustersIndex[clusterCSShard.ID()]
-		if !ok {
-			return provisionShardsToServiceProviderClustersIndex, utils.TrackError(fmt.Errorf("provision shard %s for cluster %s is not present in provision shards index", clusterCSShard.ID(), cluster.Name))
-		}
-		currentProvisionShardServiceProviderClusters.serviceProviderClusters = append(currentProvisionShardServiceProviderClusters.serviceProviderClusters, spc)
-	}
-
-	return provisionShardsToServiceProviderClustersIndex, nil
+	return maestroClientsByProvisionShard, nil
 }
 
-// ensureOrphanedMaestroReadonlyBundlesAreDeleted ensures that all the Maestro Readonly Bundles that are not referenced by any
-// of the ServiceProviderClusters allocated to a Provision Shard (Management Cluster) are deleted.
-// Only Maestro Readonly Bundles that are managed by the cluster scoped maestro readonly bundles controller are considered.
-func (c *deleteOrphanedMaestroReadonlyBundles) ensureOrphanedMaestroReadonlyBundlesAreDeleted(ctx context.Context, provisionShardsToServiceProviderClustersIndex map[string]*provisionShardServiceProviderClusters) error {
+// mapServiceProviderClustersByProvisionShard groups ServiceProviderClusters by Cluster Service provision shard ID.
+// Every resolved shard must exist in maestroClientsByShard (registered provision shards).
+func (c *deleteOrphanedMaestroReadonlyBundles) mapServiceProviderClustersByProvisionShard(ctx context.Context, spcs []*api.ServiceProviderCluster, maestroClientsByShard map[string]*shardMaestroClient) (map[string][]*api.ServiceProviderCluster, error) {
+	res := make(map[string][]*api.ServiceProviderCluster)
+	for _, spc := range spcs {
+		shardID, err := c.clusterProvisionShardIDForServiceProviderCluster(ctx, spc)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := maestroClientsByShard[shardID]; !ok {
+			return nil, utils.TrackError(fmt.Errorf("provision shard %s for ServiceProviderCluster %s is not present in provision shards map", shardID, spc.ResourceID.String()))
+		}
+		res[shardID] = append(res[shardID], spc)
+	}
+	return res, nil
+}
+
+// orphanReadonlyBundleDeleteCandidate is a Maestro bundle listed on a provision shard that was not referenced by the
+// initial SPC snapshot for that shard; delete still requires a fresh snapshot check.
+type orphanReadonlyBundleDeleteCandidate struct {
+	csShardID string
+	bundle    *workv1.ManifestWork
+}
+
+// ensureOrphanedMaestroReadonlyBundlesAreDeleted ensures that Maestro readonly bundles managed by the cluster-scoped
+// controller are deleted when no ServiceProviderCluster on that provision shard references them.
+//
+//  1. From initialShardToSPCs, build per-shard sets of referenced Maestro bundle names.
+//  2. For each shard with a Maestro client, list bundles (paginated) and add candidates when the bundle is not referenced on that shard.
+//  3. List all ServiceProviderClusters again (fresh), map them by shard, rebuild referenced sets.
+//  4. Delete each candidate that is still unreferenced on its shard in the fresh snapshot.
+func (c *deleteOrphanedMaestroReadonlyBundles) ensureOrphanedMaestroReadonlyBundlesAreDeleted(ctx context.Context, maestroClientsByShard map[string]*shardMaestroClient, initialShardToSPCs map[string][]*api.ServiceProviderCluster) error {
 	logger := utils.LoggerFromContext(ctx)
 	var syncErrors []error
-	// We iterate over each shard to list all the maestro bundles associated to that
-	// shard (assuming same maestro source ID) using the Maestro API
-	for csShardID, shardToSPCs := range provisionShardsToServiceProviderClustersIndex {
-		logger = logger.WithValues("csProvisionShardID", csShardID)
-		ctx = utils.ContextWithLogger(ctx, logger)
-		logger.Info("processing cluster service provision shard %s with %d ServiceProviderClusters", csShardID, len(shardToSPCs.serviceProviderClusters))
-		maestroClient := shardToSPCs.maestroClient
-		// We list all the Maestro Bundles in chunks of 400 to avoid putting
-		// too much pressure on the Maestro API.
-		// We filter the Maestro Bundles by the K8s label that indicates that the Maestro Bundle is managed by the cluster scoped maestro readonly bundles controller.
+
+	referencedByShardInitial, err := referencedMaestroAPIMaestroBundleNamesByShard(initialShardToSPCs)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("error building referenced Maestro API Maestro bundle names by shard (initial snapshot): %w", err))
+	}
+
+	var deleteCandidates []orphanReadonlyBundleDeleteCandidate
+
+	for csShardID, shardEntry := range maestroClientsByShard {
+		shardLogger := logger.WithValues("csProvisionShardID", csShardID)
+		ctxShard := utils.ContextWithLogger(ctx, shardLogger)
+		initialOnShard := initialShardToSPCs[csShardID]
+		shardLogger.Info(fmt.Sprintf("listing Maestro bundles on cluster service provision shard %s (%d ServiceProviderClusters in initial shard map)", csShardID, len(initialOnShard)))
+		maestroClient := shardEntry.maestroClient
 		listOptions := metav1.ListOptions{Limit: 400, Continue: "", LabelSelector: fmt.Sprintf("%s=%s", readonlyBundleManagedByK8sLabelKey, readonlyBundleManagedByK8sLabelValueClusterScoped)}
 		for {
-			maestroBundles, err := maestroClient.List(ctx, listOptions)
+			maestroBundles, err := maestroClient.List(ctxShard, listOptions)
 			if err != nil {
 				return utils.TrackError(fmt.Errorf("failed to list Maestro Bundles for shard %s: %w", csShardID, err))
 			}
-			// For each Maestro Bundle retrieved from the Maestro API we check if the Maestro Bundle has the K8s annotation
-			// that indicates that the Maestro Bundle is managed by the cluster scoped maestro readonly bundles controller. If it
-			// does not we filter it out. If it is then we check if the Maestro Bundle is referenced by any of the ServiceProviderClusters
-			// allocated to that shard by checking the MaestroBundleReferences in the ServiceProviderCluster status and checking if the
-			// Maestro API Maestro Bundle Name matches. If it matches, we leave it alone. If it does not match, we delete it.
-			for _, maestroBundle := range maestroBundles.Items {
+			for i := range maestroBundles.Items {
+				maestroBundle := &maestroBundles.Items[i]
 				// Even though Maestro should filter by the K8s label we specified we double check it here to be sure
 				if maestroBundle.Labels[readonlyBundleManagedByK8sLabelKey] != readonlyBundleManagedByK8sLabelValueClusterScoped {
 					continue
 				}
-
-				// We iterate over all the Maestro Bundle References among all the Service Provider Clusters allocated to that shard
-				// to check if the Maestro Bundle is referenced by any of them.
-				found := slices.ContainsFunc(shardToSPCs.serviceProviderClusters, func(spc *api.ServiceProviderCluster) bool {
-					found := slices.ContainsFunc(spc.Status.MaestroReadonlyBundles, func(ref *api.MaestroBundleReference) bool {
-						// The Maestro API Maestro Bundle Name should be unique within a given Maestro Consumer Name and Maestro Source ID.
-						// If we find a match, it means the Maestro Bundle is referenced by the ServiceProviderCluster and we should
-						// not delete it.
-						return ref.MaestroAPIMaestroBundleName == maestroBundle.Name
-					})
-					return found
+				// We check if the Maestro bundle is referenced by any of the ServiceProviderClusters on the shard in the initial snapshot.
+				// If it is referenced we skip it as it is not an orphan.
+				// The Maestro API Maestro Bundle Name should be unique within a given Maestro Consumer Name and Maestro Source ID.
+				if shardRefSet := referencedByShardInitial[csShardID]; shardRefSet != nil {
+					if _, referenced := shardRefSet[maestroBundle.Name]; referenced {
+						continue
+					}
+				}
+				deleteCandidates = append(deleteCandidates, orphanReadonlyBundleDeleteCandidate{
+					csShardID: csShardID,
+					bundle:    maestroBundle,
 				})
-				if found {
-					continue
-				}
-
-				// TODO it would be nice to be able to log the Maestro Source ID.
-				logger.Info("Deleting orphaned Maestro readonly Bundle", "maestroBundleMetadataName", maestroBundle.Name, "maestroConsumerName", maestroBundle.Namespace, "maestroBundleID", maestroBundle.UID)
-				err := maestroClient.Delete(ctx, maestroBundle.Name, metav1.DeleteOptions{})
-				if err != nil {
-					// Failure to delete does not end the sync process. We log the error and we continue with the processing
-					// of other Maestro Bundles.
-					syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to delete Maestro Bundle: %w", err)))
-				} else {
-					logger.Info("Deleted orphaned Maestro readonly Bundle", "maestroBundleMetadataName", maestroBundle.Name, "maestroConsumerName", maestroBundle.Namespace, "maestroBundleID", maestroBundle.UID)
-				}
-
 			}
 			continuationToken := maestroBundles.GetContinue()
 			if continuationToken == "" {
@@ -305,7 +287,102 @@ func (c *deleteOrphanedMaestroReadonlyBundles) ensureOrphanedMaestroReadonlyBund
 		}
 	}
 
+	freshServiceProviderClusters, err := c.getAllServiceProviderClusters(ctx)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("error getting all ServiceProviderClusters (fresh snapshot): %w", err))
+	}
+	freshShardToSPCs, err := c.mapServiceProviderClustersByProvisionShard(ctx, freshServiceProviderClusters, maestroClientsByShard)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("error mapping fresh ServiceProviderClusters to provision shards (fresh snapshot): %w", err))
+	}
+	referencedByShardFresh, err := referencedMaestroAPIMaestroBundleNamesByShard(freshShardToSPCs)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("error building referenced Maestro API Maestro bundle names by shard (fresh snapshot): %w", err))
+	}
+
+	for _, cand := range deleteCandidates {
+		csShardID := cand.csShardID
+		candidateMaestroBundle := cand.bundle
+		shardEntry, ok := maestroClientsByShard[csShardID]
+		if !ok {
+			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("no Maestro client for shard %s when deleting bundle %q", csShardID, candidateMaestroBundle.Name)))
+			continue
+		}
+		maestroClient := shardEntry.maestroClient
+
+		shardLogger := utils.LoggerFromContext(ctx).WithValues("csProvisionShardID", csShardID)
+		ctxShard := utils.ContextWithLogger(ctx, shardLogger)
+		if shardRefSet := referencedByShardFresh[csShardID]; shardRefSet != nil {
+			if _, referenced := shardRefSet[candidateMaestroBundle.Name]; referenced {
+				// If the Maestro bundle is referenced by any of the ServiceProviderClusters on the shard in the fresh snapshot we skip it as it is not an orphan.
+				continue
+			}
+		}
+
+		shardLogger.Info("Deleting orphaned Maestro readonly Bundle", "maestroConsumerName", candidateMaestroBundle.Namespace, "maestroAPIMaestroBundleName", candidateMaestroBundle.Name, "maestroAPIMaestroBundleID", candidateMaestroBundle.UID)
+		err = maestroClient.Delete(ctxShard, candidateMaestroBundle.Name, metav1.DeleteOptions{})
+		if err != nil {
+			//  Failure to delete does not end the sync process. We log the error and we continue with the processing of other Maestro bundle deletion candidates.
+			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to delete Maestro Bundle: %w", err)))
+		} else {
+			shardLogger.Info("Deleted orphaned Maestro readonly Bundle", "maestroConsumerName", candidateMaestroBundle.Namespace, "maestroAPIMaestroBundleName", candidateMaestroBundle.Name, "maestroAPIMaestroBundleID", candidateMaestroBundle.UID)
+		}
+	}
+
 	return errors.Join(syncErrors...)
+}
+
+// clusterProvisionShardIDForServiceProviderCluster returns the Cluster Service provision shard ID for the cluster that owns the SPC.
+func (c *deleteOrphanedMaestroReadonlyBundles) clusterProvisionShardIDForServiceProviderCluster(ctx context.Context, spc *api.ServiceProviderCluster) (string, error) {
+	clusterResourceID := spc.ResourceID.Parent
+	if clusterResourceID == nil {
+		return "", utils.TrackError(fmt.Errorf("ServiceProviderCluster %s has no parent resource ID", spc.ResourceID.String()))
+	}
+	cluster, err := c.cosmosClient.HCPClusters(clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName).Get(ctx, clusterResourceID.Name)
+	if err != nil {
+		return "", utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
+	}
+	// TODO We get the provision shard ID from CS but at some point we should have
+	// the information in Cosmos and this should be changed to use that instead.
+	// TODO should we take into account that at some point in the future we will implement migration between management
+	// clusters, where a cluster could have bundles allocated to different provision shards at the same time? For now
+	// we assume that the cluster is associated to a single provision shard at a time.
+	clusterCSShard, err := c.clusterServiceClient.GetClusterProvisionShard(ctx, cluster.ServiceProviderProperties.ClusterServiceID)
+	if err != nil {
+		return "", utils.TrackError(fmt.Errorf("failed to get Cluster Provision Shard: %w", err))
+	}
+	return clusterCSShard.ID(), nil
+}
+
+// referencedMaestroAPIMaestroBundleNamesByShard maps provision shard ID to the set of Maestro API bundle names referenced by
+// SPCs grouped under that shard (shard assignment is already resolved in spcsByShard). Nil list entries or empty
+// maestroAPIMaestroBundleName return an error so the reference set cannot silently omit in-use bundles.
+func referencedMaestroAPIMaestroBundleNamesByShard(spcsByShard map[string][]*api.ServiceProviderCluster) (map[string]map[string]struct{}, error) {
+	out := make(map[string]map[string]struct{})
+
+	for shardID, spcs := range spcsByShard {
+		// If it is the first time we are processing this shard we initialize the map entry for it
+		if out[shardID] == nil {
+			out[shardID] = make(map[string]struct{})
+		}
+		// We iterate over the ServiceProviderClusters on the shard and we add the Maestro API Maestro bundle names to the map.
+		for _, spc := range spcs {
+			if spc == nil {
+				return nil, utils.TrackError(fmt.Errorf("nil ServiceProviderCluster under provision shard %s", shardID))
+			}
+			for i, ref := range spc.Status.MaestroReadonlyBundles {
+				if ref == nil {
+					return nil, utils.TrackError(fmt.Errorf("serviceProviderCluster %s: MaestroReadonlyBundles[%d] is nil", spc.ResourceID.String(), i))
+				}
+				if ref.MaestroAPIMaestroBundleName == "" {
+					return nil, utils.TrackError(fmt.Errorf("serviceProviderCluster %s: MaestroReadonlyBundles[%d] (internal name %q) has empty maestroAPIMaestroBundleName", spc.ResourceID.String(), i, ref.Name))
+				}
+				out[shardID][ref.MaestroAPIMaestroBundleName] = struct{}{}
+			}
+		}
+	}
+
+	return out, nil
 }
 
 func (c *deleteOrphanedMaestroReadonlyBundles) Run(ctx context.Context, threadiness int) {

--- a/backend/pkg/controllers/delete_orphaned_maestro_readonly_bundles_controller_test.go
+++ b/backend/pkg/controllers/delete_orphaned_maestro_readonly_bundles_controller_test.go
@@ -26,6 +26,7 @@ import (
 	workv1 "open-cluster-management.io/api/work/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
@@ -59,7 +60,6 @@ func TestDeleteOrphanedMaestroReadonlyBundles_getAllServiceProviderClusters(t *t
 		{
 			name: "returns SPCs created via CRUD",
 			setupDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient) {
-				t.Helper()
 				spc := &api.ServiceProviderCluster{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
 					ResourceID:     *spcResourceID,
@@ -85,6 +85,92 @@ func TestDeleteOrphanedMaestroReadonlyBundles_getAllServiceProviderClusters(t *t
 			if tt.wantFirstResourceID != "" {
 				assert.Equal(t, tt.wantFirstResourceID, all[0].ResourceID.String())
 			}
+		})
+	}
+}
+
+func TestReferencedMaestroAPIMaestroBundleNamesByShard(t *testing.T) {
+	spcRID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/serviceProviderClusters/default"))
+
+	tests := []struct {
+		name           string
+		spcsByShard    map[string][]*api.ServiceProviderCluster
+		wantErr        bool
+		errSubstr      string
+		wantShard      string
+		wantBundleName string
+	}{
+		{
+			name: "empty maestroAPIMaestroBundleName",
+			spcsByShard: map[string][]*api.ServiceProviderCluster{
+				"shard1": {
+					{
+						ResourceID: *spcRID,
+						Status: api.ServiceProviderClusterStatus{
+							MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+								{Name: "logical-name", MaestroAPIMaestroBundleName: ""},
+							},
+						},
+					},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "has empty maestroAPIMaestroBundleName",
+		},
+		{
+			name: "nil ref entry",
+			spcsByShard: map[string][]*api.ServiceProviderCluster{
+				"shard1": {
+					{
+						ResourceID: *spcRID,
+						Status: api.ServiceProviderClusterStatus{
+							MaestroReadonlyBundles: api.MaestroBundleReferenceList{nil},
+						},
+					},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "is nil",
+		},
+		{
+			name: "nil ServiceProviderCluster",
+			spcsByShard: map[string][]*api.ServiceProviderCluster{
+				"shard1": {nil},
+			},
+			wantErr:   true,
+			errSubstr: "nil ServiceProviderCluster",
+		},
+		{
+			name: "success",
+			spcsByShard: map[string][]*api.ServiceProviderCluster{
+				"s": {
+					{
+						ResourceID: *spcRID,
+						Status: api.ServiceProviderClusterStatus{
+							MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+								{MaestroAPIMaestroBundleName: "bundle-one"},
+							},
+						},
+					},
+				},
+			},
+			wantShard:      "s",
+			wantBundleName: "bundle-one",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := referencedMaestroAPIMaestroBundleNamesByShard(tt.spcsByShard)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			shardSet := out[tt.wantShard]
+			require.NotNil(t, shardSet, "expected shard %q in result", tt.wantShard)
+			_, ok := shardSet[tt.wantBundleName]
+			assert.True(t, ok, "expected bundle name %q under shard %q", tt.wantBundleName, tt.wantShard)
 		})
 	}
 }
@@ -338,39 +424,162 @@ func TestDeleteOrphanedMaestroReadonlyBundles_SyncOnce_NoServiceProviderClusters
 	require.NoError(t, err)
 }
 
-func TestDeleteOrphanedMaestroReadonlyBundles_buildProvisionShardToServiceProviderClustersIndex(t *testing.T) {
+func TestDeleteOrphanedMaestroReadonlyBundles_buildMaestroClientsByProvisionShard(t *testing.T) {
 	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		setup       func(ctrl *gomock.Controller) *deleteOrphanedMaestroReadonlyBundles
+		wantErr     bool
+		errSubstr   string
+		validateOut func(t *testing.T, clients map[string]*shardMaestroClient)
+	}{
+		{
+			name: "empty provision shard list",
+			setup: func(ctrl *gomock.Controller) *deleteOrphanedMaestroReadonlyBundles {
+				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mockCS.EXPECT().ListProvisionShards().Return(ocm.NewSimpleProvisionShardListIterator(nil, nil))
+				return &deleteOrphanedMaestroReadonlyBundles{clusterServiceClient: mockCS}
+			},
+			validateOut: func(t *testing.T, clients map[string]*shardMaestroClient) {
+				require.Empty(t, clients)
+			},
+		},
+		{
+			name: "success single shard",
+			setup: func(ctrl *gomock.Controller) *deleteOrphanedMaestroReadonlyBundles {
+				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mockMaestroBuilder := maestro.NewMockMaestroClientBuilder(ctrl)
+				mockMaestro := maestro.NewMockClient(ctrl)
+				provisionShard := buildTestProvisionShard("test-consumer")
+				mockCS.EXPECT().ListProvisionShards().Return(ocm.NewSimpleProvisionShardListIterator([]*arohcpv1alpha1.ProvisionShard{provisionShard}, nil))
+				restEndpoint := provisionShard.MaestroConfig().RestApiConfig().Url()
+				grpcEndpoint := provisionShard.MaestroConfig().GrpcApiConfig().Url()
+				consumerName := provisionShard.MaestroConfig().ConsumerName()
+				sourceID := maestro.GenerateMaestroSourceID("test-env", provisionShard.ID())
+				mockMaestroBuilder.EXPECT().NewClient(gomock.Any(), restEndpoint, grpcEndpoint, consumerName, sourceID).Return(mockMaestro, nil)
+				return &deleteOrphanedMaestroReadonlyBundles{
+					clusterServiceClient:               mockCS,
+					maestroClientBuilder:               mockMaestroBuilder,
+					maestroSourceEnvironmentIdentifier: "test-env",
+				}
+			},
+			validateOut: func(t *testing.T, clients map[string]*shardMaestroClient) {
+				provisionShard := buildTestProvisionShard("test-consumer")
+				require.Len(t, clients, 1)
+				_, ok := clients[provisionShard.ID()]
+				require.True(t, ok)
+			},
+		},
+		{
+			name: "success two shards",
+			setup: func(ctrl *gomock.Controller) *deleteOrphanedMaestroReadonlyBundles {
+				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mockMaestroBuilder := maestro.NewMockMaestroClientBuilder(ctrl)
+				mockMaestro1 := maestro.NewMockClient(ctrl)
+				mockMaestro2 := maestro.NewMockClient(ctrl)
+				shard1 := buildTestProvisionShard("consumer1")
+				shard2ID := "33333333333333333333333333333333"
+				shard2, err := arohcpv1alpha1.NewProvisionShard().
+					ID(shard2ID).
+					MaestroConfig(
+						arohcpv1alpha1.NewProvisionShardMaestroConfig().
+							ConsumerName("consumer2").
+							RestApiConfig(arohcpv1alpha1.NewProvisionShardMaestroRestApiConfig().Url("https://maestro2.example.com:443")).
+							GrpcApiConfig(arohcpv1alpha1.NewProvisionShardMaestroGrpcApiConfig().Url("https://maestro2.example.com:444")),
+					).
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().ListProvisionShards().Return(ocm.NewSimpleProvisionShardListIterator([]*arohcpv1alpha1.ProvisionShard{shard1, shard2}, nil))
+				mockMaestroBuilder.EXPECT().NewClient(gomock.Any(), shard1.MaestroConfig().RestApiConfig().Url(), shard1.MaestroConfig().GrpcApiConfig().Url(), shard1.MaestroConfig().ConsumerName(), maestro.GenerateMaestroSourceID("test-env", shard1.ID())).Return(mockMaestro1, nil)
+				mockMaestroBuilder.EXPECT().NewClient(gomock.Any(), shard2.MaestroConfig().RestApiConfig().Url(), shard2.MaestroConfig().GrpcApiConfig().Url(), shard2.MaestroConfig().ConsumerName(), maestro.GenerateMaestroSourceID("test-env", shard2.ID())).Return(mockMaestro2, nil)
+				return &deleteOrphanedMaestroReadonlyBundles{
+					clusterServiceClient:               mockCS,
+					maestroClientBuilder:               mockMaestroBuilder,
+					maestroSourceEnvironmentIdentifier: "test-env",
+				}
+			},
+			validateOut: func(t *testing.T, clients map[string]*shardMaestroClient) {
+				require.Len(t, clients, 2)
+			},
+		},
+		{
+			name: "NewClient error",
+			setup: func(ctrl *gomock.Controller) *deleteOrphanedMaestroReadonlyBundles {
+				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mockMaestroBuilder := maestro.NewMockMaestroClientBuilder(ctrl)
+				provisionShard := buildTestProvisionShard("test-consumer")
+				mockCS.EXPECT().ListProvisionShards().Return(ocm.NewSimpleProvisionShardListIterator([]*arohcpv1alpha1.ProvisionShard{provisionShard}, nil))
+				restEndpoint := provisionShard.MaestroConfig().RestApiConfig().Url()
+				grpcEndpoint := provisionShard.MaestroConfig().GrpcApiConfig().Url()
+				consumerName := provisionShard.MaestroConfig().ConsumerName()
+				sourceID := maestro.GenerateMaestroSourceID("test-env", provisionShard.ID())
+				mockMaestroBuilder.EXPECT().NewClient(gomock.Any(), restEndpoint, grpcEndpoint, consumerName, sourceID).Return(nil, fmt.Errorf("maestro client error"))
+				return &deleteOrphanedMaestroReadonlyBundles{
+					clusterServiceClient:               mockCS,
+					maestroClientBuilder:               mockMaestroBuilder,
+					maestroSourceEnvironmentIdentifier: "test-env",
+				}
+			},
+			wantErr:   true,
+			errSubstr: "failed to create Maestro client",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			c := tt.setup(ctrl)
+			clients, err := c.buildMaestroClientsByProvisionShard(ctx)
+			defer cancelMaestroClientsByProvisionShard(clients)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.validateOut != nil {
+				tt.validateOut(t, clients)
+			}
+		})
+	}
+}
+
+func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderClustersByProvisionShard(t *testing.T) {
+	ctx := context.Background()
+	// mapServiceProviderClustersByProvisionShard does not use the Maestro client; tests only need shard IDs in the map.
+	noopMaestroShardClient := &shardMaestroClient{
+		maestroClient:           nil,
+		maestroClientCancelFunc: func() {},
+	}
 	clusterResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster"))
 	spcResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/serviceProviderClusters/default"))
 
 	tests := []struct {
 		name        string
-		setup       func(t *testing.T, ctrl *gomock.Controller) (c *deleteOrphanedMaestroReadonlyBundles, allSPCs []*api.ServiceProviderCluster)
+		setup       func(ctrl *gomock.Controller) (c *deleteOrphanedMaestroReadonlyBundles, clients map[string]*shardMaestroClient, spcs []*api.ServiceProviderCluster)
 		wantErr     bool
 		errSubstr   string
-		validateIdx func(t *testing.T, idx map[string]*provisionShardServiceProviderClusters)
+		validateOut func(t *testing.T, shardToSPCs map[string][]*api.ServiceProviderCluster)
 	}{
 		{
 			name: "Get cluster error",
-			setup: func(t *testing.T, ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, []*api.ServiceProviderCluster) {
-				t.Helper()
-				// Use databasetesting mock - cluster is not added, so Get() will return not found
+			setup: func(ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, map[string]*shardMaestroClient, []*api.ServiceProviderCluster) {
 				mockDB := databasetesting.NewMockDBClient()
 				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 				spc := &api.ServiceProviderCluster{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
 					ResourceID:     *spcResourceID,
 				}
-				mockCS.EXPECT().ListProvisionShards().Return(ocm.NewSimpleProvisionShardListIterator(nil, nil))
-				return &deleteOrphanedMaestroReadonlyBundles{cosmosClient: mockDB, clusterServiceClient: mockCS}, []*api.ServiceProviderCluster{spc}
+				return &deleteOrphanedMaestroReadonlyBundles{cosmosClient: mockDB, clusterServiceClient: mockCS},
+					map[string]*shardMaestroClient{"unused-shard": noopMaestroShardClient},
+					[]*api.ServiceProviderCluster{spc}
 			},
 			wantErr:   true,
 			errSubstr: "failed to get Cluster",
 		},
 		{
 			name: "Get provision shard error",
-			setup: func(t *testing.T, ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, []*api.ServiceProviderCluster) {
-				t.Helper()
+			setup: func(ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, map[string]*shardMaestroClient, []*api.ServiceProviderCluster) {
 				mockDB := databasetesting.NewMockDBClient()
 				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 				cluster := &api.HCPOpenShiftCluster{
@@ -385,21 +594,19 @@ func TestDeleteOrphanedMaestroReadonlyBundles_buildProvisionShardToServiceProvid
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
 					ResourceID:     *spcResourceID,
 				}
-				mockCS.EXPECT().ListProvisionShards().Return(ocm.NewSimpleProvisionShardListIterator(nil, nil))
 				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), cluster.ServiceProviderProperties.ClusterServiceID).Return(nil, fmt.Errorf("provision shard error"))
-				return &deleteOrphanedMaestroReadonlyBundles{cosmosClient: mockDB, clusterServiceClient: mockCS}, []*api.ServiceProviderCluster{spc}
+				return &deleteOrphanedMaestroReadonlyBundles{cosmosClient: mockDB, clusterServiceClient: mockCS},
+					map[string]*shardMaestroClient{"unused-shard": noopMaestroShardClient},
+					[]*api.ServiceProviderCluster{spc}
 			},
 			wantErr:   true,
 			errSubstr: "failed to get Cluster Provision Shard",
 		},
 		{
-			name: "provision shard not in index",
-			setup: func(t *testing.T, ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, []*api.ServiceProviderCluster) {
-				t.Helper()
+			name: "provision shard not in clients map",
+			setup: func(ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, map[string]*shardMaestroClient, []*api.ServiceProviderCluster) {
 				mockDB := databasetesting.NewMockDBClient()
 				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-				mockMaestroBuilder := maestro.NewMockMaestroClientBuilder(ctrl)
-				mockMaestro := maestro.NewMockClient(ctrl)
 				cluster := &api.HCPOpenShiftCluster{
 					TrackedResource: arm.TrackedResource{Resource: arm.Resource{ID: clusterResourceID}},
 					ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
@@ -412,7 +619,7 @@ func TestDeleteOrphanedMaestroReadonlyBundles_buildProvisionShardToServiceProvid
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
 					ResourceID:     *spcResourceID,
 				}
-				shardInList := buildTestProvisionShard("consumer-in-list")
+				shardInClientsMap := buildTestProvisionShard("consumer-in-list")
 				shard2ID := "33333333333333333333333333333333"
 				shardReturnedByCS, err := arohcpv1alpha1.NewProvisionShard().
 					ID(shard2ID).
@@ -424,27 +631,20 @@ func TestDeleteOrphanedMaestroReadonlyBundles_buildProvisionShardToServiceProvid
 					).
 					Build()
 				require.NoError(t, err)
-				mockCS.EXPECT().ListProvisionShards().Return(ocm.NewSimpleProvisionShardListIterator([]*arohcpv1alpha1.ProvisionShard{shardInList}, nil))
-				mockMaestroBuilder.EXPECT().NewClient(gomock.Any(), shardInList.MaestroConfig().RestApiConfig().Url(), shardInList.MaestroConfig().GrpcApiConfig().Url(), shardInList.MaestroConfig().ConsumerName(), maestro.GenerateMaestroSourceID("test-env", shardInList.ID())).Return(mockMaestro, nil)
 				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), cluster.ServiceProviderProperties.ClusterServiceID).Return(shardReturnedByCS, nil)
-				return &deleteOrphanedMaestroReadonlyBundles{
-					cosmosClient:                       mockDB,
-					clusterServiceClient:               mockCS,
-					maestroClientBuilder:               mockMaestroBuilder,
-					maestroSourceEnvironmentIdentifier: "test-env",
-				}, []*api.ServiceProviderCluster{spc}
+				clients := map[string]*shardMaestroClient{
+					shardInClientsMap.ID(): noopMaestroShardClient,
+				}
+				return &deleteOrphanedMaestroReadonlyBundles{cosmosClient: mockDB, clusterServiceClient: mockCS}, clients, []*api.ServiceProviderCluster{spc}
 			},
 			wantErr:   true,
-			errSubstr: "not present in provision shards index",
+			errSubstr: "not present in provision shards map",
 		},
 		{
-			name: "success builds index and creates maestro client",
-			setup: func(t *testing.T, ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, []*api.ServiceProviderCluster) {
-				t.Helper()
+			name: "success single shard",
+			setup: func(ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, map[string]*shardMaestroClient, []*api.ServiceProviderCluster) {
 				mockDB := databasetesting.NewMockDBClient()
 				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-				mockMaestroBuilder := maestro.NewMockMaestroClientBuilder(ctrl)
-				mockMaestro := maestro.NewMockClient(ctrl)
 				cluster := &api.HCPOpenShiftCluster{
 					TrackedResource: arm.TrackedResource{Resource: arm.Resource{ID: clusterResourceID}},
 					ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
@@ -458,39 +658,23 @@ func TestDeleteOrphanedMaestroReadonlyBundles_buildProvisionShardToServiceProvid
 					ResourceID:     *spcResourceID,
 				}
 				provisionShard := buildTestProvisionShard("test-consumer")
-				mockCS.EXPECT().ListProvisionShards().Return(ocm.NewSimpleProvisionShardListIterator([]*arohcpv1alpha1.ProvisionShard{provisionShard}, nil))
-				restEndpoint := provisionShard.MaestroConfig().RestApiConfig().Url()
-				grpcEndpoint := provisionShard.MaestroConfig().GrpcApiConfig().Url()
-				consumerName := provisionShard.MaestroConfig().ConsumerName()
-				sourceID := maestro.GenerateMaestroSourceID("test-env", provisionShard.ID())
-				mockMaestroBuilder.EXPECT().NewClient(gomock.Any(), restEndpoint, grpcEndpoint, consumerName, sourceID).Return(mockMaestro, nil)
 				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), cluster.ServiceProviderProperties.ClusterServiceID).Return(provisionShard, nil)
-				return &deleteOrphanedMaestroReadonlyBundles{
-					cosmosClient:                       mockDB,
-					clusterServiceClient:               mockCS,
-					maestroClientBuilder:               mockMaestroBuilder,
-					maestroSourceEnvironmentIdentifier: "test-env",
-				}, []*api.ServiceProviderCluster{spc}
+				clients := map[string]*shardMaestroClient{provisionShard.ID(): noopMaestroShardClient}
+				return &deleteOrphanedMaestroReadonlyBundles{cosmosClient: mockDB, clusterServiceClient: mockCS}, clients, []*api.ServiceProviderCluster{spc}
 			},
-			validateIdx: func(t *testing.T, idx map[string]*provisionShardServiceProviderClusters) {
-				t.Helper()
-				require.Len(t, idx, 1)
+			validateOut: func(t *testing.T, shardToSPCs map[string][]*api.ServiceProviderCluster) {
 				provisionShard := buildTestProvisionShard("test-consumer")
-				entry, ok := idx[provisionShard.ID()]
-				require.True(t, ok)
-				require.Len(t, entry.serviceProviderClusters, 1)
-				assert.Equal(t, spcResourceID.String(), entry.serviceProviderClusters[0].ResourceID.String())
+				require.Len(t, shardToSPCs, 1)
+				spcs := shardToSPCs[provisionShard.ID()]
+				require.Len(t, spcs, 1)
+				assert.Equal(t, spcResourceID.String(), spcs[0].ResourceID.String())
 			},
 		},
 		{
-			name: "multiple provision shards each get own index entry",
-			setup: func(t *testing.T, ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, []*api.ServiceProviderCluster) {
-				t.Helper()
+			name: "multiple provision shards each get own map entry",
+			setup: func(ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, map[string]*shardMaestroClient, []*api.ServiceProviderCluster) {
 				mockDB := databasetesting.NewMockDBClient()
 				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-				mockMaestroBuilder := maestro.NewMockMaestroClientBuilder(ctrl)
-				mockMaestro1 := maestro.NewMockClient(ctrl)
-				mockMaestro2 := maestro.NewMockClient(ctrl)
 
 				cluster1ResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster1"))
 				cluster2ResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub2/resourceGroups/rg2/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster2"))
@@ -535,52 +719,44 @@ func TestDeleteOrphanedMaestroReadonlyBundles_buildProvisionShardToServiceProvid
 					Build()
 				require.NoError(t, err)
 
-				mockCS.EXPECT().ListProvisionShards().Return(ocm.NewSimpleProvisionShardListIterator([]*arohcpv1alpha1.ProvisionShard{shard1, shard2}, nil))
-				mockMaestroBuilder.EXPECT().NewClient(gomock.Any(), shard1.MaestroConfig().RestApiConfig().Url(), shard1.MaestroConfig().GrpcApiConfig().Url(), shard1.MaestroConfig().ConsumerName(), maestro.GenerateMaestroSourceID("test-env", shard1.ID())).Return(mockMaestro1, nil)
-				mockMaestroBuilder.EXPECT().NewClient(gomock.Any(), shard2.MaestroConfig().RestApiConfig().Url(), shard2.MaestroConfig().GrpcApiConfig().Url(), shard2.MaestroConfig().ConsumerName(), maestro.GenerateMaestroSourceID("test-env", shard2.ID())).Return(mockMaestro2, nil)
 				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), cluster1.ServiceProviderProperties.ClusterServiceID).Return(shard1, nil)
 				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), cluster2.ServiceProviderProperties.ClusterServiceID).Return(shard2, nil)
 
-				return &deleteOrphanedMaestroReadonlyBundles{
-					cosmosClient:                       mockDB,
-					clusterServiceClient:               mockCS,
-					maestroClientBuilder:               mockMaestroBuilder,
-					maestroSourceEnvironmentIdentifier: "test-env",
-				}, []*api.ServiceProviderCluster{spc1, spc2}
+				clients := map[string]*shardMaestroClient{
+					shard1.ID(): noopMaestroShardClient,
+					shard2.ID(): noopMaestroShardClient,
+				}
+				return &deleteOrphanedMaestroReadonlyBundles{cosmosClient: mockDB, clusterServiceClient: mockCS}, clients, []*api.ServiceProviderCluster{spc1, spc2}
 			},
-			validateIdx: func(t *testing.T, idx map[string]*provisionShardServiceProviderClusters) {
-				t.Helper()
-				require.Len(t, idx, 2)
+			validateOut: func(t *testing.T, shardToSPCs map[string][]*api.ServiceProviderCluster) {
+				require.Len(t, shardToSPCs, 2)
 				shard1 := buildTestProvisionShard("consumer1")
-				entry1, ok := idx[shard1.ID()]
-				require.True(t, ok)
-				require.Len(t, entry1.serviceProviderClusters, 1)
+				spcs1 := shardToSPCs[shard1.ID()]
+				require.Len(t, spcs1, 1)
 				spc1RID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster1/serviceProviderClusters/default"))
-				assert.Equal(t, spc1RID.String(), entry1.serviceProviderClusters[0].ResourceID.String())
+				assert.Equal(t, spc1RID.String(), spcs1[0].ResourceID.String())
 				shard2ID := "33333333333333333333333333333333"
-				entry2, ok := idx[shard2ID]
-				require.True(t, ok)
-				require.Len(t, entry2.serviceProviderClusters, 1)
+				spcs2 := shardToSPCs[shard2ID]
+				require.Len(t, spcs2, 1)
 				spc2RID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub2/resourceGroups/rg2/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster2/serviceProviderClusters/default"))
-				assert.Equal(t, spc2RID.String(), entry2.serviceProviderClusters[0].ResourceID.String())
+				assert.Equal(t, spc2RID.String(), spcs2[0].ResourceID.String())
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			c, allSPCs := tt.setup(t, ctrl)
-			idx, err := c.buildProvisionShardToServiceProviderClustersIndex(ctx, allSPCs)
-			defer cancelMaestroClientsInIndex(idx)
+			c, clients, spcs := tt.setup(ctrl)
+			defer cancelMaestroClientsByProvisionShard(clients)
+			shardToSPCs, err := c.mapServiceProviderClustersByProvisionShard(ctx, spcs, clients)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errSubstr)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, idx)
-				if tt.validateIdx != nil {
-					tt.validateIdx(t, idx)
-				}
+				return
+			}
+			require.NoError(t, err)
+			if tt.validateOut != nil {
+				tt.validateOut(t, shardToSPCs)
 			}
 		})
 	}
@@ -592,30 +768,45 @@ func TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundl
 
 	tests := []struct {
 		name      string
-		setupMock func(*maestro.MockClient) map[string]*provisionShardServiceProviderClusters
+		setupMock func(*testing.T, *maestro.MockClient, *databasetesting.MockDBClient, *ocm.MockClusterServiceClientSpec, *arohcpv1alpha1.ProvisionShard) (map[string]*shardMaestroClient, map[string][]*api.ServiceProviderCluster)
 		wantErr   bool
 		errSubstr string
 	}{
 		{
-			name: "empty index success",
-			setupMock: func(*maestro.MockClient) map[string]*provisionShardServiceProviderClusters {
-				return nil
+			name: "empty provision shards map does not perform anything",
+			setupMock: func(t *testing.T, _ *maestro.MockClient, _ *databasetesting.MockDBClient, _ *ocm.MockClusterServiceClientSpec, _ *arohcpv1alpha1.ProvisionShard) (map[string]*shardMaestroClient, map[string][]*api.ServiceProviderCluster) {
+				return nil, nil
 			},
+			wantErr: false,
 		},
 		{
-			name: "list error",
-			setupMock: func(m *maestro.MockClient) map[string]*provisionShardServiceProviderClusters {
+			name: "second global SPC list error",
+			setupMock: func(_ *testing.T, m *maestro.MockClient, mockDB *databasetesting.MockDBClient, _ *ocm.MockClusterServiceClientSpec, shard *arohcpv1alpha1.ProvisionShard) (map[string]*shardMaestroClient, map[string][]*api.ServiceProviderCluster) {
+				listErr := fmt.Errorf("fresh list SPCs error")
+				mockDB.SetGlobalListers(&alwaysErrorGlobalListers{err: listErr})
+				// We mock the Maestro client list to return an empty list to avoid processing any Maestro bundles and going straight to the SPC list call.
+				m.EXPECT().List(gomock.Any(), gomock.Any()).Return(&workv1.ManifestWorkList{}, nil)
+				return map[string]*shardMaestroClient{
+					shard.ID(): {maestroClient: m, maestroClientCancelFunc: func() {}},
+				}, map[string][]*api.ServiceProviderCluster{}
+			},
+			wantErr:   true,
+			errSubstr: "error getting all ServiceProviderClusters (fresh snapshot)",
+		},
+		{
+			name: "an error is returned when listing Maestro bundles fails",
+			setupMock: func(_ *testing.T, m *maestro.MockClient, _ *databasetesting.MockDBClient, _ *ocm.MockClusterServiceClientSpec, shard *arohcpv1alpha1.ProvisionShard) (map[string]*shardMaestroClient, map[string][]*api.ServiceProviderCluster) {
 				m.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("maestro list error"))
-				return map[string]*provisionShardServiceProviderClusters{
-					"shard-1": {maestroClient: m, maestroClientCancelFunc: func() {}, serviceProviderClusters: []*api.ServiceProviderCluster{}},
-				}
+				return map[string]*shardMaestroClient{
+					shard.ID(): {maestroClient: m, maestroClientCancelFunc: func() {}},
+				}, map[string][]*api.ServiceProviderCluster{}
 			},
 			wantErr:   true,
 			errSubstr: "failed to list Maestro Bundles",
 		},
 		{
 			name: "skips bundle without readonly managed-by label",
-			setupMock: func(m *maestro.MockClient) map[string]*provisionShardServiceProviderClusters {
+			setupMock: func(_ *testing.T, m *maestro.MockClient, _ *databasetesting.MockDBClient, _ *ocm.MockClusterServiceClientSpec, shard *arohcpv1alpha1.ProvisionShard) (map[string]*shardMaestroClient, map[string][]*api.ServiceProviderCluster) {
 				bundleList := &workv1.ManifestWorkList{
 					Items: []workv1.ManifestWork{
 						{
@@ -628,22 +819,35 @@ func TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundl
 					},
 				}
 				m.EXPECT().List(gomock.Any(), gomock.Any()).Return(bundleList, nil)
-				return map[string]*provisionShardServiceProviderClusters{
-					"shard-1": {maestroClient: m, maestroClientCancelFunc: func() {}, serviceProviderClusters: []*api.ServiceProviderCluster{}},
-				}
+				return map[string]*shardMaestroClient{
+					shard.ID(): {maestroClient: m, maestroClientCancelFunc: func() {}},
+				}, map[string][]*api.ServiceProviderCluster{}
 			},
 		},
 		{
-			name: "skips referenced bundle",
-			setupMock: func(m *maestro.MockClient) map[string]*provisionShardServiceProviderClusters {
+			name: "skips Maestro bundle that is referenced by a ServiceProviderCluster on the shard",
+			setupMock: func(t *testing.T, m *maestro.MockClient, mockDB *databasetesting.MockDBClient, mockCS *ocm.MockClusterServiceClientSpec, shard *arohcpv1alpha1.ProvisionShard) (map[string]*shardMaestroClient, map[string][]*api.ServiceProviderCluster) {
+				clusterRID := spcResourceID.Parent
+				cluster := &api.HCPOpenShiftCluster{
+					TrackedResource: arm.TrackedResource{Resource: arm.Resource{ID: clusterRID}},
+					ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+						ClusterServiceID: api.Must(api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/csid")),
+					},
+				}
+				_, err := mockDB.HCPClusters(clusterRID.SubscriptionID, clusterRID.ResourceGroupName).Create(ctx, cluster, nil)
+				require.NoError(t, err)
+				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), cluster.ServiceProviderProperties.ClusterServiceID).Return(shard, nil).AnyTimes()
 				spc := &api.ServiceProviderCluster{
-					ResourceID: *spcResourceID,
+					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
+					ResourceID:     *spcResourceID,
 					Status: api.ServiceProviderClusterStatus{
 						MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 							{MaestroAPIMaestroBundleName: "referenced-bundle"},
 						},
 					},
 				}
+				_, err = mockDB.ServiceProviderClusters(clusterRID.SubscriptionID, clusterRID.ResourceGroupName, clusterRID.Name).Create(context.Background(), spc, nil)
+				require.NoError(t, err)
 				bundleList := &workv1.ManifestWorkList{
 					Items: []workv1.ManifestWork{
 						{
@@ -656,86 +860,109 @@ func TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundl
 					},
 				}
 				m.EXPECT().List(gomock.Any(), gomock.Any()).Return(bundleList, nil)
-				return map[string]*provisionShardServiceProviderClusters{
-					"shard-1": {maestroClient: m, maestroClientCancelFunc: func() {}, serviceProviderClusters: []*api.ServiceProviderCluster{spc}},
-				}
+				return map[string]*shardMaestroClient{
+					shard.ID(): {maestroClient: m, maestroClientCancelFunc: func() {}},
+				}, map[string][]*api.ServiceProviderCluster{shard.ID(): {spc}}
 			},
 		},
 		{
-			name: "deletes orphaned bundle",
-			setupMock: func(m *maestro.MockClient) map[string]*provisionShardServiceProviderClusters {
+			name: "deletes Maestro bundle that is not referenced by any ServiceProviderCluster on the shard",
+			setupMock: func(t *testing.T, m *maestro.MockClient, mockDB *databasetesting.MockDBClient, mockCS *ocm.MockClusterServiceClientSpec, shard *arohcpv1alpha1.ProvisionShard) (map[string]*shardMaestroClient, map[string][]*api.ServiceProviderCluster) {
+				clusterRID := spcResourceID.Parent
+				cluster := &api.HCPOpenShiftCluster{
+					TrackedResource: arm.TrackedResource{Resource: arm.Resource{ID: clusterRID}},
+					ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+						ClusterServiceID: api.Must(api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/csid")),
+					},
+				}
+				_, err := mockDB.HCPClusters(clusterRID.SubscriptionID, clusterRID.ResourceGroupName).Create(ctx, cluster, nil)
+				require.NoError(t, err)
+				mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), cluster.ServiceProviderProperties.ClusterServiceID).Return(shard, nil).AnyTimes()
 				spc := &api.ServiceProviderCluster{
-					ResourceID: *spcResourceID,
+					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
+					ResourceID:     *spcResourceID,
 					Status: api.ServiceProviderClusterStatus{
 						MaestroReadonlyBundles: api.MaestroBundleReferenceList{
 							{MaestroAPIMaestroBundleName: "referenced-bundle"},
 						},
 					},
 				}
+				_, err = mockDB.ServiceProviderClusters(clusterRID.SubscriptionID, clusterRID.ResourceGroupName, clusterRID.Name).Create(context.Background(), spc, nil)
+				require.NoError(t, err)
+				orphanMeta := metav1.ObjectMeta{
+					Name:      "orphaned-bundle",
+					Namespace: "consumer",
+					UID:       types.UID("orphan-uid"),
+					Labels:    map[string]string{readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped},
+				}
 				bundleList := &workv1.ManifestWorkList{
 					Items: []workv1.ManifestWork{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "orphaned-bundle",
-								Namespace: "consumer",
-								Labels:    map[string]string{readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped},
-							},
-						},
+						{ObjectMeta: orphanMeta},
 					},
 				}
 				m.EXPECT().List(gomock.Any(), gomock.Any()).Return(bundleList, nil)
-				m.EXPECT().Delete(gomock.Any(), "orphaned-bundle", gomock.Any()).Return(nil)
-				return map[string]*provisionShardServiceProviderClusters{
-					"shard-1": {maestroClient: m, maestroClientCancelFunc: func() {}, serviceProviderClusters: []*api.ServiceProviderCluster{spc}},
-				}
+				m.EXPECT().Delete(gomock.Any(), "orphaned-bundle", metav1.DeleteOptions{}).Return(nil)
+				return map[string]*shardMaestroClient{
+					shard.ID(): {maestroClient: m, maestroClientCancelFunc: func() {}},
+				}, map[string][]*api.ServiceProviderCluster{shard.ID(): {spc}}
 			},
 		},
 		{
-			name: "delete error joined but not fatal",
-			setupMock: func(m *maestro.MockClient) map[string]*provisionShardServiceProviderClusters {
+			// Two orphans: first Delete fails (appended to syncErrors, loop continues), second Delete succeeds;
+			// gomock call order proves the second delete was still attempted; errors.Join still returns an error.
+			name: "continues deleting remaining orphans after a delete failure",
+			setupMock: func(_ *testing.T, m *maestro.MockClient, _ *databasetesting.MockDBClient, _ *ocm.MockClusterServiceClientSpec, shard *arohcpv1alpha1.ProvisionShard) (map[string]*shardMaestroClient, map[string][]*api.ServiceProviderCluster) {
+				metaA := metav1.ObjectMeta{
+					Name:      "orphan-a",
+					Namespace: "consumer",
+					UID:       types.UID("orphan-a-uid"),
+					Labels:    map[string]string{readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped},
+				}
+				metaB := metav1.ObjectMeta{
+					Name:      "orphan-b",
+					Namespace: "consumer",
+					UID:       types.UID("orphan-b-uid"),
+					Labels:    map[string]string{readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped},
+				}
 				bundleList := &workv1.ManifestWorkList{
 					Items: []workv1.ManifestWork{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "orphaned-bundle",
-								Namespace: "consumer",
-								Labels:    map[string]string{readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped},
-							},
-						},
+						{ObjectMeta: metaA},
+						{ObjectMeta: metaB},
 					},
 				}
 				m.EXPECT().List(gomock.Any(), gomock.Any()).Return(bundleList, nil)
-				m.EXPECT().Delete(gomock.Any(), "orphaned-bundle", gomock.Any()).Return(fmt.Errorf("delete failed"))
-				return map[string]*provisionShardServiceProviderClusters{
-					"shard-1": {maestroClient: m, maestroClientCancelFunc: func() {}, serviceProviderClusters: []*api.ServiceProviderCluster{}},
-				}
+				m.EXPECT().Delete(gomock.Any(), "orphan-a", metav1.DeleteOptions{}).Return(fmt.Errorf("delete failed"))
+				m.EXPECT().Delete(gomock.Any(), "orphan-b", metav1.DeleteOptions{}).Return(nil)
+				return map[string]*shardMaestroClient{
+					shard.ID(): {maestroClient: m, maestroClientCancelFunc: func() {}},
+				}, map[string][]*api.ServiceProviderCluster{}
 			},
 			wantErr:   true,
 			errSubstr: "failed to delete Maestro Bundle",
 		},
 		{
 			name: "pagination lists and deletes across pages",
-			setupMock: func(m *maestro.MockClient) map[string]*provisionShardServiceProviderClusters {
+			setupMock: func(_ *testing.T, m *maestro.MockClient, _ *databasetesting.MockDBClient, _ *ocm.MockClusterServiceClientSpec, shard *arohcpv1alpha1.ProvisionShard) (map[string]*shardMaestroClient, map[string][]*api.ServiceProviderCluster) {
+				page1Meta := metav1.ObjectMeta{
+					Name:      "orphan-page1",
+					Namespace: "consumer",
+					UID:       types.UID("page1-uid"),
+					Labels:    map[string]string{readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped},
+				}
 				page1 := &workv1.ManifestWorkList{
 					ListMeta: metav1.ListMeta{Continue: "token"},
 					Items: []workv1.ManifestWork{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "orphan-page1",
-								Namespace: "consumer",
-								Labels:    map[string]string{readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped},
-							},
-						},
+						{ObjectMeta: page1Meta},
 					},
 				}
 				page2 := &workv1.ManifestWorkList{Items: []workv1.ManifestWork{}}
 				labelSelector := fmt.Sprintf("%s=%s", readonlyBundleManagedByK8sLabelKey, readonlyBundleManagedByK8sLabelValueClusterScoped)
 				m.EXPECT().List(gomock.Any(), metav1.ListOptions{Limit: 400, Continue: "", LabelSelector: labelSelector}).Return(page1, nil)
-				m.EXPECT().Delete(gomock.Any(), "orphan-page1", gomock.Any()).Return(nil)
 				m.EXPECT().List(gomock.Any(), metav1.ListOptions{Limit: 400, Continue: "token", LabelSelector: labelSelector}).Return(page2, nil)
-				return map[string]*provisionShardServiceProviderClusters{
-					"shard-1": {maestroClient: m, maestroClientCancelFunc: func() {}, serviceProviderClusters: []*api.ServiceProviderCluster{}},
-				}
+				m.EXPECT().Delete(gomock.Any(), "orphan-page1", metav1.DeleteOptions{}).Return(nil)
+				return map[string]*shardMaestroClient{
+					shard.ID(): {maestroClient: m, maestroClientCancelFunc: func() {}},
+				}, map[string][]*api.ServiceProviderCluster{}
 			},
 		},
 	}
@@ -743,9 +970,12 @@ func TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundl
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockMaestro := maestro.NewMockClient(ctrl)
-			index := tt.setupMock(mockMaestro)
-			c := &deleteOrphanedMaestroReadonlyBundles{}
-			err := c.ensureOrphanedMaestroReadonlyBundlesAreDeleted(ctx, index)
+			mockDB := databasetesting.NewMockDBClient()
+			mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+			shard := buildTestProvisionShard("test-consumer")
+			clients, initialShardToSPCs := tt.setupMock(t, mockMaestro, mockDB, mockCS, shard)
+			c := &deleteOrphanedMaestroReadonlyBundles{cosmosClient: mockDB, clusterServiceClient: mockCS}
+			err := c.ensureOrphanedMaestroReadonlyBundlesAreDeleted(ctx, clients, initialShardToSPCs)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errSubstr)
@@ -756,17 +986,64 @@ func TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundl
 	}
 }
 
-// TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundlesAreDeleted_BundleReferencedOnOtherShardDeletedOnThisShard
-// verifies that when processing a shard, a bundle whose name is referenced by an SPC on a different shard
-// (but not by any SPC on this shard) is deleted as orphaned on this shard.
-func TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundlesAreDeleted_BundleReferencedOnOtherShardDeletedOnThisShard(t *testing.T) {
+// TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundlesAreDeleted_shardScopedDeletes
+// verifies that when processing a Maestro bundle in shard A, if it doesn't have a corresponding SPC associated to shard A
+// it is deleted, even if there's a SPC associated to other shards that contains the same maestro bundle name (per-shard reference scope).
+func TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundlesAreDeleted_shardScopedDeletes(t *testing.T) {
 	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 	ctrl := gomock.NewController(t)
 	mockShard1 := maestro.NewMockClient(ctrl)
 	mockShard2 := maestro.NewMockClient(ctrl)
+	mockDB := databasetesting.NewMockDBClient()
+	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+
+	shard1, err := arohcpv1alpha1.NewProvisionShard().
+		ID("11111111111111111111111111111111").
+		MaestroConfig(
+			arohcpv1alpha1.NewProvisionShardMaestroConfig().
+				ConsumerName("consumer1").
+				RestApiConfig(arohcpv1alpha1.NewProvisionShardMaestroRestApiConfig().Url("https://maestro1.example.com:443")).
+				GrpcApiConfig(arohcpv1alpha1.NewProvisionShardMaestroGrpcApiConfig().Url("https://maestro1.example.com:444")),
+		).
+		Build()
+	require.NoError(t, err)
+	shard2, err := arohcpv1alpha1.NewProvisionShard().
+		ID("33333333333333333333333333333333").
+		MaestroConfig(
+			arohcpv1alpha1.NewProvisionShardMaestroConfig().
+				ConsumerName("consumer2").
+				RestApiConfig(arohcpv1alpha1.NewProvisionShardMaestroRestApiConfig().Url("https://maestro2.example.com:443")).
+				GrpcApiConfig(arohcpv1alpha1.NewProvisionShardMaestroGrpcApiConfig().Url("https://maestro2.example.com:444")),
+		).
+		Build()
+	require.NoError(t, err)
 
 	spcOnShard1ResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster1/serviceProviderClusters/default"))
+	clusterRID := spcOnShard1ResourceID.Parent
+	cluster := &api.HCPOpenShiftCluster{
+		TrackedResource: arm.TrackedResource{Resource: arm.Resource{ID: clusterRID}},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: api.Must(api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/csid")),
+		},
+	}
+	_, err = mockDB.HCPClusters(clusterRID.SubscriptionID, clusterRID.ResourceGroupName).Create(ctx, cluster, nil)
+	require.NoError(t, err)
+	mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), cluster.ServiceProviderProperties.ClusterServiceID).Return(shard1, nil).AnyTimes()
+
 	spcOnShard1 := &api.ServiceProviderCluster{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcOnShard1ResourceID},
+		ResourceID:     *spcOnShard1ResourceID,
+		Status: api.ServiceProviderClusterStatus{
+			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+				{MaestroAPIMaestroBundleName: "bundle-X"},
+			},
+		},
+	}
+	parent := spcOnShard1ResourceID.Parent
+	_, err = mockDB.ServiceProviderClusters(parent.SubscriptionID, parent.ResourceGroupName, parent.Name).Create(ctx, spcOnShard1, nil)
+	require.NoError(t, err)
+
+	spcOnShard1Lite := &api.ServiceProviderCluster{
 		ResourceID: *spcOnShard1ResourceID,
 		Status: api.ServiceProviderClusterStatus{
 			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
@@ -775,31 +1052,188 @@ func TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundl
 		},
 	}
 
-	index := map[string]*provisionShardServiceProviderClusters{
-		"shard-1": {maestroClient: mockShard1, maestroClientCancelFunc: func() {}, serviceProviderClusters: []*api.ServiceProviderCluster{spcOnShard1}},
-		"shard-2": {maestroClient: mockShard2, maestroClientCancelFunc: func() {}, serviceProviderClusters: []*api.ServiceProviderCluster{}},
+	clients := map[string]*shardMaestroClient{
+		shard1.ID(): {maestroClient: mockShard1, maestroClientCancelFunc: func() {}},
+		shard2.ID(): {maestroClient: mockShard2, maestroClientCancelFunc: func() {}},
+	}
+	initialShardToSPCs := map[string][]*api.ServiceProviderCluster{
+		shard1.ID(): {spcOnShard1Lite},
+		shard2.ID(): {},
 	}
 
-	// Shard 1: list returns empty (no orphaned bundles there).
 	mockShard1.EXPECT().List(gomock.Any(), gomock.Any()).Return(&workv1.ManifestWorkList{Items: []workv1.ManifestWork{}}, nil)
 
-	// Shard 2: list returns a bundle named "bundle-X". No SPC on shard-2 references it, so it is orphaned on this shard and must be deleted.
+	bundleXMeta := metav1.ObjectMeta{
+		Name:      "bundle-X",
+		Namespace: "consumer2",
+		UID:       types.UID("bundle-x-uid"),
+		Labels:    map[string]string{readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped},
+	}
 	bundleListShard2 := &workv1.ManifestWorkList{
+		Items: []workv1.ManifestWork{
+			{ObjectMeta: bundleXMeta},
+		},
+	}
+	mockShard2.EXPECT().List(gomock.Any(), gomock.Any()).Return(bundleListShard2, nil)
+	mockShard2.EXPECT().Delete(gomock.Any(), "bundle-X", metav1.DeleteOptions{}).Return(nil)
+
+	c := &deleteOrphanedMaestroReadonlyBundles{cosmosClient: mockDB, clusterServiceClient: mockCS}
+	err = c.ensureOrphanedMaestroReadonlyBundlesAreDeleted(ctx, clients, initialShardToSPCs)
+	require.NoError(t, err)
+}
+
+// TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundlesAreDeleted_bundleOnlyOnShardANoDeleteOnShardB
+// verifies that bundle N exists only on shard A's Maestro and is referenced by an SPC on shard A, while shard B's
+// Maestro lists no such bundle: processing shard B never issues a Delete for N (and shard A skips N as referenced).
+func TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundlesAreDeleted_bundleOnlyOnShardANoDeleteOnShardB(t *testing.T) {
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+	mockShardA := maestro.NewMockClient(ctrl)
+	mockShardB := maestro.NewMockClient(ctrl)
+	mockDB := databasetesting.NewMockDBClient()
+	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+
+	shardA, err := arohcpv1alpha1.NewProvisionShard().
+		ID("11111111111111111111111111111111").
+		MaestroConfig(
+			arohcpv1alpha1.NewProvisionShardMaestroConfig().
+				ConsumerName("consumer-a").
+				RestApiConfig(arohcpv1alpha1.NewProvisionShardMaestroRestApiConfig().Url("https://maestro-a.example.com:443")).
+				GrpcApiConfig(arohcpv1alpha1.NewProvisionShardMaestroGrpcApiConfig().Url("https://maestro-a.example.com:444")),
+		).
+		Build()
+	require.NoError(t, err)
+	shardB, err := arohcpv1alpha1.NewProvisionShard().
+		ID("33333333333333333333333333333333").
+		MaestroConfig(
+			arohcpv1alpha1.NewProvisionShardMaestroConfig().
+				ConsumerName("consumer-b").
+				RestApiConfig(arohcpv1alpha1.NewProvisionShardMaestroRestApiConfig().Url("https://maestro-b.example.com:443")).
+				GrpcApiConfig(arohcpv1alpha1.NewProvisionShardMaestroGrpcApiConfig().Url("https://maestro-b.example.com:444")),
+		).
+		Build()
+	require.NoError(t, err)
+
+	spcResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-a/serviceProviderClusters/default"))
+	clusterRID := spcResourceID.Parent
+	cluster := &api.HCPOpenShiftCluster{
+		TrackedResource: arm.TrackedResource{Resource: arm.Resource{ID: clusterRID}},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: api.Must(api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/csid")),
+		},
+	}
+	_, err = mockDB.HCPClusters(clusterRID.SubscriptionID, clusterRID.ResourceGroupName).Create(ctx, cluster, nil)
+	require.NoError(t, err)
+	mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), cluster.ServiceProviderProperties.ClusterServiceID).Return(shardA, nil).AnyTimes()
+
+	spc := &api.ServiceProviderCluster{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
+		ResourceID:     *spcResourceID,
+		Status: api.ServiceProviderClusterStatus{
+			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+				{MaestroAPIMaestroBundleName: "bundle-N"},
+			},
+		},
+	}
+	parent := spcResourceID.Parent
+	_, err = mockDB.ServiceProviderClusters(parent.SubscriptionID, parent.ResourceGroupName, parent.Name).Create(ctx, spc, nil)
+	require.NoError(t, err)
+
+	spcLite := &api.ServiceProviderCluster{
+		ResourceID: *spcResourceID,
+		Status: api.ServiceProviderClusterStatus{
+			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+				{MaestroAPIMaestroBundleName: "bundle-N"},
+			},
+		},
+	}
+
+	clients := map[string]*shardMaestroClient{
+		shardA.ID(): {maestroClient: mockShardA, maestroClientCancelFunc: func() {}},
+		shardB.ID(): {maestroClient: mockShardB, maestroClientCancelFunc: func() {}},
+	}
+	initialShardToSPCs := map[string][]*api.ServiceProviderCluster{
+		shardA.ID(): {spcLite},
+		shardB.ID(): {},
+	}
+
+	bundleNMeta := metav1.ObjectMeta{
+		Name:      "bundle-N",
+		Namespace: "consumer-a",
+		UID:       types.UID("bundle-n-uid"),
+		Labels:    map[string]string{readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped},
+	}
+	bundleListShardA := &workv1.ManifestWorkList{
+		Items: []workv1.ManifestWork{{ObjectMeta: bundleNMeta}},
+	}
+	mockShardA.EXPECT().List(gomock.Any(), gomock.Any()).Return(bundleListShardA, nil)
+	mockShardB.EXPECT().List(gomock.Any(), gomock.Any()).Return(&workv1.ManifestWorkList{Items: []workv1.ManifestWork{}}, nil)
+
+	c := &deleteOrphanedMaestroReadonlyBundles{cosmosClient: mockDB, clusterServiceClient: mockCS}
+	err = c.ensureOrphanedMaestroReadonlyBundlesAreDeleted(ctx, clients, initialShardToSPCs)
+	require.NoError(t, err)
+}
+
+// TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundlesAreDeleted_ReferenceOnlyOnFreshGlobalList
+// verifies that an SPC document present only on the second global Cosmos list (not in the cached SPC snapshot)
+// still prevents deletion of the referenced bundle.
+func TestDeleteOrphanedMaestroReadonlyBundles_ensureOrphanedMaestroReadonlyBundlesAreDeleted_ReferenceOnlyOnFreshGlobalList(t *testing.T) {
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+	mockMaestro := maestro.NewMockClient(ctrl)
+	mockDB := databasetesting.NewMockDBClient()
+	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+	shard := buildTestProvisionShard("test-consumer")
+
+	spcResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/serviceProviderClusters/default"))
+	clusterRID := spcResourceID.Parent
+	cluster := &api.HCPOpenShiftCluster{
+		TrackedResource: arm.TrackedResource{Resource: arm.Resource{ID: clusterRID}},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: api.Must(api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/csid")),
+		},
+	}
+	_, err := mockDB.HCPClusters(clusterRID.SubscriptionID, clusterRID.ResourceGroupName).Create(ctx, cluster, nil)
+	require.NoError(t, err)
+	mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), cluster.ServiceProviderProperties.ClusterServiceID).Return(shard, nil).AnyTimes()
+
+	spc := &api.ServiceProviderCluster{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
+		ResourceID:     *spcResourceID,
+		Status: api.ServiceProviderClusterStatus{
+			MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+				{MaestroAPIMaestroBundleName: "only-in-global-list"},
+			},
+		},
+	}
+	_, err = mockDB.ServiceProviderClusters(clusterRID.SubscriptionID, clusterRID.ResourceGroupName, clusterRID.Name).Create(ctx, spc, nil)
+	require.NoError(t, err)
+
+	clients := map[string]*shardMaestroClient{
+		shard.ID(): {
+			maestroClient:           mockMaestro,
+			maestroClientCancelFunc: func() {},
+		},
+	}
+	initialShardToSPCs := map[string][]*api.ServiceProviderCluster{
+		shard.ID(): {}, // stale: no SPC rows for this shard in the initial map
+	}
+
+	bundleList := &workv1.ManifestWorkList{
 		Items: []workv1.ManifestWork{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bundle-X",
-					Namespace: "consumer2",
+					Name:      "only-in-global-list",
+					Namespace: "consumer",
 					Labels:    map[string]string{readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped},
 				},
 			},
 		},
 	}
-	mockShard2.EXPECT().List(gomock.Any(), gomock.Any()).Return(bundleListShard2, nil)
-	mockShard2.EXPECT().Delete(gomock.Any(), "bundle-X", gomock.Any()).Return(nil)
+	mockMaestro.EXPECT().List(gomock.Any(), gomock.Any()).Return(bundleList, nil)
 
-	c := &deleteOrphanedMaestroReadonlyBundles{}
-	err := c.ensureOrphanedMaestroReadonlyBundlesAreDeleted(ctx, index)
+	c := &deleteOrphanedMaestroReadonlyBundles{cosmosClient: mockDB, clusterServiceClient: mockCS}
+	err = c.ensureOrphanedMaestroReadonlyBundlesAreDeleted(ctx, clients, initialShardToSPCs)
 	require.NoError(t, err)
 }
 
@@ -838,13 +1272,19 @@ func TestDeleteOrphanedMaestroReadonlyBundles_SyncOnce_FullFlow_DeletesOrphanedB
 
 	provisionShard := buildTestProvisionShard("test-consumer")
 	mockCS.EXPECT().ListProvisionShards().Return(ocm.NewSimpleProvisionShardListIterator([]*arohcpv1alpha1.ProvisionShard{provisionShard}, nil))
-	mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), cluster.ServiceProviderProperties.ClusterServiceID).Return(provisionShard, nil)
+	mockCS.EXPECT().GetClusterProvisionShard(gomock.Any(), cluster.ServiceProviderProperties.ClusterServiceID).Return(provisionShard, nil).AnyTimes()
 	restEndpoint := provisionShard.MaestroConfig().RestApiConfig().Url()
 	grpcEndpoint := provisionShard.MaestroConfig().GrpcApiConfig().Url()
 	consumerName := provisionShard.MaestroConfig().ConsumerName()
 	sourceID := maestro.GenerateMaestroSourceID("test-env", provisionShard.ID())
 	mockMaestroBuilder.EXPECT().NewClient(gomock.Any(), restEndpoint, grpcEndpoint, consumerName, sourceID).Return(mockMaestro, nil)
 
+	orphanFullFlowMeta := metav1.ObjectMeta{
+		Name:      "orphaned-bundle",
+		Namespace: "consumer",
+		UID:       types.UID("fullflow-orphan-uid"),
+		Labels:    map[string]string{readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped},
+	}
 	bundleList := &workv1.ManifestWorkList{
 		Items: []workv1.ManifestWork{
 			{
@@ -854,17 +1294,11 @@ func TestDeleteOrphanedMaestroReadonlyBundles_SyncOnce_FullFlow_DeletesOrphanedB
 					Labels:    map[string]string{readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped},
 				},
 			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "orphaned-bundle",
-					Namespace: "consumer",
-					Labels:    map[string]string{readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped},
-				},
-			},
+			{ObjectMeta: orphanFullFlowMeta},
 		},
 	}
 	mockMaestro.EXPECT().List(gomock.Any(), gomock.Any()).Return(bundleList, nil)
-	mockMaestro.EXPECT().Delete(gomock.Any(), "orphaned-bundle", gomock.Any()).Return(nil)
+	mockMaestro.EXPECT().Delete(gomock.Any(), "orphaned-bundle", metav1.DeleteOptions{}).Return(nil)
 
 	controller := NewDeleteOrphanedMaestroReadonlyBundlesController(mockDB, mockCS, mockMaestroBuilder, "test-env")
 	err = controller.SyncOnce(ctx, nil)


### PR DESCRIPTION
Harden the orphaned readonly-bundle cleanup so a bundle is only deleted when it still looks unreferenced after a second global ServiceProviderClusters read.

The first snapshot drives which Maestro bundles are even considered. The fresh snapshot re-checks references on the same provision shard before Delete.

That closes a potential race condition where an SPC or bundle reference appears only after the first list, which would otherwise look like an orphan and be removed by mistake.