### PR TITLE
deps: bump GitHub Actions (codeql-action, setup-kubectl, setup-oras)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,15 +35,15 @@ jobs:
         go-version-file: 'go.work'
     # Initializes the CodeQL tools for scanning
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
       with:
         languages: ${{ matrix.language }}
         # Use default CodeQL query packs
         # For custom queries, add: queries: security-and-quality
     # Autobuild attempts to build any compiled languages (Go, C/C++, C#, Java, etc.)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+      uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/environment-infra-cd.yml
+++ b/.github/workflows/environment-infra-cd.yml
@@ -103,7 +103,7 @@ jobs:
     - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.3
       with:
         kubelogin-version: 'v0.1.3'
-    - uses: oras-project/setup-oras@v1
+    - uses: oras-project/setup-oras@v2
       with:
         version: 1.2.3
     - name: 'Az CLI login'
@@ -160,7 +160,7 @@ jobs:
     - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
       with:
         kubelogin-version: 'v0.1.3'
-    - uses: oras-project/setup-oras@v1
+    - uses: oras-project/setup-oras@v2
       with:
         version: 1.2.3
     - name: 'Deploy or Update'

--- a/.github/workflows/environment-infra-cd.yml
+++ b/.github/workflows/environment-infra-cd.yml
@@ -156,7 +156,7 @@ jobs:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-    - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+    - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
     - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
       with:
         kubelogin-version: 'v0.1.3'

--- a/.github/workflows/services-cd.yml
+++ b/.github/workflows/services-cd.yml
@@ -53,7 +53,7 @@ jobs:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-    - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+    - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
     # Used to deploy Cluster Service
     - name: 'Install oc'
       run: |
@@ -129,7 +129,7 @@ jobs:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-    - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+    - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
     - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
       with:
         kubelogin-version: 'v0.1.3'

--- a/.github/workflows/services-cd.yml
+++ b/.github/workflows/services-cd.yml
@@ -67,7 +67,7 @@ jobs:
     - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
       with:
         kubelogin-version: 'v0.1.3'
-    - uses: oras-project/setup-oras@v1
+    - uses: oras-project/setup-oras@v2
       with:
         version: 1.2.3
     # Prepare kubeconfig
@@ -133,7 +133,7 @@ jobs:
     - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
       with:
         kubelogin-version: 'v0.1.3'
-    - uses: oras-project/setup-oras@v1
+    - uses: oras-project/setup-oras@v2
       with:
         version: 1.2.3
     - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-692

### What

Bump three GitHub Actions to latest versions:

- **github/codeql-action** 4.35.1 → 4.35.2
- **azure/setup-kubectl** 4.0.1 → 5.1.0
- **oras-project/setup-oras** 1 → 2

Closes #4914, Closes #4940, Closes #4941

### Why

Keep CI actions up to date and address 6 CVEs in transitive dependencies.

#### CVEs fixed
| **CVE** | **Severity** | **Package** | **Description** |
|---------|-------------|-------------|-----------------|
| [CVE-2026-1528](https://nvd.nist.gov/vuln/detail/CVE-2026-1528) | High (7.5) | undici | WebSocket 64-bit length overflow crashes the client (DoS) |
| [CVE-2026-1525](https://nvd.nist.gov/vuln/detail/CVE-2026-1525) | Medium (6.5) | undici | HTTP Request/Response Smuggling via duplicate Content-Length headers |
| [CVE-2026-1526](https://nvd.nist.gov/vuln/detail/CVE-2026-1526) | High (7.5) | undici | Unbounded memory consumption in WebSocket permessage-deflate decompression (DoS) |
| [CVE-2026-2229](https://nvd.nist.gov/vuln/detail/CVE-2026-2229) | High (7.5) | undici | Unhandled exception in WebSocket client due to invalid server_max_window_bits (DoS) |
| [CVE-2026-1527](https://nvd.nist.gov/vuln/detail/CVE-2026-1527) | High | undici | CRLF Injection via upgrade option |
| [CVE-2026-33671](https://nvd.nist.gov/vuln/detail/CVE-2026-33671) | High (7.5) | picomatch | ReDoS vulnerability via extglob quantifiers |

### Commits
- **github/codeql-action 4.35.1 → 4.35.2** — standard update, deprecates TRAP cache cleanup, updates CodeQL bundle to v2.25.2
- **azure/setup-kubectl 4.0.1 → 5.1.0** — CVE-2026-33671 (picomatch ReDoS), pins undici ≥6.24.1, bumps handlebars 4.7.8→4.7.9, vite 8.0.3→8.0.5, migrates to node24
- **oras-project/setup-oras 1 → 2** — CVE-2026-1528, CVE-2026-1525, CVE-2026-1526, CVE-2026-2229, CVE-2026-1527 (undici), pins undici ≥6.24.1, migrates to node24

### Testing

CI-only changes, no application code modified.