### PR TITLE
frontend: Rely on RevokeCredentialsOperationID field

### DIFF
--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -357,29 +357,10 @@ func (f *Frontend) ArmResourceActionRequestAdminCredential(writer http.ResponseW
 	}
 
 	// New credential cannot be requested while credentials are being revoked.
-
-	// XXX Enable this once the backend change to clear RevokeCredentialsOperationID reaches production.
-	//if len(cluster.ServiceProviderProperties.RevokeCredentialsOperationID) > 0 {
-	//	writer.Header().Set("Retry-After", strconv.Itoa(10))
-	//	return arm.NewConflictError(clusterResourceID, "Cannot request credential while credentials are being revoked")
-	//}
-
-	// XXX Remove this once the backend change to clear RevokeCredentialsOperationID reaches production.
-	iterator := f.dbClient.Operations(clusterResourceID.SubscriptionID).ListActiveOperations(&database.DBClientListActiveOperationDocsOptions{
-		Request:    api.Ptr(database.OperationRequestRevokeCredentials),
-		ExternalID: clusterResourceID,
-	})
-
-	for range iterator.Items(ctx) {
+	if len(cluster.ServiceProviderProperties.RevokeCredentialsOperationID) > 0 {
 		writer.Header().Set("Retry-After", strconv.Itoa(10))
 		return arm.NewConflictError(clusterResourceID, "Cannot request credential while credentials are being revoked")
 	}
-
-	err = iterator.GetError()
-	if err != nil {
-		return utils.TrackError(err)
-	}
-	// XXX End of code to remove.
 
 	csCredential, err := f.clusterServiceClient.PostBreakGlassCredential(ctx, cluster.ServiceProviderProperties.ClusterServiceID)
 	if err != nil {
@@ -467,29 +448,10 @@ func (f *Frontend) ArmResourceActionRevokeCredentials(writer http.ResponseWriter
 	}
 
 	// Credential revocation cannot be requested while another revocation is in progress.
-
-	// XXX Enable this once the backend change to clear RevokeCredentialsOperationID reaches production.
-	//if len(cluster.ServiceProviderProperties.RevokeCredentialsOperationID) > 0 {
-	//	writer.Header().Set("Retry-After", strconv.Itoa(10))
-	//	return arm.NewConflictError(clusterResourceID, "Credentials are already being revoked")
-	//}
-
-	// XXX Remove this once the backend change to clear RevokeCredentialsOperationID reaches production.
-	iterator := f.dbClient.Operations(clusterResourceID.SubscriptionID).ListActiveOperations(&database.DBClientListActiveOperationDocsOptions{
-		Request:    api.Ptr(database.OperationRequestRevokeCredentials),
-		ExternalID: clusterResourceID,
-	})
-
-	for range iterator.Items(ctx) {
+	if len(cluster.ServiceProviderProperties.RevokeCredentialsOperationID) > 0 {
 		writer.Header().Set("Retry-After", strconv.Itoa(10))
 		return arm.NewConflictError(clusterResourceID, "Credentials are already being revoked")
 	}
-
-	err = iterator.GetError()
-	if err != nil {
-		return utils.TrackError(err)
-	}
-	// XXX End of code to remove.
 
 	err = f.clusterServiceClient.DeleteBreakGlassCredentials(ctx, cluster.ServiceProviderProperties.ClusterServiceID)
 	if err != nil {


### PR DESCRIPTION
Loosely related to [ARO-24384 - Move Cluster Service CRUD calls to ARO-HCP backend](https://redhat.atlassian.net/browse/ARO-24384)

### What

Follow-up to #4796 which introduced a new `RevokeCredentialsOperationID` service-provider field for clusters.  That change has reached production, which means the backend is clearing the field when revocation completes.   So it is now safe for the frontend to depend on it.

### Testing

No new functionality being added here.  Existing E2E tests should validate credential revocation behavior.
