### PR TITLE
Revert "Remove github actions for image build, push and cspr cd"

### DIFF
--- a/.github/workflows/aro-hcp-cd.yml
+++ b/.github/workflows/aro-hcp-cd.yml
@@ -1,0 +1,78 @@
+name: ARO HCP Continuous Deployment
+env:
+  DEPLOY_ENV: dev
+  PERSIST: true
+  SKIP_CONFIRM: true
+  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  PRINCIPAL_ID: ${{ secrets.GHA_PRINCIPAL_ID }}
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Publish Service Images"]
+    types: [completed]
+    branches: [main]
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+jobs:
+  preflight:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+    - name: No reruns please
+      run: |
+        if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+            echo "No re-runs allowed, trigger workflow manually."
+            exit 1
+          else
+            echo "not a re-run"
+          fi
+  deploy_dev_environment_infra:
+    name: 'Deploy integrated DEV infrastructure'
+    needs:
+    - preflight
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    secrets: inherit
+    uses: ./.github/workflows/environment-infra-cd.yml
+    with:
+      deploy_env: dev
+  deploy_dev_environment_services:
+    name: 'Deploy services to integrated DEV'
+    needs:
+    - deploy_dev_environment_infra
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    secrets: inherit
+    uses: ./.github/workflows/services-cd.yml
+    with:
+      deploy_env: dev
+  # CS PR env deployment disabled during testing
+  deploy_cs_pr_environment_infra:
+    name: 'Deploy CS PR infrastructure'
+    needs:
+    - preflight
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    secrets: inherit
+    uses: ./.github/workflows/environment-infra-cd.yml
+    with:
+      deploy_env: cspr
+      deploy_cs_pr_check_deps: true
+  deploy_cs_pr_environment_services:
+    name: 'Deploy services to CS PR'
+    needs:
+    - deploy_cs_pr_environment_infra
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    secrets: inherit
+    uses: ./.github/workflows/services-cd.yml
+    with:
+      deploy_env: cspr
+      deploy_cs_pr_check_deps: true

--- a/.github/workflows/aro-hcp-login-check.yml
+++ b/.github/workflows/aro-hcp-login-check.yml
@@ -20,6 +20,10 @@ jobs:
       with:
         filters: |
           affected:
+            - '.github/workflows/aro-hcp-cd.yml'
+            - '.github/workflows/environment-infra-cd.yml'
+            - '.github/workflows/services-cd.yml'
+            - '.github/workflows/services-ci.yml'
             - 'config/config.yaml'
             - 'dev-infrastructure/**/*.bicep'
             - 'dev-infrastructure/**/*.bicepparam'

--- a/.github/workflows/environment-infra-cd.yml
+++ b/.github/workflows/environment-infra-cd.yml
@@ -1,0 +1,182 @@
+name: ARO HCP Environment Infrastructure Continuous Deployment
+env:
+  DEPLOY_ENV: ${{ inputs.deploy_env }}
+  SKIP_CONFIRM: true
+  PERSIST: true
+  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  #AZURE_AUTHORITY_HOST: https://login.microsoftonline.com/
+  PRINCIPAL_ID: ${{ secrets.GHA_PRINCIPAL_ID }}
+on:
+  workflow_call:
+    inputs:
+      deploy_env:
+        description: 'The deploy environment to use for service deployments'
+        required: true
+        type: string
+      deploy_cs_pr_check_deps:
+        description: 'Deploy PR check environment dependencies'
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      AZURE_CLIENT_ID:
+        description: 'Azure Client ID'
+        required: true
+      AZURE_TENANT_ID:
+        description: 'Azure Tenant ID'
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        description: 'Azure Subscription ID'
+        required: true
+      GHA_PRINCIPAL_ID:
+        description: 'GitHub Actions Azure Principal ID'
+        required: true
+concurrency:
+  group: ${{ github.workflow }}-infra-${{ inputs.deploy_env }}
+  cancel-in-progress: false
+jobs:
+  deploy_region_rg:
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        fetch-depth: 1
+    - name: "install azure-cli"
+      uses: "Azure/ARO-HCP@main"
+    - name: 'Az CLI login'
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - name: 'Deploy'
+      run: |
+        # https://github.com/actions/runner-images/issues/11987
+        az config set bicep.use_binary_from_path=false
+        az bicep install
+        cd dev-infrastructure/
+        make region
+  deploy_monitoring:
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    runs-on: 'ubuntu-latest'
+    needs:
+    - deploy_region_rg
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        fetch-depth: 1
+    - name: "install azure-cli"
+      uses: "Azure/ARO-HCP@main"
+    - name: 'Az CLI login'
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - name: 'Deploy'
+      run: |
+        # https://github.com/actions/runner-images/issues/11987
+        az config set bicep.use_binary_from_path=false
+        az bicep install
+        cd dev-infrastructure/
+        make monitoring
+  deploy_service_cluster_rg:
+    needs:
+    - deploy_region_rg
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        fetch-depth: 1
+    - name: "install azure-cli"
+      uses: "Azure/ARO-HCP@main"
+    - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.3
+      with:
+        kubelogin-version: 'v0.1.3'
+    - uses: oras-project/setup-oras@v1
+      with:
+        version: 1.2.3
+    - name: 'Az CLI login'
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - name: 'Deploy Cluster'
+      run: |
+        # https://github.com/actions/runner-images/issues/11987
+        az config set bicep.use_binary_from_path=false
+        az bicep install
+        cd dev-infrastructure/
+        PRINCIPAL_ID=${{ secrets.GHA_PRINCIPAL_ID }} make svc
+    - name: 'Az CLI login again'
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - name: 'Deploy rest'
+      run: |
+        cd dev-infrastructure/
+        PRINCIPAL_ID=${{ secrets.GHA_PRINCIPAL_ID }} make svc.aks.admin-access
+    - name: 'CS PR check MSI'
+      if: inputs.deploy_cs_pr_check_deps
+      run: |
+        cd dev-infrastructure/
+        make svc.cs-pr-check-msi
+  deploy_management_cluster_rg:
+    needs:
+    - deploy_region_rg
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        fetch-depth: 1
+    - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+      with:
+        version: 'v3.18.6'
+    - name: "install azure-cli"
+      uses: "Azure/ARO-HCP@main"
+    - name: 'Az CLI login'
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+    - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
+      with:
+        kubelogin-version: 'v0.1.3'
+    - uses: oras-project/setup-oras@v1
+      with:
+        version: 1.2.3
+    - name: 'Deploy or Update'
+      run: |
+        # https://github.com/actions/runner-images/issues/11987
+        az config set bicep.use_binary_from_path=false
+        az bicep install
+        cd dev-infrastructure/
+        PRINCIPAL_ID=${{ secrets.GHA_PRINCIPAL_ID }} make mgmt
+    - name: 'Az CLI login again'
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - name: 'Deploy rest'
+      run: |
+        cd dev-infrastructure/
+        PRINCIPAL_ID=${{ secrets.GHA_PRINCIPAL_ID }} make mgmt.aks.admin-access

--- a/.github/workflows/publish-service-images.yml
+++ b/.github/workflows/publish-service-images.yml
@@ -1,0 +1,25 @@
+name: Publish Service Images
+on:
+  push:
+    branches:
+    - main
+  workflow_dispatch:
+env:
+  DEPLOY_ENV: dev
+  PERSIST: true
+  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+jobs:
+  build_push:
+    name: 'Publish service images'
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    secrets: inherit
+    uses: ./.github/workflows/services-ci.yml
+    with:
+      push: true

--- a/.github/workflows/services-cd.yml
+++ b/.github/workflows/services-cd.yml
@@ -1,0 +1,167 @@
+name: ARO HCP Deploy Service Components
+env:
+  DEPLOY_ENV: ${{ inputs.deploy_env }}
+  SKIP_CONFIRM: true
+  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  PRINCIPAL_ID: ${{ secrets.GHA_PRINCIPAL_ID }}
+  PERSIST: true
+on:
+  workflow_call:
+    inputs:
+      deploy_env:
+        description: 'The deploy environment to use for service deployments'
+        required: true
+        type: string
+      deploy_cs_pr_check_deps:
+        description: 'Deploy PR check environment dependencies'
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      AZURE_CLIENT_ID:
+        description: 'Azure Client ID'
+        required: true
+      AZURE_TENANT_ID:
+        description: 'Azure Tenant ID'
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        description: 'Azure Subscription ID'
+        required: true
+concurrency:
+  group: ${{ github.workflow }}-service-cd-${{ inputs.deploy_env }}
+  cancel-in-progress: false
+jobs:
+  deploy_to_service_cluster:
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.work'
+    - name: "install azure-cli"
+      uses: "Azure/ARO-HCP@main"
+    - name: 'Az CLI login'
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+    # Used to deploy Cluster Service
+    - name: 'Install oc'
+      run: |
+        curl -sfLo - https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.15.9/openshift-client-linux.tar.gz | tar xzf -
+        sudo mv oc /usr/local/bin/oc
+        chmod +x /usr/local/bin/oc
+    # Used to deploy Maestro Server, Frontend
+    - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+      with:
+        version: 'v3.18.6'
+    - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
+      with:
+        kubelogin-version: 'v0.1.3'
+    - uses: oras-project/setup-oras@v1
+      with:
+        version: 1.2.3
+    # Prepare kubeconfig
+    - name: 'Prepare kubeconfig'
+      run: |
+        cd dev-infrastructure/
+        make svc.aks.kubeconfig
+    - name: 'Deploy Frontend'
+      run: |
+        OVERRIDE_CONFIG_FILE="${RUNNER_TEMP}/frontend-$(uuidgen).yaml"
+        make -C frontend/ record-override OVERRIDE_CONFIG_FILE="${OVERRIDE_CONFIG_FILE}" DETECT_DIRTY_GIT_WORKTREE=0
+        make pipeline/RP.Frontend OVERRIDE_CONFIG_FILE="${OVERRIDE_CONFIG_FILE}"
+    - name: 'Deploy Session Gate'
+      run: |
+        OVERRIDE_CONFIG_FILE="${RUNNER_TEMP}/sessiongate-$(uuidgen).yaml"
+        make -C sessiongate/ record-override OVERRIDE_CONFIG_FILE="${OVERRIDE_CONFIG_FILE}" DETECT_DIRTY_GIT_WORKTREE=0
+        make pipeline/SessionGate OVERRIDE_CONFIG_FILE="${OVERRIDE_CONFIG_FILE}"
+    - name: 'Deploy Admin API'
+      run: |
+        OVERRIDE_CONFIG_FILE="${RUNNER_TEMP}/admin-$(uuidgen).yaml"
+        make -C admin/ record-override OVERRIDE_CONFIG_FILE="${OVERRIDE_CONFIG_FILE}" DETECT_DIRTY_GIT_WORKTREE=0
+        make pipeline/AdminAPI OVERRIDE_CONFIG_FILE="${OVERRIDE_CONFIG_FILE}"
+    - name: 'Deploy Backend'
+      run: |
+        OVERRIDE_CONFIG_FILE="${RUNNER_TEMP}/backend-$(uuidgen).yaml"
+        make -C backend/ record-override OVERRIDE_CONFIG_FILE="${OVERRIDE_CONFIG_FILE}" DETECT_DIRTY_GIT_WORKTREE=0
+        make pipeline/RP.Backend OVERRIDE_CONFIG_FILE="${OVERRIDE_CONFIG_FILE}"
+    - name: 'Deploy Cluster Service'
+      if: ${{ ! inputs.deploy_cs_pr_check_deps }}
+      run: |
+        make cluster-service.deploy_pipeline
+    - name: 'Deploy Maestro'
+      run: |
+        make maestro.server.deploy_pipeline
+    - name: 'Deploy Observability/Tracing'
+      run: |
+        make observability.tracing.deploy_pipeline
+    - name: 'Deploy CS PR check environment dressup'
+      if: inputs.deploy_cs_pr_check_deps
+      run: |
+        ./svc-deploy.sh ${DEPLOY_ENV} cluster-service svc deploy-pr-env-deps
+  deploy_to_management_cluster:
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.work'
+    - name: "install azure-cli"
+      uses: "Azure/ARO-HCP@main"
+    - name: 'Az CLI login'
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+    - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
+      with:
+        kubelogin-version: 'v0.1.3'
+    - uses: oras-project/setup-oras@v1
+      with:
+        version: 1.2.3
+    - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+      with:
+        version: 'v3.18.6'
+    # Prepare kubeconfig
+    - name: 'Prepare kubeconfig'
+      run: |
+        cd dev-infrastructure/
+        make mgmt.aks.kubeconfig
+    - name: 'Deploy ACM'
+      run: |
+        make acm.deploy_pipeline
+    # - name: 'Deploy PKO'
+    #   run: |
+    #     make pko.deploy_pipeline
+    - name: 'Deploy Maestro Agent'
+      run: |
+        make maestro.agent.deploy_pipeline
+    - name: 'Deploy Hypershift Operator and External DNS Operator'
+      run: |
+        make hypershiftoperator.deploy_pipeline
+    - name: 'Deploy Secret Sync Controller'
+      run: |
+        make secret-sync-controller.deploy_pipeline
+    - name: 'Deploy Observability/Tracing'
+      run: |
+        make observability.tracing.deploy_pipeline
+    - name: 'Deploy Route Monitor Operator'
+      run: |
+        make route-monitor-operator.deploy_pipeline

--- a/.github/workflows/services-ci-pr.yml
+++ b/.github/workflows/services-ci-pr.yml
@@ -1,0 +1,32 @@
+name: ARO HCP Service Image Build (PR)
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+    - main
+    paths:
+    - '.github/workflows/services-ci.yml'
+    - '.github/workflows/services-ci-pr.yml'
+    - 'go.work'
+    - 'frontend/**'
+    - 'admin/**'
+    - 'backend/**'
+    - 'sessiongate/**'
+    - 'image-sync/**/'
+    - 'tooling/aro-hcp-exporter/**'
+    - 'tooling/hcpctl/**'
+    - 'internal/**'
+    - 'test-integration/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  build_images:
+    name: 'Build service images'
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    uses: ./.github/workflows/services-ci.yml
+    with:
+      push: false
+      cancel-in-progress: true

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -1,0 +1,116 @@
+name: ARO HCP Dev Environment Continuous Deployment
+env:
+  DEPLOY_ENV: dev
+  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  PRINCIPAL_ID: ${{ secrets.GHA_PRINCIPAL_ID }}
+  PERSIST: true
+on:
+  workflow_call:
+    inputs:
+      push:
+        description: 'Push to the registry'
+        required: true
+        type: boolean
+      cancel-in-progress:
+        description: 'Cancel in-progress runs'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      AZURE_CLIENT_ID:
+        description: 'Azure Client ID'
+        required: false
+      AZURE_TENANT_ID:
+        description: 'Azure Tenant ID'
+        required: false
+      AZURE_SUBSCRIPTION_ID:
+        description: 'Azure Subscription ID'
+        required: false
+concurrency:
+  group: ${{ github.workflow }}-service-ci
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
+jobs:
+  build_push:
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: aro-hcp-exporter
+          dir: tooling/aro-hcp-exporter
+          setup_go: true
+          acr_image: arohcpmetrics
+        - name: frontend
+          dir: frontend
+          setup_go: true
+          acr_image: arohcpfrontend
+        - name: backend
+          dir: backend
+          setup_go: true
+          acr_image: arohcpbackend
+        - name: admin-api
+          dir: admin
+          setup_go: true
+          acr_image: arohcpadminapi
+        - name: sessiongate
+          dir: sessiongate
+          setup_go: true
+          acr_image: arohcpsessiongate
+        - name: oc-mirror
+          dir: image-sync/oc-mirror
+          setup_go: false
+          acr_image: image-sync/oc-mirror
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-go@v6
+      if: matrix.setup_go
+      with:
+        go-version-file: 'go.work'
+    - name: Build ${{ matrix.name }} container image
+      if: inputs.push == false
+      run: |
+        cd ${{ matrix.dir }}
+        make image
+    - name: "install azure-cli"
+      if: inputs.push == true
+      uses: "Azure/ARO-HCP@main"
+    - name: 'Az CLI login'
+      if: inputs.push == true
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - name: Build and push ${{ matrix.name }} container image
+      if: inputs.push == true
+      run: |
+        cd ${{ matrix.dir }}
+        for attempt in 1 2 3; do
+          echo "Push attempt ${attempt}/3"
+          if make build-and-push; then
+            exit 0
+          fi
+          echo "Attempt ${attempt} failed, retrying in 30s..."
+          sleep 30
+        done
+        echo "All push attempts failed"
+        exit 1
+    - name: Verify ${{ matrix.name }} image in ACR
+      if: inputs.push == true
+      env:
+        ACR_NAME: arohcpsvcdev
+      run: |
+        TAG=$(./generate-tag.sh)
+        echo "Verifying ${{ matrix.acr_image }}:${TAG} in ${ACR_NAME}"
+        az acr manifest show \
+          --registry "${ACR_NAME}" \
+          --name "${{ matrix.acr_image }}:${TAG}" \
+          --output none
+        echo "Verified ${{ matrix.acr_image }}:${TAG}"


### PR DESCRIPTION
Reverts Azure/ARO-HCP#4762

The alternative to this was not deployed, so bumper is permafailing as Frontend / Backend / AdminAPI and SessionGate images are not being build.