### PR TITLE
test: remove hard-coded DNS suffix for keyvault

### DIFF
--- a/test/e2e-pipeline.yaml
+++ b/test/e2e-pipeline.yaml
@@ -24,7 +24,7 @@ resourceGroups:
     action: ProwJob
     validation:
     - GA
-    tokenKeyvault: "{{ .global.keyVault.name }}.vault.azure.net"
+    tokenKeyvault: "{{ .global.keyVault.name }}"
     tokenSecret: "{{ .e2e.prow.globalKeyVaultTokenSecret }}"
     jobName: "{{ .e2e.regionTest.prowJobName }}"
     gatePromotion: "{{ .e2e.regionTest.gatePromotion }}"

--- a/tooling/templatize/pkg/pipeline/prow.go
+++ b/tooling/templatize/pkg/pipeline/prow.go
@@ -34,11 +34,11 @@ func runProwJobStep(step *types.ProwJobStep, ctx context.Context, options *StepR
 
 	ev2cfg, err := ev2config.ResolveConfig(options.Cloud, executionTarget.GetRegion())
 	if err != nil {
-		return fmt.Errorf("cannot resolve config for %s/%s: %v", err, options.Cloud, executionTarget.GetRegion())
+		return fmt.Errorf("cannot resolve config for %s/%s: %w", options.Cloud, executionTarget.GetRegion(), err)
 	}
 	rawKeyVaultDNSSuffix, err := ev2cfg.GetByPath("keyVault.domainNameSuffix")
 	if err != nil {
-		return fmt.Errorf("cannot get Ev2 config value keyVault.domainNameSuffix: %v", err)
+		return fmt.Errorf("cannot get Ev2 config value keyVault.domainNameSuffix: %w", err)
 	}
 	keyVaultDNSSuffix, ok := rawKeyVaultDNSSuffix.(string)
 	if !ok {

--- a/tooling/templatize/pkg/pipeline/prow.go
+++ b/tooling/templatize/pkg/pipeline/prow.go
@@ -21,15 +21,30 @@ import (
 
 	"github.com/go-logr/logr"
 
+	"github.com/Azure/ARO-Tools/config/ev2config"
 	"github.com/Azure/ARO-Tools/pipelines/types"
 	prowjobexecutor "github.com/Azure/ARO-Tools/tools/prow-job-executor"
 )
 
-func runProwJobStep(step *types.ProwJobStep, ctx context.Context, options *StepRunOptions) error {
+func runProwJobStep(step *types.ProwJobStep, ctx context.Context, options *StepRunOptions, executionTarget ExecutionTarget) error {
 	logger, err := logr.FromContext(ctx)
 	if err != nil {
 		return err
 	}
+
+	ev2cfg, err := ev2config.ResolveConfig(options.Cloud, executionTarget.GetRegion())
+	if err != nil {
+		return fmt.Errorf("cannot resolve config for %s/%s: %v", err, options.Cloud, executionTarget.GetRegion())
+	}
+	rawKeyVaultDNSSuffix, err := ev2cfg.GetByPath("keyVault.domainNameSuffix")
+	if err != nil {
+		return fmt.Errorf("cannot get Ev2 config value keyVault.domainNameSuffix: %v", err)
+	}
+	keyVaultDNSSuffix, ok := rawKeyVaultDNSSuffix.(string)
+	if !ok {
+		return fmt.Errorf("keyVaultDNSSuffix is %T, not a string", rawKeyVaultDNSSuffix)
+	}
+	keyVaultURI := "https://" + step.TokenKeyvault + "." + keyVaultDNSSuffix
 
 	gate, err := strconv.ParseBool(step.GatePromotion)
 	if err != nil {
@@ -38,12 +53,12 @@ func runProwJobStep(step *types.ProwJobStep, ctx context.Context, options *StepR
 
 	opts := prowjobexecutor.DefaultExecuteOptions()
 	opts.Secret = step.TokenSecret
-	opts.KeyVaultURI = step.TokenKeyvault
+	opts.KeyVaultURI = keyVaultURI
 	opts.ProwJobName = step.JobName
 	opts.GatePromotion = gate
 
 	inputs := prowInputs{
-		KeyVault: step.TokenKeyvault,
+		KeyVault: keyVaultURI,
 		Secret:   step.TokenSecret,
 		JobName:  step.JobName,
 	}

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -798,7 +798,7 @@ func RunStep(id graph.Identifier, s types.Step, ctx context.Context, executionTa
 		}
 		return nil, nil, nil
 	case *types.ProwJobStep:
-		if err := runProwJobStep(step, ctx, options); err != nil {
+		if err := runProwJobStep(step, ctx, options, executionTarget); err != nil {
 			return nil, nil, fmt.Errorf("error running Prow Job Step, %v", err)
 		}
 		return nil, nil, nil


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-732

### What

Remove the hard-coded `.vault.azure.net` DNS suffix from the keyvault reference in `test/e2e-pipeline.yaml` and update the templatize pipeline code to construct the full keyvault URL from EV2 config at runtime.

### Why

The keyvault DNS suffix should not be hard-coded as it may differ across cloud environments (e.g. sovereign clouds). The suffix is now resolved from `keyVault.domainNameSuffix` in the EV2 config.

Rebased from #4255 (fork branch, could not push). The ARO-Tools bump commit was dropped as main already has a newer version.

Closes #4255

### Testing

- CI validates pipeline config and templates