### PR TITLE
Test framework custom 429 retry policy

### DIFF
--- a/test/util/framework/azure_client_policies.go
+++ b/test/util/framework/azure_client_policies.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -244,6 +246,103 @@ func (p *lroPollerRetryDeploymentNotFoundPolicy) backoff(attempt int) time.Durat
 	sleep := min(p.BaseBackoff<<attempt, p.MaxBackoff)
 	jitter := time.Duration(rand.Int63n(int64(max(p.BaseBackoff/2, time.Millisecond))))
 	return sleep + jitter
+}
+
+// throttleRetryPolicy is an outer PerCallPolicy that retries 429 (Too Many
+// Requests) responses with conservative exponential backoff.
+//
+// 429 is excluded from the SDK's inner retry StatusCodes so that throttle
+// responses bubble up here immediately (one request, no burst). This policy
+// applies exponential backoff floored by the server's Retry-After value,
+// ensuring we never retry faster than ARM asks and that delays grow across
+// successive attempts.
+type throttleRetryPolicy struct {
+	MaxRetries     int
+	BaseBackoff    time.Duration
+	MaxBackoff     time.Duration
+	MaxRetryWindow time.Duration
+}
+
+func NewThrottleRetryPolicy() *throttleRetryPolicy {
+	return &throttleRetryPolicy{
+		MaxRetries:     6,
+		BaseBackoff:    4 * time.Second,
+		MaxBackoff:     5 * time.Minute,
+		MaxRetryWindow: 2 * time.Minute,
+	}
+}
+
+func (p *throttleRetryPolicy) Do(req *policy.Request) (*http.Response, error) {
+	start := time.Now()
+
+	for attempt := 0; ; attempt++ {
+		retryReq := req.Clone(req.Raw().Context())
+		if err := retryReq.RewindBody(); err != nil {
+			return nil, err
+		}
+
+		resp, err := retryReq.Next()
+
+		if err != nil || resp == nil || resp.StatusCode != http.StatusTooManyRequests {
+			return resp, err
+		}
+
+		if attempt >= p.MaxRetries || time.Since(start) >= p.MaxRetryWindow {
+			return resp, err
+		}
+
+		retryAfter := parseRetryAfter(resp)
+		backoff := p.backoff(attempt)
+		delay := max(backoff, retryAfter)
+		runtime.Drain(resp)
+
+		ginkgo.GinkgoLogr.Info("429 throttled, backing off",
+			"attempt", attempt+1,
+			"delay", delay.String(),
+			"retryAfter", retryAfter.String(),
+			"url", req.Raw().URL.String())
+
+		select {
+		case <-time.After(delay):
+		case <-req.Raw().Context().Done():
+			return nil, req.Raw().Context().Err()
+		}
+	}
+}
+
+func (p *throttleRetryPolicy) backoff(attempt int) time.Duration {
+	sleep := min(p.BaseBackoff<<attempt, p.MaxBackoff)
+	jitter := time.Duration(rand.Int63n(int64(max(p.BaseBackoff/2, time.Millisecond))))
+	return sleep + jitter
+}
+
+// parseRetryAfter extracts the delay from Retry-After-Ms, x-ms-retry-after-ms,
+// or Retry-After (seconds / HTTP-date) headers, in priority order.
+func parseRetryAfter(resp *http.Response) time.Duration {
+	if d := parseRetryAfterMS(resp, "Retry-After-Ms"); d > 0 {
+		return d
+	}
+	if d := parseRetryAfterMS(resp, "X-Ms-Retry-After-Ms"); d > 0 {
+		return d
+	}
+	if ra := resp.Header.Get("Retry-After"); ra != "" {
+		if seconds, err := strconv.ParseInt(ra, 10, 64); err == nil && seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+		if t, err := time.Parse(time.RFC1123, ra); err == nil {
+			return time.Until(t)
+		}
+	}
+	return 0
+}
+
+func parseRetryAfterMS(resp *http.Response, header string) time.Duration {
+	if v := resp.Header.Get(header); v != "" {
+		if ms, err := strconv.ParseInt(v, 10, 64); err == nil && ms > 0 {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+	return 0
 }
 
 // sanitizeAuthHeaderPolicy is a pipeline policy that redacts the Authorization

--- a/test/util/framework/identities_helper.go
+++ b/test/util/framework/identities_helper.go
@@ -685,24 +685,33 @@ func (tc *perItOrDescribeTestContext) cleanupLeasedIdentityContainerRoleAssignme
 		return nil
 	}
 
-	wg := sync.WaitGroup{}
+	const raDeleteParallelism = 4
+
+	jobs := make(chan *armauthorization.RoleAssignment)
 	errCh := make(chan error, len(toDelete))
 
-	for _, ra := range toDelete {
-		wg.Add(1)
-		go func(ctx context.Context, ra *armauthorization.RoleAssignment) {
+	var wg sync.WaitGroup
+	wg.Add(raDeleteParallelism)
+	for range raDeleteParallelism {
+		go func() {
 			defer wg.Done()
-
-			_, err := client.Delete(ctx, *ra.Properties.Scope, *ra.Name, nil)
-			if err != nil {
-				var respErr *azcore.ResponseError
-				if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
-					return
+			for ra := range jobs {
+				_, err := client.Delete(ctx, *ra.Properties.Scope, *ra.Name, nil)
+				if err != nil {
+					var respErr *azcore.ResponseError
+					if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+						continue
+					}
+					errCh <- fmt.Errorf("failed to delete role assignment %s: %w", *ra.ID, err)
 				}
-				errCh <- fmt.Errorf("failed to delete role assignment %s: %w", *ra.ID, err)
 			}
-		}(ctx, ra)
+		}()
 	}
+
+	for _, ra := range toDelete {
+		jobs <- ra
+	}
+	close(jobs)
 
 	wg.Wait()
 	close(errCh)

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -76,11 +76,22 @@ const (
 )
 
 // azureRetryOptions configures the Azure SDK retry policy for e2e tests.
-// The defaults (3 retries, 800ms delay) are insufficient when Azure throttles
-// requests with Retry-After values of 60+ seconds.
+// 429 (Too Many Requests) is deliberately excluded from StatusCodes so that
+// throttle responses bypass the SDK's fast inner retry loop and bubble up to
+// the outer throttleRetryPolicy, which applies conservative backoff based on
+// the Retry-After header. This avoids bursts of rapid retries that worsen
+// subscription-level throttling.
 var azureRetryOptions = policy.RetryOptions{
 	MaxRetries:    6,
 	MaxRetryDelay: 5 * time.Minute,
+	StatusCodes: []int{
+		http.StatusRequestTimeout,      // 408
+		http.StatusInternalServerError, // 500
+		http.StatusBadGateway,          // 502
+		http.StatusServiceUnavailable,  // 503
+		http.StatusGatewayTimeout,      // 504
+		// 429 errors have their own custom retry policy in the throttleRetryPolicy
+	},
 }
 
 // InvocationContext requires the following env vars
@@ -158,6 +169,7 @@ func (tc *perBinaryInvocationTestContext) getClientFactoryOptions() *azcorearm.C
 				},
 				PerCallPolicies: []policy.Policy{
 					&correlationRequestIDPolicy{},
+					NewThrottleRetryPolicy(),
 					NewLROPollerRetryDeploymentNotFoundPolicy(),
 					&sanitizeAuthHeaderPolicy{},
 				},
@@ -168,6 +180,7 @@ func (tc *perBinaryInvocationTestContext) getClientFactoryOptions() *azcorearm.C
 		ClientOptions: azcore.ClientOptions{
 			Retry: azureRetryOptions,
 			PerCallPolicies: []policy.Policy{
+				NewThrottleRetryPolicy(),
 				NewLROPollerRetryDeploymentNotFoundPolicy(),
 				&sanitizeAuthHeaderPolicy{},
 			},
@@ -201,6 +214,7 @@ func (tc *perBinaryInvocationTestContext) getHCPClientFactoryOptions() *azcorear
 					&correlationRequestIDPolicy{},
 					&armSystemDataPolicy{},
 					&armResourceGroupValidationPolicy{cred: tc.azureCredentials},
+					NewThrottleRetryPolicy(),
 					&sanitizeAuthHeaderPolicy{},
 				},
 			},
@@ -210,6 +224,7 @@ func (tc *perBinaryInvocationTestContext) getHCPClientFactoryOptions() *azcorear
 		ClientOptions: azcore.ClientOptions{
 			Retry: azureRetryOptions,
 			PerCallPolicies: []policy.Policy{
+				NewThrottleRetryPolicy(),
 				&sanitizeAuthHeaderPolicy{},
 			},
 		},

--- a/tooling/cleanup-sweeper/pkg/engine/runner/engine.go
+++ b/tooling/cleanup-sweeper/pkg/engine/runner/engine.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// DefaultParallelism is used when Engine.Parallelism is not set.
-	DefaultParallelism = 8
+	DefaultParallelism = 4
 	// DefaultRetries is the minimum retry count for retryable operations.
 	DefaultRetries = 1
 )


### PR DESCRIPTION
Add a custom `throttleRetryPolicy` that handles 429 (Too Many Requests) responses with conservative exponential backoff, and remove 429 from the SDK's built-in retry status codes.

The Azure SDK's default retry policy uses `Retry-After` as the delay **verbatim** -- it does not apply exponential backoff when `Retry-After` is present. With `Retry-After: 1s` and `MaxRetries: 6`, the SDK fires 7 rapid requests in ~6 seconds. 

The new `throttleRetryPolicy` is an outer `PerCallPolicy` that sits before the SDK retry loop. 429 is excluded from the SDK's inner retry `StatusCodes`, so throttled responses bubble up immediately (1 request, no burst). The outer policy applies `max(exponentialBackoff, retryAfter)` -- the server's `Retry-After` is a floor, not a ceiling.

### Before vs After: sustained 429, assuming `Retry-After: 1s`

**Before (SDK default):**

| Attempt | Wait | Elapsed | Total requests |
|---------|------|---------|----------------|
| 1 | -- | 0s | 1 |
| 2 | 1s | ~1s | 2 |
| 3 | 1s | ~2s | 3 |
| 4 | 1s | ~3s | 4 |
| 5 | 1s | ~4s | 5 |
| 6 | 1s | ~5s | 6 |
| 7 | 1s | ~6s | 7 |
| **FAIL** | | **~6s** | **7 requests** |

**After (throttleRetryPolicy):**

| Attempt | Backoff | Retry-After | Actual delay | Elapsed | Total requests |
|---------|---------|-------------|-------------|---------|----------------|
| 1 | -- | -- | -- | 0s | 1 |
| 2 | ~5s | 1s | ~5s | ~5s | 2 |
| 3 | ~9s | 1s | ~9s | ~14s | 3 |
| 4 | ~17s | 1s | ~17s | ~31s | 4 |
| 5 | ~33s | 1s | ~33s | ~64s | 5 |
| 6 | ~65s | 1s | ~65s | ~129s | 6 |
| **FAIL** | | | | **~129s** | **6 requests** |

| | Before | After |
|---|---|---|
| Requests sent | 7 | 6 |
| Time span | ~6s | ~2min |
| Tokens consumed rate | 1.2/s | 0.05/s |
| Recoverable if throttle lifts after 10s? | No (already failed) | Yes (attempt 3) |
