### PR TITLE
test: add 150 min TestTimeout to integration E2E suites

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -70,7 +70,7 @@ func setupCli() *cobra.Command {
 		Qualifiers: []string{
 			fastTestsOnly(integrationQuery),
 		},
-		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly avobe the number of
+		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=20
 		Parallelism: 24,
@@ -82,7 +82,7 @@ func setupCli() *cobra.Command {
 		Qualifiers: []string{
 			slowTestsOnly(integrationQuery),
 		},
-		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly avobe the number of
+		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=20
 		Parallelism: 24,
@@ -96,7 +96,7 @@ func setupCli() *cobra.Command {
 		Qualifiers: []string{
 			fastTestsOnly(stageQuery),
 		},
-		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly avobe the number of
+		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=30
 		Parallelism: 34,
@@ -107,7 +107,7 @@ func setupCli() *cobra.Command {
 		Qualifiers: []string{
 			slowTestsOnly(stageQuery),
 		},
-		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly avobe the number of
+		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=30
 		Parallelism: 34,
@@ -121,7 +121,7 @@ func setupCli() *cobra.Command {
 		Qualifiers: []string{
 			fastTestsOnly(prodQuery),
 		},
-		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly avobe the number of
+		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=15
 		Parallelism: 19,
@@ -132,7 +132,7 @@ func setupCli() *cobra.Command {
 		Qualifiers: []string{
 			slowTestsOnly(prodQuery),
 		},
-		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly avobe the number of
+		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=15
 		Parallelism: 19,
@@ -161,7 +161,7 @@ func setupCli() *cobra.Command {
 	ext.AddSuite(e.Suite{
 		Name:       "rp-api-compat-all/parallel",
 		Qualifiers: []string{fastTestsOnly(rpApiCompatBaseQualifier)},
-		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly avobe the number of
+		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=20
 		Parallelism: 24,
@@ -169,7 +169,7 @@ func setupCli() *cobra.Command {
 	ext.AddSuite(e.Suite{
 		Name:       "rp-api-compat-all/parallel/slow",
 		Qualifiers: []string{slowTestsOnly(rpApiCompatBaseQualifier)},
-		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly avobe the number of
+		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=20
 		Parallelism: 24,

--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -64,6 +64,7 @@ func setupCli() *cobra.Command {
 	// The tests that a suite is composed of can be filtered by CEL expressions. By
 	// default, the qualifiers only apply to tests from this extension.
 	integrationQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.DevelopmentOnly[0], labels.StageAndProdOnly[0])
+	integrationTestTimeout := 150 * time.Minute
 	ext.AddSuite(e.Suite{
 		Name: "integration/parallel",
 		Qualifiers: []string{
@@ -73,6 +74,7 @@ func setupCli() *cobra.Command {
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=20
 		Parallelism: 24,
+		TestTimeout: &integrationTestTimeout,
 	})
 
 	ext.AddSuite(e.Suite{
@@ -84,6 +86,7 @@ func setupCli() *cobra.Command {
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=20
 		Parallelism: 24,
+		TestTimeout: &integrationTestTimeout,
 	})
 
 	stageQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0], labels.DevelopmentOnly[0])


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-695

### What

Add `TestTimeout: 150 * time.Minute` to the `integration/parallel` and `integration/parallel/slow` suites in `test/cmd/aro-hcp-tests/main.go`, matching stage and prod which already have this value.

### Why

The integration suites were the only E2E suites without a `TestTimeout`. Without one, Ginkgo runs specs indefinitely until Prow's pod timeout (default 2h) kills the process with SIGTERM. Ginkgo catches this and reports `Interrupted by User`, which hides the actual failure and prevents proper diagnostics.

This is compounded by identity container pool starvation — the INT suite has 20 identity containers for 24 parallel tests, so late-starting specs can wait 40+ minutes before getting a container. That wait counts against the 2h Prow timeout, leaving insufficient time for cluster creation + upgrade tests.

Observed in two consecutive INT periodic runs:
- [2046927318231814144](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel/2046927318231814144) (2026-04-22): 40 min identity wait + upgrade stuck at 4.20.17 Partial for 40 min → suite killed at 1h41m
- [2046283743831789568](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel/2046283743831789568) (2026-04-20): identity pool starvation → 2 nodepool upgrade tests killed at 2h02m

### Companion PR

openshift/release: https://github.com/openshift/release/pull/78188 (sets Prow job `timeout: 4h0m0s` on integration and stage to override the 2h default)

### Testing

Build verification only — no application code changes.