### PR TITLE
e2e: bump stage per-test timeout to 150 minutes

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -87,6 +87,7 @@ func setupCli() *cobra.Command {
 	})
 
 	stageQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0], labels.DevelopmentOnly[0])
+	stageTestTimeout := 150 * time.Minute
 	ext.AddSuite(e.Suite{
 		Name: "stage/parallel",
 		Qualifiers: []string{
@@ -96,6 +97,7 @@ func setupCli() *cobra.Command {
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=30
 		Parallelism: 34,
+		TestTimeout: &stageTestTimeout,
 	})
 	ext.AddSuite(e.Suite{
 		Name: "stage/parallel/slow",
@@ -106,6 +108,7 @@ func setupCli() *cobra.Command {
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=30
 		Parallelism: 34,
+		TestTimeout: &stageTestTimeout,
 	})
 
 	prodQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0], labels.DevelopmentOnly[0])


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-663

### What

Increase per-test timeout for `stage/parallel` and `stage/parallel/slow` suites from the default 90 minutes to 150 minutes.

### Why

The periodic stage E2E has failed every overnight (~04:00 UTC) run for the last 3 nights (Apr 15, 16, 17) while daytime runs pass consistently. Failures are caused by resource contention — identity container pool exhaustion and nodepool creation slowness — combined with the default 90-minute per-test timeout being too tight.

| Night | Root cause | Duration |
|-------|-----------|----------|
| Apr 15 | NodePool creation timeout (>45 min) in private-keyvault test | 76 min |
| Apr 16 | NodePool creation timeout (>45 min) in negative-tests | 90 min |
| Apr 17 | Identity container acquisition (28 min / 29 retries) + SIGABRT during cleanup | 90 min |

Failing runs:
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel/2044234261753499648
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel/2044596653784043520
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel/2044959032376037376

This is the same pattern already fixed for prod in PR #4811 ([AROSLSRE-617](https://redhat.atlassian.net/browse/AROSLSRE-617)). Stage was missed.

### Testing

Build verified locally. The change only sets `TestTimeout` on stage suites following the existing prod pattern.

### Special notes for your reviewer

Stage has more identity containers (30) than prod (15), but with higher parallelism (34 specs vs 19), so contention can still occur — especially during overnight runs.