### PR TITLE
Turning off local auth for audit logs eventhub

### DIFF
--- a/dev-infrastructure/templates/audit-logs-eventhub.bicep
+++ b/dev-infrastructure/templates/audit-logs-eventhub.bicep
@@ -29,6 +29,7 @@ resource eventHubNamespace 'Microsoft.EventHub/namespaces@2024-01-01' = if (mana
     capacity: 1
   }
   properties: {
+    disableLocalAuth: true
     minimumTlsVersion: '1.2'
     publicNetworkAccess: 'Disabled'
   }


### PR DESCRIPTION
[ARO-26129](https://redhat.atlassian.net/browse/ARO-26129)

### What

Turns off local auth for audit logs eventhub

### Why

Required by Azure policy. The kusto data connection uses aad auth, so it will be unaffected

### Testing

I ran the e2e test with this flag flipped, and with the eventhub manageInstance flag set to true. It updated the eventhub to not use local auth, and the logs continued to flow to kusto in dev

### Special notes for your reviewer

<!-- optional -->
