### PR TITLE
admin: use case-insensitive header prefix comparison

### DIFF
--- a/admin/server/middleware/ga_calling_identity.go
+++ b/admin/server/middleware/ga_calling_identity.go
@@ -33,7 +33,7 @@ func MiddlewareClientPrincipal(w http.ResponseWriter, r *http.Request, next http
 
 	var headers []string
 	for name, values := range r.Header {
-		if strings.HasPrefix(name, "X-Ms-Client-Principal-") {
+		if strings.HasPrefix(strings.ToLower(name), "x-ms-client-principal-") {
 			headers = append(headers, fmt.Sprintf("%s=%s", name, strings.Join(values, ",")))
 		}
 	}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-674

### What

Use case-insensitive prefix comparison for `X-Ms-Client-Principal-*` headers in the admin middleware.

Resolves [code scanning alert #2](https://github.com/Azure/ARO-HCP/security/code-scanning/2) (SM04506).

### Why

HTTP headers are case-insensitive per RFC 7230. While Go's `http.Header` canonicalizes keys, a case-insensitive comparison is more robust and satisfies the CodeQL scanner.

### Testing

One-line change (`strings.HasPrefix` → `strings.HasPrefix(strings.ToLower(...))`). `go build` passes. No behavioral change since Go already canonicalizes header keys.