### PR TITLE
fix: update the issuer of the cspr federated identity on redeploy

### DIFF
--- a/cluster-service/cspr/deploy-resource-cleaner.sh
+++ b/cluster-service/cspr/deploy-resource-cleaner.sh
@@ -143,7 +143,14 @@ if az identity federated-credential show \
     --name "${FEDCRED_NAME}" \
     --identity-name "${MI_NAME}" \
     --resource-group "${RESOURCE_GROUP}" &>/dev/null; then
-    echo "  ✓ Federated credential ${FEDCRED_NAME} already exists"
+    echo "  Federated credential ${FEDCRED_NAME} already exists, updating..."
+    az identity federated-credential update \
+        --name "${FEDCRED_NAME}" \
+        --identity-name "${MI_NAME}" \
+        --resource-group "${RESOURCE_GROUP}" \
+        --issuer "${ISSUER_URL}" \
+        --subject "${SUBJECT}"
+    echo "  ✓ Federated credential updated"
 else
     echo "  Creating federated credential ${FEDCRED_NAME}..."
     az identity federated-credential create \


### PR DESCRIPTION
### What
Ensure that the issuer url and subject are always up to date upon redeploy of the cspr resource cleaner.

JIRA: https://redhat.atlassian.net/browse/ARO-25994

### Why
If the CSPR service cluster was re-created on its own, the issuer url used by the federated identity will change. We need to ensure that if the federated identity already exists, we should update the issuer url as part of the script to deploy the resource cleaner.

Also updating the subject, though it may not change all the time, updating in case that is also changed as part of the cspr recreation. 

This stemmed out of an issue in the current resource cleaner. It was failing due to mismatch of the issuer url when the cspr svc cleaner was re-created. The federated identity was fixed manually, but the changes in this PR should prevent this issue from happening in the future.

### Testing
N/A

### Special notes for your reviewer
N/A
