### PR TITLE
test: retry and ignore ARM throttling errors during E2E cleanup

### DIFF
--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -226,11 +226,18 @@ func (tc *perItOrDescribeTestContext) deleteCreatedResources(ctx context.Context
 		CleanupWorkflow:    CleanupWorkflowStandard,
 		ThrottleMaxRetries: 5,
 	}
+	maxRetries := opts.ThrottleMaxRetries
+	if maxRetries <= 0 {
+		maxRetries = 1
+	}
 	var errCleanupResourceGroups error
 retryLoop:
-	for attempt := 1; attempt <= opts.ThrottleMaxRetries; attempt++ {
+	for attempt := 1; attempt <= maxRetries; attempt++ {
 		errCleanupResourceGroups = tc.CleanupResourceGroups(ctx, opts)
 		if errCleanupResourceGroups == nil || !isOnlyThrottledErrors(errCleanupResourceGroups) {
+			break
+		}
+		if attempt == maxRetries {
 			break
 		}
 		delay := time.Duration(attempt*30) * time.Second
@@ -258,10 +265,10 @@ retryLoop:
 
 	ginkgo.GinkgoLogr.Info("finished deleting created resources")
 	// Register error to ginkgo reporter to ensure the test fails if any
-	// errors occur, except for transient/ignorable ones (404 not found,
-	// 429 throttling) which are handled by the automated cleanup job.
+	// errors occur, except for not-found errors (404) which indicate the
+	// resource group was already cleaned up.
 	if isIgnorableResourceGroupCleanupError(errCleanupResourceGroups) {
-		ginkgo.GinkgoLogr.Info("ignoring transient cleanup error", "error", errCleanupResourceGroups)
+		ginkgo.GinkgoLogr.Info("ignoring cleanup error (resource already deleted)", "error", errCleanupResourceGroups)
 	} else {
 		gomega.Expect(errCleanupResourceGroups).ToNot(gomega.HaveOccurred())
 	}
@@ -320,9 +327,9 @@ func isOnlyThrottledErrors(err error) bool {
 }
 
 // isIgnorableResourceGroupCleanupError returns true when every error in a
-// (possibly joined) error tree is ignorable — either a 404 not-found or a
-// 429 throttling response. This prevents a single ignorable error from
-// masking a real failure in the same errors.Join set.
+// (possibly joined) error tree is a 404 not-found. Throttling errors are
+// NOT ignorable — they are retried, and if retries are exhausted the test
+// fails so deletion regressions remain visible.
 func isIgnorableResourceGroupCleanupError(err error) bool {
 	if err == nil {
 		return false
@@ -335,7 +342,7 @@ func isIgnorableResourceGroupCleanupError(err error) bool {
 		}
 		return true
 	}
-	return isResourceGroupNotFoundError(err) || isThrottledError(err)
+	return isResourceGroupNotFoundError(err)
 }
 
 type CleanupWorkflow string

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -242,9 +242,11 @@ func (tc *perItOrDescribeTestContext) deleteCreatedResources(ctx context.Context
 	}
 
 	ginkgo.GinkgoLogr.Info("finished deleting created resources")
-	// Register error to ginkgo reporter to ensure the test fails if any errors occur except for not found resource group or resource.
+	// Register error to ginkgo reporter to ensure the test fails if any
+	// errors occur, except for transient/ignorable ones (404 not found,
+	// 429 throttling) which are handled by the automated cleanup job.
 	if isIgnorableResourceGroupCleanupError(errCleanupResourceGroups) {
-		ginkgo.GinkgoLogr.Info("ignoring not found resource group or resource cleanup error")
+		ginkgo.GinkgoLogr.Info("ignoring transient cleanup error", "error", errCleanupResourceGroups)
 	} else {
 		gomega.Expect(errCleanupResourceGroups).ToNot(gomega.HaveOccurred())
 	}
@@ -271,11 +273,37 @@ func isResourceGroupNotFoundError(err error) bool {
 	return false
 }
 
+func isThrottledError(err error) bool {
+	var responseErr *azcore.ResponseError
+	if errors.As(err, &responseErr) {
+		if responseErr.StatusCode == http.StatusTooManyRequests {
+			return true
+		}
+		switch responseErr.ErrorCode {
+		case "SubscriptionRequestsThrottled", "RequestsThrottled":
+			return true
+		}
+	}
+	return false
+}
+
+// isIgnorableResourceGroupCleanupError returns true when every error in a
+// (possibly joined) error tree is ignorable — either a 404 not-found or a
+// 429 throttling response. This prevents a single ignorable error from
+// masking a real failure in the same errors.Join set.
 func isIgnorableResourceGroupCleanupError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return isResourceGroupNotFoundError(err)
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, e := range joined.Unwrap() {
+			if !isIgnorableResourceGroupCleanupError(e) {
+				return false
+			}
+		}
+		return true
+	}
+	return isResourceGroupNotFoundError(err) || isThrottledError(err)
 }
 
 type CleanupWorkflow string

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -227,14 +227,19 @@ func (tc *perItOrDescribeTestContext) deleteCreatedResources(ctx context.Context
 		ThrottleMaxRetries: 5,
 	}
 	var errCleanupResourceGroups error
+retryLoop:
 	for attempt := 1; attempt <= opts.ThrottleMaxRetries; attempt++ {
 		errCleanupResourceGroups = tc.CleanupResourceGroups(ctx, opts)
-		if errCleanupResourceGroups == nil || !isThrottledError(errCleanupResourceGroups) {
+		if errCleanupResourceGroups == nil || !isOnlyThrottledErrors(errCleanupResourceGroups) {
 			break
 		}
 		delay := time.Duration(attempt*30) * time.Second
 		ginkgo.GinkgoLogr.Info("cleanup throttled by ARM, retrying", "attempt", attempt, "retryIn", delay, "error", errCleanupResourceGroups)
-		time.Sleep(delay)
+		select {
+		case <-ctx.Done():
+			break retryLoop
+		case <-time.After(delay):
+		}
 	}
 	if errCleanupResourceGroups != nil {
 		if !isIgnorableResourceGroupCleanupError(errCleanupResourceGroups) {
@@ -295,6 +300,23 @@ func isThrottledError(err error) bool {
 		}
 	}
 	return false
+}
+
+// isOnlyThrottledErrors returns true when every error in a (possibly joined)
+// error tree is a throttling error. Used to decide whether retrying is useful.
+func isOnlyThrottledErrors(err error) bool {
+	if err == nil {
+		return false
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, e := range joined.Unwrap() {
+			if !isOnlyThrottledErrors(e) {
+				return false
+			}
+		}
+		return true
+	}
+	return isThrottledError(err)
 }
 
 // isIgnorableResourceGroupCleanupError returns true when every error in a

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -224,8 +224,18 @@ func (tc *perItOrDescribeTestContext) deleteCreatedResources(ctx context.Context
 		ResourceGroupNames: resourceGroupNames,
 		Timeout:            60 * time.Minute,
 		CleanupWorkflow:    CleanupWorkflowStandard,
+		ThrottleMaxRetries: 5,
 	}
-	errCleanupResourceGroups := tc.CleanupResourceGroups(ctx, opts)
+	var errCleanupResourceGroups error
+	for attempt := 1; attempt <= opts.ThrottleMaxRetries; attempt++ {
+		errCleanupResourceGroups = tc.CleanupResourceGroups(ctx, opts)
+		if errCleanupResourceGroups == nil || !isThrottledError(errCleanupResourceGroups) {
+			break
+		}
+		delay := time.Duration(attempt*30) * time.Second
+		ginkgo.GinkgoLogr.Info("cleanup throttled by ARM, retrying", "attempt", attempt, "retryIn", delay, "error", errCleanupResourceGroups)
+		time.Sleep(delay)
+	}
 	if errCleanupResourceGroups != nil {
 		if !isIgnorableResourceGroupCleanupError(errCleanupResourceGroups) {
 			ginkgo.GinkgoLogr.Error(errCleanupResourceGroups, "at least one resource group failed to delete")
@@ -316,6 +326,7 @@ const (
 type CleanupResourceGroupsOptions struct {
 	ResourceGroupNames []string
 	Timeout            time.Duration
+	ThrottleMaxRetries int
 	CleanupWorkflow    CleanupWorkflow
 }
 

--- a/test/util/framework/per_test_framework_test.go
+++ b/test/util/framework/per_test_framework_test.go
@@ -123,7 +123,51 @@ func TestIsIgnorableResourceGroupCleanupError(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "429 Too Many Requests returns true",
+			name: "429 Too Many Requests is not ignorable (retried instead)",
+			err:  &azcore.ResponseError{StatusCode: http.StatusTooManyRequests},
+			want: false,
+		},
+		{
+			name: "joined 404s all ignorable returns true",
+			err:  errors.Join(&azcore.ResponseError{StatusCode: http.StatusNotFound}, &azcore.ResponseError{StatusCode: http.StatusNotFound, ErrorCode: "ResourceGroupNotFound"}),
+			want: true,
+		},
+		{
+			name: "joined 404 with non-ignorable returns false",
+			err:  errors.Join(&azcore.ResponseError{StatusCode: http.StatusNotFound}, &azcore.ResponseError{StatusCode: http.StatusForbidden}),
+			want: false,
+		},
+		{
+			name: "403 Forbidden returns false",
+			err:  &azcore.ResponseError{StatusCode: http.StatusForbidden},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isIgnorableResourceGroupCleanupError(tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsOnlyThrottledErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil returns false",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "429 returns true",
 			err:  &azcore.ResponseError{StatusCode: http.StatusTooManyRequests},
 			want: true,
 		},
@@ -139,22 +183,27 @@ func TestIsIgnorableResourceGroupCleanupError(t *testing.T) {
 		},
 		{
 			name: "wrapped 429 returns true",
-			err:  fmt.Errorf("cleanup failed: %w", &azcore.ResponseError{StatusCode: http.StatusTooManyRequests}),
+			err:  fmt.Errorf("cleanup: %w", &azcore.ResponseError{StatusCode: http.StatusTooManyRequests}),
 			want: true,
 		},
 		{
-			name: "joined errors all ignorable returns true",
-			err:  errors.Join(&azcore.ResponseError{StatusCode: http.StatusNotFound}, &azcore.ResponseError{StatusCode: http.StatusTooManyRequests}),
+			name: "joined all throttled returns true",
+			err:  errors.Join(&azcore.ResponseError{StatusCode: http.StatusTooManyRequests}, &azcore.ResponseError{ErrorCode: "SubscriptionRequestsThrottled"}),
 			want: true,
 		},
 		{
-			name: "joined errors with non-ignorable returns false",
+			name: "joined throttled with 404 returns false",
+			err:  errors.Join(&azcore.ResponseError{StatusCode: http.StatusTooManyRequests}, &azcore.ResponseError{StatusCode: http.StatusNotFound}),
+			want: false,
+		},
+		{
+			name: "joined throttled with 403 returns false",
 			err:  errors.Join(&azcore.ResponseError{StatusCode: http.StatusTooManyRequests}, &azcore.ResponseError{StatusCode: http.StatusForbidden}),
 			want: false,
 		},
 		{
-			name: "403 Forbidden returns false",
-			err:  &azcore.ResponseError{StatusCode: http.StatusForbidden},
+			name: "non-ResponseError returns false",
+			err:  fmt.Errorf("something else"),
 			want: false,
 		},
 	}
@@ -162,7 +211,7 @@ func TestIsIgnorableResourceGroupCleanupError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := isIgnorableResourceGroupCleanupError(tt.err)
+			got := isOnlyThrottledErrors(tt.err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/test/util/framework/per_test_framework_test.go
+++ b/test/util/framework/per_test_framework_test.go
@@ -15,6 +15,7 @@
 package framework
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -120,6 +121,41 @@ func TestIsIgnorableResourceGroupCleanupError(t *testing.T) {
 			name: "ResourceGroupNotFound returns true",
 			err:  &azcore.ResponseError{StatusCode: http.StatusConflict, ErrorCode: "ResourceGroupNotFound"},
 			want: true,
+		},
+		{
+			name: "429 Too Many Requests returns true",
+			err:  &azcore.ResponseError{StatusCode: http.StatusTooManyRequests},
+			want: true,
+		},
+		{
+			name: "SubscriptionRequestsThrottled returns true",
+			err:  &azcore.ResponseError{ErrorCode: "SubscriptionRequestsThrottled"},
+			want: true,
+		},
+		{
+			name: "RequestsThrottled returns true",
+			err:  &azcore.ResponseError{ErrorCode: "RequestsThrottled"},
+			want: true,
+		},
+		{
+			name: "wrapped 429 returns true",
+			err:  fmt.Errorf("cleanup failed: %w", &azcore.ResponseError{StatusCode: http.StatusTooManyRequests}),
+			want: true,
+		},
+		{
+			name: "joined errors all ignorable returns true",
+			err:  errors.Join(&azcore.ResponseError{StatusCode: http.StatusNotFound}, &azcore.ResponseError{StatusCode: http.StatusTooManyRequests}),
+			want: true,
+		},
+		{
+			name: "joined errors with non-ignorable returns false",
+			err:  errors.Join(&azcore.ResponseError{StatusCode: http.StatusTooManyRequests}, &azcore.ResponseError{StatusCode: http.StatusForbidden}),
+			want: false,
+		},
+		{
+			name: "403 Forbidden returns false",
+			err:  &azcore.ResponseError{StatusCode: http.StatusForbidden},
+			want: false,
 		},
 	}
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-26384

## Summary

E2E tests fail with false positives when ARM returns `429 SubscriptionRequestsThrottled` during resource group cleanup. This happens during batch merge runs when concurrent E2E suites exhaust the subscription's ARM request quota. The Azure SDK already retries 6 times internally (`azureRetryOptions`), but during heavy contention that's not enough.

This PR adds cleanup-level retry with backoff on top of the SDK retries, and makes the `errors.Join` handling correct so mixed error sets don't hide real failures. Throttle errors are **not** silently ignored — if retries are exhausted the test still fails, keeping the HCP deletion path tested (per roivaz's review).

### Changes

**Commit 1 — Throttle detection and `errors.Join`-safe error handling**
- Add `isThrottledError` helper to detect ARM 429 / `SubscriptionRequestsThrottled` / `RequestsThrottled`
- Make `isIgnorableResourceGroupCleanupError` recursively walk `errors.Join` sets — only ignore when *every* error is a 404 not-found

**Commit 2 — Retry cleanup with backoff on throttling**
- Add `ThrottleMaxRetries` field to `CleanupResourceGroupsOptions` (default: 5)
- Retry cleanup with incremental 30s delays when all errors are throttling

**Commit 3 — Test coverage**
- `TestIsIgnorableResourceGroupCleanupError`: 429 is NOT ignorable, joined 404s are, mixed sets are not
- `TestIsOnlyThrottledErrors`: 429, error codes, wrapped, joined-all-throttled, mixed sets

**Commit 4 — Context-aware sleep and pure-throttle retry gate**
- Replace `time.Sleep` with `select` on `ctx.Done()` + `time.After` to respect context cancellation
- Add `isOnlyThrottledErrors` — only retry when *every* error in a joined set is throttled

**Commit 5 — Review feedback**
- Throttle errors are retried but NOT ignored — test fails if retries exhausted
- Default `ThrottleMaxRetries` to 1 when unset so cleanup always runs at least once
- Skip sleeping on the final attempt

### Example failure

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/batch/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2046862361419059200

## Test plan

- [x] `go build ./test/...` passes
- [x] Unit tests pass (`TestIsIgnorableResourceGroupCleanupError`, `TestIsOnlyThrottledErrors`)
- [ ] CI passes