### PR TITLE
Skip missing clusters during cleanup.  Clusters that don't exist don't need maestro bundles.

### DIFF
--- a/backend/pkg/controllers/delete_orphaned_maestro_readonly_bundles_controller.go
+++ b/backend/pkg/controllers/delete_orphaned_maestro_readonly_bundles_controller.go
@@ -232,6 +232,9 @@ func (c *deleteOrphanedMaestroReadonlyBundles) mapServiceProviderClustersByProvi
 			// resource with a maestro bundle reference. If for some reason during the orphan calculation inbetween the first read of cosmos
 			// resources and the read in the Maestro api there's a new bundle in maestro, the second read of cosmos resources will catch that
 			// and prevent accidental deletion.
+			// We should also be able to skip the ServiceProviderCluster if the cluster associated with it does not exist anymore
+			// between the time the sync iteration started and this point. In that case it's correct that we eliminate the maestro readonly bundle
+			// in the API because the cluster is no longer there.
 			continue
 		}
 		if _, ok := maestroClientsByShard[shardID]; !ok {
@@ -258,6 +261,9 @@ func (c *deleteOrphanedMaestroReadonlyBundles) mapServiceProviderNodePoolsByProv
 			// resource with a maestro bundle reference. If for some reason during the orphan calculation inbetween the first read of cosmos
 			// resources and the read in the Maestro api there's a new bundle in maestro, the second read of cosmos resources will catch that
 			// and prevent accidental deletion.
+			// We should also be able to skip the ServiceProviderNodePool if the cluster associated with it does not exist anymore
+			// between the time the sync iteration started and this point. In that case it's correct that we eliminate the maestro readonly bundle
+			// in the API because the cluster is no longer there.
 			continue
 		}
 		if _, ok := maestroClientsByShard[shardID]; !ok {
@@ -444,13 +450,17 @@ func (c *deleteOrphanedMaestroReadonlyBundles) conditionallyDeleteOrphanReadonly
 }
 
 // clusterProvisionShardIDForServiceProviderCluster returns the Cluster Service provision shard ID for the cluster that owns the SPC.
-// skip is true when the parent cluster has no ClusterServiceID yet.
+// skip is true when the parent cluster has no ClusterServiceID yet or when the Cluster associated with the node pool does not exist anymore.
 func (c *deleteOrphanedMaestroReadonlyBundles) clusterProvisionShardIDForServiceProviderCluster(ctx context.Context, spc *api.ServiceProviderCluster) (shardID string, skip bool, err error) {
 	clusterResourceID := spc.ResourceID.Parent
 	if clusterResourceID == nil {
 		return "", false, utils.TrackError(fmt.Errorf("ServiceProviderCluster %s has no parent resource ID", spc.ResourceID.String()))
 	}
 	cluster, err := c.cosmosClient.HCPClusters(clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName).Get(ctx, clusterResourceID.Name)
+	if database.IsNotFoundError(err) {
+		// if the cluster does not exist, then any maestro resources associated with it are orphans.
+		return "", true, nil
+	}
 	if err != nil {
 		return "", false, utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}
@@ -458,7 +468,7 @@ func (c *deleteOrphanedMaestroReadonlyBundles) clusterProvisionShardIDForService
 }
 
 // clusterProvisionShardIDForServiceProviderNodePool returns the Cluster Service provision shard ID for the cluster that owns the node pool.
-// skip is true when the parent cluster has no ClusterServiceID yet.
+// skip is true when the parent cluster has no ClusterServiceID yet or when the Cluster associated with the node pool does not exist anymore.
 func (c *deleteOrphanedMaestroReadonlyBundles) clusterProvisionShardIDForServiceProviderNodePool(ctx context.Context, spnp *api.ServiceProviderNodePool) (shardID string, skip bool, err error) {
 	nodePoolResourceID := spnp.ResourceID.Parent
 	if nodePoolResourceID == nil {
@@ -469,6 +479,10 @@ func (c *deleteOrphanedMaestroReadonlyBundles) clusterProvisionShardIDForService
 		return "", false, utils.TrackError(fmt.Errorf("ServiceProviderNodePool %s has no grandparent cluster resource ID", spnp.ResourceID.String()))
 	}
 	cluster, err := c.cosmosClient.HCPClusters(clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName).Get(ctx, clusterResourceID.Name)
+	if database.IsNotFoundError(err) {
+		// if the cluster does not exist, then any maestro resources associated with it are orphans.
+		return "", true, nil
+	}
 	if err != nil {
 		return "", false, utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}

--- a/backend/pkg/controllers/delete_orphaned_maestro_readonly_bundles_controller_test.go
+++ b/backend/pkg/controllers/delete_orphaned_maestro_readonly_bundles_controller_test.go
@@ -551,6 +551,29 @@ func (g *orphanTestGlobalListersSPNPOnly) ServiceProviderNodePools() database.Gl
 
 var _ database.GlobalListers = (*orphanTestGlobalListersSPNPOnly)(nil)
 
+// hcpClusterGetErrorInjectingDBClient wraps a MockDBClient and forces HCPClusters().Get to return a configurable
+// non-NotFound error. Lets tests exercise the "real Get failure" path without modifying the in-memory mock.
+type hcpClusterGetErrorInjectingDBClient struct {
+	*databasetesting.MockDBClient
+	getErr error
+}
+
+func (e *hcpClusterGetErrorInjectingDBClient) HCPClusters(subscriptionID, resourceGroupName string) database.HCPClusterCRUD {
+	return &hcpClusterGetErrorInjectingCRUD{
+		HCPClusterCRUD: e.MockDBClient.HCPClusters(subscriptionID, resourceGroupName),
+		getErr:         e.getErr,
+	}
+}
+
+type hcpClusterGetErrorInjectingCRUD struct {
+	database.HCPClusterCRUD
+	getErr error
+}
+
+func (e *hcpClusterGetErrorInjectingCRUD) Get(_ context.Context, _ string) (*api.HCPOpenShiftCluster, error) {
+	return nil, e.getErr
+}
+
 func TestDeleteOrphanedMaestroReadonlyBundles_SyncOnce_ListServiceProviderClustersError(t *testing.T) {
 	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 	ctrl := gomock.NewController(t)
@@ -750,7 +773,10 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderClustersByProvis
 		{
 			name: "Get cluster error",
 			setup: func(ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, map[string]*shardMaestroClient, []*api.ServiceProviderCluster) {
-				mockDB := databasetesting.NewMockDBClient()
+				mockDB := &hcpClusterGetErrorInjectingDBClient{
+					MockDBClient: databasetesting.NewMockDBClient(),
+					getErr:       fmt.Errorf("boom"),
+				}
 				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 				spc := &api.ServiceProviderCluster{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
@@ -762,6 +788,23 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderClustersByProvis
 			},
 			wantErr:   true,
 			errSubstr: "failed to get Cluster",
+		},
+		{
+			name: "cluster not found is silently skipped so its bundles can be reaped as orphans",
+			setup: func(ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, map[string]*shardMaestroClient, []*api.ServiceProviderCluster) {
+				mockDB := databasetesting.NewMockDBClient()
+				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+				spc := &api.ServiceProviderCluster{
+					CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
+					ResourceID:     *spcResourceID,
+				}
+				return &deleteOrphanedMaestroReadonlyBundles{cosmosClient: mockDB, clusterServiceClient: mockCS},
+					map[string]*shardMaestroClient{"unused-shard": noopMaestroShardClient},
+					[]*api.ServiceProviderCluster{spc}
+			},
+			validateOut: func(t *testing.T, shardToSPCs map[string][]*api.ServiceProviderCluster) {
+				assert.Empty(t, shardToSPCs)
+			},
 		},
 		{
 			name: "Get provision shard error",
@@ -1043,7 +1086,10 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderNodePoolsByProvi
 		{
 			name: "Get cluster error",
 			setup: func(ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, map[string]*shardMaestroClient, []*api.ServiceProviderNodePool) {
-				mockDB := databasetesting.NewMockDBClient()
+				mockDB := &hcpClusterGetErrorInjectingDBClient{
+					MockDBClient: databasetesting.NewMockDBClient(),
+					getErr:       fmt.Errorf("boom"),
+				}
 				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 				spnp := &api.ServiceProviderNodePool{
 					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
@@ -1055,6 +1101,23 @@ func TestDeleteOrphanedMaestroReadonlyBundles_mapServiceProviderNodePoolsByProvi
 			},
 			wantErr:   true,
 			errSubstr: "failed to get Cluster",
+		},
+		{
+			name: "cluster not found is silently skipped so its bundles can be reaped as orphans",
+			setup: func(ctrl *gomock.Controller) (*deleteOrphanedMaestroReadonlyBundles, map[string]*shardMaestroClient, []*api.ServiceProviderNodePool) {
+				mockDB := databasetesting.NewMockDBClient()
+				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+				spnp := &api.ServiceProviderNodePool{
+					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
+					ResourceID:     *spnpResourceID,
+				}
+				return &deleteOrphanedMaestroReadonlyBundles{cosmosClient: mockDB, clusterServiceClient: mockCS},
+					map[string]*shardMaestroClient{"unused-shard": noopMaestroShardClient},
+					[]*api.ServiceProviderNodePool{spnp}
+			},
+			validateOut: func(t *testing.T, shardToSPNPs map[string][]*api.ServiceProviderNodePool) {
+				assert.Empty(t, shardToSPNPs)
+			},
 		},
 		{
 			name: "Get provision shard error",


### PR DESCRIPTION
Found by inspecting Backend Metrics for https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/5020/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2048471908730540032 This failure is happening during cleanup of delete orphaned maestro readonly bundles.

