### PR TITLE
deps: bump npm deps (typespec group + uuid CVE fix)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5,22 +5,22 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-tools/typespec-autorest": "^0.65.0",
-        "@azure-tools/typespec-azure-core": "^0.65.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.65.0",
-        "@azure-tools/typespec-azure-rulesets": "0.65.0",
-        "@azure-tools/typespec-client-generator-core": "^0.65.0",
-        "@typespec/http": "~1.9.0",
-        "@typespec/openapi": "~1.9.0",
-        "@typespec/openapi3": "~1.9.0",
-        "@typespec/rest": "~0.79.0",
-        "@typespec/versioning": "~0.79.0",
+        "@azure-tools/typespec-autorest": "^0.67.0",
+        "@azure-tools/typespec-azure-core": "^0.67.1",
+        "@azure-tools/typespec-azure-resource-manager": "^0.67.1",
+        "@azure-tools/typespec-azure-rulesets": "0.67.0",
+        "@azure-tools/typespec-client-generator-core": "^0.67.3",
+        "@typespec/http": "~1.11.0",
+        "@typespec/openapi": "~1.11.0",
+        "@typespec/openapi3": "~1.11.0",
+        "@typespec/rest": "~0.81.0",
+        "@typespec/versioning": "~0.81.0",
         "oav": "^4.0.2"
       },
       "devDependencies": {
         "@microsoft.azure/openapi-validator": "2.2.4",
         "@microsoft.azure/openapi-validator-rulesets": "2.2.6",
-        "@typespec/compiler": "~1.9.0",
+        "@typespec/compiler": "~1.11.0",
         "autorest": "^3.7.2"
       },
       "engines": {
@@ -159,23 +159,23 @@
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.65.0.tgz",
-      "integrity": "sha512-R8pZt7rYdA2Hr3nck93OGapkQZe3MSzoYq4PgRtsGDHcvA5Qp7RBQMF/tP5DEcFWDDm+unoQeDpbD02POb/LTA==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.67.0.tgz",
+      "integrity": "sha512-RP0TZB46tnYGfN5FKaaXDP5/rDff0PEERKz4epoYsm4RmXeRDYXVcOjw7DXLbcgFpMLTLBf/w/5dqJZBx03KpQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.65.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.65.0",
-        "@azure-tools/typespec-client-generator-core": "^0.65.0",
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/http": "^1.9.0",
-        "@typespec/openapi": "^1.9.0",
-        "@typespec/rest": "^0.79.0",
-        "@typespec/versioning": "^0.79.0",
-        "@typespec/xml": "^0.79.0"
+        "@azure-tools/typespec-azure-core": "^0.67.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.67.0",
+        "@azure-tools/typespec-client-generator-core": "^0.67.0",
+        "@typespec/compiler": "~1.11.0",
+        "@typespec/http": "~1.11.0",
+        "@typespec/openapi": "~1.11.0",
+        "@typespec/rest": "~0.81.0",
+        "@typespec/versioning": "~0.81.0",
+        "@typespec/xml": "^0.81.0"
       },
       "peerDependenciesMeta": {
         "@typespec/xml": {
@@ -184,23 +184,23 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.65.0.tgz",
-      "integrity": "sha512-dYgHtt0CY0Q9AimdIsMV41jHKLmAT4r++TLwyxAHRbxdiRG+Sll1UKJzOIIoq45Bq64wCfEltu5OOnyPA01/sQ==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.67.1.tgz",
+      "integrity": "sha512-HBvigwr8Ub7rsg4RDpTO3WTHS+CIqAw32X3RzxsDNb8NfLoSLSZDANz05VPiDTzAXO7eMfEP42RXkKPV0tlZLg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/http": "^1.9.0",
-        "@typespec/rest": "^0.79.0"
+        "@typespec/compiler": "~1.11.0",
+        "@typespec/http": "~1.11.0",
+        "@typespec/rest": "~0.81.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.65.0.tgz",
-      "integrity": "sha512-3rvyGDIYSqraZ7jHfq5Bfet8u3ZeERWJWhwWMNvbShnrS/vVR3iuu/1z2M0p5mTRFuwUaSMlL/dbtBp1YqgGAg==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.67.1.tgz",
+      "integrity": "sha512-cIPVscR29WgUOk6NDWco95Fc0swSe1jmJz+5G24cCqt6iR/mgIiNdT7D+Njg0VkANoI1AaCT69eIa6yWpAaOIg==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -210,33 +210,33 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.65.0",
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/http": "^1.9.0",
-        "@typespec/openapi": "^1.9.0",
-        "@typespec/rest": "^0.79.0",
-        "@typespec/versioning": "^0.79.0"
+        "@azure-tools/typespec-azure-core": "^0.67.0",
+        "@typespec/compiler": "~1.11.0",
+        "@typespec/http": "~1.11.0",
+        "@typespec/openapi": "~1.11.0",
+        "@typespec/rest": "~0.81.0",
+        "@typespec/versioning": "~0.81.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.65.0.tgz",
-      "integrity": "sha512-oGuCw61uU9fUASog/1iD1rGeGhcKgnAuyBWA63wRcMMrcW1ZqUK2xvjV1XJuoYRlMxU8HpQShFcvsj715pNVLQ==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.67.0.tgz",
+      "integrity": "sha512-YCkyTm090xQR0Gb3CnIdbEd+SbVUY1TRtuPXrBPTsNu3MJwvlaESnkJ7bt9zkP94mAFTNoSTuZlAUKDfPrFaFA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.65.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.65.0",
-        "@azure-tools/typespec-client-generator-core": "^0.65.0",
-        "@typespec/compiler": "^1.9.0"
+        "@azure-tools/typespec-azure-core": "^0.67.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.67.0",
+        "@azure-tools/typespec-client-generator-core": "^0.67.0",
+        "@typespec/compiler": "~1.11.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.65.4",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.65.4.tgz",
-      "integrity": "sha512-p+MZU/nEmU3ciLEuNbqQtAybPxUKo/fKeKT9feh+tZLVpDDFO5DTefYoN4cteZQkPu/xyzxhjeUnKKvyVQxd6A==",
+      "version": "0.67.3",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.67.3.tgz",
+      "integrity": "sha512-hK+1juRH2kWPCVfqsVYKFw8RbhLJY4ioh6OTZA4JmPXwQ4zz0/nsaGHG6K+tZ9D7yRyYd06GNxJoAbWabFfDYA==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -247,16 +247,16 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.65.0",
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/events": "^0.79.0",
-        "@typespec/http": "^1.9.0",
-        "@typespec/openapi": "^1.9.0",
-        "@typespec/rest": "^0.79.0",
-        "@typespec/sse": "^0.79.0",
-        "@typespec/streams": "^0.79.0",
-        "@typespec/versioning": "^0.79.0",
-        "@typespec/xml": "^0.79.0"
+        "@azure-tools/typespec-azure-core": "^0.67.1",
+        "@typespec/compiler": "~1.11.0",
+        "@typespec/events": "^0.81.0",
+        "@typespec/http": "~1.11.0",
+        "@typespec/openapi": "~1.11.0",
+        "@typespec/rest": "~0.81.0",
+        "@typespec/sse": "^0.81.0",
+        "@typespec/streams": "^0.81.0",
+        "@typespec/versioning": "~0.81.0",
+        "@typespec/xml": "^0.81.0"
       }
     },
     "node_modules/@azure-tools/uri": {
@@ -405,9 +405,9 @@
       "license": "0BSD"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -982,21 +982,22 @@
       }
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.2.11.tgz",
-      "integrity": "sha512-Y7DLt1bIZF9dvHzJwSJTcC1lpSr1Tbf4VBhHOCRIHu23Rr7/lhQnddRxFmPV1tZXwEQKz7F7yRrubwCfKPCucw==",
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.2.18.tgz",
+      "integrity": "sha512-w1d4tpNEVZ293oB2BAgLrS0kVPUtG3eByNmOCJA5eK9vcT4D3cmsGtWjUaaqit0BQCsBFHK51rasGvSWnApYTw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@scalar/json-magic": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.9.6.tgz",
-      "integrity": "sha512-2TKoqkAophHti1nH+rvQlR4lhD6X9tqQpuNeAE0cytHSX/yndkSOE0yA7cep5T9tFjGN4Km0gMnelvY3LgWs4A==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.11.7.tgz",
+      "integrity": "sha512-GVz9E0vXu+ecypkdn0biK1gbQVkK4QTTX1Hq3eMgxlLQC91wwiqWfCqwfhuX0LRu+Z5OmYhLhufDJEEh56rVgA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.2.11",
+        "@scalar/helpers": "0.2.18",
+        "pathe": "^2.0.3",
         "yaml": "^2.8.0"
       },
       "engines": {
@@ -1018,29 +1019,6 @@
         "ajv-formats": "^3.0.1",
         "jsonpointer": "^5.0.1",
         "leven": "^4.0.0",
-        "yaml": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@scalar/openapi-parser/node_modules/@scalar/helpers": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.2.18.tgz",
-      "integrity": "sha512-w1d4tpNEVZ293oB2BAgLrS0kVPUtG3eByNmOCJA5eK9vcT4D3cmsGtWjUaaqit0BQCsBFHK51rasGvSWnApYTw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@scalar/openapi-parser/node_modules/@scalar/json-magic": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.11.7.tgz",
-      "integrity": "sha512-GVz9E0vXu+ecypkdn0biK1gbQVkK4QTTX1Hq3eMgxlLQC91wwiqWfCqwfhuX0LRu+Z5OmYhLhufDJEEh56rVgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@scalar/helpers": "0.2.18",
-        "pathe": "^2.0.3",
         "yaml": "^2.8.0"
       },
       "engines": {
@@ -1673,24 +1651,24 @@
       "license": "MIT"
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.9.0.tgz",
-      "integrity": "sha512-Rz9fFWQSTJSnhBfZvtA/bDIuO82fknYdtyMsL9lZNJE82rquC6JByHPFsnbGH1VXA0HhMj9L7Oqyp3f0m/BTOA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.11.0.tgz",
+      "integrity": "sha512-4vuWtoepc4rYJ81K+P7xn2ByXIRhBM40rfzAGnpagNuGSVHuKEC6lqJqs3ePvhCpnxiYAC8XWpaOi+BEDzyhnQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "~7.28.6",
-        "@inquirer/prompts": "^8.0.1",
-        "ajv": "~8.17.1",
+        "@babel/code-frame": "~7.29.0",
+        "@inquirer/prompts": "^8.3.0",
+        "ajv": "~8.18.0",
         "change-case": "~5.4.4",
-        "env-paths": "^3.0.0",
-        "globby": "~16.1.0",
+        "env-paths": "^4.0.0",
+        "globby": "~16.1.1",
         "is-unicode-supported": "^2.1.0",
         "mustache": "~4.2.0",
         "picocolors": "~1.1.1",
-        "prettier": "~3.8.0",
-        "semver": "^7.7.1",
-        "tar": "^7.5.2",
-        "temporal-polyfill": "^0.3.0",
+        "prettier": "~3.8.1",
+        "semver": "^7.7.4",
+        "tar": "^7.5.11",
+        "temporal-polyfill": "^0.3.2",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.12",
         "yaml": "~2.8.2",
@@ -1705,29 +1683,29 @@
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.79.0.tgz",
-      "integrity": "sha512-41R2jA7k21uMArjyUdvnqYzVnPPaSEcGi40dLMiRVP79m6XgnD3INuTdlMblaS1i+5jJ1BtS1o4QhBBuS/5/qg==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.81.0.tgz",
+      "integrity": "sha512-ee9QSBL+k6ccPlbJICZzaGt4iC1nTIl+J9sELY9yJNISvOvUEzY5MU8c7HaISB10cUESRJW+oaLWwyc8XjwHng==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0"
+        "@typespec/compiler": "~1.11.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.9.1.tgz",
-      "integrity": "sha512-agcwmbB/hK/o9KmM38UB8OGZwLgB17lJ7b4EjqYGpyshqcRMTESMRxnJIH7rRzUq4HJDTqal0tsb8z0K0zXuDg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.11.0.tgz",
+      "integrity": "sha512-/DOkN2+MUZyLdmqYmSMZDjxikJTOuNxikTeOwG2fVOibnu8e6S1jzPAuN/mn6YyQBKeBCItMPmUOXIj61Wy8Bg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/streams": "^0.79.0"
+        "@typespec/compiler": "~1.11.0",
+        "@typespec/streams": "^0.81.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -1736,28 +1714,28 @@
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.9.0.tgz",
-      "integrity": "sha512-5ieXCWRLcyFLv3IFk26ena/RW/NxvT5KiHaoNVFRd79J0XZjFcE0Od6Lxxqj4dWmCo3C8oKtOwFoQuie18G3lQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.11.0.tgz",
+      "integrity": "sha512-xUQrHExKBh0XSP4cn+HcondDXjHJM5HCq2Xfy9tB1QflsFh5uP1JJt1+67g73VmHlhZVSUDcoFrnU95pfjyubg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/http": "^1.9.0"
+        "@typespec/compiler": "~1.11.0",
+        "@typespec/http": "^1.11.0"
       }
     },
     "node_modules/@typespec/openapi3": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-1.9.0.tgz",
-      "integrity": "sha512-htwhrGHQxuoNwAljeJE8CBt5yfKOv48T9Ugv91Y+4yNnlevJfDT29yrfD2mXYMujVOr3Kte1qilazClafkUIgg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-1.11.0.tgz",
+      "integrity": "sha512-AjMpTkIUy8+YlRaqUyQ1NZxbmVbWyT4fPpztVzclyX+TXyvxo9gqLEdqoMfvQ9KUjcU0nsOjfPdaYb5rj25oIA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/json-magic": "^0.9.1",
+        "@scalar/json-magic": "^0.11.5",
         "@scalar/openapi-parser": "^0.24.1",
         "@scalar/openapi-types": "^0.5.0",
-        "@typespec/asset-emitter": "^0.79.0",
+        "@typespec/asset-emitter": "^0.79.1",
         "yaml": "~2.8.2"
       },
       "bin": {
@@ -1767,14 +1745,14 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/events": "^0.79.0",
-        "@typespec/http": "^1.9.0",
-        "@typespec/json-schema": "^1.9.0",
-        "@typespec/openapi": "^1.9.0",
-        "@typespec/sse": "^0.79.0",
-        "@typespec/streams": "^0.79.0",
-        "@typespec/versioning": "^0.79.0"
+        "@typespec/compiler": "~1.11.0",
+        "@typespec/events": "^0.81.0",
+        "@typespec/http": "^1.11.0",
+        "@typespec/json-schema": "^1.11.0",
+        "@typespec/openapi": "^1.11.0",
+        "@typespec/sse": "^0.81.0",
+        "@typespec/streams": "^0.81.0",
+        "@typespec/versioning": "~0.81.0"
       },
       "peerDependenciesMeta": {
         "@typespec/events": {
@@ -1810,45 +1788,45 @@
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.79.0.tgz",
-      "integrity": "sha512-6QIX7oaUGy/z4rseUrC86LjHxZn8rAAY4fXvGnlPRce6GhEdTb9S9OQPmlPeWngXwCx/07P2+FCR915APqmZxg==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.81.0.tgz",
+      "integrity": "sha512-qQXZRKEvq5aNlDFEUqBiiXXPIFyr/+PWgBY0kIrnhyZzMjfUqPInkB12QgXpVp2O2Wm3jmETJD45SaLHTCYBbg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/http": "^1.9.0"
+        "@typespec/compiler": "~1.11.0",
+        "@typespec/http": "^1.11.0"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.79.0.tgz",
-      "integrity": "sha512-YQYlDWCNBza75S360jc51emwntWXMZfkvqXKng+etKP4iCuogJfTX1J8h1yd8tZwkuUNBcklEPCuz3O/+psopg==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.81.0.tgz",
+      "integrity": "sha512-VinoeN+5ClKlGXf77fWayAQna8SaYtvEBhnLR8t8FdvmMsL6ce1LghR2kAL3ARbNXfwMZRmQiq+ajKKebDLIng==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/events": "^0.79.0",
-        "@typespec/http": "^1.9.0",
-        "@typespec/streams": "^0.79.0"
+        "@typespec/compiler": "~1.11.0",
+        "@typespec/events": "^0.81.0",
+        "@typespec/http": "^1.11.0",
+        "@typespec/streams": "^0.81.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.79.0.tgz",
-      "integrity": "sha512-nOXpLcEYNdWvLY/6WJ16rD6hGs7bKSmkH+WwgyVwdRON5KJ559quw56pns2DSANw+NaV0lJxJq/8ek5xKCGD6g==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.81.0.tgz",
+      "integrity": "sha512-IIEKq18aqAtM65f8ZLs3Kzua97wjkr8fTehqPs/Q4neWo2UkDJp64LfA37iXJzaku8xMFSwXdVu4EW8wo+KV8w==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0"
+        "@typespec/compiler": "~1.11.0"
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
@@ -1866,28 +1844,28 @@
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.79.0.tgz",
-      "integrity": "sha512-mk65zpKNm+ARyHASnre/lp3o3FKzb0P8Nj96ji182JUy7ShrVCCF0u+bC+ZXQ8ZTRza1d0xBjRC/Xr4iM+Uwag==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.81.0.tgz",
+      "integrity": "sha512-5bha4t64xA85zLY8VGm/6jNd2kwPHzjPq/dlCUjtgGfGXv2R6Ow/YIukqhqZnwnIgNAIlZ7nguekRMRx+2oO2w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0"
+        "@typespec/compiler": "~1.11.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.79.0.tgz",
-      "integrity": "sha512-BqbbtkL9xuiAhehHKKUCMtRg0a1vjSvoiAOanvTIuoFq3N8PbKVV3dKTcyI/oS3iCCkJErdu11HQcAoD/VsIsA==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.81.0.tgz",
+      "integrity": "sha512-4docnAcV1a8gE4c4TmYuirZf2PEzS4xHUH4QjHFU6hk6J2M6OMU6YG4iSq9tmlUzQ/2DraVcWNO/fsG8Lt383A==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0"
+        "@typespec/compiler": "~1.11.0"
       }
     },
     "node_modules/abort-controller": {
@@ -2541,12 +2519,15 @@
       }
     },
     "node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-4.0.0.tgz",
+      "integrity": "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==",
       "license": "MIT",
+      "dependencies": {
+        "is-safe-filename": "^0.1.0"
+      },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3699,6 +3680,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-safe-filename": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-safe-filename/-/is-safe-filename-0.1.1.tgz",
+      "integrity": "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-set": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5472,12 +5472,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vscode-jsonrpc": {

--- a/api/package.json
+++ b/api/package.json
@@ -39,6 +39,8 @@
     "lodash": "^4.18.0",
     "minimatch": "^3.1.3",
     "@tootallnate/once": "^3.0.1",
-    "uuid": "^14.0.0"
+    "@azure/ms-rest-js": {
+      "uuid": "^14.0.0"
+    }
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -38,6 +38,7 @@
     },
     "lodash": "^4.18.0",
     "minimatch": "^3.1.3",
-    "@tootallnate/once": "^3.0.1"
+    "@tootallnate/once": "^3.0.1",
+    "uuid": "^14.0.0"
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -1,15 +1,15 @@
 {
   "dependencies": {
-    "@azure-tools/typespec-autorest": "^0.65.0",
-    "@azure-tools/typespec-azure-core": "^0.65.0",
-    "@azure-tools/typespec-azure-resource-manager": "^0.65.0",
-    "@azure-tools/typespec-azure-rulesets": "0.65.0",
-    "@azure-tools/typespec-client-generator-core": "^0.65.0",
-    "@typespec/http": "~1.9.0",
-    "@typespec/openapi": "~1.9.0",
-    "@typespec/openapi3": "~1.9.0",
-    "@typespec/rest": "~0.79.0",
-    "@typespec/versioning": "~0.79.0",
+    "@azure-tools/typespec-autorest": "^0.67.0",
+    "@azure-tools/typespec-azure-core": "^0.67.1",
+    "@azure-tools/typespec-azure-resource-manager": "^0.67.1",
+    "@azure-tools/typespec-azure-rulesets": "0.67.0",
+    "@azure-tools/typespec-client-generator-core": "^0.67.3",
+    "@typespec/http": "~1.11.0",
+    "@typespec/openapi": "~1.11.0",
+    "@typespec/openapi3": "~1.11.0",
+    "@typespec/rest": "~0.81.0",
+    "@typespec/versioning": "~0.81.0",
     "oav": "^4.0.2"
   },
   "engines": {
@@ -23,7 +23,7 @@
     "testsdk": "autorest testsdk.md --verbose --tag=${VERSION}"
   },
   "devDependencies": {
-    "@typespec/compiler": "~1.9.0",
+    "@typespec/compiler": "~1.11.0",
     "@microsoft.azure/openapi-validator": "2.2.4",
     "@microsoft.azure/openapi-validator-rulesets": "2.2.6",
     "autorest": "^3.7.2"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-697

### What

Bump the typespec group in `/api` with 11 updates and fix the uuid CVE via npm override.

### Why

- **typespec**: Dependabot grouped update for `@azure-tools/typespec-*` and `@typespec/*` packages
- **uuid**: Fixes [CVE-2026-uuid](https://github.com/Azure/ARO-HCP/security/dependabot/230) (Medium) — missing buffer bounds check in uuid v3/v5/v6 when `buf` is provided. The uuid package is a transitive dependency of `@azure/ms-rest-js` which only uses `v4()`, so the major version bump (v8 → v14) is safe.

Closes #4572
Resolves Dependabot alert #230

### Testing

- [x] `npm install` succeeds
- [x] `npm audit` shows 0 vulnerabilities
- [x] CI passes (api-validation)

### Special notes for your reviewer

uuid v14 is a major version bump but the breaking changes are in v3/v5/v6 buffer handling. `@azure/ms-rest-js` only uses `uuid.v4()` which is unchanged. The override in `package.json` forces all transitive consumers to use v14.