### PR TITLE
Mark the cluster X.Y update operation as completed once the desired version is within the target minor and cluster service reports the cluster as ready

### DIFF
--- a/backend/pkg/controllers/controllerutils/util.go
+++ b/backend/pkg/controllers/controllerutils/util.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
-	"slices"
 
 	"github.com/go-logr/logr"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/utils"
+	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 )
 
 type Controller interface {
@@ -219,9 +219,11 @@ func ReportSyncError(syncErr error) controllerMutationFunc {
 	}
 }
 
-type initialControllerFunc func(controllerName string) *api.Controller
+// InitialControllerFunc builds a new api.Controller for the given logical controller name
+// (for example HCPClusterKey.InitialController).
+type InitialControllerFunc func(controllerName string) *api.Controller
 
-func DegradedControllerPanicHandler(ctx context.Context, controllerCRUD database.ResourceCRUD[api.Controller], controllerName string, initialControllerFn initialControllerFunc) func(interface{}) {
+func DegradedControllerPanicHandler(ctx context.Context, controllerCRUD database.ResourceCRUD[api.Controller], controllerName string, initialControllerFn InitialControllerFunc) func(interface{}) {
 	return func(panicVal interface{}) {
 		stack := debug.Stack()
 		err := WriteController(ctx, controllerCRUD, controllerName, initialControllerFn, ReportSyncError(fmt.Errorf("panic caught:\n%v\n\n%s", panicVal, stack)))
@@ -232,42 +234,118 @@ func DegradedControllerPanicHandler(ctx context.Context, controllerCRUD database
 	}
 }
 
+func controllerCRUDForParent(dbClient database.DBClient, parentResourceID *azcorearm.ResourceID) (database.ResourceCRUD[api.Controller], error) {
+	subscriptionID := parentResourceID.SubscriptionID
+	resourceGroupName := parentResourceID.ResourceGroupName
+	hcp := dbClient.HCPClusters(subscriptionID, resourceGroupName)
+
+	switch {
+	case armhelpers.ResourceTypeEqual(parentResourceID.ResourceType, api.ClusterResourceType):
+		return hcp.Controllers(parentResourceID.Name), nil
+	case armhelpers.ResourceTypeEqual(parentResourceID.ResourceType, api.NodePoolResourceType):
+		if parentResourceID.Parent == nil {
+			return nil, fmt.Errorf("node pool resource ID is missing parent cluster ID")
+		}
+		clusterName := parentResourceID.Parent.Name
+		return hcp.NodePools(clusterName).Controllers(parentResourceID.Name), nil
+	case armhelpers.ResourceTypeEqual(parentResourceID.ResourceType, api.ExternalAuthResourceType):
+		if parentResourceID.Parent == nil {
+			return nil, fmt.Errorf("external auth resource ID is missing parent cluster ID")
+		}
+		clusterName := parentResourceID.Parent.Name
+		return hcp.ExternalAuth(clusterName).Controllers(parentResourceID.Name), nil
+	default:
+		return nil, fmt.Errorf("unsupported parent resource type for controllers: %s", parentResourceID.ResourceType)
+	}
+}
+
+// getOrCreateControllerDocument returns the controller document from Cosmos, creating it with
+// initialControllerFn if missing. On create conflict (HTTP 409), it re-reads and returns the
+// existing document (same pattern as database.GetOrCreateServiceProviderCluster).
+func getOrCreateControllerDocument(
+	ctx context.Context,
+	controllerCRUD database.ResourceCRUD[api.Controller],
+	controllerName string,
+	initialControllerFn InitialControllerFunc,
+) (*api.Controller, error) {
+	if initialControllerFn == nil {
+		return nil, fmt.Errorf("initialControllerFn is required")
+	}
+
+	existingController, err := controllerCRUD.Get(ctx, controllerName)
+	if err == nil && existingController != nil {
+		return existingController, nil
+	}
+	if err == nil {
+		err = database.NewNotFoundError()
+	}
+
+	if !database.IsNotFoundError(err) {
+		return nil, fmt.Errorf("failed to get existing controller state: %w", err)
+	}
+
+	existingController, err = controllerCRUD.Create(ctx, initialControllerFn(controllerName), nil)
+	if err == nil {
+		if existingController == nil {
+			return nil, fmt.Errorf("create returned success with nil controller")
+		}
+		return existingController, nil
+	}
+
+	if !database.IsConflictError(err) {
+		return nil, fmt.Errorf("failed to create existing controller state: %w", err)
+	}
+
+	existingController, err = controllerCRUD.Get(ctx, controllerName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get existing controller state after create conflict: %w", err)
+	}
+	if existingController == nil {
+		return nil, fmt.Errorf("failed to get existing controller state after create conflict: document missing")
+	}
+
+	return existingController, nil
+}
+
+// GetOrCreateController gets the named Controller document under the given parent resource
+// (cluster, node pool, or external auth). If it does not exist, it creates one using initialControllerFn.
+// On create conflict (HTTP 409), it re-reads and returns the existing document (same pattern as
+// database.GetOrCreateServiceProviderCluster).
+func GetOrCreateController(
+	ctx context.Context, dbClient database.DBClient, parentResourceID *azcorearm.ResourceID,
+	controllerName string, initialControllerFn InitialControllerFunc,
+) (*api.Controller, error) {
+	controllerCRUD, err := controllerCRUDForParent(dbClient, parentResourceID)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+
+	doc, err := getOrCreateControllerDocument(ctx, controllerCRUD, controllerName, initialControllerFn)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	return doc, nil
+}
+
 // WriteController will read the existing value, call the mutations in order, then write the result.  It only tries *once*.
 // If it fails, then the an error is returned.  This detail is important, it doesn't even retry conflicts.  This is so that
 // if a failure happens the control-loop will re-run and restablish the information it was trying to write as valid.
 // This prevents accidental recreation of controller instances in cosmos during a delete.
-func WriteController(ctx context.Context, controllerCRUD database.ResourceCRUD[api.Controller], controllerName string, initialControllerFn initialControllerFunc, mutationFns ...controllerMutationFunc) error {
+func WriteController(ctx context.Context, controllerCRUD database.ResourceCRUD[api.Controller], controllerName string, initialControllerFn InitialControllerFunc, mutationFns ...controllerMutationFunc) error {
 	logger := utils.LoggerFromContext(ctx)
 
-	existingController, err := controllerCRUD.Get(ctx, controllerName)
-	if err != nil && !database.IsNotFoundError(err) {
-		return fmt.Errorf("failed to get existing controller state: %w", err)
+	existingController, err := getOrCreateControllerDocument(ctx, controllerCRUD, controllerName, initialControllerFn)
+	if err != nil {
+		return err
 	}
 
-	var desiredController *api.Controller
-	if existingController == nil { // fill in for conveniently avoiding NPEs
-		desiredController = initialControllerFn(controllerName)
-	} else {
-		// TODO we'd prefer a DeepCopy, but we don't have one yet.
-		temp := *existingController
-		desiredController = &temp
-		desiredController.Status.Conditions = slices.Clone(existingController.Status.Conditions)
-	}
+	desiredController := existingController.DeepCopy()
 	for _, mutationFn := range mutationFns {
 		mutationFn(desiredController)
 	}
 
 	if equality.Semantic.DeepEqual(existingController, desiredController) {
 		// nothing to report.
-		return nil
-	}
-
-	if existingController == nil {
-		_, createErr := controllerCRUD.Create(ctx, desiredController, nil)
-		if createErr != nil {
-			logger.Error(createErr, "failed to create")
-			return fmt.Errorf("failed to create existing controller state: %w", createErr)
-		}
 		return nil
 	}
 

--- a/backend/pkg/controllers/controllerutils/util_test.go
+++ b/backend/pkg/controllers/controllerutils/util_test.go
@@ -50,7 +50,7 @@ func (f *fakeControllerCRUD) Get(ctx context.Context, resourceID string) (*api.C
 	if c, ok := f.controllers[resourceID]; ok {
 		return c, nil
 	}
-	return nil, nil
+	return nil, database.NewNotFoundError()
 }
 
 func (f *fakeControllerCRUD) List(ctx context.Context, opts *database.DBClientListResourceDocsOptions) (database.DBClientIterator[api.Controller], error) {

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -146,53 +146,6 @@ func (c *operationClusterCreate) SynchronizeOperation(ctx context.Context, key c
 	return nil
 }
 
-type operationState struct {
-	provisioningState arm.ProvisioningState
-	message           string
-}
-
-func newOperationState(provisioningState arm.ProvisioningState, message string) *operationState {
-	return &operationState{
-		provisioningState: provisioningState,
-		message:           message,
-	}
-}
-
-// provisioningStatePriority is a logical merge order that decides what the most important state to return is.
-// for instance, if one check is succeeded, one is failed, and one is accepted, then failed is the most
-// reasonable state for the operation.
-var provisioningStatePriority = map[arm.ProvisioningState]int{
-	"":                                  -1, // causes an error
-	arm.ProvisioningStateFailed:         00, // always first if present in list
-	arm.ProvisioningStateCanceled:       10,
-	arm.ProvisioningStateDeleting:       20,
-	arm.ProvisioningStateProvisioning:   30,
-	arm.ProvisioningStateAwaitingSecret: 35,
-	arm.ProvisioningStateUpdating:       40,
-	arm.ProvisioningStateAccepted:       50,
-	arm.ProvisioningStateSucceeded:      100, // hardest to get if present
-}
-
-func compareOperationState(lhs, rhs *operationState) int {
-	if lhs == nil && rhs == nil {
-		return 0
-	}
-	if lhs == nil {
-		return -1
-	}
-	if rhs == nil {
-		return 1
-	}
-
-	if provisioningStatePriority[lhs.provisioningState] < provisioningStatePriority[rhs.provisioningState] {
-		return -1
-	}
-	if provisioningStatePriority[lhs.provisioningState] > provisioningStatePriority[rhs.provisioningState] {
-		return 1
-	}
-	return strings.Compare(lhs.message, rhs.message)
-}
-
 func (c *operationClusterCreate) determineOperationStatus(ctx context.Context, operation *api.Operation) (*operationState, error) {
 	logger := utils.LoggerFromContext(ctx)
 
@@ -217,19 +170,19 @@ func (c *operationClusterCreate) determineOperationStatus(ctx context.Context, o
 	if len(operationStates) == 0 {
 		return nil, errors.New("no operation states")
 	}
-
 	slices.SortStableFunc(operationStates, compareOperationState)
+
 	if operationStates[0] == nil {
 		return nil, errors.New("nil operation state")
 	}
-	if len(operationStates[0].provisioningState) == 0 {
-		return nil, errors.New("empty provisioning state")
+	logger.Info("determined cluster create operation status", "operationStates", operationStates)
+
+	picked, err := pickWorstOperationState(operationStates)
+	if err != nil {
+		return nil, utils.TrackError(err)
 	}
-	logger.Info("determined operation status", "operationStates", operationStates)
-
-	// TODO, do a nicer job of combining different states with the same provisioningState
-
-	return operationStates[0], nil
+	logger.Info("picked cluster create operation status", "provisioningState", picked.provisioningState, "message", picked.message)
+	return picked, nil
 }
 
 func (c *operationClusterCreate) clusterOperationStatus(ctx context.Context, operation *api.Operation) (*operationState, error) {

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
@@ -219,53 +219,6 @@ func newClusterWithAPIURL(url string) *api.HCPOpenShiftCluster {
 	return cluster
 }
 
-func TestCompareOperationState(t *testing.T) {
-	tests := []struct {
-		name     string
-		lhs      *operationState
-		rhs      *operationState
-		expected int
-	}{
-		{
-			name:     "both nil",
-			lhs:      nil,
-			rhs:      nil,
-			expected: 0,
-		},
-		{
-			name:     "lhs nil",
-			lhs:      nil,
-			rhs:      newOperationState(arm.ProvisioningStateSucceeded, ""),
-			expected: -1,
-		},
-		{
-			name:     "rhs nil",
-			lhs:      newOperationState(arm.ProvisioningStateSucceeded, ""),
-			rhs:      nil,
-			expected: 1,
-		},
-		{
-			name:     "Succeeded > Provisioning",
-			lhs:      newOperationState(arm.ProvisioningStateSucceeded, ""),
-			rhs:      newOperationState(arm.ProvisioningStateProvisioning, ""),
-			expected: 1,
-		},
-		{
-			name:     "Deleting < Provisioning",
-			lhs:      newOperationState(arm.ProvisioningStateDeleting, ""),
-			rhs:      newOperationState(arm.ProvisioningStateProvisioning, ""),
-			expected: -1,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := compareOperationState(tt.lhs, tt.rhs)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestDetermineOperationStatus(t *testing.T) {
 	fixture := newClusterTestFixture()
 	operation := fixture.newOperation(database.OperationRequestCreate)

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
@@ -28,6 +28,8 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/clock"
+	"k8s.io/utils/lru"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -38,9 +40,11 @@ import (
 )
 
 type operationClusterUpdate struct {
-	cosmosClient         database.DBClient
-	clusterServiceClient ocm.ClusterServiceClientSpec
-	notificationClient   *http.Client
+	cosmosClient                    database.DBClient
+	clusterServiceClient            ocm.ClusterServiceClientSpec
+	notificationClient              *http.Client
+	clock                           clock.PassiveClock
+	desiredVersionMismatchFirstSeen *lru.Cache
 }
 
 // NewOperationClusterUpdateController periodically lists all clusters and for each out when the cluster was created and its state.
@@ -51,9 +55,11 @@ func NewOperationClusterUpdateController(
 	activeOperationInformer cache.SharedIndexInformer,
 ) controllerutils.Controller {
 	syncer := &operationClusterUpdate{
-		cosmosClient:         cosmosClient,
-		clusterServiceClient: clusterServiceClient,
-		notificationClient:   notificationClient,
+		cosmosClient:                    cosmosClient,
+		clusterServiceClient:            clusterServiceClient,
+		notificationClient:              notificationClient,
+		clock:                           clock.RealClock{},
+		desiredVersionMismatchFirstSeen: lru.New(100000),
 	}
 
 	controller := NewGenericOperationController(
@@ -176,6 +182,7 @@ func (c *operationClusterUpdate) desiredVersionResolutionOperationState(ctx cont
 
 	if customerDesiredVersion.Major == resultingDesiredVersion.Major &&
 		customerDesiredVersion.Minor == resultingDesiredVersion.Minor {
+		c.desiredVersionMismatchFirstSeen.Remove(operation.ResourceID.String())
 		return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
 	}
 	clusterKey := controllerutils.HCPClusterKey{
@@ -195,8 +202,28 @@ func (c *operationClusterUpdate) desiredVersionResolutionOperationState(ctx cont
 	}
 	intentFailedCondition := apimeta.FindStatusCondition(controllerDoc.Status.Conditions, api.ControllerConditionTypeIntentFailed)
 	if intentFailedCondition == nil || intentFailedCondition.Status != metav1.ConditionTrue || intentFailedCondition.Reason != api.VersionUpgradeNotAcceptedReason {
-		return nil, utils.TrackError(fmt.Errorf("customer desired version does not match resolved desired version"))
+		// Customer desired minor differs from the service provider resolved version, and the
+		// ControlPlaneDesiredVersion controller has not yet set IntentFailed (VersionUpgradeNotAccepted).
+		// Stay Accepted while resolution runs; fail once elapsed exceeds 29s from the first
+		// time this process observed the mismatch for this operation, so a
+		// controller restart does not immediately fail long-running operations.
+		pending := newOperationState(arm.ProvisioningStateAccepted, "customer desired version does not match resolved desired version")
+		firstSeen, ok := c.desiredVersionMismatchFirstSeen.Get(operation.ResourceID.String())
+		if !ok {
+			c.desiredVersionMismatchFirstSeen.Add(operation.ResourceID.String(), c.clock.Now())
+			return pending, nil
+		}
+		if c.clock.Since(firstSeen.(time.Time)) <= 29*time.Second {
+			return pending, nil
+		}
+		msg := fmt.Sprintf(
+			"timed out after 29s waiting for resolution of desired version from '%s' cluster version",
+			existingCluster.CustomerProperties.Version.ID,
+		)
+		c.desiredVersionMismatchFirstSeen.Remove(operation.ResourceID.String())
+		return newOperationState(arm.ProvisioningStateFailed, msg), nil
 	}
+	c.desiredVersionMismatchFirstSeen.Remove(operation.ResourceID.String())
 	return newOperationState(arm.ProvisioningStateFailed, intentFailedCondition.Message), nil
 }
 

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
@@ -16,15 +16,22 @@ package operationcontrollers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -93,20 +100,107 @@ func (c *operationClusterUpdate) SynchronizeOperation(ctx context.Context, key c
 		return nil
 	}
 
+	operationalState, err := c.determineOperationState(ctx, operation)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	var persistErr *arm.CloudErrorBody
+	if operationalState.provisioningState == arm.ProvisioningStateFailed {
+		persistErr = &arm.CloudErrorBody{
+			Code:    arm.CloudErrorCodeInvalidRequestContent,
+			Message: operationalState.message,
+		}
+	}
+
+	logger.Info("updating status")
+	if err := UpdateOperationStatus(ctx, c.cosmosClient, operation, operationalState.provisioningState, persistErr, postAsyncNotificationFn(c.notificationClient)); err != nil {
+		return utils.TrackError(err)
+	}
+	return nil
+}
+
+func (c *operationClusterUpdate) determineOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {
+	logger := utils.LoggerFromContext(ctx)
+	errs := []error{}
+	operationStates := []*operationState{}
+
+	if operationState, err := c.desiredVersionResolutionOperationState(ctx, operation); err != nil {
+		errs = append(errs, utils.TrackError(err))
+	} else {
+		operationStates = append(operationStates, operationState)
+	}
+	if operationState, csErr := c.clusterServiceUpdateOperationState(ctx, operation); csErr != nil {
+		errs = append(errs, utils.TrackError(csErr))
+	} else {
+		operationStates = append(operationStates, operationState)
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+	if len(operationStates) == 0 {
+		return nil, utils.TrackError(fmt.Errorf("no operation states"))
+	}
+	slices.SortStableFunc(operationStates, compareOperationState)
+	if operationStates[0] == nil {
+		return nil, errors.New("nil operation state")
+	}
+	logger.Info("determined cluster update operation status", "operationStates", operationStates)
+	picked, err := pickWorstOperationState(operationStates)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	logger.Info("picked cluster update operation status", "provisioningState", picked.provisioningState, "message", picked.message)
+	return picked, nil
+}
+
+func (c *operationClusterUpdate) desiredVersionResolutionOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {
+	existingCluster, err := c.cosmosClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).Get(ctx, operation.ExternalID.Name)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	existingServiceProviderCluster, err := c.cosmosClient.ServiceProviderClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Name).Get(ctx, api.ServiceProviderClusterResourceName)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	resultingDesiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
+	if resultingDesiredVersion == nil {
+		return nil, utils.TrackError(fmt.Errorf("service provider cluster has no desired version"))
+	}
+
+	customerDesiredVersion, err := semver.ParseTolerant(existingCluster.CustomerProperties.Version.ID)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+
+	if customerDesiredVersion.Major == resultingDesiredVersion.Major &&
+		customerDesiredVersion.Minor == resultingDesiredVersion.Minor {
+		return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+	}
+	existingDegraded := apimeta.FindStatusCondition(existingServiceProviderCluster.Status.Conditions,
+		api.DegradedCondition)
+	if existingDegraded != nil && existingDegraded.Status == metav1.ConditionTrue &&
+		existingDegraded.Reason == api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted {
+		return newOperationState(arm.ProvisioningStateFailed, existingDegraded.Message), nil
+	}
+	return nil, utils.TrackError(fmt.Errorf("customer desired version does not match resolved desired version"))
+}
+
+func (c *operationClusterUpdate) clusterServiceUpdateOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {
+	logger := utils.LoggerFromContext(ctx)
 	clusterStatus, err := c.clusterServiceClient.GetClusterStatus(ctx, operation.InternalID)
 	if err != nil {
-		return utils.TrackError(err)
+		return nil, utils.TrackError(err)
 	}
-
 	newOperationStatus, opError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus)
 	if err != nil {
-		return utils.TrackError(err)
+		return nil, utils.TrackError(err)
 	}
-
-	err = UpdateOperationStatus(ctx, c.cosmosClient, operation, newOperationStatus, opError, postAsyncNotificationFn(c.notificationClient))
-	if err != nil {
-		return utils.TrackError(err)
+	logger.Info("new status via cluster-service", "newStatus", newOperationStatus, "newOperationError", opError)
+	msg := ""
+	if opError != nil {
+		msg = opError.Message
 	}
-
-	return nil
+	return newOperationState(newOperationStatus, msg), nil
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
@@ -140,7 +140,7 @@ func (c *operationClusterUpdate) determineOperationState(ctx context.Context, op
 		return nil, err
 	}
 	if len(operationStates) == 0 {
-		return nil, utils.TrackError(fmt.Errorf("no operation states"))
+		return nil, errors.New("no operation states")
 	}
 	slices.SortStableFunc(operationStates, compareOperationState)
 	if operationStates[0] == nil {
@@ -178,13 +178,26 @@ func (c *operationClusterUpdate) desiredVersionResolutionOperationState(ctx cont
 		customerDesiredVersion.Minor == resultingDesiredVersion.Minor {
 		return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
 	}
-	existingDegraded := apimeta.FindStatusCondition(existingServiceProviderCluster.Status.Conditions,
-		api.DegradedCondition)
-	if existingDegraded != nil && existingDegraded.Status == metav1.ConditionTrue &&
-		existingDegraded.Reason == api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted {
-		return newOperationState(arm.ProvisioningStateFailed, existingDegraded.Message), nil
+	clusterKey := controllerutils.HCPClusterKey{
+		SubscriptionID:    operation.ExternalID.SubscriptionID,
+		ResourceGroupName: operation.ExternalID.ResourceGroupName,
+		HCPClusterName:    operation.ExternalID.Name,
 	}
-	return nil, utils.TrackError(fmt.Errorf("customer desired version does not match resolved desired version"))
+	controllerDoc, getControllerErr := controllerutils.GetOrCreateController(
+		ctx,
+		c.cosmosClient,
+		operation.ExternalID,
+		"ControlPlaneDesiredVersion",
+		clusterKey.InitialController,
+	)
+	if getControllerErr != nil {
+		return nil, utils.TrackError(getControllerErr)
+	}
+	intentFailedCondition := apimeta.FindStatusCondition(controllerDoc.Status.Conditions, api.ControllerConditionTypeIntentFailed)
+	if intentFailedCondition == nil || intentFailedCondition.Status != metav1.ConditionTrue || intentFailedCondition.Reason != api.VersionUpgradeNotAcceptedReason {
+		return nil, utils.TrackError(fmt.Errorf("customer desired version does not match resolved desired version"))
+	}
+	return newOperationState(arm.ProvisioningStateFailed, intentFailedCondition.Message), nil
 }
 
 func (c *operationClusterUpdate) clusterServiceUpdateOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr/testr"
@@ -26,6 +27,8 @@ import (
 	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+	"k8s.io/utils/lru"
 	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -41,20 +44,20 @@ import (
 )
 
 func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
+	t.Parallel()
+	testClockNow := mustParseTime("2024-06-01T12:00:00Z")
 	tests := []struct {
 		name                                           string
 		clusterState                                   arohcpv1alpha1.ClusterState
-		expectError                                    bool
-		wantErrContains                                string
 		customerVersionID                              string
 		serviceProviderClusterStatusConditions         []metav1.Condition
 		controlPlaneDesiredVersionControllerConditions []metav1.Condition
+		seedMismatchFirstSeenAt                        time.Time
 		verify                                         func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture)
 	}{
 		{
 			name:              "cluster ready transitions operation to succeeded",
 			clusterState:      arohcpv1alpha1.ClusterStateReady,
-			expectError:       false,
 			customerVersionID: "4.19",
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
@@ -70,7 +73,6 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 		{
 			name:              "cluster updating transitions operation to updating",
 			clusterState:      arohcpv1alpha1.ClusterStateUpdating,
-			expectError:       false,
 			customerVersionID: "4.19",
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
@@ -86,7 +88,6 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 		{
 			name:              "cluster error transitions operation to failed",
 			clusterState:      arohcpv1alpha1.ClusterStateError,
-			expectError:       false,
 			customerVersionID: "4.19",
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
@@ -103,7 +104,6 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 		{
 			name:              "cluster pending keeps operation accepted",
 			clusterState:      arohcpv1alpha1.ClusterStatePending,
-			expectError:       false,
 			customerVersionID: "4.19",
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
@@ -140,8 +140,6 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 		{
 			name:              "customer minor mismatch without ControlPlaneDesiredVersion IntentFailed leaves operation accepted",
 			clusterState:      arohcpv1alpha1.ClusterStateReady,
-			expectError:       true,
-			wantErrContains:   "customer desired version does not match resolved desired version",
 			customerVersionID: "4.20",
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
@@ -155,10 +153,52 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 				assert.Empty(t, cluster.ServiceProviderProperties.ProvisioningState)
 			},
 		},
+		{
+			name:                    "customer minor mismatch without ControlPlaneDesiredVersion IntentFailed leaves operation accepted when first seen within 29s",
+			clusterState:            arohcpv1alpha1.ClusterStateReady,
+			customerVersionID:       "4.20",
+			seedMismatchFirstSeenAt: testClockNow.Add(-20 * time.Second),
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+				assert.Nil(t, op.Error)
+
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.Equal(t, testOperationName, cluster.ServiceProviderProperties.ActiveOperationID)
+				assert.Empty(t, cluster.ServiceProviderProperties.ProvisioningState)
+			},
+		},
+		{
+			name:                    "customer minor mismatch without IntentFailed fails when mismatch first seen exceeds 29s",
+			clusterState:            arohcpv1alpha1.ClusterStateReady,
+			customerVersionID:       "4.20",
+			seedMismatchFirstSeenAt: testClockNow.Add(-30 * time.Second),
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
+				require.NotNil(t, op.Error)
+				assert.Equal(t, arm.CloudErrorCodeInvalidRequestContent, op.Error.Code)
+
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				wantMsg := fmt.Sprintf(
+					"timed out after 29s waiting for resolution of desired version from '%s' cluster version",
+					cluster.CustomerProperties.Version.ID,
+				)
+				assert.Equal(t, wantMsg, op.Error.Message)
+
+				assert.Equal(t, arm.ProvisioningStateFailed, cluster.ServiceProviderProperties.ProvisioningState)
+				assert.Empty(t, cluster.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			ctx = utils.ContextWithLogger(ctx, testr.New(t))
 			ctrl := gomock.NewController(t)
@@ -212,21 +252,20 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 				GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
 				Return(clusterStatus, nil)
 
+			fakeClock := clocktesting.NewFakeClock(testClockNow)
 			controller := &operationClusterUpdate{
-				cosmosClient:         mockDB,
-				clusterServiceClient: mockCSClient,
-				notificationClient:   nil,
+				cosmosClient:                    mockDB,
+				clusterServiceClient:            mockCSClient,
+				notificationClient:              nil,
+				clock:                           fakeClock,
+				desiredVersionMismatchFirstSeen: lru.New(100000),
+			}
+			if !tt.seedMismatchFirstSeenAt.IsZero() {
+				controller.desiredVersionMismatchFirstSeen.Add(operation.ResourceID.String(), tt.seedMismatchFirstSeenAt)
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
-
-			if tt.expectError {
-				require.Error(t, err)
-				require.NotEmpty(t, tt.wantErrContains, "wantErrContains must be set when expectError is true")
-				assert.Contains(t, err.Error(), tt.wantErrContains)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, err)
 
 			if tt.verify != nil {
 				tt.verify(t, ctx, mockDB, fixture)

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
@@ -42,13 +42,14 @@ import (
 
 func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 	tests := []struct {
-		name                                   string
-		clusterState                           arohcpv1alpha1.ClusterState
-		expectError                            bool
-		wantErrContains                        string
-		customerVersionID                      string
-		serviceProviderClusterStatusConditions []metav1.Condition
-		verify                                 func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture)
+		name                                           string
+		clusterState                                   arohcpv1alpha1.ClusterState
+		expectError                                    bool
+		wantErrContains                                string
+		customerVersionID                              string
+		serviceProviderClusterStatusConditions         []metav1.Condition
+		controlPlaneDesiredVersionControllerConditions []metav1.Condition
+		verify                                         func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture)
 	}{
 		{
 			name:              "cluster ready transitions operation to succeeded",
@@ -111,14 +112,14 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:              "customer minor mismatch with VersionUpgradeNotAccepted Degraded marks operation failed",
+			name:              "customer minor mismatch with IntentFailed on ControlPlaneDesiredVersion controller marks operation failed",
 			clusterState:      arohcpv1alpha1.ClusterStateReady,
 			customerVersionID: "4.20",
-			serviceProviderClusterStatusConditions: []metav1.Condition{
+			controlPlaneDesiredVersionControllerConditions: []metav1.Condition{
 				{
-					Type:    api.DegradedCondition,
+					Type:    api.ControllerConditionTypeIntentFailed,
 					Status:  metav1.ConditionTrue,
-					Reason:  api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted,
+					Reason:  api.VersionUpgradeNotAcceptedReason,
 					Message: "no downgrades allowed",
 				},
 			},
@@ -137,7 +138,7 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:              "customer minor mismatch without VersionUpgradeNotAccepted leaves operation accepted",
+			name:              "customer minor mismatch without ControlPlaneDesiredVersion IntentFailed leaves operation accepted",
 			clusterState:      arohcpv1alpha1.ClusterStateReady,
 			expectError:       true,
 			wantErrContains:   "customer desired version does not match resolved desired version",
@@ -175,7 +176,7 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 				api.ServiceProviderClusterResourceName,
 			)))
 
-			spc := &api.ServiceProviderCluster{
+			_, err = mockDB.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, &api.ServiceProviderCluster{
 				CosmosMetadata: api.CosmosMetadata{ResourceID: resourceId},
 				ResourceID:     *resourceId,
 				Spec: api.ServiceProviderClusterSpec{
@@ -186,8 +187,20 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 				Status: api.ServiceProviderClusterStatus{
 					Conditions: tt.serviceProviderClusterStatusConditions,
 				},
-			}
-			_, err = mockDB.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, spc, nil)
+			}, nil)
+			require.NoError(t, err)
+
+			rid := api.Must(azcorearm.ParseResourceID(
+				fixture.clusterResourceID.String() + "/hcpOpenShiftControllers/ControlPlaneDesiredVersion",
+			))
+			_, err = mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).Controllers(testClusterName).Create(ctx, &api.Controller{
+				CosmosMetadata: api.CosmosMetadata{ResourceID: rid},
+				ResourceID:     rid,
+				ExternalID:     fixture.clusterResourceID,
+				Status: api.ControllerStatus{
+					Conditions: tt.controlPlaneDesiredVersionControllerConditions,
+				},
+			}, nil)
 			require.NoError(t, err)
 
 			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
@@ -16,15 +16,23 @@ package operationcontrollers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
@@ -34,21 +42,24 @@ import (
 
 func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 	tests := []struct {
-		name         string
-		clusterState arohcpv1alpha1.ClusterState
-		expectError  bool
-		verify       func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture)
+		name                                   string
+		clusterState                           arohcpv1alpha1.ClusterState
+		expectError                            bool
+		wantErrContains                        string
+		customerVersionID                      string
+		serviceProviderClusterStatusConditions []metav1.Condition
+		verify                                 func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture)
 	}{
 		{
-			name:         "cluster ready transitions to succeeded",
-			clusterState: arohcpv1alpha1.ClusterStateReady,
-			expectError:  false,
+			name:              "cluster ready transitions operation to succeeded",
+			clusterState:      arohcpv1alpha1.ClusterStateReady,
+			expectError:       false,
+			customerVersionID: "4.19",
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
 
-				// Verify cluster provisioning state was also updated
 				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, cluster.ServiceProviderProperties.ProvisioningState)
@@ -56,15 +67,15 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:         "cluster updating transitions to updating",
-			clusterState: arohcpv1alpha1.ClusterStateUpdating,
-			expectError:  false,
+			name:              "cluster updating transitions operation to updating",
+			clusterState:      arohcpv1alpha1.ClusterStateUpdating,
+			expectError:       false,
+			customerVersionID: "4.19",
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
 
-				// Verify cluster still has active operation
 				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateUpdating, cluster.ServiceProviderProperties.ProvisioningState)
@@ -72,16 +83,16 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:         "cluster error transitions to failed",
-			clusterState: arohcpv1alpha1.ClusterStateError,
-			expectError:  false,
+			name:              "cluster error transitions operation to failed",
+			clusterState:      arohcpv1alpha1.ClusterStateError,
+			expectError:       false,
+			customerVersionID: "4.19",
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
 				assert.NotNil(t, op.Error)
 
-				// Verify cluster also shows failed
 				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateFailed, cluster.ServiceProviderProperties.ProvisioningState)
@@ -89,13 +100,58 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:         "cluster pending stays accepted",
-			clusterState: arohcpv1alpha1.ClusterStatePending,
-			expectError:  false,
+			name:              "cluster pending keeps operation accepted",
+			clusterState:      arohcpv1alpha1.ClusterStatePending,
+			expectError:       false,
+			customerVersionID: "4.19",
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:              "customer minor mismatch with VersionUpgradeNotAccepted Degraded marks operation failed",
+			clusterState:      arohcpv1alpha1.ClusterStateReady,
+			customerVersionID: "4.20",
+			serviceProviderClusterStatusConditions: []metav1.Condition{
+				{
+					Type:    api.DegradedCondition,
+					Status:  metav1.ConditionTrue,
+					Reason:  api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted,
+					Message: "no downgrades allowed",
+				},
+			},
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
+				require.NotNil(t, op.Error)
+				assert.Equal(t, arm.CloudErrorCodeInvalidRequestContent, op.Error.Code)
+				assert.Contains(t, op.Error.Message, "no downgrades allowed")
+
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateFailed, cluster.ServiceProviderProperties.ProvisioningState)
+				assert.Empty(t, cluster.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
+		{
+			name:              "customer minor mismatch without VersionUpgradeNotAccepted leaves operation accepted",
+			clusterState:      arohcpv1alpha1.ClusterStateReady,
+			expectError:       true,
+			wantErrContains:   "customer desired version does not match resolved desired version",
+			customerVersionID: "4.20",
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockDBClient, fixture *clusterTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+				assert.Nil(t, op.Error)
+
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.Equal(t, testOperationName, cluster.ServiceProviderProperties.ActiveOperationID)
+				assert.Empty(t, cluster.ServiceProviderProperties.ProvisioningState)
 			},
 		},
 	}
@@ -105,13 +161,33 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			ctx := context.Background()
 			ctx = utils.ContextWithLogger(ctx, testr.New(t))
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			fixture := newClusterTestFixture()
 			cluster := fixture.newCluster(nil)
+			cluster.CustomerProperties.Version.ID = tt.customerVersionID
 			operation := fixture.newOperation(database.OperationRequestUpdate)
 
 			mockDB, err := databasetesting.NewMockDBClientWithResources(ctx, []any{cluster, operation})
+			require.NoError(t, err)
+			resourceId := api.Must(azcorearm.ParseResourceID(fmt.Sprintf("%s/%s/%s",
+				fixture.clusterResourceID.String(),
+				api.ServiceProviderClusterResourceTypeName,
+				api.ServiceProviderClusterResourceName,
+			)))
+
+			spc := &api.ServiceProviderCluster{
+				CosmosMetadata: api.CosmosMetadata{ResourceID: resourceId},
+				ResourceID:     *resourceId,
+				Spec: api.ServiceProviderClusterSpec{
+					ControlPlaneVersion: api.ServiceProviderClusterSpecVersion{
+						DesiredVersion: ptr.To(semver.MustParse("4.19.0")),
+					},
+				},
+				Status: api.ServiceProviderClusterStatus{
+					Conditions: tt.serviceProviderClusterStatusConditions,
+				},
+			}
+			_, err = mockDB.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, spc, nil)
 			require.NoError(t, err)
 
 			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
@@ -119,7 +195,6 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 				State(tt.clusterState).
 				Build()
 			require.NoError(t, err)
-
 			mockCSClient.EXPECT().
 				GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
 				Return(clusterStatus, nil)
@@ -134,6 +209,8 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 
 			if tt.expectError {
 				require.Error(t, err)
+				require.NotEmpty(t, tt.wantErrContains, "wantErrContains must be set when expectError is true")
+				assert.Contains(t, err.Error(), tt.wantErrContains)
 			} else {
 				require.NoError(t, err)
 			}

--- a/backend/pkg/controllers/operationcontrollers/operation_state.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_state.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationcontrollers
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+type operationState struct {
+	provisioningState arm.ProvisioningState
+	message           string
+}
+
+func newOperationState(provisioningState arm.ProvisioningState, message string) *operationState {
+	return &operationState{
+		provisioningState: provisioningState,
+		message:           message,
+	}
+}
+
+// provisioningStatePriority is a logical merge order that decides what the most important state to return is.
+// For instance, if one check is succeeded, one is failed, and one is accepted, then failed is the most
+// reasonable state for the operation.
+var provisioningStatePriority = map[arm.ProvisioningState]int{
+	"":                                  -1, // causes an error
+	arm.ProvisioningStateFailed:         0,
+	arm.ProvisioningStateCanceled:       10,
+	arm.ProvisioningStateDeleting:       20,
+	arm.ProvisioningStateProvisioning:   30,
+	arm.ProvisioningStateAwaitingSecret: 35,
+	arm.ProvisioningStateUpdating:       40,
+	arm.ProvisioningStateAccepted:       50,
+	arm.ProvisioningStateSucceeded:      100,
+}
+
+func compareOperationState(lhs, rhs *operationState) int {
+	if lhs == nil && rhs == nil {
+		return 0
+	}
+	if lhs == nil {
+		return -1
+	}
+	if rhs == nil {
+		return 1
+	}
+
+	if provisioningStatePriority[lhs.provisioningState] < provisioningStatePriority[rhs.provisioningState] {
+		return -1
+	}
+	if provisioningStatePriority[lhs.provisioningState] > provisioningStatePriority[rhs.provisioningState] {
+		return 1
+	}
+	return strings.Compare(lhs.message, rhs.message)
+}
+
+// pickWorstOperationState expects states pre-sorted and returns the worst state with merged messages.
+func pickWorstOperationState(states []*operationState) (*operationState, error) {
+	if len(states) == 0 {
+		return nil, errors.New("no operation states")
+	}
+	worstProvisioningState := states[0].provisioningState
+	if len(worstProvisioningState) == 0 {
+		return nil, errors.New("empty provisioning state")
+	}
+	var messageParts []string
+	for _, s := range states {
+		if s.provisioningState != worstProvisioningState {
+			break
+		}
+		messageParts = append(messageParts, s.message)
+	}
+	return newOperationState(worstProvisioningState, strings.Join(messageParts, "; ")), nil
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_state_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_state_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationcontrollers
+
+import (
+	"testing"
+
+	"github.com/tj/assert"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+func TestCompareOperationState(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		lhs      *operationState
+		rhs      *operationState
+		expected int
+	}{
+		{
+			name:     "both nil",
+			lhs:      nil,
+			rhs:      nil,
+			expected: 0,
+		},
+		{
+			name:     "lhs nil",
+			lhs:      nil,
+			rhs:      newOperationState(arm.ProvisioningStateSucceeded, ""),
+			expected: -1,
+		},
+		{
+			name:     "rhs nil",
+			lhs:      newOperationState(arm.ProvisioningStateSucceeded, ""),
+			rhs:      nil,
+			expected: 1,
+		},
+		{
+			name:     "Succeeded > Provisioning",
+			lhs:      newOperationState(arm.ProvisioningStateSucceeded, ""),
+			rhs:      newOperationState(arm.ProvisioningStateProvisioning, ""),
+			expected: 1,
+		},
+		{
+			name:     "Deleting < Provisioning",
+			lhs:      newOperationState(arm.ProvisioningStateDeleting, ""),
+			rhs:      newOperationState(arm.ProvisioningStateProvisioning, ""),
+			expected: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := compareOperationState(tt.lhs, tt.rhs)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPickWorstOperationState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		states      []*operationState
+		wantErr     string
+		wantProv    arm.ProvisioningState
+		wantMessage string
+	}{
+		{
+			name:    "empty slice nil",
+			states:  nil,
+			wantErr: "no operation states",
+		},
+		{
+			name:    "empty slice non-nil",
+			states:  []*operationState{},
+			wantErr: "no operation states",
+		},
+		{
+			name: "first state has empty provisioning state",
+			states: []*operationState{
+				newOperationState("", "ignored"),
+			},
+			wantErr: "empty provisioning state",
+		},
+		{
+			name: "single state",
+			states: []*operationState{
+				newOperationState(arm.ProvisioningStateFailed, "first failure"),
+			},
+			wantProv:    arm.ProvisioningStateFailed,
+			wantMessage: "first failure",
+		},
+		{
+			name: "merges messages for consecutive same provisioning state",
+			states: []*operationState{
+				newOperationState(arm.ProvisioningStateFailed, "a"),
+				newOperationState(arm.ProvisioningStateFailed, "b"),
+				newOperationState(arm.ProvisioningStateFailed, "c"),
+			},
+			wantProv:    arm.ProvisioningStateFailed,
+			wantMessage: "a; b; c",
+		},
+		{
+			name: "stops merging when provisioning state changes",
+			states: []*operationState{
+				newOperationState(arm.ProvisioningStateFailed, "worst"),
+				newOperationState(arm.ProvisioningStateSucceeded, "ignored"),
+			},
+			wantProv:    arm.ProvisioningStateFailed,
+			wantMessage: "worst",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := pickWorstOperationState(tt.states)
+			if tt.wantErr != "" {
+				assert.Nil(t, got)
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, got)
+			assert.Equal(t, tt.wantProv, got.provisioningState)
+			assert.Equal(t, tt.wantMessage, got.message)
+		})
+	}
+}

--- a/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
+++ b/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
@@ -105,6 +105,7 @@ func (f *clusterTestFixture) newOperation(request database.OperationRequest) *ap
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: f.cosmosOperationResourceID,
 		},
+		ResourceID:  f.cosmosOperationResourceID,
 		TenantID:    testTenantID,
 		Status:      arm.ProvisioningStateAccepted,
 		Request:     request,

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -154,12 +154,15 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 	}
 	desiredVersion, err := c.desiredControlPlaneZVersion(ctx, cincinnatiClient, key.GetResourceID(), customerDesiredMinor, channelGroup, activeVersions,
 		operation.HasOption(api.FeatureExperimentalReleaseFeatures))
+	logger := utils.LoggerFromContext(ctx)
+
 	if err != nil {
 		// Persist IntentFailed on the controller document for Cincinnati VersionNotFound or any non-Cincinnati resolution error.
 		// Other Cincinnati errors are treated as transient graph or transport issues.
 		var cincinnatiErr *cincinnati.Error
 		persistIntentFailed := cincinatti.IsCincinnatiVersionNotFoundError(err) || !errors.As(err, &cincinnatiErr)
 		if persistIntentFailed {
+			logger.Error(err, "desired version resolution failed, persisting IntentFailed condition")
 			controllerCRUD := c.cosmosClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Controllers(key.HCPClusterName)
 			if writeErr := controllerutils.WriteController(ctx, controllerCRUD, controlPlaneDesiredVersionControllerName, key.InitialController,
 				func(ctrl *api.Controller) {
@@ -167,7 +170,7 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 						Type:    api.ControllerConditionTypeIntentFailed,
 						Status:  metav1.ConditionTrue,
 						Reason:  api.VersionUpgradeNotAcceptedReason,
-						Message: err.Error(),
+						Message: utils.ErrorMessageWithoutLineTracking(err),
 					})
 				}); writeErr != nil {
 				return utils.TrackError(writeErr)
@@ -180,7 +183,6 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 	previousDesiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
 	desiredVersionUpdated := false
 	if desiredVersion != nil && (previousDesiredVersion == nil || !desiredVersion.EQ(*previousDesiredVersion)) {
-		logger := utils.LoggerFromContext(ctx)
 		logger.Info("Selected desired version", "desiredVersion", desiredVersion, "previousDesiredVersion", previousDesiredVersion)
 		existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion = desiredVersion
 		desiredVersionUpdated = true

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -27,7 +27,9 @@ import (
 	"github.com/golang/groupcache/lru"
 	"github.com/google/uuid"
 
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/operation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
@@ -151,29 +153,53 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 	desiredVersion, err := c.desiredControlPlaneZVersion(ctx, cincinnatiClient, key.GetResourceID(), customerDesiredMinor, channelGroup, activeVersions,
 		operation.HasOption(api.FeatureExperimentalReleaseFeatures))
 	if err != nil {
+		// Persist Degraded for Cincinnati version-not-found or any non-Cincinnati resolution error.
+		// Other Cincinnati errors are treated as transient graph or transport issues.
+		var cincinnatiErr *cincinnati.Error
+		persistDegraded := cincinatti.IsCincinnatiVersionNotFoundError(err) || !errors.As(err, &cincinnatiErr)
+		if persistDegraded {
+			apimeta.SetStatusCondition(&existingServiceProviderCluster.Status.Conditions, metav1.Condition{
+				Type:    api.DegradedCondition,
+				Status:  metav1.ConditionTrue,
+				Reason:  api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted,
+				Message: err.Error(),
+			})
+			spcClient := c.cosmosClient.ServiceProviderClusters(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+			if _, replaceErr := spcClient.Replace(ctx, existingServiceProviderCluster, nil); replaceErr != nil {
+				return utils.TrackError(fmt.Errorf("failed to determine desired control plane version: %w; failed to persist degraded condition: %v", err, replaceErr))
+			}
+		}
 		return utils.TrackError(fmt.Errorf("failed to determine desired control plane version: %w", err))
 	}
 
-	// Check if there's a new desired version to set
-	if desiredVersion == nil {
-		return nil
+	// Resolution succeeded: clear Degraded/VersionUpgradeNotAccepted if present so we persist recovery (degradedCleared).
+	degradedCleared := false
+	if existingDegraded := apimeta.FindStatusCondition(existingServiceProviderCluster.Status.Conditions, api.DegradedCondition); existingDegraded != nil &&
+		existingDegraded.Status == metav1.ConditionTrue &&
+		existingDegraded.Reason == api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted {
+		degradedCleared = apimeta.SetStatusCondition(&existingServiceProviderCluster.Status.Conditions, metav1.Condition{
+			Type:   api.DegradedCondition,
+			Status: metav1.ConditionFalse,
+			Reason: api.ServiceProviderClusterConditionReasonNoErrors,
+		})
 	}
-
-	// Check if it's the same as the previously set desired version
-	previousDesiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
-	if previousDesiredVersion != nil && desiredVersion.EQ(*previousDesiredVersion) {
-		return nil
-	}
-
-	logger := utils.LoggerFromContext(ctx)
-	logger.Info("Selected desired version", "desiredVersion", desiredVersion, "previousDesiredVersion", previousDesiredVersion)
-	existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion = desiredVersion
 	serviceProviderClustersCosmosClient := c.cosmosClient.ServiceProviderClusters(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
-	_, err = serviceProviderClustersCosmosClient.Replace(ctx, existingServiceProviderCluster, nil)
-	if err != nil {
+
+	previousDesiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
+	desiredVersionUpdated := false
+	if desiredVersion != nil && (previousDesiredVersion == nil || !desiredVersion.EQ(*previousDesiredVersion)) {
+		logger := utils.LoggerFromContext(ctx)
+		logger.Info("Selected desired version", "desiredVersion", desiredVersion, "previousDesiredVersion", previousDesiredVersion)
+		existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion = desiredVersion
+		desiredVersionUpdated = true
+	}
+
+	if !desiredVersionUpdated && !degradedCleared {
+		return nil
+	}
+	if _, err := serviceProviderClustersCosmosClient.Replace(ctx, existingServiceProviderCluster, nil); err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderCluster: %w", err))
 	}
-
 	return nil
 }
 

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -161,7 +161,7 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 		persistIntentFailed := cincinatti.IsCincinnatiVersionNotFoundError(err) || !errors.As(err, &cincinnatiErr)
 		if persistIntentFailed {
 			controllerCRUD := c.cosmosClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Controllers(key.HCPClusterName)
-			if err := controllerutils.WriteController(ctx, controllerCRUD, controlPlaneDesiredVersionControllerName, key.InitialController,
+			if writeErr := controllerutils.WriteController(ctx, controllerCRUD, controlPlaneDesiredVersionControllerName, key.InitialController,
 				func(ctrl *api.Controller) {
 					apimeta.SetStatusCondition(&ctrl.Status.Conditions, metav1.Condition{
 						Type:    api.ControllerConditionTypeIntentFailed,
@@ -169,11 +169,12 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 						Reason:  api.VersionUpgradeNotAcceptedReason,
 						Message: err.Error(),
 					})
-				}); err != nil {
-				return utils.TrackError(err)
+				}); writeErr != nil {
+				return utils.TrackError(writeErr)
 			}
+			return nil
 		}
-		return utils.TrackError(fmt.Errorf("failed to determine desired control plane version: %w", err))
+		return utils.TrackError(err)
 	}
 
 	previousDesiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -48,6 +48,9 @@ import (
 	"github.com/Azure/ARO-HCP/internal/validation"
 )
 
+// controlPlaneDesiredVersionControllerName is the Cosmos controller document ID for this syncer.
+const controlPlaneDesiredVersionControllerName = "ControlPlaneDesiredVersion"
+
 // controlPlaneDesiredVersionSyncer is a Cluster syncer that manages control plane desired version.
 // It handles automated (managed) z-stream (patch) upgrades and assists with y-stream (minor)
 // version upgrades by selecting the appropriate z-stream within the user-desired minor version.
@@ -67,7 +70,6 @@ var _ controllerutils.ClusterSyncer = (*controlPlaneDesiredVersionSyncer)(nil)
 // NewControlPlaneDesiredVersionController creates a new controller that manages the desired
 // control plane version. It periodically checks each cluster and sets the desired version
 // based on the OCPVersion logic documented in the ServiceProviderCluster type.
-// The controller name remains "ControlPlaneVersion" for compatibility.
 func NewControlPlaneDesiredVersionController(
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
@@ -86,7 +88,7 @@ func NewControlPlaneDesiredVersionController(
 	}
 
 	controller := controllerutils.NewClusterWatchingController(
-		"ControlPlaneDesiredVersion",
+		controlPlaneDesiredVersionControllerName,
 		cosmosClient,
 		informers,
 		5*time.Minute, // Check for upgrades every 5 minutes
@@ -153,37 +155,26 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 	desiredVersion, err := c.desiredControlPlaneZVersion(ctx, cincinnatiClient, key.GetResourceID(), customerDesiredMinor, channelGroup, activeVersions,
 		operation.HasOption(api.FeatureExperimentalReleaseFeatures))
 	if err != nil {
-		// Persist Degraded for Cincinnati version-not-found or any non-Cincinnati resolution error.
+		// Persist IntentFailed on the controller document for Cincinnati VersionNotFound or any non-Cincinnati resolution error.
 		// Other Cincinnati errors are treated as transient graph or transport issues.
 		var cincinnatiErr *cincinnati.Error
-		persistDegraded := cincinatti.IsCincinnatiVersionNotFoundError(err) || !errors.As(err, &cincinnatiErr)
-		if persistDegraded {
-			apimeta.SetStatusCondition(&existingServiceProviderCluster.Status.Conditions, metav1.Condition{
-				Type:    api.DegradedCondition,
-				Status:  metav1.ConditionTrue,
-				Reason:  api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted,
-				Message: err.Error(),
-			})
-			spcClient := c.cosmosClient.ServiceProviderClusters(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
-			if _, replaceErr := spcClient.Replace(ctx, existingServiceProviderCluster, nil); replaceErr != nil {
-				return utils.TrackError(fmt.Errorf("failed to determine desired control plane version: %w; failed to persist degraded condition: %v", err, replaceErr))
+		persistIntentFailed := cincinatti.IsCincinnatiVersionNotFoundError(err) || !errors.As(err, &cincinnatiErr)
+		if persistIntentFailed {
+			controllerCRUD := c.cosmosClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Controllers(key.HCPClusterName)
+			if err := controllerutils.WriteController(ctx, controllerCRUD, controlPlaneDesiredVersionControllerName, key.InitialController,
+				func(ctrl *api.Controller) {
+					apimeta.SetStatusCondition(&ctrl.Status.Conditions, metav1.Condition{
+						Type:    api.ControllerConditionTypeIntentFailed,
+						Status:  metav1.ConditionTrue,
+						Reason:  api.VersionUpgradeNotAcceptedReason,
+						Message: err.Error(),
+					})
+				}); err != nil {
+				return utils.TrackError(err)
 			}
 		}
 		return utils.TrackError(fmt.Errorf("failed to determine desired control plane version: %w", err))
 	}
-
-	// Resolution succeeded: clear Degraded/VersionUpgradeNotAccepted if present so we persist recovery (degradedCleared).
-	degradedCleared := false
-	if existingDegraded := apimeta.FindStatusCondition(existingServiceProviderCluster.Status.Conditions, api.DegradedCondition); existingDegraded != nil &&
-		existingDegraded.Status == metav1.ConditionTrue &&
-		existingDegraded.Reason == api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted {
-		degradedCleared = apimeta.SetStatusCondition(&existingServiceProviderCluster.Status.Conditions, metav1.Condition{
-			Type:   api.DegradedCondition,
-			Status: metav1.ConditionFalse,
-			Reason: api.ServiceProviderClusterConditionReasonNoErrors,
-		})
-	}
-	serviceProviderClustersCosmosClient := c.cosmosClient.ServiceProviderClusters(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
 
 	previousDesiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
 	desiredVersionUpdated := false
@@ -194,11 +185,28 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 		desiredVersionUpdated = true
 	}
 
-	if !desiredVersionUpdated && !degradedCleared {
-		return nil
+	// on successful resolution of the desired version.
+	// update the ServiceProviderCluster first and only afterwards
+	// clear the IntentFailed condition
+	if desiredVersionUpdated {
+		serviceProviderClustersCosmosClient := c.cosmosClient.ServiceProviderClusters(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+		_, err := serviceProviderClustersCosmosClient.Replace(ctx, existingServiceProviderCluster, nil)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderCluster: %w", err))
+		}
 	}
-	if _, err := serviceProviderClustersCosmosClient.Replace(ctx, existingServiceProviderCluster, nil); err != nil {
-		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderCluster: %w", err))
+
+	controllerCRUD := c.cosmosClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Controllers(key.HCPClusterName)
+	if err = controllerutils.WriteController(ctx, controllerCRUD, controlPlaneDesiredVersionControllerName, key.InitialController,
+		func(ctrl *api.Controller) {
+			apimeta.SetStatusCondition(&ctrl.Status.Conditions, metav1.Condition{
+				Type:    api.ControllerConditionTypeIntentFailed,
+				Status:  metav1.ConditionFalse,
+				Reason:  api.ControllerConditionReasonAsExpected,
+				Message: "",
+			})
+		}); err != nil {
+		return utils.TrackError(err)
 	}
 	return nil
 }

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -988,13 +988,12 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 			customerVersion:     "4.19",
 			controlPlaneVersion: "4.20.15",
 			setupCincinnati:     func(mc *cincinatti.MockClient) {},
-			wantSyncErr:         true,
-			wantErrContains:     "no downgrades",
 			wantDesiredVersion:  nil,
 			wantIntentFailed: &metav1.Condition{
-				Type:   api.ControllerConditionTypeIntentFailed,
-				Status: metav1.ConditionTrue,
-				Reason: api.VersionUpgradeNotAcceptedReason,
+				Type:    api.ControllerConditionTypeIntentFailed,
+				Status:  metav1.ConditionTrue,
+				Reason:  api.VersionUpgradeNotAcceptedReason,
+				Message: "invalid next y-stream upgrade path from 4.20.0 to 4.19.0: only upgrades to the next minor version are allowed, no downgrades",
 			},
 		},
 		{
@@ -1020,13 +1019,12 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 					configv1.Release{}, nil, nil, &cincinnati.Error{Reason: "VersionNotFound"},
 				).Times(1)
 			},
-			wantSyncErr:        true,
-			wantErrContains:    "VersionNotFound",
 			wantDesiredVersion: nil,
 			wantIntentFailed: &metav1.Condition{
-				Type:   api.ControllerConditionTypeIntentFailed,
-				Status: metav1.ConditionTrue,
-				Reason: api.VersionUpgradeNotAcceptedReason,
+				Type:    api.ControllerConditionTypeIntentFailed,
+				Status:  metav1.ConditionTrue,
+				Reason:  api.VersionUpgradeNotAcceptedReason,
+				Message: "VersionNotFound",
 			},
 		},
 	}
@@ -1052,7 +1050,7 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 				cosmosClient:                          mockDB,
 				clusterServiceClient:                  mockCS,
 				subscriptionLister:                    subscriptionLister,
-				clusterToCincinnatiClient:             lru.New(100),
+				clusterToCincinnatiClient:             lru.New(1),
 			}
 			syncer.clusterToCincinnatiClient.Add(clusterKey, mockCincinnati)
 
@@ -1063,6 +1061,7 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 				assert.ErrorContains(t, err, tt.wantErrContains)
 			} else {
 				require.NoError(t, err)
+				assert.Empty(t, tt.wantErrContains, "when wantSyncErr is false, wantErrContains must be empty")
 			}
 
 			serviceProviderCluster, getServiceProviderClusterErr := mockDB.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Get(ctx, api.ServiceProviderClusterResourceName)
@@ -1087,10 +1086,10 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 				assert.Equal(t, tt.wantIntentFailed.Status, intentFailedCondition.Status)
 				assert.Equal(t, tt.wantIntentFailed.Reason, intentFailedCondition.Reason)
 				if tt.wantIntentFailed.Status == metav1.ConditionTrue {
-					require.NotEmpty(t, tt.wantErrContains, "set wantErrContains to match the persisted IntentFailed message substring")
-					assert.Contains(t, intentFailedCondition.Message, tt.wantErrContains)
+					require.NotEmpty(t, tt.wantIntentFailed.Message, "set wantIntentFailed.Message to the exact persisted IntentFailed message")
+					assert.Contains(t, intentFailedCondition.Message, tt.wantIntentFailed.Message)
 				} else {
-					assert.Empty(t, intentFailedCondition.Message)
+					assert.Empty(t, intentFailedCondition.Message, "when wantIntentFailed.Status is false, intentFailedCondition.Message must be empty")
 				}
 			}
 		})

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -933,39 +933,6 @@ func createTestHCPClusterWithCustomerVersion(t *testing.T, ctx context.Context, 
 	require.NoError(t, err)
 }
 
-// createServiceProviderClusterWithVersionAndConditions creates a ServiceProviderCluster with the given
-// control plane active version and optional initial status conditions. Lives in this file so
-// createServiceProviderClusterWithVersion in nodepool_version_controller_test.go stays unchanged.
-func createServiceProviderClusterWithVersionAndConditions(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient, controlPlaneVersion string, initialConditions ...metav1.Condition) {
-	t.Helper()
-
-	clusterResourceID := "/subscriptions/" + testSubscriptionID +
-		"/resourceGroups/" + testResourceGroupName +
-		"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName
-	spClusterResourceID := clusterResourceID + "/" + api.ServiceProviderClusterResourceTypeName + "/" + api.ServiceProviderClusterResourceName
-
-	cpVersion := semver.MustParse(controlPlaneVersion)
-	status := api.ServiceProviderClusterStatus{
-		ControlPlaneVersion: api.ServiceProviderClusterStatusVersion{
-			ActiveVersions: []api.HCPClusterActiveVersion{
-				{Version: &cpVersion, State: configv1.CompletedUpdate},
-			},
-		},
-	}
-	if len(initialConditions) > 0 {
-		status.Conditions = append([]metav1.Condition(nil), initialConditions...)
-	}
-	spCluster := &api.ServiceProviderCluster{
-		CosmosMetadata: api.CosmosMetadata{
-			ResourceID: api.Must(azcorearm.ParseResourceID(spClusterResourceID)),
-		},
-		ResourceID: *api.Must(azcorearm.ParseResourceID(clusterResourceID)),
-		Status:     status,
-	}
-	_, err := mockDB.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, spCluster, nil)
-	require.NoError(t, err)
-}
-
 func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 	clusterKey := controllerutils.HCPClusterKey{
 		SubscriptionID:    testSubscriptionID,
@@ -982,79 +949,59 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 	}
 
 	stableURI := api.Must(cincinatti.GetCincinnatiURI("stable"))
-
-	registerSuccessfulCincinattiCall := func(mc *cincinatti.MockClient) {
-		mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.15")).Return(
-			configv1.Release{},
-			[]configv1.Release{{Version: "4.19.22"}},
-			nil,
-			nil,
-		).Times(1)
-		mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.20", semver.MustParse("4.19.22")).Return(
-			configv1.Release{}, nil, nil, &cincinnati.Error{Reason: "VersionNotFound"},
-		).Times(1)
-	}
+	const testChannelGroup = "stable"
 
 	tests := []struct {
-		name                   string
-		customerVersion        string
-		channelGroup           string
-		controlPlaneVersion    string
-		initialSPCConditions   []metav1.Condition
-		registerCincinnatiMock func(mc *cincinatti.MockClient)
-		wantSyncErr            bool
-		wantErrContains        string
-		wantDesiredVersion     *semver.Version
-		wantDegraded           *metav1.Condition
+		name                string
+		customerVersion     string
+		controlPlaneVersion string
+		setupCincinnati     func(mc *cincinatti.MockClient)
+		wantSyncErr         bool
+		wantErrContains     string
+		wantDesiredVersion  *semver.Version
+		wantIntentFailed    *metav1.Condition
 	}{
 		{
-			name:                   "without prior Degraded persists desired version and leaves no Degraded row",
-			customerVersion:        "4.19",
-			channelGroup:           "stable",
-			controlPlaneVersion:    "4.19.15",
-			registerCincinnatiMock: registerSuccessfulCincinattiCall,
-			wantDesiredVersion:     ptr.To(semver.MustParse("4.19.22")),
-			wantDegraded:           nil,
-		},
-		{
-			name:                "clears VersionUpgradeNotAccepted Degraded and persists desired version",
+			name:                "successful resolution persists desired version and sets IntentFailed False",
 			customerVersion:     "4.19",
-			channelGroup:        "stable",
 			controlPlaneVersion: "4.19.15",
-			initialSPCConditions: []metav1.Condition{{
-				Type:    api.DegradedCondition,
-				Status:  metav1.ConditionTrue,
-				Reason:  api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted,
-				Message: "previous failure",
-			}},
-			registerCincinnatiMock: registerSuccessfulCincinattiCall,
-			wantDesiredVersion:     ptr.To(semver.MustParse("4.19.22")),
-			wantDegraded: &metav1.Condition{
-				Type:   api.DegradedCondition,
+			setupCincinnati: func(mc *cincinatti.MockClient) {
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.15")).Return(
+					configv1.Release{},
+					[]configv1.Release{{Version: "4.19.22"}},
+					nil,
+					nil,
+				).Times(1)
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.20", semver.MustParse("4.19.22")).Return(
+					configv1.Release{}, nil, nil, &cincinnati.Error{Reason: "VersionNotFound"},
+				).Times(1)
+			},
+			wantDesiredVersion: ptr.To(semver.MustParse("4.19.22")),
+			wantIntentFailed: &metav1.Condition{
+				Type:   api.ControllerConditionTypeIntentFailed,
 				Status: metav1.ConditionFalse,
-				Reason: api.ServiceProviderClusterConditionReasonNoErrors,
+				Reason: api.ControllerConditionReasonAsExpected,
 			},
 		},
 		{
-			name:                "validation error persists Degraded and does not set desired version",
+			name:                "validation error persists IntentFailed and does not set desired version",
 			customerVersion:     "4.19",
-			channelGroup:        "stable",
 			controlPlaneVersion: "4.20.15",
+			setupCincinnati:     func(mc *cincinatti.MockClient) {},
 			wantSyncErr:         true,
 			wantErrContains:     "no downgrades",
 			wantDesiredVersion:  nil,
-			wantDegraded: &metav1.Condition{
-				Type:   api.DegradedCondition,
+			wantIntentFailed: &metav1.Condition{
+				Type:   api.ControllerConditionTypeIntentFailed,
 				Status: metav1.ConditionTrue,
-				Reason: api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted,
+				Reason: api.VersionUpgradeNotAcceptedReason,
 			},
 		},
 		{
-			name:                "Cincinnati upstream error does not persist Degraded or desired version",
+			name:                "Cincinnati upstream error does not persist IntentFailed or desired version",
 			customerVersion:     "4.19",
-			channelGroup:        "stable",
 			controlPlaneVersion: "4.19.15",
-			registerCincinnatiMock: func(mc *cincinatti.MockClient) {
+			setupCincinnati: func(mc *cincinatti.MockClient) {
 				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.15")).Return(
 					configv1.Release{}, nil, nil, &cincinnati.Error{Reason: "ServiceUnavailable", Message: "503 Service Unavailable"},
 				).Times(1)
@@ -1062,14 +1009,13 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 			wantSyncErr:        true,
 			wantErrContains:    "503 Service Unavailable",
 			wantDesiredVersion: nil,
-			wantDegraded:       nil,
+			wantIntentFailed:   nil,
 		},
 		{
-			name:                "Cincinnati VersionNotFound persists Degraded and does not set desired version",
+			name:                "Cincinnati VersionNotFound persists IntentFailed and does not set desired version",
 			customerVersion:     "4.19",
-			channelGroup:        "stable",
 			controlPlaneVersion: "4.19.15",
-			registerCincinnatiMock: func(mc *cincinatti.MockClient) {
+			setupCincinnati: func(mc *cincinatti.MockClient) {
 				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.15")).Return(
 					configv1.Release{}, nil, nil, &cincinnati.Error{Reason: "VersionNotFound"},
 				).Times(1)
@@ -1077,10 +1023,10 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 			wantSyncErr:        true,
 			wantErrContains:    "VersionNotFound",
 			wantDesiredVersion: nil,
-			wantDegraded: &metav1.Condition{
-				Type:   api.DegradedCondition,
+			wantIntentFailed: &metav1.Condition{
+				Type:   api.ControllerConditionTypeIntentFailed,
 				Status: metav1.ConditionTrue,
-				Reason: api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted,
+				Reason: api.VersionUpgradeNotAcceptedReason,
 			},
 		},
 	}
@@ -1094,38 +1040,34 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 			mockDB := databasetesting.NewMockDBClient()
 			mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 
-			createTestHCPClusterWithCustomerVersion(t, ctx, mockDB, tt.customerVersion, tt.channelGroup)
-			createServiceProviderClusterWithVersionAndConditions(t, ctx, mockDB, tt.controlPlaneVersion, tt.initialSPCConditions...)
-
-			mockCS.EXPECT().GetCluster(gomock.Any(), gomock.Any()).Return(newCSCluster(t), nil).Times(1)
+			createTestHCPClusterWithCustomerVersion(t, ctx, mockDB, tt.customerVersion, testChannelGroup)
+			createServiceProviderClusterWithVersion(t, ctx, mockDB, tt.controlPlaneVersion)
 
 			mockCincinnati := cincinatti.NewMockClient(ctrl)
-			if tt.registerCincinnatiMock != nil {
-				tt.registerCincinnatiMock(mockCincinnati)
-			}
+			tt.setupCincinnati(mockCincinnati)
 
 			syncer := &controlPlaneDesiredVersionSyncer{
-				cooldownChecker:           &alwaysSyncCooldownChecker{},
-				cosmosClient:              mockDB,
-				clusterServiceClient:      mockCS,
-				subscriptionLister:        subscriptionLister,
-				clusterToCincinnatiClient: lru.New(100),
+				cooldownChecker:                       &alwaysSyncCooldownChecker{},
+				clusterManagementClusterContentLister: newValidHostedClusterContentLister(t),
+				cosmosClient:                          mockDB,
+				clusterServiceClient:                  mockCS,
+				subscriptionLister:                    subscriptionLister,
+				clusterToCincinnatiClient:             lru.New(100),
 			}
 			syncer.clusterToCincinnatiClient.Add(clusterKey, mockCincinnati)
 
 			err := syncer.SyncOnce(ctx, clusterKey)
 			if tt.wantSyncErr {
 				require.Error(t, err)
-				if tt.wantErrContains != "" {
-					assert.ErrorContains(t, err, tt.wantErrContains)
-				}
+				require.NotEmpty(t, tt.wantErrContains, "when wantSyncErr is true, wantErrContains must be set to a substring of the expected error")
+				assert.ErrorContains(t, err, tt.wantErrContains)
 			} else {
 				require.NoError(t, err)
 			}
 
-			spc, getErr := mockDB.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Get(ctx, api.ServiceProviderClusterResourceName)
-			require.NoError(t, getErr)
-			gotDesired := spc.Spec.ControlPlaneVersion.DesiredVersion
+			serviceProviderCluster, getServiceProviderClusterErr := mockDB.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Get(ctx, api.ServiceProviderClusterResourceName)
+			require.NoError(t, getServiceProviderClusterErr)
+			gotDesired := serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
 			if tt.wantDesiredVersion != nil {
 				require.NotNil(t, gotDesired)
 				assert.True(t, gotDesired.EQ(*tt.wantDesiredVersion), "wanted desired version %s, got %s", tt.wantDesiredVersion.String(), gotDesired.String())
@@ -1133,20 +1075,23 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 				assert.Nil(t, gotDesired)
 			}
 
-			got := apimeta.FindStatusCondition(spc.Status.Conditions, api.DegradedCondition)
-			if tt.wantDegraded == nil {
-				assert.Nil(t, got)
-				return
-			}
-			require.NotNil(t, got)
-			assert.Equal(t, tt.wantDegraded.Type, got.Type)
-			assert.Equal(t, tt.wantDegraded.Status, got.Status)
-			assert.Equal(t, tt.wantDegraded.Reason, got.Reason)
-			if tt.wantDegraded.Status == metav1.ConditionTrue {
-				require.NotEmpty(t, tt.wantErrContains, "set wantErrContains to match the persisted Degraded message substring")
-				assert.Contains(t, got.Message, tt.wantErrContains)
-			} else {
-				assert.Empty(t, got.Message)
+			controlPlaneDesiredVersionControllerDoc, getControllerDocErr := mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).
+				Controllers(testClusterName).Get(ctx, controlPlaneDesiredVersionControllerName)
+			if tt.wantIntentFailed != nil {
+				require.NoError(t, getControllerDocErr)
+				require.NotNil(t, controlPlaneDesiredVersionControllerDoc)
+				intentFailedCondition := apimeta.FindStatusCondition(controlPlaneDesiredVersionControllerDoc.Status.Conditions,
+					api.ControllerConditionTypeIntentFailed)
+				require.NotNil(t, intentFailedCondition)
+				assert.Equal(t, tt.wantIntentFailed.Type, intentFailedCondition.Type)
+				assert.Equal(t, tt.wantIntentFailed.Status, intentFailedCondition.Status)
+				assert.Equal(t, tt.wantIntentFailed.Reason, intentFailedCondition.Reason)
+				if tt.wantIntentFailed.Status == metav1.ConditionTrue {
+					require.NotEmpty(t, tt.wantErrContains, "set wantErrContains to match the persisted IntentFailed message substring")
+					assert.Contains(t, intentFailedCondition.Message, tt.wantErrContains)
+				} else {
+					assert.Empty(t, intentFailedCondition.Message)
+				}
 			}
 		})
 	}

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -1024,7 +1024,7 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 				Type:    api.ControllerConditionTypeIntentFailed,
 				Status:  metav1.ConditionTrue,
 				Reason:  api.VersionUpgradeNotAcceptedReason,
-				Message: "VersionNotFound",
+				Message: "VersionNotFound: ",
 			},
 		},
 	}
@@ -1087,7 +1087,7 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 				assert.Equal(t, tt.wantIntentFailed.Reason, intentFailedCondition.Reason)
 				if tt.wantIntentFailed.Status == metav1.ConditionTrue {
 					require.NotEmpty(t, tt.wantIntentFailed.Message, "set wantIntentFailed.Message to the exact persisted IntentFailed message")
-					assert.Contains(t, intentFailedCondition.Message, tt.wantIntentFailed.Message)
+					assert.Equal(t, tt.wantIntentFailed.Message, intentFailedCondition.Message)
 				} else {
 					assert.Empty(t, intentFailedCondition.Message, "when wantIntentFailed.Status is false, intentFailedCondition.Message must be empty")
 				}

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -19,10 +19,14 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"github.com/go-logr/logr"
+	"github.com/golang/groupcache/lru"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -30,10 +34,14 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-version-operator/pkg/cincinnati"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	cincinatti "github.com/Azure/ARO-HCP/internal/cincinatti"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
@@ -890,5 +898,256 @@ func assertVersionResult(t *testing.T, result *semver.Version, err error, expect
 			assert.NotNil(t, result)
 			assert.True(t, result.EQ(*expectedVersion), "Expected version %q, got %q", expectedVersion.String(), result.String())
 		}
+	}
+}
+
+func createTestHCPClusterWithCustomerVersion(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient, customerVersionID, channelGroup string) {
+	t.Helper()
+	createTestSubscription(t, ctx, mockDB)
+	clusterResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscriptionID +
+		"/resourceGroups/" + testResourceGroupName +
+		"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName))
+	clusterInternalID, err := api.NewInternalID(testCSClusterIDStr)
+	require.NoError(t, err)
+	cluster := &api.HCPOpenShiftCluster{
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   clusterResourceID,
+				Name: testClusterName,
+				Type: api.ClusterResourceType.String(),
+			},
+			Location: "eastus",
+		},
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			Version: api.VersionProfile{
+				ID:           customerVersionID,
+				ChannelGroup: channelGroup,
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ProvisioningState: arm.ProvisioningStateSucceeded,
+			ClusterServiceID:  &clusterInternalID,
+		},
+	}
+	_, err = mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).Create(ctx, cluster, nil)
+	require.NoError(t, err)
+}
+
+// createServiceProviderClusterWithVersionAndConditions creates a ServiceProviderCluster with the given
+// control plane active version and optional initial status conditions. Lives in this file so
+// createServiceProviderClusterWithVersion in nodepool_version_controller_test.go stays unchanged.
+func createServiceProviderClusterWithVersionAndConditions(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient, controlPlaneVersion string, initialConditions ...metav1.Condition) {
+	t.Helper()
+
+	clusterResourceID := "/subscriptions/" + testSubscriptionID +
+		"/resourceGroups/" + testResourceGroupName +
+		"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName
+	spClusterResourceID := clusterResourceID + "/" + api.ServiceProviderClusterResourceTypeName + "/" + api.ServiceProviderClusterResourceName
+
+	cpVersion := semver.MustParse(controlPlaneVersion)
+	status := api.ServiceProviderClusterStatus{
+		ControlPlaneVersion: api.ServiceProviderClusterStatusVersion{
+			ActiveVersions: []api.HCPClusterActiveVersion{
+				{Version: &cpVersion, State: configv1.CompletedUpdate},
+			},
+		},
+	}
+	if len(initialConditions) > 0 {
+		status.Conditions = append([]metav1.Condition(nil), initialConditions...)
+	}
+	spCluster := &api.ServiceProviderCluster{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID: api.Must(azcorearm.ParseResourceID(spClusterResourceID)),
+		},
+		ResourceID: *api.Must(azcorearm.ParseResourceID(clusterResourceID)),
+		Status:     status,
+	}
+	_, err := mockDB.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, spCluster, nil)
+	require.NoError(t, err)
+}
+
+func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
+	clusterKey := controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+	subResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscriptionID))
+	subscriptionLister := &listertesting.SliceSubscriptionLister{
+		Subscriptions: []*arm.Subscription{{
+			CosmosMetadata: arm.CosmosMetadata{ResourceID: subResourceID},
+			ResourceID:     subResourceID,
+			Properties:     &arm.SubscriptionProperties{},
+		}},
+	}
+
+	stableURI := api.Must(cincinatti.GetCincinnatiURI("stable"))
+
+	registerSuccessfulCincinattiCall := func(mc *cincinatti.MockClient) {
+		mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.15")).Return(
+			configv1.Release{},
+			[]configv1.Release{{Version: "4.19.22"}},
+			nil,
+			nil,
+		).Times(1)
+		mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.20", semver.MustParse("4.19.22")).Return(
+			configv1.Release{}, nil, nil, &cincinnati.Error{Reason: "VersionNotFound"},
+		).Times(1)
+	}
+
+	tests := []struct {
+		name                   string
+		customerVersion        string
+		channelGroup           string
+		controlPlaneVersion    string
+		initialSPCConditions   []metav1.Condition
+		registerCincinnatiMock func(mc *cincinatti.MockClient)
+		wantSyncErr            bool
+		wantErrContains        string
+		wantDesiredVersion     *semver.Version
+		wantDegraded           *metav1.Condition
+	}{
+		{
+			name:                   "without prior Degraded persists desired version and leaves no Degraded row",
+			customerVersion:        "4.19",
+			channelGroup:           "stable",
+			controlPlaneVersion:    "4.19.15",
+			registerCincinnatiMock: registerSuccessfulCincinattiCall,
+			wantDesiredVersion:     ptr.To(semver.MustParse("4.19.22")),
+			wantDegraded:           nil,
+		},
+		{
+			name:                "clears VersionUpgradeNotAccepted Degraded and persists desired version",
+			customerVersion:     "4.19",
+			channelGroup:        "stable",
+			controlPlaneVersion: "4.19.15",
+			initialSPCConditions: []metav1.Condition{{
+				Type:    api.DegradedCondition,
+				Status:  metav1.ConditionTrue,
+				Reason:  api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted,
+				Message: "previous failure",
+			}},
+			registerCincinnatiMock: registerSuccessfulCincinattiCall,
+			wantDesiredVersion:     ptr.To(semver.MustParse("4.19.22")),
+			wantDegraded: &metav1.Condition{
+				Type:   api.DegradedCondition,
+				Status: metav1.ConditionFalse,
+				Reason: api.ServiceProviderClusterConditionReasonNoErrors,
+			},
+		},
+		{
+			name:                "validation error persists Degraded and does not set desired version",
+			customerVersion:     "4.19",
+			channelGroup:        "stable",
+			controlPlaneVersion: "4.20.15",
+			wantSyncErr:         true,
+			wantErrContains:     "no downgrades",
+			wantDesiredVersion:  nil,
+			wantDegraded: &metav1.Condition{
+				Type:   api.DegradedCondition,
+				Status: metav1.ConditionTrue,
+				Reason: api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted,
+			},
+		},
+		{
+			name:                "Cincinnati upstream error does not persist Degraded or desired version",
+			customerVersion:     "4.19",
+			channelGroup:        "stable",
+			controlPlaneVersion: "4.19.15",
+			registerCincinnatiMock: func(mc *cincinatti.MockClient) {
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.15")).Return(
+					configv1.Release{}, nil, nil, &cincinnati.Error{Reason: "ServiceUnavailable", Message: "503 Service Unavailable"},
+				).Times(1)
+			},
+			wantSyncErr:        true,
+			wantErrContains:    "503 Service Unavailable",
+			wantDesiredVersion: nil,
+			wantDegraded:       nil,
+		},
+		{
+			name:                "Cincinnati VersionNotFound persists Degraded and does not set desired version",
+			customerVersion:     "4.19",
+			channelGroup:        "stable",
+			controlPlaneVersion: "4.19.15",
+			registerCincinnatiMock: func(mc *cincinatti.MockClient) {
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.15")).Return(
+					configv1.Release{}, nil, nil, &cincinnati.Error{Reason: "VersionNotFound"},
+				).Times(1)
+			},
+			wantSyncErr:        true,
+			wantErrContains:    "VersionNotFound",
+			wantDesiredVersion: nil,
+			wantDegraded: &metav1.Condition{
+				Type:   api.DegradedCondition,
+				Status: metav1.ConditionTrue,
+				Reason: api.ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := utils.ContextWithLogger(context.Background(), logr.Discard())
+			ctrl := gomock.NewController(t)
+			mockDB := databasetesting.NewMockDBClient()
+			mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+
+			createTestHCPClusterWithCustomerVersion(t, ctx, mockDB, tt.customerVersion, tt.channelGroup)
+			createServiceProviderClusterWithVersionAndConditions(t, ctx, mockDB, tt.controlPlaneVersion, tt.initialSPCConditions...)
+
+			mockCS.EXPECT().GetCluster(gomock.Any(), gomock.Any()).Return(newCSCluster(t), nil).Times(1)
+
+			mockCincinnati := cincinatti.NewMockClient(ctrl)
+			if tt.registerCincinnatiMock != nil {
+				tt.registerCincinnatiMock(mockCincinnati)
+			}
+
+			syncer := &controlPlaneDesiredVersionSyncer{
+				cooldownChecker:           &alwaysSyncCooldownChecker{},
+				cosmosClient:              mockDB,
+				clusterServiceClient:      mockCS,
+				subscriptionLister:        subscriptionLister,
+				clusterToCincinnatiClient: lru.New(100),
+			}
+			syncer.clusterToCincinnatiClient.Add(clusterKey, mockCincinnati)
+
+			err := syncer.SyncOnce(ctx, clusterKey)
+			if tt.wantSyncErr {
+				require.Error(t, err)
+				if tt.wantErrContains != "" {
+					assert.ErrorContains(t, err, tt.wantErrContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+
+			spc, getErr := mockDB.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Get(ctx, api.ServiceProviderClusterResourceName)
+			require.NoError(t, getErr)
+			gotDesired := spc.Spec.ControlPlaneVersion.DesiredVersion
+			if tt.wantDesiredVersion != nil {
+				require.NotNil(t, gotDesired)
+				assert.True(t, gotDesired.EQ(*tt.wantDesiredVersion), "wanted desired version %s, got %s", tt.wantDesiredVersion.String(), gotDesired.String())
+			} else {
+				assert.Nil(t, gotDesired)
+			}
+
+			got := apimeta.FindStatusCondition(spc.Status.Conditions, api.DegradedCondition)
+			if tt.wantDegraded == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantDegraded.Type, got.Type)
+			assert.Equal(t, tt.wantDegraded.Status, got.Status)
+			assert.Equal(t, tt.wantDegraded.Reason, got.Reason)
+			if tt.wantDegraded.Status == metav1.ConditionTrue {
+				require.NotEmpty(t, tt.wantErrContains, "set wantErrContains to match the persisted Degraded message substring")
+				assert.Contains(t, got.Message, tt.wantErrContains)
+			} else {
+				assert.Empty(t, got.Message)
+			}
+		})
 	}
 }

--- a/internal/api/controller_conditions.go
+++ b/internal/api/controller_conditions.go
@@ -14,13 +14,12 @@
 
 package api
 
+// Controller status condition Type values (metav1.Condition.Type) for HCP controller documents.
 const (
-	// DegradedCondition is True when the cluster is in a degraded state.
-	DegradedCondition = "Degraded"
+	ControllerConditionTypeIntentFailed = "IntentFailed"
 )
 
-// Known ServiceProviderCluster status condition Reason values (metav1.Condition.Reason).
+// Known controller status condition Reason values (metav1.Condition.Reason).
 const (
-	VersionUpgradeNotAcceptedReason string = "VersionUpgradeNotAccepted"
-	NoErrorsReason                  string = "NoErrors"
+	ControllerConditionReasonAsExpected = "AsExpected"
 )

--- a/internal/api/service_provider_cluster_conditions.go
+++ b/internal/api/service_provider_cluster_conditions.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+const (
+	// DegradedCondition is True when the cluster is in a degraded state.
+	DegradedCondition = "Degraded"
+)
+
+// Known ServiceProviderCluster status condition Reason values (metav1.Condition.Reason).
+const (
+	ServiceProviderClusterConditionReasonVersionUpgradeNotAccepted string = "VersionUpgradeNotAccepted"
+	ServiceProviderClusterConditionReasonNoErrors                  string = "NoErrors"
+)

--- a/internal/utils/line_tracking_error.go
+++ b/internal/utils/line_tracking_error.go
@@ -15,6 +15,7 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -63,4 +64,25 @@ func (e *LineTrackingError) Error() string {
 // to work correctly with the underlying error type.
 func (e *LineTrackingError) Unwrap() error {
 	return e.originalError
+}
+
+// ErrorMessageWithoutLineTracking returns err.Error() after peeling zero or more *LineTrackingError
+// wrappers (from TrackError). Use this when persisting or surfacing errors to users so internal
+// file/line prefixes are not included.
+func ErrorMessageWithoutLineTracking(err error) string {
+	if err == nil {
+		return ""
+	}
+	for {
+		var lte *LineTrackingError
+		if !errors.As(err, &lte) {
+			break
+		}
+		inner := lte.Unwrap()
+		if inner == nil {
+			return ""
+		}
+		err = inner
+	}
+	return err.Error()
 }

--- a/internal/utils/line_tracking_error_test.go
+++ b/internal/utils/line_tracking_error_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // CustomError is a custom error type for testing errors.As functionality
@@ -40,10 +42,10 @@ func TestReturningNilForNil(t *testing.T) {
 
 func TestLineTrackingError_Error(t *testing.T) {
 	originalErr := errors.New("database connection failed")
-	wrappedErr := TrackError(originalErr) // This is line 55
+	wrappedErr := TrackError(originalErr) // This is line 45
 
 	errorMsg := wrappedErr.Error()
-	expectedMsg := "(wrapped at line_tracking_error_test.go:43) database connection failed"
+	expectedMsg := "(wrapped at line_tracking_error_test.go:45) database connection failed"
 
 	if errorMsg != expectedMsg {
 		t.Errorf("expected exact error message:\n%q\nbut got:\n%q", expectedMsg, errorMsg)
@@ -117,11 +119,11 @@ func TestLineTrackingError_MultipleWrapping(t *testing.T) {
 
 	t.Run("double wrapping shows both wrap locations", func(t *testing.T) {
 		originalErr := errors.New("base error")
-		firstWrap := TrackError(originalErr) // This is line 120
-		secondWrap := TrackError(firstWrap)  // This is line 121
+		firstWrap := TrackError(originalErr) // This is line 122
+		secondWrap := TrackError(firstWrap)  // This is line 123
 
 		errorMsg := secondWrap.Error()
-		expectedMsg := "(wrapped at line_tracking_error_test.go:121) (wrapped at line_tracking_error_test.go:120) base error"
+		expectedMsg := "(wrapped at line_tracking_error_test.go:123) (wrapped at line_tracking_error_test.go:122) base error"
 
 		if errorMsg != expectedMsg {
 			t.Errorf("Expected exact double-wrapped error message:\n%q\nbut got:\n%q", expectedMsg, errorMsg)
@@ -132,4 +134,24 @@ func TestLineTrackingError_MultipleWrapping(t *testing.T) {
 			t.Error("expected errors.Is to work through double wrapping")
 		}
 	})
+}
+
+func TestErrorMessageWithoutLineTracking(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil", err: nil, want: ""},
+		{name: "unwraps single TrackError", err: TrackError(errors.New("root cause")), want: "root cause"},
+		{name: "unwraps nested TrackError", err: TrackError(TrackError(errors.New("base"))), want: "base"},
+		{name: "plain error unchanged", err: errors.New("plain"), want: "plain"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ErrorMessageWithoutLineTracking(tt.err))
+		})
+	}
 }


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Mark the cluster X.Y update operation as completed once the desired version is within the target minor

### Why

Before this patch, wt the moment we mark the version update operation as completed almost instantly after the operation is created we change that with the following proposal:

- We mark the operation as succeeded when the desired version is reflected in the ServiceProviderCluster 
i.e for cluster it'll be that the desired x.y+1.z version is in the same desired minor

The benefit of this approach are:
- Marking the operation as failed if there is no version available for the chosen X.Y release line or there are no upgrade path from the current version; so the know instantly that the upgrade can't be served. This is also particularly useful so that the user gets a near instant feedback
- Operation wise, we'll closely move the marking of operation succeeded to reflect that the Service is able to honor the desired and it going to trigger the upgrade operation

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

1. Related to https://redhat.atlassian.net/browse/ARO-26048.
For node pool this is going to be addressed in a separate effort https://redhat.atlassian.net/browse/ARO-26304
2. We'll still check for cluster readiness before marking the overall operation as succeeded
