### PR TITLE
backend: Pass a PassiveClock to operation controllers

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -58,6 +58,7 @@ import (
 )
 
 type Backend struct {
+	clock   utilsclock.PassiveClock
 	options *BackendOptions
 }
 
@@ -125,6 +126,7 @@ func (o *BackendOptions) metricsGatherer() prometheus.Gatherer {
 
 func NewBackend(options *BackendOptions) *Backend {
 	return &Backend{
+		clock:   utilsclock.RealClock{},
 		options: options,
 	}
 }
@@ -316,18 +318,19 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	billingDumpController := datadumpcontrollers.NewBillingDumpController(b.options.CosmosDBClient, activeOperationLister, backendInformers)
 	doNothingController := controllers.NewDoNothingExampleController(b.options.CosmosDBClient, subscriptionLister)
 	dispatchRequestCredentialController := operationcontrollers.NewDispatchRequestCredentialController(
-		utilsclock.RealClock{},
+		b.clock,
 		b.options.CosmosDBClient,
 		b.options.ClustersServiceClient,
 		activeOperationInformer,
 	)
 	dispatchRevokeCredentialsController := operationcontrollers.NewDispatchRevokeCredentialsController(
-		utilsclock.RealClock{},
+		b.clock,
 		b.options.CosmosDBClient,
 		b.options.ClustersServiceClient,
 		activeOperationInformer,
 	)
 	operationClusterCreateController := operationcontrollers.NewOperationClusterCreateController(
+		b.clock,
 		b.options.CosmosDBClient,
 		b.options.ClustersServiceClient,
 		http.DefaultClient,
@@ -335,60 +338,70 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		backendInformers,
 	)
 	operationClusterUpdateController := operationcontrollers.NewOperationClusterUpdateController(
+		b.clock,
 		b.options.CosmosDBClient,
 		b.options.ClustersServiceClient,
 		http.DefaultClient,
 		activeOperationInformer,
 	)
 	operationClusterDeleteController := operationcontrollers.NewOperationClusterDeleteController(
+		b.clock,
 		b.options.CosmosDBClient,
 		b.options.ClustersServiceClient,
 		http.DefaultClient,
 		activeOperationInformer,
 	)
 	operationNodePoolCreateController := operationcontrollers.NewOperationNodePoolCreateController(
+		b.clock,
 		b.options.CosmosDBClient,
 		b.options.ClustersServiceClient,
 		http.DefaultClient,
 		activeOperationInformer,
 	)
 	operationNodePoolUpdateController := operationcontrollers.NewOperationNodePoolUpdateController(
+		b.clock,
 		b.options.CosmosDBClient,
 		b.options.ClustersServiceClient,
 		http.DefaultClient,
 		activeOperationInformer,
 	)
 	operationNodePoolDeleteController := operationcontrollers.NewOperationNodePoolDeleteController(
+		b.clock,
 		b.options.CosmosDBClient,
 		b.options.ClustersServiceClient,
 		http.DefaultClient,
 		activeOperationInformer,
 	)
 	operationExternalAuthCreateController := operationcontrollers.NewOperationExternalAuthCreateController(
+		b.clock,
 		b.options.CosmosDBClient,
 		b.options.ClustersServiceClient,
 		http.DefaultClient,
 		activeOperationInformer,
 	)
 	operationExternalAuthUpdateController := operationcontrollers.NewOperationExternalAuthUpdateController(
+		b.clock,
 		b.options.CosmosDBClient,
 		b.options.ClustersServiceClient,
 		http.DefaultClient,
 		activeOperationInformer,
 	)
 	operationExternalAuthDeleteController := operationcontrollers.NewOperationExternalAuthDeleteController(
+		b.clock,
 		b.options.CosmosDBClient,
 		b.options.ClustersServiceClient,
 		http.DefaultClient,
 		activeOperationInformer,
 	)
 	operationRequestCredentialController := operationcontrollers.NewOperationRequestCredentialController(
+		b.clock,
 		b.options.CosmosDBClient,
 		b.options.ClustersServiceClient,
 		http.DefaultClient,
 		activeOperationInformer,
 	)
 	operationRevokeCredentialsController := operationcontrollers.NewOperationRevokeCredentialsController(
+		b.clock,
 		b.options.CosmosDBClient,
 		b.options.ClustersServiceClient,
 		http.DefaultClient,
@@ -397,7 +410,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	clusterServiceMatchingClusterController := mismatchcontrollers.NewClusterServiceClusterMatchingController(b.options.CosmosDBClient, subscriptionLister, b.options.ClustersServiceClient)
 	cosmosMatchingNodePoolController := mismatchcontrollers.NewCosmosNodePoolMatchingController(b.options.CosmosDBClient, b.options.ClustersServiceClient, backendInformers)
 	cosmosMatchingExternalAuthController := mismatchcontrollers.NewCosmosExternalAuthMatchingController(b.options.CosmosDBClient, b.options.ClustersServiceClient, backendInformers)
-	cosmosMatchingClusterController := mismatchcontrollers.NewCosmosClusterMatchingController(utilsclock.RealClock{}, b.options.CosmosDBClient, b.options.ClustersServiceClient, backendInformers)
+	cosmosMatchingClusterController := mismatchcontrollers.NewCosmosClusterMatchingController(b.clock, b.options.CosmosDBClient, b.options.ClustersServiceClient, backendInformers)
 	alwaysSuccessClusterValidationController := validationcontrollers.NewClusterValidationController(
 		validations.NewAlwaysSuccessValidation(),
 		activeOperationLister,
@@ -407,11 +420,11 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	deleteOrphanedCosmosResourcesController := mismatchcontrollers.NewDeleteOrphanedCosmosResourcesController(b.options.CosmosDBClient, subscriptionLister)
 	backfillClusterUIDController := controllerutils.NewClusterWatchingController(
 		"BackfillClusterUID", b.options.CosmosDBClient, backendInformers, 60*time.Minute,
-		mismatchcontrollers.NewBackfillClusterUIDController(utilsclock.RealClock{}, b.options.CosmosDBClient, clusterLister))
-	orphanedBillingCleanupController := billingcontrollers.NewOrphanedBillingCleanupController(utilsclock.RealClock{}, b.options.CosmosDBClient, clusterLister, billingLister)
+		mismatchcontrollers.NewBackfillClusterUIDController(b.clock, b.options.CosmosDBClient, clusterLister))
+	orphanedBillingCleanupController := billingcontrollers.NewOrphanedBillingCleanupController(b.clock, b.options.CosmosDBClient, clusterLister, billingLister)
 	createBillingDocController := controllerutils.NewClusterWatchingController(
 		"CreateBillingDoc", b.options.CosmosDBClient, backendInformers, 60*time.Second,
-		billingcontrollers.NewCreateBillingDocController(utilsclock.RealClock{}, b.options.AzureLocation, b.options.CosmosDBClient, clusterLister, billingLister))
+		billingcontrollers.NewCreateBillingDocController(b.clock, b.options.AzureLocation, b.options.CosmosDBClient, clusterLister, billingLister))
 	controlPlaneActiveVersionController := upgradecontrollers.NewControlPlaneActiveVersionController(
 		b.options.CosmosDBClient,
 		activeOperationLister,

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/tools/cache"
+	utilsclock "k8s.io/utils/clock"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -43,6 +44,7 @@ import (
 )
 
 type operationClusterCreate struct {
+	clock                                 utilsclock.PassiveClock
 	clusterLister                         listers.ClusterLister
 	clusterManagementClusterContentLister listers.ManagementClusterContentLister
 	cosmosClient                          database.DBClient
@@ -65,6 +67,7 @@ type operationClusterCreate struct {
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
 func NewOperationClusterCreateController(
+	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	notificationClient *http.Client,
@@ -74,6 +77,7 @@ func NewOperationClusterCreateController(
 	_, clusterLister := informers.Clusters()
 	_, clusterManagementClusterContentLister := informers.ManagementClusterContents()
 	syncer := &operationClusterCreate{
+		clock:                                 clock,
 		clusterLister:                         clusterLister,
 		clusterManagementClusterContentLister: clusterManagementClusterContentLister,
 		cosmosClient:                          cosmosClient,
@@ -151,7 +155,7 @@ func (c *operationClusterCreate) SynchronizeOperation(ctx context.Context, key c
 	}
 
 	logger.Info("updating status")
-	err = UpdateOperationStatus(ctx, c.cosmosClient, operation, newOperationStatus, opError, postAsyncNotificationFn(c.notificationClient))
+	err = UpdateOperationStatus(ctx, c.clock, c.cosmosClient, operation, newOperationStatus, opError, postAsyncNotificationFn(c.notificationClient))
 	if err != nil {
 		return utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
@@ -28,6 +28,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
+	utilsclock "k8s.io/utils/clock"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
@@ -123,6 +124,7 @@ func TestOperationClusterCreate_SynchronizeOperation(t *testing.T) {
 			})
 
 			controller := &operationClusterCreate{
+				clock:                utilsclock.RealClock{},
 				cosmosClient:         mockDB,
 				clusterServiceClient: mockCSClient,
 				notificationClient:   nil,

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
@@ -56,13 +56,14 @@ type operationClusterDelete struct {
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
 func NewOperationClusterDeleteController(
+	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
 ) controllerutils.Controller {
 	syncer := &operationClusterDelete{
-		clock:                utilsclock.RealClock{},
+		clock:                clock,
 		cosmosClient:         cosmosClient,
 		clusterServiceClient: clusterServiceClient,
 		notificationClient:   notificationClient,
@@ -129,7 +130,7 @@ func (c *operationClusterDelete) SynchronizeOperation(ctx context.Context, key c
 			return utils.TrackError(err)
 		}
 
-		err = SetDeleteOperationAsCompleted(ctx, c.cosmosClient, operation, postAsyncNotificationFn(c.notificationClient))
+		err = SetDeleteOperationAsCompleted(ctx, c.clock, c.cosmosClient, operation, postAsyncNotificationFn(c.notificationClient))
 		if err != nil {
 			return utils.TrackError(err)
 		}
@@ -145,7 +146,7 @@ func (c *operationClusterDelete) SynchronizeOperation(ctx context.Context, key c
 		return utils.TrackError(err)
 	}
 
-	err = UpdateOperationStatus(ctx, c.cosmosClient, operation, newOperationStatus, newOperationError, postAsyncNotificationFn(c.notificationClient))
+	err = UpdateOperationStatus(ctx, c.clock, c.cosmosClient, operation, newOperationStatus, newOperationError, postAsyncNotificationFn(c.notificationClient))
 	if err != nil {
 		return utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
@@ -28,7 +28,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/clock"
+	utilsclock "k8s.io/utils/clock"
 	"k8s.io/utils/lru"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
@@ -40,10 +40,10 @@ import (
 )
 
 type operationClusterUpdate struct {
+	clock                           utilsclock.PassiveClock
 	cosmosClient                    database.DBClient
 	clusterServiceClient            ocm.ClusterServiceClientSpec
 	notificationClient              *http.Client
-	clock                           clock.PassiveClock
 	desiredVersionMismatchFirstSeen *lru.Cache
 }
 
@@ -62,16 +62,17 @@ type operationClusterUpdate struct {
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
 func NewOperationClusterUpdateController(
+	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
 ) controllerutils.Controller {
 	syncer := &operationClusterUpdate{
+		clock:                           clock,
 		cosmosClient:                    cosmosClient,
 		clusterServiceClient:            clusterServiceClient,
 		notificationClient:              notificationClient,
-		clock:                           clock.RealClock{},
 		desiredVersionMismatchFirstSeen: lru.New(100000),
 	}
 
@@ -133,7 +134,7 @@ func (c *operationClusterUpdate) SynchronizeOperation(ctx context.Context, key c
 	}
 
 	logger.Info("updating status")
-	if err := UpdateOperationStatus(ctx, c.cosmosClient, operation, operationalState.provisioningState, persistErr, postAsyncNotificationFn(c.notificationClient)); err != nil {
+	if err := UpdateOperationStatus(ctx, c.clock, c.cosmosClient, operation, operationalState.provisioningState, persistErr, postAsyncNotificationFn(c.notificationClient)); err != nil {
 		return utils.TrackError(err)
 	}
 	return nil

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_create.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/tools/cache"
+	utilsclock "k8s.io/utils/clock"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -31,6 +32,7 @@ import (
 )
 
 type operationExternalAuthCreate struct {
+	clock                utilsclock.PassiveClock
 	cosmosClient         database.DBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
 	notificationClient   *http.Client
@@ -51,12 +53,14 @@ type operationExternalAuthCreate struct {
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
 func NewOperationExternalAuthCreateController(
+	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
 ) controllerutils.Controller {
 	syncer := &operationExternalAuthCreate{
+		clock:                clock,
 		cosmosClient:         cosmosClient,
 		clusterServiceClient: clusterServiceClient,
 		notificationClient:   notificationClient,
@@ -101,5 +105,5 @@ func (c *operationExternalAuthCreate) SynchronizeOperation(ctx context.Context, 
 		return nil // no work to do
 	}
 
-	return pollExternalAuthStatus(ctx, c.cosmosClient, c.clusterServiceClient, operation, c.notificationClient)
+	return pollExternalAuthStatus(ctx, c.clock, c.cosmosClient, c.clusterServiceClient, operation, c.notificationClient)
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_create_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	utilsclock "k8s.io/utils/clock"
+
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -97,6 +99,7 @@ func TestOperationExternalAuthCreate_SynchronizeOperation(t *testing.T) {
 			mockCSClient := tt.setupMock(ctrl, fixture)
 
 			controller := &operationExternalAuthCreate{
+				clock:                utilsclock.RealClock{},
 				cosmosClient:         mockDB,
 				clusterServiceClient: mockCSClient,
 				notificationClient:   nil,

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_delete.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/tools/cache"
+	utilsclock "k8s.io/utils/clock"
 
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
@@ -34,6 +35,7 @@ import (
 )
 
 type operationExternalAuthDelete struct {
+	clock                utilsclock.PassiveClock
 	cosmosClient         database.DBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
 	notificationClient   *http.Client
@@ -54,12 +56,14 @@ type operationExternalAuthDelete struct {
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
 func NewOperationExternalAuthDeleteController(
+	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
 ) controllerutils.Controller {
 	syncer := &operationExternalAuthDelete{
+		clock:                clock,
 		cosmosClient:         cosmosClient,
 		clusterServiceClient: clusterServiceClient,
 		notificationClient:   notificationClient,
@@ -109,7 +113,7 @@ func (c *operationExternalAuthDelete) SynchronizeOperation(ctx context.Context, 
 	if err != nil && errors.As(err, &ocmGetExternalAuthError) && ocmGetExternalAuthError.Status() == http.StatusNotFound {
 		logger.Info("external auth was deleted")
 
-		err = SetDeleteOperationAsCompleted(ctx, c.cosmosClient, operation, postAsyncNotificationFn(c.notificationClient))
+		err = SetDeleteOperationAsCompleted(ctx, c.clock, c.cosmosClient, operation, postAsyncNotificationFn(c.notificationClient))
 		if err != nil {
 			return utils.TrackError(err)
 		}

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_delete_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_delete_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	utilsclock "k8s.io/utils/clock"
+
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
@@ -107,6 +109,7 @@ func TestOperationExternalAuthDelete_SynchronizeOperation(t *testing.T) {
 			mockCSClient := tt.setupMock(ctrl, fixture)
 
 			controller := &operationExternalAuthDelete{
+				clock:                utilsclock.RealClock{},
 				cosmosClient:         mockDB,
 				clusterServiceClient: mockCSClient,
 				notificationClient:   nil,

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_update.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/tools/cache"
+	utilsclock "k8s.io/utils/clock"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -31,6 +32,7 @@ import (
 )
 
 type operationExternalAuthUpdate struct {
+	clock                utilsclock.PassiveClock
 	cosmosClient         database.DBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
 	notificationClient   *http.Client
@@ -51,12 +53,14 @@ type operationExternalAuthUpdate struct {
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
 func NewOperationExternalAuthUpdateController(
+	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
 ) controllerutils.Controller {
 	syncer := &operationExternalAuthUpdate{
+		clock:                clock,
 		cosmosClient:         cosmosClient,
 		clusterServiceClient: clusterServiceClient,
 		notificationClient:   notificationClient,
@@ -101,5 +105,5 @@ func (c *operationExternalAuthUpdate) SynchronizeOperation(ctx context.Context, 
 		return nil // no work to do
 	}
 
-	return pollExternalAuthStatus(ctx, c.cosmosClient, c.clusterServiceClient, operation, c.notificationClient)
+	return pollExternalAuthStatus(ctx, c.clock, c.cosmosClient, c.clusterServiceClient, operation, c.notificationClient)
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_update_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	utilsclock "k8s.io/utils/clock"
+
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -97,6 +99,7 @@ func TestOperationExternalAuthUpdate_SynchronizeOperation(t *testing.T) {
 			mockCSClient := tt.setupMock(ctrl, fixture)
 
 			controller := &operationExternalAuthUpdate{
+				clock:                utilsclock.RealClock{},
 				cosmosClient:         mockDB,
 				clusterServiceClient: mockCSClient,
 				notificationClient:   nil,

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_create.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/tools/cache"
+	utilsclock "k8s.io/utils/clock"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -31,6 +32,7 @@ import (
 )
 
 type operationNodePoolCreate struct {
+	clock                utilsclock.PassiveClock
 	cosmosClient         database.DBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
 	notificationClient   *http.Client
@@ -51,12 +53,14 @@ type operationNodePoolCreate struct {
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
 func NewOperationNodePoolCreateController(
+	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
 ) controllerutils.Controller {
 	syncer := &operationNodePoolCreate{
+		clock:                clock,
 		cosmosClient:         cosmosClient,
 		clusterServiceClient: clusterServiceClient,
 		notificationClient:   notificationClient,
@@ -101,5 +105,5 @@ func (c *operationNodePoolCreate) SynchronizeOperation(ctx context.Context, key 
 		return nil // no work to do
 	}
 
-	return pollNodePoolStatus(ctx, c.cosmosClient, c.clusterServiceClient, operation, c.notificationClient)
+	return pollNodePoolStatus(ctx, c.clock, c.cosmosClient, c.clusterServiceClient, operation, c.notificationClient)
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_create_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	utilsclock "k8s.io/utils/clock"
+
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -142,6 +144,7 @@ func TestOperationNodePoolCreate_SynchronizeOperation(t *testing.T) {
 				Return(nodePoolStatus, nil)
 
 			controller := &operationNodePoolCreate{
+				clock:                utilsclock.RealClock{},
 				cosmosClient:         mockDB,
 				clusterServiceClient: mockCSClient,
 				notificationClient:   nil,

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/tools/cache"
+	utilsclock "k8s.io/utils/clock"
 
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
@@ -34,6 +35,7 @@ import (
 )
 
 type operationNodePoolDelete struct {
+	clock                utilsclock.PassiveClock
 	cosmosClient         database.DBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
 	notificationClient   *http.Client
@@ -54,12 +56,14 @@ type operationNodePoolDelete struct {
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
 func NewOperationNodePoolDeleteController(
+	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
 ) controllerutils.Controller {
 	syncer := &operationNodePoolDelete{
+		clock:                clock,
 		cosmosClient:         cosmosClient,
 		clusterServiceClient: clusterServiceClient,
 		notificationClient:   notificationClient,
@@ -109,7 +113,7 @@ func (c *operationNodePoolDelete) SynchronizeOperation(ctx context.Context, key 
 	if err != nil && errors.As(err, &ocmGetNodePoolError) && ocmGetNodePoolError.Status() == http.StatusNotFound {
 		logger.Info("node pool was deleted")
 
-		err = SetDeleteOperationAsCompleted(ctx, c.cosmosClient, operation, postAsyncNotificationFn(c.notificationClient))
+		err = SetDeleteOperationAsCompleted(ctx, c.clock, c.cosmosClient, operation, postAsyncNotificationFn(c.notificationClient))
 		if err != nil {
 			return utils.TrackError(err)
 		}
@@ -124,7 +128,7 @@ func (c *operationNodePoolDelete) SynchronizeOperation(ctx context.Context, key 
 		return utils.TrackError(err)
 	}
 
-	err = UpdateOperationStatus(ctx, c.cosmosClient, operation, newOperationStatus, newOperationError, postAsyncNotificationFn(c.notificationClient))
+	err = UpdateOperationStatus(ctx, c.clock, c.cosmosClient, operation, newOperationStatus, newOperationError, postAsyncNotificationFn(c.notificationClient))
 	if err != nil {
 		return utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	utilsclock "k8s.io/utils/clock"
+
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
@@ -157,6 +159,7 @@ func TestOperationNodePoolDelete_SynchronizeOperation(t *testing.T) {
 			mockCSClient := tt.setupMock(ctrl, fixture)
 
 			controller := &operationNodePoolDelete{
+				clock:                utilsclock.RealClock{},
 				cosmosClient:         mockDB,
 				clusterServiceClient: mockCSClient,
 				notificationClient:   nil,

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/tools/cache"
+	utilsclock "k8s.io/utils/clock"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -31,6 +32,7 @@ import (
 )
 
 type operationNodePoolUpdate struct {
+	clock                utilsclock.PassiveClock
 	cosmosClient         database.DBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
 	notificationClient   *http.Client
@@ -51,12 +53,14 @@ type operationNodePoolUpdate struct {
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
 func NewOperationNodePoolUpdateController(
+	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
 ) controllerutils.Controller {
 	syncer := &operationNodePoolUpdate{
+		clock:                clock,
 		cosmosClient:         cosmosClient,
 		clusterServiceClient: clusterServiceClient,
 		notificationClient:   notificationClient,
@@ -101,5 +105,5 @@ func (c *operationNodePoolUpdate) SynchronizeOperation(ctx context.Context, key 
 		return nil // no work to do
 	}
 
-	return pollNodePoolStatus(ctx, c.cosmosClient, c.clusterServiceClient, operation, c.notificationClient)
+	return pollNodePoolStatus(ctx, c.clock, c.cosmosClient, c.clusterServiceClient, operation, c.notificationClient)
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	utilsclock "k8s.io/utils/clock"
+
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -136,6 +138,7 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 				Return(nodePoolStatus, nil)
 
 			controller := &operationNodePoolUpdate{
+				clock:                utilsclock.RealClock{},
 				cosmosClient:         mockDB,
 				clusterServiceClient: mockCSClient,
 				notificationClient:   nil,

--- a/backend/pkg/controllers/operationcontrollers/operation_request_credential.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_request_credential.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/tools/cache"
+	utilsclock "k8s.io/utils/clock"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
@@ -33,6 +34,7 @@ import (
 )
 
 type operationRequestCredential struct {
+	clock                 utilsclock.PassiveClock
 	cosmosClient          database.DBClient
 	clustersServiceClient ocm.ClusterServiceClientSpec
 	notificationClient    *http.Client
@@ -54,12 +56,14 @@ type operationRequestCredential struct {
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
 func NewOperationRequestCredentialController(
+	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,
 	clustersServiceClient ocm.ClusterServiceClientSpec,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
 ) controllerutils.Controller {
 	syncer := &operationRequestCredential{
+		clock:                 clock,
 		cosmosClient:          cosmosClient,
 		clustersServiceClient: clustersServiceClient,
 		notificationClient:    notificationClient,
@@ -133,7 +137,7 @@ func (opsync *operationRequestCredential) SynchronizeOperation(ctx context.Conte
 		return nil
 	}
 
-	err = patchOperation(ctx, opsync.cosmosClient, oldOperation, newOperationStatus, newOperationError, postAsyncNotificationFn(opsync.notificationClient))
+	err = patchOperation(ctx, opsync.clock, opsync.cosmosClient, oldOperation, newOperationStatus, newOperationError, postAsyncNotificationFn(opsync.notificationClient))
 	if err != nil {
 		return utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_request_credential_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_request_credential_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	utilsclock "k8s.io/utils/clock"
+
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -98,6 +100,7 @@ func TestOperationRequestCredential_SyncrhonizeOperation(t *testing.T) {
 				Return(breakGlassCredential, nil)
 
 			controller := &operationRequestCredential{
+				clock:                 utilsclock.RealClock{},
 				cosmosClient:          mockDB,
 				clustersServiceClient: mockCSClient,
 			}

--- a/backend/pkg/controllers/operationcontrollers/operation_revoke_credentials.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_revoke_credentials.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/tools/cache"
+	utilsclock "k8s.io/utils/clock"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
@@ -33,6 +34,7 @@ import (
 )
 
 type operationRevokeCredentials struct {
+	clock                 utilsclock.PassiveClock
 	cosmosClient          database.DBClient
 	clustersServiceClient ocm.ClusterServiceClientSpec
 	notificationClient    *http.Client
@@ -53,12 +55,14 @@ type operationRevokeCredentials struct {
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
 func NewOperationRevokeCredentialsController(
+	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,
 	clustersServiceClient ocm.ClusterServiceClientSpec,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
 ) controllerutils.Controller {
 	syncer := &operationRevokeCredentials{
+		clock:                 clock,
 		cosmosClient:          cosmosClient,
 		clustersServiceClient: clustersServiceClient,
 		notificationClient:    notificationClient,
@@ -197,7 +201,7 @@ func (opsync *operationRevokeCredentials) SynchronizeOperation(ctx context.Conte
 	}
 
 	logger.Info("updating status")
-	err = patchOperation(ctx, opsync.cosmosClient, oldOperation, newOperationStatus, newOperationError, postAsyncNotificationFn(opsync.notificationClient))
+	err = patchOperation(ctx, opsync.clock, opsync.cosmosClient, oldOperation, newOperationStatus, newOperationError, postAsyncNotificationFn(opsync.notificationClient))
 	if err != nil {
 		return utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_revoke_credentials_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_revoke_credentials_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	utilsclock "k8s.io/utils/clock"
+
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -154,6 +156,7 @@ func TestOperationRevokeCredentials_SyncrhonizeOperation(t *testing.T) {
 				})
 
 			controller := &operationRevokeCredentials{
+				clock:                 utilsclock.RealClock{},
 				cosmosClient:          mockDB,
 				clustersServiceClient: mockCSClient,
 			}

--- a/backend/pkg/controllers/operationcontrollers/utils.go
+++ b/backend/pkg/controllers/operationcontrollers/utils.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"k8s.io/utils/clock"
+	utilsclock "k8s.io/utils/clock"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
@@ -42,8 +42,6 @@ import (
 const (
 	InflightChecksFailedProvisionErrorCode = "OCM4001"
 )
-
-var localClock clock.Clock = clock.RealClock{}
 
 type PostAsyncNotificationFunc func(ctx context.Context, operation *api.Operation) error
 
@@ -78,7 +76,7 @@ const (
 //
 // In all of these cases the operation document is still persisted and ARM is
 // notified, so the operation reaches its terminal state and does not get stuck.
-func UpdateOperationStatus(ctx context.Context, cosmosClient database.DBClient, existingOperation *api.Operation, newOperationStatus arm.ProvisioningState, newOperationError *arm.CloudErrorBody, postAsyncNotificationFn PostAsyncNotificationFunc) error {
+func UpdateOperationStatus(ctx context.Context, clock utilsclock.PassiveClock, cosmosClient database.DBClient, existingOperation *api.Operation, newOperationStatus arm.ProvisioningState, newOperationError *arm.CloudErrorBody, postAsyncNotificationFn PostAsyncNotificationFunc) error {
 	logger := utils.LoggerFromContext(ctx)
 	if existingOperation == nil {
 		return nil
@@ -89,7 +87,7 @@ func UpdateOperationStatus(ctx context.Context, cosmosClient database.DBClient, 
 	}
 
 	updatedOperation := existingOperation.DeepCopy()
-	updatedOperation.LastTransitionTime = localClock.Now()
+	updatedOperation.LastTransitionTime = clock.Now()
 	updatedOperation.Status = newOperationStatus
 	if newOperationError != nil {
 		updatedOperation.Error = newOperationError
@@ -284,7 +282,7 @@ func needToPatchOperation(oldOperation *api.Operation, newOperationStatus arm.Pr
 }
 
 // patchOperation patches the status and error fields of an OperationDocument.
-func patchOperation(ctx context.Context, dbClient database.DBClient, oldOperation *api.Operation, newOperationStatus arm.ProvisioningState, newOperationError *arm.CloudErrorBody, postAsyncNotificationFn PostAsyncNotificationFunc) error {
+func patchOperation(ctx context.Context, clock utilsclock.PassiveClock, dbClient database.DBClient, oldOperation *api.Operation, newOperationStatus arm.ProvisioningState, newOperationError *arm.CloudErrorBody, postAsyncNotificationFn PostAsyncNotificationFunc) error {
 	logger := utils.LoggerFromContext(ctx)
 
 	if !needToPatchOperation(oldOperation, newOperationStatus, newOperationError) {
@@ -294,7 +292,7 @@ func patchOperation(ctx context.Context, dbClient database.DBClient, oldOperatio
 	}
 
 	operationToWrite := oldOperation.DeepCopy()
-	operationToWrite.LastTransitionTime = localClock.Now()
+	operationToWrite.LastTransitionTime = clock.Now()
 	operationToWrite.Status = newOperationStatus
 	if newOperationError != nil {
 		operationToWrite.Error = newOperationError
@@ -484,6 +482,7 @@ func convertClusterStatus(ctx context.Context, clusterServiceClient ocm.ClusterS
 // Service to info for an Azure async operation status endpoint.
 func pollNodePoolStatus(
 	ctx context.Context,
+	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	operation *api.Operation,
@@ -508,7 +507,7 @@ func pollNodePoolStatus(
 	logger.Info("new status", "newStatus", newOperationStatus)
 
 	logger.Info("updating status")
-	err = UpdateOperationStatus(ctx, cosmosClient, operation, newOperationStatus, newOperationError, postAsyncNotificationFn(notificationClient))
+	err = UpdateOperationStatus(ctx, clock, cosmosClient, operation, newOperationStatus, newOperationError, postAsyncNotificationFn(notificationClient))
 	if err != nil {
 		return utils.TrackError(err)
 	}
@@ -566,6 +565,7 @@ func convertNodePoolStatus(operation *api.Operation, nodePoolStatus *arohcpv1alp
 // Service to info for an Azure async operation status endpoint.
 func pollExternalAuthStatus(
 	ctx context.Context,
+	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	operation *api.Operation,
@@ -587,7 +587,7 @@ func pollExternalAuthStatus(
 	logger.Info("new status", "newStatus", newOperationStatus)
 
 	logger.Info("updating status")
-	err = UpdateOperationStatus(ctx, cosmosClient, operation, newOperationStatus, nil, postAsyncNotificationFn(notificationClient))
+	err = UpdateOperationStatus(ctx, clock, cosmosClient, operation, newOperationStatus, nil, postAsyncNotificationFn(notificationClient))
 	if err != nil {
 		return utils.TrackError(err)
 	}
@@ -660,7 +660,7 @@ func convertInflightCheckDetails(inflightCheck *arohcpv1alpha1.InflightCheck) (s
 }
 
 // setDeleteOperationAsCompleted updates Cosmos DB to reflect a completed resource deletion.
-func SetDeleteOperationAsCompleted(ctx context.Context, cosmosClient database.DBClient, operation *api.Operation, postAsyncNotificationFn PostAsyncNotificationFunc) error {
+func SetDeleteOperationAsCompleted(ctx context.Context, clock utilsclock.PassiveClock, cosmosClient database.DBClient, operation *api.Operation, postAsyncNotificationFn PostAsyncNotificationFunc) error {
 	// Delete the resource document first. If it fails the backend will retry
 	// by virtue of the operation document still having a non-terminal status.
 	untypedCRUD, err := cosmosClient.UntypedCRUD(*operation.ExternalID)
@@ -702,7 +702,7 @@ func SetDeleteOperationAsCompleted(ctx context.Context, cosmosClient database.DB
 	}
 
 	// Save a final "succeeded" operation status until TTL expires.
-	err = patchOperation(ctx, cosmosClient, operation, arm.ProvisioningStateSucceeded, nil, postAsyncNotificationFn)
+	err = patchOperation(ctx, clock, cosmosClient, operation, arm.ProvisioningStateSucceeded, nil, postAsyncNotificationFn)
 	if err != nil {
 		return utils.TrackError(err)
 	}

--- a/test-integration/utils/integrationutils/utils.go
+++ b/test-integration/utils/integrationutils/utils.go
@@ -31,6 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/goleak"
 
+	utilsclock "k8s.io/utils/clock"
 	"k8s.io/utils/set"
 
 	adminApiServer "github.com/Azure/ARO-HCP/admin/server/server"
@@ -182,7 +183,7 @@ func MarkOperationsCompleteForName(ctx context.Context, dbClient database.DBClie
 		if operation.ExternalID.Name != resourceName {
 			continue
 		}
-		err := operationcontrollers.UpdateOperationStatus(ctx, dbClient, operation, arm.ProvisioningStateSucceeded, nil, nil)
+		err := operationcontrollers.UpdateOperationStatus(ctx, utilsclock.RealClock{}, dbClient, operation, arm.ProvisioningStateSucceeded, nil, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What

This allows the [RealClock instance in utils.go](https://github.com/Azure/ARO-HCP/blob/efb6799f1ef037a621b7e18f188ca0b20d0b3467/backend/pkg/controllers/operationcontrollers/utils.go#L46) to be dropped since all the operation controllers now possess a `PassiveClock` interface to pass to utility functions.

### Why

Light refactoring for controller consistency.

### Testing

Existing unit and integration tests should suffice.