### PR TITLE
feat: add validation for nodepool version id required

### DIFF
--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -396,6 +396,7 @@ func TestDeploymentPreflight(t *testing.T) {
 				},
 				"properties": map[string]any{
 					"version": map[string]any{
+						"id":           "4.20.16",
 						"channelGroup": "stable",
 					},
 					"platform": map[string]any{
@@ -419,6 +420,7 @@ func TestDeploymentPreflight(t *testing.T) {
 				},
 				"properties": map[string]any{
 					"version": map[string]any{
+						"id":           "4.20.16",
 						"channelGroup": "stable",
 					},
 					"platform": map[string]any{

--- a/internal/validation/validate_nodepools.go
+++ b/internal/validation/validate_nodepools.go
@@ -172,8 +172,9 @@ var (
 func validateNodePoolVersionProfile(ctx context.Context, op operation.Operation, fldPath *field.Path, newObj, oldObj *api.NodePoolVersionProfile) field.ErrorList {
 	errs := field.ErrorList{}
 
+	// Version ID is required since 20251223preview version but some records may not have had it originally, so don't fail them yet.
 	//ID           string `json:"id,omitempty"`
-	if newObj.ChannelGroup != "stable" {
+	if oldObj == nil || len(oldObj.ID) > 0 {
 		errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("id"), &newObj.ID, safe.Field(oldObj, toNodePoolVersionProfileID))...)
 	}
 

--- a/internal/validation/validate_nodepools_comprehensive_test.go
+++ b/internal/validation/validate_nodepools_comprehensive_test.go
@@ -208,6 +208,18 @@ func TestValidateNodePoolCreate(t *testing.T) {
 			},
 		},
 		{
+			name: "missing version ID when channel group is stable - create",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := createValidNodePool()
+				np.Properties.Version.ID = ""
+				np.Properties.Version.ChannelGroup = "stable"
+				return np
+			}(),
+			expectErrors: []expectedError{
+				{message: "Required value", fieldPath: "properties.version.id"},
+			},
+		},
+		{
 			name: "nil subnet ID - valid - create",
 			nodePool: func() *api.HCPOpenShiftClusterNodePool {
 				np := createValidNodePool()
@@ -1176,6 +1188,35 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				return np
 			}(),
 			expectErrors: []expectedError{}, // No error because version validation is skipped
+		},
+		// Version.id is required since 20251223preview, but legacy nodepools may not have it.
+		// On update with oldObj.ID empty: version.id is NOT required (legacy migration support).
+		// On update with oldObj.ID set: version.id is required (cannot be cleared).
+		{
+			name: "update: version.id can be empty when old nodepool had no version.id (legacy migration)",
+			newNodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := createValidNodePool()
+				np.Properties.Version.ID = ""
+				return np
+			}(),
+			oldNodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := createValidNodePool()
+				np.Properties.Version.ID = ""
+				return np
+			}(),
+			expectErrors: []expectedError{},
+		},
+		{
+			name: "update: version.id cannot be cleared when old nodepool had version.id",
+			newNodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := createValidNodePool()
+				np.Properties.Version.ID = ""
+				return np
+			}(),
+			oldNodePool: createValidNodePool(),
+			expectErrors: []expectedError{
+				{message: "Required value", fieldPath: "properties.version.id"},
+			},
 		},
 		{
 			name: "multiple immutable field changes - update",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/03-httpCreate-nodepool/test-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/03-httpCreate-nodepool/test-nodepool.json
@@ -22,7 +22,10 @@
 				"key": "foo.com/key",
 				"value": "valid"
 			}
-		]
+		],
+		"version": {
+			"id": "4.20.8"
+		}
 	},
 	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
@@ -45,7 +45,8 @@
 						}
 					],
 					"version": {
-						"channelGroup": "stable"
+						"channelGroup": "stable",
+						"id": "4.20.8"
 					}
 				},
 				"serviceProviderProperties": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-creating/03-httpCreate-nodepool/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-creating/03-httpCreate-nodepool/nodepool.json
@@ -3,6 +3,9 @@
 	"properties": {
 		"platform": {
 			"vmSize": "large"
+		},
+		"version": {
+			"id": "4.20.8"
 		}
 	},
 	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-deleting/03-httpCreate-nodepool/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-deleting/03-httpCreate-nodepool/nodepool.json
@@ -3,6 +3,9 @@
 	"properties": {
 		"platform": {
 			"vmSize": "large"
+		},
+		"version": {
+			"id": "4.20.8"
 		}
 	},
 	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/03-httpCreate-basic-nodepool/basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/03-httpCreate-basic-nodepool/basic-node-pool.json
@@ -22,7 +22,10 @@
 				"key": "foo.com/key",
 				"value": "valid"
 			}
-		]
+		],
+		"version": {
+			"id": "4.20.8"
+		}
 	},
 	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/04-httpCreate-second-nodepool/second-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/04-httpCreate-second-nodepool/second-node-pool.json
@@ -22,7 +22,10 @@
 				"key": "foo.com/key",
 				"value": "valid"
 			}
-		]
+		],
+		"version": {
+			"id": "4.20.8"
+		}
 	},
 	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-basic-node-pool.json
@@ -52,7 +52,8 @@
 						}
 					],
 					"version": {
-						"channelGroup": "stable"
+						"channelGroup": "stable",
+						"id": "4.20.8"
 					}
 				},
 				"serviceProviderProperties": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-node-pool-02.json
@@ -52,7 +52,8 @@
 						}
 					],
 					"version": {
-						"channelGroup": "stable"
+						"channelGroup": "stable",
+						"id": "4.20.8"
 					}
 				},
 				"serviceProviderProperties": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-name-too-long-name/03-httpCreate-node-mismatched-name/node-basic.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-name-too-long-name/03-httpCreate-node-mismatched-name/node-basic.json
@@ -22,7 +22,10 @@
 				"key": "foo.com/key",
 				"value": "valid"
 			}
-		]
+		],
+		"version": {
+			"id": "4.20.8"
+		}
 	},
 	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-name-too-long-name/04-httpCreate-node-name-too-long/node-basic.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-name-too-long-name/04-httpCreate-node-name-too-long/node-basic.json
@@ -22,7 +22,10 @@
 				"key": "foo.com/key",
 				"value": "valid"
 			}
-		]
+		],
+		"version": {
+			"id": "4.20.8"
+		}
 	},
 	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/missing-required-fields/03-httpCreate-nodepool/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/missing-required-fields/03-httpCreate-nodepool/expected-error.txt
@@ -1,5 +1,10 @@
-{
-    "code": "InvalidRequestContent",
-    "message": "Invalid value: 1: cannot specify replicas when autoScaling is enabled",
-    "target": "properties.replicas"
-  }
+      {
+        "code": "InvalidRequestContent",
+        "message": "Required value",
+        "target": "properties.version.id"
+      }
+      {
+        "code": "InvalidRequestContent",
+        "message": "Invalid value: 1: cannot specify replicas when autoScaling is enabled",
+        "target": "properties.replicas"
+      }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/noop-update/04-httpCreate-nodepool/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/noop-update/04-httpCreate-nodepool/nodepool.json
@@ -22,7 +22,10 @@
 				"key": "foo.com/key",
 				"value": "valid"
 			}
-		]
+		],
+		"version": {
+			"id": "4.20.8"
+		}
 	},
 	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/replace-with-tags-with-empty/04-httpCreate-nodepool/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/replace-with-tags-with-empty/04-httpCreate-nodepool/nodepool.json
@@ -22,7 +22,10 @@
 				"key": "foo.com/key",
 				"value": "valid"
 			}
-		]
+		],
+		"version": {
+			"id": "4.20.8"
+		}
 	},
 	"tags": {
 		"foo": "bar"

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/replace-with-tags-with-nil/04-httpCreate-nodepool/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/replace-with-tags-with-nil/04-httpCreate-nodepool/nodepool.json
@@ -22,7 +22,10 @@
 				"key": "foo.com/key",
 				"value": "valid"
 			}
-		]
+		],
+		"version": {
+			"id": "4.20.8"
+		}
 	},
 	"tags": {
 		"foo": "bar"

--- a/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/get/2024-06-10-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/get/2024-06-10-preview.json
@@ -18,7 +18,8 @@
 		},
 		"provisioningState": "Succeeded",
 		"version": {
-			"channelGroup": "stable"
+			"channelGroup": "stable",
+			"id": "4.20.8"
 		}
 	},
 	"systemData": {

--- a/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/get/2025-12-23-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/get/2025-12-23-preview.json
@@ -20,7 +20,8 @@
 		"provisioningState": "Succeeded",
 		"replicas": 0,
 		"version": {
-			"channelGroup": "stable"
+			"channelGroup": "stable",
+			"id": "4.20.8"
 		}
 	},
 	"systemData": {

--- a/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/list/2024-06-10-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/list/2024-06-10-preview.json
@@ -18,7 +18,8 @@
 		},
 		"provisioningState": "Succeeded",
 		"version": {
-			"channelGroup": "stable"
+			"channelGroup": "stable",
+			"id": "4.20.8"
 		}
 	},
 	"systemData": {

--- a/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/list/2025-12-23-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/list/2025-12-23-preview.json
@@ -20,7 +20,8 @@
 		"provisioningState": "Succeeded",
 		"replicas": 0,
 		"version": {
-			"channelGroup": "stable"
+			"channelGroup": "stable",
+			"id": "4.20.8"
 		}
 	},
 	"systemData": {

--- a/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/request.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/request.json
@@ -8,6 +8,9 @@
 		},
 		"platform": {
 			"vmSize": "Standard_D4s_v3"
+		},
+		"version": {
+			"id": "4.20.8"
 		}
 	},
 	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"


### PR DESCRIPTION
[ARO-24975](https://redhat.atlassian.net/browse/ARO-24975)

### What

Make `version.id` required for all NodePool CREATE operations, regardless of channel group.

Previously, `version.id` was only required when `channelGroup != "stable"`. This change makes it required for all new NodePool creations while maintaining backward compatibility for existing NodePools that were created without a `version.id`.

### Why

Requiring an explicit version ID for all NodePools ensures consistent version tracking and prevents ambiguity about which OpenShift version a NodePool is running, aligning with clusters. The previous exemption for the "stable" channel group allowed NodePools to be created without specifying a version, which could lead to unclear version state.

This is a **breaking change for CREATE operations** on the stable channel. Clients that previously omitted `version.id` when using `channelGroup: "stable"` will now receive a validation error and must specify a version.

### Testing

- **Unit tests**: Added two new test cases in `validate_nodepools_comprehensive_test.go`:
  - `update: version.id can be empty when old nodepool had no version.id (legacy migration)` - verifies backward compatibility for legacy records
  - `update: version.id cannot be cleared when old nodepool had version.id` - verifies version.id cannot be removed once set
- **Integration tests**: Updated all NodePool test artifacts to include `version.id`


### Special notes for your reviewer

**Backward compatibility**: The validation uses the established pattern from cluster validation (`validate_cluster.go:337-339`):
```go
if oldObj == nil || len(oldObj.ID) > 0 {
    errs = append(errs, validate.RequiredValue(...)...)
}
```

There is a controller that reconciles the `version.id` from the Cluster Service NodePool into the Cosmos NodePool object if it is nil.

This means:
- **CREATE** (`oldObj == nil`): `version.id` is always required
- **UPDATE with existing version.id**: `version.id` remains required (cannot be cleared)
- **UPDATE without existing version.id**: `version.id` validation is skipped (legacy migration support)

This approach allows existing NodePools stored in Cosmos without `version.id` to continue being updated without requiring a version to be specified retroactively.

