### PR TITLE
build-services: improve image build speed and prevent rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,11 +356,24 @@ generate-kiota:
 PERS_OVERRIDE_FILE ?= /tmp/personal-dev-override.yaml
 
 build-services:
-	$(MAKE) -C frontend build-and-push
-	$(MAKE) -C backend build-and-push
-	$(MAKE) -C admin build-and-push
-	$(MAKE) -C sessiongate build-and-push
+	$(MAKE) -j4 build-frontend build-backend build-admin build-sessiongate
 .PHONY: build-services
+
+build-frontend:
+	$(MAKE) -C frontend build-and-push
+.PHONY: build-frontend
+
+build-backend:
+	$(MAKE) -C backend build-and-push
+.PHONY: build-backend
+
+build-admin:
+	$(MAKE) -C admin build-and-push
+.PHONY: build-admin
+
+build-sessiongate:
+	$(MAKE) -C sessiongate build-and-push
+.PHONY: build-sessiongate
 
 record-services-override: $(YQ) $(ORAS)
 	$(MAKE) -C frontend record-override OVERRIDE_CONFIG_FILE=/tmp/_frontend-override.yaml

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -12,9 +12,8 @@ COPY . .
 # NOTE: starting with go 1.27, GODEBUG=fips140=only can be used at runtime to also reject
 # non-FIPS algorithms. See https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 ENV CGO_ENABLED=1 GOFIPS140=latest
-ARG ARO_HCP_IMAGE_TAG
 ARG ARO_HCP_REVISION
-RUN make --directory admin build ARO_HCP_IMAGE_TAG=${ARO_HCP_IMAGE_TAG} ARO_HCP_REVISION=${ARO_HCP_REVISION}
+RUN make --directory admin build ARO_HCP_REVISION=${ARO_HCP_REVISION}
 
 FROM --platform=${PLATFORM} mcr.microsoft.com/azurelinux/distroless/base:3.0
 USER 65532:65532

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -13,7 +13,9 @@ COPY . .
 # non-FIPS algorithms. See https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 ENV CGO_ENABLED=1 GOFIPS140=latest
 ARG ARO_HCP_REVISION
-RUN make --directory admin build ARO_HCP_REVISION=${ARO_HCP_REVISION}
+RUN --mount=type=cache,target=/go/cache \
+    GOCACHE=/go/cache \
+    make --directory admin build ARO_HCP_REVISION=${ARO_HCP_REVISION}
 
 FROM --platform=${PLATFORM} mcr.microsoft.com/azurelinux/distroless/base:3.0
 USER 65532:65532

--- a/admin/Dockerfile.dockerignore
+++ b/admin/Dockerfile.dockerignore
@@ -1,0 +1,16 @@
+**
+!image-environment
+!internal/
+!admin/
+!sessiongate/
+!test-integration/
+
+# https://github.com/containers/podman/discussions/22910
+# !image-environment
+# !internal/go.*
+# !internal/**/*.go
+# !admin/Makefile
+# !admin/server/go.*
+# !admin/server/**/*.go
+# !sessiongate/go.*
+# !sessiongate/**/*.go

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -74,7 +74,13 @@ image: Dockerfile $(ADMIN_API_SOURCES) Makefile
 
 build-and-push: image $(ORAS)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
-	$(CONTAINER_ENGINE) push ${ADMIN_API_TAGGED_IMAGE}
+	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${ADMIN_API_TAGGED_IMAGE}); \
+	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${ADMIN_API_TAGGED_IMAGE} 2>/dev/null | jq -r .config.digest | sed 's/sha256://'); \
+	if [ "$$LOCAL_DIGEST" = "$$REMOTE_DIGEST" ]; then \
+		echo "Image ${ADMIN_API_TAGGED_IMAGE} already up to date in registry, skipping push"; \
+	else \
+		$(CONTAINER_ENGINE) push ${ADMIN_API_TAGGED_IMAGE}; \
+	fi
 .PHONY: build-and-push
 
 # Unix timestamp for this make run; computed once so multiple targets see the same value.

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -75,7 +75,7 @@ image:
 
 build-and-push: image $(ORAS)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
-	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${ADMIN_API_TAGGED_IMAGE}); \
+	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${ADMIN_API_TAGGED_IMAGE} | sed 's/sha256://'); \
 	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${ADMIN_API_TAGGED_IMAGE} 2>/dev/null | jq -r .config.digest | sed 's/sha256://'); \
 	if [ "$$LOCAL_DIGEST" = "$$REMOTE_DIGEST" ]; then \
 		echo "Image ${ADMIN_API_TAGGED_IMAGE} already up to date in registry, skipping push"; \

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -6,7 +6,7 @@ CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || echo docker)
 -include ../.bingo/Variables.mk
 
 ARO_HCP_REVISION ?= $(shell git rev-parse HEAD)
-ARO_HCP_COMMIT_TIME := $(shell TZ=UTC git show -s --format=%cd --date=iso-strict-local ${ARO_HCP_REVISION})
+ARO_HCP_COMMIT_TIME ?= $(shell TZ=UTC git show -s --format=%cd --date=iso-strict-local ${ARO_HCP_REVISION})
 ARO_HCP_IMAGE_REGISTRY ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
 ADMIN_API_IMAGE_TAG ?= $(shell DETECT_DIRTY_GIT_WORKTREE=${DETECT_DIRTY_GIT_WORKTREE} DEPLOY_ENV=${DEPLOY_ENV} ../generate-tag.sh)
 ADMIN_API_GENERATED_IMAGE_REPOSITORY = $(shell DEPLOY_ENV=${DEPLOY_ENV} BASELINE_REPO=${ADMIN_API_IMAGE_REPOSITORY} ../generate-repo.sh)
@@ -70,7 +70,6 @@ image: Dockerfile $(ADMIN_API_SOURCES) Makefile
 		--build-arg PLATFORM=linux/amd64 \
 		--build-arg ARO_HCP_REVISION=${ARO_HCP_REVISION} \
 		--build-arg ARO_HCP_COMMIT_TIME=${ARO_HCP_COMMIT_TIME} \
-		--build-arg ARO_HCP_IMAGE_TAG=${ADMIN_API_IMAGE_TAG} \
 		--tag ${ADMIN_API_TAGGED_IMAGE}
 
 build-and-push: image $(ORAS)

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -63,7 +63,7 @@ clean:
 	rm -f ${BINARY}
 .PHONY: clean
 
-image: Dockerfile $(ADMIN_API_SOURCES) Makefile
+image:
 	@rm -f $(BINARY)
 	cd $(ADMIN_DIR)/.. && \
 	$(CONTAINER_ENGINE) build . --file admin/Dockerfile \
@@ -71,6 +71,7 @@ image: Dockerfile $(ADMIN_API_SOURCES) Makefile
 		--build-arg ARO_HCP_REVISION=${ARO_HCP_REVISION} \
 		--build-arg ARO_HCP_COMMIT_TIME=${ARO_HCP_COMMIT_TIME} \
 		--tag ${ADMIN_API_TAGGED_IMAGE}
+.PHONY: image
 
 build-and-push: image $(ORAS)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -73,10 +73,10 @@ image:
 		--tag ${ADMIN_API_TAGGED_IMAGE}
 .PHONY: image
 
-build-and-push: image $(ORAS)
+build-and-push: image $(ORAS) $(YQ)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
 	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${ADMIN_API_TAGGED_IMAGE} | sed 's/sha256://'); \
-	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${ADMIN_API_TAGGED_IMAGE} 2>/dev/null | jq -r .config.digest | sed 's/sha256://'); \
+	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${ADMIN_API_TAGGED_IMAGE} 2>/dev/null | $(YQ) .config.digest | sed 's/sha256://'); \
 	if [ "$$LOCAL_DIGEST" = "$$REMOTE_DIGEST" ]; then \
 		echo "Image ${ADMIN_API_TAGGED_IMAGE} already up to date in registry, skipping push"; \
 	else \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,12 +8,12 @@ COPY backend/go.mod backend/go.sum backend/
 RUN cd backend && go mod download
 WORKDIR /app
 COPY . .
-ARG TAG
+ARG ARO_HCP_REVISION
 # https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips#build-option-to-require-fips-mode
 # NOTE: starting with go 1.27, GODEBUG=fips140=only can be used at runtime to also reject
 # non-FIPS algorithms. See https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 ENV CGO_ENABLED=1 GOFIPS140=latest
-RUN make --directory backend ARO_HCP_IMAGE_TAG=${ARO_HCP_IMAGE_TAG}
+RUN make --directory backend build ARO_HCP_REVISION=${ARO_HCP_REVISION}
 
 
 # Deployment image copies aro-hcp-backend from builder image

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,8 +13,9 @@ ARG ARO_HCP_REVISION
 # NOTE: starting with go 1.27, GODEBUG=fips140=only can be used at runtime to also reject
 # non-FIPS algorithms. See https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 ENV CGO_ENABLED=1 GOFIPS140=latest
-RUN make --directory backend build ARO_HCP_REVISION=${ARO_HCP_REVISION}
-
+RUN --mount=type=cache,target=/go/cache \
+    GOCACHE=/go/cache \
+    make --directory backend build ARO_HCP_REVISION=${ARO_HCP_REVISION}
 
 # Deployment image copies aro-hcp-backend from builder image
 FROM --platform=${PLATFORM} mcr.microsoft.com/azurelinux/distroless/base:3.0

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -5,7 +5,7 @@ CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || echo docker)
 -include ../.bingo/Variables.mk
 
 ARO_HCP_REVISION ?= $(shell git rev-parse HEAD)
-ARO_HCP_COMMIT_TIME := $(shell TZ=UTC git show -s --format=%cd --date=iso-strict-local ${ARO_HCP_REVISION})
+ARO_HCP_COMMIT_TIME ?= $(shell TZ=UTC git show -s --format=%cd --date=iso-strict-local ${ARO_HCP_REVISION})
 ARO_HCP_IMAGE_REGISTRY ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
 BACKEND_IMAGE_TAG ?= $(shell DETECT_DIRTY_GIT_WORKTREE=${DETECT_DIRTY_GIT_WORKTREE} DEPLOY_ENV=${DEPLOY_ENV} ../generate-tag.sh)
 BACKEND_GENERATED_IMAGE_REPOSITORY = $(shell DEPLOY_ENV=${DEPLOY_ENV} BASELINE_REPO=${BACKEND_IMAGE_REPOSITORY} ../generate-repo.sh)
@@ -50,7 +50,6 @@ image: Dockerfile $(BACKEND_SOURCES) Makefile
 		--build-arg PLATFORM=linux/amd64 \
 		--build-arg ARO_HCP_REVISION=${ARO_HCP_REVISION} \
 		--build-arg ARO_HCP_COMMIT_TIME=${ARO_HCP_COMMIT_TIME} \
-		--build-arg ARO_HCP_IMAGE_TAG=${BACKEND_IMAGE_TAG} \
 		--tag ${BACKEND_TAGGED_IMAGE}
 
 build-and-push: image $(ORAS)

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -54,7 +54,13 @@ image: Dockerfile $(BACKEND_SOURCES) Makefile
 
 build-and-push: image $(ORAS)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
-	$(CONTAINER_ENGINE) push ${BACKEND_TAGGED_IMAGE}
+	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${BACKEND_TAGGED_IMAGE}); \
+	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${BACKEND_TAGGED_IMAGE} 2>/dev/null | jq -r .config.digest | sed 's/sha256://'); \
+	if [ "$$LOCAL_DIGEST" = "$$REMOTE_DIGEST" ]; then \
+		echo "Image ${BACKEND_TAGGED_IMAGE} already up to date in registry, skipping push"; \
+	else \
+		$(CONTAINER_ENGINE) push ${BACKEND_TAGGED_IMAGE}; \
+	fi
 .PHONY: build-and-push
 
 # Unix timestamp for this make run; computed once so multiple targets see the same value.

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -55,7 +55,7 @@ image:
 
 build-and-push: image $(ORAS)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
-	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${BACKEND_TAGGED_IMAGE}); \
+	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${BACKEND_TAGGED_IMAGE} | sed 's/sha256://'); \
 	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${BACKEND_TAGGED_IMAGE} 2>/dev/null | jq -r .config.digest | sed 's/sha256://'); \
 	if [ "$$LOCAL_DIGEST" = "$$REMOTE_DIGEST" ]; then \
 		echo "Image ${BACKEND_TAGGED_IMAGE} already up to date in registry, skipping push"; \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -53,10 +53,10 @@ image:
 		--tag ${BACKEND_TAGGED_IMAGE}
 .PHONY: image
 
-build-and-push: image $(ORAS)
+build-and-push: image $(ORAS) $(YQ)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
 	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${BACKEND_TAGGED_IMAGE} | sed 's/sha256://'); \
-	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${BACKEND_TAGGED_IMAGE} 2>/dev/null | jq -r .config.digest | sed 's/sha256://'); \
+	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${BACKEND_TAGGED_IMAGE} 2>/dev/null | $(YQ) .config.digest | sed 's/sha256://'); \
 	if [ "$$LOCAL_DIGEST" = "$$REMOTE_DIGEST" ]; then \
 		echo "Image ${BACKEND_TAGGED_IMAGE} already up to date in registry, skipping push"; \
 	else \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -44,13 +44,14 @@ clean:
 	rm -f ${BINARY}
 .PHONY: clean
 
-image: Dockerfile $(BACKEND_SOURCES) Makefile
+image:
 	cd $(BACKEND_DIR)/.. && \
 	$(CONTAINER_ENGINE) build . --file backend/Dockerfile \
 		--build-arg PLATFORM=linux/amd64 \
 		--build-arg ARO_HCP_REVISION=${ARO_HCP_REVISION} \
 		--build-arg ARO_HCP_COMMIT_TIME=${ARO_HCP_COMMIT_TIME} \
 		--tag ${BACKEND_TAGGED_IMAGE}
+.PHONY: image
 
 build-and-push: image $(ORAS)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,9 @@ ARG ARO_HCP_REVISION
 # NOTE: starting with go 1.27, GODEBUG=fips140=only can be used at runtime to also reject
 # non-FIPS algorithms. See https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 ENV CGO_ENABLED=1 GOFIPS140=latest
-RUN make --directory frontend build ARO_HCP_REVISION=${ARO_HCP_REVISION}
+RUN --mount=type=cache,target=/go/cache \
+    GOCACHE=/go/cache \
+    make --directory frontend build ARO_HCP_REVISION=${ARO_HCP_REVISION}
 
 FROM --platform=${PLATFORM} mcr.microsoft.com/azurelinux/distroless/base:3.0
 USER 65532:65532

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,12 +8,12 @@ COPY test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopens
 RUN cd frontend && go mod download
 WORKDIR /app
 COPY . .
-ARG ARO_HCP_IMAGE_TAG
+ARG ARO_HCP_REVISION
 # https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips#build-option-to-require-fips-mode
 # NOTE: starting with go 1.27, GODEBUG=fips140=only can be used at runtime to also reject
 # non-FIPS algorithms. See https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 ENV CGO_ENABLED=1 GOFIPS140=latest
-RUN make --directory frontend ARO_HCP_IMAGE_TAG=${ARO_HCP_IMAGE_TAG}
+RUN make --directory frontend build ARO_HCP_REVISION=${ARO_HCP_REVISION}
 
 FROM --platform=${PLATFORM} mcr.microsoft.com/azurelinux/distroless/base:3.0
 USER 65532:65532

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -53,7 +53,14 @@ image: Dockerfile $(FRONTEND_SOURCES) Makefile
 
 build-and-push: image $(ORAS)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
-	$(CONTAINER_ENGINE) push ${FRONTEND_TAGGED_IMAGE}
+	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${FRONTEND_TAGGED_IMAGE}); \
+	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${FRONTEND_TAGGED_IMAGE} 2>/dev/null | jq -r .config.digest | sed 's/sha256://'); \
+	if [ "$$LOCAL_DIGEST" = "$$REMOTE_DIGEST" ]; then \
+		echo "Image ${FRONTEND_TAGGED_IMAGE} already up to date in registry, skipping push"; \
+	else \
+	    echo "pushing image to registry"; \
+		$(CONTAINER_ENGINE) push ${FRONTEND_TAGGED_IMAGE}; \
+	fi
 .PHONY: build-and-push
 
 # Unix timestamp for this make run; computed once so multiple targets see the same value.

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -5,7 +5,7 @@ CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || echo docker)
 -include ../.bingo/Variables.mk
 
 ARO_HCP_REVISION ?= $(shell git rev-parse HEAD)
-ARO_HCP_COMMIT_TIME := $(shell TZ=UTC git show -s --format=%cd --date=iso-strict-local ${ARO_HCP_REVISION})
+ARO_HCP_COMMIT_TIME ?= $(shell TZ=UTC git show -s --format=%cd --date=iso-strict-local ${ARO_HCP_REVISION})
 ARO_HCP_IMAGE_REGISTRY ?= ${ARO_HCP_IMAGE_ACR}.azurecr.io
 FRONTEND_IMAGE_TAG ?= $(shell DETECT_DIRTY_GIT_WORKTREE=${DETECT_DIRTY_GIT_WORKTREE} DEPLOY_ENV=${DEPLOY_ENV} ../generate-tag.sh)
 FRONTEND_GENERATED_IMAGE_REPOSITORY = $(shell DEPLOY_ENV=${DEPLOY_ENV} BASELINE_REPO=${FRONTEND_IMAGE_REPOSITORY} ../generate-repo.sh)
@@ -49,7 +49,6 @@ image: Dockerfile $(FRONTEND_SOURCES) Makefile
 		--build-arg PLATFORM=linux/amd64 \
 		--build-arg ARO_HCP_REVISION=${ARO_HCP_REVISION} \
 		--build-arg ARO_HCP_COMMIT_TIME=${ARO_HCP_COMMIT_TIME} \
-		--build-arg ARO_HCP_IMAGE_TAG=${FRONTEND_IMAGE_TAG} \
 		--tag ${FRONTEND_TAGGED_IMAGE}
 
 build-and-push: image $(ORAS)

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -54,7 +54,7 @@ image:
 
 build-and-push: image $(ORAS)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
-	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${FRONTEND_TAGGED_IMAGE}); \
+	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${FRONTEND_TAGGED_IMAGE} | sed 's/sha256://'); \
 	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${FRONTEND_TAGGED_IMAGE} 2>/dev/null | jq -r .config.digest | sed 's/sha256://'); \
 	if [ "$$LOCAL_DIGEST" = "$$REMOTE_DIGEST" ]; then \
 		echo "Image ${FRONTEND_TAGGED_IMAGE} already up to date in registry, skipping push"; \

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -43,13 +43,14 @@ clean:
 	rm -f ${BINARY}
 .PHONY: clean
 
-image: Dockerfile $(FRONTEND_SOURCES) Makefile
+image:
 	cd $(FRONTEND_DIR)/.. && \
 	$(CONTAINER_ENGINE) build . --file frontend/Dockerfile \
 		--build-arg PLATFORM=linux/amd64 \
 		--build-arg ARO_HCP_REVISION=${ARO_HCP_REVISION} \
 		--build-arg ARO_HCP_COMMIT_TIME=${ARO_HCP_COMMIT_TIME} \
 		--tag ${FRONTEND_TAGGED_IMAGE}
+.PHONY: image
 
 build-and-push: image $(ORAS)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -52,10 +52,10 @@ image:
 		--tag ${FRONTEND_TAGGED_IMAGE}
 .PHONY: image
 
-build-and-push: image $(ORAS)
+build-and-push: image $(ORAS) $(YQ)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
 	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${FRONTEND_TAGGED_IMAGE} | sed 's/sha256://'); \
-	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${FRONTEND_TAGGED_IMAGE} 2>/dev/null | jq -r .config.digest | sed 's/sha256://'); \
+	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${FRONTEND_TAGGED_IMAGE} 2>/dev/null | $(YQ) .config.digest | sed 's/sha256://'); \
 	if [ "$$LOCAL_DIGEST" = "$$REMOTE_DIGEST" ]; then \
 		echo "Image ${FRONTEND_TAGGED_IMAGE} already up to date in registry, skipping push"; \
 	else \

--- a/sessiongate/Dockerfile
+++ b/sessiongate/Dockerfile
@@ -11,9 +11,7 @@ COPY . .
 # NOTE: starting with go 1.27, GODEBUG=fips140=only can be used at runtime to also reject
 # non-FIPS algorithms. See https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 ENV CGO_ENABLED=1 GOFIPS140=latest
-ARG ARO_HCP_IMAGE_TAG
-ARG ARO_HCP_REVISION
-RUN make --directory sessiongate build ARO_HCP_IMAGE_TAG=${ARO_HCP_IMAGE_TAG} ARO_HCP_REVISION=${ARO_HCP_REVISION}
+RUN make --directory sessiongate build
 
 FROM --platform=${PLATFORM} mcr.microsoft.com/azurelinux/distroless/base:3.0
 USER 65532:65532

--- a/sessiongate/Dockerfile
+++ b/sessiongate/Dockerfile
@@ -11,7 +11,9 @@ COPY . .
 # NOTE: starting with go 1.27, GODEBUG=fips140=only can be used at runtime to also reject
 # non-FIPS algorithms. See https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 ENV CGO_ENABLED=1 GOFIPS140=latest
-RUN make --directory sessiongate build
+RUN --mount=type=cache,target=/go/cache \
+    GOCACHE=/go/cache \
+    make --directory sessiongate build
 
 FROM --platform=${PLATFORM} mcr.microsoft.com/azurelinux/distroless/base:3.0
 USER 65532:65532

--- a/sessiongate/Dockerfile.dockerignore
+++ b/sessiongate/Dockerfile.dockerignore
@@ -1,0 +1,9 @@
+**
+!image-environment
+!sessiongate/
+
+# https://github.com/containers/podman/discussions/22910
+# !image-environment
+# !sessiongate/go.*
+# !sessiongate/Makefile
+# !sessiongate/**/*.go

--- a/sessiongate/Makefile
+++ b/sessiongate/Makefile
@@ -44,7 +44,7 @@ run:
 	go run . controller --namespace ${NAMESPACE} --ingress-base-url "http://localhost:8080" -v 2
 .PHONY: run
 
-image: Dockerfile $(SESSION_GATE_SOURCES) Makefile
+image:
 	rm -f $(BINARY)
 	cd $(SESSIONGATE_DIR)/.. && \
 	$(CONTAINER_ENGINE) build . --file sessiongate/Dockerfile \
@@ -52,6 +52,7 @@ image: Dockerfile $(SESSION_GATE_SOURCES) Makefile
 		--build-arg ARO_HCP_REVISION=${ARO_HCP_REVISION} \
 		--build-arg ARO_HCP_COMMIT_TIME=${ARO_HCP_COMMIT_TIME} \
 		--tag ${SESSION_GATE_TAGGED_IMAGE}
+.PHONY: image
 
 build-and-push: image $(ORAS)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}

--- a/sessiongate/Makefile
+++ b/sessiongate/Makefile
@@ -8,7 +8,7 @@ SESSIONGATE_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # Image
 ARO_HCP_REVISION ?= $(shell git rev-parse HEAD)
-ARO_HCP_COMMIT_TIME := $(shell TZ=UTC git show -s --format=%cd --date=iso-strict-local ${ARO_HCP_REVISION})
+ARO_HCP_COMMIT_TIME ?= $(shell TZ=UTC git show -s --format=%cd --date=iso-strict-local ${ARO_HCP_REVISION})
 SESSION_GATE_IMAGE_TAG ?= $(shell DETECT_DIRTY_GIT_WORKTREE=${DETECT_DIRTY_GIT_WORKTREE} DEPLOY_ENV=${DEPLOY_ENV} ../generate-tag.sh)
 SESSION_GATE_GENERATED_IMAGE_REPOSITORY = $(shell DEPLOY_ENV=${DEPLOY_ENV} BASELINE_REPO=${SESSION_GATE_IMAGE_REPOSITORY} ../generate-repo.sh)
 SESSION_GATE_TAGGED_IMAGE ?= $(ARO_HCP_IMAGE_REGISTRY)/$(SESSION_GATE_GENERATED_IMAGE_REPOSITORY):$(SESSION_GATE_IMAGE_TAG)
@@ -51,7 +51,6 @@ image: Dockerfile $(SESSION_GATE_SOURCES)
 		--build-arg PLATFORM=linux/amd64 \
 		--build-arg ARO_HCP_REVISION=${ARO_HCP_REVISION} \
 		--build-arg ARO_HCP_COMMIT_TIME=${ARO_HCP_COMMIT_TIME} \
-		--build-arg ARO_HCP_IMAGE_TAG=${SESSION_GATE_IMAGE_TAG} \
 		--tag ${SESSION_GATE_TAGGED_IMAGE}
 
 build-and-push: image

--- a/sessiongate/Makefile
+++ b/sessiongate/Makefile
@@ -44,7 +44,7 @@ run:
 	go run . controller --namespace ${NAMESPACE} --ingress-base-url "http://localhost:8080" -v 2
 .PHONY: run
 
-image: Dockerfile $(SESSION_GATE_SOURCES)
+image: Dockerfile $(SESSION_GATE_SOURCES) Makefile
 	rm -f $(BINARY)
 	cd $(SESSIONGATE_DIR)/.. && \
 	$(CONTAINER_ENGINE) build . --file sessiongate/Dockerfile \
@@ -53,9 +53,15 @@ image: Dockerfile $(SESSION_GATE_SOURCES)
 		--build-arg ARO_HCP_COMMIT_TIME=${ARO_HCP_COMMIT_TIME} \
 		--tag ${SESSION_GATE_TAGGED_IMAGE}
 
-build-and-push: image
+build-and-push: image $(ORAS)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
-	$(CONTAINER_ENGINE) push ${SESSION_GATE_TAGGED_IMAGE}
+	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${SESSION_GATE_TAGGED_IMAGE}); \
+	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${SESSION_GATE_TAGGED_IMAGE} 2>/dev/null | jq -r .config.digest | sed 's/sha256://'); \
+	if [ "$$LOCAL_DIGEST" = "$$REMOTE_DIGEST" ]; then \
+		echo "Image ${SESSION_GATE_TAGGED_IMAGE} already up to date in registry, skipping push"; \
+	else \
+		$(CONTAINER_ENGINE) push ${SESSION_GATE_TAGGED_IMAGE}; \
+	fi
 .PHONY: build-and-push
 
 # Unix timestamp for this make run; computed once so multiple targets see the same value.

--- a/sessiongate/Makefile
+++ b/sessiongate/Makefile
@@ -56,7 +56,7 @@ image:
 
 build-and-push: image $(ORAS)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
-	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${SESSION_GATE_TAGGED_IMAGE}); \
+	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${SESSION_GATE_TAGGED_IMAGE} | sed 's/sha256://'); \
 	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${SESSION_GATE_TAGGED_IMAGE} 2>/dev/null | jq -r .config.digest | sed 's/sha256://'); \
 	if [ "$$LOCAL_DIGEST" = "$$REMOTE_DIGEST" ]; then \
 		echo "Image ${SESSION_GATE_TAGGED_IMAGE} already up to date in registry, skipping push"; \

--- a/sessiongate/Makefile
+++ b/sessiongate/Makefile
@@ -54,10 +54,10 @@ image:
 		--tag ${SESSION_GATE_TAGGED_IMAGE}
 .PHONY: image
 
-build-and-push: image $(ORAS)
+build-and-push: image $(ORAS) $(YQ)
 	az acr login --name ${ARO_HCP_IMAGE_ACR}
 	@LOCAL_DIGEST=$$($(CONTAINER_ENGINE) image inspect --format '{{.Id}}' ${SESSION_GATE_TAGGED_IMAGE} | sed 's/sha256://'); \
-	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${SESSION_GATE_TAGGED_IMAGE} 2>/dev/null | jq -r .config.digest | sed 's/sha256://'); \
+	REMOTE_DIGEST=$$($(ORAS) manifest fetch ${SESSION_GATE_TAGGED_IMAGE} 2>/dev/null | $(YQ) .config.digest | sed 's/sha256://'); \
 	if [ "$$LOCAL_DIGEST" = "$$REMOTE_DIGEST" ]; then \
 		echo "Image ${SESSION_GATE_TAGGED_IMAGE} already up to date in registry, skipping push"; \
 	else \


### PR DESCRIPTION
### What

Speed improvements for personal dev env local service image builds
* Added .dockerignore files for admin and sessiongate to shrink build contexts
* Concurrent builds: `make build-services` now runs all four service builds in parallel
* Conditional image push: compares local vs remote image digest via oras, skips push if unchanged
* Go build cache mounts:  `--mount=type=cache,target=/go/cache` in all four Dockerfiles for incremental compilation across builds / just speeds up local builds

Other improvements
* preventing git failures in build context without .git (not really a speed improvement but the errors about missing git during build were annoying)

Result:
noop `make build-services` now takes around < 10s

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
