### PR TITLE
kusto: pass location to audit-logs data connection

### DIFF
--- a/dev-infrastructure/configurations/audit-logs-data-connection.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/audit-logs-data-connection.tmpl.bicepparam
@@ -1,5 +1,6 @@
 using '../templates/audit-logs-data-connection.bicep'
 
+param location = '{{ .kusto.location }}'
 param kustoName = '{{ .kusto.kustoName }}'
 param auditLogsKustoConsumerGroupName = '{{ .auditLogsEventHub.kustoConsumerGroupName }}'
 param auditLogsEventHubId = '__auditLogsEventHubId__'

--- a/dev-infrastructure/templates/audit-logs-data-connection.bicep
+++ b/dev-infrastructure/templates/audit-logs-data-connection.bicep
@@ -13,6 +13,9 @@ param databaseName string
 @description('Kusto data connection resource name')
 param kustoDataConnectionName string
 
+@description('Azure Region Location')
+param location string = resourceGroup().location
+
 @description('Whether the arobit Kusto cluster is enabled in this region')
 param kustoEnabled bool
 
@@ -29,7 +32,7 @@ resource kustoCluster 'Microsoft.Kusto/clusters@2024-04-13' existing = if (kusto
 // Kusto Event Hub data connection for AKS audit logs
 resource kustoDataConnection 'Microsoft.Kusto/clusters/databases/dataConnections@2024-04-13' = if (kustoEnabled && eventhubEnabled && manageInstance) {
   name: '${kustoName}/${databaseName}/${kustoDataConnectionName}'
-  location: resourceGroup().location
+  location: location
   kind: 'EventHub'
   properties: {
     eventHubResourceId: auditLogsEventHubId


### PR DESCRIPTION
<!-- Link to Jira issue -->

https://redhat.atlassian.net/browse/AROSLSRE-714

<!-- Briefly describe what this PR does -->

### Why


The eastus2euap canary region deploys its Kusto cluster in eastus2 (via the location override from #4894), but data connections still used `resourceGroup().location` which resolves to eastus2euap. Since `Microsoft.Kusto/clusters/databases/dataConnections` is not available in eastus2euap, the deployment fails.
This follows the same pattern already applied to `database.bicep` and
`cluster.bicep` in #4894. 

### Testing

- No impact on existing regions: `location` defaults to `resourceGroup().location` for backward compatibility

### Special notes for your reviewer

<!-- optional -->
