### PR TITLE
security: set RequireAzureTokenCredentials on DefaultAzureCredential

### DIFF
--- a/backend/pkg/app/backend_identity_wiring.go
+++ b/backend/pkg/app/backend_identity_wiring.go
@@ -35,7 +35,8 @@ func NewBackendIdentityAzureClients(ctx context.Context, azureConfig *azureconfi
 	// for more details on it.
 	defaultAzureCredential, err := azidentity.NewDefaultAzureCredential(
 		&azidentity.DefaultAzureCredentialOptions{
-			ClientOptions: *azureConfig.CloudEnvironment.AZCoreClientOptions(),
+			ClientOptions:                *azureConfig.CloudEnvironment.AZCoreClientOptions(),
+			RequireAzureTokenCredentials: true,
 		},
 	)
 	if err != nil {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -219,7 +219,8 @@ func (d *cosmosDBClient) GlobalListers() GlobalListers {
 func NewCosmosDatabaseClient(url string, dbName string, clientOptions azcore.ClientOptions) (*azcosmos.DatabaseClient, error) {
 	credential, err := azidentity.NewDefaultAzureCredential(
 		&azidentity.DefaultAzureCredentialOptions{
-			ClientOptions: clientOptions,
+			ClientOptions:                clientOptions,
+			RequireAzureTokenCredentials: true,
 		})
 	if err != nil {
 		return nil, utils.TrackError(err)

--- a/test/cmd/aro-hcp-tests/gather-observability/options.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/options.go
@@ -180,7 +180,8 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 	}
 
 	cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
-		AdditionallyAllowedTenants: []string{"*"},
+		AdditionallyAllowedTenants:   []string{"*"},
+		RequireAzureTokenCredentials: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Azure credential: %w", err)


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-673

### What

Set `RequireAzureTokenCredentials: true` on all remaining `DefaultAzureCredential` call sites:

- **`internal/database/database.go`** — `NewCosmosDatabaseClient` credential. Resolves [code scanning alert #4](https://github.com/Azure/ARO-HCP/security/code-scanning/4) (SM05142).
- **`backend/pkg/app/backend_identity_wiring.go`** — Backend identity Azure clients. Resolves [code scanning alert #3](https://github.com/Azure/ARO-HCP/security/code-scanning/3) (SM05142).
- **`test/cmd/aro-hcp-tests/gather-observability/options.go`** — Test gather-observability command.

### Why

Without this option, `DefaultAzureCredential` falls back to developer credentials (`AzureCLICredential`, `AzurePowerShellCredential`) during managed identity service (IMDS) outages in production, which introduces latency and security risk. This option is already applied across the rest of the codebase.

### Testing

Adds a single boolean field to existing credential options. `go build` passes. No behavioral change when `AZURE_TOKEN_CREDENTIALS` env var is already set (which it is in all environments).