### PR TITLE
Add MemoryPressure alert

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1547,3 +1547,42 @@ resource kubeContainerOomRules 'Microsoft.AlertsManagement/prometheusRuleGroups@
     ]
   }
 }
+
+resource kubeNodeRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'kube-node-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'KubeMemoryPressure'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'KubeMemoryPressure/{{ $labels.cluster }}/{{ $labels.node }}'
+          description: 'Node {{ $labels.node }} is reporting MemoryPressure condition'
+          info: 'Node {{ $labels.node }} is reporting MemoryPressure condition'
+          summary: 'Node under memory pressure'
+          title: 'Node under memory pressure'
+        }
+        expression: 'kube_node_status_condition{condition="MemoryPressure",status="true"} == 1'
+        for: 'PT5M'
+        severity: 3
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}

--- a/observability/alerts/kubeNode-prometheusRule.yaml
+++ b/observability/alerts/kubeNode-prometheusRule.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kube-node-rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: kube-node-rules
+    rules:
+    - alert: KubeMemoryPressure
+      annotations:
+        summary: "Node under memory pressure"
+        description: "Node {{ $labels.node }} is reporting MemoryPressure condition"
+      expr: |
+        kube_node_status_condition{condition="MemoryPressure",status="true"} == 1
+      for: 5m
+      labels:
+        severity: warning

--- a/observability/alerts/kubeNode-prometheusRule_test.yaml
+++ b/observability/alerts/kubeNode-prometheusRule_test.yaml
@@ -1,0 +1,41 @@
+rule_files:
+- kubeNode-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# Scenario 1: Node under MemoryPressure for more than 5 minutes - alert should fire
+- interval: 1m
+  input_series:
+  - series: 'kube_node_status_condition{cluster="svc-1",node="node-1",condition="MemoryPressure",status="true"}'
+    values: "1+0x10"
+  alert_rule_test:
+  - eval_time: 6m
+    alertname: KubeMemoryPressure
+    exp_alerts:
+    - exp_labels:
+        alertname: KubeMemoryPressure
+        severity: warning
+        cluster: svc-1
+        node: node-1
+        condition: MemoryPressure
+        status: "true"
+      exp_annotations:
+        summary: "Node under memory pressure"
+        description: "Node node-1 is reporting MemoryPressure condition"
+# Scenario 5: MemoryPressure clears before 5 minutes - alert should NOT fire
+- interval: 1m
+  input_series:
+  - series: 'kube_node_status_condition{cluster="svc-1",node="node-1",condition="MemoryPressure",status="true"}'
+    values: "1 1 1 1 0 0 0 0 0 0"
+  alert_rule_test:
+  - eval_time: 6m
+    alertname: KubeMemoryPressure
+    exp_alerts: []
+# Scenario 6: MemoryPressure never happens - no alert
+- interval: 1m
+  input_series:
+  - series: 'kube_node_status_condition{cluster="svc-1",node="node-1",condition="MemoryPressure",status="true"}'
+    values: "0+0x10"
+  alert_rule_test:
+  - eval_time: 6m
+    alertname: KubeMemoryPressure
+    exp_alerts: []

--- a/observability/observability.yaml
+++ b/observability/observability.yaml
@@ -10,6 +10,7 @@ prometheusRules:
   - alerts/service-tag-public-ip-usage.yaml
   - ../observability/alerts/HCPdeletionStuck-prometheusRule.yaml
   - ../observability/alerts/kubeContainerOOM-prometheusRule.yaml
+  - ../observability/alerts/kubeNode-prometheusRule.yaml
   untestedRules: []
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
   prometheusOperatorVersion: e02554298cb62b5533f3407c8eacc664e80bc74b


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

This pull request adds a MemoryPressure alert to the existing observability/monitoring configuration so that nodes under sustained memory pressure are detected and surfaced through our alerting pipeline.

### Why

The new alert helps operators proactively identify clusters where memory consumption is close to critical levels, reducing the risk of node instability, OOM kills, and service degradation. By having an explicit MemoryPressure signal, we can react earlier, improve incident response, and maintain higher overall reliability of the platform.

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
