### PR TITLE
Fix E2E cleanup: Force-delete managed RGs stuck in Deleting state

### DIFF
--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -507,9 +507,24 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 		managedResourceGroups, err = tc.waitForManagedResourceGroupsDeletion(ctx, resourceGroupName, 10*time.Minute)
 		if err != nil {
 			if len(managedResourceGroups) > 0 {
-				return fmt.Errorf("found %d managed resource groups left behind HCP clusters in %s: %v: %w", len(managedResourceGroups), resourceGroupName, managedResourceGroups, err)
+				ginkgo.GinkgoLogr.Info("managed resource groups still present after timeout, attempting force deletion",
+					"resourceGroup", resourceGroupName, "managedResourceGroups", managedResourceGroups)
+				// Force-delete remaining managed resource groups to unblock cleanup.
+				// This prevents resource groups from getting permanently stuck in "Deleting" state
+				// when the 10-minute wait timeout expires. See: AROSLSRE-642
+				for _, managedRG := range managedResourceGroups {
+					ginkgo.GinkgoLogr.Info("force-deleting managed resource group", "resourceGroup", managedRG, "parentResourceGroup", resourceGroupName)
+					if err := DeleteResourceGroup(ctx, resourceClientFactory.NewResourceGroupsClient(), networkClientFactory, managedRG, true, timeout); err != nil {
+						if isIgnorableResourceGroupCleanupError(err) {
+							ginkgo.GinkgoLogr.Info("ignoring not found resource group", "resourceGroup", managedRG)
+						} else {
+							return fmt.Errorf("failed to force-delete managed resource group %q: %w", managedRG, err)
+						}
+					}
+				}
+			} else {
+				return fmt.Errorf("failed waiting for managed resource group deletion in %s: %w", resourceGroupName, err)
 			}
-			return fmt.Errorf("failed waiting for managed resource group deletion in %s: %w", resourceGroupName, err)
 		}
 	} else {
 		ginkgo.GinkgoLogr.Info("no left behind managed resource groups found", "resourceGroup", resourceGroupName)


### PR DESCRIPTION
TEMPORARY MITIGATION for resource groups getting permanently stuck in Azure "Deleting" state, causing 100% failure rate in cleanup jobs.

When cleanupResourceGroup() times out waiting for managed resource groups to be deleted (after 10 minutes), it now attempts to force-delete them instead of returning an error immediately. This prevents RG accumulation and unblocks the periodic cleanup jobs while we investigate the root cause.

Uses the same force-deletion pattern as cleanupResourceGroupNoRP() with Azure ForceDeletionTypes for VMs/VMSSs.

This is a workaround that treats the symptom. The underlying issue of why Azure fails to complete RG deletion within 10 minutes needs separate investigation (blocked resources, permission issues, Azure API problems, etc).

[AROSLSRE-642](https://redhat.atlassian.net/browse/AROSLSRE-642)

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
