### PR TITLE
deps: bump azure/login v3, codeql-action v4.35.1

### DIFF
--- a/.github/workflows/aro-hcp-login-check.yml
+++ b/.github/workflows/aro-hcp-login-check.yml
@@ -47,7 +47,7 @@ jobs:
       contents: 'read'
     steps:
     - name: 'Az CLI login - will fail if PR is submitted from a fork of the repo'
-      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,15 +35,15 @@ jobs:
         go-version-file: 'go.work'
     # Initializes the CodeQL tools for scanning
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         languages: ${{ matrix.language }}
         # Use default CodeQL query packs
         # For custom queries, add: queries: security-and-quality
     # Autobuild attempts to build any compiled languages (Go, C/C++, C#, Java, etc.)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
+      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/runbook-cicd.yml
+++ b/.github/workflows/runbook-cicd.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         fetch-depth: 1
     - name: Az CLI login
-      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -86,7 +86,7 @@ jobs:
       with:
         fetch-depth: 1
     - name: Az CLI login
-      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
[AROSLSRE-656](https://redhat.atlassian.net/browse/AROSLSRE-656)

### What

Bumps GitHub Actions dependencies:

- **azure/login**: v2.2.0 → v3 (Node.js 20 → 24, updated dependencies)
- **github/codeql-action**: v4.33.0 → v4.35.1 (incremental analysis improvements, Git version fix)

### Why

Keep CI actions up to date with security and compatibility fixes.

### Testing

- [x] Verify `aro-hcp-login-check` workflow runs successfully
- [x] Verify `runbook-cicd` workflow runs successfully
- [x] Verify `codeql-analysis` workflow runs successfully

### Special notes for your reviewer

Closes #4680
Closes #4499
