### PR TITLE
bump clusters-service image digest

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -889,7 +889,7 @@ defaults:
     image:
       registry: quay.io
       repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:f9586c08cfd6ae55d2988352218680bc0b6f0bfb46808e696d665312ad603421 # 295693e2b0a57c4da27ae8e670add15bd9c16583 (2026-04-17 16:52)
+      digest: sha256:27fd7a951a2de43e4288ea9c5c2abafb64ef4b36035c2dd6b70a19510c930762 # 4b1ad6f1aec3436d9fbe5b05a8f18ba69e51abc7 (2026-04-19 13:55)
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -167,7 +167,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:f9586c08cfd6ae55d2988352218680bc0b6f0bfb46808e696d665312ad603421
+    digest: sha256:27fd7a951a2de43e4288ea9c5c2abafb64ef4b36035c2dd6b70a19510c930762
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -167,7 +167,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:f9586c08cfd6ae55d2988352218680bc0b6f0bfb46808e696d665312ad603421
+    digest: sha256:27fd7a951a2de43e4288ea9c5c2abafb64ef4b36035c2dd6b70a19510c930762
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -167,7 +167,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:f9586c08cfd6ae55d2988352218680bc0b6f0bfb46808e696d665312ad603421
+    digest: sha256:27fd7a951a2de43e4288ea9c5c2abafb64ef4b36035c2dd6b70a19510c930762
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -167,7 +167,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:f9586c08cfd6ae55d2988352218680bc0b6f0bfb46808e696d665312ad603421
+    digest: sha256:27fd7a951a2de43e4288ea9c5c2abafb64ef4b36035c2dd6b70a19510c930762
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -167,7 +167,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpprow
   image:
-    digest: sha256:f9586c08cfd6ae55d2988352218680bc0b6f0bfb46808e696d665312ad603421
+    digest: sha256:27fd7a951a2de43e4288ea9c5c2abafb64ef4b36035c2dd6b70a19510c930762
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -167,7 +167,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpswft
   image:
-    digest: sha256:f9586c08cfd6ae55d2988352218680bc0b6f0bfb46808e696d665312ad603421
+    digest: sha256:27fd7a951a2de43e4288ea9c5c2abafb64ef4b36035c2dd6b70a19510c930762
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-675

## Summary

The previous CS image digest (`sha256:f9586c08cfd6…`, 2026-04-17) was deleted from `quay.io/app-sre/aro-hcp-clusters-service`, blocking all E2E Prow jobs at the image mirror step.

Updated to `sha256:27fd7a951a2d…` (2026-04-19 13:55).

## Test plan
- [x] E2E mirror step passes