### PR TITLE
test: improve ARO-25884 retry with wait-for-ready and framework exports

### DIFF
--- a/test/e2e/idms_lifecycle.go
+++ b/test/e2e/idms_lifecycle.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -169,23 +168,9 @@ var _ = Describe("Customer", func() {
 				},
 			}
 
-			// ARO-25884 backoff: 3 retries with exponential backoff
-			aro25884Backoff := wait.Backoff{
-				Steps:    3,
-				Duration: 1 * time.Minute,
-				Factor:   2.0,
-				Jitter:   0.0,
-			}
-
-			// When the frontend updates a cluster, it:
-			// 1. Calls cluster-service synchronously ==> cluster-service commits state change to its database
-			// 2. Then attempts Cosmos DB update ==> fails with 412 Precondition Failed (ETag conflict from concurrent updates)
-			// 3. Frontend returns HTTP 500 to client
-			// 4. No rollback occurs ==> cluster stuck in pending_update state
-			// 5. Client retry gets HTTP 400 "can't update cluster in pending_update state"
-			// The fix uses framework.UpdateHCPCluster20251223WithRetry with Kubernetes-style retry pattern
 			updateAddResp, err := framework.UpdateHCPCluster20251223WithRetry(
-				ctx, hcpClient, *resourceGroup.Name, customerClusterName, updateAdd, 10*time.Minute, aro25884Backoff, framework.IsStateConflictError,
+				ctx, hcpClient, *resourceGroup.Name, customerClusterName, updateAdd, 10*time.Minute,
+				framework.StateConflictBackoff, framework.IsStateConflictError,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -233,15 +218,9 @@ var _ = Describe("Customer", func() {
 				},
 			}
 
-			// When the frontend updates a cluster, it:
-			// 1. Calls cluster-service synchronously ==> cluster-service commits state change to its database
-			// 2. Then attempts Cosmos DB update ==> fails with 412 Precondition Failed (ETag conflict from concurrent updates)
-			// 3. Frontend returns HTTP 500 to client
-			// 4. No rollback occurs ==> cluster stuck in pending_update state
-			// 5. Client retry gets HTTP 400 "can't update cluster in pending_update state"
-			// The fix uses framework.UpdateHCPCluster20251223WithRetry with Kubernetes-style retry pattern
 			updateRemoveResp, err := framework.UpdateHCPCluster20251223WithRetry(
-				ctx, hcpClient, *resourceGroup.Name, customerClusterName, updateRemove, 10*time.Minute, aro25884Backoff, framework.IsStateConflictError,
+				ctx, hcpClient, *resourceGroup.Name, customerClusterName, updateRemove, 10*time.Minute,
+				framework.StateConflictBackoff, framework.IsStateConflictError,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/idms_lifecycle.go
+++ b/test/e2e/idms_lifecycle.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -37,22 +36,6 @@ import (
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
 )
-
-// isStateConflictError detects transient errors from ARO-25884 scenario:
-// - HTTP 500: Cosmos DB ETag conflict after cluster-service commit
-// - HTTP 409: Conflict
-// Note: HTTP 400 is NOT retried - cluster needs time to return to "ready" state
-func isStateConflictError(err error) bool {
-	if err == nil {
-		return false
-	}
-	var responseError *azcore.ResponseError
-	if !errors.As(err, &responseError) {
-		return false
-	}
-	return responseError.StatusCode == http.StatusInternalServerError ||
-		responseError.StatusCode == http.StatusConflict
-}
 
 var _ = Describe("Customer", func() {
 
@@ -202,7 +185,7 @@ var _ = Describe("Customer", func() {
 			// 5. Client retry gets HTTP 400 "can't update cluster in pending_update state"
 			// The fix uses framework.UpdateHCPCluster20251223WithRetry with Kubernetes-style retry pattern
 			updateAddResp, err := framework.UpdateHCPCluster20251223WithRetry(
-				ctx, hcpClient, *resourceGroup.Name, customerClusterName, updateAdd, 10*time.Minute, aro25884Backoff, isStateConflictError,
+				ctx, hcpClient, *resourceGroup.Name, customerClusterName, updateAdd, 10*time.Minute, aro25884Backoff, framework.IsStateConflictError,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -258,7 +241,7 @@ var _ = Describe("Customer", func() {
 			// 5. Client retry gets HTTP 400 "can't update cluster in pending_update state"
 			// The fix uses framework.UpdateHCPCluster20251223WithRetry with Kubernetes-style retry pattern
 			updateRemoveResp, err := framework.UpdateHCPCluster20251223WithRetry(
-				ctx, hcpClient, *resourceGroup.Name, customerClusterName, updateRemove, 10*time.Minute, aro25884Backoff, isStateConflictError,
+				ctx, hcpClient, *resourceGroup.Name, customerClusterName, updateRemove, 10*time.Minute, aro25884Backoff, framework.IsStateConflictError,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -329,6 +329,14 @@ func UpdateHCPCluster20251223(
 		noRetry, neverRetry)
 }
 
+// StateConflictBackoff is the default retry config for ARO-25884 state conflicts.
+var StateConflictBackoff = wait.Backoff{
+	Steps:    3,             // up to 3 attempts total
+	Duration: 1 * time.Minute, // initial wait before first retry
+	Factor:   2.0,           // double the wait each retry (1m, 2m)
+	Jitter:   0.1,           // ±10% randomization to avoid thundering herd
+}
+
 // IsStateConflictError detects transient errors from the ARO-25884 scenario:
 //   - HTTP 500: Cosmos DB ETag conflict after cluster-service commit
 //   - HTTP 409: Conflict

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -371,9 +371,16 @@ func UpdateHCPCluster20251223WithRetry(
 	err := retry.OnError(backoff, retryPredicate, func() error {
 		attempt++
 		if attempt > 1 {
-			ginkgo.GinkgoLogr.Info("Retrying cluster update due to state conflict",
+			ginkgo.GinkgoLogr.Info("Waiting for cluster to leave transitional state before retry",
 				"cluster", hcpClusterName,
-				"resourceGroup", resourceGroupName,
+				"attempt", attempt)
+			if waitErr := waitForClusterReady(ctx, hcpClient, resourceGroupName, hcpClusterName); waitErr != nil {
+				ginkgo.GinkgoLogr.Info("Cluster did not return to ready state",
+					"cluster", hcpClusterName,
+					"error", waitErr.Error())
+			}
+			ginkgo.GinkgoLogr.Info("Retrying cluster update",
+				"cluster", hcpClusterName,
 				"attempt", attempt)
 		}
 
@@ -405,6 +412,28 @@ func UpdateHCPCluster20251223WithRetry(
 	}
 
 	return hcpOpenShiftCluster, err
+}
+
+// waitForClusterReady polls until the cluster's provisioningState is no longer
+// a transitional state (Updating, Creating), or until the context is cancelled.
+func waitForClusterReady(
+	ctx context.Context,
+	hcpClient *hcpsdk20251223preview.HcpOpenShiftClustersClient,
+	resourceGroupName string,
+	hcpClusterName string,
+) error {
+	return wait.PollUntilContextCancel(ctx, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+		resp, err := hcpClient.Get(ctx, resourceGroupName, hcpClusterName, nil)
+		if err != nil {
+			return false, nil
+		}
+		if resp.Properties == nil || resp.Properties.ProvisioningState == nil {
+			return false, nil
+		}
+		state := string(*resp.Properties.ProvisioningState)
+		ginkgo.GinkgoLogr.Info("Cluster provisioning state", "cluster", hcpClusterName, "state", state)
+		return state != "Updating" && state != "Creating", nil
+	})
 }
 
 // GetHCPCluster fetches an HCP cluster

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -329,6 +329,21 @@ func UpdateHCPCluster20251223(
 		noRetry, neverRetry)
 }
 
+// IsStateConflictError detects transient errors from the ARO-25884 scenario:
+//   - HTTP 500: Cosmos DB ETag conflict after cluster-service commit
+//   - HTTP 409: Conflict
+func IsStateConflictError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var responseError *azcore.ResponseError
+	if !errors.As(err, &responseError) {
+		return false
+	}
+	return responseError.StatusCode == http.StatusInternalServerError ||
+		responseError.StatusCode == http.StatusConflict
+}
+
 func UpdateHCPCluster20251223WithRetry(
 	ctx context.Context,
 	hcpClient *hcpsdk20251223preview.HcpOpenShiftClustersClient,


### PR DESCRIPTION
Improvements on top of #4955:

### What

- Move `isStateConflictError` to `framework.IsStateConflictError` so any test doing cluster updates can reuse it
- Add `framework.StateConflictBackoff` default with jitter
- Add `waitForClusterReady` between retries — polls cluster until `provisioningState` leaves `Updating`/`Creating` before retrying, avoiding the `pending_update` HTTP 400
- Remove duplicated [ARO-25884](https://redhat.atlassian.net/browse/ARO-25884) comment blocks from test file

### Why

The retry alone doesn't prevent the HTTP 400 `pending_update` error that causes the stage E2E failures. After a 500/409, the cluster is stuck in a transitional state. Without waiting for it to return to ready, the next retry immediately hits `pending_update` and gets a non-retryable 400. The `waitForClusterReady` poll closes this gap.

### Testing

`go build ./test/...` passes.