### PR TITLE
Reduce e2e cleanup Azure operation bursts

### DIFF
--- a/test/util/framework/identities_helper.go
+++ b/test/util/framework/identities_helper.go
@@ -685,24 +685,33 @@ func (tc *perItOrDescribeTestContext) cleanupLeasedIdentityContainerRoleAssignme
 		return nil
 	}
 
-	wg := sync.WaitGroup{}
+	const raDeleteParallelism = 4
+
+	jobs := make(chan *armauthorization.RoleAssignment)
 	errCh := make(chan error, len(toDelete))
 
-	for _, ra := range toDelete {
-		wg.Add(1)
-		go func(ctx context.Context, ra *armauthorization.RoleAssignment) {
+	var wg sync.WaitGroup
+	wg.Add(raDeleteParallelism)
+	for range raDeleteParallelism {
+		go func() {
 			defer wg.Done()
-
-			_, err := client.Delete(ctx, *ra.Properties.Scope, *ra.Name, nil)
-			if err != nil {
-				var respErr *azcore.ResponseError
-				if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
-					return
+			for ra := range jobs {
+				_, err := client.Delete(ctx, *ra.Properties.Scope, *ra.Name, nil)
+				if err != nil {
+					var respErr *azcore.ResponseError
+					if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+						continue
+					}
+					errCh <- fmt.Errorf("failed to delete role assignment %s: %w", *ra.ID, err)
 				}
-				errCh <- fmt.Errorf("failed to delete role assignment %s: %w", *ra.ID, err)
 			}
-		}(ctx, ra)
+		}()
 	}
+
+	for _, ra := range toDelete {
+		jobs <- ra
+	}
+	close(jobs)
 
 	wg.Wait()
 	close(errCh)

--- a/tooling/cleanup-sweeper/pkg/engine/runner/engine.go
+++ b/tooling/cleanup-sweeper/pkg/engine/runner/engine.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// DefaultParallelism is used when Engine.Parallelism is not set.
-	DefaultParallelism = 8
+	DefaultParallelism = 4
 	// DefaultRetries is the minimum retry count for retryable operations.
 	DefaultRetries = 1
 )


### PR DESCRIPTION
Reduce Azure operation bursts by bounding cleanup parallelism to 4 in cleanup-sweeper and role assignment e2e cleanup.
This change is aimed towards reducing the chance of exhausting the per principal token bucket in the testing subscriptions.
