### PR TITLE
Fix controller CRUD path mismatch for nodepool/externalauth operations

### DIFF
--- a/backend/pkg/controllers/operationcontrollers/generic_operation.go
+++ b/backend/pkg/controllers/operationcontrollers/generic_operation.go
@@ -17,6 +17,7 @@ package operationcontrollers
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -92,12 +93,28 @@ func NewGenericOperationController(
 	return c
 }
 
+func (c *genericOperation) controllerCRUD(key controllerutils.OperationKey) database.ResourceCRUD[api.Controller] {
+	parentResourceID := key.GetParentResourceID()
+	sub := parentResourceID.SubscriptionID
+	rg := parentResourceID.ResourceGroupName
+
+	switch {
+	case strings.EqualFold(parentResourceID.ResourceType.String(), api.NodePoolResourceType.String()):
+		return c.cosmosClient.HCPClusters(sub, rg).NodePools(parentResourceID.Parent.Name).Controllers(parentResourceID.Name)
+	case strings.EqualFold(parentResourceID.ResourceType.String(), api.ExternalAuthResourceType.String()):
+		return c.cosmosClient.HCPClusters(sub, rg).ExternalAuth(parentResourceID.Parent.Name).Controllers(parentResourceID.Name)
+	default:
+		return c.cosmosClient.HCPClusters(sub, rg).Controllers(parentResourceID.Name)
+	}
+}
+
 func (c *genericOperation) SyncOnce(ctx context.Context, keyObj any) error {
 	key := keyObj.(controllerutils.OperationKey)
-	parentResourceID := key.GetParentResourceID()
+	controllerCRUD := c.controllerCRUD(key)
+
 	defer utilruntime.HandleCrash(controllerutils.DegradedControllerPanicHandler(
 		ctx,
-		c.cosmosClient.HCPClusters(key.SubscriptionID, parentResourceID.ResourceGroupName).Controllers(parentResourceID.Name),
+		controllerCRUD,
 		c.name,
 		key.InitialController))
 
@@ -105,7 +122,7 @@ func (c *genericOperation) SyncOnce(ctx context.Context, keyObj any) error {
 
 	controllerWriteErr := controllerutils.WriteController(
 		ctx,
-		c.cosmosClient.HCPClusters(key.SubscriptionID, parentResourceID.ResourceGroupName).Controllers(parentResourceID.Name),
+		controllerCRUD,
 		c.name,
 		key.InitialController,
 		controllerutils.ReportSyncError(syncErr),

--- a/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
+++ b/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
@@ -115,8 +115,9 @@ func (f *clusterTestFixture) newOperation(request database.OperationRequest) *ap
 
 func (f *clusterTestFixture) operationKey() controllerutils.OperationKey {
 	return controllerutils.OperationKey{
-		SubscriptionID: testSubscriptionID,
-		OperationName:  testOperationName,
+		SubscriptionID:   testSubscriptionID,
+		OperationName:    testOperationName,
+		ParentResourceID: f.clusterResourceID.String(),
 	}
 }
 
@@ -208,8 +209,9 @@ func (f *nodePoolTestFixture) newOperation(request database.OperationRequest) *a
 
 func (f *nodePoolTestFixture) operationKey() controllerutils.OperationKey {
 	return controllerutils.OperationKey{
-		SubscriptionID: testSubscriptionID,
-		OperationName:  testOperationName,
+		SubscriptionID:   testSubscriptionID,
+		OperationName:    testOperationName,
+		ParentResourceID: f.nodePoolResourceID.String(),
 	}
 }
 
@@ -301,7 +303,8 @@ func (f *externalAuthTestFixture) newOperation(request database.OperationRequest
 
 func (f *externalAuthTestFixture) operationKey() controllerutils.OperationKey {
 	return controllerutils.OperationKey{
-		SubscriptionID: testSubscriptionID,
-		OperationName:  testOperationName,
+		SubscriptionID:   testSubscriptionID,
+		OperationName:    testOperationName,
+		ParentResourceID: f.externalAuthResourceID.String(),
 	}
 }

--- a/test/cmd/aro-hcp-tests/gather-observability/knownIssues.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/knownIssues.yaml
@@ -1,21 +1,7 @@
-knownIssues:
-- name: "BackendControllerRetryHotLoop"
-  labels:
-    name: "operationnodepoolcreate"
-  reason: "Nodepool create controller retry hot loops are observed during e2e runs. Needs investigation."
-- name: "BackendControllerRetryHotLoop"
-  labels:
-    name: "operationnodepooldelete"
-  reason: "Nodepool delete controller retry hot loops are observed during e2e runs. Needs investigation."
-- name: "BackendControllerRetryHotLoop"
-  labels:
-    name: "operationexternalauthcreate"
-  reason: "ExternalAuth create controller retry hot loops are observed during e2e runs. Needs investigation."
-- name: "BackendControllerRetryHotLoop"
-  labels:
-    name: "operationexternalauthupdate"
-  reason: "ExternalAuth update controller retry hot loops are observed during e2e runs. Needs investigation."
-- name: "BackendControllerRetryHotLoop"
-  labels:
-    name: "operationexternalauthdelete"
-  reason: "ExternalAuth delete controller retry hot loops are observed during e2e runs. Needs investigation."
+knownIssues: []
+
+# the following is an example definition of a known issue
+# - name: "BackendControllerRetryHotLoop"
+#   labels:
+#     name: "operationnodepoolcreate"
+#   reason: "Nodepool create controller retry hot loops are observed during e2e runs. Needs investigation."


### PR DESCRIPTION
### What

SyncOnce always used the cluster controller CRUD to write controller status. For nodepool operations, `parentResourceID.Name` is the nodepool name, not the cluster name. This created a CRUD that searched under `.../hcpOpenShiftClusters/{nodePoolName}/...` while InitialController built the ResourceID under `.../hcpOpenShiftClusters/{cluster}/nodePools/{nodePool}/...`

The path mismatch caused Get to return 404 and Create to return 409 Conflict on every sync cycle, triggering the BackendControllerRetryHotLoop alert with a retry ratio of ~1 for operationnodepoolcreate and operationnodepooldelete.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
