### PR TITLE
fetch vm serial console logs

### DIFF
--- a/test/e2e/admin_api.go
+++ b/test/e2e/admin_api.go
@@ -312,7 +312,9 @@ var _ = Describe("SRE", func() {
 			nodePoolParams.Replicas = int32(1)
 
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				engineeringClusterName,
 				nodePoolParams,
 				45*time.Minute,
@@ -419,7 +421,9 @@ var _ = Describe("SRE", func() {
 			nodePoolParams.Replicas = int32(1)
 
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				engineeringClusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/e2e/arm64_nodepool.go
+++ b/test/e2e/arm64_nodepool.go
@@ -101,7 +101,9 @@ var _ = Describe("Customer", func() {
 			nodePoolParams.VMSize = nodePoolVMSize
 
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				customerClusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -233,7 +233,9 @@ var _ = Describe("Authorized CIDRs", func() {
 				nodePoolParams.Replicas = int32(2)
 
 				err = tc.CreateNodePoolFromParam(ctx,
+					GinkgoLogr,
 					*resourceGroup.Name,
+					managedResourceGroupName,
 					clusterName,
 					nodePoolParams,
 					45*time.Minute,

--- a/test/e2e/cluster_autoscaling.go
+++ b/test/e2e/cluster_autoscaling.go
@@ -66,7 +66,8 @@ var _ = Describe("Customer", func() {
 
 			clusterParams := framework.NewDefaultClusterParams()
 			clusterParams.ClusterName = customerClusterName
-			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 			clusterParams.Autoscaling = &hcpsdk20240610preview.ClusterAutoscalingProfile{
 				MaxNodeProvisionTimeSeconds: to.Ptr(autoscalingMaxNodeProvisionTimeSeconds),
 				MaxPodGracePeriodSeconds:    to.Ptr(autoscalingMaxPodGracePeriodSeconds),
@@ -116,7 +117,9 @@ var _ = Describe("Customer", func() {
 			nodePoolParams.Replicas = int32(2)
 
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				customerClusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/e2e/cluster_create_cni_cilium.go
+++ b/test/e2e/cluster_create_cni_cilium.go
@@ -150,8 +150,11 @@ var _ = Describe("Customer", func() {
 			By("creating the node pool")
 			nodePoolParams := framework.NewDefaultNodePoolParams()
 			nodePoolParams.NodePoolName = customerNodePoolName
-			nodePoolErr := tc.CreateNodePoolFromParam(ctx,
+			nodePoolErr := tc.CreateNodePoolFromParam(
+				ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				clusterParams.ManagedResourceGroupName,
 				customerClusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/e2e/cluster_create_complex_cilium_kv.go
+++ b/test/e2e/cluster_create_complex_cilium_kv.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 
 	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 
@@ -188,9 +189,22 @@ var _ = Describe("Customer", func() {
 			// We delay checking the error on purpose to get more details
 			// about the issue by running the verifiers.
 
+			var consoleLogErr error = nil
+			if nodePoolErr != nil {
+				var computeFactory *armcompute.ClientFactory
+				computeFactory, consoleLogErr = tc.GetARMComputeClientFactory(ctx)
+				if consoleLogErr == nil {
+					consoleLogErr = framework.DownloadAllVirtualMachineConsoleLogs(
+						ctx,
+						computeFactory,
+						clusterParams.ManagedResourceGroupName,
+						tc.LogDirPath)
+				}
+			}
+
 			By("verifying nodes become Ready with Cilium CNI")
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodesReady(), verifiers.VerifyCiliumOperational("kube-system", "k8s-app=cilium"))
-			Expect(errors.Join(err, nodePoolErr)).NotTo(HaveOccurred())
+			Expect(errors.Join(err, nodePoolErr, consoleLogErr)).NotTo(HaveOccurred())
 
 			By("verifying a simple web app can run with cilium")
 			err = verifiers.VerifySimpleWebApp().Verify(ctx, adminRESTConfig)

--- a/test/e2e/cluster_create_nodepool_osdisk.go
+++ b/test/e2e/cluster_create_nodepool_osdisk.go
@@ -86,7 +86,9 @@ var _ = Describe("Customer", func() {
 			nodePoolParams.OSDiskSizeGiB = customerNodeOsDiskSizeGiB
 
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				customerClusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/e2e/cluster_create_private_kv.go
+++ b/test/e2e/cluster_create_private_kv.go
@@ -143,7 +143,9 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			nodePoolParams.Replicas = int32(2)
 
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				customerClusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/e2e/cluster_delete_cx_rg.go
+++ b/test/e2e/cluster_delete_cx_rg.go
@@ -117,7 +117,9 @@ var _ = Describe("Customer", func() {
 				group.Go(func() error {
 					createErr := tc.CreateNodePoolFromParam(
 						groupCtx,
+						GinkgoLogr,
 						*resourceGroup.Name,
+						managedResourceGroupName,
 						customerClusterName,
 						nodePoolParams,
 						45*time.Minute,

--- a/test/e2e/cluster_pullsecret.go
+++ b/test/e2e/cluster_pullsecret.go
@@ -138,7 +138,9 @@ var _ = Describe("Customer", func() {
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.Replicas = int32(2)
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				customerClusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -115,7 +115,9 @@ var _ = Describe("Customer", func() {
 			nodePoolParams.NodePoolName = customerNodePoolName
 
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				customerClusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -152,7 +152,9 @@ var _ = Describe("ARO-HCP", func() {
 			By(fmt.Sprintf("creating node pool %q with version '%s' on %s channel", nodePoolName, nodePoolParams.OpenshiftVersionId, nodePoolChannelGroup))
 			err = tc.CreateNodePoolFromParam(
 				ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				clusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -112,7 +112,9 @@ var _ = Describe("Customer", func() {
 			nodePoolParams.NodePoolName = customerNodePoolName
 
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				customerClusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/e2e/gpu_nodepools_create_delete.go
+++ b/test/e2e/gpu_nodepools_create_delete.go
@@ -76,7 +76,8 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 
 				clusterParams := framework.NewDefaultClusterParams()
 				clusterParams.ClusterName = customerClusterName
-				clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+				managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+				clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 				By("creating customer resources (infrastructure and managed identities) for cluster")
 				clusterParams, err = tc.CreateClusterCustomerResources(ctx,
@@ -121,7 +122,9 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				defaultNodePoolParams.Replicas = int32(2)
 
 				err = tc.CreateNodePoolFromParam(ctx,
+					GinkgoLogr,
 					*resourceGroup.Name,
+					managedResourceGroupName,
 					customerClusterName,
 					defaultNodePoolParams,
 					45*time.Minute,
@@ -136,7 +139,9 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				gpuNodePoolParams.VMSize = sku.vmSize
 
 				err = tc.CreateNodePoolFromParam(ctx,
+					GinkgoLogr,
 					*resourceGroup.Name,
+					managedResourceGroupName,
 					customerClusterName,
 					gpuNodePoolParams,
 					45*time.Minute,

--- a/test/e2e/nodepool_autoscaling.go
+++ b/test/e2e/nodepool_autoscaling.go
@@ -72,7 +72,8 @@ var _ = Describe("Customer", func() {
 			By("creating cluster parameters")
 			clusterParams := framework.NewDefaultClusterParams()
 			clusterParams.ClusterName = customerClusterName
-			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
 			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
@@ -135,7 +136,9 @@ var _ = Describe("Customer", func() {
 				azNodePoolParams.AvailabilityZone = availabilityZone
 
 				err = tc.CreateNodePoolFromParam(ctx,
+					GinkgoLogr,
 					*resourceGroup.Name,
+					managedResourceGroupName,
 					customerClusterName,
 					azNodePoolParams,
 					45*time.Minute,
@@ -199,7 +202,9 @@ var _ = Describe("Customer", func() {
 			}
 
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				customerClusterName,
 				noAZNodePoolParams,
 				45*time.Minute,
@@ -253,7 +258,8 @@ var _ = Describe("Customer", func() {
 			By("creating cluster with MaxNodesTotal limit")
 			clusterParams := framework.NewDefaultClusterParams()
 			clusterParams.ClusterName = customerClusterName
-			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 			clusterParams.Autoscaling = &hcpsdk20240610preview.ClusterAutoscalingProfile{
 				MaxNodesTotal: to.Ptr(int32(3)), // Set low limit
 			}
@@ -286,7 +292,9 @@ var _ = Describe("Customer", func() {
 
 			// Should fail quickly during validation
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				customerClusterName,
 				nodePoolParams,
 				5*time.Minute,

--- a/test/e2e/nodepool_ephemeral_osdisk.go
+++ b/test/e2e/nodepool_ephemeral_osdisk.go
@@ -190,7 +190,7 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 
 			By("verifying Azure VMs actually have ephemeral OS disks")
 			computeFactory := tc.GetARMComputeClientFactoryOrDie(ctx)
-			vms, err := framework.GetVirtualMachinesInResourceGroup(ctx, computeFactory, managedResourceGroupName, int(nodePoolParams.Replicas), 5*time.Minute)
+			vms, err := framework.GetVirtualMachinesInResourceGroup(ctx, computeFactory, managedResourceGroupName, int(nodePoolParams.Replicas))
 			Expect(err).NotTo(HaveOccurred())
 
 			workerVMs := filterNodePoolVMs(vms, customerNodePoolName)

--- a/test/e2e/nodepool_update_nodes.go
+++ b/test/e2e/nodepool_update_nodes.go
@@ -109,7 +109,9 @@ var _ = Describe("Customer", func() {
 				group.Go(func() error {
 					createErr := tc.CreateNodePoolFromParam(
 						groupCtx,
+						GinkgoLogr,
 						*resourceGroup.Name,
+						managedResourceGroupName,
 						customerClusterName,
 						nodePoolParams,
 						45*time.Minute,

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -103,7 +103,8 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 			clusterParams.OpenshiftVersionId = clusterInstallVersion
 			clusterParams.ChannelGroup = channelGroup
-			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name+"-np-upgrade-"+suffix, "-managed", 64)
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name+"-np-upgrade-"+suffix, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
 			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
@@ -139,7 +140,9 @@ var _ = Describe("Customer", func() {
 			nodePoolParams.NodeDrainTimeoutMinutes = to.Ptr(int32(10))
 			err = tc.CreateNodePoolFromParam(
 				ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				clusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/e2e/oidc_issuer_workload_identity.go
+++ b/test/e2e/oidc_issuer_workload_identity.go
@@ -249,7 +249,9 @@ var _ = Describe("Customer", func() {
 			nodePoolParams.Replicas = int32(2)
 
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				customerClusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/e2e/simple_negative_cases.go
+++ b/test/e2e/simple_negative_cases.go
@@ -136,7 +136,9 @@ var _ = Describe("Customer", func() {
 
 			By("attempting to create a node pool with invalid instance type")
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				clusterParams.ClusterName,
 				nodePoolParamsInvalidInstance,
 				5*time.Minute,
@@ -145,7 +147,9 @@ var _ = Describe("Customer", func() {
 
 			By("attempting to create a node pool with invalid quota")
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				clusterParams.ClusterName,
 				nodePoolParamsInvalidQuota,
 				5*time.Minute,
@@ -154,7 +158,9 @@ var _ = Describe("Customer", func() {
 
 			By("creating a nodepool")
 			err = tc.CreateNodePoolFromParam(ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				managedResourceGroupName,
 				clusterParams.ClusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/util/framework/deployment_helper.go
+++ b/test/util/framework/deployment_helper.go
@@ -405,12 +405,14 @@ func (tc *perItOrDescribeTestContext) CreateHCPCluster20251223FromParam(
 
 func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam(
 	ctx context.Context,
+	logger logr.Logger,
 	resourceGroupName string,
+	managedResourceGroupName string,
 	hcpClusterName string,
 	parameters NodePoolParams,
 	timeout time.Duration,
 ) error {
-	ctx, cancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during CreateNodePoolFromParam for node pool %s in resource group %s", timeout.Minutes(), parameters.NodePoolName, resourceGroupName))
+	nodePoolCtx, cancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during CreateNodePoolFromParam for node pool %s in resource group %s", timeout.Minutes(), parameters.NodePoolName, resourceGroupName))
 	defer cancel()
 
 	startTime := time.Now()
@@ -427,16 +429,39 @@ func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam(
 	nodePool := BuildNodePoolFromParams(parameters, tc.Location())
 
 	if _, err := CreateNodePoolAndWait(
-		ctx,
-		tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+		nodePoolCtx,
+		tc.Get20240610ClientFactoryOrDie(nodePoolCtx).NewNodePoolsClient(),
 		resourceGroupName,
 		hcpClusterName,
 		nodePoolName,
 		nodePool,
 		timeout,
 	); err != nil {
+		// a separate context for console log download with its own timeout,
+		// to make sure logs are fetched even when the node pool deployment
+		// context is cancelled due to timeout
+		downloadTimeout := 5 * time.Minute
+		downloadCtx, downloadCancel := context.WithTimeoutCause(
+			ctx,
+			downloadTimeout,
+			fmt.Errorf("timeout '%f' minutes exceeded during DownloadAllVirtualMachineConsoleLogs for VMs in managed resource group %s", downloadTimeout.Minutes(), managedResourceGroupName))
+		defer downloadCancel()
+		computeFactory, clientErr := tc.GetARMComputeClientFactory(downloadCtx)
+		if clientErr == nil {
+			consoleLogErr := DownloadAllVirtualMachineConsoleLogs(
+				downloadCtx,
+				computeFactory,
+				managedResourceGroupName,
+				tc.LogDirPath)
+			if consoleLogErr != nil {
+				logger.Error(consoleLogErr, "failed to download VM console logs")
+			}
+		} else {
+			logger.Error(clientErr, "failed to get ARM compute client to download VM console logs")
+		}
+
 		if errors.Is(err, context.DeadlineExceeded) {
-			return fmt.Errorf("failed to create NodePool %s, caused by: %w, error: %w", nodePoolName, context.Cause(ctx), err)
+			return fmt.Errorf("failed to create NodePool %s, caused by: %w, error: %w", nodePoolName, context.Cause(nodePoolCtx), err)
 		}
 		return fmt.Errorf("failed to create NodePool %s: %w", nodePoolName, err)
 	}

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -51,7 +50,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
@@ -1032,92 +1030,6 @@ func BuildNodePoolFromParams(
 	return nodePool
 }
 
-// Helper to run command on VM
-func RunVMCommand(ctx context.Context, tc interface {
-	SubscriptionID(ctx context.Context) (string, error)
-	AzureCredential() (azcore.TokenCredential, error)
-}, resourceGroup, vmName, command string, pollTimeout time.Duration) (string, error) {
-	subscriptionID, err := tc.SubscriptionID(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	azCreds, err := tc.AzureCredential()
-	if err != nil {
-		return "", err
-	}
-
-	computeClient, err := armcompute.NewVirtualMachinesClient(subscriptionID, azCreds, nil)
-	if err != nil {
-		return "", err
-	}
-
-	runCommandInput := armcompute.RunCommandInput{
-		CommandID: to.Ptr("RunShellScript"),
-		Script: []*string{
-			to.Ptr(command),
-		},
-	}
-
-	poller, err := computeClient.BeginRunCommand(ctx, resourceGroup, vmName, runCommandInput, nil)
-	if err != nil {
-		return "", err
-	}
-
-	// Create a timeout context to avoid waiting too long on VM command failures
-	// VM commands should complete quickly (within a few minutes at most)
-	pollCtx, cancel := context.WithTimeout(ctx, pollTimeout)
-	defer cancel()
-
-	result, err := poller.PollUntilDone(pollCtx, nil)
-	if err != nil {
-		return "", err
-	}
-
-	if len(result.Value) > 0 && result.Value[0].Message != nil {
-		// Azure Run Command returns output in format:
-		// "Enable succeeded: \n[stdout]\n<actual output>\n[stderr]\n<errors>"
-		// We need to extract stdout and stderr content
-		message := *result.Value[0].Message
-
-		// Find the stdout section
-		stdoutStart := strings.Index(message, "[stdout]\n")
-		if stdoutStart == -1 {
-			// If no stdout marker, return the whole message
-			return message, nil
-		}
-
-		// Skip past the "[stdout]\n" marker
-		stdoutStart += len("[stdout]\n")
-
-		// Find where stderr starts (if present)
-		stderrStart := strings.Index(message[stdoutStart:], "\n[stderr]")
-
-		var output string
-		if stderrStart == -1 {
-			// No stderr marker, take everything after stdout
-			output = message[stdoutStart:]
-		} else {
-			// Take only the stdout section
-			output = message[stdoutStart : stdoutStart+stderrStart]
-
-			// Extract and inspect stderr
-			stderrAbsoluteStart := stdoutStart + stderrStart + len("\n[stderr]\n")
-			if stderrAbsoluteStart < len(message) {
-				stderr := strings.TrimSpace(message[stderrAbsoluteStart:])
-				if stderr != "" {
-					// Return an error if stderr is not empty
-					return "", fmt.Errorf("%s", stderr)
-				}
-			}
-		}
-
-		return strings.TrimSpace(output), nil
-	}
-
-	return "", nil
-}
-
 // Helper to generate SSH key pair
 func GenerateSSHKeyPair() (publicKey string, privateKey string, err error) {
 	// Generate RSA key pair
@@ -1467,48 +1379,6 @@ func GetNodePool20251223(
 		return nil, err
 	}
 	return &resp.NodePool, nil
-}
-
-// GetVirtualMachinesInResourceGroup lists all VMs in the given resource group
-// with a polling loop to handle ARM replication delays.
-func GetVirtualMachinesInResourceGroup(
-	ctx context.Context,
-	computeClientFactory *armcompute.ClientFactory,
-	resourceGroupName string,
-	expectedMinimumCount int,
-	timeout time.Duration,
-) ([]*armcompute.VirtualMachine, error) {
-	ctx, cancel := context.WithTimeoutCause(ctx, timeout,
-		fmt.Errorf("timed out waiting for %d VMs in resource group %q", expectedMinimumCount, resourceGroupName))
-	defer cancel()
-
-	vmClient := computeClientFactory.NewVirtualMachinesClient()
-	const pollInterval = 10 * time.Second
-
-	for {
-		var vms []*armcompute.VirtualMachine
-		pager := vmClient.NewListPager(resourceGroupName, nil)
-		for pager.More() {
-			page, err := pager.NextPage(ctx)
-			if err != nil {
-				if errors.Is(err, context.DeadlineExceeded) {
-					return nil, fmt.Errorf("caused by: %w, error: %w", context.Cause(ctx), err)
-				}
-				return nil, fmt.Errorf("failed to list VMs in resource group %q: %w", resourceGroupName, err)
-			}
-			vms = append(vms, page.Value...)
-		}
-
-		if len(vms) >= expectedMinimumCount {
-			return vms, nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return nil, fmt.Errorf("caused by: %w, error: %w", context.Cause(ctx), ctx.Err())
-		case <-time.After(pollInterval):
-		}
-	}
 }
 
 // BuildHCPClusterFromParamsV20251223 builds a v20251223preview HCP cluster from ClusterParamsV20251223

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -71,6 +71,7 @@ type perItOrDescribeTestContext struct {
 	armNetworkClientFactory       *armnetwork.ClientFactory
 	graphClient                   *graphutil.Client
 
+	LogDirPath       string
 	azureLogFile     *os.File
 	timingMetadata   timing.SpecTimingMetadata
 	knownDeployments []deploymentInfo
@@ -81,22 +82,32 @@ type deploymentInfo struct {
 	deploymentName    string
 }
 
-func setupAzureLogging(artifactDir string) *os.File {
+// Create log directory for the test in ${ARTIFACT_DIR}/<test-name>/
+func setupTestLogDir(artifactDir string) string {
 	if len(artifactDir) == 0 {
-		return nil
+		return ""
 	}
 
-	// Set up Azure SDK logging to a file so it doesn't pollute test output but is
-	// available for debugging. The log file is written to ${ARTIFACT_DIR}/<test-name>/azure.log.
 	report := ginkgo.CurrentSpecReport()
 	testName := sanitizeTestName(append(report.ContainerHierarchyTexts, report.LeafNodeText))
-	logDir := filepath.Join(artifactDir, testName)
-	if err := os.MkdirAll(logDir, 0755); err != nil {
+	logDirPath := filepath.Join(artifactDir, testName)
+
+	if err := os.MkdirAll(logDirPath, 0755); err != nil {
 		ginkgo.GinkgoLogr.Error(err, "failed to create azure log file")
+		return ""
+	}
+
+	return logDirPath
+}
+
+// Set up Azure SDK logging to a file so it doesn't pollute test output but is
+// available for debugging. The log file is written to ${ARTIFACT_DIR}/<test-name>/azure.log.
+func setupAzureLogging(logDirPath string) *os.File {
+	if len(logDirPath) == 0 {
 		return nil
 	}
 
-	azureLogFile, err := os.Create(filepath.Join(logDir, "azure.log"))
+	azureLogFile, err := os.Create(filepath.Join(logDirPath, "azure.log"))
 	if err != nil {
 		ginkgo.GinkgoLogr.Error(err, "failed to create azure log file")
 		return nil
@@ -113,10 +124,12 @@ func setupAzureLogging(artifactDir string) *os.File {
 }
 
 func NewTestContext() *perItOrDescribeTestContext {
-	azureLogFile := setupAzureLogging(artifactDir())
+	logDirPath := setupTestLogDir(artifactDir())
+	azureLogFile := setupAzureLogging(logDirPath)
 
 	tc := &perItOrDescribeTestContext{
 		perBinaryInvocationTestContext: invocationContext(),
+		LogDirPath:                     logDirPath,
 		azureLogFile:                   azureLogFile,
 		timingMetadata: timing.SpecTimingMetadata{
 			// Answering the question of "what's the currently-running test name?" in Ginkgo is difficult -

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -971,6 +971,10 @@ func (tc *perItOrDescribeTestContext) PullSecretPath() string {
 	return tc.perBinaryInvocationTestContext.pullSecretPath
 }
 
+// FindVirtualMachineSizeMatching queries Azure for available VM sizes in the test location
+// and returns a randomly selected size name that matches the provided regex pattern.
+// This is useful for finding VM sizes that meet specific criteria (e.g., matching a family like "Standard_D.*")
+// while avoiding bias towards any particular size.
 func (tc *perItOrDescribeTestContext) FindVirtualMachineSizeMatching(ctx context.Context, pattern *regexp.Regexp) (string, error) {
 	if pattern == nil {
 		return "", fmt.Errorf("pattern cannot be nil")

--- a/test/util/framework/vm_helper.go
+++ b/test/util/framework/vm_helper.go
@@ -16,7 +16,6 @@ package framework
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -113,43 +112,39 @@ func RunVMCommand(ctx context.Context, tc interface {
 }
 
 // GetVirtualMachinesInResourceGroup lists all VMs in the given resource group
-// with a polling loop to handle ARM replication delays.
+// if the VM list contains at least expectedMinimumCount items
 func GetVirtualMachinesInResourceGroup(
 	ctx context.Context,
 	computeClientFactory *armcompute.ClientFactory,
 	resourceGroupName string,
 	expectedMinimumCount int,
-	timeout time.Duration,
 ) ([]*armcompute.VirtualMachine, error) {
-	ctx, cancel := context.WithTimeoutCause(ctx, timeout,
-		fmt.Errorf("timed out waiting for %d VMs in resource group %q", expectedMinimumCount, resourceGroupName))
-	defer cancel()
-
 	vmClient := computeClientFactory.NewVirtualMachinesClient()
-	const pollInterval = 10 * time.Second
-
-	for {
-		var vms []*armcompute.VirtualMachine
-		pager := vmClient.NewListPager(resourceGroupName, nil)
-		for pager.More() {
-			page, err := pager.NextPage(ctx)
-			if err != nil {
-				if errors.Is(err, context.DeadlineExceeded) {
-					return nil, fmt.Errorf("caused by: %w, error: %w", context.Cause(ctx), err)
-				}
-				return nil, fmt.Errorf("failed to list VMs in resource group %q: %w", resourceGroupName, err)
-			}
-			vms = append(vms, page.Value...)
+	var vms []*armcompute.VirtualMachine
+	pager := vmClient.NewListPager(resourceGroupName, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list VMs in resource group %q: %w", resourceGroupName, err)
 		}
-
-		if len(vms) >= expectedMinimumCount {
-			return vms, nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return nil, fmt.Errorf("caused by: %w, error: %w", context.Cause(ctx), ctx.Err())
-		case <-time.After(pollInterval):
-		}
+		vms = append(vms, page.Value...)
 	}
+
+	if len(vms) < expectedMinimumCount {
+		vmNames := make([]string, 0, len(vms))
+		for _, vm := range vms {
+			if vm.Name != nil {
+				vmNames = append(vmNames, *vm.Name)
+			}
+		}
+		return nil, fmt.Errorf(
+			"not enough VMs in resource group %q: expecting %d, got %d (%v)",
+			resourceGroupName,
+			expectedMinimumCount,
+			len(vms),
+			vmNames,
+		)
+	}
+
+	return vms, nil
 }

--- a/test/util/framework/vm_helper.go
+++ b/test/util/framework/vm_helper.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+)
+
+// Helper to run command on VM
+func RunVMCommand(ctx context.Context, tc interface {
+	SubscriptionID(ctx context.Context) (string, error)
+	AzureCredential() (azcore.TokenCredential, error)
+}, resourceGroup, vmName, command string, pollTimeout time.Duration) (string, error) {
+	subscriptionID, err := tc.SubscriptionID(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	azCreds, err := tc.AzureCredential()
+	if err != nil {
+		return "", err
+	}
+
+	computeClient, err := armcompute.NewVirtualMachinesClient(subscriptionID, azCreds, nil)
+	if err != nil {
+		return "", err
+	}
+
+	runCommandInput := armcompute.RunCommandInput{
+		CommandID: to.Ptr("RunShellScript"),
+		Script: []*string{
+			to.Ptr(command),
+		},
+	}
+
+	poller, err := computeClient.BeginRunCommand(ctx, resourceGroup, vmName, runCommandInput, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// Create a timeout context to avoid waiting too long on VM command failures
+	// VM commands should complete quickly (within a few minutes at most)
+	pollCtx, cancel := context.WithTimeout(ctx, pollTimeout)
+	defer cancel()
+
+	result, err := poller.PollUntilDone(pollCtx, nil)
+	if err != nil {
+		return "", err
+	}
+
+	if len(result.Value) > 0 && result.Value[0].Message != nil {
+		// Azure Run Command returns output in format:
+		// "Enable succeeded: \n[stdout]\n<actual output>\n[stderr]\n<errors>"
+		// We need to extract stdout and stderr content
+		message := *result.Value[0].Message
+
+		// Find the stdout section
+		stdoutStart := strings.Index(message, "[stdout]\n")
+		if stdoutStart == -1 {
+			// If no stdout marker, return the whole message
+			return message, nil
+		}
+
+		// Skip past the "[stdout]\n" marker
+		stdoutStart += len("[stdout]\n")
+
+		// Find where stderr starts (if present)
+		stderrStart := strings.Index(message[stdoutStart:], "\n[stderr]")
+
+		var output string
+		if stderrStart == -1 {
+			// No stderr marker, take everything after stdout
+			output = message[stdoutStart:]
+		} else {
+			// Take only the stdout section
+			output = message[stdoutStart : stdoutStart+stderrStart]
+
+			// Extract and inspect stderr
+			stderrAbsoluteStart := stdoutStart + stderrStart + len("\n[stderr]\n")
+			if stderrAbsoluteStart < len(message) {
+				stderr := strings.TrimSpace(message[stderrAbsoluteStart:])
+				if stderr != "" {
+					// Return an error if stderr is not empty
+					return "", fmt.Errorf("%s", stderr)
+				}
+			}
+		}
+
+		return strings.TrimSpace(output), nil
+	}
+
+	return "", nil
+}
+
+// GetVirtualMachinesInResourceGroup lists all VMs in the given resource group
+// with a polling loop to handle ARM replication delays.
+func GetVirtualMachinesInResourceGroup(
+	ctx context.Context,
+	computeClientFactory *armcompute.ClientFactory,
+	resourceGroupName string,
+	expectedMinimumCount int,
+	timeout time.Duration,
+) ([]*armcompute.VirtualMachine, error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, timeout,
+		fmt.Errorf("timed out waiting for %d VMs in resource group %q", expectedMinimumCount, resourceGroupName))
+	defer cancel()
+
+	vmClient := computeClientFactory.NewVirtualMachinesClient()
+	const pollInterval = 10 * time.Second
+
+	for {
+		var vms []*armcompute.VirtualMachine
+		pager := vmClient.NewListPager(resourceGroupName, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					return nil, fmt.Errorf("caused by: %w, error: %w", context.Cause(ctx), err)
+				}
+				return nil, fmt.Errorf("failed to list VMs in resource group %q: %w", resourceGroupName, err)
+			}
+			vms = append(vms, page.Value...)
+		}
+
+		if len(vms) >= expectedMinimumCount {
+			return vms, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("caused by: %w, error: %w", context.Cause(ctx), ctx.Err())
+		case <-time.After(pollInterval):
+		}
+	}
+}

--- a/test/util/framework/vm_helper.go
+++ b/test/util/framework/vm_helper.go
@@ -17,8 +17,14 @@ package framework
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/onsi/ginkgo/v2"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -147,4 +153,113 @@ func GetVirtualMachinesInResourceGroup(
 	}
 
 	return vms, nil
+}
+
+// GetVirtualMachineConsoleLog retrieves the boot diagnostics serial console log from an Azure VM.
+// Returns an io.ReadCloser for streaming the console log data. The caller is responsible for closing the reader.
+// Returns an error if the retrieval fails or boot diagnostics is not enabled.
+func GetVirtualMachineConsoleLog(
+	ctx context.Context,
+	computeClientFactory *armcompute.ClientFactory,
+	resourceGroupName string,
+	vmName string,
+) (io.ReadCloser, error) {
+	vmClient := computeClientFactory.NewVirtualMachinesClient()
+
+	// Retrieve boot diagnostics data which includes the serial console log
+	result, err := vmClient.RetrieveBootDiagnosticsData(ctx, resourceGroupName, vmName, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve boot diagnostics data for VM %q: %w", vmName, err)
+	}
+
+	// Check if serial console log URI is available
+	if result.SerialConsoleLogBlobURI == nil || *result.SerialConsoleLogBlobURI == "" {
+		return nil, fmt.Errorf("serial console log URI not available for VM %q (boot diagnostics may not be enabled)", vmName)
+	}
+
+	// Fetch the actual log content from the blob storage URL
+	resp, err := http.Get(*result.SerialConsoleLogBlobURI)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch console log from blob storage for VM %q: %w", vmName, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("failed to fetch console log for VM %q, HTTP status: %d", vmName, resp.StatusCode)
+	}
+
+	return resp.Body, nil
+}
+
+// DownloadAllVirtualMachineConsoleLogs downloads boot diagnostics console logs for all VMs
+// in the specified resource group and saves them to the target directory.
+// Each log file is named "<vmName>-console.log". VMs without boot diagnostics enabled are skipped.
+// Returns an error if the directory cannot be created or if listing VMs fails.
+func DownloadAllVirtualMachineConsoleLogs(
+	ctx context.Context,
+	computeClientFactory *armcompute.ClientFactory,
+	resourceGroupName string,
+	targetDirectory string,
+) error {
+	logger := ginkgo.GinkgoLogr
+
+	// Create target directory if it doesn't exist
+	if err := os.MkdirAll(targetDirectory, 0755); err != nil {
+		return fmt.Errorf("failed to create target directory %q: %w", targetDirectory, err)
+	}
+
+	// List all VMs in the resource group
+	// Use 0 as expectedMinimumCount to return immediately with whatever VMs exist,
+	// as we expect to run this after a node pool deployment failures
+	vms, err := GetVirtualMachinesInResourceGroup(ctx, computeClientFactory, resourceGroupName, 0)
+	if err != nil {
+		return fmt.Errorf("failed to list VMs: %w", err)
+	}
+
+	if len(vms) == 0 {
+		return fmt.Errorf("no VMs found in resource group %q", resourceGroupName)
+	}
+
+	// Download console log for each VM
+	var downloadErrors []string
+	for _, vm := range vms {
+		if vm.Name == nil {
+			continue
+		}
+
+		logReader, err := GetVirtualMachineConsoleLog(ctx, computeClientFactory, resourceGroupName, *vm.Name)
+		if err != nil {
+			// Don't fail completely if one VM doesn't have boot diagnostics enabled
+			logger.Info("failed to fetch VM console log", "vmName", *vm.Name)
+			downloadErrors = append(downloadErrors, fmt.Sprintf("VM %q: %v", *vm.Name, err))
+			continue
+		}
+
+		// Save the console log to a file
+		logFilePath := filepath.Join(targetDirectory, fmt.Sprintf("%s-console.log", *vm.Name))
+		logFile, err := os.Create(logFilePath)
+		if err != nil {
+			logReader.Close()
+			downloadErrors = append(downloadErrors, fmt.Sprintf("VM %q: failed to create file: %v", *vm.Name, err))
+			continue
+		}
+
+		_, err = io.Copy(logFile, logReader)
+		logFile.Close()
+		logReader.Close()
+
+		logger.Info("VM console log fetched", "vmName", *vm.Name, "targetPath", logFilePath)
+
+		if err != nil {
+			downloadErrors = append(downloadErrors, fmt.Sprintf("VM %q: failed to write log: %v", *vm.Name, err))
+			continue
+		}
+	}
+
+	// If there were any errors, return them as a combined error message
+	if len(downloadErrors) > 0 {
+		return fmt.Errorf("encountered errors downloading console logs:\n  - %s", strings.Join(downloadErrors, "\n  - "))
+	}
+
+	return nil
 }

--- a/test/util/framework/vm_helper.go
+++ b/test/util/framework/vm_helper.go
@@ -16,6 +16,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -178,7 +179,12 @@ func GetVirtualMachineConsoleLog(
 	}
 
 	// Fetch the actual log content from the blob storage URL
-	resp, err := http.Get(*result.SerialConsoleLogBlobURI)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, *result.SerialConsoleLogBlobURI, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for console log blob for VM %q: %w", vmName, err)
+	}
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch console log from blob storage for VM %q: %w", vmName, err)
 	}
@@ -217,7 +223,8 @@ func DownloadAllVirtualMachineConsoleLogs(
 	}
 
 	if len(vms) == 0 {
-		return fmt.Errorf("no VMs found in resource group %q", resourceGroupName)
+		logger.Info("no VMs found in resource group", "resourceGroup", resourceGroupName)
+		return nil
 	}
 
 	// Download console log for each VM
@@ -244,15 +251,16 @@ func DownloadAllVirtualMachineConsoleLogs(
 			continue
 		}
 
-		_, err = io.Copy(logFile, logReader)
-		logFile.Close()
+		_, copyErr := io.Copy(logFile, logReader)
+		closeErr := logFile.Close()
 		logReader.Close()
 
-		logger.Info("VM console log fetched", "vmName", *vm.Name, "targetPath", logFilePath)
-
+		err = errors.Join(copyErr, closeErr)
 		if err != nil {
 			downloadErrors = append(downloadErrors, fmt.Sprintf("VM %q: failed to write log: %v", *vm.Name, err))
 			continue
+		} else {
+			logger.Info("VM console log fetched", "vmName", *vm.Name, "targetPath", logFilePath)
 		}
 	}
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-26562

### What

- implement ability to fetch vm serial console logs via `DownloadAllVirtualMachineConsoleLogs` and `GetVirtualMachineConsoleLog` functions in framework module
- add `LogDirPath` into test context (so that we can store VM console log files there)
- function `CreateNodePoolFromParam` is extended (now it requires logger in the same was as `CreateHCPClusterFromParam` and managed resource group) so that it will fetch VM console logs in case of a node pool deployment failure
- updates E2E tests to align with new API of CreateNodePoolFromParam function

### Why

To improve ability to debug node pool deployment timeouts.

### Testing

During development, introduce temporary testing commits to:

- fetch the console logs every time (even if the node pool deploys with success)
- make node deployment fail

To make sure the functionality is able to fetch the logs into expected location as expected.

See results in [2051720498206740480](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/5078/pull-ci-Azure-ARO-HCP-main-stage-e2e-parallel/2051720498206740480) run:

*Customer should be able to create a HCP cluster and use cilium CNI plugin* test failed, and the VM console logs were fetched:

```
  STEP: creating the node pool @ 05/05/26 18:22:13.794
"ts"="2026-05-05 19:07:15.699253" "level"=0 "msg"="VM console log fetched" "vmName"="cilium-cl-cilium-np-xbl5c-j4j6k" "targetPath"="/logs/artifacts/Customer_should_be_able_to_create_a_HCP_cluster_and_use_cilium_CNI_plugin/cilium-cl-cilium-np-xbl5c-j4j6k-console.log"
"ts"="2026-05-05 19:07:16.530894" "level"=0 "msg"="VM console log fetched" "vmName"="cilium-cl-cilium-np-xbl5c-lv7dp" "targetPath"="/logs/artifacts/Customer_should_be_able_to_create_a_HCP_cluster_and_use_cilium_CNI_plugin/cilium-cl-cilium-np-xbl5c-lv7dp-console.log"
  STEP: checking that cilium is running and nodes are in Ready state @ 05/05/26 19:07:16.53
```

And stored in artifacts directory of the test [2051720498206740480/artifacts/stage-e2e-parallel/aro-hcp-test-persistent/artifacts/Customer_should_be_able_to_create_a_HCP_cluster_and_use_cilium_CNI_plugin](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/5078/pull-ci-Azure-ARO-HCP-main-stage-e2e-parallel/2051720498206740480/artifacts/stage-e2e-parallel/aro-hcp-test-persistent/artifacts/Customer_should_be_able_to_create_a_HCP_cluster_and_use_cilium_CNI_plugin/)

### Special notes for your reviewer

- In a separate commit, I moved RunVMCommand and GetVirtualMachinesInResourceGroup into new file dedicated to vm functions, to avoid adding these all over the place, and to avoid having everything in hcp helpers.
- The functionality is added to `CreateNodePoolFromParam` so that it will be available for most of E2E test cases. We can consider moving the functionality to a lower level, to cover more tests though.
