### PR TITLE
Refactor gather-observability to workspace-based architecture

### DIFF
--- a/test/E2ELocal.mk
+++ b/test/E2ELocal.mk
@@ -42,7 +42,7 @@ e2e-local/gather-observability: $(ARO_HCP_TESTS) $(TEMPLATIZE)
 	  --dev-settings-file $(DEV_SETTINGS_FILE) \
 	  --output "$(OBSERVABILITY_RENDERED_CONFIG)"
 	mkdir -p $(OBSERVABILITY_OUTPUT)
-	$(ARO_HCP_TESTS) gather-observability \
+	AZURE_TOKEN_CREDENTIALS=dev $(ARO_HCP_TESTS) gather-observability \
 		--rendered-config $(OBSERVABILITY_RENDERED_CONFIG) \
 		--subscription-id "$$(az account show --query id -o tsv)" \
 		--output $(OBSERVABILITY_OUTPUT) \

--- a/test/cmd/aro-hcp-tests/gather-observability/alerts.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/alerts.go
@@ -46,9 +46,10 @@ type alertData struct {
 
 // alertMetadata holds enrichments added by our tooling.
 type alertMetadata struct {
-	KnownIssue          bool   `json:"knownIssue"`
-	KnownIssueReason    string `json:"knownIssueReason,omitempty"`
-	MonitoringWorkspace string `json:"monitoringWorkspace,omitempty"`
+	KnownIssue              bool   `json:"knownIssue"`
+	KnownIssueReason        string `json:"knownIssueReason,omitempty"`
+	MonitoringWorkspace     string `json:"monitoringWorkspace,omitempty"`
+	MonitoringWorkspaceType string `json:"monitoringWorkspaceType,omitempty"`
 }
 
 // alert combines the alert data with our metadata.
@@ -62,6 +63,7 @@ func fetchAlerts(ctx context.Context, cred azcore.TokenCredential, scope string,
 	if err != nil {
 		return nil, fmt.Errorf("logger not found in context: %w", err)
 	}
+	logger = logger.WithValues("scope", scope)
 
 	client, err := armalertsmanagement.NewAlertsClient(scope, cred, nil)
 	if err != nil {
@@ -74,7 +76,7 @@ func fetchAlerts(ctx context.Context, cred azcore.TokenCredential, scope string,
 		start.UTC().Format(time.RFC3339),
 		end.UTC().Format(time.RFC3339),
 	)
-	logger.Info("querying alerts fired within window", "scope", scope, "timeRange", customTimeRange)
+	logger.Info("querying alerts fired within window", "timeRange", customTimeRange)
 
 	includeContext := true
 	pager := client.NewGetAllPager(&armalertsmanagement.AlertsClientGetAllOptions{

--- a/test/cmd/aro-hcp-tests/gather-observability/alerts_test.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/alerts_test.go
@@ -290,7 +290,6 @@ func TestAlertsPipeline(t *testing.T) {
 	}
 
 	output := alertsOutput{
-		Scope:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hcp-underlay-test-rg",
 		Alerts: classified,
 		Summary: alertsSummary{
 			Total:      len(classified),

--- a/test/cmd/aro-hcp-tests/gather-observability/artifacts/alerts.html.tmpl
+++ b/test/cmd/aro-hcp-tests/gather-observability/artifacts/alerts.html.tmpl
@@ -326,14 +326,20 @@
     .alert-links a:hover {
       text-decoration: underline;
     }
+
+    .badge-workspace {
+      background: #21262d;
+      border: 1px solid #30363d;
+      color: #8b949e;
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
   </style>
 </head>
 
 <body>
-
-  <div class="meta">
-    <span>Scope: {{.Scope}}</span>
-  </div>
 
   {{if .HasAlerts}}
   <div class="summary-bar">
@@ -382,6 +388,7 @@
   <div class="alert-card alert-card-known">
     <details class="known-details">
       <summary>
+        <span class="badge badge-workspace">{{$a.Metadata.MonitoringWorkspaceType}}</span>
         <span class="badge {{severityClass $a.Alert.Severity}}">{{$a.Alert.Severity}}</span>
         <span class="{{conditionClass $a.Alert.Condition}}">{{$a.Alert.Condition}}</span>
         <span class="alert-title-inline">{{$a.Alert.Name}}</span>
@@ -417,6 +424,7 @@
   {{else}}
   <div class="alert-card">
     <div class="alert-header">
+      <span class="badge badge-workspace">{{$a.Metadata.MonitoringWorkspaceType}}</span>
       <span class="badge {{severityClass $a.Alert.Severity}}">{{$a.Alert.Severity}}</span>
       <span class="{{conditionClass $a.Alert.Condition}}">{{$a.Alert.Condition}}</span>
       <span class="alert-time">

--- a/test/cmd/aro-hcp-tests/gather-observability/chart.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/chart.go
@@ -161,6 +161,8 @@ func buildChartData(title, description, query, queryErr string, results []Promet
 			continue
 		}
 
+		data = insertGapMarkers(data)
+
 		series = append(series, parsedSeries{
 			metric: result.Metric,
 			data:   data,
@@ -227,7 +229,8 @@ func buildChartData(title, description, query, queryErr string, results []Promet
 	for _, s := range series {
 		line.AddSeries(s.label, s.data,
 			charts.WithLineChartOpts(opts.LineChart{
-				ShowSymbol: ptr.To(false),
+				ShowSymbol:   ptr.To(false),
+				ConnectNulls: ptr.To(false),
 			}),
 		)
 	}
@@ -336,6 +339,50 @@ func parsePrometheusValue(v []any) (ts int64, val float64, ok bool) {
 		val = -math.MaxFloat64
 	}
 	return ts, val, true
+}
+
+// insertGapMarkers inserts null data points where the time between consecutive
+// points is much larger than the typical interval, causing ECharts to break
+// the line instead of drawing a misleading straight line across the gap.
+// The typical interval is inferred as the minimum gap between consecutive points.
+func insertGapMarkers(data []opts.LineData) []opts.LineData {
+	if len(data) < 3 {
+		return data
+	}
+	var minGap int64 = math.MaxInt64
+	for i := 1; i < len(data); i++ {
+		gap := dataPointTimestamp(data[i]) - dataPointTimestamp(data[i-1])
+		if gap > 0 && gap < minGap {
+			minGap = gap
+		}
+	}
+	if minGap == math.MaxInt64 {
+		return data
+	}
+	threshold := 3 * minGap
+	var result []opts.LineData
+	result = append(result, data[0])
+	for i := 1; i < len(data); i++ {
+		gap := dataPointTimestamp(data[i]) - dataPointTimestamp(data[i-1])
+		if gap > threshold {
+			midpoint := (dataPointTimestamp(data[i-1]) + dataPointTimestamp(data[i])) / 2
+			result = append(result, opts.LineData{Value: []any{midpoint, nil}})
+		}
+		result = append(result, data[i])
+	}
+	return result
+}
+
+func dataPointTimestamp(d opts.LineData) int64 {
+	if arr, ok := d.Value.([]any); ok && len(arr) >= 1 {
+		switch v := arr[0].(type) {
+		case int64:
+			return v
+		case float64:
+			return int64(v)
+		}
+	}
+	return 0
 }
 
 // metricLabel builds a display label from Prometheus metric labels.

--- a/test/cmd/aro-hcp-tests/gather-observability/chart_test.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/chart_test.go
@@ -19,6 +19,8 @@ import (
 	"math"
 	"strings"
 	"testing"
+
+	"github.com/go-echarts/go-echarts/v2/opts"
 )
 
 func TestParsePrometheusValue(t *testing.T) {
@@ -361,49 +363,6 @@ func TestSanitizeTitle(t *testing.T) {
 	}
 }
 
-func TestResolveWorkspaceEndpoint(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name        string
-		spec        QuerySpec
-		svcEndpoint string
-		hcpEndpoint string
-		want        string
-	}{
-		{
-			name:        "hcp workspace returns hcp endpoint",
-			spec:        QuerySpec{Workspace: "hcp"},
-			svcEndpoint: "https://svc.prometheus.example.com",
-			hcpEndpoint: "https://hcp.prometheus.example.com",
-			want:        "https://hcp.prometheus.example.com",
-		},
-		{
-			name:        "svc workspace returns svc endpoint",
-			spec:        QuerySpec{Workspace: "svc"},
-			svcEndpoint: "https://svc.prometheus.example.com",
-			hcpEndpoint: "https://hcp.prometheus.example.com",
-			want:        "https://svc.prometheus.example.com",
-		},
-		{
-			name:        "unknown workspace defaults to svc endpoint",
-			spec:        QuerySpec{Workspace: "other"},
-			svcEndpoint: "https://svc.prometheus.example.com",
-			hcpEndpoint: "https://hcp.prometheus.example.com",
-			want:        "https://svc.prometheus.example.com",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := resolveWorkspaceEndpoint(tt.spec, tt.svcEndpoint, tt.hcpEndpoint)
-			if got != tt.want {
-				t.Errorf("resolveWorkspaceEndpoint() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestLoadQueriesConfig(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -558,5 +517,130 @@ func TestLoadQueriesConfigEmbedded(t *testing.T) {
 		if len(p.Queries) == 0 {
 			t.Errorf("panel %q should contain at least one query", p.Title)
 		}
+	}
+}
+
+func makePoint(tsMs int64, val float64) opts.LineData {
+	return opts.LineData{Value: []any{tsMs, val}}
+}
+
+func TestDataPointTimestamp(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		data opts.LineData
+		want int64
+	}{
+		{
+			name: "int64 timestamp",
+			data: opts.LineData{Value: []any{int64(1700000000000), 1.0}},
+			want: 1700000000000,
+		},
+		{
+			name: "float64 timestamp",
+			data: opts.LineData{Value: []any{float64(1700000000000), 1.0}},
+			want: 1700000000000,
+		},
+		{
+			name: "unsupported type returns zero",
+			data: opts.LineData{Value: []any{"not-a-number", 1.0}},
+			want: 0,
+		},
+		{
+			name: "empty array returns zero",
+			data: opts.LineData{Value: []any{}},
+			want: 0,
+		},
+		{
+			name: "nil value returns zero",
+			data: opts.LineData{Value: nil},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := dataPointTimestamp(tt.data)
+			if got != tt.want {
+				t.Errorf("dataPointTimestamp() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInsertGapMarkers(t *testing.T) {
+	t.Parallel()
+	base := int64(1700000000000)
+
+	tests := []struct {
+		name     string
+		data     []opts.LineData
+		wantLen  int
+		wantNils []int // indices in result that should be null markers
+	}{
+		{
+			name:    "empty",
+			data:    nil,
+			wantLen: 0,
+		},
+		{
+			name:    "two points",
+			data:    []opts.LineData{makePoint(base, 1.0), makePoint(base+60000, 2.0)},
+			wantLen: 2,
+		},
+		{
+			name: "uniform spacing no gaps",
+			data: []opts.LineData{
+				makePoint(base, 1.0),
+				makePoint(base+60000, 2.0),
+				makePoint(base+120000, 3.0),
+				makePoint(base+180000, 4.0),
+			},
+			wantLen: 4,
+		},
+		{
+			name: "one large gap",
+			data: []opts.LineData{
+				makePoint(base, 1.0),
+				makePoint(base+60000, 2.0),
+				makePoint(base+120000, 3.0),
+				makePoint(base+600000, 4.0), // 480s gap vs 60s min → exceeds 3x threshold
+			},
+			wantLen:  5,
+			wantNils: []int{3},
+		},
+		{
+			name: "multiple gaps",
+			data: []opts.LineData{
+				makePoint(base, 1.0),
+				makePoint(base+60000, 2.0),
+				makePoint(base+500000, 3.0),  // large gap
+				makePoint(base+560000, 4.0),  // normal
+				makePoint(base+1200000, 5.0), // large gap
+			},
+			wantLen:  7,
+			wantNils: []int{2, 5},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := insertGapMarkers(tt.data)
+			if len(result) != tt.wantLen {
+				t.Fatalf("got %d points, want %d", len(result), tt.wantLen)
+			}
+			for _, idx := range tt.wantNils {
+				arr, ok := result[idx].Value.([]any)
+				if !ok || len(arr) < 2 {
+					t.Errorf("result[%d] should be a [ts, nil] pair, got %v", idx, result[idx].Value)
+					continue
+				}
+				if arr[1] != nil {
+					t.Errorf("result[%d] value should be nil, got %v", idx, arr[1])
+				}
+			}
+		})
 	}
 }

--- a/test/cmd/aro-hcp-tests/gather-observability/known_issues_test.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/known_issues_test.go
@@ -103,17 +103,6 @@ func TestParseKnownIssues(t *testing.T) {
 	}
 }
 
-func TestLoadKnownIssuesEmbedded(t *testing.T) {
-	t.Skip("embedded knownIssues.yaml is currently empty")
-	issues, err := parseKnownIssues(defaultKnownIssuesData)
-	if err != nil {
-		t.Fatalf("embedded knownIssues.yaml should parse without error: %v", err)
-	}
-	if len(issues) == 0 {
-		t.Fatal("embedded knownIssues.yaml should contain at least one known issue")
-	}
-}
-
 func TestClassifyAlerts(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/test/cmd/aro-hcp-tests/gather-observability/options.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/options.go
@@ -15,16 +15,12 @@
 package gatherobservability
 
 import (
-	"bytes"
 	"context"
-	"embed"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -33,24 +29,15 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/alertsmanagement/armalertsmanagement"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/utils"
 	"github.com/Azure/ARO-HCP/test/cmd/aro-hcp-tests/internal/testutil"
 	"github.com/Azure/ARO-HCP/test/util/timing"
 )
-
-//go:embed artifacts/*.html.tmpl
-var templatesFS embed.FS
-
-func mustReadArtifact(name string) []byte {
-	ret, err := templatesFS.ReadFile("artifacts/" + name)
-	if err != nil {
-		panic(fmt.Sprintf("failed to read embedded template %q: %v", name, err))
-	}
-	return ret
-}
 
 func DefaultOptions() *RawOptions {
 	return &RawOptions{}
@@ -86,14 +73,10 @@ type ValidatedOptions struct {
 
 type completedOptions struct {
 	OutputDir         string
-	Scope             string // Azure resource scope: /subscriptions/{sub}/resourceGroups/{rg}
-	SvcWorkspace      string
-	HcpWorkspace      string
+	Workspaces        map[string]azcorearm.ResourceID
 	TimeWindow        timing.TimeWindow
 	Queries           *QueriesConfig
 	SeverityThreshold int // -1 means no filter; 0=Sev0 .. 4=Sev4
-	SvcPromEndpoint   string
-	HcpPromEndpoint   string
 	cred              azcore.TokenCredential
 	knownIssues       []knownIssue
 }
@@ -187,7 +170,10 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 		return nil, fmt.Errorf("failed to create Azure credential: %w", err)
 	}
 
-	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", o.SubscriptionID, regionRG)
+	workspaces := map[string]azcorearm.ResourceID{
+		workspaceSvc: *api.Must(azcorearm.ParseResourceID(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Monitor/accounts/%s", o.SubscriptionID, regionRG, svcWorkspace))),
+		workspaceHcp: *api.Must(azcorearm.ParseResourceID(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Monitor/accounts/%s", o.SubscriptionID, regionRG, hcpWorkspace))),
+	}
 
 	queries, err := loadQueriesConfig()
 	if err != nil {
@@ -199,19 +185,6 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 	}
 	logger.Info("loaded embedded queries config", "panels", len(queries.Panels), "queries", totalQueries)
 
-	// Resolve Prometheus endpoints eagerly so we fail fast
-	svcPromEndpoint, err := lookupPrometheusEndpoint(ctx, cred, o.SubscriptionID, regionRG, svcWorkspace)
-	if err != nil {
-		return nil, fmt.Errorf("failed to look up svc Prometheus endpoint for workspace %s in %s: %w", svcWorkspace, regionRG, err)
-	}
-	logger.Info("resolved svc Prometheus endpoint", "endpoint", svcPromEndpoint)
-
-	hcpPromEndpoint, err := lookupPrometheusEndpoint(ctx, cred, o.SubscriptionID, regionRG, hcpWorkspace)
-	if err != nil {
-		return nil, fmt.Errorf("failed to look up hcp Prometheus endpoint for workspace %s in %s: %w", hcpWorkspace, regionRG, err)
-	}
-	logger.Info("resolved hcp Prometheus endpoint", "endpoint", hcpPromEndpoint)
-
 	knownIssues, err := parseKnownIssues(defaultKnownIssuesData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse known issues config: %w", err)
@@ -220,45 +193,14 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 
 	return &Options{completedOptions: &completedOptions{
 		OutputDir:         o.OutputDir,
-		Scope:             scope,
-		SvcWorkspace:      svcWorkspace,
-		HcpWorkspace:      hcpWorkspace,
+		Workspaces:        workspaces,
 		TimeWindow:        tw,
 		Queries:           queries,
 		SeverityThreshold: o.severityThreshold,
-		SvcPromEndpoint:   svcPromEndpoint,
-		HcpPromEndpoint:   hcpPromEndpoint,
 		cred:              cred,
 		knownIssues:       knownIssues,
 	}}, nil
 }
-
-// alertsOutput is written to alerts.json and passed to the HTML template.
-type alertsSummary struct {
-	Total      int                                  `json:"total"`
-	Known      int                                  `json:"known"`
-	Unknown    int                                  `json:"unknown"`
-	BySeverity map[armalertsmanagement.Severity]int `json:"bySeverity"`
-}
-
-type alertsOutput struct {
-	Scope      string `json:"scope"`
-	TimeWindow struct {
-		Start string `json:"start"`
-		End   string `json:"end"`
-	} `json:"timeWindow"`
-	Summary alertsSummary `json:"summary"`
-	Alerts  []alert       `json:"alerts"`
-}
-
-// Template helpers for the HTML template.
-func (o alertsOutput) SeverityCounts() map[armalertsmanagement.Severity]int {
-	return o.Summary.BySeverity
-}
-func (o alertsOutput) HasAlerts() bool        { return o.Summary.Total > 0 }
-func (o alertsOutput) HasUnknownAlerts() bool { return o.Summary.Unknown > 0 }
-func (o alertsOutput) KnownCount() int        { return o.Summary.Known }
-func (o alertsOutput) UnknownCount() int      { return o.Summary.Unknown }
 
 func (o Options) Run(ctx context.Context) error {
 	logger, err := logr.FromContext(ctx)
@@ -266,19 +208,20 @@ func (o Options) Run(ctx context.Context) error {
 		return fmt.Errorf("logger not found in context: %w", err)
 	}
 
-	allAlerts, err := fetchAlerts(ctx, o.cred, o.Scope, o.TimeWindow.Start, o.TimeWindow.End)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to fetch alerts for scope %s, time window [%s to %s]: %w",
-			o.Scope,
-			o.TimeWindow.Start.Format(time.RFC3339), o.TimeWindow.End.Format(time.RFC3339), err))
+	workspaces := make(map[string]*workspaceData, len(o.Workspaces))
+	for wsType, ws := range o.Workspaces {
+		wsData, err := fetchWorkspaceData(ctx, o.cred, wsType, ws, o.TimeWindow.Start, o.TimeWindow.End, o.SeverityThreshold, o.knownIssues)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("failed to fetch data for %s workspace: %w", wsType, err))
+		}
+		workspaces[wsType] = wsData
 	}
 
-	alerts := filterAlertsBySeverity(allAlerts, o.SeverityThreshold)
-	if o.SeverityThreshold >= 0 {
-		logger.Info("filtered alerts by severity threshold", "threshold", fmt.Sprintf("Sev%d", o.SeverityThreshold), "before", len(allAlerts), "after", len(alerts))
+	// Collect all alerts across workspaces for JSON/HTML output
+	var alerts []alert
+	for _, ws := range workspaces {
+		alerts = append(alerts, ws.FiredAlerts...)
 	}
-
-	alerts = classifyAlerts(alerts, o.knownIssues)
 
 	// Build output used for both JSON and HTML
 	severityCounts := map[armalertsmanagement.Severity]int{}
@@ -294,7 +237,6 @@ func (o Options) Run(ctx context.Context) error {
 	logger.Info("classified alerts", "known", knownCount, "unknown", unknownCount)
 
 	output := alertsOutput{
-		Scope:  o.Scope,
 		Alerts: alerts,
 		Summary: alertsSummary{
 			Total:      len(alerts),
@@ -302,10 +244,13 @@ func (o Options) Run(ctx context.Context) error {
 			Unknown:    unknownCount,
 			BySeverity: severityCounts,
 		},
+		TimeWindow: timeWindow{
+			Start: o.TimeWindow.Start.UTC().Format(time.RFC3339),
+			End:   o.TimeWindow.End.UTC().Format(time.RFC3339),
+		},
 	}
-	output.TimeWindow.Start = o.TimeWindow.Start.UTC().Format(time.RFC3339)
-	output.TimeWindow.End = o.TimeWindow.End.UTC().Format(time.RFC3339)
 
+	// Write JSON artifact
 	jsonPath := filepath.Join(o.OutputDir, "alerts.json")
 	jsonData, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
@@ -323,9 +268,9 @@ func (o Options) Run(ctx context.Context) error {
 	}
 	logger.Info("wrote alert HTML artifact", "path", htmlPath)
 
-	// Execute PromQL queries and render timeseries charts with alert overlays
+	// Execute PromQL queries and render timeseries charts
 	if o.Queries != nil {
-		if err := o.runQueries(ctx); err != nil {
+		if err := o.runQueries(ctx, workspaces); err != nil {
 			return utils.TrackError(fmt.Errorf("PromQL query execution failed: %w", err))
 		}
 	}
@@ -333,7 +278,7 @@ func (o Options) Run(ctx context.Context) error {
 	return nil
 }
 
-func (o Options) runQueries(ctx context.Context) error {
+func (o Options) runQueries(ctx context.Context, workspaces map[string]*workspaceData) error {
 	logger, err := logr.FromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("logger not found in context: %w", err)
@@ -345,7 +290,11 @@ func (o Options) runQueries(ctx context.Context) error {
 
 		var panelCharts []chartData
 		for _, q := range panel.Queries {
-			endpoint := resolveWorkspaceEndpoint(q, o.SvcPromEndpoint, o.HcpPromEndpoint)
+			ws, ok := workspaces[q.Workspace]
+			if !ok {
+				return fmt.Errorf("unknown workspace %q for query %q", q.Workspace, q.Title)
+			}
+			endpoint := ws.PromEndpoint
 
 			logger.Info("executing PromQL query", "panel", panel.Title, "title", q.Title, "workspace", q.Workspace)
 
@@ -376,80 +325,6 @@ func (o Options) runQueries(ctx context.Context) error {
 			continue
 		}
 		logger.Info("wrote panel", "path", panelPath, "charts", len(panelCharts))
-	}
-	return nil
-}
-
-// sanitizeTitle converts a title to a lowercase kebab-case string suitable for
-// use in file names.
-func sanitizeTitle(title string) string {
-	title = strings.ToLower(title)
-	title = strings.Map(func(r rune) rune {
-		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
-			return r
-		}
-		return '-'
-	}, title)
-	// collapse multiple dashes
-	for strings.Contains(title, "--") {
-		title = strings.ReplaceAll(title, "--", "-")
-	}
-	return strings.Trim(title, "-")
-}
-
-func renderTemplate(outputPath string, data any) error {
-	funcMap := template.FuncMap{
-		"formatTime": func(t *time.Time) string {
-			if t == nil {
-				return "-"
-			}
-			return t.UTC().Format("2006-01-02 15:04:05")
-		},
-		"severityClass": severityCSSClass,
-		"conditionClass": func(s string) string {
-			switch s {
-			case "Fired":
-				return "condition-fired"
-			case "Resolved":
-				return "condition-resolved"
-			default:
-				return ""
-			}
-		},
-		"label": func(labels map[string]string, key string) string {
-			return labels[key]
-		},
-		"annotation": func(annotations map[string]string, key string) string {
-			return annotations[key]
-		},
-		"relativeTime": func(windowStart string, t *time.Time) string {
-			if t == nil {
-				return ""
-			}
-			start, err := time.Parse(time.RFC3339, windowStart)
-			if err != nil {
-				return ""
-			}
-			minutes := int(t.Sub(start).Minutes())
-			if minutes < 0 {
-				return fmt.Sprintf("T%dm", minutes)
-			}
-			return fmt.Sprintf("T+%dm", minutes)
-		},
-	}
-
-	tmplContent := mustReadArtifact("alerts.html.tmpl")
-	tmpl, err := template.New("alerts").Funcs(funcMap).Parse(string(tmplContent))
-	if err != nil {
-		return fmt.Errorf("failed to parse template: %w", err)
-	}
-
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, data); err != nil {
-		return fmt.Errorf("failed to execute template: %w", err)
-	}
-	if err := os.WriteFile(outputPath, buf.Bytes(), 0644); err != nil {
-		return fmt.Errorf("failed to write %s: %w", outputPath, err)
 	}
 	return nil
 }

--- a/test/cmd/aro-hcp-tests/gather-observability/promql.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/promql.go
@@ -104,7 +104,7 @@ func parseQueriesConfig(data []byte) (*QueriesConfig, error) {
 			if q.Query == "" {
 				return nil, fmt.Errorf("panel %d (%s), query %d (%s): query is required", pi, p.Title, qi, q.Title)
 			}
-			if q.Workspace != "svc" && q.Workspace != "hcp" {
+			if q.Workspace != workspaceSvc && q.Workspace != workspaceHcp {
 				return nil, fmt.Errorf("panel %d (%s), query %d (%s): workspace must be \"svc\" or \"hcp\", got %q", pi, p.Title, qi, q.Title, q.Workspace)
 			}
 			if q.Step == "" {
@@ -187,11 +187,4 @@ func queryRange(ctx context.Context, httpClient *http.Client, cred azcore.TokenC
 		return nil, fmt.Errorf("prometheus query error (%s): %s", promResp.ErrorType, promResp.Error)
 	}
 	return &promResp, nil
-}
-
-func resolveWorkspaceEndpoint(spec QuerySpec, svcEndpoint, hcpEndpoint string) string {
-	if spec.Workspace == "hcp" {
-		return hcpEndpoint
-	}
-	return svcEndpoint
 }

--- a/test/cmd/aro-hcp-tests/gather-observability/render.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/render.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatherobservability
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"html/template"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/alertsmanagement/armalertsmanagement"
+)
+
+//go:embed artifacts/*.html.tmpl
+var templatesFS embed.FS
+
+func mustReadArtifact(name string) []byte {
+	ret, err := templatesFS.ReadFile("artifacts/" + name)
+	if err != nil {
+		panic(fmt.Sprintf("failed to read embedded template %q: %v", name, err))
+	}
+	return ret
+}
+
+type alertsSummary struct {
+	Total      int                                  `json:"total"`
+	Known      int                                  `json:"known"`
+	Unknown    int                                  `json:"unknown"`
+	BySeverity map[armalertsmanagement.Severity]int `json:"bySeverity"`
+}
+
+type timeWindow struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// alertsOutput is written to alerts.json and passed to the HTML template.
+type alertsOutput struct {
+	TimeWindow timeWindow    `json:"timeWindow"`
+	Summary    alertsSummary `json:"summary"`
+	Alerts     []alert       `json:"alerts"`
+}
+
+// Template helpers for the HTML template.
+func (o alertsOutput) SeverityCounts() map[armalertsmanagement.Severity]int {
+	return o.Summary.BySeverity
+}
+func (o alertsOutput) HasAlerts() bool        { return o.Summary.Total > 0 }
+func (o alertsOutput) HasUnknownAlerts() bool { return o.Summary.Unknown > 0 }
+func (o alertsOutput) KnownCount() int        { return o.Summary.Known }
+func (o alertsOutput) UnknownCount() int      { return o.Summary.Unknown }
+
+// sanitizeTitle converts a title to a lowercase kebab-case string suitable for
+// use in file names.
+func sanitizeTitle(title string) string {
+	title = strings.ToLower(title)
+	title = strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			return r
+		}
+		return '-'
+	}, title)
+	// collapse multiple dashes
+	for strings.Contains(title, "--") {
+		title = strings.ReplaceAll(title, "--", "-")
+	}
+	return strings.Trim(title, "-")
+}
+
+func renderTemplate(outputPath string, data any) error {
+	funcMap := template.FuncMap{
+		"formatTime": func(t *time.Time) string {
+			if t == nil {
+				return "-"
+			}
+			return t.UTC().Format("2006-01-02 15:04:05")
+		},
+		"severityClass": severityCSSClass,
+		"conditionClass": func(s string) string {
+			switch s {
+			case "Fired":
+				return "condition-fired"
+			case "Resolved":
+				return "condition-resolved"
+			default:
+				return ""
+			}
+		},
+		"label": func(labels map[string]string, key string) string {
+			return labels[key]
+		},
+		"annotation": func(annotations map[string]string, key string) string {
+			return annotations[key]
+		},
+		"relativeTime": func(windowStart string, t *time.Time) string {
+			if t == nil {
+				return ""
+			}
+			start, err := time.Parse(time.RFC3339, windowStart)
+			if err != nil {
+				return ""
+			}
+			minutes := int(t.Sub(start).Minutes())
+			if minutes < 0 {
+				return fmt.Sprintf("T%dm", minutes)
+			}
+			return fmt.Sprintf("T+%dm", minutes)
+		},
+	}
+
+	tmplContent := mustReadArtifact("alerts.html.tmpl")
+	tmpl, err := template.New("alerts").Funcs(funcMap).Parse(string(tmplContent))
+	if err != nil {
+		return fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("failed to execute template: %w", err)
+	}
+	if err := os.WriteFile(outputPath, buf.Bytes(), 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", outputPath, err)
+	}
+	return nil
+}

--- a/test/cmd/aro-hcp-tests/gather-observability/rules.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/rules.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatherobservability
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/prometheusrulegroups/armprometheusrulegroups"
+)
+
+func fetchAlertRules(ctx context.Context, cred azcore.TokenCredential, workspaceResourceID azcorearm.ResourceID) ([]string, error) {
+	client, err := armprometheusrulegroups.NewClient(workspaceResourceID.SubscriptionID, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create prometheus rule groups client: %w", err)
+	}
+
+	seen := make(map[string]bool)
+	pager := client.NewListByResourceGroupPager(workspaceResourceID.ResourceGroupName, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list prometheus rule groups: %w", err)
+		}
+		for _, group := range page.Value {
+			if group.Properties == nil || !scopeContainsWorkspace(group.Properties.Scopes, workspaceResourceID) {
+				continue
+			}
+			for _, rule := range group.Properties.Rules {
+				if rule.Alert != nil && *rule.Alert != "" {
+					seen[*rule.Alert] = true
+				}
+			}
+		}
+	}
+
+	rules := make([]string, 0, len(seen))
+	for name := range seen {
+		rules = append(rules, name)
+	}
+	slices.Sort(rules)
+	return rules, nil
+}
+
+func scopeContainsWorkspace(scopes []*string, ws azcorearm.ResourceID) bool {
+	wsID := strings.ToLower(ws.String())
+	for _, s := range scopes {
+		if s != nil && strings.ToLower(*s) == wsID {
+			return true
+		}
+	}
+	return false
+}

--- a/test/cmd/aro-hcp-tests/gather-observability/testdata/zz_fixture_TestAlertsPipeline.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/testdata/zz_fixture_TestAlertsPipeline.yaml
@@ -82,7 +82,6 @@ alerts:
   metadata:
     knownIssue: false
     monitoringWorkspace: /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/hcp-underlay-test-rg/providers/microsoft.monitor/accounts/test-workspace
-scope: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hcp-underlay-test-rg
 summary:
   bySeverity:
     Sev3: 1

--- a/test/cmd/aro-hcp-tests/gather-observability/workspace.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/workspace.go
@@ -1,0 +1,87 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatherobservability
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+)
+
+const (
+	workspaceSvc = "svc"
+	workspaceHcp = "hcp"
+)
+
+type workspaceData struct {
+	Type         string
+	PromEndpoint string
+	AlertRules   []string
+	FiredAlerts  []alert
+}
+
+func fetchWorkspaceData(ctx context.Context, cred azcore.TokenCredential, wsType string, workspaceResourceID azcorearm.ResourceID, start, end time.Time, severityThreshold int, knownIssues []knownIssue) (*workspaceData, error) {
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("logger not found in context: %w", err)
+	}
+
+	promEndpoint, err := lookupPrometheusEndpoint(ctx, cred, workspaceResourceID.SubscriptionID, workspaceResourceID.ResourceGroupName, workspaceResourceID.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up Prometheus endpoint: %w", err)
+	}
+	logger.Info("resolved Prometheus endpoint", "workspace", wsType, "endpoint", promEndpoint)
+
+	rules, err := fetchAlertRules(ctx, cred, workspaceResourceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch alert rules: %w", err)
+	}
+	logger.Info("fetched alert rules", "workspace", wsType, "count", len(rules))
+
+	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", workspaceResourceID.SubscriptionID, workspaceResourceID.ResourceGroupName)
+	allAlerts, err := fetchAlerts(ctx, cred, scope, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch alerts: %w", err)
+	}
+
+	var alerts []alert
+	for _, a := range allAlerts {
+		if alertBelongsToWorkspace(a, workspaceResourceID) {
+			a.Metadata.MonitoringWorkspaceType = wsType
+			alerts = append(alerts, a)
+		}
+	}
+
+	alerts = filterAlertsBySeverity(alerts, severityThreshold)
+	alerts = classifyAlerts(alerts, knownIssues)
+	logger.Info("fetched fired alerts", "workspace", wsType, "count", len(alerts))
+
+	return &workspaceData{
+		Type:         wsType,
+		PromEndpoint: promEndpoint,
+		AlertRules:   rules,
+		FiredAlerts:  alerts,
+	}, nil
+}
+
+func alertBelongsToWorkspace(a alert, ws azcorearm.ResourceID) bool {
+	return strings.EqualFold(a.Metadata.MonitoringWorkspace, ws.String())
+}

--- a/test/cmd/aro-hcp-tests/gather-observability/workspace_test.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/workspace_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatherobservability
+
+import (
+	"fmt"
+	"testing"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+)
+
+func mustParseResourceID(sub, rg, name string) *azcorearm.ResourceID {
+	id, err := azcorearm.ParseResourceID(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Monitor/accounts/%s", sub, rg, name))
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
+func TestAlertBelongsToWorkspace(t *testing.T) {
+	t.Parallel()
+	ws := mustParseResourceID("sub-123", "my-rg", "services-westus3")
+
+	tests := []struct {
+		name                string
+		monitoringWorkspace string
+		want                bool
+	}{
+		{
+			name:                "matching_workspace",
+			monitoringWorkspace: ws.String(),
+
+			want: true,
+		},
+		{
+			name:                "different_workspace",
+			monitoringWorkspace: mustParseResourceID("sub-123", "my-rg", "hcps-westus3").String(),
+			want:                false,
+		},
+		{
+			name:                "empty_no_match",
+			monitoringWorkspace: "",
+			want:                false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := alert{Metadata: alertMetadata{MonitoringWorkspace: tt.monitoringWorkspace}}
+			got := alertBelongsToWorkspace(a, *ws)
+			if got != tt.want {
+				t.Errorf("alertBelongsToWorkspace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScopeContainsWorkspace(t *testing.T) {
+	t.Parallel()
+	wsPtr := mustParseResourceID("sub-123", "my-rg", "hcps-westus3")
+	wsStr := wsPtr.String()
+
+	strPtr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name   string
+		scopes []*string
+		want   bool
+	}{
+		{
+			name:   "matching_scope",
+			scopes: []*string{&wsStr},
+			want:   true,
+		},
+		{
+			name:   "no_match",
+			scopes: []*string{strPtr(mustParseResourceID("sub-123", "my-rg", "services-westus3").String())},
+			want:   false,
+		},
+		{
+			name:   "nil_scope_skipped",
+			scopes: []*string{nil, &wsStr},
+			want:   true,
+		},
+		{
+			name:   "empty_scopes",
+			scopes: []*string{},
+			want:   false,
+		},
+		{
+			name:   "nil_scopes",
+			scopes: nil,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := scopeContainsWorkspace(tt.scopes, *wsPtr)
+			if got != tt.want {
+				t.Errorf("scopeContainsWorkspace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/prometheusrulegroups/armprometheusrulegroups v0.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1

--- a/test/go.sum
+++ b/test/go.sum
@@ -128,6 +128,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0 h1:L7G3d
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0/go.mod h1:Ms6gYEy0+A2knfKrwdatsggTXYA2+ICKug8w7STorFw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0 h1:HYGD75g0bQ3VO/Omedm54v4LrD3B1cGImuRF3AJ5wLo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0/go.mod h1:ulHyBFJOI0ONiRL4vcJTmS7rx18jQQlEPmAgo80cRdM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/prometheusrulegroups/armprometheusrulegroups v0.1.0 h1:7hIyhsWoAy/n8PgH4RjJlGj3MdI47M+05l6igVZDAx0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/prometheusrulegroups/armprometheusrulegroups v0.1.0/go.mod h1:2E6zmRYul50Rju64xaJNI6UXwbszw9nxEIfGV4AjhFQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v0.2.0 h1:bYq3jfB2x36hslKMHyge3+esWzROtJNk/4dCjsKlrl4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v0.2.0/go.mod h1:fewgRjNVE84QVVh798sIMFb7gPXPp7NmnekGnboSnXk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeploymentstacks v1.0.1 h1:bcgO/crpp7wqI0Froi/I4C2fme7Vk/WLusbV399Do8I=


### PR DESCRIPTION
### What

Consolidate per-workspace data fetching (Prometheus endpoint, alert rules, fired alerts) into a single workspaceData struct, replacing the flat field proliferation in completedOptions. Extract rendering functions into render.go. Add chart gap markers to break misleading straight lines across time gaps.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
