### PR TITLE
Fix ci /go/pkg/mod failures

### DIFF
--- a/dev-infrastructure/openshift-ci/Dockerfile
+++ b/dev-infrastructure/openshift-ci/Dockerfile
@@ -40,4 +40,6 @@ RUN cd /tmp/aro-hcp && \
     GOFLAGS='-mod=readonly' GOBIN=/usr/local/bin make install-tools && \
     go clean -cache -modcache && \
     rm -rf /tmp/aro-hcp
-RUN mkdir -p /go/pkg/mod /go/bin && chmod -R 777 /go
+RUN mkdir -p /go/pkg/mod /go/bin && \
+    chgrp -R 0 /go && \
+    chmod -R g=u /go

--- a/dev-infrastructure/openshift-ci/Dockerfile
+++ b/dev-infrastructure/openshift-ci/Dockerfile
@@ -40,3 +40,4 @@ RUN cd /tmp/aro-hcp && \
     GOFLAGS='-mod=readonly' GOBIN=/usr/local/bin make install-tools && \
     go clean -cache -modcache && \
     rm -rf /tmp/aro-hcp
+RUN mkdir -p /go/pkg/mod /go/bin && chmod -R 777 /go


### PR DESCRIPTION


### What

creates /go/pkg/mod in ci image and sets permissions

### Why

PR 4884 added `go clean -cache -modcache` which removes /go/pkg/mod, as such all PR's are failing.

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
