### PR TITLE
upgrade AKS only if needed and wait until cluster upgrade is finished

### DIFF
--- a/dev-infrastructure/scripts/upgrade-aks-cluster.sh
+++ b/dev-infrastructure/scripts/upgrade-aks-cluster.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -euo pipefail
-}
 
 # Inputs via environment variables:
 #   RESOURCE_GROUP - Resource group containing the cluster
@@ -9,6 +8,7 @@ set -euo pipefail
 
 version_greater_than() {
     [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" != "$1" ]
+}
 
 echo "Checking if cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' needs upgrade to '${KUBERNETES_VERSION}'..."
 

--- a/dev-infrastructure/scripts/upgrade-aks-cluster.sh
+++ b/dev-infrastructure/scripts/upgrade-aks-cluster.sh
@@ -14,8 +14,8 @@ echo "Checking if cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' needs upgr
 
 # Get current control plane version
 CURRENT_CP_VERSION=$(az aks show \
-    --resource-group ${RESOURCE_GROUP} \
-    --name ${CLUSTER_NAME} \
+    --resource-group "${RESOURCE_GROUP}" \
+    --name "${CLUSTER_NAME}" \
     --query currentKubernetesVersion \
     --output tsv)
 
@@ -34,8 +34,8 @@ fi
 # Get node pool versions and check if any need upgrade
 echo "Checking node pool versions..."
 NODE_POOLS=$(az aks nodepool list \
-    --resource-group ${RESOURCE_GROUP} \
-    --cluster-name ${CLUSTER_NAME} \
+    --resource-group "${RESOURCE_GROUP}" \
+    --cluster-name "${CLUSTER_NAME}" \
     --query '[].{name:name,version:orchestratorVersion}' \
     --output tsv)
 
@@ -60,15 +60,15 @@ fi
 echo "Upgrading cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' to '${KUBERNETES_VERSION}'..."
 
 az aks upgrade \
-    --resource-group ${RESOURCE_GROUP} \
-    --name ${CLUSTER_NAME} \
-    --kubernetes-version ${KUBERNETES_VERSION} \
+    --resource-group "${RESOURCE_GROUP}" \
+    --name "${CLUSTER_NAME}" \
+    --kubernetes-version "${KUBERNETES_VERSION}" \
     --yes
 
 echo "Waiting for upgrade to complete..."
 az aks wait \
-    --resource-group ${RESOURCE_GROUP} \
-    --name ${CLUSTER_NAME} \
+    --resource-group "${RESOURCE_GROUP}" \
+    --name "${CLUSTER_NAME}" \
     --updated \
     --timeout 3600
 

--- a/dev-infrastructure/scripts/upgrade-aks-cluster.sh
+++ b/dev-infrastructure/scripts/upgrade-aks-cluster.sh
@@ -1,10 +1,61 @@
 #!/bin/bash
 set -euo pipefail
+}
 
 # Inputs via environment variables:
-#   CLUSTER_NAME   - AKS cluster name
 #   RESOURCE_GROUP - Resource group containing the cluster
+#   CLUSTER_NAME   - AKS cluster name
 #   KUBERNETES_VERSION - Kubernetes Version
+
+version_greater_than() {
+    [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" != "$1" ]
+
+echo "Checking if cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' needs upgrade to '${KUBERNETES_VERSION}'..."
+
+# Get current control plane version
+CURRENT_CP_VERSION=$(az aks show \
+    --resource-group ${RESOURCE_GROUP} \
+    --name ${CLUSTER_NAME} \
+    --query currentKubernetesVersion \
+    --output tsv)
+
+echo "Current control plane version: ${CURRENT_CP_VERSION}"
+echo "Target version: ${KUBERNETES_VERSION}"
+
+# Check if control plane needs upgrade
+NEEDS_UPGRADE=false
+if version_greater_than "${KUBERNETES_VERSION}" "${CURRENT_CP_VERSION}"; then
+    echo "Control plane needs upgrade from ${CURRENT_CP_VERSION} to ${KUBERNETES_VERSION}"
+    NEEDS_UPGRADE=true
+else
+    echo "Control plane is at ${CURRENT_CP_VERSION}, target is ${KUBERNETES_VERSION} - no upgrade needed"
+fi
+
+# Get node pool versions and check if any need upgrade
+echo "Checking node pool versions..."
+NODE_POOLS=$(az aks nodepool list \
+    --resource-group ${RESOURCE_GROUP} \
+    --cluster-name ${CLUSTER_NAME} \
+    --query '[].{name:name,version:orchestratorVersion}' \
+    --output tsv)
+
+if [ -n "${NODE_POOLS}" ]; then
+    while IFS=$'\t' read -r POOL_NAME POOL_VERSION; do
+        echo "  Node pool '${POOL_NAME}': ${POOL_VERSION}"
+
+        if version_greater_than "${KUBERNETES_VERSION}" "${POOL_VERSION}"; then
+            echo "  Node pool '${POOL_NAME}' needs upgrade from ${POOL_VERSION} to ${KUBERNETES_VERSION}"
+            NEEDS_UPGRADE=true
+        else
+            echo "  Node pool '${POOL_NAME}' is at ${POOL_VERSION}, target is ${KUBERNETES_VERSION} - no upgrade needed"
+        fi
+    done <<< "${NODE_POOLS}"
+fi
+
+if [ "${NEEDS_UPGRADE}" = "false" ]; then
+    echo "Cluster does not need upgrade - all components are at or above target version ${KUBERNETES_VERSION}."
+    exit 0
+fi
 
 echo "Upgrading cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' to '${KUBERNETES_VERSION}'..."
 
@@ -13,4 +64,13 @@ az aks upgrade \
     --name ${CLUSTER_NAME} \
     --kubernetes-version ${KUBERNETES_VERSION} \
     --yes
+
+echo "Waiting for upgrade to complete..."
+az aks wait \
+    --resource-group ${RESOURCE_GROUP} \
+    --name ${CLUSTER_NAME} \
+    --updated \
+    --timeout 3600
+
+echo "Upgrade completed successfully."
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-25883

### What

Makes sure that the az cli AKS upgrade is only triggered when needed - and that the script that calls it (upgrade-aks-cluster.sh) will wait until the upgrade is finished in case.

### Why

https://github.com/Azure/ARO-HCP/pull/4836 upgrades AKS cluster using a shell script (upgrade-aks-cluster.sh) that performs the upgrade (via az cli) - but we experienced problems during the rollout. @geoberle & @raelga deduced, that the upgrade causes problems when run in parallel to other pipeline steps. To resolve this, @raelga  created https://github.com/Azure/ARO-HCP/pull/4868 - which makes sure that following steps will wait for the upgrade-aks-cluster step. As that step does not wait for update completion, this is not sufficient. This will be resolved with the current PR.

### Testing

- manual testing (target version smaller, equal or greater than actual version - via pure script execution and also make personal-dev-env)
- e2e test will (hopefully) show that everything still works afterwards (upgrade will not be triggered by the test, but is handled in the rollout)

### Special notes for your reviewer

<!-- optional -->
