### PR TITLE
skip mise routing test in higher envs

### DIFF
--- a/test/e2e/mise_routing.go
+++ b/test/e2e/mise_routing.go
@@ -17,6 +17,8 @@ package e2e
 import (
 	"context"
 	"net/http"
+	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,6 +61,13 @@ func (p *miseVersionCapture) Do(req *policy.Request) (*http.Response, error) {
 // rules are always evaluated.
 var _ = Describe("MISE Routing", func() {
 	defer GinkgoRecover()
+
+	BeforeEach(func() {
+		suiteName := strings.ToLower(os.Getenv("ARO_HCP_SUITE_NAME"))
+		if strings.Contains(suiteName, "prod") || strings.Contains(suiteName, "stage") {
+			Skip("Skipping MISE routing test in production or staging environment")
+		}
+	})
 
 	DescribeTable("routes to the correct frontend based on version header",
 		labels.RequireNothing,


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-26431

### What

Skipping MISE routing E2E test case in staging or prod environments

### Why

The E2E test case was implemented in https://github.com/Azure/ARO-HCP/pull/4886 together with the feature code, which is suggested, but the code doesn't try to avoid running the tests in higher environments. For this reason, this test will fail there until we rollout new version of the service there as well.

This is happening because of know testing and release engineering gaps on our side.

### Testing

When merged, we should create a follow up PR which will revert this change, and there we can schedule the test runs in both environments to check that it works there.

### Special notes for your reviewer

Verify that the assumptions here are correct.
