### PR TITLE
istio: phase 2 - target asm-1-28 in dev rollout overrides

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1149,8 +1149,8 @@ clouds:
         nsp:
           accessMode: 'Learning'
         istio:
-          targetVersion: "asm-1-26"
-          versions: "asm-1-26,asm-1-28"
+          targetVersion: "asm-1-28"
+          versions: "asm-1-28"
         aks:
           etcd:
             softDelete: false
@@ -1228,6 +1228,11 @@ clouds:
         # this is the integrated DEV environment
         defaults:
           regionRG: hcp-underlay-{{ .ctx.environment }}-{{ .ctx.region }}
+          svc:
+            # Temporary override during the asm-1-28 rollout; remove once versions is asm-1-28 only.
+            istio:
+              targetVersion: "asm-1-28"
+              versions: "asm-1-26,asm-1-28"
           mgmt:
             aks:
               systemAgentPool:
@@ -1274,6 +1279,10 @@ clouds:
             svcWorkspaceName: 'services-{{ .ctx.environment }}-{{ .ctx.regionShort }}'
             hcpWorkspaceName: 'hcps-{{ .ctx.environment }}-{{ .ctx.regionShort }}'
           svc:
+            # Temporary override during the asm-1-28 rollout; remove once versions is asm-1-28 only.
+            istio:
+              targetVersion: "asm-1-28"
+              versions: "asm-1-26,asm-1-28"
             aks:
               # MC AKS nodepools
               # big enough for multiple CS instances during PR checks
@@ -1425,9 +1434,6 @@ clouds:
           # SVC
           svc:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
-            istio:
-              targetVersion: "asm-1-28"
-              versions: "asm-1-28"
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
               userAgentPool:
@@ -1448,6 +1454,10 @@ clouds:
           # SVC
           svc:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
+            # Temporary override during the asm-1-28 rollout; remove once versions is asm-1-28 only.
+            istio:
+              targetVersion: "asm-1-28"
+              versions: "asm-1-26,asm-1-28"
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
           mgmt:
@@ -1602,9 +1612,6 @@ clouds:
           # SVC
           svc:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
-            istio:
-              targetVersion: "asm-1-28"
-              versions: "asm-1-28"
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
               userAgentPool:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -881,7 +881,7 @@ svc:
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
     istioctlVersion: 1.29.2
     tag: prod-stable
-    targetVersion: asm-1-26
+    targetVersion: asm-1-28
     versions: asm-1-26,asm-1-28
   nsp:
     accessMode: Learning

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -881,7 +881,7 @@ svc:
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
     istioctlVersion: 1.29.2
     tag: prod-stable
-    targetVersion: asm-1-26
+    targetVersion: asm-1-28
     versions: asm-1-26,asm-1-28
   nsp:
     accessMode: Learning

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -881,7 +881,7 @@ svc:
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
     istioctlVersion: 1.29.2
     tag: prod-stable
-    targetVersion: asm-1-26
+    targetVersion: asm-1-28
     versions: asm-1-26,asm-1-28
   nsp:
     accessMode: Learning

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -883,8 +883,8 @@ svc:
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
     istioctlVersion: 1.29.2
     tag: prod-stable
-    targetVersion: asm-1-26
-    versions: asm-1-26,asm-1-28
+    targetVersion: asm-1-28
+    versions: asm-1-28
   nsp:
     accessMode: Learning
     name: nsp-lnstest-svc


### PR DESCRIPTION
### What

Move the remaining dev-cloud Istio rollout overrides to target `asm-1-28`.

This updates `targetVersion` to `asm-1-28` for the temporary `svc.istio`
overrides in `dev`, `cspr`, and `perf`, while keeping
`versions: "asm-1-26,asm-1-28"` for now.

### Why

`asm-1-26` is no longer available.

This change advances the rollout by making `asm-1-28` the active target in the
remaining canary environments without yet removing the older revision from the
declared version list.

### Testing

* `make -C config validate`
* `make -C config materialize`

### Special notes for your reviewer

Changes:
* kept the shared dev default at `targetVersion: "asm-1-28"` and `versions: "asm-1-28"`
* updated the temporary `svc.istio` overrides in `dev`, `cspr`, and `perf` to target `asm-1-28`
* left `versions: "asm-1-26,asm-1-28"` in place for those overrides as a temporary rollout state
* added comments in the override blocks to make the follow-up cleanup explicit
* swft environment is ephemeral and have adjusted for that.
* will most likely need to rebase as swft components have been removed before this will be merged.
* https://github.com/Azure/ARO-HCP/pull/4874


A follow-up will remove `asm-1-26` from `versions` and drop the redundant
overrides once the upgrade is complete.