### PR TITLE
Create service-lifecycle-critical priority class

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -503,6 +503,32 @@ resourceGroups:
       - "Internal error occurred"
       maximumRetryCount: 3
       durationBetweenRetries: 1m
+  - name: service-lifecycle
+    aksCluster: '{{ .mgmt.aks.name }}'
+    action: Helm
+    releaseName: service-lifecycle
+    releaseNamespace: kube-system
+    chartDir: ../service-lifecycle/deploy
+    valuesFile: ../service-lifecycle/deploy/values.yaml
+    kustoEndpoint:
+      resourceGroup: kusto
+      step: output
+      name: kustoUri
+    kustoDatabase: '{{ .kusto.serviceLogsDatabase }}'
+    kustoTable: 'containerLogs'
+    dependsOn:
+    - resourceGroup: management
+      step: cluster
+    identityFrom:
+      resourceGroup: global
+      step: output
+      name: globalMSIId
+    automatedRetry:
+      errorContainsAny:
+      - "500 Internal Server Error"
+      - "Internal error occurred"
+      maximumRetryCount: 3
+      durationBetweenRetries: 1m
   - name: arobit-output
     action: ARM
     template: templates/arobit-lookup.bicep

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -403,6 +403,32 @@ resourceGroups:
       - "Internal error occurred"
       maximumRetryCount: 3
       durationBetweenRetries: 1m
+  - name: service-lifecycle
+    aksCluster: '{{ .svc.aks.name }}'
+    action: Helm
+    releaseName: service-lifecycle
+    releaseNamespace: kube-system
+    chartDir: ../service-lifecycle/deploy
+    valuesFile: ../service-lifecycle/deploy/values.yaml
+    kustoEndpoint:
+      resourceGroup: kusto
+      step: output
+      name: kustoUri
+    kustoDatabase: '{{ .kusto.serviceLogsDatabase }}'
+    kustoTable: 'containerLogs'
+    dependsOn:
+    - resourceGroup: service
+      step: cluster
+    identityFrom:
+      resourceGroup: global
+      step: output
+      name: globalMSIId
+    automatedRetry:
+      errorContainsAny:
+      - "500 Internal Server Error"
+      - "Internal error occurred"
+      maximumRetryCount: 3
+      durationBetweenRetries: 1m
   - name: arobit-output
     action: ARM
     template: templates/arobit-lookup.bicep

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -446,6 +446,7 @@ spec:
       annotations:
         checksum/configmap: 9afe0b0e572704d69b07e4e38b66ed79a51a992261adcae0e6f8ca0f207442f3
     spec:
+      priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true
       containers:

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_service_lifecycle.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_service_lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+# Source: service-lifecycle/templates/priorityclass.yaml
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: service-lifecycle-critical
+value: 1e+06
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: "Priority class for ARO-HCP service lifecycle critical DaemonSets"
+

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -423,6 +423,7 @@ spec:
       annotations:
         checksum/configmap: 3fb766bdf40341544c6336207a928fec85e0c84648636dd57385d6f3ae7d985d
     spec:
+      priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true
       containers:

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_service_lifecycle.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_service_lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+# Source: service-lifecycle/templates/priorityclass.yaml
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: service-lifecycle-critical
+value: 1e+06
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: "Priority class for ARO-HCP service lifecycle critical DaemonSets"
+

--- a/observability/arobit/deploy/templates/forwarder-daemonset.yaml
+++ b/observability/arobit/deploy/templates/forwarder-daemonset.yaml
@@ -28,6 +28,7 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/forwarder-configmap.yaml") . | sha256sum }}
     spec:
+      priorityClassName: service-lifecycle-critical
       serviceAccountName: '{{ .Values.forwarder.serviceAccountName }}'
       shareProcessNamespace: true
       containers:

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
@@ -362,6 +362,7 @@ spec:
       annotations:
         checksum/configmap: 49ad24d064241d58dbdcf15dded3d32901f320110de9a827f2ed85bfe2946764
     spec:
+      priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true
       containers:

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -422,6 +422,7 @@ spec:
       annotations:
         checksum/configmap: 58b2807afa24ee46f3ba427bcab6b89eed552a06c7be382344ca476e428a96e0
     spec:
+      priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true
       containers:

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
@@ -423,6 +423,7 @@ spec:
       annotations:
         checksum/configmap: 643e5d82eececc106e29c6bb0118bada1ea34a79cb0bfab0656b2a682448a450
     spec:
+      priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true
       containers:

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -593,6 +593,7 @@ spec:
       annotations:
         checksum/configmap: 5eddbcc6b7c0b33ba4639aad4bb8da430ddb92a59020259f2ac48fdd4da2fe65
     spec:
+      priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true
       containers:

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -423,6 +423,7 @@ spec:
       annotations:
         checksum/configmap: 4c45c3d9e10f0ef64d3d79de3d1f0c75bc4faad17fdb8bc09707c9480d1ec992
     spec:
+      priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
       shareProcessNamespace: true
       containers:

--- a/service-lifecycle/deploy/Chart.yaml
+++ b/service-lifecycle/deploy/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: service-lifecycle
+description: Service lifecycle definitions for ARO-HCP critical workloads
+version: 0.1.0
+appVersion: "0.1.0"

--- a/service-lifecycle/deploy/templates/priorityclass.yaml
+++ b/service-lifecycle/deploy/templates/priorityclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: service-lifecycle-critical
+value: {{ .Values.value }}
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: {{ .Values.description | quote }}

--- a/service-lifecycle/deploy/values.yaml
+++ b/service-lifecycle/deploy/values.yaml
@@ -1,0 +1,2 @@
+value: 1000000
+description: "Priority class for ARO-HCP service lifecycle critical DaemonSets"

--- a/velero/deploy/templates/kustomize-patch.yaml
+++ b/velero/deploy/templates/kustomize-patch.yaml
@@ -29,3 +29,20 @@ data:
             operator: "Equal"
             value: "true"
             effect: "NoSchedule"
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: node-agent
+      namespace: {{ .Release.Namespace }}
+    spec:
+      template:
+        spec:
+          priorityClassName: service-lifecycle-critical
+          nodeSelector:
+            aro-hcp.azure.com/role: infra
+          tolerations:
+          - key: "infra"
+            operator: "Equal"
+            value: "true"
+            effect: "NoSchedule"

--- a/velero/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_velero.yaml
+++ b/velero/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_velero.yaml
@@ -357,6 +357,23 @@ data:
             operator: "Equal"
             value: "true"
             effect: "NoSchedule"
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: node-agent
+      namespace: velero
+    spec:
+      template:
+        spec:
+          priorityClassName: service-lifecycle-critical
+          nodeSelector:
+            aro-hcp.azure.com/role: infra
+          tolerations:
+          - key: "infra"
+            operator: "Equal"
+            value: "true"
+            effect: "NoSchedule"
 ---
 # Source: velero-hcp-cli/templates/install-job.yaml
 apiVersion: batch/v1


### PR DESCRIPTION


https://redhat.atlassian.net/browse/AROSLSRE-614


### What/Why
Create a priority class that is higher than the usual

Pod pressure can cause the scheduler to evict lower-priority pods. Without an explicit priority class, DaemonSet pods compete with regular workloads on equal footing. This can cause errors during rollouts, causing rollouts to fail. Customer workloads can move, DaemonSets cannot, hence the priority class is required. 