### PR TITLE
kusto: allow overriding deployment location for Kusto clusters

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1851,6 +1851,10 @@
     "kusto": {
       "type": "object",
       "properties": {
+        "location": {
+          "type": "string",
+          "description": "Override the Azure region where the Kusto cluster is deployed. Defaults to the region being deployed."
+        },
         "rg": {
           "type": "string"
         },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -254,6 +254,7 @@ defaults:
           keyVault: "empty-sentinel"
           name: "empty-sentinel"
   kusto:
+    location: "{{ .ctx.region }}"
     enableAutoScale: false
     manageInstance: false
     autoScaleMin: 2

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -446,6 +446,7 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
+  location: westus3
   manageInstance: false
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -446,6 +446,7 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
+  location: westus3
   manageInstance: true
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -446,6 +446,7 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
+  location: westus3
   manageInstance: false
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -446,6 +446,7 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
+  location: westus3
   manageInstance: false
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -446,6 +446,7 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
+  location: westus3
   manageInstance: false
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -446,6 +446,7 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
+  location: uksouth
   manageInstance: false
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs

--- a/dev-infrastructure/cleanup/delete.kusto.instance.pipeline.yaml
+++ b/dev-infrastructure/cleanup/delete.kusto.instance.pipeline.yaml
@@ -32,6 +32,7 @@ resourceGroups:
     - canadacentral
     - centralindia
     - eastus2
+    - eastus2euap
     - westeurope
     - switzerlandnorth
     - uksouth

--- a/dev-infrastructure/configurations/kusto.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/kusto.tmpl.bicepparam
@@ -1,5 +1,6 @@
 using '../templates/kusto.bicep'
 
+param location = '{{ .kusto.location }}'
 
 param sku = '{{ .kusto.sku }}'
 param tier = '{{ .kusto.tier }}'

--- a/dev-infrastructure/geography-pipeline.yaml
+++ b/dev-infrastructure/geography-pipeline.yaml
@@ -28,6 +28,7 @@ resourceGroups:
     - canadacentral
     - centralindia
     - eastus2
+    - eastus2euap
     - westeurope
     - switzerlandnorth
     - uksouth

--- a/dev-infrastructure/modules/logs/kusto/cluster.bicep
+++ b/dev-infrastructure/modules/logs/kusto/cluster.bicep
@@ -2,6 +2,9 @@ import {
   csvToArray
 } from '../../../modules/common.bicep'
 
+@description('Azure Region Location')
+param location string = resourceGroup().location
+
 @description('Name of the Kusto cluster to create')
 param kustoName string
 
@@ -48,7 +51,7 @@ var viewerPermissions = [
 // Core Kusto cluster (no databases here; those are in separate modules)
 resource kusto 'Microsoft.Kusto/clusters@2024-04-13' = {
   name: kustoName
-  location: resourceGroup().location
+  location: location
   sku: {
     name: sku
     tier: tier

--- a/dev-infrastructure/modules/logs/kusto/database.bicep
+++ b/dev-infrastructure/modules/logs/kusto/database.bicep
@@ -1,3 +1,6 @@
+@description('Azure Region Location')
+param location string = resourceGroup().location
+
 @description('Name of the Kusto cluster owning this database')
 param kustoName string
 
@@ -25,7 +28,7 @@ param icmViewerTenantId string?
 // Create the database as a resource whose name includes the cluster (parent)
 resource database 'Microsoft.Kusto/clusters/databases@2024-04-13' = {
   name: '${kustoName}/${databaseName}'
-  location: resourceGroup().location
+  location: location
   kind: 'ReadWrite'
   properties: {
     softDeletePeriod: softDeletePeriod

--- a/dev-infrastructure/modules/logs/kusto/main.bicep
+++ b/dev-infrastructure/modules/logs/kusto/main.bicep
@@ -1,3 +1,6 @@
+@description('Azure Region Location')
+param location string = resourceGroup().location
+
 @description('The SKU of the cluster')
 param sku string = 'Standard_D12_v2'
 
@@ -59,6 +62,7 @@ var allCustomerLogsTablesKQL = {
 module cluster 'cluster.bicep' = {
   name: 'cluster'
   params: {
+    location: location
     kustoName: kustoName
     sku: sku
     tier: tier
@@ -74,6 +78,7 @@ module cluster 'cluster.bicep' = {
 module serviceLogs 'database.bicep' = {
   name: 'servicelogs'
   params: {
+    location: location
     kustoName: kustoName
     databaseName: db.serviceLogs
     softDeletePeriod: 'P90D'
@@ -85,6 +90,7 @@ module serviceLogs 'database.bicep' = {
 module hostedControlPlaneLogs 'database.bicep' = {
   name: 'hostedControlPlaneLogs'
   params: {
+    location: location
     kustoName: kustoName
     databaseName: db.hostedControlPlaneLogs
     softDeletePeriod: 'P14D'

--- a/dev-infrastructure/templates/kusto.bicep
+++ b/dev-infrastructure/templates/kusto.bicep
@@ -37,6 +37,7 @@ param enableAutoScale bool
 module kusto '../modules/logs/kusto/main.bicep' = if (manageInstance) {
   name: 'kusto-${location}'
   params: {
+    location: location
     kustoName: kustoName
     dstsGroups: []
     sku: sku


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

This is to resolve: https://redhat.atlassian.net/browse/AROSLSRE-605 
- Adds `kusto.location` config parameter to override Kusto deployment region
- Threads location through bicep: kusto.tmpl.bicepparam → kusto.bicep → main.bicep → cluster.bicep
- Re-adds eastus2euap to geography-pipeline.yaml prod regions
- No impact on existing regions: default is `{{ .ctx.region }}` which matches current behavior

### Why

eastus2euap (Canary) belongs to the "Canary (US)" geography (geoShortId: usc), which requires its own Kusto cluster per the one-Kusto-per-geography model. However, Azure Data Explorer is not available in eastus2euap. This change
allows deploying the canary Kusto cluster (hcp-prod-usc) in eastus2 instead.


<!-- optional -->
