### PR TITLE
frontend: Remove CS calls from credential handlers

### DIFF
--- a/backend/pkg/controllers/operationcontrollers/operation_request_credential.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_request_credential.go
@@ -68,6 +68,9 @@ func (opsync *operationRequestCredential) ShouldProcess(ctx context.Context, ope
 	if operation.Request != database.OperationRequestRequestCredential {
 		return false
 	}
+	if len(operation.InternalID.String()) == 0 {
+		return false
+	}
 	return true
 }
 

--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -16,7 +16,6 @@ require (
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.uber.org/mock v0.6.0
 	k8s.io/apimachinery v0.35.3
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 )
@@ -71,6 +70,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.19.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.uber.org/mock v0.6.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect
 	google.golang.org/appengine v1.6.8 // indirect

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -365,22 +365,12 @@ func (f *Frontend) ArmResourceActionRequestAdminCredential(writer http.ResponseW
 		return arm.NewConflictError(clusterResourceID, "Cannot request credential while credentials are being revoked")
 	}
 
-	csCredential, err := f.clusterServiceClient.PostBreakGlassCredential(ctx, *cluster.ServiceProviderProperties.ClusterServiceID)
-	if err != nil {
-		return utils.TrackError(err)
-	}
-
-	csCredentialClusterServiceID, err := api.NewInternalID(csCredential.HREF())
-	if err != nil {
-		return utils.TrackError(err)
-	}
-
 	transaction := f.dbClient.NewTransaction(clusterResourceID.SubscriptionID)
 
 	operationDoc := database.NewOperation(
 		operationRequest,
 		clusterResourceID,
-		csCredentialClusterServiceID,
+		api.InternalID{},
 		f.azureLocation,
 		request.Header.Get(arm.HeaderNameHomeTenantID),
 		request.Header.Get(arm.HeaderNameClientObjectID),
@@ -458,11 +448,6 @@ func (f *Frontend) ArmResourceActionRevokeCredentials(writer http.ResponseWriter
 		return arm.NewConflictError(clusterResourceID, "Credentials are already being revoked")
 	}
 
-	err = f.clusterServiceClient.DeleteBreakGlassCredentials(ctx, *cluster.ServiceProviderProperties.ClusterServiceID)
-	if err != nil {
-		return utils.TrackError(err)
-	}
-
 	transaction := f.dbClient.NewTransaction(clusterResourceID.SubscriptionID)
 
 	// Just as deleting an ARM resource cancels any other operations on the resource,
@@ -487,18 +472,6 @@ func (f *Frontend) ArmResourceActionRevokeCredentials(writer http.ResponseWriter
 		request.Header.Get(arm.HeaderNameClientObjectID),
 		request.Header.Get(arm.HeaderNameAsyncNotificationURI),
 		correlationData)
-
-	// XXX TEMPORARY: This must be removed along with the Clusters Service call.
-	//
-	//     For this operation type, because there is no single Clusters Service
-	//     resource to poll for completion, the operation's status field is used
-	//     for backend controller coordination. "Accepted" means the revocation
-	//     has not yet been dispatched to Clusters Service. Once dispatched, the
-	//     operation status becomes "Deleting" and is ready for status polling.
-	//
-	//     Because the credentials revocation has already been dispatched here,
-	//     set the initial operation status to "Deleting".
-	operationDoc.Status = arm.ProvisioningStateDeleting
 
 	transaction.OnSuccess(addOperationResponseHeaders(writer, request, operationDoc.NotificationURI, operationDoc.OperationID))
 	_, err = f.dbClient.Operations(operationDoc.OperationID.SubscriptionID).AddCreateToTransaction(ctx, transaction, operationDoc, nil)

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -33,11 +33,8 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -577,10 +574,8 @@ func TestRequestAdminCredential(t *testing.T) {
 
 			requestPath := path.Join(clusterResourceID.String(), "requestAdminCredential")
 
-			ctrl := gomock.NewController(t)
 			reg := prometheus.NewRegistry()
 			mockDBClient := databasetesting.NewMockDBClient()
-			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 
 			f := NewFrontend(
 				testr.New(t),
@@ -588,7 +583,7 @@ func TestRequestAdminCredential(t *testing.T) {
 				nil,
 				reg,
 				mockDBClient,
-				mockCSClient,
+				nil,
 				newNoopAuditClient(t),
 				api.TestLocation,
 				"", false, false, true,
@@ -629,14 +624,6 @@ func TestRequestAdminCredential(t *testing.T) {
 				}
 				_, err := mockDBClient.Operations(clusterResourceID.SubscriptionID).Create(ctx, revokeOp, nil)
 				require.NoError(t, err)
-			}
-
-			// Set up cluster service expectations for success case
-			if test.clusterProvisioningState.IsTerminal() && len(test.revokeCredentialsOperationID) == 0 {
-				mockCSClient.EXPECT().
-					PostBreakGlassCredential(gomock.Any(), clusterInternalID).
-					Return(cmv1.NewBreakGlassCredential().
-						HREF(ocm.GenerateOCMCommercialBreakGlassCredentialHREF(clusterInternalID.String(), "0")).Build())
 			}
 
 			subs := map[string]*arm.Subscription{
@@ -696,10 +683,8 @@ func TestRevokeCredentials(t *testing.T) {
 
 			requestPath := path.Join(clusterResourceID.String(), "revokeCredentials")
 
-			ctrl := gomock.NewController(t)
 			reg := prometheus.NewRegistry()
 			mockDBClient := databasetesting.NewMockDBClient()
-			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 
 			f := NewFrontend(
 				testr.New(t),
@@ -707,7 +692,7 @@ func TestRevokeCredentials(t *testing.T) {
 				nil,
 				reg,
 				mockDBClient,
-				mockCSClient,
+				nil,
 				newNoopAuditClient(t),
 				api.TestLocation,
 				"", false, false, true,
@@ -767,13 +752,6 @@ func TestRevokeCredentials(t *testing.T) {
 				}
 				_, err := mockDBClient.Operations(clusterResourceID.SubscriptionID).Create(ctx, requestOp, nil)
 				require.NoError(t, err)
-			}
-
-			// Set up cluster service expectations for success case
-			if test.clusterProvisioningState.IsTerminal() && len(test.revokeCredentialsOperationID) == 0 {
-				mockCSClient.EXPECT().
-					DeleteBreakGlassCredentials(gomock.Any(), clusterInternalID).
-					Return(nil)
 			}
 
 			subs := map[string]*arm.Subscription{

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/03-listActiveOperations-revoke-credentials/operation-revoke-credentials.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/03-listActiveOperations-revoke-credentials/operation-revoke-credentials.json
@@ -8,6 +8,6 @@
 	"request": "RevokeCredentials",
 	"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/00000000-0000-0000-0000-000000000000",
 	"startTime": "2025-01-01T00:00:00Z",
-	"status": "Deleting",
+	"status": "Accepted",
 	"tenantId": "00000000-0000-0000-0000-000000000000"
 }


### PR DESCRIPTION
[ARO-24384 - Move Cluster Service CRUD calls to ARO-HCP backend](https://redhat.atlassian.net/browse/ARO-24384)

### What

This is **stage three** of a three-stage deployment plan described in #4901 to move the Cluster Service calls for requesting and revoking break-glass credentials to the RP backend.

This pull request finally removes the Cluster Service calls for break-glass credentials from the RP frontend, and changes the initial state for credential revocation operations back to **Accepted**.

Doing this will activate the dispatch controllers introduced in #4891.

### Why

This is part of a plan to move _all_ Cluster Service calls to the RP backend, but I'm starting with break-glass credentials because I believe it will have the largest impact in meeting the [Control Plane Latency KPI](https://redhat.atlassian.net/browse/ARO-21536).

### Testing

Existing E2E tests are sufficient to verify the new dispatch controllers in the backend are working correctly.

### Special notes for your reviewer

Holding until #4891 is merged and reaches production environments.
