### PR TITLE
feat: change cs log level to logr format and increase verbosity

### DIFF
--- a/cluster-service/helm-charts/cluster-service/values.yaml
+++ b/cluster-service/helm-charts/cluster-service/values.yaml
@@ -21,8 +21,8 @@ imageRegistry: ""
 imageRepository: ""
 # Image Digest
 imageDigest: ""
-# log verbosity level
-logLevel: "debug"
+# log verbosity level. It is a go-logr/logr verbosity level.
+logLevel: 4
 # Number of replicas of the service to run.
 replicas: 1
 # Location of the JSON web key set used to verify tokens.


### PR DESCRIPTION
We set the cs log level to logr format which now CS accepts and we also increase the verbosity to level 4. This will allow us to see logs on the maestro client library side that CS uses.