### PR TITLE
Distinguish userAgent by component via clientOptions in azure-sdk-for-go

### DIFF
--- a/.bingo/go.mod
+++ b/.bingo/go.mod
@@ -1,1 +1,3 @@
 module _ // Fake go.mod auto-created by 'bingo' for go -moddir compatibility with non-Go projects. Commit this file, together with other .mod files.
+
+go 1.25.7

--- a/admin/server/cmd/server/options.go
+++ b/admin/server/cmd/server/options.go
@@ -33,13 +33,13 @@ import (
 	"k8s.io/utils/set"
 
 	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 
 	"github.com/Azure/ARO-HCP/admin/server/server"
 	"github.com/Azure/ARO-HCP/internal/audit"
+	"github.com/Azure/ARO-HCP/internal/azsdk"
 	"github.com/Azure/ARO-HCP/internal/certificate"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/fpa"
@@ -201,13 +201,13 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 	csClient := ocm.NewClusterServiceClient(csConnection)
 
 	// Create the database client.
+	clientOpts := azsdk.NewClientOptions(azsdk.ComponentAdmin)
+	// FIXME Cloud should be determined by other means.
+	clientOpts.Cloud = cloud.AzurePublic
 	cosmosDatabaseClient, err := database.NewCosmosDatabaseClient(
 		o.CosmosURL,
 		o.CosmosName,
-		azcore.ClientOptions{
-			// FIXME Cloud should be determined by other means.
-			Cloud: cloud.AzurePublic,
-		},
+		clientOpts,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the CosmosDB client: %w", err)
@@ -237,7 +237,7 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to run certificate reader: %w", err)
 	}
-	fpaCredentialRetriever, err := fpa.NewFirstPartyApplicationTokenCredentialRetriever(o.FpaClientID, certReader, azcore.ClientOptions{})
+	fpaCredentialRetriever, err := fpa.NewFirstPartyApplicationTokenCredentialRetriever(o.FpaClientID, certReader, azsdk.NewClientOptions(azsdk.ComponentAdmin))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the FPA token credentials: %w", err)
 	}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect

--- a/backend/pkg/azure/config/azure_cloud_environment.go
+++ b/backend/pkg/azure/config/azure_cloud_environment.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel"
 
 	apisconfigv1 "github.com/Azure/ARO-HCP/backend/pkg/apis/config/v1"
+	"github.com/Azure/ARO-HCP/internal/azsdk"
 )
 
 // AzureCloudEnvironment represents an Azure cloud environment.
@@ -97,6 +98,9 @@ func NewAzureCloudEnvironment(
 
 	clientOptions := &policy.ClientOptions{
 		Cloud: configuration.cloud,
+		Telemetry: policy.TelemetryOptions{
+			ApplicationID: azsdk.ApplicationID(azsdk.ComponentBackend),
+		},
 	}
 	if tracerProvider != nil {
 		clientOptions.TracingProvider = azotel.NewTracingProvider(tracerProvider, nil)

--- a/frontend/cmd/cmd.go
+++ b/frontend/cmd/cmd.go
@@ -32,7 +32,7 @@ import (
 
 	"k8s.io/component-base/metrics/legacyregistry"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel"
@@ -42,6 +42,7 @@ import (
 	"github.com/Azure/ARO-HCP/frontend/pkg/frontend"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/audit"
+	"github.com/Azure/ARO-HCP/internal/azsdk"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/signal"
@@ -189,15 +190,15 @@ func (opts *FrontendOpts) Run() error {
 	}
 
 	// Create the database client.
+	clientOpts := azsdk.NewClientOptions(azsdk.ComponentFrontend)
+	// FIXME Cloud should be determined by other means.
+	clientOpts.Cloud = cloud.AzurePublic
+	clientOpts.PerCallPolicies = []policy.Policy{PolicyFunc(CorrelationIDPolicy)}
+	clientOpts.TracingProvider = azotel.NewTracingProvider(otel.GetTracerProvider(), nil)
 	cosmosDatabaseClient, err := database.NewCosmosDatabaseClient(
 		opts.cosmosURL,
 		opts.cosmosName,
-		azcore.ClientOptions{
-			// FIXME Cloud should be determined by other means.
-			Cloud:           cloud.AzurePublic,
-			PerCallPolicies: []policy.Policy{PolicyFunc(CorrelationIDPolicy)},
-			TracingProvider: azotel.NewTracingProvider(otel.GetTracerProvider(), nil),
-		},
+		clientOpts,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create the CosmosDB client: %w", err)

--- a/frontend/cmd/cmd.go
+++ b/frontend/cmd/cmd.go
@@ -32,7 +32,6 @@ import (
 
 	"k8s.io/component-base/metrics/legacyregistry"
 
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel"

--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -24,7 +24,6 @@ require (
 
 require (
 	dario.cat/mergo v1.0.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
 	github.com/Azure/retry v0.0.0-20250221010952-92c9290cea0f // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/internal/azsdk/clientoptions.go
+++ b/internal/azsdk/clientoptions.go
@@ -1,0 +1,58 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azsdk
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+
+	"github.com/Azure/ARO-HCP/internal/version"
+)
+
+type Component string
+
+const (
+	ComponentFrontend        Component = "frontend"
+	ComponentBackend         Component = "backend"
+	ComponentAdmin           Component = "admin"
+	ComponentResourceCleaner Component = "resource-cleaner"
+	ComponentE2E             Component = "e2e"
+)
+
+// ApplicationID returns a telemetry application ID for the given component,
+// truncated to 24 characters per Azure SDK guidelines.
+func ApplicationID(component Component) string {
+	return firstN(fmt.Sprintf("%s/%s", component, version.CommitSHA), 24)
+}
+
+// NewClientOptions returns azcore.ClientOptions with Telemetry.ApplicationID
+// set to identify the ARO-HCP component and its version.
+func NewClientOptions(component Component) azcore.ClientOptions {
+	return azcore.ClientOptions{
+		Telemetry: policy.TelemetryOptions{
+			ApplicationID: ApplicationID(component),
+		},
+	}
+}
+
+func firstN(str string, n int) string {
+	v := []rune(str)
+	if n >= len(v) {
+		return str
+	}
+	return string(v[:n])
+}

--- a/internal/azsdk/clientoptions.go
+++ b/internal/azsdk/clientoptions.go
@@ -50,6 +50,9 @@ func NewClientOptions(component Component) azcore.ClientOptions {
 }
 
 func firstN(str string, n int) string {
+	if n <= 0 {
+		return ""
+	}
 	v := []rune(str)
 	if n >= len(v) {
 		return str

--- a/internal/azsdk/clientoptions_test.go
+++ b/internal/azsdk/clientoptions_test.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -156,7 +156,7 @@ func TestClientOptionsUserAgentHeader(t *testing.T) {
 		},
 	}
 
-	rgClient, err := armresources.NewResourceGroupsClient("test-subscription", &fakeCredential{}, &arm.ClientOptions{
+	rgClient, err := armresources.NewResourceGroupsClient("test-subscription", &fakeCredential{}, &azcorearm.ClientOptions{
 		ClientOptions: clientOptions,
 	})
 	if err != nil {

--- a/internal/azsdk/clientoptions_test.go
+++ b/internal/azsdk/clientoptions_test.go
@@ -1,0 +1,170 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azsdk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+
+	"github.com/Azure/ARO-HCP/internal/version"
+)
+
+type fakeCredential struct{}
+
+func (f *fakeCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{
+		Token:     "fake-token",
+		ExpiresOn: time.Now().Add(1 * time.Hour),
+	}, nil
+}
+
+func TestFirstN(t *testing.T) {
+	tests := []struct {
+		name     string
+		str      string
+		n        int
+		expected string
+	}{
+		{
+			name:     "string shorter than n",
+			str:      "hello",
+			n:        10,
+			expected: "hello",
+		},
+		{
+			name:     "string equal to n",
+			str:      "hello",
+			n:        5,
+			expected: "hello",
+		},
+		{
+			name:     "string longer than n",
+			str:      "hello world",
+			n:        5,
+			expected: "hello",
+		},
+		{
+			name:     "empty string",
+			str:      "",
+			n:        5,
+			expected: "",
+		},
+		{
+			name:     "n is zero",
+			str:      "hello",
+			n:        0,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := firstN(tt.str, tt.n)
+			if result != tt.expected {
+				t.Errorf("firstN(%q, %d) = %q, expected %q", tt.str, tt.n, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestApplicationID(t *testing.T) {
+	tests := []struct {
+		name      string
+		component Component
+		commitSHA string
+		expected  string
+	}{
+		{
+			name:      "short SHA fits within limit",
+			component: ComponentFrontend,
+			commitSHA: "abc123",
+			expected:  "frontend/abc123",
+		},
+		{
+			name:      "long SHA gets truncated to 24 chars",
+			component: ComponentBackend,
+			commitSHA: "abcdef1234567890abcdef12",
+			expected:  "backend/abcdef1234567890",
+		},
+		{
+			name:      "default development value",
+			component: ComponentAdmin,
+			commitSHA: "development",
+			expected:  "admin/development",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := version.CommitSHA
+			version.CommitSHA = tt.commitSHA
+			t.Cleanup(func() { version.CommitSHA = original })
+
+			result := ApplicationID(tt.component)
+			if result != tt.expected {
+				t.Errorf("ApplicationID(%q) = %q, expected %q", tt.component, result, tt.expected)
+			}
+			if len(result) > 24 {
+				t.Errorf("ApplicationID(%q) length %d exceeds 24-char limit", tt.component, len(result))
+			}
+		})
+	}
+}
+
+func TestClientOptionsUserAgentHeader(t *testing.T) {
+	expectedValue := fmt.Sprintf("%s/%s", ComponentFrontend, version.CommitSHA)
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent := r.Header.Get("User-Agent")
+		if !strings.Contains(userAgent, expectedValue) {
+			t.Errorf("expected User-Agent to contain %q, got %q", expectedValue, userAgent)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	clientOptions := NewClientOptions(ComponentFrontend)
+	clientOptions.Cloud = cloud.AzurePublic
+	clientOptions.Transport = ts.Client()
+	clientOptions.Cloud.Services = map[cloud.ServiceName]cloud.ServiceConfiguration{
+		cloud.ResourceManager: {
+			Endpoint: ts.URL,
+			Audience: "test",
+		},
+	}
+
+	rgClient, err := armresources.NewResourceGroupsClient("test-subscription", &fakeCredential{}, &arm.ClientOptions{
+		ClientOptions: clientOptions,
+	})
+	if err != nil {
+		t.Fatalf("failed to create ResourceGroupsClient: %v", err)
+	}
+
+	_, err = rgClient.Get(context.Background(), "test-rg", nil)
+	if err != nil {
+		t.Fatalf("failed to make Get request: %v", err)
+	}
+}

--- a/internal/azsdk/clientoptions_test.go
+++ b/internal/azsdk/clientoptions_test.go
@@ -16,7 +16,6 @@ package azsdk
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -78,6 +77,12 @@ func TestFirstN(t *testing.T) {
 			n:        0,
 			expected: "",
 		},
+		{
+			name:     "n is negative",
+			str:      "hello",
+			n:        -1,
+			expected: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -135,14 +140,16 @@ func TestApplicationID(t *testing.T) {
 }
 
 func TestClientOptionsUserAgentHeader(t *testing.T) {
-	expectedValue := fmt.Sprintf("%s/%s", ComponentFrontend, version.CommitSHA)
+	expectedValue := ApplicationID(ComponentFrontend)
 
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userAgent := r.Header.Get("User-Agent")
 		if !strings.Contains(userAgent, expectedValue) {
 			t.Errorf("expected User-Agent to contain %q, got %q", expectedValue, userAgent)
 		}
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
 	}))
 	defer ts.Close()
 

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/go-logr/logr v1.4.3

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0 // indirect
 	github.com/Azure/retry v0.0.0-20250221010952-92c9290cea0f // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect

--- a/internal/go.sum
+++ b/internal/go.sum
@@ -15,6 +15,7 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dB
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0 h1:akP6VpxJGgQRpDR1P462piz/8OhYLRCreDj48AyNabc=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0/go.mod h1:8wzvopPfyZYPaQUoKW87Zfdul7jmJMDfp/k7YY3oJyA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/retry v0.0.0-20250221010952-92c9290cea0f h1:XjKfallhRhddiRmBG0u2gs+Rd75QjvAlPVDy3ZWLjPg=

--- a/internal/go.sum
+++ b/internal/go.sum
@@ -12,6 +12,12 @@ github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2 h1:zqxnp53f5Jn5PFU5Av
 github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2/go.mod h1:Krtog/7tz27z75TwM5cIS8bxEH4dcBUezcq+kGVeZEo=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0 h1:pPvTJ1dY0sA35JOeFq6TsY2xj6Z85Yo23Pj4wCCvu4o=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0/go.mod h1:mLfWfj8v3jfWKsL9G4eoBoXVcsqcIUTapmdKy7uGOp0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/retry v0.0.0-20250221010952-92c9290cea0f h1:XjKfallhRhddiRmBG0u2gs+Rd75QjvAlPVDy3ZWLjPg=
 github.com/Azure/retry v0.0.0-20250221010952-92c9290cea0f/go.mod h1:4FpEaBWwrdI8kVPeNESpqzIYAZipu7K6MCGCCC6bJ/A=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=

--- a/internal/go.sum
+++ b/internal/go.sum
@@ -14,8 +14,7 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6Xu
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0 h1:pPvTJ1dY0sA35JOeFq6TsY2xj6Z85Yo23Pj4wCCvu4o=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0/go.mod h1:mLfWfj8v3jfWKsL9G4eoBoXVcsqcIUTapmdKy7uGOp0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0 h1:akP6VpxJGgQRpDR1P462piz/8OhYLRCreDj48AyNabc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/retry v0.0.0-20250221010952-92c9290cea0f h1:XjKfallhRhddiRmBG0u2gs+Rd75QjvAlPVDy3ZWLjPg=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -14,4 +14,4 @@
 package version
 
 // CommitSHA is the SHA of the current HEAD. Populated at build-time.
-var CommitSHA string
+var CommitSHA string = "development"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,5 +13,6 @@
 // limitations under the License.
 package version
 
-// CommitSHA is the SHA of the current HEAD. Populated at build-time.
+// CommitSHA is the SHA of the current HEAD. It defaults to "development"
+// when not set at build-time via ldflags.
 var CommitSHA string = "development"

--- a/test-integration/utils/integrationutils/cosmos_testinfo.go
+++ b/test-integration/utils/integrationutils/cosmos_testinfo.go
@@ -29,13 +29,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 
 	"github.com/Azure/ARO-HCP/frontend/cmd"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/azsdk"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/utils"
 	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
@@ -381,11 +381,11 @@ func createCosmosClientFromEnv() (*azcosmos.Client, error) {
 	}
 
 	// Create a custom pipeline option for the client
+	cosmosClientOpts := azsdk.NewClientOptions(azsdk.ComponentE2E)
+	cosmosClientOpts.Transport = httpClient
+	cosmosClientOpts.PerCallPolicies = []policy.Policy{cmd.PolicyFunc(cmd.CorrelationIDPolicy)}
 	clientOptions := &azcosmos.ClientOptions{
-		ClientOptions: azcore.ClientOptions{
-			Transport:       httpClient,
-			PerCallPolicies: []policy.Policy{cmd.PolicyFunc(cmd.CorrelationIDPolicy)},
-		},
+		ClientOptions: cosmosClientOpts,
 	}
 
 	// Create key credential

--- a/test-integration/utils/integrationutils/frontend_testinfo.go
+++ b/test-integration/utils/integrationutils/frontend_testinfo.go
@@ -22,7 +22,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -31,6 +30,7 @@ import (
 	"github.com/Azure/ARO-HCP/frontend/pkg/frontend"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/azsdk"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
@@ -62,27 +62,27 @@ type IntegrationTestInfo struct {
 }
 
 func Get20240610ClientFactory(frontendURL string, subscriptionID string) *hcpsdk20240610preview.ClientFactory {
+	clientOpts := azsdk.NewClientOptions(azsdk.ComponentE2E)
+	clientOpts.Retry = policy.RetryOptions{
+		MaxRetries: -1, // no retries
+	}
+	clientOpts.Cloud = cloud.Configuration{
+		//ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Audience: "https://management.core.windows.net/",
+				Endpoint: frontendURL,
+			},
+		},
+	}
+	clientOpts.InsecureAllowCredentialWithHTTP = true
+	clientOpts.PerCallPolicies = []policy.Policy{
+		emptySystemData{},
+	}
 	return api.Must(
 		hcpsdk20240610preview.NewClientFactory(subscriptionID, nil,
 			&azcorearm.ClientOptions{
-				ClientOptions: azcore.ClientOptions{
-					Retry: policy.RetryOptions{
-						MaxRetries: -1, // no retries
-					},
-					Cloud: cloud.Configuration{
-						//ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
-						Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
-							cloud.ResourceManager: {
-								Audience: "https://management.core.windows.net/",
-								Endpoint: frontendURL,
-							},
-						},
-					},
-					InsecureAllowCredentialWithHTTP: true,
-					PerCallPolicies: []policy.Policy{
-						emptySystemData{},
-					},
-				},
+				ClientOptions: clientOpts,
 			},
 		),
 	)

--- a/test/e2e/shoebox_logs.go
+++ b/test/e2e/shoebox_logs.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 
+	"github.com/Azure/ARO-HCP/internal/azsdk"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -293,7 +294,9 @@ var _ = Describe("Customer", func() {
 			resourceID := clusterResourceID(subscriptionID, *resourceGroup.Name, customerClusterName)
 			logSettings := shoeboxDiagnosticLogSettings()
 
-			diagnosticsClient, err := armmonitor.NewDiagnosticSettingsClient(creds, &azcorearm.ClientOptions{})
+			diagnosticsClient, err := armmonitor.NewDiagnosticSettingsClient(creds, &azcorearm.ClientOptions{
+				ClientOptions: azsdk.NewClientOptions(azsdk.ComponentE2E),
+			})
 			if err != nil {
 				GinkgoLogr.Error(err, "failed to create diagnostics client")
 				return

--- a/test/go.mod
+++ b/test/go.mod
@@ -73,7 +73,6 @@ require (
 	github.com/Azure/azure-kusto-go/azkustodata v1.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dashboard/armdashboard/v2 v2.0.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeploymentstacks v1.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armfeatures v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1 // indirect

--- a/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod
+++ b/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod
@@ -3,3 +3,9 @@ module github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armr
 go 1.25.7
 
 require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0
+
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	golang.org/x/net v0.42.0 // indirect
+	golang.org/x/text v0.27.0 // indirect
+)

--- a/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.sum
+++ b/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.sum
@@ -1,0 +1,16 @@
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0 h1:ci6Yd6nysBRLEodoziB6ah1+YOzZbZk+NYneoA6q+6E=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0/go.mod h1:QyVsSSN64v5TGltphKLQ2sQxe4OBQg0J1eKRcVBnfgE=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=
+golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=
+golang.org/x/text v0.27.0 h1:4fGWRpyh641NLlecmyl4LOe6yDdfaYNrGb2zdfo4JV4=
+golang.org/x/text v0.27.0/go.mod h1:1D28KMCvyooCX9hBiosv5Tz/+YLxj0j7XhWjpSUF7CU=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod
+++ b/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod
@@ -3,3 +3,9 @@ module github.com/Azure/ARO-HCP/test/sdk/v20240610preview/resourcemanager/redhat
 go 1.25.7
 
 require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0
+
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	golang.org/x/net v0.42.0 // indirect
+	golang.org/x/text v0.27.0 // indirect
+)

--- a/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.sum
+++ b/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.sum
@@ -1,0 +1,16 @@
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0 h1:ci6Yd6nysBRLEodoziB6ah1+YOzZbZk+NYneoA6q+6E=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0/go.mod h1:QyVsSSN64v5TGltphKLQ2sQxe4OBQg0J1eKRcVBnfgE=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=
+golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=
+golang.org/x/text v0.27.0 h1:4fGWRpyh641NLlecmyl4LOe6yDdfaYNrGb2zdfo4JV4=
+golang.org/x/text v0.27.0/go.mod h1:1D28KMCvyooCX9hBiosv5Tz/+YLxj0j7XhWjpSUF7CU=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod
+++ b/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.mod
@@ -3,3 +3,9 @@ module github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhat
 go 1.25.7
 
 require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0
+
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	golang.org/x/net v0.42.0 // indirect
+	golang.org/x/text v0.27.0 // indirect
+)

--- a/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.sum
+++ b/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/go.sum
@@ -1,0 +1,16 @@
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0 h1:ci6Yd6nysBRLEodoziB6ah1+YOzZbZk+NYneoA6q+6E=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0/go.mod h1:QyVsSSN64v5TGltphKLQ2sQxe4OBQg0J1eKRcVBnfgE=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=
+golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=
+golang.org/x/text v0.27.0 h1:4fGWRpyh641NLlecmyl4LOe6yDdfaYNrGb2zdfo4JV4=
+golang.org/x/text v0.27.0/go.mod h1:1D28KMCvyooCX9hBiosv5Tz/+YLxj0j7XhWjpSUF7CU=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/test/.gitignore
+++ b/test/test/.gitignore
@@ -1,0 +1,1 @@
+prow-job-executor

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -151,26 +151,17 @@ func (tc *perBinaryInvocationTestContext) getAzureCredentials() (azcore.TokenCre
 }
 
 func (tc *perBinaryInvocationTestContext) getClientFactoryOptions() *azcorearm.ClientOptions {
-	if tc.isDevelopmentEnvironment {
-		clientOpts := azsdk.NewClientOptions(azsdk.ComponentE2E)
-		clientOpts.Retry = azureRetryOptions
-		clientOpts.Transport = &proxiedConnectionTransporter{
-			delegate: tc.defaultTransport,
-		}
-		clientOpts.PerCallPolicies = []policy.Policy{
-			&correlationRequestIDPolicy{},
-			NewLROPollerRetryDeploymentNotFoundPolicy(),
-			&sanitizeAuthHeaderPolicy{},
-		}
-		return &azcorearm.ClientOptions{
-			ClientOptions: clientOpts,
-		}
-	}
 	clientOpts := azsdk.NewClientOptions(azsdk.ComponentE2E)
 	clientOpts.Retry = azureRetryOptions
 	clientOpts.PerCallPolicies = []policy.Policy{
 		NewLROPollerRetryDeploymentNotFoundPolicy(),
 		&sanitizeAuthHeaderPolicy{},
+	}
+	if tc.isDevelopmentEnvironment {
+		clientOpts.Transport = &proxiedConnectionTransporter{
+			delegate: tc.defaultTransport,
+		}
+		clientOpts.PerCallPolicies = append([]policy.Policy{&correlationRequestIDPolicy{}}, clientOpts.PerCallPolicies...)
 	}
 	return &azcorearm.ClientOptions{
 		ClientOptions: clientOpts,

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -38,6 +38,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+
+	"github.com/Azure/ARO-HCP/internal/azsdk"
 )
 
 type perBinaryInvocationTestContext struct {
@@ -150,28 +152,28 @@ func (tc *perBinaryInvocationTestContext) getAzureCredentials() (azcore.TokenCre
 
 func (tc *perBinaryInvocationTestContext) getClientFactoryOptions() *azcorearm.ClientOptions {
 	if tc.isDevelopmentEnvironment {
+		clientOpts := azsdk.NewClientOptions(azsdk.ComponentE2E)
+		clientOpts.Retry = azureRetryOptions
+		clientOpts.Transport = &proxiedConnectionTransporter{
+			delegate: tc.defaultTransport,
+		}
+		clientOpts.PerCallPolicies = []policy.Policy{
+			&correlationRequestIDPolicy{},
+			NewLROPollerRetryDeploymentNotFoundPolicy(),
+			&sanitizeAuthHeaderPolicy{},
+		}
 		return &azcorearm.ClientOptions{
-			ClientOptions: azcore.ClientOptions{
-				Retry: azureRetryOptions,
-				Transport: &proxiedConnectionTransporter{
-					delegate: tc.defaultTransport,
-				},
-				PerCallPolicies: []policy.Policy{
-					&correlationRequestIDPolicy{},
-					NewLROPollerRetryDeploymentNotFoundPolicy(),
-					&sanitizeAuthHeaderPolicy{},
-				},
-			},
+			ClientOptions: clientOpts,
 		}
 	}
+	clientOpts := azsdk.NewClientOptions(azsdk.ComponentE2E)
+	clientOpts.Retry = azureRetryOptions
+	clientOpts.PerCallPolicies = []policy.Policy{
+		NewLROPollerRetryDeploymentNotFoundPolicy(),
+		&sanitizeAuthHeaderPolicy{},
+	}
 	return &azcorearm.ClientOptions{
-		ClientOptions: azcore.ClientOptions{
-			Retry: azureRetryOptions,
-			PerCallPolicies: []policy.Policy{
-				NewLROPollerRetryDeploymentNotFoundPolicy(),
-				&sanitizeAuthHeaderPolicy{},
-			},
-		},
+		ClientOptions: clientOpts,
 	}
 }
 
@@ -181,38 +183,38 @@ func (tc *perBinaryInvocationTestContext) getHCPClientFactoryOptions() *azcorear
 		if tc.skipCertVerification {
 			transport.TLSClientConfig.InsecureSkipVerify = true
 		}
-		return &azcorearm.ClientOptions{
-			ClientOptions: azcore.ClientOptions{
-				Retry: azureRetryOptions,
-				Cloud: cloud.Configuration{
-					ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
-					Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
-						cloud.ResourceManager: {
-							Audience: "https://management.core.windows.net/",
-							Endpoint: tc.frontendAddress,
-						},
-					},
-				},
-				Transport: &proxiedConnectionTransporter{
-					delegate: transport,
-				},
-				InsecureAllowCredentialWithHTTP: true,
-				PerCallPolicies: []policy.Policy{
-					&correlationRequestIDPolicy{},
-					&armSystemDataPolicy{},
-					&armResourceGroupValidationPolicy{cred: tc.azureCredentials},
-					&sanitizeAuthHeaderPolicy{},
+		clientOpts := azsdk.NewClientOptions(azsdk.ComponentE2E)
+		clientOpts.Retry = azureRetryOptions
+		clientOpts.Cloud = cloud.Configuration{
+			ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+				cloud.ResourceManager: {
+					Audience: "https://management.core.windows.net/",
+					Endpoint: tc.frontendAddress,
 				},
 			},
 		}
+		clientOpts.Transport = &proxiedConnectionTransporter{
+			delegate: transport,
+		}
+		clientOpts.InsecureAllowCredentialWithHTTP = true
+		clientOpts.PerCallPolicies = []policy.Policy{
+			&correlationRequestIDPolicy{},
+			&armSystemDataPolicy{},
+			&armResourceGroupValidationPolicy{cred: tc.azureCredentials},
+			&sanitizeAuthHeaderPolicy{},
+		}
+		return &azcorearm.ClientOptions{
+			ClientOptions: clientOpts,
+		}
+	}
+	clientOpts := azsdk.NewClientOptions(azsdk.ComponentE2E)
+	clientOpts.Retry = azureRetryOptions
+	clientOpts.PerCallPolicies = []policy.Policy{
+		&sanitizeAuthHeaderPolicy{},
 	}
 	return &azcorearm.ClientOptions{
-		ClientOptions: azcore.ClientOptions{
-			Retry: azureRetryOptions,
-			PerCallPolicies: []policy.Policy{
-				&sanitizeAuthHeaderPolicy{},
-			},
-		},
+		ClientOptions: clientOpts,
 	}
 }
 

--- a/tooling/cleanup-sweeper/go.mod
+++ b/tooling/cleanup-sweeper/go.mod
@@ -25,7 +25,6 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/tooling/cleanup-sweeper/go.mod
+++ b/tooling/cleanup-sweeper/go.mod
@@ -3,6 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/cleanup-sweeper
 go 1.25.7
 
 require (
+	github.com/Azure/ARO-HCP/internal v0.0.0-00010101000000-000000000000
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.2
@@ -22,7 +23,6 @@ require (
 )
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0 // indirect
@@ -60,3 +60,5 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 )
+
+replace github.com/Azure/ARO-HCP/internal => ../../internal

--- a/tooling/cleanup-sweeper/go.sum
+++ b/tooling/cleanup-sweeper/go.sum
@@ -1,3 +1,4 @@
+github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzUOPYN9KEUUuC0Yd0/vC0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1/go.mod h1:pzBXCYn05zvYIrwLgtK8Ap8QcjRg+0i76tMQdWN6wOk=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=

--- a/tooling/cleanup-sweeper/pkg/engine/client_options.go
+++ b/tooling/cleanup-sweeper/pkg/engine/client_options.go
@@ -17,9 +17,10 @@ package engine
 import (
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+
+	"github.com/Azure/ARO-HCP/internal/azsdk"
 )
 
 var defaultARMRetryOptions = policy.RetryOptions{
@@ -31,10 +32,10 @@ var defaultARMRetryOptions = policy.RetryOptions{
 
 // DefaultARMClientOptions returns cleanup-sweeper's default ARM client options.
 func DefaultARMClientOptions() *azcorearm.ClientOptions {
+	clientOpts := azsdk.NewClientOptions(azsdk.ComponentResourceCleaner)
+	clientOpts.Retry = defaultARMRetryOptions
 	return &azcorearm.ClientOptions{
-		ClientOptions: azcore.ClientOptions{
-			Retry: defaultARMRetryOptions,
-		},
+		ClientOptions: clientOpts,
 	}
 }
 


### PR DESCRIPTION
### What

Defines a set of components and sets the component within clientOptions to set user agent on azure calls

### Why

userAgent defaults to the version of the azure client in use, with no distinguishing factors between what component is running where.  This adds components and part of the commit sha in order to determine what component is what when running.  


### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
