### PR TITLE
acm: quote toleration value in upstream klusterlet-addon template

### DIFF
--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml
@@ -72,7 +72,7 @@ spec:
       {{- range . }}
       - {{ if .Key }} key: {{ .Key }} {{- end }}
         {{ if .Operator }} operator: {{ .Operator }} {{- end }}
-        {{ if .Value }} value: "{{ .Value }}" {{- end }}
+        {{ if .Value }} value: {{ .Value | quote }} {{- end }}
         {{ if .Effect }} effect: {{ .Effect }} {{- end }}
         {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
         {{- end }}

--- a/acm/update-policy-chart.sh
+++ b/acm/update-policy-chart.sh
@@ -132,6 +132,10 @@ done
 
 # the Values.global.registryOverride is not defined in the upstream helm chart so need override here.
 sed -i.bak 's|^\([[:space:]]*image:[[:space:]]*\)"{{ .Values.global.imageOverrides.klusterlet_addon_controller }}"|\1"{{ .Values.global.registryOverride }}/{{ .Values.global.imageOverrides.klusterlet_addon_controller }}"|' "$policy_helm_charts_dir/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml"
+
+# the upstream helm chart renders toleration values without quotes, which causes
+# Kubernetes to interpret "true" as a boolean instead of a string.
+sed -i.bak 's|{{ if .Value }} value: {{ .Value }}|{{ if .Value }} value: "{{ .Value }}"|' "$policy_helm_charts_dir/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml"
 rm -f "$policy_helm_charts_dir/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml.bak"
 
 

--- a/acm/update-policy-chart.sh
+++ b/acm/update-policy-chart.sh
@@ -135,7 +135,7 @@ sed -i.bak 's|^\([[:space:]]*image:[[:space:]]*\)"{{ .Values.global.imageOverrid
 
 # the upstream helm chart renders toleration values without quotes, which causes
 # Kubernetes to interpret "true" as a boolean instead of a string.
-sed -i.bak 's|{{ if .Value }} value: {{ .Value }}|{{ if .Value }} value: "{{ .Value }}"|' "$policy_helm_charts_dir/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml"
+sed -i.bak 's#{{ if .Value }} value: {{ .Value }}#{{ if .Value }} value: {{ .Value | quote }}#' "$policy_helm_charts_dir/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml"
 rm -f "$policy_helm_charts_dir/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml.bak"
 
 

--- a/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
+++ b/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
@@ -1,7 +1,6 @@
 ---
 # Source: multicluster-engine-local-cluster/charts/policy/crds/agent.open-cluster-management.io_klusterletaddonconfigs_crd.yaml
 # Copyright (c) 2020 Red Hat, Inc.
-
 # Copyright Contributors to the Open Cluster Management project
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
+++ b/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
@@ -1,6 +1,7 @@
 ---
 # Source: multicluster-engine-local-cluster/charts/policy/crds/agent.open-cluster-management.io_klusterletaddonconfigs_crd.yaml
 # Copyright (c) 2020 Red Hat, Inc.
+
 # Copyright Contributors to the Open Cluster Management project
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
https://issues.redhat.com/browse/AROSLSRE-644

### What

Adds a sed fixup in `update-policy-chart.sh` to re-quote the toleration `value` field after copying the upstream `klusterlet-addon-deployment.yaml` template from `stolostron/multiclusterhub-operator`.

Uses Helm's `{{ .Value | quote }}` pipeline instead of literal quotes for safe string escaping.

### Why

The upstream release-2.16 template renders toleration values without quotes:
```
{{ if .Value }} value: {{ .Value }} {{- end }}
```

This causes Kubernetes server-side apply to fail because `true` is interpreted as a boolean instead of a string:
```
.spec.template.spec.tolerations[0].value: expected string, got &value.valueUnstructured{Value:true}
```

This is the root cause of 10 consecutive E2E failures on PR #4851 (and any other PR that triggers `make -C acm helm-charts`). The `deploy-mce-config` step fails, killing the entire provision pipeline before any tests run.

### Testing

- Ran `make -C config materialize && make -C acm helm-charts && make update-helm-fixtures && make yamlfmt`
- Verified the generated template has `value: {{ .Value | quote }}`
- Verified the test fixture renders `value: "true"` (string, not boolean)
- Verified `make -C config materialize` produces no diff

### Special notes for your reviewer

This follows the same pattern as the existing `registryOverride` sed fixup — both patch the upstream template after copying to work around upstream differences. The upstream fix would be in `stolostron/multiclusterhub-operator` release-2.16 branch.