### PR TITLE
Make CS provision shard status configurable via Helm chart

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -75,6 +75,7 @@ deploy:
 	  --set shard.maestroGrpUrl="maestro-grpc.maestro.svc.cluster.local:8090" \
 	  --set shard.Id=$(PROVISION_SHARD_ID) \
 	  --set shard.aksManagementClusterResourceId=$(AKS_MGMT_CLUSTER_RESOURCE_ID) \
+	  --set shard.status=$(PROVISION_SHARD_STATUS) \
 	  --set databaseHost=$${DB_HOST} \
 	  --set azureMiMockServicePrincipalPrincipalId=${AZURE_MI_MOCK_SERVICE_PRINCIPAL_PRINCIPAL_ID} \
 	  --set azureMiMockServicePrincipalClientId=${AZURE_MI_MOCK_SERVICE_PRINCIPAL_CLIENT_ID} \

--- a/cluster-service/helm-charts/cluster-service/templates/provisioning-shards.secret.yaml
+++ b/cluster-service/helm-charts/cluster-service/templates/provisioning-shards.secret.yaml
@@ -15,7 +15,7 @@ stringData:
         grpc_api_config:
           url: "{{ .Values.shard.maestroGrpUrl }}"
         consumer_name: "{{ .Values.shard.consumerName }}"
-      status: active
+      status: {{ .Values.shard.status }}
       region: '{{ .Values.region }}'
       cloud_provider: azure
       topology: shared

--- a/cluster-service/helm-charts/cluster-service/values.yaml
+++ b/cluster-service/helm-charts/cluster-service/values.yaml
@@ -196,6 +196,7 @@ shard:
   maestroRestUrl: ""
   maestroGrpUrl: ""
   aksManagementClusterResourceId: ""
+  status: ""
 # ocm client id
 clientId: "foo"
 # ocm secret

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -166,6 +166,8 @@ resourceGroups:
         resourceGroup: global
         step: output
         name: ocpAcrLoginServer
+    - name: PROVISION_SHARD_STATUS
+      configRef: clustersService.provisionShardStatus
     - name: PROVISION_SHARD_CLUSTER_LIMIT
       configRef: clustersService.provisionShardClusterLimit
     - name: OCP_VERSIONS_DEFAULT_VERSION_VERSION

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1143,6 +1143,11 @@
           "type": "integer",
           "description": "The maximum number of HCPs that can be placed on an MC, sadly not configurable per MC"
         },
+        "provisionShardStatus": {
+          "type": "string",
+          "enum": ["active", "maintenance"],
+          "description": "Status of the provision shard"
+        },
         "k8s": {
           "$ref": "#/definitions/k8sDeployment"
         },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -891,6 +891,7 @@ defaults:
       digest: sha256:b70f064cad11f7374d475e7078826912d07451c0389dc00de21bb723ca0761c5 # 28911b36ad59807e10fb4443679ec676f206ebf2 (2026-04-09 16:18)
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
+    provisionShardStatus: active
     # batch processes
     batchProcessesDryRun: true
     batchProcesses: ""

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -218,6 +218,7 @@ clustersService:
     serverVersion: "17"
     zoneRedundantMode: Auto
   provisionShardClusterLimit: 100
+  provisionShardStatus: active
   tracing:
     address: ""
     exporter: ""

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -218,6 +218,7 @@ clustersService:
     serverVersion: "17"
     zoneRedundantMode: Auto
   provisionShardClusterLimit: 100
+  provisionShardStatus: active
   tracing:
     address: ""
     exporter: ""

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -218,6 +218,7 @@ clustersService:
     serverVersion: "17"
     zoneRedundantMode: Auto
   provisionShardClusterLimit: 100
+  provisionShardStatus: active
   tracing:
     address: ""
     exporter: ""

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -218,6 +218,7 @@ clustersService:
     serverVersion: "17"
     zoneRedundantMode: Auto
   provisionShardClusterLimit: 100
+  provisionShardStatus: active
   tracing:
     address: http://ingest.observability:4318
     exporter: otlp

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -218,6 +218,7 @@ clustersService:
     serverVersion: "17"
     zoneRedundantMode: Auto
   provisionShardClusterLimit: 100
+  provisionShardStatus: active
   tracing:
     address: http://ingest.observability:4318
     exporter: otlp

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -218,6 +218,7 @@ clustersService:
     serverVersion: "17"
     zoneRedundantMode: Auto
   provisionShardClusterLimit: 100
+  provisionShardStatus: active
   tracing:
     address: ""
     exporter: ""


### PR DESCRIPTION
### What

The provision shard status was hardcoded to active in the CS Helm chart. This change makes it configurable through the standard config pipeline with the default remaining `active`.

While we will likely not require this, it is an enabler for more control when we go for controller managed provision shards and need to rollback to helm chart managed.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
