### PR TITLE
feat: configure the AZURE_TOKEN_CREDENTIALS for cs deployment and set it to 'WorkloadIdentityCredential'

### DIFF
--- a/cluster-service/helm-charts/cluster-service/templates/deployment.yaml
+++ b/cluster-service/helm-charts/cluster-service/templates/deployment.yaml
@@ -100,6 +100,11 @@ spec:
       - name: clusters-service-init
         image: '{{ .Values.imageRegistry }}/{{ .Values.imageRepository }}@{{ .Values.imageDigest }}'
         imagePullPolicy: IfNotPresent
+        env:
+        # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
+        # Azure Workload Identity (azure.workload.identity/use); that effectively restricts other credential chains from being tried.
+        - name: AZURE_TOKEN_CREDENTIALS
+          value: "WorkloadIdentityCredential"
         volumeMounts:
         - name: rds
           mountPath: /secrets/rds
@@ -133,6 +138,10 @@ spec:
         env:
         - name: DENYASSIGNMENTS
           value: {{ .Values.denyAssignments }}
+        # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
+        # Azure Workload Identity (azure.workload.identity/use); that effectively restricts other credential chains from being tried.
+        - name: AZURE_TOKEN_CREDENTIALS
+          value: "WorkloadIdentityCredential"
         volumeMounts:
         - name: service
           mountPath: /secrets/service


### PR DESCRIPTION

### What

<!-- Briefly describe what this PR does -->

feat: configure the AZURE_TOKEN_CREDENTIALS for cs deployment and set it to 'WorkloadIdentityCredential'

### Why

<!-- Briefly explain why this change is needed -->

CS is going to require RequireAzureTokenCredentials and set it to true. Follows up https://github.com/Azure/ARO-HCP/pull/4259 but applied for CS

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

CS change to require RequireAzureTokenCredentials are being worked on as part of https://redhat.atlassian.net/browse/ARO-26335; we need this merged first and rolled out all the way to prod before those CS changes can be merged