### PR TITLE
ci: fix Go cache in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,6 +33,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version-file: 'go.work'
+        cache-dependency-path: '**/go.sum'
     # Initializes the CodeQL tools for scanning
     - name: Initialize CodeQL
       uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1


### PR DESCRIPTION
## Summary

Fix the `setup-go` cache warning in the CodeQL workflow by adding `cache-dependency-path: '*/go.sum'`. The action defaults to looking for `go.mod` in the repo root, which doesn't exist in this Go workspace — the `go.mod` files are in subdirectories.

## Test plan

- [ ] CodeQL workflow runs without the "Restore cache failed" warning