### PR TITLE
Improve VerifyNodeCount error diagnostics

### DIFF
--- a/test/e2e/nodepool_ephemeral_osdisk.go
+++ b/test/e2e/nodepool_ephemeral_osdisk.go
@@ -184,8 +184,8 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("verifying nodes from the ephemeral nodepool are ready")
-			Expect(verifiers.VerifyNodeCount(int(nodePoolParams.Replicas)).Verify(ctx, adminRESTConfig)).To(Succeed())
+			By("verifying count and ready status of nodes from the ephemeral nodepool")
+			Expect(verifiers.VerifyNodeCount(customerClusterName, int(nodePoolParams.Replicas)).Verify(ctx, adminRESTConfig)).To(Succeed())
 			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
 
 			By("verifying Azure VMs actually have ephemeral OS disks")

--- a/test/e2e/nodepool_update_nodes.go
+++ b/test/e2e/nodepool_update_nodes.go
@@ -128,9 +128,9 @@ var _ = Describe("Customer", func() {
 			}
 			Expect(creationErrors).To(BeEmpty(), "nodepool creation errors: %v", creationErrors)
 
-			By("verifying nodes count and status after initial creation")
+			By("verifying nodes count and ready status")
 			totalNodeCount := mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
+			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
 			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
 
 			By("scaling up the nodepool replicas from 2 to 3 replicas")
@@ -153,9 +153,9 @@ var _ = Describe("Customer", func() {
 			Expect(scaleUpResp.Properties.Replicas).NotTo(BeNil(), "scale up response Properties.Replicas was nil")
 			Expect(*scaleUpResp.Properties.Replicas).To(Equal(int32(mainNodeCount)))
 
-			By("verifying nodes count and status after scaling up")
+			By("verifying nodes count and ready status")
 			totalNodeCount = mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
+			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
 			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
 
 			nodePoolsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
@@ -180,9 +180,9 @@ var _ = Describe("Customer", func() {
 			Expect(scaleDownResp.Properties.Replicas).NotTo(BeNil(), "scale down response Properties.Replicas was nil")
 			Expect(*scaleDownResp.Properties.Replicas).To(Equal(int32(mainNodeCount)))
 
-			By("verifying nodes count and status after scaling down")
+			By("verifying nodes count and ready status")
 			totalNodeCount = mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
+			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
 			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
 
 			By("updating the one-replica nodepool replicas to 0 and enabling autoscaling with a PATCH")
@@ -211,10 +211,10 @@ var _ = Describe("Customer", func() {
 			Expect(*autoscaleResp.Properties.AutoScaling.Min).To(Equal(int32(2)))
 			Expect(*autoscaleResp.Properties.AutoScaling.Max).To(Equal(int32(3)))
 
-			By("verifying nodes count and status after enabling autoscaling")
+			By("verifying nodes count and ready status")
 			oneNodeCount = 2
 			totalNodeCount = mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
+			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
 			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
 		})
 })

--- a/test/e2e/oidc_issuer_workload_identity.go
+++ b/test/e2e/oidc_issuer_workload_identity.go
@@ -256,8 +256,8 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("verifying nodes are ready")
-			Expect(verifiers.VerifyNodeCount(int(nodePoolParams.Replicas)).Verify(ctx, adminRESTConfig)).To(Succeed())
+			By("verifying nodes count and ready status")
+			Expect(verifiers.VerifyNodeCount(customerClusterName, int(nodePoolParams.Replicas)).Verify(ctx, adminRESTConfig)).To(Succeed())
 			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
 
 			By("creating a user-assigned managed identity for the test")

--- a/test/util/verifiers/nodes.go
+++ b/test/util/verifiers/nodes.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/blang/semver/v4"
@@ -30,6 +31,8 @@ import (
 	"k8s.io/utils/set"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
+	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/Azure/ARO-HCP/test/util/framework"
 )
@@ -73,11 +76,12 @@ func VerifyNodesReady() HostedClusterVerifier {
 }
 
 type verifyNodeCount struct {
-	expected int
+	clusterName string
+	expected    int
 }
 
 func (v verifyNodeCount) Name() string {
-	return fmt.Sprintf("VerifyNodeCount(%d)", v.expected)
+	return fmt.Sprintf("VerifyNodeCount(cluster=%s, expected=%d)", v.clusterName, v.expected)
 }
 
 func (v verifyNodeCount) Verify(ctx context.Context, adminRESTConfig *rest.Config) error {
@@ -92,16 +96,72 @@ func (v verifyNodeCount) Verify(ctx context.Context, adminRESTConfig *rest.Confi
 	}
 
 	if len(nodes.Items) != v.expected {
-		return fmt.Errorf("expected %d nodes, found %d", v.expected, len(nodes.Items))
+		if len(nodes.Items) == 0 {
+			return fmt.Errorf("cluster %s: expected %d nodes, found 0", v.clusterName, v.expected)
+		}
+		return fmt.Errorf("cluster %s: expected %d nodes, found %d; nodes per pool: %s",
+			v.clusterName, v.expected, len(nodes.Items), formatNodesByPool(nodes.Items))
 	}
 
 	return nil
 }
 
-func VerifyNodeCount(expected int) HostedClusterVerifier {
+func VerifyNodeCount(clusterName string, expected int) HostedClusterVerifier {
 	return verifyNodeCount{
-		expected: expected,
+		clusterName: clusterName,
+		expected:    expected,
 	}
+}
+
+// nodePoolNameRegex matches valid ARO-HCP node pool resource names
+// Same pattern as internal/validation/validators.go nodePoolResourceName, which is unexported.
+var nodePoolNameRegex = regexp.MustCompile(`^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$`)
+
+// extractNodePoolName extracts the node pool name from a node's node pool label value.
+// The node pool label format is "<HostedCluster prefix>-<nodePoolName>". This scans left to right
+// for each "-" and returns the first suffix that matches the node pool name regex.
+// Falls back to the full label if no suffix matches.
+func extractNodePoolName(nodePoolLabel string) string {
+	for i := range len(nodePoolLabel) {
+		if nodePoolLabel[i] == '-' {
+			suffix := nodePoolLabel[i+1:]
+			if nodePoolNameRegex.MatchString(suffix) {
+				return suffix
+			}
+		}
+	}
+	return nodePoolLabel
+}
+
+// formatNodesByPool groups node names by their node pool name (extracted from the
+// node's node pool label value) and returns a sorted, human-readable summary such as:
+//
+//	np-scale-down: [node-1, node-2], np-scale-up: [node-3]
+func formatNodesByPool(nodes []corev1.Node) string {
+	const noLabel = "<no-nodepool-label>"
+	byNodePool := make(map[string][]string)
+	for i := range nodes {
+		nodePoolLabel, ok := nodes[i].Labels[hypershiftv1beta1.NodePoolLabel]
+		nodePoolName := noLabel
+		if ok {
+			nodePoolName = extractNodePoolName(nodePoolLabel)
+		}
+		byNodePool[nodePoolName] = append(byNodePool[nodePoolName], nodes[i].Name)
+	}
+
+	nodePoolNames := make([]string, 0, len(byNodePool))
+	for name := range byNodePool {
+		nodePoolNames = append(nodePoolNames, name)
+	}
+	sort.Strings(nodePoolNames)
+
+	parts := make([]string, 0, len(nodePoolNames))
+	for _, nodePoolName := range nodePoolNames {
+		nodeNames := byNodePool[nodePoolName]
+		sort.Strings(nodeNames)
+		parts = append(parts, fmt.Sprintf("%s: [%s]", nodePoolName, strings.Join(nodeNames, ", ")))
+	}
+	return strings.Join(parts, ", ")
 }
 
 type verifyNodePoolReadyAndSchedulableNodeCount struct {


### PR DESCRIPTION
[ARO-26082](https://redhat.atlassian.net/browse/ARO-26082)

### What

Enhanced the `VerifyNodeCount` verifier to produce better error messages when the node count doesn't match expectations:
- Includes the cluster name in the error.
- Lists all nodes grouped by node pool name (e.g., np-scale-down: [node-a, node-b]).

Updated all `VerifyNodeCount` calls to pass the cluster name.

Example output:

```
cluster oidc-wi-cluster: expected 3 nodes, found 2; nodes per pool: oidc-wi-np: [oidc-wi-cluster-oidc-wi-np-nh6vf-6nwlc, oidc-wi-cluster-oidc-wi-np-nh6vf-dj464]
```


### Why

The test "Customer should be able to update nodepool replicas and autoscaling" ([nodepool_update_nodes.go](https://github.com/Azure/ARO-HCP/blob/c66c503c1b9d5df065741762f0079c31491b75e8/test/e2e/nodepool_update_nodes.go), introduced in [4645)](https://github.com/Azure/ARO-HCP/pull/4645) started failing intermittently with expected 4 nodes, found 5. The previous error message gave no information about which nodes existed or which pool the extraneous node belonged to, making it impossible to diagnose the root cause from test's output. With the improved output, the failing pool and node status are immediately visible.



### Testing

No new tests added. This is a diagnostic improvement to existing E2E test infrastructure. The change was verified by running the `nodepool_update_nodes`, `oidc_issuer_workload_identity`, and `nodepool_ephemeral_osdisk` E2E tests locally against a dev environment and confirming the enriched error output on count mismatch.
