### PR TITLE
Add Azure Monitor Workspace ingestion limit alerts

### DIFF
--- a/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
+++ b/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
@@ -29,7 +29,7 @@ resource approachingActiveTimeSeries 'Microsoft.Insights/metricAlerts@2018-03-01
     evaluationFrequency: 'PT5M'
     windowSize: 'PT30M'
     criteria: {
-      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
       allOf: [
         {
           threshold: 75
@@ -63,7 +63,7 @@ resource highRiskActiveTimeSeries 'Microsoft.Insights/metricAlerts@2018-03-01' =
     evaluationFrequency: 'PT5M'
     windowSize: 'PT30M'
     criteria: {
-      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
       allOf: [
         {
           threshold: 95
@@ -97,7 +97,7 @@ resource approachingEventIngestion 'Microsoft.Insights/metricAlerts@2018-03-01' 
     evaluationFrequency: 'PT5M'
     windowSize: 'PT30M'
     criteria: {
-      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
       allOf: [
         {
           threshold: 75
@@ -131,7 +131,7 @@ resource highRiskEventIngestion 'Microsoft.Insights/metricAlerts@2018-03-01' = {
     evaluationFrequency: 'PT5M'
     windowSize: 'PT30M'
     criteria: {
-      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
       allOf: [
         {
           threshold: 95

--- a/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
+++ b/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
@@ -1,0 +1,152 @@
+@description('Resource ID of the Azure Monitor Workspace to monitor')
+param azureMonitorWorkspaceId string
+
+@description('Short name to identify the workspace in alert names (e.g. "svc" or "hcp")')
+param workspaceLabel string
+
+@description('Action group resource IDs to notify when alerts fire')
+param actionGroups array
+
+@description('Whether alerts are enabled')
+param enabled bool
+
+var amwName = last(split(azureMonitorWorkspaceId, '/'))
+
+// Severity 4 (Informational): approaching limits — capacity planning signal
+// Severity 3 (Warning): high risk of throttling — matches all other production alerts in the repo
+
+resource approachingActiveTimeSeries 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: 'AMW Approaching Active TimeSeries Limit - ${workspaceLabel} - ${amwName}'
+  location: 'global'
+  properties: {
+    description: 'Active Time Series utilization is above 75%. Plan a limit increase before throttling occurs. https://learn.microsoft.com/azure/azure-monitor/metrics/azure-monitor-workspace-monitor-ingest-limits'
+    severity: 4
+    enabled: enabled
+    autoMitigate: true
+    scopes: [
+      azureMonitorWorkspaceId
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT30M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          threshold: 75
+          name: 'ActiveTimeSeriesCriteria'
+          metricName: 'ActiveTimeSeriesPercentUtilization'
+          operator: 'GreaterThan'
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    actions: [
+      for g in actionGroups: {
+        actionGroupId: g
+      }
+    ]
+  }
+}
+
+resource highRiskActiveTimeSeries 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: 'AMW High Risk Active TimeSeries Limit - ${workspaceLabel} - ${amwName}'
+  location: 'global'
+  properties: {
+    description: 'Active Time Series utilization is above 95%. Throttling is imminent. Request a limit increase immediately. https://learn.microsoft.com/azure/azure-monitor/metrics/azure-monitor-workspace-monitor-ingest-limits'
+    severity: 3
+    enabled: enabled
+    autoMitigate: true
+    scopes: [
+      azureMonitorWorkspaceId
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT30M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          threshold: 95
+          name: 'ActiveTimeSeriesCriteria'
+          metricName: 'ActiveTimeSeriesPercentUtilization'
+          operator: 'GreaterThan'
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    actions: [
+      for g in actionGroups: {
+        actionGroupId: g
+      }
+    ]
+  }
+}
+
+resource approachingEventIngestion 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: 'AMW Approaching Event Ingestion Limit - ${workspaceLabel} - ${amwName}'
+  location: 'global'
+  properties: {
+    description: 'Events Per Minute utilization is above 75%. Plan a limit increase before throttling occurs. https://learn.microsoft.com/azure/azure-monitor/metrics/azure-monitor-workspace-monitor-ingest-limits'
+    severity: 4
+    enabled: enabled
+    autoMitigate: true
+    scopes: [
+      azureMonitorWorkspaceId
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT30M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          threshold: 75
+          name: 'EventsPerMinuteCriteria'
+          metricName: 'EventsPerMinuteIngestedPercentUtilization'
+          operator: 'GreaterThan'
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    actions: [
+      for g in actionGroups: {
+        actionGroupId: g
+      }
+    ]
+  }
+}
+
+resource highRiskEventIngestion 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: 'AMW High Risk Event Ingestion Limit - ${workspaceLabel} - ${amwName}'
+  location: 'global'
+  properties: {
+    description: 'Events Per Minute utilization is above 95%. Throttling is imminent. Request a limit increase immediately. https://learn.microsoft.com/azure/azure-monitor/metrics/azure-monitor-workspace-monitor-ingest-limits'
+    severity: 3
+    enabled: enabled
+    autoMitigate: true
+    scopes: [
+      azureMonitorWorkspaceId
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT30M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          threshold: 95
+          name: 'EventsPerMinuteCriteria'
+          metricName: 'EventsPerMinuteIngestedPercentUtilization'
+          operator: 'GreaterThan'
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    actions: [
+      for g in actionGroups: {
+        actionGroupId: g
+      }
+    ]
+  }
+}

--- a/dev-infrastructure/templates/monitoring.bicep
+++ b/dev-infrastructure/templates/monitoring.bicep
@@ -104,3 +104,23 @@ module msftAlerts '../modules/metrics/msft-rules.bicep' = {
     actionGroups: msftActionGroups
   }
 }
+
+module svcIngestionAlerts '../modules/metrics/amw-ingestion-alerts.bicep' = {
+  name: 'svcIngestionAlerts'
+  params: {
+    azureMonitorWorkspaceId: azureMonitoringWorkspaceId
+    workspaceLabel: 'svc'
+    actionGroups: sreActionGroups
+    enabled: alertsEnabled
+  }
+}
+
+module hcpIngestionAlerts '../modules/metrics/amw-ingestion-alerts.bicep' = {
+  name: 'hcpIngestionAlerts'
+  params: {
+    azureMonitorWorkspaceId: hcpAzureMonitoringWorkspaceId
+    workspaceLabel: 'hcp'
+    actionGroups: sreActionGroups
+    enabled: alertsEnabled
+  }
+}


### PR DESCRIPTION
## What

Adds metric alerts on Azure Monitor Workspace (AMW) ingestion utilization for both **svc** and **hcp** workspaces. Four alerts are created per workspace:

| Alert | Metric | Threshold | Severity | Purpose |
|-------|--------|-----------|----------|---------|
| Approaching Active TimeSeries Limit | `ActiveTimeSeriesPercentUtilization` | >75% avg | 4 (Informational) | Early warning for capacity planning |
| High Risk Active TimeSeries Limit | `ActiveTimeSeriesPercentUtilization` | >95% avg | 3 (Warning) | Throttling imminent |
| Approaching Event Ingestion Limit | `EventsPerMinuteIngestedPercentUtilization` | >75% avg | 4 (Informational) | Early warning for capacity planning |
| High Risk Event Ingestion Limit | `EventsPerMinuteIngestedPercentUtilization` | >95% avg | 3 (Warning) | Throttling imminent |

## Why

Without these alerts, if AMW ingestion hits its configured limit, Prometheus metrics get **silently throttled** — we lose observability data with no notification. The 75% alert gives the team time to plan a limit bump; the 95% alert signals that throttling is about to start.

This matches [Azure's recommended practice](https://learn.microsoft.com/azure/azure-monitor/metrics/azure-monitor-workspace-monitor-ingest-limits) for monitoring AMW ingestion limits.

## How

### New file: `dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep`

A reusable Bicep module that creates 4 `Microsoft.Insights/metricAlerts` resources on a given Azure Monitor Workspace. Key design decisions:

- **Thresholds and metric names** match Azure's recommended out-of-the-box alerts exactly
- **Severities** (3 and 4 only) are consistent with every other alert in the repo — no new paging tiers introduced
- **5-min evaluation / 30-min average window** filters transient spikes, avoids noisy alerts
- **`autoMitigate: true`** — alerts auto-resolve when utilization drops back below threshold
- **Parameterized** with `workspaceLabel` (e.g. "svc", "hcp") for clear alert naming

### Modified: `dev-infrastructure/templates/monitoring.bicep`

Added two module calls to deploy ingestion alerts for both workspaces:
- `svcIngestionAlerts` — monitors the services Azure Monitor Workspace
- `hcpIngestionAlerts` — monitors the hosted control planes Azure Monitor Workspace

Both route to the **SRE action group** and respect the existing `alertsEnabled` flag — no new config parameters needed.

## Deployment

- **Dev environments**: Auto-deploys after merge via GitHub Actions
- **Int/Stage/Prod**: Bump `Revision.mk` in sdp-pipelines, then trigger the `Microsoft.Azure.ARO.HCP.Monitoring` pipeline

## Ticket

[AROSLSRE-580: Set up alerting on Azure Monitor Workspace ingestion limits](https://redhat.atlassian.net/browse/AROSLSRE-580)