### PR TITLE
restoring personal-dev-env target and adding new target for images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,14 +379,20 @@ record-services-override: $(YQ) $(ORAS)
 # One-Step Personal Dev Environment
 #
 ifeq ($(DEPLOY_ENV),$(filter $(DEPLOY_ENV),pers swft))
-personal-dev-env: install-tools build-services record-services-override
+personal-dev-env: install-tools
+	$(MAKE) entrypoint/Region
+	$(MAKE) infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing infra.cosmos.access
+
+personal-dev-env-images: install-tools build-services record-services-override
 	$(MAKE) entrypoint/Region OVERRIDE_CONFIG_FILE=$(PERS_OVERRIDE_FILE)
 	$(MAKE) infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing infra.cosmos.access
 else
 personal-dev-env:
 	$(error personal-dev-env: DEPLOY_ENV must be set to "pers" or "swft", not "$(DEPLOY_ENV)")
+personal-dev-env-images:
+	$(error personal-dev-env-images: DEPLOY_ENV must be set to "pers" or "swft", not "$(DEPLOY_ENV)")
 endif
-.PHONY: personal-dev-env
+.PHONY: personal-dev-env personal-dev-env-images
 
 #
 # Opstool topology local run

--- a/Makefile
+++ b/Makefile
@@ -379,20 +379,14 @@ record-services-override: $(YQ) $(ORAS)
 # One-Step Personal Dev Environment
 #
 ifeq ($(DEPLOY_ENV),$(filter $(DEPLOY_ENV),pers swft))
-personal-dev-env: install-tools
-	$(MAKE) entrypoint/Region
-	$(MAKE) infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing infra.cosmos.access
-
-personal-dev-env-images: install-tools build-services record-services-override
+personal-dev-env: build-services record-services-override
 	$(MAKE) entrypoint/Region OVERRIDE_CONFIG_FILE=$(PERS_OVERRIDE_FILE)
 	$(MAKE) infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing infra.cosmos.access
 else
 personal-dev-env:
 	$(error personal-dev-env: DEPLOY_ENV must be set to "pers" or "swft", not "$(DEPLOY_ENV)")
-personal-dev-env-images:
-	$(error personal-dev-env-images: DEPLOY_ENV must be set to "pers" or "swft", not "$(DEPLOY_ENV)")
 endif
-.PHONY: personal-dev-env personal-dev-env-images
+.PHONY: personal-dev-env
 
 #
 # Opstool topology local run

--- a/docs/personal-dev.md
+++ b/docs/personal-dev.md
@@ -47,19 +47,11 @@ The creation process can take up to 20 minutes.
    make personal-dev-env
    ```
 
-This command creates a personal DEV environment with a unique name that is derived from your username and deploys all required infrastructure components.
+This command creates a personal DEV environment with a unique name that is derived from your username. It builds and pushes all in-repo service images (frontend, backend, admin, sessiongate) from your local checkout and deploys them along with all required infrastructure components.
 
 > [!TIP]
 > This command can be used to update your personal DEV environment as well. It will apply the latest changes to the infrastructure and services. Steps are cached, so it's quick and safe to re-run the entire environment setup.
 > If you only want to update individual aspects of the environment, follow the [partial setup](#partial-personal-dev-environment-setup) instructions.
-
-If you need to build and deploy custom images for the in-repo services (frontend, backend, admin, sessiongate), use:
-
-   ```bash
-   make personal-dev-env-images
-   ```
-
-This builds and pushes all service images from your local checkout, then deploys with those images instead of the defaults from `config.yaml`.
 
 ### Local Cluster Service Development Setup
 

--- a/docs/personal-dev.md
+++ b/docs/personal-dev.md
@@ -53,6 +53,14 @@ This command creates a personal DEV environment with a unique name that is deriv
 > This command can be used to update your personal DEV environment as well. It will apply the latest changes to the infrastructure and services. Steps are cached, so it's quick and safe to re-run the entire environment setup.
 > If you only want to update individual aspects of the environment, follow the [partial setup](#partial-personal-dev-environment-setup) instructions.
 
+If you need to build and deploy custom images for the in-repo services (frontend, backend, admin, sessiongate), use:
+
+   ```bash
+   make personal-dev-env-images
+   ```
+
+This builds and pushes all service images from your local checkout, then deploys with those images instead of the defaults from `config.yaml`.
+
 ### Local Cluster Service Development Setup
 
 If you plan to run the Cluster Service locally (not deployed to Kubernetes) for development, use the following command instead:


### PR DESCRIPTION
## Summary

Restore the `personal-dev-env` Makefile target, always building and deploying service images from the local checkout. Personal dev environments should always use locally built images — there's no use case for deploying without them.

## Changes

- `personal-dev-env` now runs `build-services` and `record-services-override` as prerequisites, then deploys with the override config
- Removed the separate `personal-dev-env-images` target (no longer needed)
- Updated docs to reflect that `personal-dev-env` always builds images

## Test plan

- [x] `make personal-dev-env` builds images and deploys successfully on a pers environment