### PR TITLE
Add new CI infra sub to quota monitoring tool

### DIFF
--- a/config/config-opstool.yaml
+++ b/config/config-opstool.yaml
@@ -97,6 +97,10 @@ clouds:
               roleAssignmentLimit: 8000
               regions:
               - westus3
+            - name: "ARO HCP E2E Infrastructure (EA Subscription)"
+              roleAssignmentLimit: 4000
+              regions:
+              - westus3
             - name: "ARO SRE Team - INT (EA Subscription 3)"
               roleAssignmentLimit: 4000
               regions:

--- a/tooling/tenant-quota/scripts/manage-service-principals.sh
+++ b/tooling/tenant-quota/scripts/manage-service-principals.sh
@@ -86,8 +86,9 @@ setup_redhat() {
     local DIRECTORY_QUOTA=true
     local SUBSCRIPTIONS=(
         "ARO Hosted Control Planes (EA Subscription 1)"
-        "ARO SRE Team - INT (EA Subscription 3)"
         "ARO HCP E2E Hosted Clusters (EA Subscription)"
+        "ARO HCP E2E Infrastructure (EA Subscription)"
+        "ARO SRE Team - INT (EA Subscription 3)"
     )
 
     create_or_get_sp "${APPLICATION_NAME}"


### PR DESCRIPTION
Adds subscription "ARO HCP E2E Infrastructure (EA Subscription)" to the tenant-quota tool config. 