### PR TITLE
fix: add multiArch flag for hypershift-shared-ingress image

### DIFF
--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -38,6 +38,7 @@ images:
     source:
       image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
       tagPattern: "^[a-f0-9]{40}$"
+      multiArch: true
     targets:
     - jsonPath: defaults.hypershift.sharedIngressImage.digest
       filePath: ../../config/config.yaml


### PR DESCRIPTION
## What

Adds `multiArch: true` to the `hypershift-shared-ingress` source configuration in `tooling/image-updater/config.yaml`.

## Why

The periodic image-updater job fails with:

```
ERROR: command failed {
  "err": "failed to fetch latest value for hypershift-shared-ingress: no single-arch amd64/linux image found for repository redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main (all tags are either multi-arch or different architecture)"
}
```

The upstream repository (`redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main`) now only publishes **multi-arch manifest lists** for the bare SHA tags that match our `tagPattern: "^[a-f0-9]{40}$"`. Per-architecture images are published under suffixed tags (e.g. `<sha>-linux-x86-64`, `<sha>-linux-arm64`), but those don't match the pattern.

Without `multiArch: true`, the image-updater treats every matching tag as a single-arch image, fails the architecture check on the manifest list, skips all tags, and errors out. This blocks the entire periodic image-updater job.

- Jira: https://redhat.atlassian.net/browse/AROSLSRE-712
- Failing Prow job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-image-updater-image-updater-tooling/2047314565997268992

## Verification

Built the image-updater locally and ran a dry-run targeting `hypershift-shared-ingress`:

```
./image-updater update --config config.yaml --components hypershift-shared-ingress --dry-run --verbosity 2 --output-format markdown
```

Result:

| Name | Old Digest | New Digest | Tag | Date | Status |
| --- | --- | --- | --- | --- | --- |
| hypershift-shared-ingress | 1af59b7a2943… | 5e22710fe440… | 0903f6b78a608541892ecbe8005899a91bda9ad5 | 2026-04-15 14:40 | dry-run |

The updater now correctly resolves the multi-arch manifest list digest.