### PR TITLE
istio: bump istio for swft envs to asm-1-28 target

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1240,7 +1240,7 @@ clouds:
         # this is the integrated DEV environment
         defaults:
           regionRG: hcp-underlay-{{ .ctx.environment }}-{{ .ctx.region }}
-          svc: 
+          svc:
             istio:
               targetVersion: "asm-1-26"
               versions: "asm-1-26,asm-1-28"
@@ -1298,7 +1298,7 @@ clouds:
                 maxCount: 12
             istio:
               targetVersion: "asm-1-26"
-              versions: "asm-1-26,asm-1-28"                
+              versions: "asm-1-26,asm-1-28"
           mgmt:
             aks:
               systemAgentPool:
@@ -1468,7 +1468,7 @@ clouds:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
             istio:
               targetVersion: "asm-1-26"
-              versions: "asm-1-26,asm-1-28"              
+              versions: "asm-1-26,asm-1-28"
           mgmt:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"
             aks:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1161,8 +1161,8 @@ clouds:
         nsp:
           accessMode: 'Learning'
         istio:
-          targetVersion: "asm-1-26"
-          versions: "asm-1-26,asm-1-28"
+          targetVersion: "asm-1-28"
+          versions: "asm-1-28"
         aks:
           etcd:
             softDelete: false
@@ -1240,6 +1240,10 @@ clouds:
         # this is the integrated DEV environment
         defaults:
           regionRG: hcp-underlay-{{ .ctx.environment }}-{{ .ctx.region }}
+          svc: 
+            istio:
+              targetVersion: "asm-1-26"
+              versions: "asm-1-26,asm-1-28"
           mgmt:
             aks:
               systemAgentPool:
@@ -1292,6 +1296,9 @@ clouds:
               userAgentPool:
                 minCount: 2
                 maxCount: 12
+            istio:
+              targetVersion: "asm-1-26"
+              versions: "asm-1-26,asm-1-28"                
           mgmt:
             aks:
               systemAgentPool:
@@ -1437,9 +1444,6 @@ clouds:
           # SVC
           svc:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
-            istio:
-              targetVersion: "asm-1-28"
-              versions: "asm-1-28"
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
               userAgentPool:
@@ -1462,6 +1466,9 @@ clouds:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
+            istio:
+              targetVersion: "asm-1-26"
+              versions: "asm-1-26,asm-1-28"              
           mgmt:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"
             aks:
@@ -1613,9 +1620,6 @@ clouds:
           # SVC
           svc:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
-            istio:
-              targetVersion: "asm-1-28"
-              versions: "asm-1-28"
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
               userAgentPool:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -895,8 +895,8 @@ svc:
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
     istioctlVersion: 1.29.1
     tag: prod-stable
-    targetVersion: asm-1-26
-    versions: asm-1-26,asm-1-28
+    targetVersion: asm-1-28
+    versions: asm-1-28
   nsp:
     accessMode: Learning
     name: nsp-lnstest-svc


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Broken swift environments which don't have istio asm-1-28 revision defined.

```
az aks mesh get-revisions -l uksouth | jq -r '.[].[].revision'
asm-1-27
asm-1-28
asm-1-29
```
### Why

We need to continuously upgrade istio to ensure it's not out of support.  This should not impact any INT/Stage/Prod envs as they have their own defaults defined in config in sdp-pipelines.  

Swift environment is treated as ephemeral.  Therefore, we should update this to 1-28.  Trevor is working on updating non-ephemeral (perf, dev, cspr) using canary upgrades.  

### Testing

Ran `DEPLOY_ENV=swft make entrypoint/Region` locally.  

### Note:
Since this is just updating dev environments, I have no problem changing `targetVersion` at the same time I remove the older version, even though they happen in order.  

If this were to apply itself to an int/stage/prod environment as is, i believe there would be downtime on our istio external gateway because we remove the version we're actively using.  

In dev envs, it's not a big deal since it _should_ just work if you're upgrading.  