### PR TITLE
observability: add prometheusrules for hosted cluster namespace pods

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -2033,3 +2033,43 @@ This usually indicates critical operators (Network, API, etc.) are down.
     ]
   }
 }
+
+resource hcpPodNotReadyRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'hcp-pod-not-ready-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'HCPPodNotReady'
+        enabled: true
+        labels: {
+          severity: 'info'
+        }
+        annotations: {
+          correlationId: 'HCPPodNotReady/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.pod }}'
+          description: 'Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} (on Mgmt Cluster {{ $labels.cluster }}) has not been ready for more than 5 minutes.'
+          info: 'Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} (on Mgmt Cluster {{ $labels.cluster }}) has not been ready for more than 5 minutes.'
+          runbook_url: 'TBD'
+          summary: 'HCP pod not ready in {{ $labels.namespace }}'
+          title: 'HCP pod not ready in {{ $labels.namespace }}'
+        }
+        expression: 'max by (cluster, namespace, pod) ( kube_pod_status_ready{condition="true", namespace=~"ocm-.*"} ) == 0'
+        for: 'PT5M'
+        severity: 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}

--- a/observability/alerts/HCPPodNotReady-prometheusRule.yaml
+++ b/observability/alerts/HCPPodNotReady-prometheusRule.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: hcp-pod-not-ready-rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: hcp-pod-not-ready-rules
+    rules:
+    - alert: HCPPodNotReady
+      expr: |
+        max by (cluster, namespace, pod) (
+          kube_pod_status_ready{condition="true", namespace=~"ocm-.*"}
+        ) == 0
+      for: 5m
+      labels:
+        severity: info
+      annotations:
+        summary: "HCP pod not ready in {{ $labels.namespace }}"
+        description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} (on Mgmt Cluster {{ $labels.cluster }}) has not been ready for more than 5 minutes."
+        runbook_url: TBD

--- a/observability/alerts/HCPPodNotReady-prometheusRule_test.yaml
+++ b/observability/alerts/HCPPodNotReady-prometheusRule_test.yaml
@@ -1,0 +1,63 @@
+rule_files:
+- HCPPodNotReady-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# Test 1: Pod is ready in ocm- namespace, no alert fires
+- interval: 1m
+  input_series:
+  - series: 'kube_pod_status_ready{cluster="mgmt-1", namespace="ocm-test-hcp", pod="router-abc123-xyz", condition="true"}'
+    values: "1+0x30"
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: HCPPodNotReady
+    exp_alerts: []
+# Test 2: Pod not ready in ocm- namespace for > 5 minutes, alert fires
+- interval: 1m
+  input_series:
+  - series: 'kube_pod_status_ready{cluster="mgmt-1", namespace="ocm-test-hcp", pod="router-abc123-xyz", condition="true"}'
+    values: "0+0x30"
+  alert_rule_test:
+  - eval_time: 3m
+    alertname: HCPPodNotReady
+    exp_alerts: []
+  - eval_time: 7m
+    alertname: HCPPodNotReady
+    exp_alerts:
+    - exp_labels:
+        alertname: HCPPodNotReady
+        severity: info
+        cluster: mgmt-1
+        namespace: ocm-test-hcp
+        pod: router-abc123-xyz
+      exp_annotations:
+        summary: "HCP pod not ready in ocm-test-hcp"
+        description: "Pod router-abc123-xyz in namespace ocm-test-hcp (on Mgmt Cluster mgmt-1) has not been ready for more than 5 minutes."
+        runbook_url: TBD
+# Test 3: Pod not ready in non-ocm namespace, no alert fires
+- interval: 1m
+  input_series:
+  - series: 'kube_pod_status_ready{cluster="mgmt-1", namespace="kube-system", pod="coredns-abc123", condition="true"}'
+    values: "0+0x30"
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: HCPPodNotReady
+    exp_alerts: []
+# Test 4: Non-router pod not ready in ocm- namespace, alert still fires
+- interval: 1m
+  input_series:
+  - series: 'kube_pod_status_ready{cluster="mgmt-1", namespace="ocm-test-hcp", pod="kube-apiserver-abc123", condition="true"}'
+    values: "0+0x30"
+  alert_rule_test:
+  - eval_time: 7m
+    alertname: HCPPodNotReady
+    exp_alerts:
+    - exp_labels:
+        alertname: HCPPodNotReady
+        severity: info
+        cluster: mgmt-1
+        namespace: ocm-test-hcp
+        pod: kube-apiserver-abc123
+      exp_annotations:
+        summary: "HCP pod not ready in ocm-test-hcp"
+        description: "Pod kube-apiserver-abc123 in namespace ocm-test-hcp (on Mgmt Cluster mgmt-1) has not been ready for more than 5 minutes."
+        runbook_url: TBD

--- a/observability/observability-hcp.yaml
+++ b/observability/observability-hcp.yaml
@@ -5,6 +5,7 @@ prometheusRules:
   - ../observability/alerts/HCPkasRecord-prometheusRule-KSM.yaml
   - ../observability/alerts/HCPkasMonitor-prometheusRule-KSM.yaml
   - ../observability/alerts/HCPclusterHealth-prometheusRule.yaml
+  - ../observability/alerts/HCPPodNotReady-prometheusRule.yaml
   untestedRules:
   - ../observability/alerts/kubernetesControlPlane-prometheusRule.yaml
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep


### PR DESCRIPTION
Needs jira

### What

Raises an alert whenever a pod in the hosted cluster namespace is not ready for 5 minutes or longer.

### Why

There was a bug with azure CNI plugin that resulted in router pods getting stuck in container creating.  As a result, the updated configmap which includes the ignition config wouldnt' roll out because of a singular stuck pod and no nodes would join the cluster. 

This alerts us if this condition happens or another and allows us to react to it.  

We apply this widespread because we own the workload in the hosted cluster namespace.  Although this is a wide net we're casting, there may be scenarios where we want to narrow it, or add more specific alerts for specific scenarios.  

### Testing

TODO:
- [ ] mark nodes as unscheduled, delete pods, confirm unscheduled alert fires
- [ ] try to create two swift clusters on mgmt cluster infra that only supports one, confirm ContainerCreating alert fires
- [ ] figure out a way to make health / liveness probe unhealthy, confirm alert fires.

### Special notes for your reviewer

<!-- optional -->
