### PR TITLE
dev-infrastructure: disable microsoftGraphBeta pipeline steps (AROSLSRE-718)

### DIFF
--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -27,18 +27,21 @@ resourceGroups:
     parameters: configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-  - name: geneva-output
-    action: ARM
-    template: templates/entra-app-lookup.bicep
-    parameters: configurations/geneva-identities-lookup.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
-    outputOnly: true
-  - name: mise-output
-    action: ARM
-    template: templates/entra-app-lookup.bicep
-    parameters: configurations/mise-identity-lookup.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
-    outputOnly: true
+    # AROSLSRE-718: geneva-output and mise-output temporarily disabled due to ARM
+    # regression rejecting Microsoft.Graph/applications@beta with internal extension.
+    # Re-enable when the ARM provider team resolves the issue.
+    # - name: geneva-output
+    #   action: ARM
+    #   template: templates/entra-app-lookup.bicep
+    #   parameters: configurations/geneva-identities-lookup.tmpl.bicepparam
+    #   deploymentLevel: ResourceGroup
+    #   outputOnly: true
+    # - name: mise-output
+    #   action: ARM
+    #   template: templates/entra-app-lookup.bicep
+    #   parameters: configurations/mise-identity-lookup.tmpl.bicepparam
+    #   deploymentLevel: ResourceGroup
+    #   outputOnly: true
 # Query parameters from regional deployment, e.g. Azure Monitor workspace ID
 - name: regional
   resourceGroup: '{{ .regionRG }}'
@@ -341,19 +344,21 @@ resourceGroups:
       resourceGroup: global
       step: output
       name: globalMSIId
-    inputVariables:
-      genevaActionsAppId:
-        resourceGroup: global
-        step: geneva-output
-        name: appId
-      tenantId:
-        resourceGroup: global
-        step: geneva-output
-        name: tenantId
-      miseAppId:
-        resourceGroup: global
-        step: mise-output
-        name: appId
+    # AROSLSRE-718: inputVariables for geneva-output and mise-output temporarily
+    # disabled. Re-enable with the steps above.
+    # inputVariables:
+    #   genevaActionsAppId:
+    #     resourceGroup: global
+    #     step: geneva-output
+    #     name: appId
+    #   tenantId:
+    #     resourceGroup: global
+    #     step: geneva-output
+    #     name: tenantId
+    #   miseAppId:
+    #     resourceGroup: global
+    #     step: mise-output
+    #     name: appId
     automatedRetry:
       errorContainsAny:
       - "500 Internal Server Error"

--- a/test/e2e/mise_routing.go
+++ b/test/e2e/mise_routing.go
@@ -16,7 +16,9 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,6 +61,16 @@ func (p *miseVersionCapture) Do(req *policy.Request) (*http.Response, error) {
 // rules are always evaluated.
 var _ = Describe("MISE Routing", func() {
 	defer GinkgoRecover()
+
+	// AROSLSRE-718: MISE v2 pipeline steps temporarily disabled due to ARM regression
+	// rejecting Microsoft.Graph/applications@beta with the internal extension.
+	// This time bomb will start failing after the deadline to ensure re-enablement.
+	timeBombDeadline := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	BeforeEach(func() {
+		if time.Now().Before(timeBombDeadline) {
+			Skip(fmt.Sprintf("MISE v2 pipeline steps disabled due to ARM regression (AROSLSRE-718); skipping until %s", timeBombDeadline.Format(time.RFC3339)))
+		}
+	})
 
 	DescribeTable("routes to the correct frontend based on version header",
 		labels.RequireNothing,


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-718

### What

Disable the `geneva-output` and `mise-output` pipeline steps in `svc-pipeline.yaml` and time bomb the MISE routing E2E test until 2026-06-01.

### Why

Starting ~2026-04-24T21:20Z, ARM started rejecting `Microsoft.Graph/applications@beta` with the internal extension (`1.0.0-internal`). This is a server-side regression on the ARM/Microsoft Graph provider, confirmed to affect multiple tenants and subscriptions. A Sev3 incident has been opened.

This blocks ALL PR E2E runs at the `aro-hcp-provision-environment` step.

### Changes

- Comment out `geneva-output` and `mise-output` step definitions in `svc-pipeline.yaml`
- Comment out `inputVariables` referencing those steps
- Add time bomb to `test/e2e/mise_routing.go` skipping until 2026-06-01

### Known issue: INT+ EV2 manifest generation

Commenting out the `inputVariables` for `miseAppId` breaks the EV2 manifest resolver in sdp-pipelines for INT:

```
failed to resolve config reference miseAppId: configuration: key miseAppId not found
```

The `istio-config` step requires `miseAppId` even when the pipeline step providing it is disabled. This means #5022 unblocks PR E2E but breaks INT deployments. The revert PR #5023 is on hold waiting for the ARM regression fix.

### Testing

- [x] `go build ./test/...` passes
- [x] CI verify passes
- [x] E2E provision-environment step passes (39 passed, 1 flaky metrics test)
- [x] INT EV2 manifest generation (known broken, see above)

### Special notes for your reviewer

This is a minimal fix to unblock PR merges. The MISE v2 stack and all other #4886 changes remain intact. Revert PR: #5023 (on hold).