### PR TITLE
fix: Update prod ch kusto link

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -47,3 +47,7 @@ clouds:
           frontend:
             audit:
               connectSocket: true
+        regions:
+          switzerlandnorth:
+            kusto:
+              kustoName: "hcp-prod-ch-2"


### PR DESCRIPTION
### What

Add `kustoName: "hcp-prod-ch-2"` region-level override for prod `switzerlandnorth` in the non-sensitive clouds overlay.

### Why

E2E Kusto diagnostic links for prod Switzerland point to `hcp-prod-ch` (generated from the default template `hcp-{{ .ctx.environment }}-{{ .ev2.geoShortId }}`), but the actual cluster is `hcp-prod-ch-2`. The correct name exists in the sensitive overlay (sdp-pipelines), but Prow E2E jobs only have access to the non-sensitive overlay in this repo, so the links are broken.

This follows the same pattern as the existing stg override (`hcp-stg-uk-2` on line 24).

### Testing

Config-only change. Verified with `make -C config materialize` — no rendered config changes in the dev cloud (prod configs are only rendered in sdp-pipelines).

### Special notes for your reviewer

The duplicate in the sdp-pipelines sensitive overlay can remain (same value, no conflict) or be cleaned up separately with a comment like the stg one has (`# kustoName override is in ARO-HCP's config so ci kusto links work`).
