### PR TITLE
Revert "Move install-tools to base-ci image and update e2e tests image"

### DIFF
--- a/dev-infrastructure/openshift-ci/Dockerfile
+++ b/dev-infrastructure/openshift-ci/Dockerfile
@@ -34,9 +34,3 @@ RUN ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "amd64") && \
     mv prometheus-${PROMTOOL_VERSION}.linux-${ARCH}/promtool /usr/local/bin/promtool && \
     chmod +x /usr/local/bin/promtool && \
     rm -rf prometheus-${PROMTOOL_VERSION}.linux-${ARCH}
-# Install Go-based development tools (bingo-managed)
-COPY . /tmp/aro-hcp
-RUN cd /tmp/aro-hcp && \
-    GOFLAGS='-mod=readonly' GOBIN=/usr/local/bin make install-tools && \
-    go clean -cache -modcache && \
-    rm -rf /tmp/aro-hcp

--- a/dev-infrastructure/openshift-ci/Makefile
+++ b/dev-infrastructure/openshift-ci/Makefile
@@ -34,8 +34,7 @@ verify: ## Verify versions are consistent across config files
 build: verify ## Build the CI image
 	$(CONTAINER_ENGINE) build --platform=$(PLATFORM) \
 		$(foreach v,$(VERSION_ARGS),--build-arg $(v)=$($(v))) \
-		-f Dockerfile \
-		-t $(IMAGE_NAME) ../..
+		-t $(IMAGE_NAME) .
 
 ##@ Test
 
@@ -51,8 +50,4 @@ test: build ## Build and smoke-test all tools in the image
 		echo "promtool:  $$(promtool --version 2>&1 | head -1)" && \
 		echo "make:      $$(make --version | head -1)" && \
 		echo "git:       $$(git --version)" && \
-		echo "helm:      $$(helm version --short 2>&1)" && \
-		echo "yq:        $$(yq --version 2>&1)" && \
-		echo "jq:        $$(jq --version 2>&1)" && \
-		echo "oras:      $$(oras version 2>&1 | head -1)" && \
 		echo "=== All tools OK ==="'

--- a/test/Containerfile.e2e
+++ b/test/Containerfile.e2e
@@ -3,8 +3,6 @@ USER root
 WORKDIR /opt/app-root/src/github.com/Azure/ARO-HCP
 COPY . .
 ENV GOFLAGS='-mod=readonly'
-RUN make build-hcpctl && \
-    make -C tooling/templatize templatize && \
-    make -C test/ build && \
-    go clean -cache -modcache && rm -f go.work.sum
+RUN make -C test/ build && go clean -cache -modcache && rm -f go.work.sum
 RUN chmod 777 /opt/app-root/src/github.com/Azure/ARO-HCP
+


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-691

## Summary

Reverts #4884 ("Move install-tools to base-ci image and update e2e tests image") which broke all CI checks on every PR against main.

The PR added `go clean -cache -modcache` to the CI Dockerfile, deleting `/go/pkg/mod` and `/go/.cache`. CI steps run as a non-root user and cannot recreate these directories, causing `permission denied` errors on lint, test-unit, and verify.

## Test plan

- [ ] CI passes on this PR (lint, test-unit, verify)
- [ ] Other open PRs unblocked after merge