### PR TITLE
Switch systemd input to filesystem storage type

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -39,7 +39,7 @@ data:
         storage.path              /var/fluent-bit/flb-storage
         # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
         # (default: 128)
-        storage.max_chunks_up     128
+        storage.max_chunks_up     256
         # This option configure a hint of maximum value of memory to use when processing the backlog data.
         # (default: 5M)
         storage.backlog.mem_limit 50M
@@ -71,28 +71,12 @@ data:
         DB                /var/log/flb-tail.db
         DB.sync           normal
         DB.locking        true
-        # The interval of refreshing the list of watched files in seconds.
-        # (default: 60)
         Refresh_Interval  15
-        # For new discovered files on start (without a database offset/position), read the content from the head of the file.
-        # (default: off)
         Read_from_Head    On
-        # Set the initial buffer size to read files data. This value is used to increase buffer size.
-        # (default: 32K)
         Buffer_Chunk_Size 128K
-        # Set the limit of the buffer size per monitored file. When a buffer needs to be increased (e.g: very long lines),
-        # this value is used to restrict how much the memory buffer can grow.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
-        # When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file.
-        # Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size.
-        # (default: Off)
         Skip_Long_Lines   On
-        # Set a limit of memory that Tail plugin can use when appending data to the Engine.
-        # If the limit is reach, it will be paused; when the data is flushed it resumes.
-        Mem_Buf_Limit     50M
         storage.type      filesystem
-        # The new threaded mechanism allows input plugins to run in a separate thread which helps to desaturate the main pipeline
         Threaded          On
 
     [INPUT]
@@ -100,12 +84,7 @@ data:
         Alias             input.forward
         Listen            0.0.0.0
         Port              24224
-        # By default, the buffer to store the incoming Forward messages, do not allocate the maximum memory allowed,
-        # instead it allocate memory when is required. The rounds of allocations are set by Buffer_Chunk_Size.
-        # (default: 32KB)
         Buffer_Chunk_Size 128K
-        # Specify the maximum buffer memory size used to receive a Forward message.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
         Mem_Buf_Limit     50M
 
@@ -130,6 +109,8 @@ data:
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
+        Threaded          On
+        storage.type      filesystem
   filter.conf: |
     [FILTER]
         Name modify
@@ -463,7 +444,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 6c565f8cf24e82b1c51675d76905b1a1f55a5ba96e1bb26ec501f4e2256aec89
+        checksum/configmap: 9afe0b0e572704d69b07e4e38b66ed79a51a992261adcae0e6f8ca0f207442f3
     spec:
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -39,7 +39,7 @@ data:
         storage.path              /var/fluent-bit/flb-storage
         # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
         # (default: 128)
-        storage.max_chunks_up     128
+        storage.max_chunks_up     256
         # This option configure a hint of maximum value of memory to use when processing the backlog data.
         # (default: 5M)
         storage.backlog.mem_limit 50M
@@ -71,28 +71,12 @@ data:
         DB                /var/log/flb-tail.db
         DB.sync           normal
         DB.locking        true
-        # The interval of refreshing the list of watched files in seconds.
-        # (default: 60)
         Refresh_Interval  15
-        # For new discovered files on start (without a database offset/position), read the content from the head of the file.
-        # (default: off)
         Read_from_Head    On
-        # Set the initial buffer size to read files data. This value is used to increase buffer size.
-        # (default: 32K)
         Buffer_Chunk_Size 128K
-        # Set the limit of the buffer size per monitored file. When a buffer needs to be increased (e.g: very long lines),
-        # this value is used to restrict how much the memory buffer can grow.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
-        # When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file.
-        # Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size.
-        # (default: Off)
         Skip_Long_Lines   On
-        # Set a limit of memory that Tail plugin can use when appending data to the Engine.
-        # If the limit is reach, it will be paused; when the data is flushed it resumes.
-        Mem_Buf_Limit     50M
         storage.type      filesystem
-        # The new threaded mechanism allows input plugins to run in a separate thread which helps to desaturate the main pipeline
         Threaded          On
 
     [INPUT]
@@ -100,12 +84,7 @@ data:
         Alias             input.forward
         Listen            0.0.0.0
         Port              24224
-        # By default, the buffer to store the incoming Forward messages, do not allocate the maximum memory allowed,
-        # instead it allocate memory when is required. The rounds of allocations are set by Buffer_Chunk_Size.
-        # (default: 32KB)
         Buffer_Chunk_Size 128K
-        # Specify the maximum buffer memory size used to receive a Forward message.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
         Mem_Buf_Limit     50M
 
@@ -130,6 +109,8 @@ data:
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
+        Threaded          On
+        storage.type      filesystem
   filter.conf: |
     [FILTER]
         Name modify
@@ -440,7 +421,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 0a3fb63ac3381955fb0b19200437d20f40152a106d0b4d8e77c9d81f0b583271
+        checksum/configmap: 3fb766bdf40341544c6336207a928fec85e0c84648636dd57385d6f3ae7d985d
     spec:
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true

--- a/observability/arobit/deploy/templates/forwarder-configmap.yaml
+++ b/observability/arobit/deploy/templates/forwarder-configmap.yaml
@@ -45,7 +45,7 @@ data:
         storage.path              /var/fluent-bit/flb-storage
         # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
         # (default: 128)
-        storage.max_chunks_up     128
+        storage.max_chunks_up     256
         # This option configure a hint of maximum value of memory to use when processing the backlog data.
         # (default: 5M)
         storage.backlog.mem_limit 50M
@@ -77,28 +77,12 @@ data:
         DB                /var/log/flb-tail.db
         DB.sync           normal
         DB.locking        true
-        # The interval of refreshing the list of watched files in seconds.
-        # (default: 60)
         Refresh_Interval  15
-        # For new discovered files on start (without a database offset/position), read the content from the head of the file.
-        # (default: off)
         Read_from_Head    On
-        # Set the initial buffer size to read files data. This value is used to increase buffer size.
-        # (default: 32K)
         Buffer_Chunk_Size 128K
-        # Set the limit of the buffer size per monitored file. When a buffer needs to be increased (e.g: very long lines),
-        # this value is used to restrict how much the memory buffer can grow.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
-        # When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file.
-        # Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size.
-        # (default: Off)
         Skip_Long_Lines   On
-        # Set a limit of memory that Tail plugin can use when appending data to the Engine.
-        # If the limit is reach, it will be paused; when the data is flushed it resumes.
-        Mem_Buf_Limit     50M
         storage.type      filesystem
-        # The new threaded mechanism allows input plugins to run in a separate thread which helps to desaturate the main pipeline
         Threaded          On
 
     [INPUT]
@@ -106,12 +90,7 @@ data:
         Alias             input.forward
         Listen            0.0.0.0
         Port              24224
-        # By default, the buffer to store the incoming Forward messages, do not allocate the maximum memory allowed,
-        # instead it allocate memory when is required. The rounds of allocations are set by Buffer_Chunk_Size.
-        # (default: 32KB)
         Buffer_Chunk_Size 128K
-        # Specify the maximum buffer memory size used to receive a Forward message.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
         Mem_Buf_Limit     50M
 
@@ -136,6 +115,8 @@ data:
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
+        Threaded          On
+        storage.type      filesystem
   filter.conf: |
     [FILTER]
         Name modify

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
@@ -39,7 +39,7 @@ data:
         storage.path              /var/fluent-bit/flb-storage
         # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
         # (default: 128)
-        storage.max_chunks_up     128
+        storage.max_chunks_up     256
         # This option configure a hint of maximum value of memory to use when processing the backlog data.
         # (default: 5M)
         storage.backlog.mem_limit 50M
@@ -71,28 +71,12 @@ data:
         DB                /var/log/flb-tail.db
         DB.sync           normal
         DB.locking        true
-        # The interval of refreshing the list of watched files in seconds.
-        # (default: 60)
         Refresh_Interval  15
-        # For new discovered files on start (without a database offset/position), read the content from the head of the file.
-        # (default: off)
         Read_from_Head    On
-        # Set the initial buffer size to read files data. This value is used to increase buffer size.
-        # (default: 32K)
         Buffer_Chunk_Size 128K
-        # Set the limit of the buffer size per monitored file. When a buffer needs to be increased (e.g: very long lines),
-        # this value is used to restrict how much the memory buffer can grow.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
-        # When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file.
-        # Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size.
-        # (default: Off)
         Skip_Long_Lines   On
-        # Set a limit of memory that Tail plugin can use when appending data to the Engine.
-        # If the limit is reach, it will be paused; when the data is flushed it resumes.
-        Mem_Buf_Limit     50M
         storage.type      filesystem
-        # The new threaded mechanism allows input plugins to run in a separate thread which helps to desaturate the main pipeline
         Threaded          On
 
     [INPUT]
@@ -100,12 +84,7 @@ data:
         Alias             input.forward
         Listen            0.0.0.0
         Port              24224
-        # By default, the buffer to store the incoming Forward messages, do not allocate the maximum memory allowed,
-        # instead it allocate memory when is required. The rounds of allocations are set by Buffer_Chunk_Size.
-        # (default: 32KB)
         Buffer_Chunk_Size 128K
-        # Specify the maximum buffer memory size used to receive a Forward message.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
         Mem_Buf_Limit     50M
 
@@ -130,6 +109,8 @@ data:
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
+        Threaded          On
+        storage.type      filesystem
   filter.conf: |
     [FILTER]
         Name modify
@@ -379,7 +360,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: c75cea0e6b533eac396742ab33ea2d14531887056906d92a3773e690720d0a8d
+        checksum/configmap: 49ad24d064241d58dbdcf15dded3d32901f320110de9a827f2ed85bfe2946764
     spec:
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -38,7 +38,7 @@ data:
         storage.path              /var/fluent-bit/flb-storage
         # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
         # (default: 128)
-        storage.max_chunks_up     128
+        storage.max_chunks_up     256
         # This option configure a hint of maximum value of memory to use when processing the backlog data.
         # (default: 5M)
         storage.backlog.mem_limit 50M
@@ -70,28 +70,12 @@ data:
         DB                /var/log/flb-tail.db
         DB.sync           normal
         DB.locking        true
-        # The interval of refreshing the list of watched files in seconds.
-        # (default: 60)
         Refresh_Interval  15
-        # For new discovered files on start (without a database offset/position), read the content from the head of the file.
-        # (default: off)
         Read_from_Head    On
-        # Set the initial buffer size to read files data. This value is used to increase buffer size.
-        # (default: 32K)
         Buffer_Chunk_Size 128K
-        # Set the limit of the buffer size per monitored file. When a buffer needs to be increased (e.g: very long lines),
-        # this value is used to restrict how much the memory buffer can grow.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
-        # When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file.
-        # Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size.
-        # (default: Off)
         Skip_Long_Lines   On
-        # Set a limit of memory that Tail plugin can use when appending data to the Engine.
-        # If the limit is reach, it will be paused; when the data is flushed it resumes.
-        Mem_Buf_Limit     50M
         storage.type      filesystem
-        # The new threaded mechanism allows input plugins to run in a separate thread which helps to desaturate the main pipeline
         Threaded          On
 
     [INPUT]
@@ -99,12 +83,7 @@ data:
         Alias             input.forward
         Listen            0.0.0.0
         Port              24224
-        # By default, the buffer to store the incoming Forward messages, do not allocate the maximum memory allowed,
-        # instead it allocate memory when is required. The rounds of allocations are set by Buffer_Chunk_Size.
-        # (default: 32KB)
         Buffer_Chunk_Size 128K
-        # Specify the maximum buffer memory size used to receive a Forward message.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
         Mem_Buf_Limit     50M
 
@@ -129,6 +108,8 @@ data:
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
+        Threaded          On
+        storage.type      filesystem
   filter.conf: |
     [FILTER]
         Name modify
@@ -439,7 +420,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 9de59d94e206c0c671cdd44c59539ce19033f4af5b974a1eb1a636aa052f6c0a
+        checksum/configmap: 58b2807afa24ee46f3ba427bcab6b89eed552a06c7be382344ca476e428a96e0
     spec:
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
@@ -39,7 +39,7 @@ data:
         storage.path              /var/fluent-bit/flb-storage
         # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
         # (default: 128)
-        storage.max_chunks_up     128
+        storage.max_chunks_up     256
         # This option configure a hint of maximum value of memory to use when processing the backlog data.
         # (default: 5M)
         storage.backlog.mem_limit 50M
@@ -71,28 +71,12 @@ data:
         DB                /var/log/flb-tail.db
         DB.sync           normal
         DB.locking        true
-        # The interval of refreshing the list of watched files in seconds.
-        # (default: 60)
         Refresh_Interval  15
-        # For new discovered files on start (without a database offset/position), read the content from the head of the file.
-        # (default: off)
         Read_from_Head    On
-        # Set the initial buffer size to read files data. This value is used to increase buffer size.
-        # (default: 32K)
         Buffer_Chunk_Size 128K
-        # Set the limit of the buffer size per monitored file. When a buffer needs to be increased (e.g: very long lines),
-        # this value is used to restrict how much the memory buffer can grow.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
-        # When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file.
-        # Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size.
-        # (default: Off)
         Skip_Long_Lines   On
-        # Set a limit of memory that Tail plugin can use when appending data to the Engine.
-        # If the limit is reach, it will be paused; when the data is flushed it resumes.
-        Mem_Buf_Limit     50M
         storage.type      filesystem
-        # The new threaded mechanism allows input plugins to run in a separate thread which helps to desaturate the main pipeline
         Threaded          On
 
     [INPUT]
@@ -100,12 +84,7 @@ data:
         Alias             input.forward
         Listen            0.0.0.0
         Port              24224
-        # By default, the buffer to store the incoming Forward messages, do not allocate the maximum memory allowed,
-        # instead it allocate memory when is required. The rounds of allocations are set by Buffer_Chunk_Size.
-        # (default: 32KB)
         Buffer_Chunk_Size 128K
-        # Specify the maximum buffer memory size used to receive a Forward message.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
         Mem_Buf_Limit     50M
 
@@ -130,6 +109,8 @@ data:
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
+        Threaded          On
+        storage.type      filesystem
   filter.conf: |
     [FILTER]
         Name modify
@@ -440,7 +421,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 231a646cae4ac5cd54692c2ba80c8ef67342ce15aaa1afcaa0c78a257a5a1bba
+        checksum/configmap: 643e5d82eececc106e29c6bb0118bada1ea34a79cb0bfab0656b2a682448a450
     spec:
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -41,7 +41,7 @@ data:
         storage.path              /var/fluent-bit/flb-storage
         # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
         # (default: 128)
-        storage.max_chunks_up     128
+        storage.max_chunks_up     256
         # This option configure a hint of maximum value of memory to use when processing the backlog data.
         # (default: 5M)
         storage.backlog.mem_limit 50M
@@ -73,28 +73,12 @@ data:
         DB                /var/log/flb-tail.db
         DB.sync           normal
         DB.locking        true
-        # The interval of refreshing the list of watched files in seconds.
-        # (default: 60)
         Refresh_Interval  15
-        # For new discovered files on start (without a database offset/position), read the content from the head of the file.
-        # (default: off)
         Read_from_Head    On
-        # Set the initial buffer size to read files data. This value is used to increase buffer size.
-        # (default: 32K)
         Buffer_Chunk_Size 128K
-        # Set the limit of the buffer size per monitored file. When a buffer needs to be increased (e.g: very long lines),
-        # this value is used to restrict how much the memory buffer can grow.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
-        # When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file.
-        # Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size.
-        # (default: Off)
         Skip_Long_Lines   On
-        # Set a limit of memory that Tail plugin can use when appending data to the Engine.
-        # If the limit is reach, it will be paused; when the data is flushed it resumes.
-        Mem_Buf_Limit     50M
         storage.type      filesystem
-        # The new threaded mechanism allows input plugins to run in a separate thread which helps to desaturate the main pipeline
         Threaded          On
 
     [INPUT]
@@ -102,12 +86,7 @@ data:
         Alias             input.forward
         Listen            0.0.0.0
         Port              24224
-        # By default, the buffer to store the incoming Forward messages, do not allocate the maximum memory allowed,
-        # instead it allocate memory when is required. The rounds of allocations are set by Buffer_Chunk_Size.
-        # (default: 32KB)
         Buffer_Chunk_Size 128K
-        # Specify the maximum buffer memory size used to receive a Forward message.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
         Mem_Buf_Limit     50M
 
@@ -132,6 +111,8 @@ data:
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
+        Threaded          On
+        storage.type      filesystem
   filter.conf: |
     [FILTER]
         Name modify
@@ -610,7 +591,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 65a05c04c5786078eb5ff61b96923ccdd1868ac7fb1c72e481fcddacc15918b6
+        checksum/configmap: 5eddbcc6b7c0b33ba4639aad4bb8da430ddb92a59020259f2ac48fdd4da2fe65
     spec:
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -39,7 +39,7 @@ data:
         storage.path              /var/fluent-bit/flb-storage
         # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
         # (default: 128)
-        storage.max_chunks_up     128
+        storage.max_chunks_up     256
         # This option configure a hint of maximum value of memory to use when processing the backlog data.
         # (default: 5M)
         storage.backlog.mem_limit 50M
@@ -71,28 +71,12 @@ data:
         DB                /var/log/flb-tail.db
         DB.sync           normal
         DB.locking        true
-        # The interval of refreshing the list of watched files in seconds.
-        # (default: 60)
         Refresh_Interval  15
-        # For new discovered files on start (without a database offset/position), read the content from the head of the file.
-        # (default: off)
         Read_from_Head    On
-        # Set the initial buffer size to read files data. This value is used to increase buffer size.
-        # (default: 32K)
         Buffer_Chunk_Size 128K
-        # Set the limit of the buffer size per monitored file. When a buffer needs to be increased (e.g: very long lines),
-        # this value is used to restrict how much the memory buffer can grow.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
-        # When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file.
-        # Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size.
-        # (default: Off)
         Skip_Long_Lines   On
-        # Set a limit of memory that Tail plugin can use when appending data to the Engine.
-        # If the limit is reach, it will be paused; when the data is flushed it resumes.
-        Mem_Buf_Limit     50M
         storage.type      filesystem
-        # The new threaded mechanism allows input plugins to run in a separate thread which helps to desaturate the main pipeline
         Threaded          On
 
     [INPUT]
@@ -100,12 +84,7 @@ data:
         Alias             input.forward
         Listen            0.0.0.0
         Port              24224
-        # By default, the buffer to store the incoming Forward messages, do not allocate the maximum memory allowed,
-        # instead it allocate memory when is required. The rounds of allocations are set by Buffer_Chunk_Size.
-        # (default: 32KB)
         Buffer_Chunk_Size 128K
-        # Specify the maximum buffer memory size used to receive a Forward message.
-        # (default: Buffer_Chunk_Size)
         Buffer_Max_Size   2M
         Mem_Buf_Limit     50M
 
@@ -130,6 +109,8 @@ data:
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
+        Threaded          On
+        storage.type      filesystem
   filter.conf: |
     [FILTER]
         Name modify
@@ -440,7 +421,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: a0fcc32e8558386825bfafdfeb6ac9c22d00ca09d9e50cdb7bbea3d27ab34b14
+        checksum/configmap: 4c45c3d9e10f0ef64d3d79de3d1f0c75bc4faad17fdb8bc09707c9480d1ec992
     spec:
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true


### PR DESCRIPTION


### What/Why
Buffer inputs on FS to redurce pressure on Memory. Remove Memory limit, as it is only relevent for Memory storage type. Increase storage.max_chunks_up, cause systemd also uses it now.

Relevant documentation: https://docs.fluentbit.io/manual/4.0/administration/backpressure
