### PR TITLE
WIP test: force-delete managed RGs stuck in Deleting state

### DIFF
--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -483,9 +483,20 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 		managedResourceGroups, err = tc.waitForManagedResourceGroupsDeletion(ctx, resourceGroupName, 10*time.Minute)
 		if err != nil {
 			if len(managedResourceGroups) > 0 {
-				return fmt.Errorf("found %d managed resource groups left behind HCP clusters in %s: %v: %w", len(managedResourceGroups), resourceGroupName, managedResourceGroups, err)
+				ginkgo.GinkgoLogr.Info("managed resource groups stuck after timeout, force-deleting",
+					"resourceGroup", resourceGroupName, "managedResourceGroups", managedResourceGroups)
+				for _, managedRG := range managedResourceGroups {
+					if delErr := DeleteResourceGroup(ctx, resourceClientFactory.NewResourceGroupsClient(), networkClientFactory, managedRG, true, timeout); delErr != nil {
+						if isIgnorableResourceGroupCleanupError(delErr) {
+							ginkgo.GinkgoLogr.Info("ignoring not found managed resource group during force deletion", "resourceGroup", managedRG)
+						} else {
+							return fmt.Errorf("failed to force-delete stuck managed resource group %q: %w", managedRG, delErr)
+						}
+					}
+				}
+			} else {
+				return fmt.Errorf("failed waiting for managed resource group deletion in %s: %w", resourceGroupName, err)
 			}
-			return fmt.Errorf("failed waiting for managed resource group deletion in %s: %w", resourceGroupName, err)
 		}
 	} else {
 		ginkgo.GinkgoLogr.Info("no left behind managed resource groups found", "resourceGroup", resourceGroupName)


### PR DESCRIPTION
### What

When `cleanupResourceGroup` polls for managed resource group deletion and the 10-minute timeout expires, fall back to force-deleting the stuck managed RGs (using Azure's `ForceDeletionTypes` for VMs/VMSS) instead of returning an error. After force-deletion, proceed to delete the parent resource group. This is the same approach already used by `cleanupResourceGroupNoRP`.

### Why

All three periodic cleanup jobs (`periodic-delete-expired-{integration,stage,prod}-resource-groups`) are **100% failing** (20/20 recent runs) because managed resource groups from `idms` and `cluster-listing` E2E tests are permanently stuck in Azure's "Deleting" state. Every 30-minute cleanup run hits the same 10-minute timeout on the same stuck RGs and exits without making progress.

Stuck RGs across environments:
- **INT**: 10 (`idms-*-managed`, `cluster-listing-*-managed`, `rg-cluster-nsg-subnet-reuse-*`)
- **Stage**: 1 (`rg-cluster-nsg-subnet-reuse-*`)
- **Prod**: 4 (`cluster-listing-*-managed`)

### Testing

No new tests added. The happy path (managed RGs deleted within 10 minutes) is unchanged. The fix reuses the existing `DeleteResourceGroup(..., force=true, ...)` code path already validated by `cleanupResourceGroupNoRP`. Verification will come from monitoring the periodic cleanup jobs after merge.

### Special notes for your reviewer

There is an existing branch `fix-e2e-rg-cleanup` on origin that may be addressing the same issue.
