### PR TITLE
mgmt cluster infra nodes: bump cores

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1419,6 +1419,8 @@ clouds:
                 osDiskSizeGB: 100
                 vmSize: Standard_D4s_v3
                 secondaryNicCount: 1
+              infraAgentPool:
+                vmSize: 'Standard_D4s_v3'
               enableSwiftV2Vnet: true
               enableSwiftV2Nodepools: true
             jaeger:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -543,7 +543,7 @@ mgmt:
       name: infra
       osDiskSizeGB: 32
       poolCount: 2
-      vmSize: Standard_D2s_v3
+      vmSize: Standard_D4s_v3
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.34.4


### PR DESCRIPTION
### What

ACM components now run on infra nodes and in the 2 core nodes are not big enough. this manifested in personal dev where the required scaling of the infra pool took longer than the ACM helm chart was able to wait and run into a timeout, failing pers dev env creation occasionally.

https://redhat-external.slack.com/archives/C075PHEFZKQ/p1777349048367509

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
