### PR TITLE
Embed nodepool listing test cases into nodepool_update_nodes.go

### DIFF
--- a/test/e2e/nodepool_update_nodes.go
+++ b/test/e2e/nodepool_update_nodes.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -32,7 +33,7 @@ import (
 )
 
 var _ = Describe("Customer", func() {
-	It("should be able to update nodepool replicas and autoscaling",
+	It("should be able to update nodepool replicas and autoscaling as well as list node pools by cluster and resource group",
 		labels.RequireNothing,
 		labels.High,
 		labels.Positive,
@@ -69,9 +70,65 @@ var _ = Describe("Customer", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 
+			verifyNodePoolListByCluster := func(ctx context.Context, rgName, clusterName string, expectedNodePoolNames []string) {
+				npClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
+				pager := npClient.NewListByParentPager(rgName, clusterName, nil)
+
+				var listedNodePoolNames []string
+				for pager.More() {
+					page, err := pager.NextPage(ctx)
+					Expect(err).NotTo(HaveOccurred(), "failed to list node pools by cluster %s", clusterName)
+					for _, np := range page.Value {
+						Expect(np.ID).NotTo(BeNil(), "listed node pool ID was nil in cluster %s", clusterName)
+						Expect(*np.ID).NotTo(BeEmpty(), "listed node pool ID was empty in cluster %s", clusterName)
+						if np.Name != nil {
+							listedNodePoolNames = append(listedNodePoolNames, *np.Name)
+						}
+					}
+				}
+
+				Expect(listedNodePoolNames).To(ConsistOf(expectedNodePoolNames), "expected %v node pools listed by cluster %s, got %v", expectedNodePoolNames, clusterName, listedNodePoolNames)
+			}
+
+			verifyNodePoolListByRG := func(ctx context.Context, rgName string, expectedNodePoolNames []string) {
+				clientFactory := tc.Get20240610ClientFactoryOrDie(ctx)
+				hcpClient := clientFactory.NewHcpOpenShiftClustersClient()
+				npClient := clientFactory.NewNodePoolsClient()
+
+				clusterPager := hcpClient.NewListByResourceGroupPager(rgName, nil)
+
+				var listedNodePoolNames []string
+				for clusterPager.More() {
+					clusterPage, err := clusterPager.NextPage(ctx)
+					Expect(err).NotTo(HaveOccurred(), "failed to list clusters in resource group %s", rgName)
+					for _, cluster := range clusterPage.Value {
+						if cluster.Name == nil {
+							continue
+						}
+						npPager := npClient.NewListByParentPager(rgName, *cluster.Name, nil)
+						for npPager.More() {
+							npPage, err := npPager.NextPage(ctx)
+							Expect(err).NotTo(HaveOccurred(), "failed to list node pools for cluster %s in resource group %s", *cluster.Name, rgName)
+							for _, np := range npPage.Value {
+								Expect(np.ID).NotTo(BeNil(), "listed node pool ID was nil in cluster %s", *cluster.Name)
+								Expect(*np.ID).NotTo(BeEmpty(), "listed node pool ID was empty in cluster %s", *cluster.Name)
+								if np.Name != nil {
+									listedNodePoolNames = append(listedNodePoolNames, *np.Name)
+								}
+							}
+						}
+					}
+				}
+
+				Expect(listedNodePoolNames).To(ConsistOf(expectedNodePoolNames), "expected %v node pools listed by resource group %s, got %v", expectedNodePoolNames, rgName, listedNodePoolNames)
+			}
+
 			By("creating a resource group")
 			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-update-nodes", tc.Location())
 			Expect(err).NotTo(HaveOccurred())
+
+			By("listing node pools by empty resource group")
+			verifyNodePoolListByRG(ctx, *resourceGroup.Name, []string{})
 
 			By("creating cluster parameters")
 			clusterParams := framework.NewDefaultClusterParams()
@@ -98,6 +155,9 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
+			By("listing node pools by cluster without node pools")
+			verifyNodePoolListByCluster(ctx, *resourceGroup.Name, customerClusterName, []string{})
+
 			By("getting admin credentials for the cluster")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
@@ -108,7 +168,7 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("creating three node pools in parallel")
+			By(fmt.Sprintf("creating %d node pools in parallel", deployedNodePoolsNumber))
 			scaleDownParams := framework.NewDefaultNodePoolParams()
 			scaleDownParams.NodePoolName = scaleDownNodePoolName
 			scaleDownParams.Replicas = scaleDownNodePoolInitialReplicas
@@ -150,6 +210,13 @@ var _ = Describe("Customer", func() {
 			By("verifying nodes count and status after initial creation")
 			Expect(verifiers.VerifyNodeCount(initialNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
 			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
+
+			deployedNodePoolNames := []string{scaleDownNodePoolName, scaleUpNodePoolName, autoscaleNodePoolName}
+			By(fmt.Sprintf("listing node pools by cluster after creating %d node pools", deployedNodePoolsNumber))
+			verifyNodePoolListByCluster(ctx, *resourceGroup.Name, customerClusterName, deployedNodePoolNames)
+
+			By(fmt.Sprintf("listing node pools by resource group after creating %d node pools", deployedNodePoolsNumber))
+			verifyNodePoolListByRG(ctx, *resourceGroup.Name, deployedNodePoolNames)
 
 			By("scaling down, scaling up, and enabling autoscaling in parallel")
 			nodePoolsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
@@ -261,5 +328,11 @@ var _ = Describe("Customer", func() {
 			By("verifying nodes count and status after all updates")
 			Expect(verifiers.VerifyNodeCount(finalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
 			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
+
+			By("listing node pools by cluster after node pools updates")
+			verifyNodePoolListByCluster(ctx, *resourceGroup.Name, customerClusterName, deployedNodePoolNames)
+
+			By("listing node pools by resource group after node pools updates")
+			verifyNodePoolListByRG(ctx, *resourceGroup.Name, deployedNodePoolNames)
 		})
 })

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -60,7 +60,7 @@ Engineering should be able to retrieve kusto logs for a cluster and services
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
-Customer should be able to update nodepool replicas and autoscaling
+Customer should be able to update nodepool replicas and autoscaling as well as list node pools by cluster and resource group
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -62,7 +62,7 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
-Customer should be able to update nodepool replicas and autoscaling
+Customer should be able to update nodepool replicas and autoscaling as well as list node pools by cluster and resource group
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -61,7 +61,7 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
-Customer should be able to update nodepool replicas and autoscaling
+Customer should be able to update nodepool replicas and autoscaling as well as list node pools by cluster and resource group
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -63,7 +63,7 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
-Customer should be able to update nodepool replicas and autoscaling
+Customer should be able to update nodepool replicas and autoscaling as well as list node pools by cluster and resource group
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -58,7 +58,7 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
-Customer should be able to update nodepool replicas and autoscaling
+Customer should be able to update nodepool replicas and autoscaling as well as list node pools by cluster and resource group
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -61,7 +61,7 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
-Customer should be able to update nodepool replicas and autoscaling
+Customer should be able to update nodepool replicas and autoscaling as well as list node pools by cluster and resource group
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL


### PR DESCRIPTION
[ARO-21295](https://redhat.atlassian.net/browse/ARO-21295)

### What

Adds node pool listing validations into the existing `nodepool_update_nodes` E2E test. The listing is verified at four points in the test:

1. By resource group before the cluster is created - expect 0 node pools
2. By cluster after the cluster is created with 0 node pools - expect 0 node pools
3. By cluster and by resource group after all 3 node pools are created - expect all 3 listed
4. By cluster and by resource group after all node pools are updated - expect all 3 still listed

### Why

Node pool listing was identified as a use case that needs E2E test coverage (listing by cluster and by resource group). Instead of creating a dedicated test that deploys a new cluster solely for listing, the validations are embedded into the existing `nodepool_update_nodes` test which already creates a cluster and 3 node pools. This avoids adding cluster and nodepool creation time to the test suite.

Subscription-level listing is intentionally excluded, following the precedent set in [#4520](https://github.com/Azure/ARO-HCP/pull/4559): the subscription-level list fans out across all regions and can fail due to availability issues in unrelated regions, and the underlying code path is identical to the resource-group-level list.

### Testing

The change itself is the test. The listing helpers use `NodePoolsClient.NewListByParentPager` (by cluster) and `HcpOpenShiftClustersClient.NewListByResourceGroupPager` + `NewListByParentPager` (by resource group), both from the HCP SDK, so the `AroRpApiCompatible` label is preserved.