### PR TITLE
observability: backend panic and maestro alerts

### DIFF
--- a/backend/alerts/backend-prometheusRule.yaml
+++ b/backend/alerts/backend-prometheusRule.yaml
@@ -46,7 +46,7 @@ spec:
         ) > 0.5
       for: 10m
       labels:
-        severity: critical
+        severity: warning
       annotations:
         description: 'Backend controller workqueue {{ $labels.name }} has a retry ratio of > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
         runbook_url: 'TBD'
@@ -65,3 +65,15 @@ spec:
         description: 'Backend controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed.'
         runbook_url: 'TBD'
         summary: 'Backend controller workqueue {{ $labels.name }} depth is high'
+    - alert: BackendControllerPanic
+      expr: |
+        sum by (controller, cluster) (
+          increase(panic_total{namespace="aro-hcp"}[5m])
+        ) > 0
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        description: 'Backend controller {{ $labels.controller }} has panicked {{ printf "%.0f" $value }} time(s) in the last 5 minutes.'
+        runbook_url: 'TBD'
+        summary: 'Backend controller {{ $labels.controller }} is panicking'

--- a/backend/alerts/backend-prometheusRule_test.yaml
+++ b/backend/alerts/backend-prometheusRule_test.yaml
@@ -43,7 +43,7 @@ tests:
     exp_alerts:
     - exp_labels:
         name: OperationClusterCreate
-        severity: critical
+        severity: warning
       exp_annotations:
         description: 'Backend controller workqueue OperationClusterCreate has a retry ratio of > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
         runbook_url: 'TBD'
@@ -83,4 +83,29 @@ tests:
   alert_rule_test:
   - eval_time: 6m
     alertname: BackendControllerQueueDepthHigh
+    exp_alerts: []
+# Test: BackendControllerPanic fires when panics occur
+- interval: 1m
+  input_series:
+  - series: 'panic_total{controller="DoNothingExample", namespace="aro-hcp"}'
+    values: "0 1 2 3 4 5 6 7 8 9 10"
+  alert_rule_test:
+  - eval_time: 6m
+    alertname: BackendControllerPanic
+    exp_alerts:
+    - exp_labels:
+        controller: DoNothingExample
+        severity: warning
+      exp_annotations:
+        description: 'Backend controller DoNothingExample has panicked 5 time(s) in the last 5 minutes.'
+        runbook_url: 'TBD'
+        summary: 'Backend controller DoNothingExample is panicking'
+# Test: BackendControllerPanic does not fire when no panics
+- interval: 1m
+  input_series:
+  - series: 'panic_total{controller="DoNothingExample", namespace="aro-hcp"}'
+    values: "0+0x10"
+  alert_rule_test:
+  - eval_time: 6m
+    alertname: BackendControllerPanic
     exp_alerts: []

--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -1363,7 +1363,7 @@ resource msftPrometheusOperatorRules 'Microsoft.AlertsManagement/prometheusRuleG
           title: 'Resources rejected by Prometheus operator'
         }
         expression: 'min_over_time(prometheus_operator_managed_resources{job="prometheus-operator",namespace="prometheus",state="rejected"}[5m]) > 0'
-        for: 'PT5M'
+        for: 'PT20M'
         severity: 3
       }
     ]

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -338,48 +338,8 @@ resource prometheusOperatorRules 'Microsoft.AlertsManagement/prometheusRuleGroup
           title: 'Resources rejected by Prometheus operator'
         }
         expression: 'min_over_time(prometheus_operator_managed_resources{job="prometheus-operator",namespace="prometheus",state="rejected"}[5m]) > 0'
-        for: 'PT5M'
+        for: 'PT20M'
         severity: 3
-      }
-    ]
-    scopes: [
-      azureMonitoring
-    ]
-  }
-}
-
-resource mise 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
-  name: 'mise'
-  location: location
-  properties: {
-    interval: 'PT1M'
-    rules: [
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'MiseEnvoyScrapeDown'
-        enabled: true
-        labels: {
-          severity: 'info'
-        }
-        annotations: {
-          correlationId: 'MiseEnvoyScrapeDown/{{ $labels.cluster }}'
-          description: 'Prometheus scrape for envoy-stats job in namespace mise is failing or missing.'
-          info: 'Prometheus scrape for envoy-stats job in namespace mise is failing or missing.'
-          runbook_url: 'TBD'
-          summary: 'Envoy scrape target down for namespace=mise'
-          title: 'Envoy scrape target down for namespace=mise'
-        }
-        expression: 'group by (cluster) (up{job="kube-state-metrics", cluster=~".*-svc(-[0-9]+)?$"}) unless on(cluster) group by (cluster) (up{endpoint="http-envoy-prom", container="istio-proxy", namespace="mise"} == 1)'
-        for: 'PT5M'
-        severity: 4
       }
     ]
     scopes: [
@@ -741,7 +701,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'BackendControllerRetryHotLoop'
         enabled: true
         labels: {
-          severity: 'critical'
+          severity: 'warning'
         }
         annotations: {
           correlationId: 'BackendControllerRetryHotLoop/{{ $labels.cluster }}/{{ $labels.name }}'
@@ -780,6 +740,33 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         }
         expression: 'max by (name, cluster) ( max without(prometheus_replica) ( workqueue_depth{namespace="aro-hcp"} ) ) > 10'
         for: 'PT5M'
+        severity: 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'BackendControllerPanic'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'BackendControllerPanic/{{ $labels.cluster }}/{{ $labels.controller }}'
+          description: 'Backend controller {{ $labels.controller }} has panicked {{ printf "%.0f" $value }} time(s) in the last 5 minutes.'
+          info: 'Backend controller {{ $labels.controller }} has panicked {{ printf "%.0f" $value }} time(s) in the last 5 minutes.'
+          runbook_url: 'TBD'
+          summary: 'Backend controller {{ $labels.controller }} is panicking'
+          title: 'Backend controller {{ $labels.controller }} is panicking'
+        }
+        expression: 'sum by (controller, cluster) ( increase(panic_total{namespace="aro-hcp"}[5m]) ) > 0'
+        for: 'PT1M'
         severity: 3
       }
     ]
@@ -848,6 +835,127 @@ resource adminApi 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
         expression: 'otel_audit_log_connection_degraded{job="aro-hcp-admin-api-metrics"} == 1'
         for: 'PT5M'
         severity: 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
+resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'maestro'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'MaestroGRPCSourceClientExcessConnections'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'MaestroGRPCSourceClientExcessConnections/{{ $labels.cluster }}'
+          description: 'Maestro gRPC server has {{ $value }} registered source clients, which is unusually high. Only clusters-service and backend are expected as source clients. This may indicate a connection leak or clients failing to unregister.'
+          info: 'Maestro gRPC server has {{ $value }} registered source clients, which is unusually high. Only clusters-service and backend are expected as source clients. This may indicate a connection leak or clients failing to unregister.'
+          runbook_url: 'TBD'
+          summary: 'Maestro has too many gRPC source client connections'
+          title: 'Maestro has too many gRPC source client connections'
+        }
+        expression: 'sum(grpc_server_registered_source_clients{namespace="maestro"}) > 100'
+        for: 'PT10M'
+        severity: 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'MaestroRESTAPIErrorRate'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'MaestroRESTAPIErrorRate/{{ $labels.cluster }}'
+          description: 'Maestro REST API 5xx error rate is above 5% for the last 5 minutes. Current value: {{ $value | humanizePercentage }}.'
+          info: 'Maestro REST API 5xx error rate is above 5% for the last 5 minutes. Current value: {{ $value | humanizePercentage }}.'
+          runbook_url: 'TBD'
+          summary: 'Maestro REST API error rate is high'
+          title: 'Maestro REST API error rate is high'
+        }
+        expression: 'sum(rate(rest_api_inbound_request_count{namespace="maestro", code=~"5.."}[5m])) / sum(rate(rest_api_inbound_request_count{namespace="maestro"}[5m])) > 0.05'
+        for: 'PT5M'
+        severity: 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'MaestroGRPCServerErrorRate'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'MaestroGRPCServerErrorRate/{{ $labels.cluster }}'
+          description: 'Maestro gRPC server error rate is above 5% for the last 5 minutes. Current value: {{ $value | humanizePercentage }}.'
+          info: 'Maestro gRPC server error rate is above 5% for the last 5 minutes. Current value: {{ $value | humanizePercentage }}.'
+          runbook_url: 'TBD'
+          summary: 'Maestro gRPC server error rate is high'
+          title: 'Maestro gRPC server error rate is high'
+        }
+        expression: 'sum(rate(grpc_server_processed_total{namespace="maestro", code!="OK"}[5m])) / sum(rate(grpc_server_processed_total{namespace="maestro"}[5m])) > 0.05'
+        for: 'PT5M'
+        severity: 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'MaestroSpecControllerReconcileErrors'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'MaestroSpecControllerReconcileErrors/{{ $labels.cluster }}'
+          description: 'Maestro spec controller reconcile error rate is above 10% for the last 10 minutes. Resources may not be reaching management clusters. Current value: {{ $value | humanizePercentage }}.'
+          info: 'Maestro spec controller reconcile error rate is above 10% for the last 10 minutes. Resources may not be reaching management clusters. Current value: {{ $value | humanizePercentage }}.'
+          runbook_url: 'TBD'
+          summary: 'Maestro spec controller reconcile error rate is high'
+          title: 'Maestro spec controller reconcile error rate is high'
+        }
+        expression: 'sum(rate(spec_controller_event_reconcile_total{namespace="maestro", status="error"}[5m])) / sum(rate(spec_controller_event_reconcile_total{namespace="maestro"}[5m])) > 0.1'
+        for: 'PT10M'
+        severity: 3
       }
     ]
     scopes: [

--- a/maestro/alerts/maestro-prometheusRule.yaml
+++ b/maestro/alerts/maestro-prometheusRule.yaml
@@ -1,0 +1,79 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: alert-rules
+  name: maestro-monitoring-rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: maestro
+    rules:
+    - alert: MaestroGRPCSourceClientExcessConnections
+      # Fires when the number of registered gRPC source clients is
+      # unusually high. Only clusters-service and backend connect as
+      # source clients, so a sustained count above 100 indicates a
+      # connection leak or clients failing to unregister properly.
+      expr: |
+        sum(grpc_server_registered_source_clients{namespace="maestro"}) > 100
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        description: 'Maestro gRPC server has {{ $value }} registered source clients, which is unusually high. Only clusters-service and backend are expected as source clients. This may indicate a connection leak or clients failing to unregister.'
+        runbook_url: 'TBD'
+        summary: 'Maestro has too many gRPC source client connections'
+    - alert: MaestroRESTAPIErrorRate
+      # Fires when the 5xx error rate on the Maestro REST API exceeds
+      # 5%. Clusters-service and backend use this API to create, update,
+      # and delete resources. A sustained error rate means resource
+      # CRUD operations are failing.
+      expr: |
+        sum(rate(rest_api_inbound_request_count{namespace="maestro", code=~"5.."}[5m]))
+        /
+        sum(rate(rest_api_inbound_request_count{namespace="maestro"}[5m]))
+        > 0.05
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        description: 'Maestro REST API 5xx error rate is above 5% for the last 5 minutes. Current value: {{ $value | humanizePercentage }}.'
+        runbook_url: 'TBD'
+        summary: 'Maestro REST API error rate is high'
+    - alert: MaestroGRPCServerErrorRate
+      # Fires when the gRPC error rate exceeds 5%. The gRPC server
+      # handles publish (spec distribution) and subscribe (status
+      # callbacks) operations. Errors here break resource distribution
+      # to management clusters.
+      expr: |
+        sum(rate(grpc_server_processed_total{namespace="maestro", code!="OK"}[5m]))
+        /
+        sum(rate(grpc_server_processed_total{namespace="maestro"}[5m]))
+        > 0.05
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        description: 'Maestro gRPC server error rate is above 5% for the last 5 minutes. Current value: {{ $value | humanizePercentage }}.'
+        runbook_url: 'TBD'
+        summary: 'Maestro gRPC server error rate is high'
+    - alert: MaestroSpecControllerReconcileErrors
+      # Fires when the spec controller reconcile error rate exceeds
+      # 10%. The spec controller distributes resource specs to
+      # management cluster work agents. Sustained errors mean resources
+      # are not reaching their target clusters.
+      expr: |
+        sum(rate(spec_controller_event_reconcile_total{namespace="maestro", status="error"}[5m]))
+        /
+        sum(rate(spec_controller_event_reconcile_total{namespace="maestro"}[5m]))
+        > 0.1
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        description: 'Maestro spec controller reconcile error rate is above 10% for the last 10 minutes. Resources may not be reaching management clusters. Current value: {{ $value | humanizePercentage }}.'
+        runbook_url: 'TBD'
+        summary: 'Maestro spec controller reconcile error rate is high'

--- a/maestro/alerts/maestro-prometheusRule_test.yaml
+++ b/maestro/alerts/maestro-prometheusRule_test.yaml
@@ -1,0 +1,112 @@
+rule_files:
+- maestro-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# Test: MaestroGRPCSourceClientExcessConnections fires when > 100 clients for 10m
+- interval: 1m
+  input_series:
+  - series: 'grpc_server_registered_source_clients{namespace="maestro", source="maestro"}'
+    values: "125x15" # 125 clients sustained for 15 minutes
+  alert_rule_test:
+  - eval_time: 11m
+    alertname: MaestroGRPCSourceClientExcessConnections
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+      exp_annotations:
+        description: 'Maestro gRPC server has 125 registered source clients, which is unusually high. Only clusters-service and backend are expected as source clients. This may indicate a connection leak or clients failing to unregister.'
+        runbook_url: 'TBD'
+        summary: 'Maestro has too many gRPC source client connections'
+# Test: MaestroGRPCSourceClientExcessConnections does not fire when <= 100
+- interval: 1m
+  input_series:
+  - series: 'grpc_server_registered_source_clients{namespace="maestro", source="maestro"}'
+    values: "50x15" # 50 clients (within normal range)
+  alert_rule_test:
+  - eval_time: 11m
+    alertname: MaestroGRPCSourceClientExcessConnections
+    exp_alerts: []
+# Test: MaestroRESTAPIErrorRate fires when 5xx rate > 5%
+- interval: 1m
+  input_series:
+  - series: 'rest_api_inbound_request_count{namespace="maestro", code="500", method="POST", path="/api/maestro/v1/resources"}'
+    values: "0+6x10" # 6 errors per minute
+  - series: 'rest_api_inbound_request_count{namespace="maestro", code="200", method="POST", path="/api/maestro/v1/resources"}'
+    values: "0+94x10" # 94 successes per minute → 6/100 = 6% error rate
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: MaestroRESTAPIErrorRate
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+      exp_annotations:
+        description: 'Maestro REST API 5xx error rate is above 5% for the last 5 minutes. Current value: 6%.'
+        runbook_url: 'TBD'
+        summary: 'Maestro REST API error rate is high'
+# Test: MaestroRESTAPIErrorRate does not fire when 5xx rate < 5%
+- interval: 1m
+  input_series:
+  - series: 'rest_api_inbound_request_count{namespace="maestro", code="500", method="POST", path="/api/maestro/v1/resources"}'
+    values: "0+2x10" # 2 errors per minute
+  - series: 'rest_api_inbound_request_count{namespace="maestro", code="200", method="POST", path="/api/maestro/v1/resources"}'
+    values: "0+98x10" # 98 successes per minute → 2/100 = 2%
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: MaestroRESTAPIErrorRate
+    exp_alerts: []
+# Test: MaestroGRPCServerErrorRate fires when error rate > 5%
+- interval: 1m
+  input_series:
+  - series: 'grpc_server_processed_total{namespace="maestro", code="Internal", type="publish", source="maestro"}'
+    values: "0+8x10" # 8 errors per minute
+  - series: 'grpc_server_processed_total{namespace="maestro", code="OK", type="publish", source="maestro"}'
+    values: "0+92x10" # 92 successes per minute → 8/100 = 8%
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: MaestroGRPCServerErrorRate
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+      exp_annotations:
+        description: 'Maestro gRPC server error rate is above 5% for the last 5 minutes. Current value: 8%.'
+        runbook_url: 'TBD'
+        summary: 'Maestro gRPC server error rate is high'
+# Test: MaestroGRPCServerErrorRate does not fire when error rate < 5%
+- interval: 1m
+  input_series:
+  - series: 'grpc_server_processed_total{namespace="maestro", code="Internal", type="publish", source="maestro"}'
+    values: "0+2x10" # 2 errors per minute
+  - series: 'grpc_server_processed_total{namespace="maestro", code="OK", type="publish", source="maestro"}'
+    values: "0+98x10" # 98 successes per minute → 2/100 = 2%
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: MaestroGRPCServerErrorRate
+    exp_alerts: []
+# Test: MaestroSpecControllerReconcileErrors fires when error rate > 10%
+- interval: 1m
+  input_series:
+  - series: 'spec_controller_event_reconcile_total{namespace="maestro", status="error", event_type="create"}'
+    values: "0+15x20" # 15 errors per minute
+  - series: 'spec_controller_event_reconcile_total{namespace="maestro", status="success", event_type="create"}'
+    values: "0+85x20" # 85 successes per minute → 15/100 = 15%
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: MaestroSpecControllerReconcileErrors
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+      exp_annotations:
+        description: 'Maestro spec controller reconcile error rate is above 10% for the last 10 minutes. Resources may not be reaching management clusters. Current value: 15%.'
+        runbook_url: 'TBD'
+        summary: 'Maestro spec controller reconcile error rate is high'
+# Test: MaestroSpecControllerReconcileErrors does not fire when error rate < 10%
+- interval: 1m
+  input_series:
+  - series: 'spec_controller_event_reconcile_total{namespace="maestro", status="error", event_type="create"}'
+    values: "0+5x20" # 5 errors per minute
+  - series: 'spec_controller_event_reconcile_total{namespace="maestro", status="success", event_type="create"}'
+    values: "0+95x20" # 95 successes per minute → 5/100 = 5%
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: MaestroSpecControllerReconcileErrors
+    exp_alerts: []

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -125,7 +125,7 @@ spec:
         summary: Prometheus operator not ready
     - alert: PrometheusOperatorRejectedResources
       expr: min_over_time(prometheus_operator_managed_resources{job="prometheus-operator",namespace="prometheus",state="rejected"}[5m]) > 0
-      for: 5m
+      for: 20m
       labels:
         severity: warning
       annotations:

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -165,9 +165,9 @@ tests:
 - interval: 1m
   input_series:
   - series: 'prometheus_operator_managed_resources{job="prometheus-operator",namespace="prometheus",state="rejected",controller="prometheus",resource="prometheusrule"}'
-    values: "5+0x10"
+    values: "5+0x30"
   alert_rule_test:
-  - eval_time: 5m
+  - eval_time: 25m
     alertname: PrometheusOperatorRejectedResources
     exp_alerts:
     - exp_labels:
@@ -334,11 +334,11 @@ tests:
 - interval: 1m
   input_series:
   - series: 'prometheus_operator_managed_resources{job="prometheus-operator",namespace="prometheus",state="rejected",controller="prometheus",resource="servicemonitor"}'
-    values: "3+0x10"
+    values: "3+0x30"
   - series: 'prometheus_operator_managed_resources{job="prometheus-operator",namespace="prometheus",state="rejected",controller="prometheus",resource="podmonitor"}'
-    values: "2+0x10"
+    values: "2+0x30"
   alert_rule_test:
-  - eval_time: 5m
+  - eval_time: 25m
     alertname: PrometheusOperatorRejectedResources
     exp_alerts:
     - exp_labels:
@@ -577,20 +577,20 @@ tests:
 - interval: 1m
   input_series:
   - series: 'prometheus_operator_managed_resources{job="prometheus-operator",namespace="prometheus",state="rejected",controller="prometheus",resource="prometheusrule"}'
-    values: "0+0x10"
+    values: "0+0x30"
   alert_rule_test:
-  - eval_time: 5m
+  - eval_time: 25m
     alertname: PrometheusOperatorRejectedResources
     exp_alerts: []
 # Test PrometheusOperatorRejectedResources with mixed states
 - interval: 1m
   input_series:
   - series: 'prometheus_operator_managed_resources{job="prometheus-operator",namespace="prometheus",state="rejected",controller="prometheus",resource="prometheusrule"}'
-    values: "2+0x10"
+    values: "2+0x30"
   - series: 'prometheus_operator_managed_resources{job="prometheus-operator",namespace="prometheus",state="created",controller="prometheus",resource="prometheusrule"}'
-    values: "10+0x10"
+    values: "10+0x30"
   alert_rule_test:
-  - eval_time: 5m
+  - eval_time: 25m
     alertname: PrometheusOperatorRejectedResources
     exp_alerts:
     - exp_labels:

--- a/observability/observability.yaml
+++ b/observability/observability.yaml
@@ -1,11 +1,11 @@
 prometheusRules:
   rulesFolders:
   - ../observability/alerts/prometheus-prometheusRule.yaml
-  - ../frontend/alerts/mise-prometheusRule.yaml
   - ../frontend/alerts/frontend-prometheusRule.yaml
   - ../cluster-service/alerts/cluster-service-slo-rules.yaml
   - ../backend/alerts/backend-prometheusRule.yaml
   - ../admin/alerts/admin-prometheusRule.yaml
+  - ../maestro/alerts/maestro-prometheusRule.yaml
   - ../observability/alerts/arobit-prometheusRule.yaml
   - alerts/service-tag-public-ip-usage.yaml
   - ../observability/alerts/HCPdeletionStuck-prometheusRule.yaml

--- a/test/cmd/aro-hcp-tests/gather-observability/artifacts/alerts.html.tmpl
+++ b/test/cmd/aro-hcp-tests/gather-observability/artifacts/alerts.html.tmpl
@@ -159,6 +159,53 @@
       color: #58a6ff;
     }
 
+    /* Collapsible known-issue alerts */
+    details.alert-card-known {
+      list-style: none;
+    }
+    details.alert-card-known > summary {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      cursor: pointer;
+      user-select: none;
+      list-style: none;
+    }
+    details.alert-card-known > summary::-webkit-details-marker { display: none; }
+    details.alert-card-known > summary::before {
+      content: "\25B6";
+      font-size: 10px;
+      color: #8b949e;
+      transition: transform 0.15s;
+    }
+    details[open].alert-card-known > summary::before {
+      transform: rotate(90deg);
+    }
+    details.alert-card-known > summary .badge { padding: 2px 8px; font-size: 12px; }
+    .alert-title-inline {
+      font-size: 15px;
+      font-weight: 700;
+      color: #e6edf3;
+    }
+    .known-reason-inline {
+      font-size: 13px;
+      color: #d29922;
+      margin-left: auto;
+    }
+    .known-reason-inline strong {
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+      font-size: 11px;
+      background: rgba(158, 106, 3, 0.15);
+      padding: 2px 6px;
+      border-radius: 3px;
+      border: 1px solid #9e6a03;
+    }
+    .alert-details-body {
+      margin-top: 12px;
+    }
+
     /* Collapsible PromQL */
     details.query-details {
       margin-top: 8px;
@@ -219,7 +266,42 @@
   </div>
 
   {{range .Alerts}}
-  <div class="alert-card{{if .Metadata.KnownIssue}} alert-card-known{{end}}">
+  {{if .Metadata.KnownIssue}}
+  <details class="alert-card alert-card-known">
+    <summary>
+      <span class="badge {{severityClass .Alert.Severity}}">{{.Alert.Severity}}</span>
+      <span class="{{conditionClass .Alert.Condition}}">{{.Alert.Condition}}</span>
+      <span class="alert-title-inline">{{.Alert.Name}}</span>
+      <span class="known-reason-inline">{{.Metadata.KnownIssueReason}} <strong>Known Issue</strong></span>
+    </summary>
+    <div class="alert-details-body">
+      <div class="alert-header">
+        <span class="alert-time">
+          Fired: {{formatTime .Alert.StartsAt}} {{relativeTime $.TimeWindow.Start .Alert.StartsAt}}{{if .Alert.EndsAt}} &middot; Resolved: {{formatTime .Alert.EndsAt}} {{relativeTime $.TimeWindow.Start .Alert.EndsAt}}{{end}}
+        </span>
+      </div>
+      {{if .Alert.Description}}<div class="alert-description">{{.Alert.Description}}</div>{{end}}
+
+      {{if .Alert.Labels}}
+      <div class="alert-labels">
+        {{range $k, $v := .Alert.Labels}}<span class="label-chip"><span class="label-key">{{$k}}</span>=<span>{{$v}}</span></span>{{end}}
+      </div>
+      {{end}}
+
+      {{with annotation .Alert.Annotations "runbook_url"}}{{if ne . "TBD"}}
+      <div class="alert-links"><a href="{{.}}" target="_blank" rel="noopener">View Runbook &rarr;</a></div>
+      {{end}}{{end}}
+
+      {{if .Alert.Expression}}
+      <details class="query-details">
+        <summary>View PromQL Query</summary>
+        <div class="alert-expr">{{.Alert.Expression}}</div>
+      </details>
+      {{end}}
+    </div>
+  </details>
+  {{else}}
+  <div class="alert-card">
     <div class="alert-header">
       <span class="badge {{severityClass .Alert.Severity}}">{{.Alert.Severity}}</span>
       <span class="{{conditionClass .Alert.Condition}}">{{.Alert.Condition}}</span>
@@ -228,9 +310,6 @@
       </span>
     </div>
     <div class="alert-title">{{.Alert.Name}}</div>
-    {{if .Metadata.KnownIssueReason}}
-    <div class="known-reason"><strong>Known Issue:</strong> {{.Metadata.KnownIssueReason}}</div>
-    {{end}}
     {{if .Alert.Description}}<div class="alert-description">{{.Alert.Description}}</div>{{end}}
 
     {{if .Alert.Labels}}
@@ -250,6 +329,7 @@
     </details>
     {{end}}
   </div>
+  {{end}}
   {{end}}
 
   {{if not .HasUnknownAlerts}}

--- a/test/cmd/aro-hcp-tests/gather-observability/knownIssues.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/knownIssues.yaml
@@ -7,7 +7,15 @@ knownIssues:
   labels:
     name: "operationnodepooldelete"
   reason: "Nodepool delete controller retry hot loops are observed during e2e runs. Needs investigation."
-- name: "LowOutputBytesProcessed"
-  reason: "Fluent Bit output bytes can drop during e2e cluster provisioning and teardown while pods restart or clusters scale."
-- name: "prometheusJobUp"
-  reason: "Prometheus job up alerts are expected during e2e runs as clusters and pods are created and destroyed."
+- name: "BackendControllerRetryHotLoop"
+  labels:
+    name: "operationexternalauthcreate"
+  reason: "ExternalAuth create controller retry hot loops are observed during e2e runs. Needs investigation."
+- name: "BackendControllerRetryHotLoop"
+  labels:
+    name: "operationexternalauthupdate"
+  reason: "ExternalAuth update controller retry hot loops are observed during e2e runs. Needs investigation."
+- name: "BackendControllerRetryHotLoop"
+  labels:
+    name: "operationexternalauthdelete"
+  reason: "ExternalAuth delete controller retry hot loops are observed during e2e runs. Needs investigation."

--- a/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
@@ -38,6 +38,14 @@ panels:
       ) > 0
     workspace: svc
     step: "60s"
+  - title: "Controller Panic Rate"
+    description: "Rate of panics caught by the runtime panic handler, per controller. Any non-zero rate indicates a controller is actively crashing and recovering via the panic handler."
+    query: |
+      sum by (controller, cluster) (
+        rate(panic_total{namespace="aro-hcp"}[5m])
+      ) > 0
+    workspace: svc
+    step: "60s"
 - title: "Maestro"
   queries:
   - title: "REST API Request Rate by Status"


### PR DESCRIPTION
### What

* added BackendControllerPanic alert to detect panics caught by the runtime panic handler
* added Maestro alerts: MaestroGRPCSourceClientExcessConnections, MaestroRESTAPIErrorRate, MaestroGRPCServerErrorRate, MaestroSpecControllerReconcileErrors
* removed mise alert from non-msft alerts
* Increase PrometheusOperatorRejectedResources for duration from 5m to 20m to reduce noise during infra provisioning
* known issues require less screen estate in gather-observability rendering
* registered known issues for backend external auth controllers

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
