### PR TITLE
remove ownerIds fall back logic & update schema

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -39,9 +39,6 @@
         "useSNI": {
           "type": "boolean"
         },
-        "ownerIds": {
-          "$ref": "#/definitions/csv"
-        },
         "manage": {
           "type": "boolean"
         }
@@ -3138,6 +3135,7 @@
     "msiCredentialsRefresher",
     "keyVaultDNSSuffix",
     "acrDNSSuffix",
-    "e2e"
+    "e2e",
+    "entraAppOwnerIds"
   ]
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -242,7 +242,6 @@ defaults:
       genevaActionsPrincipalId: ""
       application:
         name: "arohcp-ga-{{ .ctx.environment }}" # [tenant unique]
-        ownerIds: ""
         useSNI: true
         manage: true
       publish:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -295,7 +295,6 @@ geneva:
     application:
       manage: true
       name: arohcp-ga-dev
-      ownerIds: ""
       useSNI: false
     certificate:
       issuer: Self

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -295,7 +295,6 @@ geneva:
     application:
       manage: true
       name: arohcp-ga-dev
-      ownerIds: ""
       useSNI: false
     certificate:
       issuer: Self

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -295,7 +295,6 @@ geneva:
     application:
       manage: true
       name: arohcp-ga-dev
-      ownerIds: ""
       useSNI: false
     certificate:
       issuer: Self

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -295,7 +295,6 @@ geneva:
     application:
       manage: true
       name: arohcp-ga-dev
-      ownerIds: ""
       useSNI: false
     certificate:
       issuer: Self

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -295,7 +295,6 @@ geneva:
     application:
       manage: true
       name: arohcp-ga-dev
-      ownerIds: ""
       useSNI: false
     certificate:
       issuer: Self

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -295,7 +295,6 @@ geneva:
     application:
       manage: true
       name: arohcp-ga-dev
-      ownerIds: ""
       useSNI: false
     certificate:
       issuer: Self

--- a/dev-infrastructure/configurations/geneva-identities.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/geneva-identities.tmpl.bicepparam
@@ -18,4 +18,3 @@ param genevaActionApplicationUseSNI = {{ .geneva.actions.application.useSNI }}
 param genevaActionApplicationManage = {{ .geneva.actions.application.manage }}
 param genevaActionApplicationName = '{{ .geneva.actions.application.name }}'
 param entraAppOwnerIds = '{{ .entraAppOwnerIds }}'
-param genevaActionApplicationOwnerIds = '{{ .geneva.actions.application.ownerIds }}'

--- a/dev-infrastructure/configurations/mise-identity.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mise-identity.tmpl.bicepparam
@@ -2,5 +2,4 @@ using '../templates/mise-identity.bicep'
 
 param miseApplicationName = '{{ .mise.applicationName }}'
 param entraAppOwnerIds = '{{ .entraAppOwnerIds }}'
-param genevaActionApplicationOwnerIds = '{{ .geneva.actions.application.ownerIds }}'
 param miseApplicationDeploy = {{ .mise.deploy }}

--- a/dev-infrastructure/modules/entra/app.bicep
+++ b/dev-infrastructure/modules/entra/app.bicep
@@ -29,6 +29,8 @@ param requestedAccessTokenVersion int = 2
 @description('Key credentials for the application (e.g. certificate-based auth)')
 param keyCredentials array = []
 
+var validatedOwnerIds = !empty(ownerIds) ? ownerIds : fail('EntraId App ownerIds must not be empty')
+
 resource entraApp 'Microsoft.Graph/applications@beta' = {
   displayName: applicationName
   isFallbackPublicClient: isFallbackPublicClient
@@ -41,7 +43,7 @@ resource entraApp 'Microsoft.Graph/applications@beta' = {
   }
   trustedSubjectNameAndIssuers: trustedSubjectNameAndIssuers
   owners: {
-    relationships: [for ownerId in csvToArray(ownerIds): ownerId]
+    relationships: [for ownerId in csvToArray(validatedOwnerIds): ownerId]
   }
   keyCredentials: keyCredentials
 }
@@ -49,7 +51,7 @@ resource entraApp 'Microsoft.Graph/applications@beta' = {
 resource servicePrincipal 'Microsoft.Graph/servicePrincipals@beta' = if (manageSp) {
   appId: entraApp.appId
   owners: {
-    relationships: [for ownerId in csvToArray(ownerIds): ownerId]
+    relationships: [for ownerId in csvToArray(validatedOwnerIds): ownerId]
   }
 }
 

--- a/dev-infrastructure/templates/geneva-identities.bicep
+++ b/dev-infrastructure/templates/geneva-identities.bicep
@@ -20,16 +20,8 @@ param genevaActionsManageCertificates bool
 param genevaActionsCertificateDomain string
 param genevaActionApplicationName string
 param entraAppOwnerIds string
-param genevaActionApplicationOwnerIds string
 param genevaActionApplicationManage bool
 param genevaActionApplicationUseSNI bool
-
-// TODO: remove genevaActionApplicationOwnerIds fallback once entraAppOwnerIds is set in sdp-pipelines config
-var ownerIds = !empty(entraAppOwnerIds)
-  ? entraAppOwnerIds
-  : !empty(genevaActionApplicationOwnerIds)
-      ? genevaActionApplicationOwnerIds
-      : fail('At least one of entraAppOwnerIds or genevaActionApplicationOwnerIds must be provided')
 
 resource ev2MSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
   name: ev2MsiName
@@ -89,7 +81,7 @@ module entraApp '../modules/entra/app.bicep' = if (genevaActionApplicationManage
   name: 'geneva-actions-entra-app'
   params: {
     applicationName: genevaActionApplicationName
-    ownerIds: ownerIds
+    ownerIds: entraAppOwnerIds
     isFallbackPublicClient: true
     manageSp: true
     trustedSubjectNameAndIssuers: genevaActionApplicationUseSNI

--- a/dev-infrastructure/templates/mise-identity.bicep
+++ b/dev-infrastructure/templates/mise-identity.bicep
@@ -1,20 +1,12 @@
 param miseApplicationName string
 param entraAppOwnerIds string
-param genevaActionApplicationOwnerIds string
 param miseApplicationDeploy bool
-
-// TODO: remove genevaActionApplicationOwnerIds fallback once entraAppOwnerIds is set in sdp-pipelines config
-var ownerIds = !empty(entraAppOwnerIds)
-  ? entraAppOwnerIds
-  : !empty(genevaActionApplicationOwnerIds)
-      ? genevaActionApplicationOwnerIds
-      : fail('At least one of entraAppOwnerIds or genevaActionApplicationOwnerIds must be provided')
 
 module miseApp '../modules/entra/app.bicep' = if (miseApplicationDeploy) {
   name: 'mise-entra-app'
   params: {
     applicationName: miseApplicationName
-    ownerIds: ownerIds
+    ownerIds: entraAppOwnerIds
     manageSp: false
     serviceManagementReference: 'b8e9ef87-cd63-4085-ab14-1c637806568c'
     isFallbackPublicClient: false


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-25646

### What

Removes `ownerIds` or `entraAppOwnerIds` logic in bicep templates.  Updates the schema to require `entraAppOwnerIds`, removes `entraApplication.ownerIds`, removes `geneva.application.ownerIds` from config.

### Why

To finish migration to the new top level entraAppOwnerIds field that all apps should use.

### Testing

Will be tested on global pipeline deployment, all bicep/config renders properly in a local env.
### Special notes for your reviewer

<!-- optional -->
