### PR TITLE
upgrade to AKS version 1.34.4

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -406,7 +406,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.33.8
+      kubernetesVersion: 1.34.4
       networkDataplane: "cilium"
       networkPolicy: "cilium"
       systemAgentPool:
@@ -530,7 +530,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.33.8
+      kubernetesVersion: 1.34.4
       networkDataplane: "azure"
       networkPolicy: "azure"
       etcd:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -556,7 +556,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.8
+    kubernetesVersion: 1.34.4
     name: cspr-westus3-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -863,7 +863,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.8
+    kubernetesVersion: 1.34.4
     name: cspr-westus3-svc-1
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -556,7 +556,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.8
+    kubernetesVersion: 1.34.4
     name: dev-westus3-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -863,7 +863,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.8
+    kubernetesVersion: 1.34.4
     name: dev-westus3-svc-1
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -556,7 +556,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.8
+    kubernetesVersion: 1.34.4
     name: perf-usw3ptest-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -863,7 +863,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.8
+    kubernetesVersion: 1.34.4
     name: perf-usw3ptest-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -556,7 +556,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.8
+    kubernetesVersion: 1.34.4
     name: pers-usw3test-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -865,7 +865,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.8
+    kubernetesVersion: 1.34.4
     name: pers-usw3test-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -556,7 +556,7 @@ mgmt:
       vmSize: Standard_D4ds_v5
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.8
+    kubernetesVersion: 1.34.4
     name: prow-j7654321-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -865,7 +865,7 @@ svc:
       vmSize: Standard_D4ds_v5
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.8
+    kubernetesVersion: 1.34.4
     name: prow-j7654321-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -556,7 +556,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.8
+    kubernetesVersion: 1.34.4
     name: swft-lnstest-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -865,7 +865,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.33.8
+    kubernetesVersion: 1.34.4
     name: swft-lnstest-svc
     networkDataplane: cilium
     networkPolicy: cilium


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-26041

### What

Upgrade AKS Cluster to Version 1.34

### Why

We're on 1.33 at the moment. The goal is to reach 1.35 - but we’ll have to do it step by step. 

Meanwhile we’ll also try to automate the mechanism in [ARO-25873](https://redhat.atlassian.net/browse/ARO-25873): Enable rolling updates for AKS Clusters
In Progress

### Testing

- manual testing showed that the functionality worked (1.33.8 -> 1.34.4)
- prow E2E tests will not trigger real upgrades because the install version matches already the target version enforced by the upgrade script. Still they will prove that the system still work after an upgrade - and that a fresh system will work as well.

### Special notes for your reviewer

<!-- optional -->
