### PR TITLE
Increase prow infra nodepool os disk size

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1594,6 +1594,7 @@ clouds:
                 secondaryNicCount: 7
               infraAgentPool:
                 vmSize: Standard_D4ds_v5
+                osDiskSizeGB: 64
               enableSwiftV2Nodepools: true
               enableSwiftV2Vnet: true
             jaeger:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -540,7 +540,7 @@ mgmt:
       maxCount: 3
       minCount: 1
       name: infra
-      osDiskSizeGB: 32
+      osDiskSizeGB: 64
       poolCount: 2
       vmSize: Standard_D4ds_v5
       zoneRedundantMode: Auto


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-662

### What

Increase prow env's infra node pool os disk size

### Why

Started in 09/04/2026

📍 [dptools search: failed post-install resource not ready finalize-mce-config](https://search.dptools.openshift.org/?search=failed+post-install%3A+resource+not+ready%2C+name%3A+finalize-mce-config&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=ARO-HCP&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)

Looks to be node disk pressure on Infra node pools (32 GB) and started to evict pods to reclaim space. This caused a delay and in turn helm deployment couldn't finish in 5 min timeout.

```kql
kubernetesEvents
| where timestamp between (datetime("2026-04-17T23:02:32Z") .. datetime("2026-04-17T23:07:40Z"))
| where eventNamespace == 'multicluster-engine'
| project timestamp, podName, objectKind, objectName, eventNamespace, message
| order by timestamp desc
```

| timestamp | podName | objectKind | objectName | eventNamespace | message |
|-----------|---------|------------|------------|----------------|---------|
| 17/04/2026, 23:02:38.948 | kube-events-857f6bb648-gn8gx | Pod | grc-policy-propagator-6ccd87bd8f-pt7bt | multicluster-engine | 0/12 nodes are available: 1 node(s) had untolerated taint {CriticalAddonsOnly: true}, 2 node(s) had untolerated taint {node.kubernetes.io/disk-pressure: }, 9 node(s) didn't match Pod's node affinity/selector. preemption: 0/12 nodes are available: 12 Preemption is not helpful for scheduling. |
| 17/04/2026, 23:02:38.49 | kube-events-857f6bb648-gn8gx | Pod | grc-policy-addon-controller-59df98bcf7-xps7w | multicluster-engine | 0/12 nodes are available: 1 node(s) had untolerated taint {CriticalAddonsOnly: true}, 2 node(s) had untolerated taint {node.kubernetes.io/disk-pressure: }, 9 node(s) didn't match Pod's node affinity/selector. |
| 17/04/2026, 23:02:38.49 | kube-events-857f6bb648-gn8gx | Pod | klusterlet-addon-controller-v2-65ddbb87d4-8qkjr | multicluster-engine | 0/12 nodes are available: 1 node(s) had untolerated taint {CriticalAddonsOnly: true}, 2 node(s) had untolerated taint {node.kubernetes.io/disk-pressure: }, 9 node(s) didn't match Pod's node affinity/selector. |
| 17/04/2026, 23:02:38.467 | kube-events-857f6bb648-gn8gx | Pod | grc-policy-propagator-6ccd87bd8f-8g5wj | multicluster-engine | 0/12 nodes are available: 1 node(s) had untolerated taint {CriticalAddonsOnly: true}, 2 node(s) had untolerated taint {node.kubernetes.io/disk-pressure: }, 9 node(s) didn't match Pod's node affinity/selector. |
| 17/04/2026, 23:02:38.467 | kube-events-857f6bb648-gn8gx | Pod | klusterlet-addon-controller-v2-65ddbb87d4-g4b75 | multicluster-engine | 0/12 nodes are available: 1 node(s) had untolerated taint {CriticalAddonsOnly: true}, 2 node(s) had untolerated taint {node.kubernetes.io/disk-pressure: }, 9 node(s) didn't match Pod's node affinity/selector. |
| 17/04/2026, 23:02:38.467 | kube-events-857f6bb648-gn8gx | Pod | grc-policy-addon-controller-59df98bcf7-wl4mh | multicluster-engine | 0/12 nodes are available: 1 node(s) had untolerated taint {CriticalAddonsOnly: true}, 2 node(s) had untolerated taint {node.kubernetes.io/disk-pressure: }, 9 node(s) didn't match Pod's node affinity/selector. |

### Testing

Only infra change. Tested in personal dev env
