### PR TITLE
dev-infrastructure: restore inputVariables for istio-config step (AROSLSRE-718)

### DIFF
--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -344,21 +344,19 @@ resourceGroups:
       resourceGroup: global
       step: output
       name: globalMSIId
-    # AROSLSRE-718: inputVariables for geneva-output and mise-output temporarily
-    # disabled. Re-enable with the steps above.
-    # inputVariables:
-    #   genevaActionsAppId:
-    #     resourceGroup: global
-    #     step: geneva-output
-    #     name: appId
-    #   tenantId:
-    #     resourceGroup: global
-    #     step: geneva-output
-    #     name: tenantId
-    #   miseAppId:
-    #     resourceGroup: global
-    #     step: mise-output
-    #     name: appId
+    inputVariables:
+      genevaActionsAppId:
+        resourceGroup: global
+        step: geneva-output
+        name: appId
+      tenantId:
+        resourceGroup: global
+        step: geneva-output
+        name: tenantId
+      miseAppId:
+        resourceGroup: global
+        step: mise-output
+        name: appId
     automatedRetry:
       errorContainsAny:
       - "500 Internal Server Error"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-718

### What

Uncomment the \`inputVariables\` block in the \`istio-config\` pipeline step for \`genevaActionsAppId\`, \`tenantId\`, and \`miseAppId\`.

The \`geneva-output\` and \`mise-output\` pipeline steps remain disabled.

### Why

PR #5022 disabled the \`geneva-output\` and \`mise-output\` steps **and** commented out the \`inputVariables\` block that binds their outputs to the \`__miseAppId__\`, \`__genevaActionsAppId__\`, and \`__tenantId__\` placeholders in \`istio/values.yaml\`.

With the \`inputVariables\` commented out, the EV2 manifest resolver has no binding for the \`__placeholder__\` syntax and fails with:

\`\`\`
failed to create binding for miseAppId: failed to resolve config reference miseAppId: configuration: key miseAppId not found
\`\`\`

Restoring the \`inputVariables\` block provides the binding definitions. Even though the source steps are disabled, the resolver can resolve the references without error.

### Testing

- \`make -C hcp/ validate-aro-hcp-ev2-manifests\` in sdp-pipelines against this commit
- Helm template tests pass