### PR TITLE
fix: update cluster resource id name regex to match what CS enforces

### DIFF
--- a/internal/validation/validate_cluster_comprehensive_test.go
+++ b/internal/validation/validate_cluster_comprehensive_test.go
@@ -944,6 +944,18 @@ func TestValidateClusterCreate(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid cluster resource name - ends with hyphen",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.ID.Name = "my-cluster-"
+				c.Name = "my-cluster-"
+				return c
+			}(),
+			expectErrors: []expectedError{
+				{message: "must be a valid DNS RFC 1035 label", fieldPath: "id"},
+			},
+		},
+		{
 			name: "invalid cluster resource name - too long",
 			cluster: func() *api.HCPOpenShiftCluster {
 				c := createValidCluster()

--- a/internal/validation/validate_nodepools_comprehensive_test.go
+++ b/internal/validation/validate_nodepools_comprehensive_test.go
@@ -692,6 +692,17 @@ func TestValidateNodePoolCreate(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid nodepool resource name - ends with hyphen",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := createValidNodePool()
+				np.ID.Name = "my-pool-"
+				return np
+			}(),
+			expectErrors: []expectedError{
+				{message: "must be a valid DNS RFC 1035 label", fieldPath: "id"},
+			},
+		},
+		{
 			name: "invalid nodepool resource name - too long",
 			nodePool: func() *api.HCPOpenShiftClusterNodePool {
 				np := createValidNodePool()

--- a/internal/validation/validators.go
+++ b/internal/validation/validators.go
@@ -236,7 +236,7 @@ var (
 	clusterResourceNameRegex       = regexp.MustCompile(clusterResourceName)
 	clusterResourceNameErrorString = `(must be a valid DNS RFC 1035 label)`
 
-	nodePoolResourceName            = `^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-z-A-Z0-9]$`
+	nodePoolResourceName            = `^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$`
 	nodePoolResourceNameRegex       = regexp.MustCompile(nodePoolResourceName)
 	nodePoolResourceNameErrorString = `(must be a valid DNS RFC 1035 label)`
 


### PR DESCRIPTION
The cluster resource id name regex was allowing a hyphen as the last
character. This didn't match what CS currently enforces nor the
documented typespec associated to it. This commit fixes that.
