### PR TITLE
Lower upload_file_size

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -188,7 +188,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -212,7 +212,7 @@ data:
         azure_kusto_buffer_key frontendLogs
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -236,7 +236,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -260,7 +260,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -283,7 +283,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -307,7 +307,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -341,7 +341,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -444,7 +444,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 9afe0b0e572704d69b07e4e38b66ed79a51a992261adcae0e6f8ca0f207442f3
+        checksum/configmap: 6cd105a5d137e52af9da24c7962786df326951dd5c98f24e2c93839bdc0a3e36
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -189,7 +189,7 @@ data:
         azure_kusto_buffer_key frontendLogs
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -213,7 +213,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -237,7 +237,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -260,7 +260,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -284,7 +284,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -318,7 +318,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -421,7 +421,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 3fb766bdf40341544c6336207a928fec85e0c84648636dd57385d6f3ae7d985d
+        checksum/configmap: 5b6688244d10cbd8adb28880185ad51d63fafef5c567c47310c38d90500760cc
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -188,7 +188,7 @@ data:
         azure_kusto_buffer_key frontendLogs
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -212,7 +212,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -236,7 +236,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -259,7 +259,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -283,7 +283,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -317,7 +317,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -420,7 +420,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 58b2807afa24ee46f3ba427bcab6b89eed552a06c7be382344ca476e428a96e0
+        checksum/configmap: fe3b7004c2bdd1d39da1fbc08d996aa6db2276b40255fe44b79815bef46a7f7d
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
@@ -189,7 +189,7 @@ data:
         azure_kusto_buffer_key frontendLogs
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -213,7 +213,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -237,7 +237,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -260,7 +260,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -284,7 +284,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -318,7 +318,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -421,7 +421,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 643e5d82eececc106e29c6bb0118bada1ea34a79cb0bfab0656b2a682448a450
+        checksum/configmap: 6281184d4b8f16c0df6b6fa090f68155462edc356a0aaaaeb32da041e68d2b7a
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -335,7 +335,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -359,7 +359,7 @@ data:
         azure_kusto_buffer_key frontendLogs
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -383,7 +383,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -407,7 +407,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -430,7 +430,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -454,7 +454,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -488,7 +488,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -591,7 +591,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 5eddbcc6b7c0b33ba4639aad4bb8da430ddb92a59020259f2ac48fdd4da2fe65
+        checksum/configmap: 1bcf41031ddd939fc7fda8e95915cce0382741abc5ff4e73a4047e9ef9569141
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -189,7 +189,7 @@ data:
         azure_kusto_buffer_key frontendLogs
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -213,7 +213,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -237,7 +237,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -260,7 +260,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -284,7 +284,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -318,7 +318,7 @@ data:
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
-        upload_file_size            48M
+        upload_file_size            16M
         buffer_file_delete_early    false
         unify_tag                   true
         store_dir_limit_size        1.8GB
@@ -421,7 +421,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 4c45c3d9e10f0ef64d3d79de3d1f0c75bc4faad17fdb8bc09707c9480d1ec992
+        checksum/configmap: ecfea847f2164f8937eb5cd3e0a8237769dccd75842f35fa428546ae5ea66d0c
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/values-mgmt.yaml
+++ b/observability/arobit/values-mgmt.yaml
@@ -69,7 +69,7 @@ forwarder:
     buffer_dir: /var/kusto
     buffering_enabled: On
     upload_timeout: 1m
-    upload_file_size: 48M
+    upload_file_size: 16M
     buffer_file_delete_early: Off
     unify_tag: On
     store_dir_limit_size: 1.8GB

--- a/observability/arobit/values-svc.yaml
+++ b/observability/arobit/values-svc.yaml
@@ -69,7 +69,7 @@ forwarder:
     buffer_dir: /var/kusto
     buffering_enabled: On
     upload_timeout: 1m
-    upload_file_size: 48M
+    upload_file_size: 16M
     buffer_file_delete_early: Off
     unify_tag: On
     store_dir_limit_size: 1.8GB


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-680

### What/Why

We have multiple Kusto outputs, all using 48 MByte as flush peak memory, where given the gzip implementation it requires more than that. With i.e. 3 concurrent flushes this could worst case mean around 330MByte for flushes.

Reducing the flush trigger (lower upload_file_size), this triggers uploads faster, reducing the concurrent memory to around 110 MByte.

