### PR TITLE
Revert "disable microsoftGraphBeta pipeline steps" - re-enable geneva-output and mise-output

### DIFF
--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -27,21 +27,18 @@ resourceGroups:
     parameters: configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-    # AROSLSRE-718: geneva-output and mise-output temporarily disabled due to ARM
-    # regression rejecting Microsoft.Graph/applications@beta with internal extension.
-    # Re-enable when the ARM provider team resolves the issue.
-    # - name: geneva-output
-    #   action: ARM
-    #   template: templates/entra-app-lookup.bicep
-    #   parameters: configurations/geneva-identities-lookup.tmpl.bicepparam
-    #   deploymentLevel: ResourceGroup
-    #   outputOnly: true
-    # - name: mise-output
-    #   action: ARM
-    #   template: templates/entra-app-lookup.bicep
-    #   parameters: configurations/mise-identity-lookup.tmpl.bicepparam
-    #   deploymentLevel: ResourceGroup
-    #   outputOnly: true
+  - name: geneva-output
+    action: ARM
+    template: templates/entra-app-lookup.bicep
+    parameters: configurations/geneva-identities-lookup.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
+  - name: mise-output
+    action: ARM
+    template: templates/entra-app-lookup.bicep
+    parameters: configurations/mise-identity-lookup.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
 # Query parameters from regional deployment, e.g. Azure Monitor workspace ID
 - name: regional
   resourceGroup: '{{ .regionRG }}'
@@ -344,21 +341,19 @@ resourceGroups:
       resourceGroup: global
       step: output
       name: globalMSIId
-    # AROSLSRE-718: inputVariables for geneva-output and mise-output temporarily
-    # disabled. Re-enable with the steps above.
-    # inputVariables:
-    #   genevaActionsAppId:
-    #     resourceGroup: global
-    #     step: geneva-output
-    #     name: appId
-    #   tenantId:
-    #     resourceGroup: global
-    #     step: geneva-output
-    #     name: tenantId
-    #   miseAppId:
-    #     resourceGroup: global
-    #     step: mise-output
-    #     name: appId
+    inputVariables:
+      genevaActionsAppId:
+        resourceGroup: global
+        step: geneva-output
+        name: appId
+      tenantId:
+        resourceGroup: global
+        step: geneva-output
+        name: tenantId
+      miseAppId:
+        resourceGroup: global
+        step: mise-output
+        name: appId
     automatedRetry:
       errorContainsAny:
       - "500 Internal Server Error"

--- a/test/e2e/mise_routing.go
+++ b/test/e2e/mise_routing.go
@@ -16,9 +16,7 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -61,16 +59,6 @@ func (p *miseVersionCapture) Do(req *policy.Request) (*http.Response, error) {
 // rules are always evaluated.
 var _ = Describe("MISE Routing", func() {
 	defer GinkgoRecover()
-
-	// AROSLSRE-718: MISE v2 pipeline steps temporarily disabled due to ARM regression
-	// rejecting Microsoft.Graph/applications@beta with the internal extension.
-	// This time bomb will start failing after the deadline to ensure re-enablement.
-	timeBombDeadline := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
-	BeforeEach(func() {
-		if time.Now().Before(timeBombDeadline) {
-			Skip(fmt.Sprintf("MISE v2 pipeline steps disabled due to ARM regression (AROSLSRE-718); skipping until %s", timeBombDeadline.Format(time.RFC3339)))
-		}
-	})
 
 	DescribeTable("routes to the correct frontend based on version header",
 		labels.RequireNothing,


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-718

### What

Revert #5022 to re-enable the `geneva-output` and `mise-output` pipeline steps in `svc-pipeline.yaml` and remove the time bomb skip from the MISE routing E2E test.

### Why

#5022 disabled these steps as a workaround for an ARM regression that started rejecting `Microsoft.Graph/applications@beta` with the internal extension (`1.0.0-internal`) on 2026-04-24.

This PR should be merged once the ARM/Microsoft Graph Service provider team resolves the regression.

### Context

- JIRA: https://redhat.atlassian.net/browse/AROSLSRE-718
- Sev3 incident opened with the Microsoft Graph Service ARM Provider team
- The issue is server-side, affecting multiple tenants and subscriptions
- Our `bicepconfig.json` uses `br:mcr.microsoft.com/bicep/extensions/microsoftgraph/internal/beta:1.0.0-internal` for SNI (`trustedSubjectNameAndIssuers`) support

### How to test

Once the ARM regression is fixed, remove the `/hold` and let CI run. The `e2e-parallel` provision-environment step should pass with `geneva-output` and `mise-output` executing successfully.

### Testing

- [ ] ARM regression confirmed fixed by Microsoft Graph team
- [ ] CI passes (e2e-parallel provision-environment step)