### PR TITLE
Bump services database retention

### DIFF
--- a/dev-infrastructure/modules/logs/kusto/main.bicep
+++ b/dev-infrastructure/modules/logs/kusto/main.bicep
@@ -76,7 +76,7 @@ module serviceLogs 'database.bicep' = {
   params: {
     kustoName: kustoName
     databaseName: db.serviceLogs
-    softDeletePeriod: 'P14D'
+    softDeletePeriod: 'P90D'
     hotCachePeriod: 'P2D'
   }
   dependsOn: [cluster]


### PR DESCRIPTION


<!-- Link to Jira issue -->

### What
Bump the retention, cause it will greatly improve our debugging capabilities. The price increase is neglect able according to calculations done here: https://azure.microsoft.com/en-us/pricing/calculator/\?service\=azure-data-explorer

Also, these values align with what is configured in Aro classic.

Not bumping hcp retention for compliance reasons
