### PR TITLE
feat: add external auth resource id name validation

### DIFF
--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
@@ -48,7 +48,7 @@ model NodePool is TrackedResource<NodePoolProperties> {
 model ExternalAuth is ProxyResource<ExternalAuthProperties> {
   ...ResourceNameParameter<
     ExternalAuth,
-    NamePattern = "^[a-zA-Z][-a-zA-Z0-9]{1,15}$"
+    NamePattern = "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
   >;
 }
 

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
@@ -692,7 +692,7 @@
             "description": "The name of the ExternalAuth",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,15}$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -745,7 +745,7 @@
             "description": "The name of the ExternalAuth",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,15}$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           },
           {
             "name": "resource",
@@ -828,7 +828,7 @@
             "description": "The name of the ExternalAuth",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,15}$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           },
           {
             "name": "properties",
@@ -908,7 +908,7 @@
             "description": "The name of the ExternalAuth",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,15}$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
@@ -692,7 +692,7 @@
             "description": "The name of the ExternalAuth",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,15}$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -745,7 +745,7 @@
             "description": "The name of the ExternalAuth",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,15}$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           },
           {
             "name": "resource",
@@ -828,7 +828,7 @@
             "description": "The name of the ExternalAuth",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,15}$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           },
           {
             "name": "properties",
@@ -908,7 +908,7 @@
             "description": "The name of the ExternalAuth",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,15}$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {

--- a/internal/api/testhelpers.go
+++ b/internal/api/testhelpers.go
@@ -43,7 +43,7 @@ const (
 	TestResourceGroupName         = "testResourceGroup"
 	TestClusterName               = "testCluster"
 	TestNodePoolName              = "testNodePool"
-	TestExternalAuthName          = "testExternalAuth"
+	TestExternalAuthName          = "testExtAuth"
 	TestDeploymentName            = "testDeployment"
 	TestManagedResourceGroupName  = "testManagedResourceGroup"
 	TestNetworkSecurityGroupName  = "testNetworkSecurityGroup"

--- a/internal/validation/validate_externalauth.go
+++ b/internal/validation/validate_externalauth.go
@@ -54,6 +54,10 @@ func validateExternalAuth(ctx context.Context, op operation.Operation, newObj, o
 	//arm.ProxyResource
 	errs = append(errs, validateProxyResource(ctx, op, field.NewPath("trackedResource"), &newObj.ProxyResource, safe.Field(oldObj, toExternalAuthProxyResource))...)
 	errs = append(errs, RestrictedResourceIDWithResourceGroup(ctx, op, field.NewPath("id"), newObj.ID, nil, api.ExternalAuthResourceType.String())...)
+	if newObj.ID != nil {
+		errs = append(errs, MaxLen(ctx, op, field.NewPath("id"), &newObj.ID.Name, nil, 15)...)
+		errs = append(errs, MatchesRegex(ctx, op, field.NewPath("id"), &newObj.ID.Name, nil, externalAuthResourceNameRegex, externalAuthResourceNameErrorString)...)
+	}
 
 	//Properties HCPOpenShiftClusterExternalAuthProperties `json:"properties"`
 	errs = append(errs, validateExternalAuthProperties(ctx, op, field.NewPath("properties"), &newObj.Properties, safe.Field(oldObj, toExternalAuthProperties))...)

--- a/internal/validation/validate_externalauth_comprehensive_test.go
+++ b/internal/validation/validate_externalauth_comprehensive_test.go
@@ -343,6 +343,120 @@ func TestValidateExternalAuth(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid external auth resource name - empty",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				obj.ID.Name = ""
+				obj.Name = ""
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "trackedResource.resource.id", Message: "resource name is required"},
+				{FieldPath: "id", Message: "resource name is required"},
+			},
+		},
+		{
+			name: "invalid external auth resource name - special character",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				obj.ID.Name = "$"
+				obj.Name = "$"
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "id", Message: "must be a valid DNS RFC 1035 label"},
+			},
+		},
+		{
+			name: "invalid external auth resource name - starts with hyphen",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				obj.ID.Name = "-abcde"
+				obj.Name = "-abcde"
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "id", Message: "must be a valid DNS RFC 1035 label"},
+			},
+		},
+		{
+			name: "invalid external auth resource name - starts with number",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				obj.ID.Name = "1externalauth"
+				obj.Name = "1externalauth"
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "id", Message: "must be a valid DNS RFC 1035 label"},
+			},
+		},
+		{
+			name: "invalid external auth resource name - ends with hyphen",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				obj.ID.Name = "my-auth-"
+				obj.Name = "my-auth-"
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "id", Message: "must be a valid DNS RFC 1035 label"},
+			},
+		},
+		{
+			name: "invalid external auth resource name - too long",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				long := "07B4gc00vjA2C8KL3Ns4No9fi"
+				obj.ID.Name = long
+				obj.Name = long
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "id", Message: "may not be more than 15 bytes"},
+				{FieldPath: "id", Message: "must be a valid DNS RFC 1035 label"},
+			},
+		},
+		{
+			name: "valid external auth resource name - minimum length",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				obj.ID.Name = "a"
+				obj.Name = "a"
+				return obj
+			}(),
+			op:           operation.Operation{Type: operation.Create},
+			expectErrors: nil,
+		},
+		{
+			name: "valid external auth resource name - with hyphens",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				obj.ID.Name = "my-auth-1"
+				obj.Name = "my-auth-1"
+				return obj
+			}(),
+			op:           operation.Operation{Type: operation.Create},
+			expectErrors: nil,
+		},
+		{
+			name: "valid external auth resource name - maximum length",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				obj.ID.Name = "myExternalAuth1" // 15 chars — max for this pattern
+				obj.Name = "myExternalAuth1"
+				return obj
+			}(),
+			op:           operation.Operation{Type: operation.Create},
+			expectErrors: nil,
+		},
+		{
 			name: "immutable provisioning state on update",
 			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
 				obj := createValidExternalAuth()

--- a/internal/validation/validators.go
+++ b/internal/validation/validators.go
@@ -327,6 +327,11 @@ var (
 	nodePoolResourceNameRegex       = regexp.MustCompile(nodePoolResourceName)
 	nodePoolResourceNameErrorString = `(must be a valid DNS RFC 1035 label)`
 
+	externalAuthResourceName      = `^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$`
+	externalAuthResourceNameRegex = regexp.MustCompile(externalAuthResourceName)
+
+	externalAuthResourceNameErrorString = `(must be a valid DNS RFC 1035 label)`
+
 	// resourceGroupName See https://learn.microsoft.com/en-gb/azure/azure-resource-manager/management/resource-name-rules#microsoftresources
 	resourceGroupName            = `^[\p{L}\p{N}_\-.()]{0,89}[\p{L}\p{N}_\-()]$`
 	resourceGroupNameRegex       = regexp.MustCompile(resourceGroupName)

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/clientid-not-in-audiences/03-httpCreate-externalauth/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/clientid-not-in-audiences/03-httpCreate-externalauth/00-key.json
@@ -1,4 +1,4 @@
 {
 	"id": "4490ce55-0b36-59f8-b66e-50fb9ad68d3d",
-	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/clientid-not-in-audiences/externalAuths/clientid-not-in-audiences-auth"
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/clientid-not-in-audiences/externalAuths/ea-cid-aud"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/clientid-not-in-audiences/03-httpCreate-externalauth/externalauth.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/clientid-not-in-audiences/03-httpCreate-externalauth/externalauth.json
@@ -1,5 +1,5 @@
 {
-	"name": "clientid-not-in-audiences-auth",
+	"name": "ea-cid-aud",
 	"properties": {
 		"claim": {
 			"mappings": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/duplicate-client-components/03-httpCreate-externalauth/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/duplicate-client-components/03-httpCreate-externalauth/00-key.json
@@ -1,4 +1,4 @@
 {
 	"id": "a7efb364-bdc9-5293-94f2-e19372039c23",
-	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/duplicate-client-components/externalAuths/duplicate-client-components-auth"
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/duplicate-client-components/externalAuths/ea-dup-clnt"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/duplicate-client-components/03-httpCreate-externalauth/externalauth.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/duplicate-client-components/03-httpCreate-externalauth/externalauth.json
@@ -1,5 +1,5 @@
 {
-	"name": "duplicate-client-components-auth",
+	"name": "ea-dup-clnt",
 	"properties": {
 		"claim": {
 			"mappings": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-format/03-httpCreate-externalauth/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-format/03-httpCreate-externalauth/00-key.json
@@ -1,4 +1,4 @@
 {
 	"id": "3897f32e-eaaa-594d-a90f-e3c3876b7312",
-	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/invalid-format/externalAuths/basic-external-auth"
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/invalid-format/externalAuths/ea-inv-form"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-format/03-httpCreate-externalauth/externalauth.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-format/03-httpCreate-externalauth/externalauth.json
@@ -1,5 +1,5 @@
 {
-	"name": "basic-external-auth",
+	"name": "ea-inv-form",
 	"properties": {
 		"claim": {
 			"mappings": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/missing-non-leaf-required-fields/03-httpCreate-externalauth/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/missing-non-leaf-required-fields/03-httpCreate-externalauth/00-key.json
@@ -1,4 +1,4 @@
 {
 	"id": "307e2be2-97b5-51e4-92eb-91ce9b41c468",
-	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/missing-non-leaf-required-fields/externalAuths/missing-non-leaf-required-fields-auth"
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/missing-non-leaf-required-fields/externalAuths/ea-non-leaf"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/missing-non-leaf-required-fields/03-httpCreate-externalauth/externalauth.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/missing-non-leaf-required-fields/03-httpCreate-externalauth/externalauth.json
@@ -1,5 +1,5 @@
 {
-	"name": "missing-non-leaf-required-fields-auth",
+	"name": "ea-non-leaf",
 	"properties": {},
 	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/missing-required-fields/03-httpCreate-externalauth/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/missing-required-fields/03-httpCreate-externalauth/00-key.json
@@ -1,4 +1,4 @@
 {
 	"id": "ceea74de-7815-5ccd-87ba-c7c6fa349242",
-	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/missing-required-fields/externalAuths/missing-required-fields-auth"
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/missing-required-fields/externalAuths/ea-miss-req"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/missing-required-fields/03-httpCreate-externalauth/externalauth.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/missing-required-fields/03-httpCreate-externalauth/externalauth.json
@@ -1,5 +1,5 @@
 {
-	"name": "missing-required-fields-auth",
+	"name": "ea-miss-req",
 	"properties": {
 		"claim": {
 			"mappings": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/multiple-validation-errors/03-httpCreate-externalauth/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/multiple-validation-errors/03-httpCreate-externalauth/00-key.json
@@ -1,4 +1,4 @@
 {
 	"id": "f4a36f42-ff30-5c29-bcf0-790eda2c2fb0",
-	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/multiple-validation-errors/externalAuths/multiple-validation-errors-auth"
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/multiple-validation-errors/externalAuths/ea-mult-err"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/multiple-validation-errors/03-httpCreate-externalauth/externalauth.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/multiple-validation-errors/03-httpCreate-externalauth/externalauth.json
@@ -1,5 +1,5 @@
 {
-	"name": "multiple-validation-errors-auth",
+	"name": "ea-mult-err",
 	"properties": {
 		"claim": {
 			"mappings": {


### PR DESCRIPTION
Enforce what CS currently enforces, which is: minimum 1 characters
and the charset of RFC1035 DNS label. A difference compared to what
CS enforces is that CS mandates only lowercase characters whereas here
we allow uppercase ones. The reason for this is that the resource id
in azure are case insensitive. To comply with CS enforcement when we
pass the resource name to CS on external auth creation we lowercase all
the characters
