### PR TITLE
istio: bump istio for dev envs to asm-1-28

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1161,8 +1161,8 @@ clouds:
         nsp:
           accessMode: 'Learning'
         istio:
-          targetVersion: "asm-1-26"
-          versions: "asm-1-26,asm-1-28"
+          targetVersion: "asm-1-28"
+          versions: "asm-1-28"
         aks:
           etcd:
             softDelete: false
@@ -1437,9 +1437,6 @@ clouds:
           # SVC
           svc:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
-            istio:
-              targetVersion: "asm-1-28"
-              versions: "asm-1-28"
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
               userAgentPool:
@@ -1613,9 +1610,6 @@ clouds:
           # SVC
           svc:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
-            istio:
-              targetVersion: "asm-1-28"
-              versions: "asm-1-28"
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
               userAgentPool:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -893,8 +893,8 @@ svc:
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
     istioctlVersion: 1.29.1
     tag: prod-stable
-    targetVersion: asm-1-26
-    versions: asm-1-26,asm-1-28
+    targetVersion: asm-1-28
+    versions: asm-1-28
   nsp:
     accessMode: Learning
     name: nsp-usw3-svc

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -893,8 +893,8 @@ svc:
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
     istioctlVersion: 1.29.1
     tag: prod-stable
-    targetVersion: asm-1-26
-    versions: asm-1-26,asm-1-28
+    targetVersion: asm-1-28
+    versions: asm-1-28
   nsp:
     accessMode: Learning
     name: nsp-usw3-svc

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -893,8 +893,8 @@ svc:
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
     istioctlVersion: 1.29.1
     tag: prod-stable
-    targetVersion: asm-1-26
-    versions: asm-1-26,asm-1-28
+    targetVersion: asm-1-28
+    versions: asm-1-28
   nsp:
     accessMode: Learning
     name: nsp-usw3ptest-svc

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -895,8 +895,8 @@ svc:
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
     istioctlVersion: 1.29.1
     tag: prod-stable
-    targetVersion: asm-1-26
-    versions: asm-1-26,asm-1-28
+    targetVersion: asm-1-28
+    versions: asm-1-28
   nsp:
     accessMode: Learning
     name: nsp-lnstest-svc

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_istio.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_istio.yaml
@@ -4,24 +4,6 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   labels:
-    istio.io/rev: 'asm-1-26'
-  name: istio-shared-configmap-asm-1-26
-  namespace: aks-istio-system
-data:
-  mesh: |-
-    extensionProviders:
-    - name: "ext-authz"
-      envoyExtAuthzHttp:
-        service: "mise/mise.mise.svc.cluster.local"
-        port: "8080"
-        includeRequestHeadersInCheck: ["x-ext-authz", "mise-inbound-policies-to-filter"]
-        pathPrefix: "/v1/EnvoyValidateRequest"
----
-# Source: istio/templates/istio-shared-configmap.yml
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  labels:
     istio.io/rev: 'asm-1-28'
   name: istio-shared-configmap-asm-1-28
   namespace: aks-istio-system

--- a/istio/testdata/zz_fixture_TestHelmTemplate_istio_mise_enabled.yaml
+++ b/istio/testdata/zz_fixture_TestHelmTemplate_istio_mise_enabled.yaml
@@ -4,24 +4,6 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   labels:
-    istio.io/rev: 'asm-1-26'
-  name: istio-shared-configmap-asm-1-26
-  namespace: aks-istio-system
-data:
-  mesh: |-
-    extensionProviders:
-    - name: "ext-authz"
-      envoyExtAuthzHttp:
-        service: "mise/mise.mise.svc.cluster.local"
-        port: "8080"
-        includeRequestHeadersInCheck: ["x-ext-authz", "mise-inbound-policies-to-filter"]
-        pathPrefix: "/v1/EnvoyValidateRequest"
----
-# Source: istio/templates/istio-shared-configmap.yml
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  labels:
     istio.io/rev: 'asm-1-28'
   name: istio-shared-configmap-asm-1-28
   namespace: aks-istio-system


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Broken swift/dev environments which don't have istio asm-1-28 revision defined.

```
az aks mesh get-revisions -l uksouth | jq -r '.[].[].revision'
asm-1-27
asm-1-28
asm-1-29
```
### Why

We need to continuously upgrade istio to ensure it's not out of support.  This should not impact any INT/Stage/Prod envs as they have their own defaults defined in config in sdp-pipelines.  

### Testing

Ran `DEPLOY_ENV=swft make entrypoint/Region` locally.  
