### PR TITLE
validation: fix "visiblity" typo in API field path

### DIFF
--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -377,7 +377,7 @@ func TestDeploymentPreflight(t *testing.T) {
 			expectErrors: []expectedPreflightError{
 				{message: "Required value", target: "properties.version.id"},
 				{message: "Invalid value: \"invalidCidr\": invalid CIDR address: invalidCidr", target: "properties.network.podCidr"},
-				{message: "Unsupported value: \"invisible\": supported values: \"Private\", \"Public\"", target: "properties.api.visiblity"},
+				{message: "Unsupported value: \"invisible\": supported values: \"Private\", \"Public\"", target: "properties.api.visibility"},
 				{message: "Required value", target: "properties.platform.subnetId"},
 				{message: "Required value", target: "properties.platform.networkSecurityGroupId"},
 			},

--- a/internal/validation/hcpopenshiftcluster_test.go
+++ b/internal/validation/hcpopenshiftcluster_test.go
@@ -100,11 +100,11 @@ func TestClusterRequired(t *testing.T) {
 				},
 				{
 					message:   "Required value",
-					fieldPath: "customerProperties.api.visiblity",
+					fieldPath: "customerProperties.api.visibility",
 				},
 				{
 					message:   "Unsupported value",
-					fieldPath: "customerProperties.api.visiblity",
+					fieldPath: "customerProperties.api.visibility",
 				},
 				{
 					message:   "Required value",
@@ -492,7 +492,7 @@ func TestClusterValidate(t *testing.T) {
 			expectErrors: []expectedError{
 				{
 					message:   "supported values: \"Private\", \"Public\"",
-					fieldPath: "customerProperties.api.visiblity",
+					fieldPath: "customerProperties.api.visibility",
 				},
 			},
 		},

--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -487,9 +487,9 @@ func validateCustomerAPIProfile(ctx context.Context, op operation.Operation, fld
 	errs := field.ErrorList{}
 
 	// Visibility      Visibility `json:"visibility,omitempty"`
-	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("visiblity"), &newObj.Visibility, nil)...)
-	errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath.Child("visiblity"), &newObj.Visibility, safe.Field(oldObj, toAPIVisibility))...)
-	errs = append(errs, validate.Enum(ctx, op, fldPath.Child("visiblity"), &newObj.Visibility, nil, api.ValidVisibility)...)
+	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("visibility"), &newObj.Visibility, nil)...)
+	errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath.Child("visibility"), &newObj.Visibility, safe.Field(oldObj, toAPIVisibility))...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath.Child("visibility"), &newObj.Visibility, nil, api.ValidVisibility)...)
 
 	// AuthorizedCIDRs []string   `json:"authorizedCidrs,omitempty"`
 	errs = append(errs, MaxItems(ctx, op, fldPath.Child("authorizedCidrs"), newObj.AuthorizedCIDRs, nil, 500)...)

--- a/internal/validation/validate_cluster_comprehensive_test.go
+++ b/internal/validation/validate_cluster_comprehensive_test.go
@@ -152,7 +152,7 @@ func TestValidateClusterCreate(t *testing.T) {
 				return c
 			}(),
 			expectErrors: []expectedError{
-				{message: "Unsupported value", fieldPath: "customerProperties.api.visiblity"},
+				{message: "Unsupported value", fieldPath: "customerProperties.api.visibility"},
 			},
 		},
 		{
@@ -586,7 +586,7 @@ func TestValidateClusterCreate(t *testing.T) {
 			expectErrors: []expectedError{
 				{message: "must be a valid DNS RFC 1035 label", fieldPath: "customerProperties.dns.baseDomainPrefix"},
 				{message: "Unsupported value", fieldPath: "customerProperties.network.networkType"},
-				{message: "Unsupported value", fieldPath: "customerProperties.api.visiblity"},
+				{message: "Unsupported value", fieldPath: "customerProperties.api.visibility"},
 			},
 		},
 		// Tests for validateOperatorAuthenticationAgainstIdentities
@@ -1495,7 +1495,7 @@ func TestValidateClusterUpdate(t *testing.T) {
 				return c
 			}(),
 			expectErrors: []expectedError{
-				{message: "field is immutable", fieldPath: "customerProperties.api.visiblity"},
+				{message: "field is immutable", fieldPath: "customerProperties.api.visibility"},
 			},
 		},
 		{
@@ -1972,7 +1972,7 @@ func TestValidateClusterUpdate(t *testing.T) {
 			expectErrors: []expectedError{
 				{message: "field is immutable", fieldPath: "customerProperties.version.id"},
 				{message: "field is immutable", fieldPath: "customerProperties.dns.baseDomainPrefix"},
-				{message: "field is immutable", fieldPath: "customerProperties.api.visiblity"},
+				{message: "field is immutable", fieldPath: "customerProperties.api.visibility"},
 				{message: "field is immutable", fieldPath: "serviceProviderProperties.managedIdentitiesDataPlaneIdentityURL"},
 			},
 		},


### PR DESCRIPTION
## Summary
- Fix misspelled validation error field path `visiblity` → `visibility` for the API visibility field
- Updates validation source and all matching test expectations

## Test plan
- [x] `internal/validation` tests pass
- [x] `frontend/pkg/frontend` tests pass
- [x] CI passes