### PR TITLE
SLC: give whole team ability to approve image bumps

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,7 +6,7 @@ aliases:
   - mmazur
   - raelga 
   - roivaz 
-  service-lifecycle:
+  service-lifecycle-approvers:
   - ashishmax31
   - avollmer-redhat
   - hbhushan3

--- a/acm/OWNERS
+++ b/acm/OWNERS
@@ -2,3 +2,4 @@ approvers:
 - geoberle
 - janboll
 - raelga
+- service-lifecycle-approvers

--- a/config/OWNERS
+++ b/config/OWNERS
@@ -2,3 +2,4 @@ approvers:
 - geoberle
 - janboll
 - raelga
+- service-lifecycle-approvers

--- a/dev-infrastructure/OWNERS
+++ b/dev-infrastructure/OWNERS
@@ -2,3 +2,4 @@ approvers:
 - geoberle
 - janboll
 - stevekuznetsov
+- service-lifecycle-approvers

--- a/observability/OWNERS
+++ b/observability/OWNERS
@@ -2,3 +2,4 @@ approvers:
 - janboll
 - geoberle
 - raelga
+- service-lifecycle-approvers


### PR DESCRIPTION
Rename the `service-lifecycle` alias in OWNERS_ALIASES to `service-lifecycle-approvers` and add it as an approver group to acm/, config/, dev-infrastructure/, and observability/.

These 4 dirs are sufficient to merge all the image updater PRs thus far.