### PR TITLE
deps: bump @microsoft.azure/openapi-validator-rulesets to 2.2.6

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@microsoft.azure/openapi-validator": "2.2.4",
-        "@microsoft.azure/openapi-validator-rulesets": "2.2.1",
+        "@microsoft.azure/openapi-validator-rulesets": "2.2.6",
         "@typespec/compiler": "~1.9.0",
         "autorest": "^3.7.2"
       },
@@ -924,9 +924,9 @@
       }
     },
     "node_modules/@microsoft.azure/openapi-validator-rulesets": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@microsoft.azure/openapi-validator-rulesets/-/openapi-validator-rulesets-2.2.1.tgz",
-      "integrity": "sha512-YdbU5oFuoXo1w3uyvYr9oQ3J+/Nu3KjTq/fApMS8s5vt4Ehj4SdfGOo2SlCrnqpPAcKhPjEXp2oF5dOgC5lKsA==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@microsoft.azure/openapi-validator-rulesets/-/openapi-validator-rulesets-2.2.6.tgz",
+      "integrity": "sha512-WUManjLzzEJpcCrhvJc4YyFANIzBHLY6N1YwVQFXFMcWW88WfDWMpSNWR6AqUXl1C/cq/wgOe/N4qGb9wfY3pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -943,7 +943,7 @@
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/api/package.json
+++ b/api/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@typespec/compiler": "~1.9.0",
     "@microsoft.azure/openapi-validator": "2.2.4",
-    "@microsoft.azure/openapi-validator-rulesets": "2.2.1",
+    "@microsoft.azure/openapi-validator-rulesets": "2.2.6",
     "autorest": "^3.7.2"
   },
   "overrides": {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-694

### What

Bump `@microsoft.azure/openapi-validator-rulesets` from 2.2.1 to 2.2.6 in `api/`.

Closes #4942

### Why

Keep API validation tooling up to date. No CVEs — this is a dev dependency used for API specification validation.

### Testing

Dependency-only change, no application code modified. CI validates API specs still pass.