### PR TITLE
skip test that fails after the revert

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/known_issues_test.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/known_issues_test.go
@@ -104,6 +104,7 @@ func TestParseKnownIssues(t *testing.T) {
 }
 
 func TestLoadKnownIssuesEmbedded(t *testing.T) {
+	t.Skip("embedded knownIssues.yaml is currently empty")
 	issues, err := parseKnownIssues(defaultKnownIssuesData)
 	if err != nil {
 		t.Fatalf("embedded knownIssues.yaml should parse without error: %v", err)


### PR DESCRIPTION
this fails on master after merging https://github.com/Azure/ARO-HCP/pull/5019