### PR TITLE
test: re-enable MISE routing timebomb (AROSLSRE-718)

### DIFF
--- a/test/e2e/mise_routing.go
+++ b/test/e2e/mise_routing.go
@@ -62,12 +62,13 @@ func (p *miseVersionCapture) Do(req *policy.Request) (*http.Response, error) {
 var _ = Describe("MISE Routing", func() {
 	defer GinkgoRecover()
 
-	// AROSLSRE-748: MISE routing test is permafailing across all E2E jobs.
-	// This time bomb will start failing after the deadline to ensure re-enablement.
+	// AROSLSRE-718: Temporarily skip this MISE routing E2E test due to an ARM regression
+	// rejecting Microsoft.Graph/applications@beta with the internal extension.
+	// After the deadline, this test will run again to ensure re-enablement.
 	timeBombDeadline := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
 	BeforeEach(func() {
 		if time.Now().Before(timeBombDeadline) {
-			Skip(fmt.Sprintf("MISE routing test permafailing (https://redhat.atlassian.net/browse/AROSLSRE-748); skipping until %s", timeBombDeadline.Format(time.RFC3339)))
+			Skip(fmt.Sprintf("MISE routing E2E test temporarily skipped due to ARM regression (AROSLSRE-718); skipping until %s", timeBombDeadline.Format(time.RFC3339)))
 		}
 	})
 

--- a/test/e2e/mise_routing.go
+++ b/test/e2e/mise_routing.go
@@ -16,7 +16,9 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,6 +61,15 @@ func (p *miseVersionCapture) Do(req *policy.Request) (*http.Response, error) {
 // rules are always evaluated.
 var _ = Describe("MISE Routing", func() {
 	defer GinkgoRecover()
+
+	// AROSLSRE-748: MISE routing test is permafailing across all E2E jobs.
+	// This time bomb will start failing after the deadline to ensure re-enablement.
+	timeBombDeadline := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	BeforeEach(func() {
+		if time.Now().Before(timeBombDeadline) {
+			Skip(fmt.Sprintf("MISE routing test permafailing (https://redhat.atlassian.net/browse/AROSLSRE-748); skipping until %s", timeBombDeadline.Format(time.RFC3339)))
+		}
+	})
 
 	DescribeTable("routes to the correct frontend based on version header",
 		labels.RequireNothing,


### PR DESCRIPTION
[AROSLSRE-748](https://redhat.atlassian.net/browse/AROSLSRE-748)

### What

Re-add the timebomb to skip MISE routing E2E tests until 2026-06-01.

### Why

The MISE routing test `MISE Routing routes to the correct frontend based on version header MISE v2 when x-ms-mise-version header is set` is permafailing across all E2E jobs:

- `e2e-prod-e2e-parallel`: 3 runs, 100% failed
- `periodic-prod-e2e-parallel-ocp-nightly`: 14 runs, 100% failed
- `prod-e2e-parallel`: 5 runs, 100% failed
- `e2e-parallel` (PR checks): 9% impact across 1,072 runs

[Search results](https://search.dptools.openshift.org/?search=MISE+Routing+routes+to+the+correct+frontend+based+on+version+header+MISE+v2+when+x-ms-mise-version+header+is+set&maxAge=336h&context=1&type=build-log&name=ARO-HCP&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)

The timebomb was originally added in #5022 and reverted in #5023 when the pipeline steps were re-enabled.

### Testing

- [x] `go build -tags E2Etests ./e2e/...` passes