### PR TITLE
hypershift: use the SRE metrics set, opt into everything

### DIFF
--- a/hypershiftoperator/deploy/templates/installer.job.yaml
+++ b/hypershiftoperator/deploy/templates/installer.job.yaml
@@ -27,6 +27,7 @@ spec:
             --registry-overrides "{{ .Values.registryOverrides }}" \
             --hypershift-image {{ .Values.image }}@{{ .Values.imageDigest }} \
             --platform-monitoring=None \
+            --metrics-set=SRE \
             --enable-size-tagging=true \
             --limit-crd-install=Azure \
             {{- if .Values.operatorEnvVars.sharedIngressIPTag }}

--- a/hypershiftoperator/deploy/templates/sre-metrics-set.configmap.yaml
+++ b/hypershiftoperator/deploy/templates/sre-metrics-set.configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sre-metric-set
+  namespace: '{{ .Release.Namespace }}'
+data:
+  config: |
+    etcd:
+      - action:       "keep"
+        regex:        ".*"
+        sourceLabels: ["__name__"]
+    kubeAPIServer:
+      - action:       "keep"
+        regex:        ".*"
+        sourceLabels: ["__name__"]
+    kubeControllerManager:
+      - action:       "keep"
+        regex:        ".*"
+        sourceLabels: ["__name__"]
+    openshiftAPIServer:
+      - action:       "keep"
+        regex:        ".*"
+        sourceLabels: ["__name__"]
+    openshiftControllerManager:
+      - action:       "keep"
+        regex:        ".*"
+        sourceLabels: ["__name__"]
+    cvo:
+      - action:       "keep"
+        regex:        ".*"
+        sourceLabels: ["__name__"]

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -644,6 +644,39 @@ metadata:
   namespace: 'hypershift'
 type: kubernetes.io/dockerconfigjson
 ---
+# Source: aro-hcp-hypershift-operator/templates/sre-metrics-set.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sre-metric-set
+  namespace: 'hypershift'
+data:
+  config: |
+    etcd:
+      - action:       "keep"
+        regex:        ".*"
+        sourceLabels: ["__name__"]
+    kubeAPIServer:
+      - action:       "keep"
+        regex:        ".*"
+        sourceLabels: ["__name__"]
+    kubeControllerManager:
+      - action:       "keep"
+        regex:        ".*"
+        sourceLabels: ["__name__"]
+    openshiftAPIServer:
+      - action:       "keep"
+        regex:        ".*"
+        sourceLabels: ["__name__"]
+    openshiftControllerManager:
+      - action:       "keep"
+        regex:        ".*"
+        sourceLabels: ["__name__"]
+    cvo:
+      - action:       "keep"
+        regex:        ".*"
+        sourceLabels: ["__name__"]
+---
 # Source: aro-hcp-hypershift-operator/templates/installer.clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -690,6 +723,7 @@ spec:
             --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat" \
             --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890 \
             --platform-monitoring=None \
+            --metrics-set=SRE \
             --enable-size-tagging=true \
             --limit-crd-install=Azure \
             --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890 \


### PR DESCRIPTION
Previously, we seem to have been using the telemetry metrics set for hosted clusters, which leads us to miss most of the useful metrics we need from the control planes. The SRE metrics set mechanism exists in HyperShift to support this exact use case - we opt into it with the install flag and supply the required ConfigMap to configure which metrics we need. For now, we ask for all metrics from the components most likely to matter for us. If we run into cardinality issues we can always winnow these down later.
