### PR TITLE
cfg: re-enable PKO service group in topology

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -18,6 +18,7 @@ The tree of pipelines making up the ARO HCP service are documented here from the
         - Microsoft.Azure.ARO.HCP.SecretSyncController ([ref](https://github.com/Azure/ARO-HCP/tree/main/secret-sync-controller/pipeline.yaml)): Deploy the Secret Sync Controller.
         - Microsoft.Azure.ARO.HCP.ACM ([ref](https://github.com/Azure/ARO-HCP/tree/main/acm/pipeline.yaml)): Deploy Advanced Cluster Management and Multi-Cluster Engine.
         - Microsoft.Azure.ARO.HCP.RP.HypershiftOperator ([ref](https://github.com/Azure/ARO-HCP/tree/main/hypershiftoperator/pipeline.yaml)): Deploy the HyperShift operator.
+        - Microsoft.Azure.ARO.HCP.PKO ([ref](https://github.com/Azure/ARO-HCP/tree/main/pko/pipeline.yaml)): Deploy the Package Operator.
         - Microsoft.Azure.ARO.HCP.Maestro.Agent ([ref](https://github.com/Azure/ARO-HCP/tree/main/maestro/agent/pipeline.yaml)): Deploy the Maestro Agent and register it with the MQTT stream.
         - Microsoft.Azure.ARO.HCP.RouteMonitorOperator ([ref](https://github.com/Azure/ARO-HCP/tree/main/route-monitor-operator/pipeline.yaml)): Deploy the Route Monitor Operator.
       - Microsoft.Azure.ARO.HCP.Monitoring ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/monitoring-pipeline.yaml)): Deploy the Monitoring resources

--- a/pko/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_package_operator.yaml
+++ b/pko/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_package_operator.yaml
@@ -1,0 +1,137 @@
+---
+# Source: package-operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: 'package-operator'
+  namespace: 'package-operator-system'
+  labels:
+    package-operator.run/cache: "True"
+  annotations:
+    azure.workload.identity/client-id: '__pkoMsiClientId__'
+    azure.workload.identity/tenant-id: '__pkoMsiTenantId__'
+---
+# Source: package-operator/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: package-operator
+  labels:
+    package-operator.run/cache: "True"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: 'package-operator'
+  namespace: 'package-operator-system'
+---
+# Source: package-operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: package-operator-metrics
+  namespace: 'package-operator-system'
+  labels:
+    app.kubernetes.io/name: package-operator
+    port: metrics
+spec:
+  selector:
+    app.kubernetes.io/name: package-operator
+  ports:
+  - port: 8080
+    targetPort: metrics
+    name: metrics
+    protocol: TCP
+---
+# Source: package-operator/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: package-operator-bootstrap
+  namespace: 'package-operator-system'
+spec:
+  # delete 90seconds after completion, so helm can finish successfully
+  ttlSecondsAfterFinished: 90
+  # set deadline to 30min
+  activeDeadlineSeconds: 1800
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      restartPolicy: OnFailure
+      serviceAccountName: 'package-operator'
+      containers:
+      - name: package-operator
+        image: "arohcpsvcdev.azurecr.io/package-operator/package-operator-manager@sha256:1234567890"
+        args: ["-self-bootstrap=arohcpsvcdev.azurecr.io/package-operator/package-operator-package@sha256:1234567890"]
+        imagePullPolicy: Always
+        env:
+        - name: LOG_LEVEL
+          value: "0"
+        - name: PKO_REGISTRY_HOST_OVERRIDES
+          value: ''
+        - name: PKO_CONFIG
+          value: ''
+        - name: PKO_IMAGE_PREFIX_OVERRIDES
+          value: 'quay.io/package-operator=arohcpsvcdev.azurecr.io/package-operator'
+        - name: PKO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+  backoffLimit: 3
+---
+# Source: package-operator/templates/acrpullbinding.yaml
+apiVersion: acrpull.microsoft.com/v1beta2
+kind: AcrPullBinding
+metadata:
+  name: pull-binding
+  namespace: 'package-operator-system'
+spec:
+  acr:
+    environment: PublicCloud
+    server: 'arohcpsvcdev.azurecr.io'
+    scope: 'repository:package-operator/package-operator-package:pull repository:package-operator/package-operator-manager:pull'
+  auth:
+    workloadIdentity:
+      serviceAccountRef: 'package-operator'
+      clientID: '__imagePullerMsiClientId__'
+      tenantID: '__imagePullerMsiTenantId__'
+  serviceAccountName: 'package-operator'
+---
+# Source: package-operator/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: package-operator
+  namespace: 'package-operator-system'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'package-operator-system'
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: package-operator
+      port: metrics
+

--- a/topology.yaml
+++ b/topology.yaml
@@ -51,9 +51,9 @@ services:
         - serviceGroup: Microsoft.Azure.ARO.HCP.RP.HypershiftOperator
           pipelinePath: hypershiftoperator/pipeline.yaml
           purpose: Deploy the HyperShift operator.
-        # - serviceGroup: Microsoft.Azure.ARO.HCP.PKO
-        #   pipelinePath: pko/pipeline.yaml
-        #   purpose: Deploy the Package Operator.
+        - serviceGroup: Microsoft.Azure.ARO.HCP.PKO
+          pipelinePath: pko/pipeline.yaml
+          purpose: Deploy the Package Operator.
         - serviceGroup: Microsoft.Azure.ARO.HCP.Maestro.Agent
           pipelinePath: maestro/agent/pipeline.yaml
           purpose: Deploy the Maestro Agent and register it with the MQTT stream.


### PR DESCRIPTION
### What

Re-enable the PKO (Package Operator) service group in `topology.yaml`, restoring deployment to management clusters.

### Why

PKO deployment was temporarily disabled in [PR #3474](https://github.com/Azure/ARO-HCP/pull/3474) (Dec 2025) by commenting out its service group entry. The intent was temporary, but full removal ([ARO-23308](https://redhat.atlassian.net/browse/ARO-23308)) was never completed. Per [AROSLSRE-686](https://redhat.atlassian.net/browse/AROSLSRE-686), either PKO needs to be brought back and deployed everywhere, or fully removed. This PR re-enables it.

The revert PR [#3476](https://github.com/Azure/ARO-HCP/pull/3476) was opened at the time but closed without merging.

### Changes

- **`topology.yaml`**: Uncommented PKO service group (lines 54-56)
- **`docs/pipelines.md`**: Regenerated via `make -C docs/ pipelines.md`
- **`pko/zz_fixture_*`**: New helm test fixture generated by `make -C config/ detect-change`

### Notes

- PKO images remain pinned at **v1.18.3** (Dec 2025) in both `config/config.yaml` and `tooling/image-updater/config.yaml` (auto-update disabled due to v1.18.4 failures). An image bump should be considered separately.
- The downstream `sdp-pipelines` repo inherits this file via its bump mechanism — no separate change needed there.

[AROSLSRE-686](https://redhat.atlassian.net/browse/AROSLSRE-686)