### PR TITLE
fix: make upgrade-aks-cluster step exclusive in svc and mgmt pipelines

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -292,7 +292,7 @@ resourceGroups:
         name: subscriptionId
     dependsOn:
     - resourceGroup: management
-      step: cluster
+      step: upgrade-aks-cluster
     - resourceGroup: management
       step: infra
   - name: cluster-output
@@ -305,7 +305,7 @@ resourceGroups:
     - resourceGroup: regional
       step: output
     - resourceGroup: management
-      step: cluster
+      step: upgrade-aks-cluster
   - name: exporter-permissions
     action: ARM
     template: templates/exporter-permissions.bicep
@@ -373,7 +373,7 @@ resourceGroups:
         name: prometheusUAMIClientId
     dependsOn:
     - resourceGroup: management
-      step: cluster
+      step: upgrade-aks-cluster
     identityFrom:
       resourceGroup: global
       step: output
@@ -438,7 +438,7 @@ resourceGroups:
     kustoTable: 'containerLogs'
     dependsOn:
     - resourceGroup: management
-      step: cluster
+      step: upgrade-aks-cluster
     identityFrom:
       resourceGroup: global
       step: output
@@ -466,7 +466,7 @@ resourceGroups:
     kustoTable: 'containerLogs'
     dependsOn:
     - resourceGroup: management
-      step: cluster
+      step: upgrade-aks-cluster
     identityFrom:
       resourceGroup: global
       step: output
@@ -492,7 +492,7 @@ resourceGroups:
     kustoTable: 'containerLogs'
     dependsOn:
     - resourceGroup: management
-      step: cluster
+      step: upgrade-aks-cluster
     identityFrom:
       resourceGroup: global
       step: output
@@ -511,7 +511,7 @@ resourceGroups:
     outputOnly: true
     dependsOn:
     - resourceGroup: management
-      step: cluster
+      step: upgrade-aks-cluster
   - name: arobit
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Helm
@@ -566,7 +566,7 @@ resourceGroups:
     kustoTable: 'containerLogs'
     dependsOn:
     - resourceGroup: management
-      step: cluster
+      step: upgrade-aks-cluster
     identityFrom:
       resourceGroup: global
       step: output

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -227,7 +227,7 @@ resourceGroups:
     - resourceGroup: regional
       step: output
     - resourceGroup: service
-      step: cluster
+      step: upgrade-aks-cluster
   - name: kusto-ingest-service-logs
     action: ARM
     template: templates/kusto-grant-ingest.bicep
@@ -290,7 +290,7 @@ resourceGroups:
         name: prometheusUAMIClientId
     dependsOn:
     - resourceGroup: service
-      step: cluster
+      step: upgrade-aks-cluster
     identityFrom:
       resourceGroup: global
       step: output
@@ -411,7 +411,7 @@ resourceGroups:
     outputOnly: true
     dependsOn:
     - resourceGroup: service
-      step: cluster
+      step: upgrade-aks-cluster
   - name: arobit
     aksCluster: '{{ .svc.aks.name }}'
     action: Helm
@@ -466,7 +466,7 @@ resourceGroups:
     kustoTable: 'containerLogs'
     dependsOn:
     - resourceGroup: service
-      step: cluster
+      step: upgrade-aks-cluster
     identityFrom:
       resourceGroup: global
       step: output
@@ -511,7 +511,7 @@ resourceGroups:
     outputOnly: true
     dependsOn:
     - resourceGroup: service
-      step: cluster
+      step: upgrade-aks-cluster
   - name: exporter-permissions
     action: ARM
     template: templates/exporter-permissions.bicep
@@ -541,7 +541,7 @@ resourceGroups:
     kustoTable: 'containerLogs'
     dependsOn:
     - resourceGroup: service
-      step: cluster
+      step: upgrade-aks-cluster
     - resourceGroup: service
       step: prometheus
     - resourceGroup: service


### PR DESCRIPTION
### What

Change all pipeline steps that depended on `cluster` to depend on `upgrade-aks-cluster` instead, in both `svc-pipeline.yaml` and `mgmt-pipeline.yaml`.

### Why

Previously, steps like prometheus, storageclass, mitigations, kube-events, arobit, etc. depended directly on the `cluster` step, which meant they could run in parallel with `delete-*-nodepools` and `upgrade-aks-cluster`. This caused conflicts when workloads were deployed to a cluster mid-upgrade.

By making all downstream steps depend on `upgrade-aks-cluster`, we create an exclusive window: `cluster` → `delete-nodepools` → `upgrade-aks-cluster` → everything else. No workloads deploy until the upgrade is complete.

### Testing

Pipeline YAML-only change. Verified dependency graph correctness by reviewing all `dependsOn` references in both files.

### Special notes for your reviewer

- 8 steps changed in `mgmt-pipeline.yaml`: nsp, cluster-output, prometheus, storageclass, mitigations, kubelet-ds, arobit-output, kube-events
- 6 steps changed in `svc-pipeline.yaml`: cluster-output, prometheus, arobit-output, kube-events, exporter-output, aro-hcp-exporter
- Steps that already depended on `upgrade-aks-cluster` or on another step that transitively depends on it (e.g. `arobit` depends on `prometheus`) were left unchanged
