### PR TITLE
Fix cleanup-sweeper to propagate ARM client options

### DIFF
--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -578,6 +578,9 @@ func (tc *perItOrDescribeTestContext) runOrderedResourceGroupCleanup(ctx context
 	}
 
 	ctx = logr.NewContext(ctx, ginkgo.GinkgoLogr)
+	if opts.ClientOptions == nil {
+		opts.ClientOptions = tc.perBinaryInvocationTestContext.getClientFactoryOptions()
+	}
 
 	workflow, err := cleanupengine.ResourceGroupOrderedCleanupWorkflow(
 		ctx, resourceGroupName, subscriptionID, credential, opts,

--- a/tooling/cleanup-sweeper/pkg/engine/client_options.go
+++ b/tooling/cleanup-sweeper/pkg/engine/client_options.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+var defaultARMRetryOptions = policy.RetryOptions{
+	// The Azure SDK defaults MaxRetryDelay to 60 seconds and skips retries when
+	// Retry-After exceeds that cap. Cleanup workflows regularly see longer
+	// server-provided delays when subscriptions are throttled.
+	MaxRetryDelay: 5 * time.Minute,
+}
+
+// DefaultARMClientOptions returns cleanup-sweeper's default ARM client options.
+func DefaultARMClientOptions() *azcorearm.ClientOptions {
+	return &azcorearm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Retry: defaultARMRetryOptions,
+		},
+	}
+}
+
+func normalizeARMClientOptions(opts *azcorearm.ClientOptions) *azcorearm.ClientOptions {
+	if opts != nil {
+		return opts
+	}
+	return DefaultARMClientOptions()
+}

--- a/tooling/cleanup-sweeper/pkg/engine/resourcegroup_ordered_cleanup.go
+++ b/tooling/cleanup-sweeper/pkg/engine/resourcegroup_ordered_cleanup.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v8"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armlocks"
@@ -52,6 +53,7 @@ type WorkflowOptions struct {
 	DryRun          bool
 	Parallelism     int
 	ContinueOnError bool
+	ClientOptions   *azcorearm.ClientOptions
 }
 
 // ResourceGroupOrderedCleanupWorkflow builds an ordered cleanup workflow for a
@@ -102,7 +104,9 @@ func ResourceGroupOrderedCleanupWorkflow(
 		return nil, fmt.Errorf("azure credential is required")
 	}
 
-	rgClient, err := armresources.NewResourceGroupsClient(subscriptionID, credential, nil)
+	clientOptions := normalizeARMClientOptions(opts.ClientOptions)
+
+	rgClient, err := armresources.NewResourceGroupsClient(subscriptionID, credential, clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resource groups client: %w", err)
 	}
@@ -129,30 +133,30 @@ func ResourceGroupOrderedCleanupWorkflow(
 		return nil, fmt.Errorf("failed to get resource group %q: %w", resourceGroupName, err)
 	}
 
-	resourcesClient, err := armresources.NewClient(subscriptionID, credential, nil)
+	resourcesClient, err := armresources.NewClient(subscriptionID, credential, clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resources client: %w", err)
 	}
-	locksClient, err := armlocks.NewManagementLocksClient(subscriptionID, credential, nil)
+	locksClient, err := armlocks.NewManagementLocksClient(subscriptionID, credential, clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create management locks client: %w", err)
 	}
-	providersClient, err := armresources.NewProvidersClient(subscriptionID, credential, nil)
+	providersClient, err := armresources.NewProvidersClient(subscriptionID, credential, clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create providers client: %w", err)
 	}
 	apiVersionCache := armsteps.NewAPIVersionCache(providersClient)
 
-	clientFactory, err := armnetwork.NewClientFactory(subscriptionID, credential, nil)
+	clientFactory, err := armnetwork.NewClientFactory(subscriptionID, credential, clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create network client factory: %w", err)
 	}
 	nspClient := clientFactory.NewSecurityPerimetersClient()
-	vaultsClient, err := armkeyvault.NewVaultsClient(subscriptionID, credential, nil)
+	vaultsClient, err := armkeyvault.NewVaultsClient(subscriptionID, credential, clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create vaults client: %w", err)
 	}
-	subsClient, err := armsubscriptions.NewClient(credential, nil)
+	subsClient, err := armsubscriptions.NewClient(credential, clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create subscriptions client: %w", err)
 	}
@@ -247,6 +251,7 @@ func ResourceGroupOrderedCleanupWorkflow(
 			dnssteps.MustNewDeleteNSDelegationRecordsStep(dnssteps.DeleteNSDelegationRecordsStepConfig{
 				ResourceGroupName: resourceGroupName,
 				Credential:        credential,
+				ClientOptions:     clientOptions,
 				LocksClient:       locksClient,
 				ResourcesClient:   resourcesClient,
 				SubsClient:        subsClient,

--- a/tooling/cleanup-sweeper/pkg/engine/role_assignments_sweeper.go
+++ b/tooling/cleanup-sweeper/pkg/engine/role_assignments_sweeper.go
@@ -42,7 +42,9 @@ func RoleAssignmentsSweeperWorkflow(
 		return nil, fmt.Errorf("azure credential is required")
 	}
 
-	roleAssignmentsClient, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, credential, nil)
+	clientOptions := normalizeARMClientOptions(opts.ClientOptions)
+
+	roleAssignmentsClient, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, credential, clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create role assignments client: %w", err)
 	}

--- a/tooling/cleanup-sweeper/pkg/engine/steps/dns/dns_step.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/dns/dns_step.go
@@ -44,6 +44,7 @@ const NSRecordSetResourceType = "Microsoft.Network/dnszones/NS"
 type DeleteNSDelegationRecordsStepConfig struct {
 	ResourceGroupName string
 	Credential        azcore.TokenCredential
+	ClientOptions     *azcorearm.ClientOptions
 	LocksClient       *armlocks.ManagementLocksClient
 	ResourcesClient   *armresources.Client
 	SubsClient        *armsubscriptions.Client
@@ -163,6 +164,7 @@ func (s *deleteNSDelegationRecordsStep) Discover(ctx context.Context) ([]runner.
 		delegationTargets, err := discoverNSDelegationRecordTargets(
 			ctx,
 			s.cfg.Credential,
+			s.cfg.ClientOptions,
 			s.cfg.SubsClient,
 			parentZone,
 			recordSetName,
@@ -187,12 +189,13 @@ func (s *deleteNSDelegationRecordsStep) Delete(ctx context.Context, target runne
 	if err != nil {
 		return err
 	}
-	return deleteNSRecordSet(ctx, s.cfg.Credential, subscriptionID, resourceGroup, zoneName, recordSetName)
+	return deleteNSRecordSet(ctx, s.cfg.Credential, s.cfg.ClientOptions, subscriptionID, resourceGroup, zoneName, recordSetName)
 }
 
 func discoverNSDelegationRecordTargets(
 	ctx context.Context,
 	credential azcore.TokenCredential,
+	clientOptions *azcorearm.ClientOptions,
 	subsClient *armsubscriptions.Client,
 	parentZone, recordSetName string,
 	logger logr.Logger,
@@ -221,13 +224,13 @@ func discoverNSDelegationRecordTargets(
 			}
 
 			subID := *sub.SubscriptionID
-			dnsClient, err := armdns.NewZonesClient(subID, credential, nil)
+			dnsClient, err := armdns.NewZonesClient(subID, credential, clientOptions)
 			if err != nil {
 				wrappedErr := fmt.Errorf("failed creating DNS zones client for subscription %q: %w", subID, err)
 				errs = append(errs, wrappedErr)
 				continue
 			}
-			recordSetsClient, err := armdns.NewRecordSetsClient(subID, credential, nil)
+			recordSetsClient, err := armdns.NewRecordSetsClient(subID, credential, clientOptions)
 			if err != nil {
 				wrappedErr := fmt.Errorf("failed creating DNS record-sets client for subscription %q: %w", subID, err)
 				errs = append(errs, wrappedErr)
@@ -288,8 +291,13 @@ func discoverNSDelegationRecordTargets(
 	return targets, errors.Join(errs...)
 }
 
-func deleteNSRecordSet(ctx context.Context, credential azcore.TokenCredential, subscriptionID, resourceGroup, zoneName, recordSetName string) error {
-	recordSetsClient, err := armdns.NewRecordSetsClient(subscriptionID, credential, nil)
+func deleteNSRecordSet(
+	ctx context.Context,
+	credential azcore.TokenCredential,
+	clientOptions *azcorearm.ClientOptions,
+	subscriptionID, resourceGroup, zoneName, recordSetName string,
+) error {
+	recordSetsClient, err := armdns.NewRecordSetsClient(subscriptionID, credential, clientOptions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Propagate ARM client options through cleanup-sweeper instead of creating ARM clients with nil options
- Add default cleanup-sweeper ARM retry options so non-test callers honor longer server-provided retry delays
- Make e2e rg-ordered cleanup reuse the existing test framework ARM retry/throttle policies