### PR TITLE
frontend: Initialize credential revocation operations to "Deleting"

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -517,6 +517,19 @@ func (f *Frontend) ArmResourceActionRevokeCredentials(writer http.ResponseWriter
 		request.Header.Get(arm.HeaderNameClientObjectID),
 		request.Header.Get(arm.HeaderNameAsyncNotificationURI),
 		correlationData)
+
+	// XXX TEMPORARY: This must be removed along with the Clusters Service call.
+	//
+	//     For this operation type, because there is no single Clusters Service
+	//     resource to poll for completion, the operation's status field is used
+	//     for backend controller coordination. "Accepted" means the revocation
+	//     has not yet been dispatched to Clusters Service. Once dispatched, the
+	//     operation status becomes "Deleting" and is ready for status polling.
+	//
+	//     Because the credentials revocation has already been dispatched here,
+	//     set the initial operation status to "Deleting".
+	operationDoc.Status = arm.ProvisioningStateDeleting
+
 	transaction.OnSuccess(addOperationResponseHeaders(writer, request, operationDoc.NotificationURI, operationDoc.OperationID))
 	_, err = f.dbClient.Operations(operationDoc.OperationID.SubscriptionID).AddCreateToTransaction(ctx, transaction, operationDoc, nil)
 	if err != nil {

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/03-listActiveOperations-revoke-credentials/operation-revoke-credentials.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/03-listActiveOperations-revoke-credentials/operation-revoke-credentials.json
@@ -8,6 +8,6 @@
 	"request": "RevokeCredentials",
 	"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/00000000-0000-0000-0000-000000000000",
 	"startTime": "2025-01-01T00:00:00Z",
-	"status": "Accepted",
+	"status": "Deleting",
 	"tenantId": "00000000-0000-0000-0000-000000000000"
 }


### PR DESCRIPTION
[ARO-24384 - Move Cluster Service CRUD calls to ARO-HCP backend](https://redhat.atlassian.net/browse/ARO-24384)

### What

Moving the Clusters Service DELETE call for break-glass credentials to the backend is proving to be tricky.

Because there's no single Clusters Service resource to poll for status, the backend controllers for dispatching the CS call and polling CS for revocation completion can't reliably coordinate.

Imagine a credential revocation when there's no present break-glass credentials but there _are_ pending requests in Cosmos DB that haven't yet been dispatched to Clusters Service. The controller for polling status on this operation will see there's no credentials pending revocation and immediately mark the revocation operation as successful. If that happens before the controller for dispatching the revocation to Clusters Service has a chance to run, then the Clusters Service call will never be made and the pending credential requests will complete despite the client requesting revocation.

To resolve this, for the `RevokeCredentials` operation type only I'm imbuing new meaning into some of the operation's non-terminal status values:

  - **Accepted**
    - The client's request for credential revocation is underway. An operation document exists in Cosmos DB but the Clusters Service call has not yet been made.
  - **Deleting**
    - The Clusters Service call has been made and status polling should commence.

Eventually, the dispatch controller for credential revocations will update the operation status from **Accepted** to **Deleting** after calling Clusters Service. Meanwhile, the controller for polling status will disregard credential revocation operations with an **Accepted** status.

First, however, the frontend must initialize credential revocation operations to status **Deleting** instead of **Accepted**, since it's still making the Clusters Service call immediately for now.

### Testing

The relevant frontend integration test has been updated to confirm `RevokeCredentials` operations now begin with a **Deleting** status.

### Special notes for your reviewer

In order to keep the frontend and backend images compatible with a +/-1 version skew, moving break-glass credential calls to the backend is going to have to be a three-stage deployment.

#### Stage 1

This pull requests changes the initial state of credential revocation operations to **Deleting**, since the frontend is making the CS call.

#### Stage 2

The status polling controller for `RevokeCredentials` will begin disregarding operations with status **Accepted**.

At the same time, introduce a dispatch controller for `RevokeCredentials` that makes the CS call when the operation has an **Accepted** status, and then updates the status to **Deleting**.

Note, at this stage the frontend is still making the CS call itself and initializing the operation to **Deleting**, so the new dispatch controller is dormant.

#### Stage 3

Remove the CS call from the frontend and change the initial state of credential revocation operations back to **Accepted**.
