### PR TITLE
deps: bump Python packages to fix 5 CVEs

### DIFF
--- a/.github/workflows/runbook-cicd.yml
+++ b/.github/workflows/runbook-cicd.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         cd tooling/azure-automation/resources-cleanup
         pip install -r requirements.txt
-        pip install pylint pytest
+        pip install pylint
     - name: Lint Python runbooks
       run: |
         cd tooling/azure-automation/resources-cleanup/src

--- a/tooling/azure-automation/resources-cleanup/requirements.txt
+++ b/tooling/azure-automation/resources-cleanup/requirements.txt
@@ -14,11 +14,11 @@ isodate==0.6.1
 msal==1.36.0
 msal-extensions==1.1.0
 packaging==23.2
-pluggy==1.3.0
+pluggy==1.5.0
 portalocker==2.8.2
 pycparser==2.21
 PyJWT==2.12.0
-pytest==7.4.4
+pytest==9.0.3
 requests==2.32.4
 six==1.16.0
 tomli==2.0.1

--- a/tooling/azure-automation/resources-cleanup/requirements.txt
+++ b/tooling/azure-automation/resources-cleanup/requirements.txt
@@ -19,7 +19,7 @@ portalocker==2.8.2
 pycparser==2.21
 PyJWT==2.12.0
 pytest==9.0.3
-requests==2.32.4
+requests==2.33.0
 six==1.16.0
 tomli==2.0.1
 typing_extensions==4.13.2

--- a/tooling/azure-automation/resources-cleanup/requirements.txt
+++ b/tooling/azure-automation/resources-cleanup/requirements.txt
@@ -6,7 +6,7 @@ azure-mgmt-resource==23.0.1
 certifi==2024.7.4
 cffi==2.0.0
 charset-normalizer==3.3.2
-cryptography==46.0.5
+cryptography==46.0.7
 exceptiongroup==1.2.0
 idna==3.7
 iniconfig==2.0.0

--- a/tooling/azure-automation/resources-cleanup/requirements.txt
+++ b/tooling/azure-automation/resources-cleanup/requirements.txt
@@ -17,7 +17,7 @@ packaging==23.2
 pluggy==1.3.0
 portalocker==2.8.2
 pycparser==2.21
-PyJWT==2.8.0
+PyJWT==2.12.0
 pytest==7.4.4
 requests==2.32.4
 six==1.16.0


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-670

Closes #4918

### What

Bump pinned Python dependencies in `tooling/azure-automation/resources-cleanup/requirements.txt`.

- **PyJWT 2.8.0 → 2.12.0** — CVE-2026-32597 (high): accepts unknown `crit` header extensions. Resolves Dependabot alert #155.
- **cryptography 46.0.5 → 46.0.7** — CVE-2026-39892: buffer overflow with non-contiguous buffers. CVE-2026-34073 (low): incomplete DNS name constraint enforcement. Resolves Dependabot alerts #219, #176.
- **pytest 7.4.4 → 9.0.3** — CVE-2025-71176: vulnerable tmpdir handling. Also bumps pluggy 1.3.0 → 1.5.0 (required by pytest >= 9). Resolves Dependabot alert #214.
- **requests 2.32.4 → 2.33.0** — CVE-2026-25645: insecure temp file reuse in `extract_zipped_paths()`. Resolves Dependabot alert #170.

Also removes the unpinned `pip install pytest` from the CI workflow so the pinned version from `requirements.txt` is used.

### Why

Fix 5 Dependabot security alerts (1 high, 3 medium, 1 low).

### Testing

Dependency-only changes, no application code modified. CI validates the runbook still lints and tests pass.