### PR TITLE
fix: skip a call stack frame in logr to ocm adapter

### DIFF
--- a/backend/pkg/maestro/logr_to_ocm_adapter.go
+++ b/backend/pkg/maestro/logr_to_ocm_adapter.go
@@ -35,7 +35,9 @@ var _ ocmsdkgologging.Logger = (*logrToOCMLoggerAdapter)(nil)
 
 // LogrToOCMLogger returns an ocm-sdk-go Logger that delegates to the given logr.Logger.
 func NewLogrToOCMLoggerAdapter(l logr.Logger) ocmsdkgologging.Logger {
-	return &logrToOCMLoggerAdapter{Logger: l}
+	// When creating the logger adapter, skip one frame in the call stack to avoid
+	// the logged lines by the adapter showing the source as the adapter itself.
+	return &logrToOCMLoggerAdapter{Logger: l.WithCallDepth(1)}
 }
 
 func (l *logrToOCMLoggerAdapter) DebugEnabled() bool { return l.V(1).Enabled() }


### PR DESCRIPTION
The maestro library, which requires an OCM logger, uses the logr to OCM logger adapter we defined. However, this made the logged lines by adapter show as the source the call stack of the adapter itself and not of the callers to the adapter. To fix this we create the adapter skipping a call stack frame. This should allow us to see the actual location of the code that performed the logging.
