### PR TITLE
Update cincinatti interaction to use maestro for clusterID

### DIFF
--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/admission"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/cincinatti"
@@ -49,10 +50,11 @@ import (
 // It handles automated (managed) z-stream (patch) upgrades and assists with y-stream (minor)
 // version upgrades by selecting the appropriate z-stream within the user-desired minor version.
 type controlPlaneDesiredVersionSyncer struct {
-	cooldownChecker      controllerutils.CooldownChecker
-	cosmosClient         database.DBClient
-	clusterServiceClient ocm.ClusterServiceClientSpec
-	subscriptionLister   listers.SubscriptionLister
+	cooldownChecker                       controllerutils.CooldownChecker
+	clusterManagementClusterContentLister listers.ManagementClusterContentLister
+	cosmosClient                          database.DBClient
+	clusterServiceClient                  ocm.ClusterServiceClientSpec
+	subscriptionLister                    listers.SubscriptionLister
 
 	cincinnatiClientLock      sync.RWMutex
 	clusterToCincinnatiClient *lru.Cache
@@ -71,13 +73,14 @@ func NewControlPlaneDesiredVersionController(
 	informers informers.BackendInformers,
 	subscriptionLister listers.SubscriptionLister,
 ) controllerutils.Controller {
-
+	_, clusterManagementClusterContentLister := informers.ManagementClusterContents()
 	syncer := &controlPlaneDesiredVersionSyncer{
-		cooldownChecker:           controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
-		cosmosClient:              cosmosClient,
-		clusterToCincinnatiClient: lru.New(100000),
-		clusterServiceClient:      clusterServiceClient,
-		subscriptionLister:        subscriptionLister,
+		cooldownChecker:                       controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		clusterManagementClusterContentLister: clusterManagementClusterContentLister,
+		cosmosClient:                          cosmosClient,
+		clusterToCincinnatiClient:             lru.New(100000),
+		clusterServiceClient:                  clusterServiceClient,
+		subscriptionLister:                    subscriptionLister,
 	}
 
 	controller := controllerutils.NewClusterWatchingController(
@@ -123,16 +126,14 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
 	}
 
-	// TODO bring the cluster uuid into serviceprovidercluster
-	clusterServiceCluster, err := c.clusterServiceClient.GetCluster(ctx, *existingCluster.ServiceProviderProperties.ClusterServiceID)
+	// Resolve the cluster UUID from the cached HostedCluster so we can build the Cincinnati client.
+	clusterUUID, found, err := maestrohelpers.GetCachedHostedClusterUUIDForCluster(ctx, c.clusterManagementClusterContentLister, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get cluster from Cluster Service: %w", err))
+		return err
 	}
-
-	// Create Cincinnati client with cluster UUID from Cluster Service
-	clusterUUID, err := uuid.Parse(clusterServiceCluster.ExternalID())
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("invalid cluster UUID from Cluster Service: %w", err))
+	if !found {
+		// will reappear once the informer relists; without the UUID we cannot build the Cincinnati client
+		return nil
 	}
 	cincinnatiClient := c.getCincinnatiClient(key, clusterUUID)
 

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/cincinatti"
@@ -47,9 +48,10 @@ import (
 // from CS and internal and helps selecting a valid desiredVersion within the user's
 // desired
 type nodePoolVersionSyncer struct {
-	cooldownChecker      controllerutils.CooldownChecker
-	cosmosClient         database.DBClient
-	clusterServiceClient ocm.ClusterServiceClientSpec
+	cooldownChecker                       controllerutils.CooldownChecker
+	clusterManagementClusterContentLister listers.ManagementClusterContentLister
+	cosmosClient                          database.DBClient
+	clusterServiceClient                  ocm.ClusterServiceClientSpec
 
 	cincinnatiClientLock      sync.RWMutex
 	clusterToCincinnatiClient *lru.Cache
@@ -66,11 +68,13 @@ func NewNodePoolVersionController(
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
 ) controllerutils.Controller {
+	_, clusterManagementClusterContentLister := informers.ManagementClusterContents()
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:           controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
-		cosmosClient:              cosmosClient,
-		clusterServiceClient:      clusterServiceClient,
-		clusterToCincinnatiClient: lru.New(100000),
+		cooldownChecker:                       controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		clusterManagementClusterContentLister: clusterManagementClusterContentLister,
+		cosmosClient:                          cosmosClient,
+		clusterServiceClient:                  clusterServiceClient,
+		clusterToCincinnatiClient:             lru.New(100000),
 	}
 
 	controller := controllerutils.NewNodePoolWatchingController(
@@ -107,6 +111,8 @@ func NewNodePoolVersionController(
 // If the desired version is already among the active versions, validation is skipped
 // (the upgrade is already in progress or complete).
 func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
 	// Get node pool from Cosmos to get CS internal ID
 	nodePool, err := c.cosmosClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).
 		NodePools(key.HCPClusterName).Get(ctx, key.HCPNodePoolName)
@@ -144,15 +150,14 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 		return nil
 	}
 
-	// Get the cluster from Cluster Service to obtain the cluster UUID for Cincinnati
-	csCluster, err := c.clusterServiceClient.GetCluster(ctx, *cluster.ServiceProviderProperties.ClusterServiceID)
+	// Resolve the cluster UUID from the cached HostedCluster so we can build the Cincinnati client.
+	clusterUUID, found, err := maestrohelpers.GetCachedHostedClusterUUIDForCluster(ctx, c.clusterManagementClusterContentLister, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get cluster from Cluster Service: %w", err))
+		return err
 	}
-
-	clusterUUID, err := uuid.Parse(csCluster.ExternalID())
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("invalid cluster UUID from Cluster Service: %w", err))
+	if !found {
+		// will reappear once the informer relists; without the UUID we cannot build the Cincinnati client
+		return nil
 	}
 
 	clusterKey := controllerutils.HCPClusterKey{
@@ -189,7 +194,6 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 	//   	- upgradepolicy.targetVersion: if the policy has started this version is applying to the nodepool
 	//   - In Hypershift
 	//		- .Status.Version: shows the latest applied version https://github.com/openshift/hypershift/blob/main/api/hypershift/v1beta1/nodepool_types.go#L246-L251
-	logger := utils.LoggerFromContext(ctx)
 	if !slices.Equal(oldActiveVersions, existingServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions) {
 		logger.Info("Active versions changed", "oldActiveVersions", oldActiveVersions, "newActiveVersions", existingServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions)
 		existingServiceProviderNodePool, err = serviceProviderCosmosNodePoolClient.Replace(ctx, existingServiceProviderNodePool, nil)

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
@@ -16,6 +16,7 @@ package upgradecontrollers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -26,14 +27,19 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/cincinatti"
@@ -158,16 +164,68 @@ func newCSNodePool(t *testing.T, version string) *arohcpv1alpha1.NodePool {
 	return csNodePool
 }
 
-// newCSCluster creates a Cluster Service cluster for testing.
-func newCSCluster(t *testing.T) *arohcpv1alpha1.Cluster {
+// hostedClusterContentResourceID returns the resource ID for the readonly HostedCluster ManagementClusterContent
+// associated with the test cluster. The slice lister matches on this ID to satisfy GetForCluster.
+func hostedClusterContentResourceID(t *testing.T) *azcorearm.ResourceID {
 	t.Helper()
+	return api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/" + api.ManagementClusterContentResourceTypeName + "/" + string(api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster)))
+}
 
-	csCluster, err := arohcpv1alpha1.NewCluster().
-		ID(testClusterName).
-		ExternalID(testClusterExternalID).
-		Build()
+// newHostedClusterContent builds a ManagementClusterContent whose KubeContent contains a single HostedCluster
+// with the given Spec.ClusterID. The controller parses spec.clusterID out of this raw payload via
+// unstructured.Unstructured, which requires apiVersion/kind to be present.
+func newHostedClusterContent(t *testing.T, clusterID string) *api.ManagementClusterContent {
+	t.Helper()
+	hostedCluster := &v1beta1.HostedCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HostedCluster",
+			APIVersion: v1beta1.GroupVersion.String(),
+		},
+		Spec: v1beta1.HostedClusterSpec{
+			ClusterID: clusterID,
+		},
+	}
+	raw, err := json.Marshal(hostedCluster)
 	require.NoError(t, err)
-	return csCluster
+	return &api.ManagementClusterContent{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: hostedClusterContentResourceID(t)},
+		Status: api.ManagementClusterContentStatus{
+			KubeContent: &metav1.List{
+				Items: []kruntime.RawExtension{{Raw: raw}},
+			},
+		},
+	}
+}
+
+// newValidHostedClusterContentLister returns a lister with a HostedCluster carrying the canonical test UUID.
+// Tests that don't care about the new error paths get a working lister this way.
+func newValidHostedClusterContentLister(t *testing.T) listers.ManagementClusterContentLister {
+	t.Helper()
+	return &listertesting.SliceManagementClusterContentLister{
+		Contents: []*api.ManagementClusterContent{newHostedClusterContent(t, testClusterExternalID)},
+	}
+}
+
+// errorManagementClusterContentLister always returns the configured error for every method.
+type errorManagementClusterContentLister struct {
+	err error
+}
+
+func (l *errorManagementClusterContentLister) List(_ context.Context) ([]*api.ManagementClusterContent, error) {
+	return nil, l.err
+}
+func (l *errorManagementClusterContentLister) GetForCluster(_ context.Context, _, _, _, _ string) (*api.ManagementClusterContent, error) {
+	return nil, l.err
+}
+func (l *errorManagementClusterContentLister) ListForCluster(_ context.Context, _, _, _ string) ([]*api.ManagementClusterContent, error) {
+	return nil, l.err
+}
+func (l *errorManagementClusterContentLister) ListForNodePool(_ context.Context, _, _, _, _ string) ([]*api.ManagementClusterContent, error) {
+	return nil, l.err
 }
 
 func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
@@ -182,6 +240,7 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 		name                  string
 		seedDB                func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient)
 		mockCS                func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec)
+		contentLister         func(t *testing.T) listers.ManagementClusterContentLister
 		expectedError         bool
 		expectedErrorContains string
 	}{
@@ -198,22 +257,6 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "cluster service get cluster call returns error",
-			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient) {
-				t.Helper()
-				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
-			},
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				mockCS.EXPECT().
-					GetCluster(gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("cluster service unavailable")).
-					Times(1)
-			},
-			expectedError:         true,
-			expectedErrorContains: "cluster service unavailable",
-		},
-		{
 			name: "cluster service get nodepool call returns error",
 			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient) {
 				t.Helper()
@@ -221,11 +264,6 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 			},
 			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
 				t.Helper()
-				csCluster := newCSCluster(t)
-				mockCS.EXPECT().
-					GetCluster(gomock.Any(), gomock.Any()).
-					Return(csCluster, nil).
-					Times(1)
 				mockCS.EXPECT().
 					GetNodePool(gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("cluster service unavailable")).
@@ -242,11 +280,6 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 			},
 			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
 				t.Helper()
-				csCluster := newCSCluster(t)
-				mockCS.EXPECT().
-					GetCluster(gomock.Any(), gomock.Any()).
-					Return(csCluster, nil).
-					Times(1)
 				csNodePool := newCSNodePool(t, "") // No version
 				mockCS.EXPECT().
 					GetNodePool(gomock.Any(), gomock.Any()).
@@ -255,6 +288,137 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 			},
 			expectedError:         true,
 			expectedErrorContains: "node pool version not found in Cluster Service respons",
+		},
+		{
+			name: "management cluster content not found is silently skipped",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+			},
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+				// No CS mock setup - we return before reaching GetNodePool.
+			},
+			contentLister: func(t *testing.T) listers.ManagementClusterContentLister {
+				t.Helper()
+				return &listertesting.SliceManagementClusterContentLister{}
+			},
+			expectedError: false,
+		},
+		{
+			name: "management cluster content lister error is propagated",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+			},
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+			},
+			contentLister: func(t *testing.T) listers.ManagementClusterContentLister {
+				t.Helper()
+				return &errorManagementClusterContentLister{err: errors.New("indexer is on fire")}
+			},
+			expectedError:         true,
+			expectedErrorContains: "failed to get cluster management cluster content",
+		},
+		{
+			name: "management cluster content with nil KubeContent is silently skipped",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+			},
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+			},
+			contentLister: func(t *testing.T) listers.ManagementClusterContentLister {
+				t.Helper()
+				return &listertesting.SliceManagementClusterContentLister{
+					Contents: []*api.ManagementClusterContent{{
+						CosmosMetadata: api.CosmosMetadata{ResourceID: hostedClusterContentResourceID(t)},
+					}},
+				}
+			},
+			expectedError: false,
+		},
+		{
+			name: "management cluster content with multiple kubecontent items is silently skipped",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+			},
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+			},
+			contentLister: func(t *testing.T) listers.ManagementClusterContentLister {
+				t.Helper()
+				content := newHostedClusterContent(t, testClusterExternalID)
+				// Duplicate the single item so the count check (!= 1) fails.
+				content.Status.KubeContent.Items = append(content.Status.KubeContent.Items, content.Status.KubeContent.Items[0])
+				return &listertesting.SliceManagementClusterContentLister{
+					Contents: []*api.ManagementClusterContent{content},
+				}
+			},
+			expectedError: false,
+		},
+		{
+			name: "kubecontent unmarshal failure is returned as error",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+			},
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+			},
+			contentLister: func(t *testing.T) listers.ManagementClusterContentLister {
+				t.Helper()
+				return &listertesting.SliceManagementClusterContentLister{
+					Contents: []*api.ManagementClusterContent{{
+						CosmosMetadata: api.CosmosMetadata{ResourceID: hostedClusterContentResourceID(t)},
+						Status: api.ManagementClusterContentStatus{
+							KubeContent: &metav1.List{
+								Items: []kruntime.RawExtension{{Raw: []byte("not-json")}},
+							},
+						},
+					}},
+				}
+			},
+			expectedError:         true,
+			expectedErrorContains: "failed to unmarshal kubecontent",
+		},
+		{
+			name: "kubecontent without HostedCluster.Spec.ClusterID is silently skipped",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+			},
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+			},
+			contentLister: func(t *testing.T) listers.ManagementClusterContentLister {
+				t.Helper()
+				return &listertesting.SliceManagementClusterContentLister{
+					Contents: []*api.ManagementClusterContent{newHostedClusterContent(t, "")},
+				}
+			},
+			expectedError: false,
+		},
+		{
+			name: "invalid HostedCluster.Spec.ClusterID is returned as error",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+			},
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+			},
+			contentLister: func(t *testing.T) listers.ManagementClusterContentLister {
+				t.Helper()
+				return &listertesting.SliceManagementClusterContentLister{
+					Contents: []*api.ManagementClusterContent{newHostedClusterContent(t, "not-a-uuid")},
+				}
+			},
+			expectedError:         true,
+			expectedErrorContains: "failed to parse cluster UUID",
 		},
 	}
 
@@ -269,11 +433,17 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 			tt.seedDB(t, ctx, mockDB)
 			tt.mockCS(t, mockCS)
 
+			contentLister := newValidHostedClusterContentLister(t)
+			if tt.contentLister != nil {
+				contentLister = tt.contentLister(t)
+			}
+
 			syncer := &nodePoolVersionSyncer{
-				cooldownChecker:           &alwaysSyncCooldownChecker{},
-				cosmosClient:              mockDB,
-				clusterServiceClient:      mockCS,
-				clusterToCincinnatiClient: lru.New(100),
+				cooldownChecker:                       &alwaysSyncCooldownChecker{},
+				clusterManagementClusterContentLister: contentLister,
+				cosmosClient:                          mockDB,
+				clusterServiceClient:                  mockCS,
+				clusterToCincinnatiClient:             lru.New(100),
 			}
 
 			ctx = utils.ContextWithLogger(ctx, logr.Discard())
@@ -617,13 +787,6 @@ func TestNodePoolVersionSyncer_SyncOnce_SkipMinorVersionFails(t *testing.T) {
 	// Create ServiceProviderNodePool with active version 4.18.10 (to create skew)
 	createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.18.10")
 
-	// Setup CS mocks
-	csCluster := newCSCluster(t)
-	mockCS.EXPECT().
-		GetCluster(gomock.Any(), gomock.Any()).
-		Return(csCluster, nil).
-		Times(1)
-
 	// CS returns node pool with current version 4.18.10
 	csNodePool := newCSNodePoolWithVersion(t, "4.18.10")
 	mockCS.EXPECT().
@@ -632,10 +795,11 @@ func TestNodePoolVersionSyncer_SyncOnce_SkipMinorVersionFails(t *testing.T) {
 		Times(1)
 
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:           &alwaysSyncCooldownChecker{},
-		cosmosClient:              mockDB,
-		clusterServiceClient:      mockCS,
-		clusterToCincinnatiClient: lru.New(100),
+		cooldownChecker:                       &alwaysSyncCooldownChecker{},
+		clusterManagementClusterContentLister: newValidHostedClusterContentLister(t),
+		cosmosClient:                          mockDB,
+		clusterServiceClient:                  mockCS,
+		clusterToCincinnatiClient:             lru.New(100),
 	}
 
 	testKey := controllerutils.HCPNodePoolKey{
@@ -668,13 +832,6 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredExceedsControlPlaneFails(t *testi
 	// Create ServiceProviderNodePool with active version 4.19.5 (so desired is not already active)
 	createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.5")
 
-	// Setup CS mocks
-	csCluster := newCSCluster(t)
-	mockCS.EXPECT().
-		GetCluster(gomock.Any(), gomock.Any()).
-		Return(csCluster, nil).
-		Times(1)
-
 	// CS returns node pool with current version 4.19.5
 	csNodePool := newCSNodePoolWithVersion(t, "4.19.5")
 	mockCS.EXPECT().
@@ -683,10 +840,11 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredExceedsControlPlaneFails(t *testi
 		Times(1)
 
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:           &alwaysSyncCooldownChecker{},
-		cosmosClient:              mockDB,
-		clusterServiceClient:      mockCS,
-		clusterToCincinnatiClient: lru.New(100),
+		cooldownChecker:                       &alwaysSyncCooldownChecker{},
+		clusterManagementClusterContentLister: newValidHostedClusterContentLister(t),
+		cosmosClient:                          mockDB,
+		clusterServiceClient:                  mockCS,
+		clusterToCincinnatiClient:             lru.New(100),
 	}
 
 	testKey := controllerutils.HCPNodePoolKey{
@@ -717,13 +875,6 @@ func TestNodePoolVersionSyncer_SyncOnce_NoUpgradePathInCincinnatiFails(t *testin
 	// Create ServiceProviderCluster with control plane at 4.20.0 (allows the desired version)
 	createServiceProviderClusterWithVersion(t, ctx, mockDB, "4.20.0")
 
-	// Setup CS mocks
-	csCluster := newCSCluster(t)
-	mockCS.EXPECT().
-		GetCluster(gomock.Any(), gomock.Any()).
-		Return(csCluster, nil).
-		Times(1)
-
 	// CS returns node pool with current version 4.19.7
 	csNodePool := newCSNodePoolWithVersion(t, "4.19.7")
 	mockCS.EXPECT().
@@ -743,10 +894,11 @@ func TestNodePoolVersionSyncer_SyncOnce_NoUpgradePathInCincinnatiFails(t *testin
 		Times(1)
 
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:           &alwaysSyncCooldownChecker{},
-		cosmosClient:              mockDB,
-		clusterServiceClient:      mockCS,
-		clusterToCincinnatiClient: lru.New(100),
+		cooldownChecker:                       &alwaysSyncCooldownChecker{},
+		clusterManagementClusterContentLister: newValidHostedClusterContentLister(t),
+		cosmosClient:                          mockDB,
+		clusterServiceClient:                  mockCS,
+		clusterToCincinnatiClient:             lru.New(100),
 	}
 
 	// Pre-populate Cincinnati client cache
@@ -787,13 +939,6 @@ func TestNodePoolVersionSyncer_SyncOnce_DowngradeFails(t *testing.T) {
 	// Create ServiceProviderNodePool with active version 4.19.10 (higher than desired)
 	createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.10")
 
-	// Setup CS mocks
-	csCluster := newCSCluster(t)
-	mockCS.EXPECT().
-		GetCluster(gomock.Any(), gomock.Any()).
-		Return(csCluster, nil).
-		Times(1)
-
 	// CS returns node pool with current version 4.19.10
 	csNodePool := newCSNodePoolWithVersion(t, "4.19.10")
 	mockCS.EXPECT().
@@ -802,10 +947,11 @@ func TestNodePoolVersionSyncer_SyncOnce_DowngradeFails(t *testing.T) {
 		Times(1)
 
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:           &alwaysSyncCooldownChecker{},
-		cosmosClient:              mockDB,
-		clusterServiceClient:      mockCS,
-		clusterToCincinnatiClient: lru.New(100),
+		cooldownChecker:                       &alwaysSyncCooldownChecker{},
+		clusterManagementClusterContentLister: newValidHostedClusterContentLister(t),
+		cosmosClient:                          mockDB,
+		clusterServiceClient:                  mockCS,
+		clusterToCincinnatiClient:             lru.New(100),
 	}
 
 	testKey := controllerutils.HCPNodePoolKey{
@@ -836,13 +982,6 @@ func TestNodePoolVersionSyncer_SyncOnce_UpgradePathExistsSucceeds(t *testing.T) 
 	// Create ServiceProviderCluster with control plane at 4.20.0
 	createServiceProviderClusterWithVersion(t, ctx, mockDB, "4.20.0")
 
-	// Setup CS mocks
-	csCluster := newCSCluster(t)
-	mockCS.EXPECT().
-		GetCluster(gomock.Any(), gomock.Any()).
-		Return(csCluster, nil).
-		Times(1)
-
 	// CS returns node pool with current version 4.19.10
 	csNodePool := newCSNodePoolWithVersion(t, "4.19.10")
 	mockCS.EXPECT().
@@ -866,10 +1005,11 @@ func TestNodePoolVersionSyncer_SyncOnce_UpgradePathExistsSucceeds(t *testing.T) 
 		Times(1)
 
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:           &alwaysSyncCooldownChecker{},
-		cosmosClient:              mockDB,
-		clusterServiceClient:      mockCS,
-		clusterToCincinnatiClient: lru.New(100),
+		cooldownChecker:                       &alwaysSyncCooldownChecker{},
+		clusterManagementClusterContentLister: newValidHostedClusterContentLister(t),
+		cosmosClient:                          mockDB,
+		clusterServiceClient:                  mockCS,
+		clusterToCincinnatiClient:             lru.New(100),
 	}
 
 	// Pre-populate Cincinnati client cache
@@ -914,13 +1054,6 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	// Seed the database with a node pool
 	createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
 
-	// Setup CS mock to return a cluster with UUID
-	csCluster := newCSCluster(t)
-	mockCS.EXPECT().
-		GetCluster(gomock.Any(), gomock.Any()).
-		Return(csCluster, nil).
-		Times(1)
-
 	// Setup CS mock to return a node pool with version
 	csNodePool := newCSNodePool(t, "4.19.10")
 	mockCS.EXPECT().
@@ -940,10 +1073,11 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 		AnyTimes()
 
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:           &alwaysSyncCooldownChecker{},
-		cosmosClient:              mockDB,
-		clusterServiceClient:      mockCS,
-		clusterToCincinnatiClient: lru.New(100),
+		cooldownChecker:                       &alwaysSyncCooldownChecker{},
+		clusterManagementClusterContentLister: newValidHostedClusterContentLister(t),
+		cosmosClient:                          mockDB,
+		clusterServiceClient:                  mockCS,
+		clusterToCincinnatiClient:             lru.New(100),
 	}
 
 	// Pre-populate Cincinnati client cache
@@ -999,10 +1133,6 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 
 	// Setup CS mocks for second sync
 	mockCS.EXPECT().
-		GetCluster(gomock.Any(), gomock.Any()).
-		Return(csCluster, nil).
-		Times(1)
-	mockCS.EXPECT().
 		GetNodePool(gomock.Any(), gomock.Any()).
 		Return(csNodePool, nil).
 		Times(1)
@@ -1039,10 +1169,6 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	// --- Phase 3: Cincinnati succeeds, desired should change ---
 
 	// Setup CS mocks for third sync
-	mockCS.EXPECT().
-		GetCluster(gomock.Any(), gomock.Any()).
-		Return(csCluster, nil).
-		Times(1)
 	mockCS.EXPECT().
 		GetNodePool(gomock.Any(), gomock.Any()).
 		Return(csNodePool, nil).

--- a/backend/pkg/maestrohelpers/clusters.go
+++ b/backend/pkg/maestrohelpers/clusters.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maestrohelpers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func GetCachedHostedClusterForCluster(ctx context.Context, clusterManagementClusterContentLister listers.ManagementClusterContentLister, subscriptionName, resourceGroupName, clusterName string) (*v1beta1.HostedCluster, error) {
+	hostedClusterContent, err := clusterManagementClusterContentLister.GetForCluster(ctx, subscriptionName, resourceGroupName, clusterName, string(api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster))
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to get cluster management cluster content: %w", err))
+	}
+	if hostedClusterContent.Status.KubeContent == nil {
+		return nil, nil
+	}
+	if len(hostedClusterContent.Status.KubeContent.Items) != 1 {
+		return nil, nil
+	}
+	hostedCluster := &v1beta1.HostedCluster{}
+	if err := json.Unmarshal(hostedClusterContent.Status.KubeContent.Items[0].Raw, hostedCluster); err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to unmarshal kubecontent: %w", err))
+	}
+	return hostedCluster, nil
+}
+
+// GetCachedHostedClusterUUIDForCluster resolves the cluster UUID parsed from the cached HostedCluster's
+// Spec.ClusterID for the given cluster.
+//
+// Returns (uuid, true, nil) on success.
+//
+// Returns (uuid.Nil, false, nil) for transient situations the caller should treat as a silent skip:
+// the management cluster content has not yet been observed, the kubecontent does not contain exactly
+// one HostedCluster, or the HostedCluster's Spec.ClusterID is empty. The reason is logged via the
+// context logger so callers don't need to.
+//
+// Returns a non-nil error only for hard failures: a non-NotFound lister error, malformed kubecontent,
+// or an unparseable UUID.
+func GetCachedHostedClusterUUIDForCluster(ctx context.Context, clusterManagementClusterContentLister listers.ManagementClusterContentLister, subscriptionName, resourceGroupName, clusterName string) (uuid.UUID, bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+	hostedCluster, err := GetCachedHostedClusterForCluster(ctx, clusterManagementClusterContentLister, subscriptionName, resourceGroupName, clusterName)
+	if database.IsNotFoundError(err) {
+		// will reappear once the informer relists; until then there is no UUID to derive
+		return uuid.Nil, false, nil
+	}
+	if err != nil {
+		return uuid.Nil, false, err
+	}
+	if hostedCluster == nil {
+		logger.Info("hosted cluster not found")
+		return uuid.Nil, false, nil
+	}
+	if len(hostedCluster.Spec.ClusterID) == 0 {
+		logger.Info("missing cluster UUID")
+		return uuid.Nil, false, nil
+	}
+	clusterUUID, err := uuid.Parse(hostedCluster.Spec.ClusterID)
+	if err != nil {
+		return uuid.Nil, false, utils.TrackError(fmt.Errorf("failed to parse cluster UUID: %w", err))
+	}
+	return clusterUUID, true, nil
+}


### PR DESCRIPTION
This disconnects cluster-service from another piece of our controllers.
    
We should consider a backup flow that uses an value when missing and see    if we can supply the value to cluster-service and generate it ourselves.

Addresses the first cause of the nodepoolversion controller retry in https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/5020/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2048471908730540032
