### PR TITLE
gather-observability: add JUnit output for alerts - attemp 2

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/artifacts/failure-output.tmpl
+++ b/test/cmd/aro-hcp-tests/gather-observability/artifacts/failure-output.tmpl
@@ -1,0 +1,18 @@
+{{- if .Header}}{{.Header}}
+{{end -}}
+{{- range $i, $f := .Firings}}Firing {{inc $i}}:{{if $f.Metadata.KnownIssueReason}} (known issue: {{$f.Metadata.KnownIssueReason}}){{end}}
+  State:       {{state $f.Alert.Condition}}
+{{- if $f.Alert.StartsAt}}
+  Started:     {{formatTime $f.Alert.StartsAt}}
+{{- end}}
+{{- if $f.Alert.EndsAt}}
+  Ended:       {{formatTime $f.Alert.EndsAt}}
+{{- end}}
+  Severity:    {{$f.Alert.Severity}}
+{{- if $f.Alert.Labels}}
+  Labels:      {{formatLabels $f.Alert.Labels}}
+{{- end}}
+{{- if $f.Alert.Description}}
+  Description: {{$f.Alert.Description}}
+{{- end}}
+{{end -}}

--- a/test/cmd/aro-hcp-tests/gather-observability/junit.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/junit.go
@@ -1,0 +1,230 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatherobservability
+
+import (
+	"bytes"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"text/template"
+	"time"
+
+	_ "embed"
+
+	"github.com/go-logr/logr"
+
+	"github.com/Azure/ARO-HCP/test/util/junit"
+	"github.com/Azure/ARO-HCP/test/util/timing"
+)
+
+//go:embed artifacts/failure-output.tmpl
+var failureOutputTmplData string
+
+func buildTestName(workspace, ruleName string) string {
+	return fmt.Sprintf("[aro-hcp-observability] [%s] alert %s does not fire", workspace, ruleName)
+}
+
+func alertsToJUnit(logger logr.Logger, workspaces map[string]*workspaceData, timeWindow timing.TimeWindow) *junit.TestSuites {
+	testSuite := junit.TestSuite{
+		Name: "aro-hcp-tests",
+	}
+	for _, wsType := range slices.Sorted(maps.Keys(workspaces)) {
+		ws := workspaces[wsType]
+		workspaceTestSuite := workspaceDataToJUnit(logger, ws, timeWindow)
+		testSuite.TestCases = append(testSuite.TestCases, workspaceTestSuite.TestCases...)
+		testSuite.NumTests += workspaceTestSuite.NumTests
+		testSuite.NumFailed += workspaceTestSuite.NumFailed
+		testSuite.NumSkipped += workspaceTestSuite.NumSkipped
+		testSuite.Duration += workspaceTestSuite.Duration
+	}
+	return &junit.TestSuites{
+		Suites: []*junit.TestSuite{&testSuite},
+	}
+}
+
+func workspaceDataToJUnit(logger logr.Logger, ws *workspaceData, timeWindow timing.TimeWindow) *junit.TestSuite {
+	logger = logger.WithValues("workspace", ws.Type)
+	ruleNames := make(map[string]bool, len(ws.AlertRules))
+	for _, r := range ws.AlertRules {
+		ruleNames[r] = true
+	}
+
+	groups := make(map[string][]alert)
+	for _, a := range ws.FiredAlerts {
+		if !ruleNames[a.Alert.Name] {
+			logger.Info("ignoring fired alert with no matching rule definition", "alert", a.Alert.Name)
+			continue
+		}
+		groups[a.Alert.Name] = append(groups[a.Alert.Name], a)
+	}
+
+	var testCases []*junit.TestCase
+	var totalDuration float64
+	var numFailed, numSkipped uint
+
+	for _, rule := range ws.AlertRules {
+		tc := &junit.TestCase{
+			Name: buildTestName(ws.Type, rule),
+		}
+
+		firings, hasFirings := groups[rule]
+		if !hasFirings {
+			testCases = append(testCases, tc)
+			continue
+		}
+
+		duration := computeGroupDuration(firings, timeWindow)
+		totalDuration += duration
+		tc.Duration = duration
+
+		allKnown := true
+		for _, f := range firings {
+			if !f.Metadata.KnownIssue {
+				allKnown = false
+				break
+			}
+		}
+
+		if allKnown {
+			// if all alert firings for this alert rule are known issues
+			// we mark the test case as skipped
+			numSkipped++
+			tc.SkipMessage = &junit.SkipMessage{
+				Message: buildSkipMessage(firings),
+			}
+		} else {
+			// if not all alert firings for this alert rule are known issues
+			// we mark the test case as failed and
+			// * report the unknown firings as failures
+			// * report the known firings as system output
+			numFailed++
+			var unknown, known []alert
+			for _, f := range firings {
+				if f.Metadata.KnownIssue {
+					known = append(known, f)
+				} else {
+					unknown = append(unknown, f)
+				}
+			}
+			tc.FailureOutput = &junit.FailureOutput{
+				Message: buildFailureMessage(firings),
+				Output:  renderFirings("", unknown),
+			}
+			if len(known) > 0 {
+				tc.SystemOut = renderFirings("Known firings (not counted as failures):", known)
+			}
+		}
+
+		testCases = append(testCases, tc)
+	}
+
+	return &junit.TestSuite{
+		Name:       "aro-hcp-tests",
+		NumTests:   uint(len(testCases)),
+		NumFailed:  numFailed,
+		NumSkipped: numSkipped,
+		Duration:   totalDuration,
+		TestCases:  testCases,
+	}
+}
+
+func computeGroupDuration(firings []alert, tw timing.TimeWindow) float64 {
+	var total float64
+	for _, f := range firings {
+		if f.Alert.StartsAt == nil {
+			continue
+		}
+		end := tw.End
+		if f.Alert.EndsAt != nil {
+			end = *f.Alert.EndsAt
+		}
+		d := end.Sub(*f.Alert.StartsAt).Seconds()
+		if d > 0 {
+			total += d
+		}
+	}
+	return total
+}
+
+func buildSkipMessage(firings []alert) string {
+	reasons := make(map[string]bool)
+	var ordered []string
+	for _, f := range firings {
+		r := f.Metadata.KnownIssueReason
+		if r != "" && !reasons[r] {
+			reasons[r] = true
+			ordered = append(ordered, r)
+		}
+	}
+	return "known issue: " + strings.Join(ordered, "; ")
+}
+
+func buildFailureMessage(firings []alert) string {
+	var unknown, known int
+	for _, f := range firings {
+		if f.Metadata.KnownIssue {
+			known++
+		} else {
+			unknown++
+		}
+	}
+	total := len(firings)
+	if known == 0 {
+		return fmt.Sprintf("alert fired %d time(s)", total)
+	}
+	return fmt.Sprintf("alert fired %d time(s) (%d unknown, %d known)", total, unknown, known)
+}
+
+var tmplFuncs = template.FuncMap{
+	"state": func(condition string) string {
+		if condition == "Fired" {
+			return "Fired (not resolved)"
+		}
+		return condition
+	},
+	"formatTime": func(t any) string {
+		if t == nil {
+			return ""
+		}
+		if v, ok := t.(*time.Time); ok && v != nil {
+			return v.UTC().Format("2006-01-02T15:04:05Z")
+		}
+		return ""
+	},
+	"formatLabels": func(labels map[string]string) string {
+		keys := slices.Sorted(maps.Keys(labels))
+		parts := make([]string, len(keys))
+		for i, k := range keys {
+			parts[i] = fmt.Sprintf("%s=%q", k, labels[k])
+		}
+		return strings.Join(parts, ", ")
+	},
+	"inc": func(i int) int { return i + 1 },
+}
+
+var firingsTemplate = template.Must(template.New("failure-output.tmpl").Funcs(tmplFuncs).Parse(failureOutputTmplData))
+
+func renderFirings(header string, firings []alert) string {
+	var buf bytes.Buffer
+	if err := firingsTemplate.Execute(&buf, struct {
+		Header  string
+		Firings []alert
+	}{Header: header, Firings: firings}); err != nil {
+		return fmt.Sprintf("(failed to render output: %v)", err)
+	}
+	return buf.String()
+}

--- a/test/cmd/aro-hcp-tests/gather-observability/junit_test.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/junit_test.go
@@ -1,0 +1,260 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatherobservability
+
+import (
+	"encoding/xml"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/alertsmanagement/armalertsmanagement"
+
+	"github.com/Azure/ARO-HCP/test/util/timing"
+)
+
+func mustTime(s string) *time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return &t
+}
+
+var defaultTimeWindow = timing.TimeWindow{
+	Start: *mustTime("2026-04-13T06:00:00Z"),
+	End:   *mustTime("2026-04-13T08:00:00Z"),
+}
+
+func TestBuildTestName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		workspace string
+		ruleName  string
+		want      string
+	}{
+		{
+			name:      "svc_workspace",
+			workspace: "svc",
+			ruleName:  "MiseEnvoyScrapeDown",
+			want:      "[aro-hcp-observability] [svc] alert MiseEnvoyScrapeDown does not fire",
+		},
+		{
+			name:      "hcp_workspace",
+			workspace: "hcp",
+			ruleName:  "BackendControllerRetryHotLoop",
+			want:      "[aro-hcp-observability] [hcp] alert BackendControllerRetryHotLoop does not fire",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildTestName(tt.workspace, tt.ruleName)
+			if got != tt.want {
+				t.Errorf("buildTestName() =\n  %q\nwant:\n  %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComputeGroupDuration(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		firings []alert
+		want    float64
+	}{
+		{
+			name:    "nil_starts_at_skipped",
+			firings: []alert{{Alert: alertData{StartsAt: nil}}},
+			want:    0,
+		},
+		{
+			name: "ends_before_starts_clamped_to_zero",
+			firings: []alert{{Alert: alertData{
+				StartsAt: mustTime("2026-04-13T07:30:00Z"),
+				EndsAt:   mustTime("2026-04-13T07:00:00Z"),
+			}}},
+			want: 0,
+		},
+		{
+			name: "uses_window_end_when_no_ends_at",
+			firings: []alert{{Alert: alertData{
+				StartsAt: mustTime("2026-04-13T07:00:00Z"),
+			}}},
+			want: 3600,
+		},
+		{
+			name:    "empty_firings",
+			firings: nil,
+			want:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := computeGroupDuration(tt.firings, defaultTimeWindow)
+			if got != tt.want {
+				t.Errorf("computeGroupDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAlertsToJUnit(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		workspaces map[string]*workspaceData
+	}{
+		{
+			name: "main",
+			workspaces: map[string]*workspaceData{
+				"svc": {
+					Type: "svc",
+					AlertRules: []string{
+						"BackendControllerRetryHotLoop",
+						"KubePodImagePull",
+						"MiseEnvoyScrapeDown",
+						"SomeRuleThatDidNotFire",
+					},
+					FiredAlerts: []alert{
+						{
+							Alert: alertData{
+								Name: "BackendControllerRetryHotLoop", Severity: armalertsmanagement.SeveritySev3, Condition: "Fired",
+								StartsAt: mustTime("2026-04-13T06:10:00Z"), EndsAt: mustTime("2026-04-13T06:53:23Z"),
+								Labels:      map[string]string{"alertname": "BackendControllerRetryHotLoop", "name": "operationnodepoolcreate", "severity": "warning", "cluster": "prow-j3151872-svc", "namespace": "aro-hcp"},
+								Description: "Backend controller workqueue operationnodepoolcreate has a retry ratio of > 50%",
+							},
+							Metadata: alertMetadata{KnownIssue: true, KnownIssueReason: "Nodepool create controller retry hot loops are observed during e2e runs. Needs investigation."},
+						},
+						{
+							Alert: alertData{
+								Name: "MiseEnvoyScrapeDown", Severity: armalertsmanagement.SeveritySev3, Condition: "Resolved",
+								StartsAt: mustTime("2026-04-13T06:20:00Z"), EndsAt: mustTime("2026-04-13T06:30:00Z"),
+								Labels:      map[string]string{"alertname": "MiseEnvoyScrapeDown", "severity": "warning", "cluster": "prow-j3151872-svc", "namespace": "aro-hcp"},
+								Description: "Mise Envoy scrape target is down",
+							},
+							Metadata: alertMetadata{KnownIssue: true, KnownIssueReason: "Mise Envoy scrape targets intermittently go down during e2e runs."},
+						},
+						{
+							Alert: alertData{
+								Name: "KubePodImagePull", Severity: armalertsmanagement.SeveritySev4, Condition: "Fired",
+								StartsAt: mustTime("2026-04-13T07:00:00Z"),
+								Labels:   map[string]string{"alertname": "KubePodImagePull", "severity": "warning", "cluster": "prow-j3151872-svc", "pod": "frontend-abc123", "namespace": "aro-hcp"},
+							},
+						},
+					},
+				},
+				"hcp": {
+					Type:       "hcp",
+					AlertRules: []string{"HCPClusterHealth"},
+				},
+			},
+		},
+		{
+			name: "same_alert_rule_multiple_workspaces",
+			workspaces: map[string]*workspaceData{
+				"svc": {Type: "svc", AlertRules: []string{"KubeNodeNotReady"}},
+				"hcp": {
+					Type:       "hcp",
+					AlertRules: []string{"KubeNodeNotReady"},
+					FiredAlerts: []alert{{
+						Alert: alertData{
+							Name: "KubeNodeNotReady", Severity: armalertsmanagement.SeveritySev2, Condition: "Fired",
+							StartsAt: mustTime("2026-04-13T07:00:00Z"),
+							Labels:   map[string]string{"alertname": "KubeNodeNotReady", "node": "worker-1"},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "no_alert_rules",
+			workspaces: map[string]*workspaceData{
+				"svc": {
+					Type: "svc",
+					FiredAlerts: []alert{{
+						Alert: alertData{
+							Name: "UnexpectedAlert", Severity: armalertsmanagement.SeveritySev3, Condition: "Fired",
+							StartsAt: mustTime("2026-04-13T07:00:00Z"),
+							Labels:   map[string]string{"alertname": "UnexpectedAlert"},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "alert_not_in_rules",
+			workspaces: map[string]*workspaceData{
+				"svc": {
+					Type:       "svc",
+					AlertRules: []string{"DefinedRule"},
+					FiredAlerts: []alert{{
+						Alert: alertData{
+							Name: "UndefinedAlert", Severity: armalertsmanagement.SeveritySev3, Condition: "Fired",
+							StartsAt: mustTime("2026-04-13T07:00:00Z"),
+							Labels:   map[string]string{"alertname": "UndefinedAlert"},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "known_and_unknown_firings_in_alert_rule",
+			workspaces: map[string]*workspaceData{
+				"svc": {
+					Type:       "svc",
+					AlertRules: []string{"BackendControllerRetryHotLoop"},
+					FiredAlerts: []alert{
+						{
+							Alert: alertData{
+								Name: "BackendControllerRetryHotLoop", Severity: armalertsmanagement.SeveritySev3, Condition: "Fired",
+								StartsAt: mustTime("2026-04-13T06:10:00Z"), EndsAt: mustTime("2026-04-13T06:30:00Z"),
+								Labels:      map[string]string{"alertname": "BackendControllerRetryHotLoop", "name": "operationnodepoolcreate", "severity": "warning", "cluster": "prow-j3151872-svc"},
+								Description: "Backend controller retry hot loop (known firing)",
+							},
+							Metadata: alertMetadata{KnownIssue: true, KnownIssueReason: "Known issue: hot loop during provisioning."},
+						},
+						{
+							Alert: alertData{
+								Name: "BackendControllerRetryHotLoop", Severity: armalertsmanagement.SeveritySev3, Condition: "Fired",
+								StartsAt: mustTime("2026-04-13T07:00:00Z"), EndsAt: mustTime("2026-04-13T07:15:00Z"),
+								Labels:      map[string]string{"alertname": "BackendControllerRetryHotLoop", "name": "operationnodepoolcreate", "severity": "warning", "cluster": "prow-j3151872-svc"},
+								Description: "Backend controller retry hot loop (unknown firing)",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			suites := alertsToJUnit(logr.Discard(), tt.workspaces, defaultTimeWindow)
+			xmlBytes, err := xml.MarshalIndent(suites, "", "  ")
+			if err != nil {
+				t.Fatalf("failed to marshal JUnit XML: %v", err)
+			}
+			CompareWithFixture(t, string(xmlBytes), WithExtension(".xml"))
+		})
+	}
+}

--- a/test/cmd/aro-hcp-tests/gather-observability/options.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/options.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/utils"
 	"github.com/Azure/ARO-HCP/test/cmd/aro-hcp-tests/internal/testutil"
+	"github.com/Azure/ARO-HCP/test/util/junit"
 	"github.com/Azure/ARO-HCP/test/util/timing"
 )
 
@@ -267,6 +268,14 @@ func (o Options) Run(ctx context.Context) error {
 		return utils.TrackError(fmt.Errorf("failed to render alerts HTML: %w", err))
 	}
 	logger.Info("wrote alert HTML artifact", "path", htmlPath)
+
+	// Write JUnit
+	junitPath := filepath.Join(o.OutputDir, "junit_alerts.xml")
+	suites := alertsToJUnit(logger, workspaces, o.TimeWindow)
+	if err := junit.Write(junitPath, suites); err != nil {
+		return utils.TrackError(fmt.Errorf("failed to write JUnit output: %w", err))
+	}
+	logger.Info("wrote alert JUnit artifact", "path", junitPath)
 
 	// Execute PromQL queries and render timeseries charts
 	if o.Queries != nil {

--- a/test/cmd/aro-hcp-tests/gather-observability/testdata/zz_fixture_TestAlertsToJUnit_alert_not_in_rules.xml
+++ b/test/cmd/aro-hcp-tests/gather-observability/testdata/zz_fixture_TestAlertsToJUnit_alert_not_in_rules.xml
@@ -1,0 +1,6 @@
+<testsuites>
+  <testsuite name="aro-hcp-tests" tests="1" skipped="0" failures="0" time="0">
+    <properties></properties>
+    <testcase name="[aro-hcp-observability] [svc] alert DefinedRule does not fire" time="0"></testcase>
+  </testsuite>
+</testsuites>

--- a/test/cmd/aro-hcp-tests/gather-observability/testdata/zz_fixture_TestAlertsToJUnit_known_and_unknown_firings_in_alert_rule.xml
+++ b/test/cmd/aro-hcp-tests/gather-observability/testdata/zz_fixture_TestAlertsToJUnit_known_and_unknown_firings_in_alert_rule.xml
@@ -1,0 +1,9 @@
+<testsuites>
+  <testsuite name="aro-hcp-tests" tests="1" skipped="0" failures="1" time="2100">
+    <properties></properties>
+    <testcase name="[aro-hcp-observability] [svc] alert BackendControllerRetryHotLoop does not fire" time="2100">
+      <failure message="alert fired 2 time(s) (1 unknown, 1 known)">Firing 1:&#xA;  State:       Fired (not resolved)&#xA;  Started:     2026-04-13T07:00:00Z&#xA;  Ended:       2026-04-13T07:15:00Z&#xA;  Severity:    Sev3&#xA;  Labels:      alertname=&#34;BackendControllerRetryHotLoop&#34;, cluster=&#34;prow-j3151872-svc&#34;, name=&#34;operationnodepoolcreate&#34;, severity=&#34;warning&#34;&#xA;  Description: Backend controller retry hot loop (unknown firing)&#xA;</failure>
+      <system-out>Known firings (not counted as failures):&#xA;Firing 1: (known issue: Known issue: hot loop during provisioning.)&#xA;  State:       Fired (not resolved)&#xA;  Started:     2026-04-13T06:10:00Z&#xA;  Ended:       2026-04-13T06:30:00Z&#xA;  Severity:    Sev3&#xA;  Labels:      alertname=&#34;BackendControllerRetryHotLoop&#34;, cluster=&#34;prow-j3151872-svc&#34;, name=&#34;operationnodepoolcreate&#34;, severity=&#34;warning&#34;&#xA;  Description: Backend controller retry hot loop (known firing)&#xA;</system-out>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/test/cmd/aro-hcp-tests/gather-observability/testdata/zz_fixture_TestAlertsToJUnit_main.xml
+++ b/test/cmd/aro-hcp-tests/gather-observability/testdata/zz_fixture_TestAlertsToJUnit_main.xml
@@ -1,0 +1,16 @@
+<testsuites>
+  <testsuite name="aro-hcp-tests" tests="5" skipped="2" failures="1" time="6803">
+    <properties></properties>
+    <testcase name="[aro-hcp-observability] [hcp] alert HCPClusterHealth does not fire" time="0"></testcase>
+    <testcase name="[aro-hcp-observability] [svc] alert BackendControllerRetryHotLoop does not fire" time="2603">
+      <skipped message="known issue: Nodepool create controller retry hot loops are observed during e2e runs. Needs investigation."></skipped>
+    </testcase>
+    <testcase name="[aro-hcp-observability] [svc] alert KubePodImagePull does not fire" time="3600">
+      <failure message="alert fired 1 time(s)">Firing 1:&#xA;  State:       Fired (not resolved)&#xA;  Started:     2026-04-13T07:00:00Z&#xA;  Severity:    Sev4&#xA;  Labels:      alertname=&#34;KubePodImagePull&#34;, cluster=&#34;prow-j3151872-svc&#34;, namespace=&#34;aro-hcp&#34;, pod=&#34;frontend-abc123&#34;, severity=&#34;warning&#34;&#xA;</failure>
+    </testcase>
+    <testcase name="[aro-hcp-observability] [svc] alert MiseEnvoyScrapeDown does not fire" time="600">
+      <skipped message="known issue: Mise Envoy scrape targets intermittently go down during e2e runs."></skipped>
+    </testcase>
+    <testcase name="[aro-hcp-observability] [svc] alert SomeRuleThatDidNotFire does not fire" time="0"></testcase>
+  </testsuite>
+</testsuites>

--- a/test/cmd/aro-hcp-tests/gather-observability/testdata/zz_fixture_TestAlertsToJUnit_no_alert_rules.xml
+++ b/test/cmd/aro-hcp-tests/gather-observability/testdata/zz_fixture_TestAlertsToJUnit_no_alert_rules.xml
@@ -1,0 +1,5 @@
+<testsuites>
+  <testsuite name="aro-hcp-tests" tests="0" skipped="0" failures="0" time="0">
+    <properties></properties>
+  </testsuite>
+</testsuites>

--- a/test/cmd/aro-hcp-tests/gather-observability/testdata/zz_fixture_TestAlertsToJUnit_same_alert_rule_multiple_workspaces.xml
+++ b/test/cmd/aro-hcp-tests/gather-observability/testdata/zz_fixture_TestAlertsToJUnit_same_alert_rule_multiple_workspaces.xml
@@ -1,0 +1,9 @@
+<testsuites>
+  <testsuite name="aro-hcp-tests" tests="2" skipped="0" failures="1" time="3600">
+    <properties></properties>
+    <testcase name="[aro-hcp-observability] [hcp] alert KubeNodeNotReady does not fire" time="3600">
+      <failure message="alert fired 1 time(s)">Firing 1:&#xA;  State:       Fired (not resolved)&#xA;  Started:     2026-04-13T07:00:00Z&#xA;  Severity:    Sev2&#xA;  Labels:      alertname=&#34;KubeNodeNotReady&#34;, node=&#34;worker-1&#34;&#xA;</failure>
+    </testcase>
+    <testcase name="[aro-hcp-observability] [svc] alert KubeNodeNotReady does not fire" time="0"></testcase>
+  </testsuite>
+</testsuites>

--- a/test/util/junit/types.go
+++ b/test/util/junit/types.go
@@ -1,0 +1,115 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package junit
+
+import (
+	"encoding/xml"
+)
+
+// The below types are directly marshalled into XML. The types correspond to jUnit
+// XML schema, but do not contain all valid fields. For instance, the class name
+// field for test cases is omitted, as this concept does not directly apply to Go.
+// For XML specifications see http://help.catchsoftware.com/display/ET/JUnit+Format
+// or view the XSD included in this package as 'junit.xsd'
+
+// TestSuites represents a flat collection of jUnit test suites.
+type TestSuites struct {
+	XMLName xml.Name `xml:"testsuites"`
+
+	// Suites are the jUnit test suites held in this collection
+	Suites []*TestSuite `xml:"testsuite"`
+}
+
+// TestSuite represents a single jUnit test suite, potentially holding child suites.
+type TestSuite struct {
+	XMLName xml.Name `xml:"testsuite"`
+
+	// Name is the name of the test suite
+	Name string `xml:"name,attr"`
+
+	// NumTests records the number of tests in the TestSuite
+	NumTests uint `xml:"tests,attr"`
+
+	// NumSkipped records the number of skipped tests in the suite
+	NumSkipped uint `xml:"skipped,attr"`
+
+	// NumFailed records the number of failed tests in the suite
+	NumFailed uint `xml:"failures,attr"`
+
+	// Duration is the time taken in seconds to run all tests in the suite
+	Duration float64 `xml:"time,attr"`
+
+	// Properties holds other properties of the test suite as a mapping of name to value
+	Properties []*TestSuiteProperty `xml:"properties>property,omitempty"`
+
+	// TestCases are the test cases contained in the test suite
+	TestCases []*TestCase `xml:"testcase"`
+
+	// Children holds nested test suites
+	Children []*TestSuite `xml:"testsuite"`
+}
+
+// TestSuiteProperty contains a mapping of a property name to a value
+type TestSuiteProperty struct {
+	XMLName xml.Name `xml:"property"`
+
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// TestCase represents a jUnit test case
+type TestCase struct {
+	XMLName xml.Name `xml:"testcase"`
+
+	// Name is the name of the test case
+	Name string `xml:"name,attr"`
+
+	// Classname is an attribute set by the package type and is required
+	Classname string `xml:"classname,attr,omitempty"`
+
+	// Duration is the time taken in seconds to run the test
+	Duration float64 `xml:"time,attr"`
+
+	// SkipMessage holds the reason why the test was skipped
+	SkipMessage *SkipMessage `xml:"skipped"`
+
+	// FailureOutput holds the output from a failing test
+	FailureOutput *FailureOutput `xml:"failure"`
+
+	// SystemOut is output written to stdout during the execution of this test case
+	SystemOut string `xml:"system-out,omitempty"`
+
+	// SystemErr is output written to stderr during the execution of this test case
+	SystemErr string `xml:"system-err,omitempty"`
+}
+
+// SkipMessage holds a message explaining why a test was skipped
+type SkipMessage struct {
+	XMLName xml.Name `xml:"skipped"`
+
+	// Message explains why the test was skipped
+	Message string `xml:"message,attr,omitempty"`
+}
+
+// FailureOutput holds the output from a failing test
+type FailureOutput struct {
+	XMLName xml.Name `xml:"failure"`
+
+	// Message holds the failure message from the test
+	Message string `xml:"message,attr"`
+
+	// Output holds verbose failure output from the test
+	Output string `xml:",chardata"`
+}

--- a/test/util/junit/write.go
+++ b/test/util/junit/write.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package junit
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"sort"
+)
+
+// Write ensures stable sort order and emits jUnit data to disk.
+func Write(intoPath string, suites *TestSuites) error {
+	if suites == nil {
+		return nil
+	}
+	sort.Slice(suites.Suites, func(i, j int) bool {
+		return suites.Suites[i].Name < suites.Suites[j].Name
+	})
+	for i := range suites.Suites {
+		sortSuite(suites.Suites[i])
+	}
+	out, err := xml.MarshalIndent(suites, "", "  ")
+	if err != nil {
+		return fmt.Errorf("could not marshal jUnit XML: %w", err)
+	}
+	return os.WriteFile(intoPath, out, 0644)
+}
+
+func sortSuite(suite *TestSuite) {
+	sort.Slice(suite.Properties, func(i, j int) bool {
+		return suite.Properties[i].Name < suite.Properties[j].Name
+	})
+	sort.Slice(suite.Children, func(i, j int) bool {
+		return suite.Children[i].Name < suite.Children[j].Name
+	})
+	sort.Slice(suite.TestCases, func(i, j int) bool {
+		return suite.TestCases[i].Name < suite.TestCases[j].Name
+	})
+	for i := range suite.Children {
+		sortSuite(suite.Children[i])
+	}
+}


### PR DESCRIPTION
### What

Generate junit XML file containing all the alerts defined in the azure monitoring workspaces. fired alerts will be tracked as failed "alert foo did not fire" tests in the junit file.

Unknown alerts will not yet fail the gather step. For now only the junit file with the failures will be exposed.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
