### PR TITLE
Move install-tools to base-ci image and update e2e tests image

### DIFF
--- a/dev-infrastructure/openshift-ci/Dockerfile
+++ b/dev-infrastructure/openshift-ci/Dockerfile
@@ -34,3 +34,9 @@ RUN ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "amd64") && \
     mv prometheus-${PROMTOOL_VERSION}.linux-${ARCH}/promtool /usr/local/bin/promtool && \
     chmod +x /usr/local/bin/promtool && \
     rm -rf prometheus-${PROMTOOL_VERSION}.linux-${ARCH}
+# Install Go-based development tools (bingo-managed)
+COPY . /tmp/aro-hcp
+RUN cd /tmp/aro-hcp && \
+    GOFLAGS='-mod=readonly' GOBIN=/usr/local/bin make install-tools && \
+    go clean -cache -modcache && \
+    rm -rf /tmp/aro-hcp

--- a/dev-infrastructure/openshift-ci/Makefile
+++ b/dev-infrastructure/openshift-ci/Makefile
@@ -34,7 +34,8 @@ verify: ## Verify versions are consistent across config files
 build: verify ## Build the CI image
 	$(CONTAINER_ENGINE) build --platform=$(PLATFORM) \
 		$(foreach v,$(VERSION_ARGS),--build-arg $(v)=$($(v))) \
-		-t $(IMAGE_NAME) .
+		-f Dockerfile \
+		-t $(IMAGE_NAME) ../..
 
 ##@ Test
 
@@ -50,4 +51,8 @@ test: build ## Build and smoke-test all tools in the image
 		echo "promtool:  $$(promtool --version 2>&1 | head -1)" && \
 		echo "make:      $$(make --version | head -1)" && \
 		echo "git:       $$(git --version)" && \
+		echo "helm:      $$(helm version --short 2>&1)" && \
+		echo "yq:        $$(yq --version 2>&1)" && \
+		echo "jq:        $$(jq --version 2>&1)" && \
+		echo "oras:      $$(oras version 2>&1 | head -1)" && \
 		echo "=== All tools OK ==="'

--- a/test/Containerfile.e2e
+++ b/test/Containerfile.e2e
@@ -3,7 +3,8 @@ USER root
 WORKDIR /opt/app-root/src/github.com/Azure/ARO-HCP
 COPY . .
 ENV GOFLAGS='-mod=readonly'
-RUN make -C tooling/templatize templatize && \
+RUN make build-hcpctl && \
+    make -C tooling/templatize templatize && \
     make -C test/ build && \
     go clean -cache -modcache && rm -f go.work.sum
 RUN chmod 777 /opt/app-root/src/github.com/Azure/ARO-HCP

--- a/test/Containerfile.e2e
+++ b/test/Containerfile.e2e
@@ -3,6 +3,7 @@ USER root
 WORKDIR /opt/app-root/src/github.com/Azure/ARO-HCP
 COPY . .
 ENV GOFLAGS='-mod=readonly'
-RUN make -C test/ build && go clean -cache -modcache && rm -f go.work.sum
+RUN make -C tooling/templatize templatize && \
+    make -C test/ build && \
+    go clean -cache -modcache && rm -f go.work.sum
 RUN chmod 777 /opt/app-root/src/github.com/Azure/ARO-HCP
-


### PR DESCRIPTION
[ARO-23919](https://redhat.atlassian.net/browse/ARO-23919)

### What

The PR moves install-tools from aro-hcp-e2e-tools image to base-ci image. This change affects e2e tests (aro-hcp-e2e-tests) image.

### Why

To not install 'install-tools' on every CI execution that require this tools.

### Special notes for your reviewer

Related changes in PROW CI https://github.com/openshift/release/pull/75802
