### PR TITLE
templatize: exclude broken gen-crd-api-reference-docs pseudo-version

### DIFF
--- a/tooling/templatize/go.mod
+++ b/tooling/templatize/go.mod
@@ -305,6 +305,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
 
+exclude github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c
+
 replace helm.sh/helm/v4 => github.com/geoberle/helm/v4 v4.0.0-20251102095138-e64345e0f7ed
 
 replace github.com/go-echarts/go-echarts/v2 => github.com/stevekuznetsov/go-echarts/v2 v2.0.0-20251106144453-30c025b42a65


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-740

## What

Add `exclude` directive for `github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c` to `tooling/templatize/go.mod`.

This was already done for `test/go.mod` in #5056 but was missing from `tooling/templatize/go.mod`.

## Why

`tektoncd/pipeline@v1.11.1` requires this pseudo-version but the referenced commit only exists in tektoncd's fork, not the upstream repo. Their `go.mod` `replace` directive handles this locally but is invisible to consumers, causing `go get` to fail on graph resolution.

This is **blocking the sdp-pipelines bumper** — every bump attempt fails at `go get github.com/Azure/ARO-HCP/tooling/templatize@<sha>`, preventing HCP deployments from progressing.

## Testing

`go mod tidy` passes cleanly after the change.