### PR TITLE
ARO-26227: backend metrics controller followups

### DIFF
--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/otel"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/app"
@@ -409,6 +410,8 @@ func (f *BackendRootCmdFlags) ToBackendOptions(ctx context.Context, cmd *cobra.C
 		SMIClientBuilder:                   smiClientBuilder,
 		CheckAccessV2ClientBuilder:         checkAccessV2ClientBuilder,
 		ClusterScopedIdentitiesConfig:      clusterScopedIdentitiesConfig,
+		MetricsRegisterer:                  legacyregistry.Registerer(),
+		MetricsGatherer:                    legacyregistry.DefaultGatherer,
 	}
 
 	return backendOptions, nil

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -32,7 +32,6 @@ import (
 	k8sutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	"k8s.io/component-base/metrics/legacyregistry"
 	utilsclock "k8s.io/utils/clock"
 
 	azureclient "github.com/Azure/ARO-HCP/backend/pkg/azure/client"
@@ -90,7 +89,10 @@ func (o *BackendOptions) RunBackend(ctx context.Context) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(fmt.Errorf("function returned"))
 
-	backend := NewBackend(o)
+	backend, err := NewBackend(o)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to construct backend: %w", err))
+	}
 	runErrCh := make(chan error, 1)
 	go func() {
 		runErrCh <- backend.Run(ctx)
@@ -109,24 +111,32 @@ func (o *BackendOptions) RunBackend(ctx context.Context) error {
 	return nil
 }
 
-func (o *BackendOptions) metricsRegisterer() prometheus.Registerer {
-	if o.MetricsRegisterer != nil {
-		return o.MetricsRegisterer
+func NewBackend(options *BackendOptions) (*Backend, error) {
+	if options == nil {
+		return nil, errors.New("BackendOptions must not be nil")
 	}
-	return legacyregistry.Registerer()
-}
-
-func (o *BackendOptions) metricsGatherer() prometheus.Gatherer {
-	if o.MetricsGatherer != nil {
-		return o.MetricsGatherer
+	if err := options.validate(); err != nil {
+		return nil, err
 	}
-	return legacyregistry.DefaultGatherer
-}
-
-func NewBackend(options *BackendOptions) *Backend {
 	return &Backend{
 		options: options,
+	}, nil
+}
+
+// validate checks BackendOptions for invariants that must hold before Run.
+// Any failure here is a programmer error in the calling code (flag wiring or
+// test setup), not a user-facing condition — we fail fast before any goroutine,
+// tracer, or leader-election resource is allocated.
+func (o *BackendOptions) validate() error {
+	// Registerer and Gatherer must both be explicitly wired by the caller.
+	// The production path sets them in cmd/root.go; tests must inject their
+	// own. A single half-configured field would silently expose metrics from
+	// one registry while populating another, so we refuse to start.
+	if o.MetricsRegisterer == nil || o.MetricsGatherer == nil {
+		return fmt.Errorf("BackendOptions.MetricsRegisterer and BackendOptions.MetricsGatherer must both be set (MetricsRegisterer set=%t, MetricsGatherer set=%t)",
+			o.MetricsRegisterer != nil, o.MetricsGatherer != nil)
 	}
+	return nil
 }
 
 func (b *Backend) Run(ctx context.Context) error {
@@ -176,57 +186,12 @@ func (b *Backend) Run(ctx context.Context) error {
 	errCh := make(chan error, 3)
 	wg := sync.WaitGroup{}
 
-	// Handle requests directly for /healthz endpoint
-	if b.options.HealthzServerListenAddress != "" {
-		backendHealthGauge := promauto.With(b.options.metricsRegisterer()).NewGauge(prometheus.GaugeOpts{Name: "backend_health", Help: "backend_health is 1 when healthy"})
+	healthzServer = b.serveHealthz(ctx, electionChecker, &wg, errCh)
 
-		http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-
-			if err := electionChecker.Check(r); err != nil {
-				logger.Error(err, "Readiness probe failed")
-				http.Error(w, "lease not renewed", http.StatusServiceUnavailable)
-				backendHealthGauge.Set(0.0)
-				return
-			}
-			w.WriteHeader(http.StatusOK)
-			backendHealthGauge.Set(1.0)
-		})
-
-		healthzServer = &http.Server{Addr: b.options.HealthzServerListenAddress}
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			logger.Info(fmt.Sprintf("Healthz server listening on %s", b.options.HealthzServerListenAddress))
-			errCh <- healthzServer.ListenAndServe()
-		}()
-	}
-
-	if b.options.MetricsServerListenAddress != "" || b.options.MetricsServerListener != nil {
-		http.Handle("/metrics", promhttp.InstrumentMetricHandler(
-			b.options.metricsRegisterer(),
-			promhttp.HandlerFor(
-				prometheus.Gatherers{b.options.metricsGatherer()},
-				promhttp.HandlerOpts{},
-			),
-		))
-
-		metricsAddr := b.options.MetricsServerListenAddress
-		if b.options.MetricsServerListener != nil {
-			metricsAddr = b.options.MetricsServerListener.Addr().String()
-		}
-		metricsServer = &http.Server{Addr: metricsAddr}
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			logger.Info(fmt.Sprintf("metrics server listening on %s", metricsAddr))
-			if b.options.MetricsServerListener != nil {
-				errCh <- metricsServer.Serve(b.options.MetricsServerListener)
-				return
-			}
-			errCh <- metricsServer.ListenAndServe()
-		}()
+	var err error
+	metricsServer, err = b.serveMetrics(ctx, &wg, errCh)
+	if err != nil {
+		return fmt.Errorf("failed to start metrics server: %w", err)
 	}
 
 	wg.Add(1)
@@ -263,6 +228,96 @@ func (b *Backend) Run(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
+// serveHealthz starts the /healthz HTTP server on its own ServeMux, in a dedicated
+// goroutine, if the option is configured. It returns the *http.Server so the caller
+// can shut it down. Returns nil when HealthzServerListenAddress is empty.
+func (b *Backend) serveHealthz(ctx context.Context, electionChecker *leaderelection.HealthzAdaptor, wg *sync.WaitGroup, errCh chan<- error) *http.Server {
+	if b.options.HealthzServerListenAddress == "" {
+		return nil
+	}
+	logger := utils.LoggerFromContext(ctx)
+
+	backendHealthGauge := promauto.With(b.options.MetricsRegisterer).NewGauge(prometheus.GaugeOpts{Name: "backend_health", Help: "backend_health is 1 when healthy"})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if err := electionChecker.Check(r); err != nil {
+			logger.Error(err, "Readiness probe failed")
+			http.Error(w, "lease not renewed", http.StatusServiceUnavailable)
+			backendHealthGauge.Set(0.0)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		backendHealthGauge.Set(1.0)
+	})
+
+	server := &http.Server{Addr: b.options.HealthzServerListenAddress, Handler: mux}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		logger.Info(fmt.Sprintf("Healthz server listening on %s", b.options.HealthzServerListenAddress))
+		errCh <- server.ListenAndServe()
+	}()
+
+	return server
+}
+
+// serveMetrics starts the /metrics HTTP server on its own ServeMux, in a dedicated
+// goroutine, if the option is configured. When MetricsServerListener is not
+// pre-supplied, a net.Listener is created from MetricsServerListenAddress here
+// so the socket only exists while Run is executing (avoiding leaked listeners
+// if Run is never called). It returns the *http.Server so the caller can shut
+// it down. Returns (nil, nil) when neither listener nor address is configured.
+func (b *Backend) serveMetrics(ctx context.Context, wg *sync.WaitGroup, errCh chan<- error) (_ *http.Server, retErr error) {
+	listener := b.options.MetricsServerListener
+	ownListener := false
+	if listener == nil {
+		if b.options.MetricsServerListenAddress == "" {
+			return nil, nil
+		}
+		l, err := net.Listen("tcp", b.options.MetricsServerListenAddress)
+		if err != nil {
+			return nil, fmt.Errorf("failed to listen on %s: %w", b.options.MetricsServerListenAddress, err)
+		}
+		listener = l
+		ownListener = true
+	}
+	// If we created the listener and something below fails before we hand
+	// it off to the serving goroutine, close it here so the socket does
+	// not leak.
+	handedOff := false
+	defer func() {
+		if ownListener && !handedOff && retErr != nil {
+			_ = listener.Close()
+		}
+	}()
+
+	logger := utils.LoggerFromContext(ctx)
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.InstrumentMetricHandler(
+		b.options.MetricsRegisterer,
+		promhttp.HandlerFor(
+			prometheus.Gatherers{b.options.MetricsGatherer},
+			promhttp.HandlerOpts{},
+		),
+	))
+
+	addr := listener.Addr().String()
+	server := &http.Server{Addr: addr, Handler: mux}
+
+	wg.Add(1)
+	handedOff = true
+	go func() {
+		defer wg.Done()
+		logger.Info(fmt.Sprintf("metrics server listening on %s", addr))
+		errCh <- server.Serve(listener)
+	}()
+
+	return server, nil
+}
+
 // shutdownHTTPServer shuts down an HTTP server, logging its outcome and returning
 // an error if the shutdown failed. If the provided server is nil, no action is taken.
 // name is a descriptive name for the server, used in the logging.
@@ -291,22 +346,26 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	_, subscriptionLister := backendInformers.Subscriptions()
 	activeOperationInformer, activeOperationLister := backendInformers.ActiveOperations()
 
+	operationPhaseHandler := metricscontrollers.NewOperationPhaseMetricsHandler(b.options.MetricsRegisterer)
 	operationPhaseMetricsController := metricscontrollers.NewController(
-		"OperationPhaseMetrics", backendInformers.AllOperations(), metricscontrollers.NewOperationPhaseMetricsHandler(b.options.metricsRegisterer()))
+		"OperationPhaseMetrics", backendInformers.AllOperations(), operationPhaseHandler)
 
 	clusterInformer, clusterLister := backendInformers.Clusters()
+	clusterHandler := metricscontrollers.NewClusterMetricsHandler(b.options.MetricsRegisterer)
 	clusterMetricsController := metricscontrollers.NewController(
-		"ClusterMetrics", clusterInformer, metricscontrollers.NewClusterMetricsHandler(b.options.metricsRegisterer()))
+		"ClusterMetrics", clusterInformer, clusterHandler)
 
 	_, billingLister := backendInformers.BillingDocs()
 
 	nodePoolInformer, _ := backendInformers.NodePools()
+	nodePoolHandler := metricscontrollers.NewNodePoolMetricsHandler(b.options.MetricsRegisterer)
 	nodePoolMetricsController := metricscontrollers.NewController(
-		"NodePoolMetrics", nodePoolInformer, metricscontrollers.NewNodePoolMetricsHandler(b.options.metricsRegisterer()))
+		"NodePoolMetrics", nodePoolInformer, nodePoolHandler)
 
 	externalAuthInformer, _ := backendInformers.ExternalAuths()
+	externalAuthHandler := metricscontrollers.NewExternalAuthMetricsHandler(b.options.MetricsRegisterer)
 	externalAuthMetricsController := metricscontrollers.NewController(
-		"ExternalAuthMetrics", externalAuthInformer, metricscontrollers.NewExternalAuthMetricsHandler(b.options.metricsRegisterer()))
+		"ExternalAuthMetrics", externalAuthInformer, externalAuthHandler)
 
 	maestroClientBuilder := maestro.NewMaestroClientBuilder()
 

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"sync"
 	"time"
 
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
@@ -83,13 +82,28 @@ type BackendOptions struct {
 	ClusterScopedIdentitiesConfig      *internalazure.ClusterScopedIdentitiesConfig
 }
 
+const backendShutdownTimeout = 31 * time.Second
+
+type backendHealthzServer struct {
+	listenAddress     string
+	metricsRegisterer prometheus.Registerer
+	electionChecker   *leaderelection.HealthzAdaptor
+}
+
+type backendMetricsServer struct {
+	listenAddress     string
+	listener          net.Listener // optional pre-created listener for tests
+	metricsRegisterer prometheus.Registerer
+	metricsGatherer   prometheus.Gatherer
+}
+
 func (o *BackendOptions) RunBackend(ctx context.Context) error {
 	logger := utils.LoggerFromContext(ctx)
 
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(fmt.Errorf("function returned"))
 
-	backend, err := NewBackend(o)
+	backend, err := o.NewBackend()
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to construct backend: %w", err))
 	}
@@ -111,15 +125,15 @@ func (o *BackendOptions) RunBackend(ctx context.Context) error {
 	return nil
 }
 
-func NewBackend(options *BackendOptions) (*Backend, error) {
-	if options == nil {
-		return nil, errors.New("BackendOptions must not be nil")
+func (o *BackendOptions) NewBackend() (*Backend, error) {
+	if o == nil {
+		return nil, errors.New("backend options must not be nil")
 	}
-	if err := options.validate(); err != nil {
+	if err := o.validate(); err != nil {
 		return nil, err
 	}
 	return &Backend{
-		options: options,
+		options: o,
 	}, nil
 }
 
@@ -133,7 +147,7 @@ func (o *BackendOptions) validate() error {
 	// own. A single half-configured field would silently expose metrics from
 	// one registry while populating another, so we refuse to start.
 	if o.MetricsRegisterer == nil || o.MetricsGatherer == nil {
-		return fmt.Errorf("BackendOptions.MetricsRegisterer and BackendOptions.MetricsGatherer must both be set (MetricsRegisterer set=%t, MetricsGatherer set=%t)",
+		return fmt.Errorf("metrics registerer and gatherer must both be set (registerer set=%t, gatherer set=%t)",
 			o.MetricsRegisterer != nil, o.MetricsGatherer != nil)
 	}
 	return nil
@@ -149,20 +163,13 @@ func (b *Backend) Run(ctx context.Context) error {
 		b.options.AppVersion,
 		b.options.AzureLocation))
 
-	var healthzServer *http.Server
-	var metricsServer *http.Server
-
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer func() {
 		cancel(fmt.Errorf("run returned"))
 
-		// always attempt a graceful shutdown, a double ctrl+c exits the process
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 31*time.Second)
-		defer shutdownCancel()
-		_ = b.shutdownHTTPServer(shutdownCtx, metricsServer, "metrics server")
-		_ = b.shutdownHTTPServer(shutdownCtx, healthzServer, "healthz server")
-
 		logger.Info("shutting down tracer provider")
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), backendShutdownTimeout)
+		defer shutdownCancel()
 		err := b.options.TracerProviderShutdownFunc(shutdownCtx)
 		if err != nil {
 			logger.Error(err, "failed to shut down tracer provider")
@@ -178,25 +185,50 @@ func (b *Backend) Run(ctx context.Context) error {
 	// Create HealthzAdaptor for leader election
 	electionChecker := leaderelection.NewLeaderHealthzAdaptor(time.Second * 20)
 
-	// Create channels and wait group for goroutines.
-	// The size of the channel is the maximum number of goroutines that are to be
-	// executed.
-	// The wait group is used to wait for all goroutines to complete. The sync.WaitGroup counter
-	// is incremented for each goroutine that is to be executed according to the configuration.
-	errCh := make(chan error, 3)
-	wg := sync.WaitGroup{}
+	// Launch servers and leader election as independent goroutines.
+	// Each goroutine sends its result on errCh when done. On first
+	// error or context cancellation, cancel propagates to all.
+	goroutines := 1 // leader election always runs
+	if b.options.HealthzServerListenAddress != "" {
+		goroutines++
+	}
+	if b.options.MetricsServerListenAddress != "" || b.options.MetricsServerListener != nil {
+		goroutines++
+	}
+	errCh := make(chan error, goroutines)
 
-	healthzServer = b.serveHealthz(ctx, electionChecker, &wg, errCh)
-
-	var err error
-	metricsServer, err = b.serveMetrics(ctx, &wg, errCh)
-	if err != nil {
-		return fmt.Errorf("failed to start metrics server: %w", err)
+	if b.options.HealthzServerListenAddress != "" {
+		s := &backendHealthzServer{
+			listenAddress:     b.options.HealthzServerListenAddress,
+			metricsRegisterer: b.options.MetricsRegisterer,
+			electionChecker:   electionChecker,
+		}
+		go func() {
+			err := s.Run(ctx)
+			if err != nil {
+				cancel(fmt.Errorf("healthz server exited: %w", err))
+			}
+			errCh <- err
+		}()
 	}
 
-	wg.Add(1)
+	if b.options.MetricsServerListenAddress != "" || b.options.MetricsServerListener != nil {
+		s := &backendMetricsServer{
+			listenAddress:     b.options.MetricsServerListenAddress,
+			listener:          b.options.MetricsServerListener,
+			metricsRegisterer: b.options.MetricsRegisterer,
+			metricsGatherer:   b.options.MetricsGatherer,
+		}
+		go func() {
+			err := s.Run(ctx)
+			if err != nil {
+				cancel(fmt.Errorf("metrics server exited: %w", err))
+			}
+			errCh <- err
+		}()
+	}
+
 	go func() {
-		defer wg.Done()
 		err := b.runBackendControllersUnderLeaderElection(ctx, electionChecker)
 		// When leader election exits (e.g. lost lease), cancel so Run() unblocks and performs shutdown.
 		cancel(fmt.Errorf("backend controllers leader election exited"))
@@ -205,20 +237,10 @@ func (b *Backend) Run(ctx context.Context) error {
 
 	<-ctx.Done()
 
-	// always attempt a graceful shutdown, a double ctrl+c exits the process
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 31*time.Second)
-	defer shutdownCancel()
-	_ = b.shutdownHTTPServer(shutdownCtx, metricsServer, "metrics server")
-	_ = b.shutdownHTTPServer(shutdownCtx, healthzServer, "healthz server")
-
-	wg.Wait()
-	close(errCh)
 	errs := []error{}
-	for err := range errCh {
-		if err != nil {
-			logger.Info("go func completed", "message", err.Error())
-		}
-		if !errors.Is(err, http.ErrServerClosed) {
+	for range goroutines {
+		if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Info("goroutine completed", "message", err.Error())
 			errs = append(errs, err)
 		}
 	}
@@ -228,20 +250,19 @@ func (b *Backend) Run(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
-// serveHealthz starts the /healthz HTTP server on its own ServeMux, in a dedicated
-// goroutine, if the option is configured. It returns the *http.Server so the caller
-// can shut it down. Returns nil when HealthzServerListenAddress is empty.
-func (b *Backend) serveHealthz(ctx context.Context, electionChecker *leaderelection.HealthzAdaptor, wg *sync.WaitGroup, errCh chan<- error) *http.Server {
-	if b.options.HealthzServerListenAddress == "" {
-		return nil
-	}
+func (s *backendHealthzServer) Run(ctx context.Context) error {
 	logger := utils.LoggerFromContext(ctx)
 
-	backendHealthGauge := promauto.With(b.options.MetricsRegisterer).NewGauge(prometheus.GaugeOpts{Name: "backend_health", Help: "backend_health is 1 when healthy"})
+	listener, err := net.Listen("tcp", s.listenAddress)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", s.listenAddress, err)
+	}
+
+	backendHealthGauge := promauto.With(s.metricsRegisterer).NewGauge(prometheus.GaugeOpts{Name: "backend_health", Help: "backend_health is 1 when healthy"})
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		if err := electionChecker.Check(r); err != nil {
+		if err := s.electionChecker.Check(r); err != nil {
 			logger.Error(err, "Readiness probe failed")
 			http.Error(w, "lease not renewed", http.StatusServiceUnavailable)
 			backendHealthGauge.Set(0.0)
@@ -251,77 +272,65 @@ func (b *Backend) serveHealthz(ctx context.Context, electionChecker *leaderelect
 		backendHealthGauge.Set(1.0)
 	})
 
-	server := &http.Server{Addr: b.options.HealthzServerListenAddress, Handler: mux}
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		logger.Info(fmt.Sprintf("Healthz server listening on %s", b.options.HealthzServerListenAddress))
-		errCh <- server.ListenAndServe()
-	}()
-
-	return server
+	addr := listener.Addr().String()
+	server := &http.Server{Addr: addr, Handler: mux}
+	return runHTTPServer(ctx, "healthz server", addr, server, func() error {
+		return server.Serve(listener)
+	})
 }
 
-// serveMetrics starts the /metrics HTTP server on its own ServeMux, in a dedicated
-// goroutine, if the option is configured. When MetricsServerListener is not
-// pre-supplied, a net.Listener is created from MetricsServerListenAddress here
-// so the socket only exists while Run is executing (avoiding leaked listeners
-// if Run is never called). It returns the *http.Server so the caller can shut
-// it down. Returns (nil, nil) when neither listener nor address is configured.
-func (b *Backend) serveMetrics(ctx context.Context, wg *sync.WaitGroup, errCh chan<- error) (_ *http.Server, retErr error) {
-	listener := b.options.MetricsServerListener
-	ownListener := false
+func (s *backendMetricsServer) Run(ctx context.Context) error {
+	listener := s.listener
 	if listener == nil {
-		if b.options.MetricsServerListenAddress == "" {
-			return nil, nil
-		}
-		l, err := net.Listen("tcp", b.options.MetricsServerListenAddress)
+		l, err := net.Listen("tcp", s.listenAddress)
 		if err != nil {
-			return nil, fmt.Errorf("failed to listen on %s: %w", b.options.MetricsServerListenAddress, err)
+			return fmt.Errorf("failed to listen on %s: %w", s.listenAddress, err)
 		}
 		listener = l
-		ownListener = true
 	}
-	// If we created the listener and something below fails before we hand
-	// it off to the serving goroutine, close it here so the socket does
-	// not leak.
-	handedOff := false
-	defer func() {
-		if ownListener && !handedOff && retErr != nil {
-			_ = listener.Close()
-		}
-	}()
-
-	logger := utils.LoggerFromContext(ctx)
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.InstrumentMetricHandler(
-		b.options.MetricsRegisterer,
+		s.metricsRegisterer,
 		promhttp.HandlerFor(
-			prometheus.Gatherers{b.options.MetricsGatherer},
+			prometheus.Gatherers{s.metricsGatherer},
 			promhttp.HandlerOpts{},
 		),
 	))
 
 	addr := listener.Addr().String()
 	server := &http.Server{Addr: addr, Handler: mux}
+	return runHTTPServer(ctx, "metrics server", addr, server, func() error {
+		return server.Serve(listener)
+	})
+}
 
-	wg.Add(1)
-	handedOff = true
+func runHTTPServer(ctx context.Context, name string, addr string, server *http.Server, serve func() error) error {
+	done := make(chan struct{})
+	defer close(done)
 	go func() {
-		defer wg.Done()
-		logger.Info(fmt.Sprintf("metrics server listening on %s", addr))
-		errCh <- server.Serve(listener)
+		select {
+		case <-ctx.Done():
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), backendShutdownTimeout)
+			defer shutdownCancel()
+			_ = shutdownHTTPServer(shutdownCtx, server, name)
+		case <-done:
+		}
 	}()
 
-	return server, nil
+	logger := utils.LoggerFromContext(ctx)
+	logger.Info(fmt.Sprintf("%s listening on %s", name, addr))
+	err := serve()
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
 }
 
 // shutdownHTTPServer shuts down an HTTP server, logging its outcome and returning
 // an error if the shutdown failed. If the provided server is nil, no action is taken.
 // name is a descriptive name for the server, used in the logging.
-func (b *Backend) shutdownHTTPServer(ctx context.Context, server *http.Server, name string) error {
+func shutdownHTTPServer(ctx context.Context, server *http.Server, name string) error {
 	if server == nil {
 		return nil
 	}

--- a/backend/pkg/app/backend_test.go
+++ b/backend/pkg/app/backend_test.go
@@ -23,7 +23,8 @@ import (
 )
 
 func TestNewBackend_NilOptionsReturnsError(t *testing.T) {
-	b, err := NewBackend(nil)
+	var options *BackendOptions
+	b, err := options.NewBackend()
 	require.Error(t, err)
 	assert.Nil(t, b)
 }
@@ -43,10 +44,10 @@ func TestNewBackend_MetricsRegistryPairing(t *testing.T) {
 		{name: "gatherer only", gatherer: registry, wantErr: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			b, err := NewBackend(&BackendOptions{
+			b, err := (&BackendOptions{
 				MetricsRegisterer: tc.registerer,
 				MetricsGatherer:   tc.gatherer,
-			})
+			}).NewBackend()
 			if tc.wantErr {
 				require.Error(t, err)
 				assert.Nil(t, b)

--- a/backend/pkg/app/backend_test.go
+++ b/backend/pkg/app/backend_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBackend_NilOptionsReturnsError(t *testing.T) {
+	b, err := NewBackend(nil)
+	require.Error(t, err)
+	assert.Nil(t, b)
+}
+
+func TestNewBackend_MetricsRegistryPairing(t *testing.T) {
+	registry := prometheus.NewRegistry()
+
+	for _, tc := range []struct {
+		name       string
+		registerer prometheus.Registerer
+		gatherer   prometheus.Gatherer
+		wantErr    bool
+	}{
+		{name: "both unset (rejected: production must wire both)", wantErr: true},
+		{name: "both set", registerer: registry, gatherer: registry, wantErr: false},
+		{name: "registerer only", registerer: registry, wantErr: true},
+		{name: "gatherer only", gatherer: registry, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := NewBackend(&BackendOptions{
+				MetricsRegisterer: tc.registerer,
+				MetricsGatherer:   tc.gatherer,
+			})
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, b)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, b)
+		})
+	}
+}


### PR DESCRIPTION
[ARO-26227](https://redhat.atlassian.net/browse/ARO-26227)

## What

This PR is intentionally narrowed to a small backend correctness fix:

- wire `MetricsRegisterer` and `MetricsGatherer` explicitly from `backend/cmd/root.go` into `BackendOptions`
- make `NewBackend` return an error and fail fast when the metrics registerer/gatherer pairing is not wired correctly
- serve `/healthz` and `/metrics` from separate `http.ServeMux` / `http.Server` instances
- create the metrics listener inside `Run` so no socket is bound when `Run` is never called
- add tests for nil options and the required metrics registry pairing

## Why

This keeps `#4912` focused on the narrow backend correctness work that surfaced in review:

- avoid silently gathering `/metrics` from one registry while controllers write to another
- avoid sharing the global `DefaultServeMux` between `/healthz` and `/metrics`
- make backend construction fail fast before any goroutine, tracer, or listener is allocated when metrics wiring is invalid

## Not in scope

- no operation metrics label-schema changes
- no `operation_id`
- no `resource_id` / `subscription_id` redesign
- no metrics controller or informer refactors

## Validation

- `go test -run '^$' ./backend/cmd/...`
- `go test ./backend/pkg/app ./test-integration/backend/launch`
