### PR TITLE
fix for az acr login error in personal-dev-env

### DIFF
--- a/admin/Makefile
+++ b/admin/Makefile
@@ -74,7 +74,8 @@ image: Dockerfile $(ADMIN_API_SOURCES) Makefile
 		--tag ${ADMIN_API_TAGGED_IMAGE}
 
 build-and-push: image $(ORAS)
-	az acr login --name ${ARO_HCP_IMAGE_ACR}
+	@TOKEN=$$(az acr login --name ${ARO_HCP_IMAGE_ACR} --expose-token --query accessToken -o tsv) && \
+	$(CONTAINER_ENGINE) login ${ARO_HCP_IMAGE_REGISTRY} -u 00000000-0000-0000-0000-000000000000 -p "$$TOKEN"
 	$(CONTAINER_ENGINE) push ${ADMIN_API_TAGGED_IMAGE}
 .PHONY: build-and-push
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -54,7 +54,8 @@ image: Dockerfile $(BACKEND_SOURCES) Makefile
 		--tag ${BACKEND_TAGGED_IMAGE}
 
 build-and-push: image $(ORAS)
-	az acr login --name ${ARO_HCP_IMAGE_ACR}
+	@TOKEN=$$(az acr login --name ${ARO_HCP_IMAGE_ACR} --expose-token --query accessToken -o tsv) && \
+	$(CONTAINER_ENGINE) login ${ARO_HCP_IMAGE_REGISTRY} -u 00000000-0000-0000-0000-000000000000 -p "$$TOKEN"
 	$(CONTAINER_ENGINE) push ${BACKEND_TAGGED_IMAGE}
 .PHONY: build-and-push
 

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -53,7 +53,8 @@ image: Dockerfile $(FRONTEND_SOURCES) Makefile
 		--tag ${FRONTEND_TAGGED_IMAGE}
 
 build-and-push: image $(ORAS)
-	az acr login --name ${ARO_HCP_IMAGE_ACR}
+	@TOKEN=$$(az acr login --name ${ARO_HCP_IMAGE_ACR} --expose-token --query accessToken -o tsv) && \
+	$(CONTAINER_ENGINE) login ${ARO_HCP_IMAGE_REGISTRY} -u 00000000-0000-0000-0000-000000000000 -p "$$TOKEN"
 	$(CONTAINER_ENGINE) push ${FRONTEND_TAGGED_IMAGE}
 .PHONY: build-and-push
 

--- a/image-sync/oc-mirror/Makefile
+++ b/image-sync/oc-mirror/Makefile
@@ -16,7 +16,8 @@ image:
 .PHONY: image
 
 build-and-push: image
-	az acr login --name ${ARO_HCP_IMAGE_ACR}
+	@TOKEN=$$(az acr login --name ${ARO_HCP_IMAGE_ACR} --expose-token --query accessToken -o tsv) && \
+	$(CONTAINER_ENGINE) login ${ARO_HCP_IMAGE_ACR}.azurecr.io -u 00000000-0000-0000-0000-000000000000 -p "$$TOKEN"
 	$(CONTAINER_ENGINE) tag ${OC_MIRROR_IMAGE_TAGGED} ${OC_MIRROR_IMAGE}:latest
 	$(CONTAINER_ENGINE) push ${OC_MIRROR_IMAGE_TAGGED}
 	$(CONTAINER_ENGINE) push ${OC_MIRROR_IMAGE}:latest

--- a/sessiongate/Makefile
+++ b/sessiongate/Makefile
@@ -56,7 +56,8 @@ image: Dockerfile $(SESSION_GATE_SOURCES)
 	touch $@
 
 build-and-push: image
-	az acr login --name ${ARO_HCP_IMAGE_ACR}
+	@TOKEN=$$(az acr login --name ${ARO_HCP_IMAGE_ACR} --expose-token --query accessToken -o tsv) && \
+	$(CONTAINER_ENGINE) login ${ARO_HCP_IMAGE_REGISTRY} -u 00000000-0000-0000-0000-000000000000 -p "$$TOKEN"
 	$(CONTAINER_ENGINE) push ${SESSION_GATE_TAGGED_IMAGE}
 .PHONY: build-and-push
 

--- a/tooling/aro-hcp-exporter/Makefile
+++ b/tooling/aro-hcp-exporter/Makefile
@@ -47,6 +47,7 @@ image: Dockerfile Makefile
 .PHONY: image
 
 build-and-push: image
-	az acr login --name ${ARO_HCP_IMAGE_ACR}
+	@TOKEN=$$(az acr login --name ${ARO_HCP_IMAGE_ACR} --expose-token --query accessToken -o tsv) && \
+	$(CONTAINER_ENGINE) login ${ARO_HCP_IMAGE_REGISTRY} -u 00000000-0000-0000-0000-000000000000 -p "$$TOKEN"
 	$(CONTAINER_ENGINE) push ${ARO_HCP_EXPORTER_TAGGED_IMAGE}
 .PHONY: build-and-push

--- a/tooling/tenant-quota/Makefile
+++ b/tooling/tenant-quota/Makefile
@@ -95,8 +95,9 @@ image: Dockerfile $(shell find . -name '*.go' -o -name 'go.mod' -o -name 'go.sum
 .PHONY: image
 
 build-and-push: image
-	az acr login --name ${ARO_HCP_IMAGE_ACR}
-	docker push ${TENANT_QUOTA_TAGGED_IMAGE}
+	@TOKEN=$$(az acr login --name ${ARO_HCP_IMAGE_ACR} --expose-token --query accessToken -o tsv) && \
+	$(CONTAINER_ENGINE) login ${ARO_HCP_IMAGE_REGISTRY} -u 00000000-0000-0000-0000-000000000000 -p "$$TOKEN"
+	$(CONTAINER_ENGINE) push ${TENANT_QUOTA_TAGGED_IMAGE}
 	@echo ""
 	@echo "Pushed: ${TENANT_QUOTA_TAGGED_IMAGE}"
 .PHONY: build-and-push


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

az acr login without --expose-token tries to store credentials via the Docker CLI, which fails when using Podman. The record-override targets already used the token-based approach correctly, but the build-and-push targets were missed during the Podman migration (066f02d41). This switches all build-and-push targets to use --expose-token with $(CONTAINER_ENGINE) login, consistent with the rest of the codebase. Also fixes a hardcoded docker push in tooling/tenant-quota/Makefile.

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
