### PR TITLE
Docs/Dashboards for HCP Golden Signals

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
@@ -14,59 +14,183 @@ resource hcpKmsRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2
     rules: [
       {
         record: 'hostedClusterAPI_kubeapiserver_available:ratio_avg_30d'
-        expression: 'avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30d])'
+        expression: 'avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30d])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:ratio_avg_7d'
-        expression: 'avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[7d])'
+        expression: 'avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[7d])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:ratio_avg_1d'
-        expression: 'avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d])'
+        expression: 'avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:ratio_avg_3d'
-        expression: 'avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d])'
+        expression: 'avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sum_over_time_30m'
-        expression: 'sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m]))'
+        expression: 'sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sum_over_time_1h'
-        expression: 'sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h]))'
+        expression: 'sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sum_over_time_2h'
-        expression: 'sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h]))'
+        expression: 'sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sum_over_time_6h'
-        expression: 'sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h]))'
+        expression: 'sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:count_over_time_30m'
-        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m]))'
+        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:count_over_time_1h'
-        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h]))'
+        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:count_over_time_2h'
-        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h]))'
+        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:count_over_time_6h'
-        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h]))'
+        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:count_over_time_1d'
-        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d]))'
+        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:count_over_time_3d'
-        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d]))'
+        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
+      {
+        record: 'hostedClusterAPI_kubeapiserver_available:sli_sum_15m'
+        expression: 'sum by (name, namespace, _id, cluster) ( sum_over_time( ( hostedClusterAPI_kubeapiserver_available{status="True"} and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[15m:1m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
+      {
+        record: 'hostedClusterAPI_kubeapiserver_available:sli_count_15m'
+        expression: 'sum by (name, namespace, _id, cluster) ( count_over_time( ( max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available) and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[15m:1m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
+      {
+        record: 'hostedClusterAPI_kubeapiserver_available:sli_sum_6h'
+        expression: 'sum by (name, namespace, _id, cluster) ( sum_over_time( ( hostedClusterAPI_kubeapiserver_available{status="True"} and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[6h:5m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
+      {
+        record: 'hostedClusterAPI_kubeapiserver_available:sli_count_6h'
+        expression: 'sum by (name, namespace, _id, cluster) ( count_over_time( ( max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available) and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[6h:5m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
+    ]
+  }
+}
+
+resource hcpKasApiserverRequestRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'hcp-kas-apiserver-request-recording-rules'
+  location: location
+  properties: {
+    scopes: [
+      azureMonitoring
+    ]
+    enabled: true
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'kas:apiserver_request_total:rate5m'
+        expression: 'sum by (namespace, cluster) (rate(apiserver_request_total{namespace=~"ocm-.*"}[5m]))'
+      }
+      {
+        record: 'kas:apiserver_request_5xx:rate5m'
+        expression: 'sum by (namespace, cluster) (rate(apiserver_request_total{namespace=~"ocm-.*", code=~"5.."}[5m]))'
+      }
+      {
+        record: 'kas:apiserver_request_total:rate_avg_30d'
+        expression: 'avg_over_time(kas:apiserver_request_total:rate5m[30d:5m])'
+      }
+      {
+        record: 'kas:apiserver_request_5xx:rate_avg_30d'
+        expression: 'avg_over_time(kas:apiserver_request_5xx:rate5m[30d:5m])'
+      }
+      {
+        record: 'kas:apiserver_request_total:rate_avg_1h'
+        expression: 'avg_over_time(kas:apiserver_request_total:rate5m[1h])'
+      }
+      {
+        record: 'kas:apiserver_request_5xx:rate_avg_1h'
+        expression: 'avg_over_time(kas:apiserver_request_5xx:rate5m[1h])'
+      }
+      {
+        record: 'kas:apiserver_request_total:rate_avg_6h'
+        expression: 'avg_over_time(kas:apiserver_request_total:rate5m[6h])'
+      }
+      {
+        record: 'kas:apiserver_request_5xx:rate_avg_6h'
+        expression: 'avg_over_time(kas:apiserver_request_5xx:rate5m[6h])'
+      }
+      {
+        record: 'kas:apiserver_request_total:rate_avg_3d'
+        expression: 'avg_over_time(kas:apiserver_request_total:rate5m[3d])'
+      }
+      {
+        record: 'kas:apiserver_request_5xx:rate_avg_3d'
+        expression: 'avg_over_time(kas:apiserver_request_5xx:rate5m[3d])'
+      }
+      {
+        record: 'kas:apiserver_request_total:rate_avg_5m'
+        expression: 'avg_over_time(kas:apiserver_request_total:rate5m[5m])'
+      }
+      {
+        record: 'kas:apiserver_request_5xx:rate_avg_5m'
+        expression: 'avg_over_time(kas:apiserver_request_5xx:rate5m[5m])'
+      }
+      {
+        record: 'kas:apiserver_request_total:rate_avg_30m'
+        expression: 'avg_over_time(kas:apiserver_request_total:rate5m[30m])'
+      }
+      {
+        record: 'kas:apiserver_request_5xx:rate_avg_30m'
+        expression: 'avg_over_time(kas:apiserver_request_5xx:rate5m[30m])'
+      }
+    ]
+  }
+}
+
+resource hcpKasLatencyRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'hcp-kas-latency-recording-rules'
+  location: location
+  properties: {
+    scopes: [
+      azureMonitoring
+    ]
+    enabled: true
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio:rate5m'
+        expression: 'sum by (namespace, cluster) ( rate(apiserver_request_sli_duration_seconds_bucket{ namespace=~"ocm-.*", verb=~"POST|PUT|PATCH|DELETE", scope=~"resource|namespace|cluster", subresource!~"proxy|attach|log|exec|portforward", le="1.0" }[5m]) or rate(apiserver_request_sli_duration_seconds_bucket{ namespace=~"ocm-.*", verb=~"GET|LIST", scope="resource", subresource!~"proxy|attach|log|exec|portforward", le="1.0" }[5m]) or rate(apiserver_request_sli_duration_seconds_bucket{ namespace=~"ocm-.*", verb=~"GET|LIST", scope="namespace", subresource!~"proxy|attach|log|exec|portforward", le="5.0" }[5m]) or rate(apiserver_request_sli_duration_seconds_bucket{ namespace=~"ocm-.*", verb=~"GET|LIST", scope="cluster", subresource!~"proxy|attach|log|exec|portforward", le="30.0" }[5m]) ) / sum by (namespace, cluster) ( rate(apiserver_request_sli_duration_seconds_count{ namespace=~"ocm-.*", verb=~"POST|PUT|PATCH|DELETE|GET|LIST", scope=~"resource|namespace|cluster", subresource!~"proxy|attach|log|exec|portforward" }[5m]) )'
+      }
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio:rate_avg_30m'
+        expression: 'avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[30m])'
+      }
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio:rate_avg_1h'
+        expression: 'avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[1h])'
+      }
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio:rate_avg_6h'
+        expression: 'avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[6h])'
+      }
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio:rate_avg_3d'
+        expression: 'avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[3d])'
+      }
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio:rate_avg_30d'
+        expression: 'avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[30d:5m])'
       }
     ]
   }

--- a/docs/sre/hcp-metrics.md
+++ b/docs/sre/hcp-metrics.md
@@ -1,0 +1,162 @@
+# HCP Metrics Architecture
+
+How metrics flow from Hosted Control Plane (HCP) components to Azure Monitor, and how to extend what we collect.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph MC["Management Cluster (AKS)"]
+        subgraph HCP["HCP Namespace (ocm-aro-ENV-XX)"]
+            KAS["kube-apiserver"]
+            ETCD["etcd"]
+            KCM["kube-controller-manager"]
+            SM["ServiceMonitor<br/>(created by HyperShift CPO,<br/>filtered by METRICS_SET)"]
+        end
+
+        subgraph PROM["prometheus namespace"]
+            PA["PrometheusAgent<br/>serviceMonitorSelector: {}"]
+        end
+    end
+
+    subgraph AZURE["Azure Monitor"]
+        AMW_SVC["AMW services<br/>(non-HCP metrics)"]
+        AMW_HCP["AMW hcps-REGION<br/>(HCP metrics)"]
+    end
+
+    SM -->|"/metrics"| KAS
+    SM -->|"/metrics"| ETCD
+    SM -->|"/metrics"| KCM
+    PA -->|"discovers all<br/>ServiceMonitors"| SM
+    PA -->|"remote_write<br/>DROP namespace=ocm-*"| AMW_SVC
+    PA -->|"remote_write<br/>KEEP namespace=ocm-*"| AMW_HCP
+```
+
+### How it works
+
+1. **HyperShift's control-plane-operator** creates a ServiceMonitor per HCP namespace for each component (KAS, etcd, KCM). This happens unconditionally — `--platform-monitoring` does not affect it.
+
+2. The **`METRICS_SET` environment variable** on the HyperShift Operator controls which `metricRelabelings` are applied to those ServiceMonitors. We use `SRE`, which loads its config from the `sre-metrics-set` ConfigMap in the `hypershift` namespace.
+
+3. **PrometheusAgent** (in `prometheus` namespace) discovers all ServiceMonitors via an empty selector and scrapes them.
+
+4. PrometheusAgent **remote_writes** to two Azure Monitor Workspaces, routed by namespace:
+   - `namespace=~"ocm-.*"` → `hcps-REGION` workspace (HCP metrics)
+   - everything else → `services` workspace (management cluster metrics)
+
+### What METRICS_SET controls
+
+| Value | Behavior |
+|-------|----------|
+| `Telemetry` (default) | Hardcoded `keep` rule: 3 KAS metrics only |
+| **`SRE`** (our setting) | Reads `metricRelabelings` from `sre-metrics-set` ConfigMap |
+| `All` | Drops only legacy/renamed metrics, keeps everything else |
+
+### AMA (Azure Monitor Agent)
+
+AMA's `controlplane-*` settings (`controlplane-apiserver`, `controlplane-etcd`, etc.) scrape the **AKS management cluster's own control plane** — the AKS apiserver that manages the management cluster itself. These have no overlap with HCP metrics.
+
+## File Locations
+
+| What | Where |
+|------|-------|
+| SRE metric allowlist | `hypershiftoperator/deploy/templates/sre-metrics-set.configmap.yaml` |
+| HyperShift install flags | `hypershiftoperator/deploy/templates/installer.job.yaml` |
+| PrometheusAgent spec | `observability/prometheus/deploy/templates/prometheus.yaml` |
+| KSM custom resource state | `observability/prometheus/values-mgmt.yaml` |
+| AMA config | `observability/prometheus/deploy/templates/ama-metrics-settings-configmap.yaml` |
+| Grafana dashboards | `observability/grafana-dashboards/<folder>/` |
+| Dashboard registration | `observability/observability.yaml` → `grafana-dashboards.dashboardFolders` |
+| Alert rules | `observability/alerts/` |
+| Alert registration | `observability/observability.yaml` → `prometheusRules.rulesFolders` |
+| Recording rules (HCP workspace) | `observability/observability-hcp-recording-rules.yaml` |
+| Generated Bicep alerting rules | `dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep` |
+| DCR/DCE routing (Azure) | `dev-infrastructure/modules/metrics/datacollection.bicep` |
+
+## SOPs
+
+### Adding a new KAS/etcd/KCM metric
+
+Edit `hypershiftoperator/deploy/templates/sre-metrics-set.configmap.yaml`. Add the metric name to the appropriate component's `keep` regex.
+
+Example — adding `apiserver_admission_controller_admission_duration_seconds_bucket` to the KAS allowlist:
+
+```yaml
+kubeAPIServer:
+  - action: "keep"
+    regex: "(apiserver_request_total|...|apiserver_admission_controller_admission_duration_seconds_bucket)"
+    sourceLabels: ["__name__"]
+```
+
+Then update the Helm fixture and deploy:
+
+```bash
+make update-helm-fixtures
+# Deploy to your environment:
+make pipeline/HypershiftOperator DEPLOY_ENV=pers
+```
+
+The new metric will appear in the `hcps-REGION` Azure Monitor Workspace after the next ServiceMonitor reconciliation and scrape cycle (~2-5 min).
+
+**Cardinality warning**: Every metric you add is scraped per-HCP. A histogram with 10 buckets and 5 label dimensions across 200 HCPs produces significant cardinality. Prefer `_count` and `_sum` over `_bucket` unless you need percentile queries. If you must add buckets, consider a `drop` rule for unused `le` values (see the existing bucket drop rule in the ConfigMap).
+
+### Adding a new Grafana dashboard
+
+1. Create a JSON dashboard file in the appropriate folder under `observability/grafana-dashboards/`. For HCP metrics, use `kas-monitor/`.
+
+2. If you created a new folder, register it in `observability/observability.yaml`:
+   ```yaml
+   grafana-dashboards:
+     dashboardFolders:
+     - name: My New Folder
+       path: ./grafana-dashboards/my-new-folder
+   ```
+
+3. Use template variables for datasource and cluster selection. Recommended regex filters:
+
+   | Variable | Regex | Shows |
+   |----------|-------|-------|
+   | datasource | `^Managed_Prometheus_hcps-.*$` | HCP data sources |
+   | datasource | `^Managed_Prometheus_services-.*$` | Service data sources |
+   | cluster | `^.*-mgmt-\\d+$` | Management clusters |
+   | cluster | `^.*-svc-\\d+$` | Service clusters |
+
+4. Deploy:
+   ```bash
+   make infra.monitoring DEPLOY_ENV=pers
+   ```
+
+### Adding a new alert rule
+
+1. Create a `PrometheusRule` YAML in `observability/alerts/`. Follow the naming convention: `<Name>-prometheusRule.yaml`.
+
+2. Create a matching test file: `<Name>-prometheusRule_test.yaml`. See existing test files for the format (`rule_files`, `evaluation_interval`, `tests` with `input_series` and `alert_rule_test`).
+
+3. Register the rule file in `observability/observability.yaml` under `prometheusRules.rulesFolders`.
+
+4. Generate the Bicep rules and run tests:
+   ```bash
+   cd observability && make alerts
+   ```
+   This runs `promtool` tests, processes all PrometheusRules, and regenerates `dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep`.
+
+5. For HCP-workspace rules (metrics from `ocm-*` namespaces), register in `observability/observability-hcp.yaml` instead.
+
+### Verifying which metrics are available
+
+After deploying the SRE metric set, check what's actually being scraped:
+
+```bash
+# Get mgmt cluster kubeconfig
+make infra.mgmt.aks.kubeconfigfile
+
+# Check ServiceMonitor metricRelabelings in an HCP namespace
+kubectl -n <ocm-aro-*-namespace> get servicemonitor -o yaml
+
+# Verify the ConfigMap is loaded
+kubectl -n hypershift get configmap sre-metrics-set -o yaml
+
+# Query Azure Monitor (via Grafana or az cli) for a metric that was
+# previously filtered out by the Telemetry set:
+#   apiserver_request_duration_seconds_count{namespace=~"ocm-.*"}
+```

--- a/observability/alerts/HCPkasRecord-prometheusRule-KSM.yaml
+++ b/observability/alerts/HCPkasRecord-prometheusRule-KSM.yaml
@@ -7,35 +7,137 @@ spec:
   groups:
   - name: hcp-kms-recording-rules
     rules:
+    # All rules are gated on the raw KSM metric currently being reported.
+    # This prevents stale data from deleted clusters.
+
     # Long-window averages for slow-burn alerts
     - record: hostedClusterAPI_kubeapiserver_available:ratio_avg_30d
-      expr: avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30d])
+      expr: |
+        avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30d]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:ratio_avg_7d
-      expr: avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[7d])
+      expr: |
+        avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[7d]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:ratio_avg_1d
-      expr: avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d])
+      expr: |
+        avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:ratio_avg_3d
-      expr: avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d])
+      expr: |
+        avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
     # Short-window sum_over_time for burn-rate calculations
     - record: hostedClusterAPI_kubeapiserver_available:sum_over_time_30m
-      expr: sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m]))
+      expr: |
+        sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:sum_over_time_1h
-      expr: sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h]))
+      expr: |
+        sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:sum_over_time_2h
-      expr: sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h]))
+      expr: |
+        sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:sum_over_time_6h
-      expr: sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h]))
+      expr: |
+        sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
     # Short-window count_over_time for burn-rate calculations
     - record: hostedClusterAPI_kubeapiserver_available:count_over_time_30m
-      expr: sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m]))
+      expr: |
+        sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:count_over_time_1h
-      expr: sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h]))
+      expr: |
+        sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:count_over_time_2h
-      expr: sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h]))
+      expr: |
+        sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:count_over_time_6h
-      expr: sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h]))
+      expr: |
+        sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
     # Long-window count_over_time for sample-count guards
     - record: hostedClusterAPI_kubeapiserver_available:count_over_time_1d
-      expr: sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d]))
+      expr: |
+        sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:count_over_time_3d
-      expr: sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d]))
+      expr: |
+        sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d]))
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+    # SLI rules using 15m offset blackout to exclude newly-provisioned clusters.
+    # The offset blackout ensures a cluster existed at least 15 minutes ago before
+    # contributing to SLI calculations, preventing provisioning noise from skewing
+    # availability metrics. Numerator counts status="True" samples; denominator counts
+    # all samples (any status via max by) so downtime is counted as 0, not skipped.
+    - record: hostedClusterAPI_kubeapiserver_available:sli_sum_15m
+      expr: |
+        sum by (name, namespace, _id, cluster) (
+          sum_over_time(
+            (
+              hostedClusterAPI_kubeapiserver_available{status="True"}
+              and on (name, namespace, _id, cluster)
+              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+            )[15m:1m]
+          )
+        )
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+    - record: hostedClusterAPI_kubeapiserver_available:sli_count_15m
+      expr: |
+        sum by (name, namespace, _id, cluster) (
+          count_over_time(
+            (
+              max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+              and on (name, namespace, _id, cluster)
+              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+            )[15m:1m]
+          )
+        )
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+    - record: hostedClusterAPI_kubeapiserver_available:sli_sum_6h
+      expr: |
+        sum by (name, namespace, _id, cluster) (
+          sum_over_time(
+            (
+              hostedClusterAPI_kubeapiserver_available{status="True"}
+              and on (name, namespace, _id, cluster)
+              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+            )[6h:5m]
+          )
+        )
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+    - record: hostedClusterAPI_kubeapiserver_available:sli_count_6h
+      expr: |
+        sum by (name, namespace, _id, cluster) (
+          count_over_time(
+            (
+              max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+              and on (name, namespace, _id, cluster)
+              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+            )[6h:5m]
+          )
+        )
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)

--- a/observability/alerts/HCPkasRecord-prometheusRule-KSM_test.yaml
+++ b/observability/alerts/HCPkasRecord-prometheusRule-KSM_test.yaml
@@ -13,25 +13,25 @@ tests:
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_30d{name="test-cluster-1", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_30d", status="True", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_30d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
       value: 1
   # Test the 7d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_7d{name="test-cluster-1", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_7d", status="True", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_7d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
       value: 1
   # Test the 1d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_1d{name="test-cluster-1", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_1d", status="True", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_1d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
       value: 1
   # Test the 3d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_3d{name="test-cluster-1", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_3d", status="True", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_3d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
       value: 1
 # Test 2: 50% Availability (Intermittent Failures)
 - interval: 1m
@@ -43,25 +43,25 @@ tests:
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_30d{name="test-cluster-2", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_30d", status="True", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_30d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster"}'
       value: 0.5
   # Test the 7d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_7d{name="test-cluster-2", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_7d", status="True", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_7d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster"}'
       value: 0.5
   # Test the 1d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_1d{name="test-cluster-2", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_1d", status="True", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_1d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster"}'
       value: 0.5
   # Test the 3d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_3d{name="test-cluster-2", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_3d", status="True", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_3d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster"}'
       value: 0.5
 # Test 3: 0% Availability (Complete Failure)
 - interval: 1m
@@ -73,25 +73,25 @@ tests:
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_30d{name="test-cluster-3", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_30d", status="True", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_30d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster"}'
       value: 0
   # Test the 7d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_7d{name="test-cluster-3", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_7d", status="True", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_7d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster"}'
       value: 0
   # Test the 1d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_1d{name="test-cluster-3", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_1d", status="True", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_1d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster"}'
       value: 0
   # Test the 3d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_3d{name="test-cluster-3", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_3d", status="True", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_3d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster"}'
       value: 0
 # Test 4: Burn-rate recording rules (sum_over_time and count_over_time)
 - interval: 1m
@@ -125,3 +125,38 @@ tests:
     exp_samples:
     - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:count_over_time_1h", name="test-cluster-4", namespace="clusters", _id="xyz-789", cluster="mgmt-cluster"}'
       value: 60
+# Test 5: SLI recording rules - perfect availability
+# The sli_* rules use a 15m offset blackout gate and [15m:1m] subquery.
+# At eval_time=35m, the subquery samples at t=21,22,...,34,35 (15 steps).
+# All offset gates pass (earliest check: t=21-15=6, data exists since t=0).
+- interval: 1m
+  name: "Test 5: SLI recording rules - perfect availability"
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-5", namespace="clusters", _id="sli-100", cluster="mgmt-cluster"}'
+    values: "1+0x60"
+  promql_expr_test:
+  - expr: hostedClusterAPI_kubeapiserver_available:sli_sum_15m{name="test-cluster-5"}
+    eval_time: 35m
+    exp_samples:
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:sli_sum_15m", name="test-cluster-5", namespace="clusters", _id="sli-100", cluster="mgmt-cluster"}'
+      value: 15
+  - expr: hostedClusterAPI_kubeapiserver_available:sli_count_15m{name="test-cluster-5"}
+    eval_time: 35m
+    exp_samples:
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:sli_count_15m", name="test-cluster-5", namespace="clusters", _id="sli-100", cluster="mgmt-cluster"}'
+      value: 15
+# Test 6: SLI offset blackout - newly provisioned cluster excluded
+# A cluster with only 10m of data should produce no SLI values because
+# the 15m offset gate filters it out (no data exists at t-15m).
+- interval: 1m
+  name: "Test 6: SLI offset blackout - new cluster excluded"
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-6", namespace="clusters", _id="sli-new", cluster="mgmt-cluster"}'
+    values: "1+0x10"
+  promql_expr_test:
+  - expr: hostedClusterAPI_kubeapiserver_available:sli_sum_15m{name="test-cluster-6"}
+    eval_time: 10m
+    exp_samples: []
+  - expr: hostedClusterAPI_kubeapiserver_available:sli_count_15m{name="test-cluster-6"}
+    eval_time: 10m
+    exp_samples: []

--- a/observability/alerts/HCPkasRecord-prometheusRule-apiserver-requests.yaml
+++ b/observability/alerts/HCPkasRecord-prometheusRule-apiserver-requests.yaml
@@ -1,0 +1,57 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: hcp-kas-apiserver-request-recording-rules
+  namespace: prometheus
+spec:
+  groups:
+  - name: hcp-kas-apiserver-request-recording-rules
+    interval: 1m
+    rules:
+    # Pre-aggregated request rates for error budget calculations
+    # These run every 1m to build up sample density for long-window queries (30d)
+
+    # Total request rate per namespace (all status codes)
+    # Uses rate[5m] (industry standard for SLI recording rules with 30s scrape)
+    # for resilience to missed scrapes and smoother base signal.
+    - record: kas:apiserver_request_total:rate5m
+      expr: sum by (namespace, cluster) (rate(apiserver_request_total{namespace=~"ocm-.*"}[5m]))
+    # 5xx error request rate per namespace
+    - record: kas:apiserver_request_5xx:rate5m
+      expr: sum by (namespace, cluster) (rate(apiserver_request_total{namespace=~"ocm-.*", code=~"5.."}[5m]))
+    # Long-window averages for error budget monitoring
+    # These enable 30-day error budget queries without hitting cardinality limits
+    # 30-day average total request rate
+    # Using :5m resolution to reduce query cost (8640 samples vs 43200)
+    # Sufficient accuracy for 30-day error budget trends
+    - record: kas:apiserver_request_total:rate_avg_30d
+      expr: avg_over_time(kas:apiserver_request_total:rate5m[30d:5m])
+    # 30-day average 5xx error rate
+    - record: kas:apiserver_request_5xx:rate_avg_30d
+      expr: avg_over_time(kas:apiserver_request_5xx:rate5m[30d:5m])
+    # Additional windows for multi-burn-rate alerting
+    # 1-hour window (for critical 30m/1h burn rate alert)
+    - record: kas:apiserver_request_total:rate_avg_1h
+      expr: avg_over_time(kas:apiserver_request_total:rate5m[1h])
+    - record: kas:apiserver_request_5xx:rate_avg_1h
+      expr: avg_over_time(kas:apiserver_request_5xx:rate5m[1h])
+    # 6-hour window (for critical 30m/6h burn rate alert)
+    - record: kas:apiserver_request_total:rate_avg_6h
+      expr: avg_over_time(kas:apiserver_request_total:rate5m[6h])
+    - record: kas:apiserver_request_5xx:rate_avg_6h
+      expr: avg_over_time(kas:apiserver_request_5xx:rate5m[6h])
+    # 3-day window (for warning 6h/3d burn rate alert)
+    - record: kas:apiserver_request_total:rate_avg_3d
+      expr: avg_over_time(kas:apiserver_request_total:rate5m[3d])
+    - record: kas:apiserver_request_5xx:rate_avg_3d
+      expr: avg_over_time(kas:apiserver_request_5xx:rate5m[3d])
+    # 5-minute window (short window for Fast burn-rate tier)
+    - record: kas:apiserver_request_total:rate_avg_5m
+      expr: avg_over_time(kas:apiserver_request_total:rate5m[5m])
+    - record: kas:apiserver_request_5xx:rate_avg_5m
+      expr: avg_over_time(kas:apiserver_request_5xx:rate5m[5m])
+    # 30-minute window (short window for Medium burn-rate tier)
+    - record: kas:apiserver_request_total:rate_avg_30m
+      expr: avg_over_time(kas:apiserver_request_total:rate5m[30m])
+    - record: kas:apiserver_request_5xx:rate_avg_30m
+      expr: avg_over_time(kas:apiserver_request_5xx:rate5m[30m])

--- a/observability/alerts/HCPkasRecord-prometheusRule-apiserver-requests_test.yaml
+++ b/observability/alerts/HCPkasRecord-prometheusRule-apiserver-requests_test.yaml
@@ -1,0 +1,119 @@
+rule_files:
+- HCPkasRecord-prometheusRule-apiserver-requests.yaml
+evaluation_interval: 1m
+tests:
+# Test 1: Steady traffic with no errors (100% success)
+- interval: 1m
+  input_series:
+  - series: 'apiserver_request_total{cluster="test-mgmt-1", namespace="ocm-aro-test-01", code="200", resource="pods", verb="GET"}'
+    # Counter incrementing by 100 each minute (100 req/min)
+    values: "0+100x15"
+  - series: 'apiserver_request_total{cluster="test-mgmt-1", namespace="ocm-aro-test-01", code="201", resource="pods", verb="POST"}'
+    # Counter incrementing by 50 each minute (50 req/min)
+    values: "0+50x15"
+  promql_expr_test:
+  # Test total request rate recording (should aggregate all codes/resources/verbs)
+  - expr: kas:apiserver_request_total:rate5m{cluster="test-mgmt-1", namespace="ocm-aro-test-01"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_total:rate5m", cluster="test-mgmt-1", namespace="ocm-aro-test-01"}'
+      # rate over 5m of 100+50=150 req/min = 2.5 req/sec
+      value: 2.5
+  # Test 5xx error rate (should be 0 since no 5xx codes)
+  - expr: kas:apiserver_request_5xx:rate5m{cluster="test-mgmt-1", namespace="ocm-aro-test-01"}
+    eval_time: 5m
+    exp_samples: []
+  # Test 1-hour average
+  - expr: kas:apiserver_request_total:rate_avg_1h{cluster="test-mgmt-1", namespace="ocm-aro-test-01"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_total:rate_avg_1h", cluster="test-mgmt-1", namespace="ocm-aro-test-01"}'
+      value: 2
+# Test 2: Traffic with 5xx errors (99% success rate)
+- interval: 1m
+  input_series:
+  # Successful requests: counter incrementing by 990/min
+  - series: 'apiserver_request_total{cluster="test-mgmt-2", namespace="ocm-aro-test-02", code="200", resource="configmaps", verb="LIST"}'
+    values: "0+990x15"
+  # Failed requests (5xx): counter incrementing by 10/min
+  - series: 'apiserver_request_total{cluster="test-mgmt-2", namespace="ocm-aro-test-02", code="500", resource="secrets", verb="GET"}'
+    values: "0+10x15"
+  promql_expr_test:
+  # Total request rate should be 990+10=1000 req/min = 16.67 req/sec
+  - expr: kas:apiserver_request_total:rate5m{cluster="test-mgmt-2", namespace="ocm-aro-test-02"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_total:rate5m", cluster="test-mgmt-2", namespace="ocm-aro-test-02"}'
+      value: 16.666666666666668
+  # 5xx error rate should be 10 req/min = 0.167 req/sec
+  - expr: kas:apiserver_request_5xx:rate5m{cluster="test-mgmt-2", namespace="ocm-aro-test-02"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_5xx:rate5m", cluster="test-mgmt-2", namespace="ocm-aro-test-02"}'
+      value: 0.16666666666666666
+# Test 3: Multiple namespaces (ensure proper aggregation by namespace)
+- interval: 1m
+  input_series:
+  # Namespace 1: counter incrementing by 100/min, no errors
+  - series: 'apiserver_request_total{cluster="test-mgmt-3", namespace="ocm-aro-test-03", code="200", resource="nodes", verb="GET"}'
+    values: "0+100x15"
+  # Namespace 2: counter incrementing by 50/min, all errors
+  - series: 'apiserver_request_total{cluster="test-mgmt-3", namespace="ocm-aro-test-04", code="503", resource="pods", verb="DELETE"}'
+    values: "0+50x15"
+  promql_expr_test:
+  # Test namespace 1 has traffic but no 5xx
+  - expr: kas:apiserver_request_total:rate5m{cluster="test-mgmt-3", namespace="ocm-aro-test-03"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_total:rate5m", cluster="test-mgmt-3", namespace="ocm-aro-test-03"}'
+      value: 1.6666666666666667
+  - expr: kas:apiserver_request_5xx:rate5m{cluster="test-mgmt-3", namespace="ocm-aro-test-03"}
+    eval_time: 5m
+    exp_samples: []
+  # Test namespace 2 has 5xx errors
+  - expr: kas:apiserver_request_total:rate5m{cluster="test-mgmt-3", namespace="ocm-aro-test-04"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_total:rate5m", cluster="test-mgmt-3", namespace="ocm-aro-test-04"}'
+      value: 0.8333333333333334
+  - expr: kas:apiserver_request_5xx:rate5m{cluster="test-mgmt-3", namespace="ocm-aro-test-04"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_5xx:rate5m", cluster="test-mgmt-3", namespace="ocm-aro-test-04"}'
+      value: 0.8333333333333334
+# Test 4: Namespace filter validation (non-ocm namespace should be excluded)
+- interval: 1m
+  input_series:
+  # This should NOT be included (not ocm-* namespace)
+  - series: 'apiserver_request_total{cluster="test-mgmt-4", namespace="default", code="200", resource="pods", verb="GET"}'
+    values: "0+1000x15"
+  # This SHOULD be included (ocm-* namespace)
+  - series: 'apiserver_request_total{cluster="test-mgmt-4", namespace="ocm-aro-prod-01", code="200", resource="pods", verb="GET"}'
+    values: "0+50x15"
+  promql_expr_test:
+  # Should only see ocm-aro-prod-01, not default
+  - expr: kas:apiserver_request_total:rate5m{cluster="test-mgmt-4"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_total:rate5m", cluster="test-mgmt-4", namespace="ocm-aro-prod-01"}'
+      value: 0.8333333333333334
+# Test 5: Validate 5m avg_over_time window recording rules
+- interval: 1m
+  input_series:
+  - series: 'apiserver_request_total{cluster="test-mgmt-5", namespace="ocm-aro-test-05", code="200", resource="pods", verb="GET"}'
+    values: "0+60x15"
+  - series: 'apiserver_request_total{cluster="test-mgmt-5", namespace="ocm-aro-test-05", code="500", resource="pods", verb="GET"}'
+    values: "0+6x15"
+  promql_expr_test:
+  # After 10m, rate5m stabilizes at 66/min = 1.1 req/s
+  # avg_over_time of the stabilized rate5m samples converges to 1.1
+  - expr: kas:apiserver_request_total:rate_avg_5m{cluster="test-mgmt-5", namespace="ocm-aro-test-05"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_total:rate_avg_5m", cluster="test-mgmt-5", namespace="ocm-aro-test-05"}'
+      value: 1.1
+  - expr: kas:apiserver_request_5xx:rate_avg_5m{cluster="test-mgmt-5", namespace="ocm-aro-test-05"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_5xx:rate_avg_5m", cluster="test-mgmt-5", namespace="ocm-aro-test-05"}'
+      value: 0.1

--- a/observability/alerts/HCPkasRecord-prometheusRule-latency.yaml
+++ b/observability/alerts/HCPkasRecord-prometheusRule-latency.yaml
@@ -1,0 +1,91 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: hcp-kas-latency-recording-rules
+  namespace: prometheus
+spec:
+  groups:
+  - name: hcp-kas-latency-recording-rules
+    interval: 1m
+    rules:
+    # Atomic latency SLI ratio: good requests / total requests, evaluated in a
+    # single expression so numerator and denominator share the same scrape
+    # timestamp. This prevents good/total > 1.0 skew that arises when two
+    # separate recording rules are evaluated at independent timestamps during
+    # load changes.
+    #
+    # A request is "good" if it completes within the upstream K8s threshold for
+    # its verb/scope category (mutating: 1s, resource-scope reads: 1s,
+    # namespace-scope reads: 5s, cluster-scope reads: 30s). WATCH requests are
+    # excluded; they have unbounded duration by design and are not part of the
+    # upstream K8s latency SLI definition.
+    #
+    # The `or` operator in the numerator is correct: the verb/scope selectors
+    # are mutually exclusive, so `or` unions disjoint series without double-
+    # counting. The bucket and count metrics are scraped atomically from the
+    # same histogram scrape, so the ratio is mathematically bounded to [0, 1].
+    #
+    # Division by zero: when total is zero (no traffic), PromQL binary `/`
+    # drops the sample entirely rather than producing +Inf. This is the correct
+    # behavior — no traffic means no SLI data point. Do not add
+    # `or vector(0)` or `clamp_max` here; either would corrupt the metric.
+    - record: kas:apiserver_request_latency:sli_ratio:rate5m
+      expr: |
+        sum by (namespace, cluster) (
+          rate(apiserver_request_sli_duration_seconds_bucket{
+            namespace=~"ocm-.*",
+            verb=~"POST|PUT|PATCH|DELETE",
+            scope=~"resource|namespace|cluster",
+            subresource!~"proxy|attach|log|exec|portforward",
+            le="1.0"
+          }[5m])
+          or
+          rate(apiserver_request_sli_duration_seconds_bucket{
+            namespace=~"ocm-.*",
+            verb=~"GET|LIST",
+            scope="resource",
+            subresource!~"proxy|attach|log|exec|portforward",
+            le="1.0"
+          }[5m])
+          or
+          rate(apiserver_request_sli_duration_seconds_bucket{
+            namespace=~"ocm-.*",
+            verb=~"GET|LIST",
+            scope="namespace",
+            subresource!~"proxy|attach|log|exec|portforward",
+            le="5.0"
+          }[5m])
+          or
+          rate(apiserver_request_sli_duration_seconds_bucket{
+            namespace=~"ocm-.*",
+            verb=~"GET|LIST",
+            scope="cluster",
+            subresource!~"proxy|attach|log|exec|portforward",
+            le="30.0"
+          }[5m])
+        )
+        /
+        sum by (namespace, cluster) (
+          rate(apiserver_request_sli_duration_seconds_count{
+            namespace=~"ocm-.*",
+            verb=~"POST|PUT|PATCH|DELETE|GET|LIST",
+            scope=~"resource|namespace|cluster",
+            subresource!~"proxy|attach|log|exec|portforward"
+          }[5m])
+        )
+    # Window averages over the base 5m ratio. avg_over_time of a ratio is
+    # correct here because the base rule already produces a dimensionless [0,1]
+    # value; smoothing it preserves that bound and gives burn-rate alert
+    # consumers a stable signal.
+    - record: kas:apiserver_request_latency:sli_ratio:rate_avg_30m
+      expr: avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[30m])
+    - record: kas:apiserver_request_latency:sli_ratio:rate_avg_1h
+      expr: avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[1h])
+    - record: kas:apiserver_request_latency:sli_ratio:rate_avg_6h
+      expr: avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[6h])
+    - record: kas:apiserver_request_latency:sli_ratio:rate_avg_3d
+      expr: avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[3d])
+    # 30-day window (for dashboard SLO status gauge only, not alerting).
+    # Subquery step of 5m matches the base rule rate window (rate5m).
+    - record: kas:apiserver_request_latency:sli_ratio:rate_avg_30d
+      expr: avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[30d:5m])

--- a/observability/alerts/HCPkasRecord-prometheusRule-latency_test.yaml
+++ b/observability/alerts/HCPkasRecord-prometheusRule-latency_test.yaml
@@ -1,0 +1,103 @@
+rule_files:
+- HCPkasRecord-prometheusRule-latency.yaml
+evaluation_interval: 1m
+tests:
+# Test 1: All requests within threshold (100% good latency — ratio = 1.0)
+- interval: 1m
+  input_series:
+  # Mutating requests: 100/min, all completing within 1s (le="1.0" captures all)
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-1", namespace="ocm-aro-test-01", verb="POST", scope="resource", le="0.1"}'
+    values: "0+50x15"
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-1", namespace="ocm-aro-test-01", verb="POST", scope="resource", le="1.0"}'
+    values: "0+100x15"
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-1", namespace="ocm-aro-test-01", verb="POST", scope="resource", le="+Inf"}'
+    values: "0+100x15"
+  - series: 'apiserver_request_sli_duration_seconds_count{cluster="test-mgmt-1", namespace="ocm-aro-test-01", verb="POST", scope="resource"}'
+    values: "0+100x15"
+  promql_expr_test:
+  # Ratio: 100 good / 100 total = 1.0 (all requests within threshold)
+  - expr: kas:apiserver_request_latency:sli_ratio:rate5m{cluster="test-mgmt-1", namespace="ocm-aro-test-01"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_latency:sli_ratio:rate5m", cluster="test-mgmt-1", namespace="ocm-aro-test-01"}'
+      value: 1.0
+# Test 2: 50% of requests exceed threshold (bad latency — ratio = 0.5)
+- interval: 1m
+  input_series:
+  # Namespace-scope GETs: 100/min total, 50/min complete within 5s threshold
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-2", namespace="ocm-aro-test-02", verb="GET", scope="namespace", le="1.0"}'
+    values: "0+30x15"
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-2", namespace="ocm-aro-test-02", verb="GET", scope="namespace", le="5.0"}'
+    values: "0+50x15"
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-2", namespace="ocm-aro-test-02", verb="GET", scope="namespace", le="+Inf"}'
+    values: "0+100x15"
+  - series: 'apiserver_request_sli_duration_seconds_count{cluster="test-mgmt-2", namespace="ocm-aro-test-02", verb="GET", scope="namespace"}'
+    values: "0+100x15"
+  promql_expr_test:
+  # Ratio: 50 good (within 5s) / 100 total = 0.5
+  - expr: kas:apiserver_request_latency:sli_ratio:rate5m{cluster="test-mgmt-2", namespace="ocm-aro-test-02"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_latency:sli_ratio:rate5m", cluster="test-mgmt-2", namespace="ocm-aro-test-02"}'
+      value: 0.5
+# Test 3: Namespace filter - non-ocm namespace excluded
+- interval: 1m
+  input_series:
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-3", namespace="kube-system", verb="GET", scope="namespace", le="5.0"}'
+    values: "0+100x15"
+  - series: 'apiserver_request_sli_duration_seconds_count{cluster="test-mgmt-3", namespace="kube-system", verb="GET", scope="namespace"}'
+    values: "0+100x15"
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-3", namespace="ocm-aro-test-03", verb="GET", scope="namespace", le="5.0"}'
+    values: "0+50x15"
+  - series: 'apiserver_request_sli_duration_seconds_count{cluster="test-mgmt-3", namespace="ocm-aro-test-03", verb="GET", scope="namespace"}'
+    values: "0+50x15"
+  promql_expr_test:
+  # Only ocm-aro-test-03 should appear; kube-system is excluded by namespace=~"ocm-.*"
+  # Ratio: 50 good / 50 total = 1.0 for ocm-aro-test-03
+  - expr: kas:apiserver_request_latency:sli_ratio:rate5m{cluster="test-mgmt-3"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_latency:sli_ratio:rate5m", cluster="test-mgmt-3", namespace="ocm-aro-test-03"}'
+      value: 1.0
+# Test 4: Multiple verb/scope categories active simultaneously — ratio bounded to [0,1]
+#
+# This validates the key fix: with the atomic single-rule design, the ratio
+# cannot exceed 1.0 even when multiple verb/scope categories contribute to the
+# numerator and denominator simultaneously. The or-union in the numerator and
+# the count-based denominator must stay consistent.
+#
+# Setup: two namespaces, each with a different verb/scope category active:
+#   - ocm-aro-test-04a: POST (mutating), 50/100 within 1s -> ratio 0.5
+#   - ocm-aro-test-04b: GET cluster-scope, 25/100 within 30s -> ratio 0.25
+#
+# Values chosen to be exact binary fractions (1/2, 1/4) to avoid floating-point
+# rounding errors in promtool test comparison.
+- interval: 1m
+  input_series:
+  # ocm-aro-test-04a: POST/resource, 100/min total, 50/min within 1s threshold
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-4", namespace="ocm-aro-test-04a", verb="POST", scope="resource", le="1.0"}'
+    values: "0+50x15"
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-4", namespace="ocm-aro-test-04a", verb="POST", scope="resource", le="+Inf"}'
+    values: "0+100x15"
+  - series: 'apiserver_request_sli_duration_seconds_count{cluster="test-mgmt-4", namespace="ocm-aro-test-04a", verb="POST", scope="resource"}'
+    values: "0+100x15"
+  # ocm-aro-test-04b: GET/cluster, 100/min total, 25/min within 30s threshold
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-4", namespace="ocm-aro-test-04b", verb="GET", scope="cluster", le="30.0"}'
+    values: "0+25x15"
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-4", namespace="ocm-aro-test-04b", verb="GET", scope="cluster", le="+Inf"}'
+    values: "0+100x15"
+  - series: 'apiserver_request_sli_duration_seconds_count{cluster="test-mgmt-4", namespace="ocm-aro-test-04b", verb="GET", scope="cluster"}'
+    values: "0+100x15"
+  promql_expr_test:
+  # ocm-aro-test-04a: 50 good / 100 total = 0.5 (bounded, not > 1.0)
+  - expr: kas:apiserver_request_latency:sli_ratio:rate5m{cluster="test-mgmt-4", namespace="ocm-aro-test-04a"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_latency:sli_ratio:rate5m", cluster="test-mgmt-4", namespace="ocm-aro-test-04a"}'
+      value: 0.5
+  # ocm-aro-test-04b: 25 good / 100 total = 0.25 (bounded, not > 1.0)
+  - expr: kas:apiserver_request_latency:sli_ratio:rate5m{cluster="test-mgmt-4", namespace="ocm-aro-test-04b"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_latency:sli_ratio:rate5m", cluster="test-mgmt-4", namespace="ocm-aro-test-04b"}'
+      value: 0.25

--- a/observability/grafana-dashboards/kas-monitor/kas_golden_signals.json
+++ b/observability/grafana-dashboards/kas-monitor/kas_golden_signals.json
@@ -1,0 +1,2000 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 99,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# HCP KAS Golden Signals\n\n**Three-Tier Alerting Model:**\n\n- **Tier 1 — SLA (99.95% availability)**: Per the ARO SLA, KAS availability is measured via the KSM hostedClusterAPI_kubeapiserver_available signal (interim Tier 1 SLI while awaiting HyperShift blackbox probe RFE). SLI: `hostedClusterAPI_kubeapiserver_available` (KSM). Alerts: `hostedcluster-KubeAPIServer-Outage`, `hostedcluster-KubeAPIServer-ErrorBudgetBurn`.\n- **Tier 2 — Internal Error Rate SLO (99.9%)**: Whitebox 5xx rate on `apiserver_request_total`. Alerts: `HCPKASErrorRateBurnFast/Medium/Slow`. Fires before Tier 1 to enable proactive response.\n- **Tier 3 — Internal Latency SLO (99.9%)**: Request latency against upstream K8s thresholds. Alerts: `HCPKASLatencyBurnFast/Medium/Slow` (planned — defined in a separate alerting component, not yet deployed).\n\n**Runbook**: See [HCP Metrics SRE Guide](https://github.com/Azure/ARO-HCP/blob/main/docs/sre/hcp-metrics.md) for burn rate thresholds and response procedures.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.0",
+      "title": "Dashboard Overview",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 800,
+      "title": "Burn Rates",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "SLA error budget burn rate based on KSM KAS availability condition. Values above 14.4x consume the 30-day budget in 2 days; above 6x in 5 days.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Page Threshold (1h)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "solid"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Page Threshold (6h)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "solid"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 802,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "SLA Budget Burn Rate (15m / 6h)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(\n  1 - (\n    hostedClusterAPI_kubeapiserver_available:sli_sum_15m{cluster=~\"$cluster\", namespace=~\"$namespace\"}\n    /\n    hostedClusterAPI_kubeapiserver_available:sli_count_15m{cluster=~\"$cluster\", namespace=~\"$namespace\"}\n  )\n) / (1 - 0.9995)",
+          "legendFormat": "15m: {{ name }}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(\n  1 - (\n    hostedClusterAPI_kubeapiserver_available:sli_sum_6h{cluster=~\"$cluster\", namespace=~\"$namespace\"}\n    /\n    hostedClusterAPI_kubeapiserver_available:sli_count_6h{cluster=~\"$cluster\", namespace=~\"$namespace\"}\n  )\n) / (1 - 0.9995)",
+          "legendFormat": "6h: {{ name }}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "14.4",
+          "legendFormat": "Page Threshold (1h)",
+          "refId": "C",
+          "hide": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "6",
+          "legendFormat": "Page Threshold (6h)",
+          "refId": "D",
+          "hide": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^(1h|6h):.*"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Page Threshold (1h)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "solid"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Page Threshold (6h)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "solid"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Error Budget Burn Rate (1h / 6h)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(\n  sum by (namespace) (\n    kas:apiserver_request_5xx:rate_avg_1h{cluster=~\"$cluster\", namespace=~\"$namespace\"}\n  )\n  /\n  sum by (namespace) (\n    kas:apiserver_request_total:rate_avg_1h{cluster=~\"$cluster\", namespace=~\"$namespace\"}\n  )\n) / (1 - 0.999)",
+          "legendFormat": "1h: {{ namespace }}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(\n  sum by (namespace) (\n    kas:apiserver_request_5xx:rate_avg_6h{cluster=~\"$cluster\", namespace=~\"$namespace\"}\n  )\n  /\n  sum by (namespace) (\n    kas:apiserver_request_total:rate_avg_6h{cluster=~\"$cluster\", namespace=~\"$namespace\"}\n  )\n) / (1 - 0.999)",
+          "legendFormat": "6h: {{ namespace }}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "14.4",
+          "legendFormat": "Page Threshold (1h)",
+          "refId": "C",
+          "hide": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "6",
+          "legendFormat": "Page Threshold (6h)",
+          "refId": "D",
+          "hide": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Ratio of requests completing within their latency threshold (mutating: 1s, namespace-scope: 5s, cluster-scope: 30s). WATCH excluded. SLO target: 99.9%. Value below 0.999 contributes to latency error budget burn.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "percentunit",
+          "min": 0.9,
+          "max": 1
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SLO Target (99.9%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 710,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Latency SLI — % Requests Within Threshold (1h)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace) (kas:apiserver_request_latency:sli_ratio:rate_avg_1h{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+          "legendFormat": "{{ namespace }}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "0.999",
+          "legendFormat": "SLO Target (99.9%)",
+          "refId": "B",
+          "hide": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Latency error budget burn rate. Values above 14.4 trigger HCPKASLatencyBurnFast. Values above 6 trigger HCPKASLatencyBurnMedium.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Fast Burn Threshold (14.4x)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Medium Burn Threshold (6x)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 711,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Latency Budget Burn Rate (1h / 6h)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(\n  1\n  -\n  sum by (namespace) (kas:apiserver_request_latency:sli_ratio:rate_avg_1h{cluster=~\"$cluster\", namespace=~\"$namespace\"})\n) / (1 - 0.999)",
+          "legendFormat": "1h: {{ namespace }}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(\n  1\n  -\n  sum by (namespace) (kas:apiserver_request_latency:sli_ratio:rate_avg_6h{cluster=~\"$cluster\", namespace=~\"$namespace\"})\n) / (1 - 0.999)",
+          "legendFormat": "6h: {{ namespace }}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "14.4",
+          "legendFormat": "Fast Burn Threshold (14.4x)",
+          "refId": "C",
+          "hide": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "6",
+          "legendFormat": "Medium Burn Threshold (6x)",
+          "refId": "D",
+          "hide": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "SLI pass rate broken out by verb/scope category against upstream K8s latency thresholds (writes ≤1s, resource reads ≤1s, namespace reads ≤5s, cluster reads ≤30s). Identifies which request category is dragging down the aggregate latency SLO.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "percentunit",
+          "min": 0.9,
+          "max": 1
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SLO Target (99.9%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 712,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Latency SLI by Verb/Scope Category",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace) (\n  rate(apiserver_request_sli_duration_seconds_bucket{\n    cluster=~\"$cluster\", namespace=~\"$namespace\",\n    verb=~\"POST|PUT|PATCH|DELETE\",\n    scope=~\"resource|namespace|cluster\",\n    subresource!~\"proxy|attach|log|exec|portforward\",\n    le=\"1.0\"\n  }[$__rate_interval])\n)\n/\nsum by (namespace) (\n  rate(apiserver_request_sli_duration_seconds_count{\n    cluster=~\"$cluster\", namespace=~\"$namespace\",\n    verb=~\"POST|PUT|PATCH|DELETE\",\n    scope=~\"resource|namespace|cluster\",\n    subresource!~\"proxy|attach|log|exec|portforward\"\n  }[$__rate_interval])\n)",
+          "legendFormat": "Writes ≤1s — {{ namespace }}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace) (\n  rate(apiserver_request_sli_duration_seconds_bucket{\n    cluster=~\"$cluster\", namespace=~\"$namespace\",\n    verb=~\"GET|LIST\", scope=\"resource\",\n    subresource!~\"proxy|attach|log|exec|portforward\",\n    le=\"1.0\"\n  }[$__rate_interval])\n)\n/\nsum by (namespace) (\n  rate(apiserver_request_sli_duration_seconds_count{\n    cluster=~\"$cluster\", namespace=~\"$namespace\",\n    verb=~\"GET|LIST\", scope=\"resource\",\n    subresource!~\"proxy|attach|log|exec|portforward\"\n  }[$__rate_interval])\n)",
+          "legendFormat": "Resource reads ≤1s — {{ namespace }}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace) (\n  rate(apiserver_request_sli_duration_seconds_bucket{\n    cluster=~\"$cluster\", namespace=~\"$namespace\",\n    verb=~\"GET|LIST\", scope=\"namespace\",\n    subresource!~\"proxy|attach|log|exec|portforward\",\n    le=\"5.0\"\n  }[$__rate_interval])\n)\n/\nsum by (namespace) (\n  rate(apiserver_request_sli_duration_seconds_count{\n    cluster=~\"$cluster\", namespace=~\"$namespace\",\n    verb=~\"GET|LIST\", scope=\"namespace\",\n    subresource!~\"proxy|attach|log|exec|portforward\"\n  }[$__rate_interval])\n)",
+          "legendFormat": "Namespace reads ≤5s — {{ namespace }}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace) (\n  rate(apiserver_request_sli_duration_seconds_bucket{\n    cluster=~\"$cluster\", namespace=~\"$namespace\",\n    verb=~\"GET|LIST\", scope=\"cluster\",\n    subresource!~\"proxy|attach|log|exec|portforward\",\n    le=\"30.0\"\n  }[$__rate_interval])\n)\n/\nsum by (namespace) (\n  rate(apiserver_request_sli_duration_seconds_count{\n    cluster=~\"$cluster\", namespace=~\"$namespace\",\n    verb=~\"GET|LIST\", scope=\"cluster\",\n    subresource!~\"proxy|attach|log|exec|portforward\"\n  }[$__rate_interval])\n)",
+          "legendFormat": "Cluster reads ≤30s — {{ namespace }}",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "0.999",
+          "legendFormat": "SLO Target (99.9%)",
+          "refId": "E",
+          "hide": false
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 100,
+      "title": "Errors",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SLO Threshold (99.9%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 45
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Error Rate (5xx / total)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace) (\n  rate(apiserver_request_total{cluster=~\"$cluster\", namespace=~\"$namespace\", code=~\"5..\"}[$__rate_interval])\n)\n/\nsum by (namespace) (\n  rate(apiserver_request_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n)",
+          "legendFormat": "{{ namespace }}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "0.001",
+          "legendFormat": "SLO Threshold (99.9%)",
+          "refId": "B",
+          "hide": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 45
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Server Errors (5xx) by Code",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace, code) (\n  rate(apiserver_request_total{cluster=~\"$cluster\", namespace=~\"$namespace\", code=~\"5..\"}[$__rate_interval])\n)",
+          "legendFormat": "{{ namespace }} - {{ code }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "noData": {
+          "message": "Normal: no request terminations"
+        }
+      },
+      "title": "Request Terminations",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace) (\n  rate(apiserver_request_terminations_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n)",
+          "legendFormat": "{{ namespace }}",
+          "refId": "A"
+        }
+      ],
+      "description": "Requests terminated by the API server before completion (e.g. due to timeouts, priority/fairness enforcement, or server shutdown). No data is NORMAL — terminations are rare under healthy conditions. Spikes correlate with API server restarts, APF enforcement, or client timeout issues."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "5xx Errors by Resource",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10,\n  sum by (namespace, resource, verb, client) (\n    rate(apiserver_request_total{cluster=~\"$cluster\", namespace=~\"$namespace\", code=~\"5..\"}[$__rate_interval])\n  )\n)",
+          "legendFormat": "{{ namespace }} - {{ verb }} {{ resource }} ({{ client }})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 61
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Client Errors (4xx) by Code",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace, code) (\n  rate(apiserver_request_total{cluster=~\"$cluster\", namespace=~\"$namespace\", code=~\"4..\"}[$__rate_interval])\n)",
+          "legendFormat": "{{ namespace }} - {{ code }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 69
+      },
+      "id": 200,
+      "title": "Latency",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 70
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Read Request Latency (p50 / p90 / p99) - Successful Requests",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50,\n  sum by (namespace, le) (\n    rate(apiserver_request_sli_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", verb=~\"GET|LIST\", code!~\"5..\"}[$__rate_interval])\n  )\n)",
+          "legendFormat": "p50 - {{ namespace }}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.90,\n  sum by (namespace, le) (\n    rate(apiserver_request_sli_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", verb=~\"GET|LIST\", code!~\"5..\"}[$__rate_interval])\n  )\n)",
+          "legendFormat": "p90 - {{ namespace }}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99,\n  sum by (namespace, le) (\n    rate(apiserver_request_sli_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", verb=~\"GET|LIST\", code!~\"5..\"}[$__rate_interval])\n  )\n)",
+          "legendFormat": "p99 - {{ namespace }}",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 70
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Write Request Latency (p50 / p90 / p99) - Successful Requests",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50,\n  sum by (namespace, le) (\n    rate(apiserver_request_sli_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", verb=~\"POST|PUT|PATCH|DELETE\", code!~\"5..\"}[$__rate_interval])\n  )\n)",
+          "legendFormat": "p50 - {{ namespace }}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.90,\n  sum by (namespace, le) (\n    rate(apiserver_request_sli_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", verb=~\"POST|PUT|PATCH|DELETE\", code!~\"5..\"}[$__rate_interval])\n  )\n)",
+          "legendFormat": "p90 - {{ namespace }}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99,\n  sum by (namespace, le) (\n    rate(apiserver_request_sli_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", verb=~\"POST|PUT|PATCH|DELETE\", code!~\"5..\"}[$__rate_interval])\n  )\n)",
+          "legendFormat": "p99 - {{ namespace }}",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 78
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Latency by Resource (p99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10,\n  histogram_quantile(0.99,\n    sum by (namespace, resource, verb, le) (\n      rate(apiserver_request_sli_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", code!~\"5..\"}[$__rate_interval])\n    )\n  )\n)",
+          "legendFormat": "{{ namespace }} - {{ verb }} {{ resource }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 86
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Admission Controller Latency (p99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10,\n  histogram_quantile(0.99,\n    sum by (namespace, name, operation, le) (\n      rate(apiserver_admission_controller_admission_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n    )\n  )\n)",
+          "legendFormat": "{{ namespace }} - {{ name }} ({{ operation }})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 94
+      },
+      "id": 300,
+      "title": "Traffic",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 95
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Request Rate by Verb",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace, verb) (\n  rate(apiserver_request_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n)",
+          "legendFormat": "{{ namespace }} - {{ verb }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 95
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Request Rate by Resource (top 10)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10,\n  sum by (namespace, resource) (\n    rate(apiserver_request_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n  )\n)",
+          "legendFormat": "{{ namespace }} - {{ resource }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 103
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "WATCH Request Rate by Resource",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace, resource) (\n  rate(apiserver_request_total{cluster=~\"$cluster\", namespace=~\"$namespace\", verb=\"WATCH\"}[$__rate_interval])\n)",
+          "legendFormat": "{{ namespace }} - {{ resource }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 103
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "WATCH Error Rate by Resource",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace, resource, code) (\n  rate(apiserver_request_total{cluster=~\"$cluster\", namespace=~\"$namespace\", verb=\"WATCH\", code!~\"2..\"}[$__rate_interval])\n)",
+          "legendFormat": "{{ namespace }} - {{ resource }} ({{ code }})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 111
+      },
+      "id": 400,
+      "title": "Saturation",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 112
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "In-Flight Requests",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace, requestKind) (\n  apiserver_current_inflight_requests{cluster=~\"$cluster\", namespace=~\"$namespace\"}\n)",
+          "legendFormat": "{{ namespace }} - {{ requestKind }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 120
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Long-Running Requests",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace, verb) (\n  apiserver_longrunning_requests{cluster=~\"$cluster\", namespace=~\"$namespace\"}\n)",
+          "legendFormat": "{{ namespace }} - {{ verb }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 120
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Storage Objects",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10,\n  sum by (namespace, resource) (\n    apiserver_storage_objects{cluster=~\"$cluster\", namespace=~\"$namespace\"}\n  )\n)",
+          "legendFormat": "{{ namespace }} - {{ resource }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 128
+      },
+      "id": 500,
+      "title": "etcd Client",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 129
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "etcd Request Latency (p99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99,\n  sum by (namespace, operation, le) (\n    rate(etcd_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n  )\n)",
+          "legendFormat": "{{ namespace }} - {{ operation }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 129
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "noData": {
+          "message": "Normal: no etcd errors"
+        }
+      },
+      "title": "etcd Request Errors",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace, operation) (\n  rate(etcd_request_errors_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n)",
+          "legendFormat": "{{ namespace }} - {{ operation }}",
+          "refId": "A"
+        }
+      ],
+      "description": "Failed etcd requests from the KAS client perspective. No data is NORMAL under healthy conditions — etcd errors are rare. Non-zero values indicate etcd connectivity or performance issues. Any sustained errors should be investigated alongside etcd health."
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "golden-signals",
+    "kas",
+    "hcp"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": true,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_hcps-.*$",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(apiserver_request_total,cluster)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Management Cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(apiserver_request_total,cluster)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(hostedClusterAPI_kubeapiserver_available{cluster=~\"$cluster\"},namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "HCP (namespace)",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(hostedClusterAPI_kubeapiserver_available{cluster=~\"$cluster\"},namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "HCP KAS Golden Signals",
+  "uid": "hcp-kas-golden-signals"
+}

--- a/observability/observability-hcp-recording-rules.yaml
+++ b/observability/observability-hcp-recording-rules.yaml
@@ -1,5 +1,7 @@
 prometheusRules:
   rulesFolders:
   - ../observability/alerts/HCPkasRecord-prometheusRule-KSM.yaml
+  - ../observability/alerts/HCPkasRecord-prometheusRule-apiserver-requests.yaml
+  - ../observability/alerts/HCPkasRecord-prometheusRule-latency.yaml
   untestedRules: []
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep


### PR DESCRIPTION
## Summary

Builds on https://github.com/Azure/ARO-HCP/pull/4988 which enabled the SRE metrics set.

- Adds `observability/alerts/*` Recording Rules for aggregated metrics useful for dashboarding
- Adds `observability/grafana-dashboards/kas-monitor/kas_golden_signals.json` to dashboard standard KAS golden signals
- Adds `docs/sre/hcp-metrics.md`** documenting the metrics architecture and SOPs for adding metrics, dashboards, and alerts

## Context

Provides a way for SREs to view standard information without needing to know all the individual queries. Single pane of glass for any cluster.

## Test plan

- [x] Deploy to personal dev environment
- [x] Verify KAS Golden Signals dashboard renders with data in Grafana