### PR TITLE
bump clusters-service image (ClassicStorage deny assignment fix)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -880,7 +880,7 @@ defaults:
     image:
       registry: quay.io
       repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:f4f7dd17e161eaf061d01920869215302774317d115c1f8be658f13575236661 # 46b8776fa3c7feeac7ed5c6d1e0d15b21a8af307 (2026-04-24 16:38)
+      digest: sha256:29661ed0101a54fa6eab1e8fb4e2dea0c57c248ba375c15fd1df4d625abf97ed # 6627d487bb30217c7a076a9767123127ec51b3b9 (2026-04-28 23:19)
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -162,7 +162,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:f4f7dd17e161eaf061d01920869215302774317d115c1f8be658f13575236661
+    digest: sha256:29661ed0101a54fa6eab1e8fb4e2dea0c57c248ba375c15fd1df4d625abf97ed
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -162,7 +162,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:f4f7dd17e161eaf061d01920869215302774317d115c1f8be658f13575236661
+    digest: sha256:29661ed0101a54fa6eab1e8fb4e2dea0c57c248ba375c15fd1df4d625abf97ed
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -162,7 +162,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:f4f7dd17e161eaf061d01920869215302774317d115c1f8be658f13575236661
+    digest: sha256:29661ed0101a54fa6eab1e8fb4e2dea0c57c248ba375c15fd1df4d625abf97ed
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -162,7 +162,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:f4f7dd17e161eaf061d01920869215302774317d115c1f8be658f13575236661
+    digest: sha256:29661ed0101a54fa6eab1e8fb4e2dea0c57c248ba375c15fd1df4d625abf97ed
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -162,7 +162,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpprow
   image:
-    digest: sha256:f4f7dd17e161eaf061d01920869215302774317d115c1f8be658f13575236661
+    digest: sha256:29661ed0101a54fa6eab1e8fb4e2dea0c57c248ba375c15fd1df4d625abf97ed
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/swft/uksouth.yaml
+++ b/config/rendered/dev/swft/uksouth.yaml
@@ -162,7 +162,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpswft
   image:
-    digest: sha256:f4f7dd17e161eaf061d01920869215302774317d115c1f8be658f13575236661
+    digest: sha256:29661ed0101a54fa6eab1e8fb4e2dea0c57c248ba375c15fd1df4d625abf97ed
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-738

### What

Bump clusters-service image from `46b8776f` (Apr 24) to `6627d487` (Apr 28).

### Why

Includes the fix for [ARO-26544](https://issues.redhat.com/browse/ARO-26544): removes deprecated `Microsoft.ClassicStorage/storageAccounts/vmImages/read` actions from deny assignment `NotActions` list. Azure ARM now rejects these as invalid (`InvalidActionOrNotAction`), causing all cluster creations to enter an infinite retry loop at the `deny-assignment-provision-step`.

This was a fleet-wide blocker affecting customer clusters, PM clusters, scale test clusters, and all E2E CI.

CS fix: https://gitlab.cee.redhat.com/service/aro-hcp-clusters-service/-/merge_requests/314

### Testing

- E2E validates cluster creation end-to-end
- The deny assignment step should now succeed without the deprecated ClassicStorage actions