### PR TITLE
Increase pers env mgmt infra os disk size

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1420,6 +1420,7 @@ clouds:
                 vmSize: Standard_D4s_v3
                 secondaryNicCount: 1
               infraAgentPool:
+                osDiskSizeGB: 64
                 vmSize: 'Standard_D4s_v3'
               enableSwiftV2Vnet: true
               enableSwiftV2Nodepools: true

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -541,7 +541,7 @@ mgmt:
       maxCount: 3
       minCount: 1
       name: infra
-      osDiskSizeGB: 32
+      osDiskSizeGB: 64
       poolCount: 2
       vmSize: Standard_D4s_v3
       zoneRedundantMode: Auto


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-739

### What

Increase pers env's mgmt cluster infra node pool os disk size

### Why

Disk pressure in Infra node pools (32 GB) and started to evict pods to reclaim space. This caused a delay and in turn helm deployment couldn't finish in 5 min timeout.

### Testing

Tested in personal dev
