### PR TITLE
fix: add nightly registry to registryOverride

### DIFF
--- a/hypershiftoperator/values.yaml
+++ b/hypershiftoperator/values.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to manage Hypershift Operator and dependencies for ARO
 name: aro-hcp-hypershift-operator
 image: "{{ .acr.svc.name }}.azurecr.io/{{ .hypershift.image.repository }}"
 imageDigest: "{{ .hypershift.image.digest }}"
-registryOverrides: "quay.io/openshift-release-dev/ocp-v4.0-art-dev={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-release={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release,registry.redhat.io/redhat={{ .acr.ocp.name }}.azurecr.io/redhat"
+registryOverrides: "quay.io/openshift-release-dev/ocp-v4.0-art-dev={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-release={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat={{ .acr.ocp.name }}.azurecr.io/redhat"
 azureKeyVaultClientId: "__csiSecretStoreClientId__"
 additionalArgs: "{{ .hypershift.additionalInstallArg }}"
 operatorEnvVars:

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -687,7 +687,7 @@ spec:
             --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
             --aro-hcp-key-vault-users-client-id __csiSecretStoreClientId__ \
-            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat" \
+            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat" \
             --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890 \
             --platform-monitoring=None \
             --enable-size-tagging=true \


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-25997

### What

This PR adds the nightly registry to the overrideRegistry, so we can use nightly ocp release images for cluster creation.

### Why

Fix the bug described in https://redhat.atlassian.net/browse/ARO-25997

### Testing

Manual test pending

### Special notes for your reviewer

This should be added although there is a bug in hypershift that doesn't use this override correctly.
https://redhat.atlassian.net/browse/OCPBUGS-83564


