### PR TITLE
deps: bump cryptography to 46.0.5 (CVE-2026-26007)

### DIFF
--- a/tooling/azure-automation/resources-cleanup/requirements.txt
+++ b/tooling/azure-automation/resources-cleanup/requirements.txt
@@ -6,7 +6,7 @@ azure-mgmt-resource==23.0.1
 certifi==2024.7.4
 cffi==1.17.1
 charset-normalizer==3.3.2
-cryptography==44.0.1
+cryptography==46.0.5
 exceptiongroup==1.2.0
 idna==3.7
 iniconfig==2.0.0

--- a/tooling/azure-automation/resources-cleanup/requirements.txt
+++ b/tooling/azure-automation/resources-cleanup/requirements.txt
@@ -11,7 +11,7 @@ exceptiongroup==1.2.0
 idna==3.7
 iniconfig==2.0.0
 isodate==0.6.1
-msal==1.28.0
+msal==1.36.0
 msal-extensions==1.1.0
 packaging==23.2
 pluggy==1.3.0

--- a/tooling/azure-automation/resources-cleanup/requirements.txt
+++ b/tooling/azure-automation/resources-cleanup/requirements.txt
@@ -4,7 +4,7 @@ azure-identity==1.16.1
 azure-mgmt-core==1.4.0
 azure-mgmt-resource==23.0.1
 certifi==2024.7.4
-cffi==1.17.1
+cffi==2.0.0
 charset-normalizer==3.3.2
 cryptography==46.0.5
 exceptiongroup==1.2.0

--- a/tooling/azure-automation/resources-cleanup/requirements.txt
+++ b/tooling/azure-automation/resources-cleanup/requirements.txt
@@ -22,5 +22,5 @@ pytest==7.4.4
 requests==2.32.4
 six==1.16.0
 tomli==2.0.1
-typing_extensions==4.9.0
+typing_extensions==4.13.2
 urllib3==2.6.3


### PR DESCRIPTION
[AROSLSRE-654](https://redhat.atlassian.net/browse/AROSLSRE-654)

### What

Bumps `cryptography` from 44.0.1 to 46.0.5 and its dependencies in `tooling/azure-automation/resources-cleanup/requirements.txt`.

- `cffi` 1.17.1 → 2.0.0 (required by cryptography 46.0.5)
- `typing_extensions` 4.9.0 → 4.13.2 (required by cryptography 46.0.5 on Python <3.11)
- `msal` 1.28.0 → 1.36.0 (msal 1.28.0 caps cryptography <45)

### Why

**CVE-2026-26007**: An attacker could create a malicious public key that reveals portions of your private key when using certain uncommon elliptic curves (binary curves).

### Testing

No tests — pinned dependency version bumps only.

### Special notes for your reviewer

Closes #4500
