### PR TITLE
Prow provision shard ci01

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -2893,6 +2893,9 @@
         "tagKey": {
           "type": "string"
         },
+        "subscription": {
+          "$ref": "#/definitions/subscriptionMetadata"
+        },
         "tagValue": {
           "type": "string"
         }

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -685,8 +685,8 @@
         "sourceEnvironmentIdentifier": {
           "type": "string",
           "maxLength": 10,
-          "pattern": "^[a-z]+$",
-          "description": "The source environment identifier must be between 1 and 10 characters and can contain only lowercase letters"
+          "pattern": "^[a-z][a-z0-9]*$",
+          "description": "The source environment identifier must be between 1 and 10 characters, start with a lowercase letter, and can contain only lowercase letters and digits"
         }
       },
       "required": [

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1128,6 +1128,9 @@ clouds:
       serviceKeyVault:
         name: 'aro-hcp-dev-svc-kv'
         rg: 'global'
+        subscription:
+          key: ARO Hosted Control Planes (EA Subscription 1)
+          displayName: ARO Hosted Control Planes (EA Subscription 1)
         region: 'westus3'
         softDelete: true
       # MSI Credentials Refresher

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1568,3 +1568,100 @@ clouds:
         regions:
           monitoring:
             alertsEnabled: true
+      ci01:
+        # prow infra shard1 - deploys into "ARO HCP E2E Infrastructure" subscription
+        defaults:
+          # Service Key Vault
+          serviceKeyVault:
+            assignNSP: false
+          # Cluster Service
+          clustersService:
+            postgres:
+              deploy: false
+              password: 'TheBlurstOfTimes'
+              containerizedDb:
+                image: "docker.io/library/postgres:14.2"
+                pvcCapacity: 512Mi
+            tracing:
+              address: "http://ingest.observability:4318"
+              exporter: "otlp"
+          # Geneva
+          geneva:
+            logs:
+              manageCertificates: false
+          # DNS
+          dns:
+            regionalSubdomain: '{{ .ctx.regionShort }}'
+          # Maestro
+          maestro:
+            postgres:
+              deploy: false
+              password: 'TheBlurstOfTimes'
+              containerizedDb:
+                image: "docker.io/library/postgres:14.2"
+                pvcCapacity: 512Mi
+            server:
+              mqttClientName: 'maestro-server-{{ .ctx.regionShort }}'
+              tracing:
+                address: "http://ingest.observability:4318"
+                exporter: "otlp"
+          # Backend
+          backend:
+            tracing:
+              address: "http://ingest.observability:4318"
+              exporter: "otlp"
+          # Frontend
+          frontend:
+            audit:
+              connectSocket: false
+            cosmosDB:
+              private: false
+              zoneRedundantMode: 'Disabled'
+            tracing:
+              address: "http://ingest.observability:4318"
+              exporter: "otlp"
+          # MC
+          mgmt:
+            subscription:
+              key: ARO HCP E2E Infrastructure (EA Subscription)
+            rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"
+            aks:
+              name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"
+              systemAgentPool:
+                maxCount: 4
+                osDiskSizeGB: 32
+                vmSize: Standard_D4ds_v6
+              userAgentPool:
+                maxCount: 14
+                minCount: 3
+                osDiskSizeGB: 100
+                vmSize: Standard_D16ds_v6
+                secondaryNicCount: 7
+              infraAgentPool:
+                vmSize: Standard_D4ds_v6
+                osDiskSizeGB: 64
+              enableSwiftV2Nodepools: true
+              enableSwiftV2Vnet: true
+            jaeger:
+              deploy: false
+            applyKubeletFixes: false
+          # SVC
+          svc:
+            subscription:
+              key: ARO HCP E2E Infrastructure (EA Subscription)
+            rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
+            aks:
+              name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
+              systemAgentPool:
+                vmSize: Standard_D4ds_v6
+              userAgentPool:
+                name: 'u64d8dsv6'
+                vmSize: Standard_D8ds_v6
+                osDiskSizeGB: 64
+              infraAgentPool:
+                vmSize: Standard_D4ds_v6
+            jaeger:
+              deploy: true
+        regions:
+          monitoring:
+            alertsEnabled: true

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -1,0 +1,986 @@
+acm:
+  mce:
+    bundle:
+      digest: sha256:0081161dd8f61845417594ede3af90447fba743e07dac67fbbb528f152096966
+      registry: quay.io
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
+  operator:
+    bundle:
+      digest: sha256:bc1d6b03cea0ee814c53c604e6f8eb07f7653d0761759c4bb02d2a40a33bb090
+      registry: quay.io
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
+acr:
+  ocp:
+    name: arohcpocpdev
+    untaggedImagesRetention:
+      days: 90
+      enabled: true
+    zoneRedundantMode: Disabled
+  svc:
+    name: arohcpsvcdev
+    untaggedImagesRetention:
+      days: 365
+      enabled: false
+    zoneRedundantMode: Disabled
+acrDNSSuffix: azurecr.io
+acrPull:
+  image:
+    digest: sha256:adeca388b97a8dbc4ebcbe2883458db0daac3780ba681aefd8398fe2cda2063d
+    registry: mcr.microsoft.com
+    repository: aks/msi-acrpull
+adminApi:
+  audit:
+    connectSocket: false
+  cert:
+    issuer: Self
+    name: admin-api-cert-ci01-j7654321
+  image:
+    digest: sha256:51c708b2ad0e2a403be2e9218716a1f6177f4a13f61ffb76884db2a30b68dce6
+    registry: arohcpsvcdev.azurecr.io
+    repository: arohcpadminapi
+  k8s:
+    namespace: aro-hcp-admin-api
+    replicas: 2
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 200m
+        memory: 512Mi
+    serviceAccountName: admin-api
+  managedIdentityName: admin-api
+administration:
+  readerGroupId: ""
+  releaseManagementGroupId: ""
+  sreServiceTag: ""
+aksCommandRuntime:
+  image:
+    digest: sha256:a249d179ee44de7951020ebf0f141e689dadd7207c228b355734b35b772c3333
+    registry: mcr.microsoft.com
+    repository: aks/command/runtime
+armHelperCertName: armHelperCert2
+armHelperClientId: 3331e670-0804-48e8-a086-6241671ddc93
+armHelperFPAPrincipalId: 47f69502-0065-4d9a-b19b-d403e183d2f4
+armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
+arobit:
+  forwarder:
+    image:
+      digest: sha256:e9abd61d30c646c07ec29895b25f8c25ac72818be3937643e417cce2435cc601
+      registry: mcr.microsoft.com
+      repository: oss/v2/fluent/fluent-bit
+    resources:
+      limits:
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+  kusto:
+    buffering: true
+    enabled: true
+    environmentName: dev
+  mdsd:
+    enabled: false
+    image:
+      digest: sha256:bda1e3e68b1da236426661e1f77daebf34243dd29c2b29f78ce77cb1713ac114
+      registry: mcr.microsoft.com
+      repository: geneva/distroless/mdsd
+auditLogsEventHub:
+  authRuleName: SendRule
+  enabled: false
+  kustoConsumerGroupName: AuditLogsToKusto
+  kustoDataConnectionName: ci01-westus3-auditlogs
+  name: aks-auditlogs
+  namespace: hcp-ci01-westus3-auditlogs-eh
+  rg: westus3-shared-resources
+automationDryRun: false
+azureGeoShortId: us
+azureRegionAvailabilityZoneCount: 4
+backend:
+  azureRuntimeConfig:
+    tlsCertificatesIssuer: Self
+  clusterScopedIdentitiesConfig:
+    roleSetName: dev
+  exitOnPanic: true
+  image:
+    digest: sha256:355899720ca891d402f52b7e52a64cdeddf5bed0276c55ecaf2c72998becf5c3
+    registry: arohcpsvcdev.azurecr.io
+    repository: arohcpbackend
+  k8s:
+    namespace: aro-hcp
+    replicas: 2
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 100m
+        memory: 500Mi
+    serviceAccountName: backend
+  maestro:
+    sourceEnvironmentIdentifier: arohcpci01
+  managedIdentityName: backend
+  tracing:
+    address: http://ingest.observability:4318
+    exporter: otlp
+billing:
+  aub:
+    accountName: ""
+    cloudSuffix: ""
+  eventHub:
+    namespace: ""
+    resourceGroupName: ""
+    subscriptionId: ""
+  imageArtifact:
+    adoProject: ""
+    artifactName: ""
+    buildId: 0
+  kusto:
+    clusterName: ""
+    clusterPrincipals:
+    - id: ""
+      name: ""
+      role: ""
+      tenantId: ""
+      type: ""
+    dstsGroups:
+    - description: ""
+      name: ""
+    sku: ""
+    vmUsageStaleThreshold: ""
+  pav2:
+    cloudName: ""
+  rg: placeholder
+cloud: Public
+cloudEnvironmentName: AzurePublicCloud
+clustersService:
+  azureOperatorsManagedIdentities:
+    roleSetName: dev
+  azureRuntimeConfig:
+    tlsCertificatesIssuer: Self
+  batchProcesses: ""
+  batchProcessesDryRun: true
+  denyAssignments: disabled
+  deployDebugJobs: false
+  environment: arohcpci01
+  image:
+    digest: sha256:db1fe5745325f8b9a80176afa25b1e5bae457c8efd400a986278f2bad2a32d13
+    registry: quay.io
+    repository: app-sre/aro-hcp-clusters-service
+  k8s:
+    deploymentStrategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    namespace: clusters-service
+    replicas: 3
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 50m
+        memory: 150Mi
+    serviceAccountName: clusters-service
+  managedIdentityName: clusters-service
+  postgres:
+    backupRetentionDays: 7
+    containerizedDb:
+      image: docker.io/library/postgres:14.2
+      pvcCapacity: 512Mi
+    databaseName: clusters-service
+    deploy: false
+    enhancedMetricsEnabled: true
+    geoRedundantBackup: false
+    minTLSVersion: TLSV1.2
+    name: arohcp-ci01-dbcs-j7654321
+    password: TheBlurstOfTimes
+    private: false
+    serverSku: Standard_D8s_v3
+    serverStorageSizeGB: 128
+    serverVersion: "17"
+    zoneRedundantMode: Auto
+  provisionShardClusterLimit: 100
+  provisionShardStatus: active
+  tracing:
+    address: http://ingest.observability:4318
+    exporter: otlp
+customExporter:
+  enabledCollectors: service-tag-usage,kusto-logs-current
+  image:
+    digest: sha256:4908c6fa4e8017a04bda09800a3285d36443e4dedbd87d74d41b60bece541341
+    registry: arohcpsvcdev.azurecr.io
+    repository: arohcpmetrics
+  k8s:
+    namespace: aro-hcp-exporter
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    serviceAccountName: aro-hcp-exporter
+  managedIdentityName: aro-hcp-exporter
+cxKeyVault:
+  name: ah-ci01-cx-j7654321-1
+  private: false
+  softDelete: false
+  tagKey: aroHCPPurpose
+  tagValue: cx
+dns:
+  baseDnsZoneRG: global
+  cxParentZoneName: hcp.osadev.cloud
+  globalCertificatesDomain: hcp-global.osadev.cloud
+  parentZoneName: osadev.cloud
+  regionalSubdomain: j7654321
+  svcParentZoneName: hcpsvc.osadev.cloud
+e2e:
+  prow:
+    globalKeyVaultTokenSecret: prow-token
+  regionTest:
+    gatePromotion: true
+    prowJobName: ""
+entraAppOwnerIds: d8837611-f550-4f0a-af48-575a7178adfb,16ea1e12-7ef3-4613-bea4-3d4a20cbc38c,770ce6b0-5afe-472d-ac0d-1fae72acc4e4
+environmentName: ci01
+ev2:
+  assistedId:
+    applicationId: ""
+    certificate:
+      keyVault: empty-sentinel
+      name: ""
+    dstsHost: usnorth-dsts.dsts.core.windows.net
+firstPartyAppCertificate:
+  issuer: Self
+  manage: false
+  name: firstPartyCert2
+firstPartyAppClientId: b3cb2fab-15cb-4583-ad06-f91da9bfe2d1
+frontend:
+  audit:
+    connectSocket: false
+  cert:
+    issuer: Self
+    name: frontend-cert-ci01-j7654321
+  cosmosDB:
+    billingContainerMaxScale: 4000
+    deploy: true
+    disableLocalAuth: true
+    locksContainerMaxScale: 4000
+    name: arohcpci01-rp-j7654321
+    private: false
+    resourceContainerMaxScale: 4000
+    zoneRedundantMode: Disabled
+  exitOnPanic: true
+  image:
+    digest: sha256:09d8e7347e11b5a100d4e2b991beabacdc8c5b2d268ce1dc63d97b0ed75273da
+    registry: arohcpsvcdev.azurecr.io
+    repository: arohcpfrontend
+  k8s:
+    namespace: aro-hcp
+    replicas: 2
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 100m
+        memory: 512Mi
+    serviceAccountName: frontend
+  managedIdentityName: frontend
+  tracing:
+    address: http://ingest.observability:4318
+    exporter: otlp
+geneva:
+  actions:
+    allowedAcisExtensions: AzureRedHatHypershiftExtension,Azure Red Hat Hypershift
+    application:
+      manage: true
+      name: arohcp-ga-dev
+      useSNI: false
+    certificate:
+      issuer: Self
+      manage: true
+      name: genevaAction
+    endpointName: westus3
+    endpointUrl: ""
+    genevaActionsPrincipalId: ""
+    keyVault:
+      name: arohcpdev-geneva-kv
+      private: false
+      softDelete: true
+      tagKey: aroHCPPurpose
+      tagValue: geneva-actions
+    publish:
+      betaCertificate:
+        keyVault: empty-sentinel
+        name: empty-sentinel
+      betaPackageName: empty-sentinel
+      buildId: 0
+      packageName: empty-sentinel
+    serviceTag: GenevaActions
+    targetRegion: West US 3
+  logs:
+    adminCertName: geneva-logs-admin
+    adminCertificateDomain: geneva.keyvault.aro-hcp-global.azure.com
+    administrators:
+      alias:
+      - AME\WEINONGW
+      securityGroup: AME\TM-AzureRedHatOpenShift-Leads
+    certificateDomain: geneva.keyvault.aro-hcp.azure.com
+    certificateIssuer: Self
+    cluster:
+      accountName: placeholder
+      configVersion: "1"
+      namespace: ""
+      san: ""
+      secretName: clusterlogs
+    environment: Test
+    manageCertificates: false
+    rp:
+      accountName: placeholder
+      configVersion: "1"
+      namespace: ""
+      san: ""
+      secretName: rplogs
+    typeName: ""
+  metrics:
+    cluster:
+      account: AzureRedHatOpenShiftCluster
+    rp:
+      account: AzureRedHatOpenShiftRP
+  principalId: ""
+  resourceContributor: ""
+global:
+  billing:
+    digest: placeholder
+    rg: placeholder
+  globalMSIName: global-rollout-identity
+  keyVault:
+    encryptionKeyName: secretSyncKey
+    name: arohcpdev-global
+    private: false
+    softDelete: true
+    tagKey: aroHCPPurpose
+    tagValue: global
+  nsp:
+    accessMode: Learning
+    name: nsp-global
+  region: westus3
+  rg: global
+  safeDnsIntAppObjectId: ""
+  subscription:
+    displayName: Azure Red Hat OpenShift HCP - ci01 - Global
+    key: ARO Hosted Control Planes (EA Subscription 1)
+    providers:
+      Microsoft.Compute:
+        features:
+        - name: EncryptionAtHost
+          poll: true
+        poll: true
+      Microsoft.ContainerService:
+        features:
+        - name: IstioNativeSidecarModePreview
+          poll: true
+        poll: true
+      Microsoft.Dashboard:
+        poll: true
+      Microsoft.Kusto:
+        poll: true
+      Microsoft.Network:
+        features:
+        - name: AllowBringYourOwnPublicIpAddress
+          poll: true
+        poll: true
+hcpRecovery:
+  image:
+    digest: ""
+    registry: arohcpsvcdev.azurecr.io
+    repository: arohcprecovery
+  k8s:
+    namespace: hcp-recovery
+    replicas: 2
+    serviceAccountName: hcp-recovery
+hypershift:
+  additionalInstallArg: --enable-cpo-overrides
+  image:
+    digest: sha256:928af777977b31806c3fd4094a4fedb9dbbbccdc54328e70ff484cb8c7f300b8
+    registry: quay.io
+    repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
+  limitClusterSizes: true
+  namespace: hypershift
+  sharedIngressIPTag: ""
+  sharedIngressImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageSync:
+  environmentName: aro-hcp-image-sync
+  ocMirror:
+    enabled: true
+    image:
+      digest: sha256:23adf01a2733784ca379e3b593f183d9f334a7c1154d29fd3f70e83f63db40e8
+      registry: arohcpsvcdev.azurecr.io
+      repository: image-sync/oc-mirror
+    jobNamePrefix: ""
+    operatorVersionsToMirror: 4.18,4.19,4.20,4.21
+    pullSecretName: ocmirror-pull-secret
+  ondemandSync:
+    pullSecretName: component-sync-pull-secret
+  outboundServiceTags: ""
+keyVaultDNSSuffix: vault.azure.net
+kubeEvents:
+  enabled: true
+  image:
+    digest: sha256:b7c21e2a50ae351b02fa42fb6accad4dafdf48e313b36adb0d7070d84f2dbe80
+    registry: kubernetesshared.azurecr.io
+    repository: shared/kube-events
+  k8s:
+    namespace: monitoring
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 200m
+        memory: 512Mi
+    serviceAccountName: ke-serviceaccount
+kusto:
+  adminGroups: ""
+  autoScaleMax: 10
+  autoScaleMin: 2
+  crossClusterHostedControlPlaneLogsScript: ""
+  crossClusterServiceLogsScript: ""
+  enableAutoScale: true
+  hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
+  kustoName: hcp-dev-us-2
+  location: westus3
+  manageInstance: true
+  rg: hcp-kusto-us
+  serviceLogsDatabase: ServiceLogs
+  sku: Standard_E8ads_v5
+  tier: Standard
+  viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
+kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
+kvCertAccessRoleId: ""
+kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
+logs:
+  mdsd:
+    cert:
+      issuer: ""
+      name: ""
+      type: ""
+    msiName: logs-mdsd
+    namespace: arobit
+    serviceAccountName: arobit-forwarder
+    subscriptions: []
+maestro:
+  agent:
+    consumerName: hcp-underlay-j7654321-mgmt-1
+    k8s:
+      namespace: maestro
+      replicas: 1
+      serviceAccountName: maestro
+    loglevel: 2
+    managedIdentityName: maestro-consumer
+    sidecar:
+      image:
+        digest: sha256:b7cec6a44aca2b9577e63285f8cb1be4d697187b8c47d6910a075ed456131031
+        registry: mcr.microsoft.com
+        repository: azurelinux/base/nginx
+  certDomain: selfsigned.maestro.keyvault.azure.com
+  certIssuer: Self
+  eventGrid:
+    maxClientSessionsPerAuthName: 6
+    name: arohcp-ci01-maestro-j7654321
+    private: false
+  image:
+    digest: sha256:91864b4571d431dbc0502d7a5cf9229c8d64fe3f85f60f1df92cddfcce3918f1
+    registry: quay.io
+    repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
+  postgres:
+    backupRetentionDays: 7
+    containerizedDb:
+      image: docker.io/library/postgres:14.2
+      pvcCapacity: 512Mi
+    databaseName: maestro
+    deploy: false
+    enhancedMetricsEnabled: true
+    geoRedundantBackup: false
+    minTLSVersion: TLSV1.2
+    name: arohcp-ci01-dbmaestro-j7654321
+    password: TheBlurstOfTimes
+    private: false
+    serverSku: Standard_D2s_v3
+    serverStorageSizeGB: 32
+    serverVersion: "15"
+    zoneRedundantMode: Auto
+  restrictIstioIngress: true
+  server:
+    k8s:
+      namespace: maestro
+      replicas: 1
+      resources:
+        limits:
+          memory: unlimited
+        requests:
+          cpu: 200m
+          memory: 512Mi
+      serviceAccountName: maestro
+    loglevel: 2
+    managedIdentityName: maestro-server
+    mqttClientName: maestro-server-j7654321
+    tracing:
+      address: http://ingest.observability:4318
+      exporter: otlp
+mgmt:
+  aks:
+    clusterOutboundIPAddressIPTags: ""
+    enableSwiftV2Nodepools: true
+    enableSwiftV2Vnet: true
+    etcd:
+      name: ah-ci01-me-j7654321-1
+      private: true
+      softDelete: false
+      tagKey: aroHCPPurpose
+      tagValue: etcd-encryption
+    infraAgentPool:
+      maxCount: 3
+      minCount: 1
+      name: infra
+      osDiskSizeGB: 64
+      poolCount: 2
+      vmSize: Standard_D4ds_v6
+      zoneRedundantMode: Auto
+      zones: ""
+    kubernetesVersion: 1.34.4
+    name: ci01-j7654321-mgmt-1
+    networkDataplane: azure
+    networkPolicy: azure
+    podSubnetPrefix: 10.128.64.0/18
+    subnetPrefix: 10.128.8.0/21
+    systemAgentPool:
+      maxCount: 4
+      minCount: 1
+      name: system
+      osDiskSizeGB: 32
+      poolCount: 1
+      vmSize: Standard_D4ds_v6
+      zoneRedundantMode: Auto
+      zones: ""
+    userAgentPool:
+      maxCount: 14
+      minCount: 3
+      name: userswft
+      osDiskSizeGB: 100
+      poolCount: 3
+      secondaryNicCount: 7
+      vmSize: Standard_D16ds_v6
+      zoneRedundantMode: Auto
+      zones: ""
+    vnetAddressPrefix: 10.128.0.0/14
+  applyKubeletFixes: false
+  hcpBackups:
+    storageAccount:
+      name: oadpci01j76543211
+      public: false
+      zoneRedundantMode: Auto
+    storageAccountContainerName: backups
+  jaeger:
+    deploy: false
+  nsp:
+    accessMode: Learning
+    name: nsp-j7654321-mgmt-1
+  prometheus:
+    admissionWebhook:
+      patch:
+        image:
+          registry: arohcpsvcdev.azurecr.io
+          repository: k8s-cache/ingress-nginx/kube-webhook-certgen
+          sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
+    kubeStateMetrics:
+      image:
+        digest: sha256:e672537f9989023dea1bbcf9e617078b99faae6a7dfeb1317521b190284dc5f4
+        registry: mcr.microsoft.com/oss/v2
+        repository: kubernetes/kube-state-metrics
+    namespace: prometheus
+    namespaceNetworkPolicyGroup: monitoring
+    prometheusConfigReloader:
+      image:
+        registry: mcr.microsoft.com/oss/v2
+        repository: prometheus/prometheus-config-reloader
+        sha: 5a2c0272c06623d75d3996c03f7a511c046464bec9ca09b4ee62a0e8655c0209
+    prometheusOperator:
+      image:
+        registry: mcr.microsoft.com/oss/v2
+        repository: prometheus/prometheus-operator
+        sha: 9fc78e435ac603769b42896d521573d1b3eab8acb2b6e46c230e763c2cafdb4f
+      version: ""
+    prometheusSpec:
+      image:
+        registry: mcr.microsoft.com/oss/v2
+        repository: prometheus/prometheus
+        sha: 695dface5e61ba84317fde2249ba493eb43a2e03e835a79f55615560d7757931
+      replicas: 2
+      resources:
+        limits:
+          cpu: NONE
+          memory: NONE
+        requests:
+          cpu: NONE
+          memory: NONE
+      shards: 1
+    thanos:
+      image:
+        registry: arohcpsvcdev.azurecr.io
+        repository: thanos/thanos
+        sha: cf3e9b292e4302ad4a4955b56379703aea39516607d382a57604a3d003c35d10
+        tag: v0.41.0
+  rg: hcp-underlay-ci01-j7654321-mgmt-1
+  subscription:
+    certificateDomains:
+    - '*.hcp.osadev.cloud'
+    - '*.hcpsvc.osadev.cloud'
+    displayName: Azure Red Hat OpenShift HCP - West US 3 - MGMT - 1
+    key: ARO HCP E2E Infrastructure (EA Subscription)
+    providers:
+      Microsoft.Compute:
+        features:
+        - name: EncryptionAtHost
+          poll: true
+        poll: true
+      Microsoft.ContainerService:
+        features:
+        - name: IstioNativeSidecarModePreview
+          poll: true
+        poll: true
+      Microsoft.Insights:
+        poll: true
+      Microsoft.Network:
+        features:
+        - name: AllowBringYourOwnPublicIpAddress
+          poll: true
+        poll: true
+      Microsoft.Storage:
+        poll: true
+    usePlannedQuota: true
+mgmtKeyVault:
+  name: ah-ci01-mg-j7654321-1
+  private: false
+  softDelete: false
+  tagKey: aroHCPPurpose
+  tagValue: mgmt
+miMockCertName: msiMockCert2
+miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
+miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
+mise:
+  applicationName: arohcp-mise-ci01
+  arm:
+    applicationId: e2c2ff5c-e5b4-4e79-8c3e-1da8c48461e7
+    audienceFQDN: management.azure.com
+    authorityFQDN: login.microsoftonline.com
+    policyLabel: ARM Policy
+    tenantId: 33e01921-4d64-4f8c-a055-5bdaffd5e33d
+  deploy: false
+  genevaActions:
+    audienceFQDN: management.azure.com
+    authorityFQDN: sts.windows.net
+    policyLabel: Geneva Actions
+  image:
+    digest: ""
+    repository: mise-1p-container-image
+  imageV2:
+    digest: ""
+    repository: mise-1p-container-image
+  sessiongate:
+    audience: 6dae42f8-4368-4678-94ff-3960e28e3630
+    authorityFQDN: sts.windows.net
+    policyLabel: Session Gate
+  tracing:
+    address: ""
+    exporter: ""
+monitoring:
+  alertRuleOwningTeamTag: ""
+  alertsEnabled: false
+  crossTenantSecurityGroup: ""
+  grafanaMajorVersion: "11"
+  grafanaName: arohcp-dev
+  grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
+  grafanaZoneRedundantMode: Disabled
+  hcpWorkspaceName: hcps-j7654321
+  icm:
+    connectionId: ""
+    connectionName: ""
+    environment: ""
+    manageConnection: false
+    msft:
+      actionGroupName: ""
+      actionGroupShortName: ""
+      automitigationEnabled: ""
+      routingId: ""
+    rp:
+      actionGroupName: ""
+      actionGroupShortName: ""
+      automitigationEnabled: ""
+      routingId: ""
+    sl:
+      actionGroupName: ""
+      actionGroupShortName: ""
+      automitigationEnabled: ""
+      routingId: ""
+    sre:
+      actionGroupName: ""
+      actionGroupShortName: ""
+      automitigationEnabled: ""
+      routingId: ""
+  maxActiveTimeSeries: 2000000
+  maxEventsPerMinute: 2000000
+  svcWorkspaceName: services-j7654321
+msiCredentialsRefresher:
+  certificate:
+    commonName: ""
+    issuer: OneCertV2-PrivateCA
+    manage: false
+    name: msi-refresher
+    sanDnsNames: []
+  earlyRefreshFrequency: "0"
+  firstPartyAppClientId: ""
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  imageArtifact:
+    adoProject: ""
+    artifactName: ""
+    buildId: 0
+  k8s:
+    namespace: msi-credential-refresher
+    serviceAccountName: msi-credential-refresher
+  managedIdentityName: msi-credential-refresher
+msiKeyVault:
+  name: ah-ci01-mi-j7654321-1
+  private: false
+  softDelete: false
+  tagKey: aroHCPPurpose
+  tagValue: msi
+msiRp:
+  dataPlaneAudienceResource: https://dummy.org
+oidc:
+  frontdoor:
+    keyVault:
+      name: ah-ci01-afd
+      private: false
+      softDelete: true
+      tagKey: aroHCPPurpose
+      tagValue: afd
+    manage: false
+    msiName: arohcp-afd
+    name: arohcpdev
+    sku: Premium_AzureFrontDoor
+    subdomain: oic
+    useManagedCertificates: true
+  storageAccount:
+    name: arohcpci01oidcj7654321
+    privateLinkLocation: westus3
+    public: true
+    zoneRedundantMode: Auto
+region: westus3
+regionRG: hcp-underlay-ci01-j7654321
+routeMonitorOperator:
+  blackboxExporterImage:
+    digest: sha256:b04a9fef4fa086a02fc7fcd8dcdbc4b7b35cc30cdee860fdc6a19dd8b208d63e
+    registry: quay.io
+    repository: prometheus/blackbox-exporter
+  operatorImage:
+    digest: sha256:5e94ff37bcb8c1ebebce0c7c1f33cef8e7cf163f1b0baf5b50c9b771ca112846
+    registry: quay.io
+    repository: app-sre/route-monitor-operator
+secretSyncController:
+  image:
+    digest: sha256:0b4799815b77c2c5c8e6375b86072e514cdc447ef1c59a5754939c32ba4147a9
+    registry: registry.k8s.io
+    repository: secrets-store-sync/controller
+  k8s:
+    namespace: secret-sync-controller
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 50m
+        memory: 100Mi
+    serviceAccountName: secrets-store-sync-controller-manager
+  providerImage:
+    digest: sha256:f619acc40ef14ccb253ddff0ced19f3f8957685e2d3015d47d8d84bf6ad6d14c
+    registry: mcr.microsoft.com
+    repository: oss/v2/azure/secrets-store/provider-azure
+serviceKeyVault:
+  assignNSP: false
+  name: aro-hcp-dev-svc-kv
+  private: false
+  region: westus3
+  rg: global
+  softDelete: true
+  subscription:
+    displayName: ARO Hosted Control Planes (EA Subscription 1)
+    key: ARO Hosted Control Planes (EA Subscription 1)
+  tagKey: aroHCPPurpose
+  tagValue: service
+sessiongate:
+  cert:
+    issuer: Self
+    name: sessiongate-cert-ci01-j7654321
+  image:
+    digest: sha256:20ca1c8e3dcef026bac4b161dad66547fe749a613e3a26f8808eccc3d2b38c23
+    registry: arohcpsvcdev.azurecr.io
+    repository: arohcpsessiongate
+  k8s:
+    namespace: sessiongate
+    replicas: 2
+    serviceAccountName: sessiongate
+  managedIdentityName: sessiongate
+svc:
+  aks:
+    clusterOutboundIPAddressIPTags: ""
+    etcd:
+      name: ah-ci01-se-j7654321-1
+      private: true
+      softDelete: false
+      tagKey: aroHCPPurpose
+      tagValue: etcd-encryption
+    infraAgentPool:
+      maxCount: 3
+      minCount: 1
+      name: infra
+      osDiskSizeGB: 32
+      poolCount: 1
+      vmSize: Standard_D4ds_v6
+      zoneRedundantMode: Auto
+      zones: ""
+    kubernetesVersion: 1.34.4
+    name: ci01-j7654321-svc
+    networkDataplane: cilium
+    networkPolicy: cilium
+    podSubnetPrefix: 10.128.64.0/18
+    subnetPrefix: 10.128.8.0/21
+    systemAgentPool:
+      maxCount: 3
+      minCount: 1
+      name: system
+      osDiskSizeGB: 32
+      poolCount: 1
+      vmSize: Standard_D4ds_v6
+      zoneRedundantMode: Auto
+      zones: ""
+    userAgentPool:
+      maxCount: 3
+      minCount: 1
+      name: u64d8dsv6
+      osDiskSizeGB: 64
+      poolCount: 3
+      vmSize: Standard_D8ds_v6
+      zoneRedundantMode: Auto
+      zones: ""
+    vnetAddressPrefix: 10.128.0.0/14
+  istio:
+    ingressGatewayIPAddressIPTags: ""
+    ingressGatewayIPAddressName: aro-hcp-istio-ingress
+    istioctlVersion: 1.29.2
+    tag: prod-stable
+    targetVersion: asm-1-28
+    versions: asm-1-28
+  jaeger:
+    deploy: true
+  nsp:
+    accessMode: Learning
+    name: nsp-j7654321-svc
+  opsIngress:
+    gateway:
+      ipAddressName: aro-hcp-ops-ingress
+      ipAddressTags: ""
+  prometheus:
+    admissionWebhook:
+      patch:
+        image:
+          registry: arohcpsvcdev.azurecr.io
+          repository: k8s-cache/ingress-nginx/kube-webhook-certgen
+          sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
+    kubeStateMetrics:
+      image:
+        digest: sha256:e672537f9989023dea1bbcf9e617078b99faae6a7dfeb1317521b190284dc5f4
+        registry: mcr.microsoft.com/oss/v2
+        repository: kubernetes/kube-state-metrics
+    namespace: prometheus
+    namespaceNetworkPolicyGroup: ""
+    prometheusConfigReloader:
+      image:
+        registry: mcr.microsoft.com/oss/v2
+        repository: prometheus/prometheus-config-reloader
+        sha: 5a2c0272c06623d75d3996c03f7a511c046464bec9ca09b4ee62a0e8655c0209
+    prometheusOperator:
+      image:
+        registry: mcr.microsoft.com/oss/v2
+        repository: prometheus/prometheus-operator
+        sha: 9fc78e435ac603769b42896d521573d1b3eab8acb2b6e46c230e763c2cafdb4f
+      version: ""
+    prometheusSpec:
+      image:
+        registry: mcr.microsoft.com/oss/v2
+        repository: prometheus/prometheus
+        sha: 695dface5e61ba84317fde2249ba493eb43a2e03e835a79f55615560d7757931
+      replicas: 2
+      resources:
+        limits:
+          cpu: NONE
+          memory: NONE
+        requests:
+          cpu: NONE
+          memory: NONE
+      shards: 1
+      version: ""
+    thanos:
+      image:
+        registry: arohcpsvcdev.azurecr.io
+        repository: thanos/thanos
+        sha: cf3e9b292e4302ad4a4955b56379703aea39516607d382a57604a3d003c35d10
+        tag: v0.41.0
+  rg: hcp-underlay-ci01-j7654321-svc
+  subscription:
+    certificateDomains:
+    - '*.hcpsvc.osadev.cloud'
+    displayName: Azure Red Hat OpenShift HCP - West US 3 - SVC
+    key: ARO HCP E2E Infrastructure (EA Subscription)
+    providers:
+      Microsoft.Compute:
+        features:
+        - name: EncryptionAtHost
+          poll: true
+        poll: true
+      Microsoft.ContainerService:
+        features:
+        - name: IstioNativeSidecarModePreview
+          poll: true
+        - name: ManagedGatewayAPIPreview
+          poll: true
+        poll: true
+      Microsoft.Dashboard:
+        poll: true
+      Microsoft.DbForPostgreSQL:
+        poll: true
+      Microsoft.Insights:
+        poll: true
+      Microsoft.Kusto:
+        poll: true
+      Microsoft.Network:
+        features:
+        - name: AllowBringYourOwnPublicIpAddress
+          poll: true
+        poll: true
+    usePlannedQuota: true
+tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
+velero:
+  azurePlugin:
+    digest: sha256:2984271cb214b7f3a1ada23921dc5e2c0e5ec7ed7bda0896314f57096a120d66
+    registry: registry.redhat.io
+    repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
+  hypershiftPlugin:
+    digest: sha256:381926cbc8ac3a769b17174452453ddc98c731981332374de7a0927617513a96
+    registry: registry.redhat.io
+    repository: oadp/oadp-hypershift-velero-plugin-rhel9
+  server:
+    digest: sha256:6f55dd26ea1d64b9469cdc88b392a285d6c2101e05a289e41e48096657e84e05
+    registry: registry.redhat.io
+    repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -812,6 +812,9 @@ serviceKeyVault:
   region: westus3
   rg: global
   softDelete: true
+  subscription:
+    displayName: ARO Hosted Control Planes (EA Subscription 1)
+    key: ARO Hosted Control Planes (EA Subscription 1)
   tagKey: aroHCPPurpose
   tagValue: service
 sessiongate:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -812,6 +812,9 @@ serviceKeyVault:
   region: westus3
   rg: global
   softDelete: true
+  subscription:
+    displayName: ARO Hosted Control Planes (EA Subscription 1)
+    key: ARO Hosted Control Planes (EA Subscription 1)
   tagKey: aroHCPPurpose
   tagValue: service
 sessiongate:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -812,6 +812,9 @@ serviceKeyVault:
   region: westus3
   rg: global
   softDelete: true
+  subscription:
+    displayName: ARO Hosted Control Planes (EA Subscription 1)
+    key: ARO Hosted Control Planes (EA Subscription 1)
   tagKey: aroHCPPurpose
   tagValue: service
 sessiongate:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -814,6 +814,9 @@ serviceKeyVault:
   region: westus3
   rg: global
   softDelete: true
+  subscription:
+    displayName: ARO Hosted Control Planes (EA Subscription 1)
+    key: ARO Hosted Control Planes (EA Subscription 1)
   tagKey: aroHCPPurpose
   tagValue: service
 sessiongate:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -814,6 +814,9 @@ serviceKeyVault:
   region: westus3
   rg: global
   softDelete: true
+  subscription:
+    displayName: ARO Hosted Control Planes (EA Subscription 1)
+    key: ARO Hosted Control Planes (EA Subscription 1)
   tagKey: aroHCPPurpose
   tagValue: service
 sessiongate:

--- a/dev-infrastructure/configurations/subscription-lookup.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/subscription-lookup.tmpl.bicepparam
@@ -1,0 +1,1 @@
+using '../templates/subscription-lookup.bicep'

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -103,6 +103,7 @@ param msiRefresherServiceAccountName = '{{ .msiCredentialsRefresher.k8s.serviceA
 
 param serviceKeyVaultName = '{{ .serviceKeyVault.name }}'
 param serviceKeyVaultResourceGroup = '{{ .serviceKeyVault.rg }}'
+param serviceKeyVaultSubscription = '__serviceKeyVaultSubscription__'
 
 param adminApiMIName = '{{ .adminApi.managedIdentityName }}'
 param adminApiNamespace = '{{ .adminApi.k8s.namespace }}'

--- a/dev-infrastructure/configurations/svc-infra-lookup.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-infra-lookup.tmpl.bicepparam
@@ -2,3 +2,4 @@ using '../templates/svc-infra-lookup.bicep'
 
 param serviceKeyVaultName = '{{ .serviceKeyVault.name }}'
 param serviceKeyVaultResourceGroup = '{{ .serviceKeyVault.rg }}'
+param serviceKeyVaultSubscription = '__serviceKeyVaultSubscription__'

--- a/dev-infrastructure/configurations/svc-infra.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-infra.tmpl.bicepparam
@@ -11,5 +11,8 @@ param serviceKeyVaultTagValue = '{{ .serviceKeyVault.tagValue }}'
 // MI for resource access during pipeline runs
 param globalMSIId = '__globalMSIId__'
 
+// Subscription where the service keyvault lives (supports cross-subscription scenarios)
+param serviceKeyVaultSubscription = '__serviceKeyVaultSubscription__'
+
 // SP for KV certificate issuer registration
 param kvCertOfficerPrincipalId = '{{ .kvCertOfficerPrincipalId }}'

--- a/dev-infrastructure/modules/maestro/maestro-server.bicep
+++ b/dev-infrastructure/modules/maestro/maestro-server.bicep
@@ -11,6 +11,7 @@ param maestroInfraResourceGroup string
 param maestroEventGridNamespaceName string
 param certKeyVaultName string
 param certKeyVaultResourceGroup string
+param certKeyVaultSubscription string = subscription().subscriptionId
 param keyVaultOfficerManagedIdentityName string
 param maestroCertificateDomain string
 param maestroCertificateIssuer string
@@ -180,7 +181,7 @@ module maestroManagedIdentityDatabaseAccess '../postgres/postgres-access.bicep' 
 
 module eventGridClientCert '../keyvault/key-vault-cert-with-access.bicep' = {
   name: 'maestro-eg-crt-${uniqueString(mqttClientName)}'
-  scope: resourceGroup(certKeyVaultResourceGroup)
+  scope: resourceGroup(certKeyVaultSubscription, certKeyVaultResourceGroup)
   params: {
     keyVaultName: certKeyVaultName
     kvCertOfficerManagedIdentityResourceId: keyVaultOfficerManagedIdentityName

--- a/dev-infrastructure/openshift-ci/grant-openshift-release-bot-dev.sh
+++ b/dev-infrastructure/openshift-ci/grant-openshift-release-bot-dev.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 APPLICATION_NAME="OpenShift Release Bot"
 SUBSCRIPTIONS=(
-    "ARO HCP E2E Service Clusters (EA Subscription)"
+    "ARO HCP E2E Infrastructure (EA Subscription)"
     "ARO HCP E2E Hosted Clusters (EA Subscription)"
     "ARO HCP E2E Management Clusters (EA Subscription)"
     "ARO Hosted Control Planes (EA Subscription 1)"
@@ -133,6 +133,14 @@ for SUBSCRIPTION_NAME in "${SUBSCRIPTIONS[@]}"; do
         --condition "${UAA_CONDITION}" \
         --condition-version "2.0" \
         --description "Allow user to assign all roles except privileged administrator roles Owner, UAA, RBAC (Recommended)" 2>/dev/null || echo "    (already assigned)"
+
+    # Assign AKS RBAC Cluster Admin for templatize Shell steps that need
+    # kubeconfig access on freshly-created AKS clusters
+    echo "  Assigning Azure Kubernetes Service RBAC Cluster Admin role..."
+    az role assignment create \
+        --assignee "${APP_ID}" \
+        --role "Azure Kubernetes Service RBAC Cluster Admin" \
+        --scope "/subscriptions/${SUBSCRIPTION_ID}" 2>/dev/null || echo "    (already assigned)"
 
     if [[ "${SUBSCRIPTION_NAME}" == "${GLOBAL_SUBSCRIPTION_NAME}" ]]; then
         GLOBAL_SUBSCRIPTION_ID="${SUBSCRIPTION_ID}"

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -60,6 +60,16 @@ resourceGroups:
     parameters: configurations/output-audit-logs-eventhub.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
+- name: svcKV
+  resourceGroup: '{{ .serviceKeyVault.rg }}'
+  subscription: '{{ if .serviceKeyVault.subscription.key }}{{ .serviceKeyVault.subscription.key }}{{ else }}{{ .svc.subscription.key }}{{ end }}'
+  steps:
+  - name: output
+    action: ARM
+    template: templates/subscription-lookup.bicep
+    parameters: configurations/subscription-lookup.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
 - name: kusto
   resourceGroup: '{{ .kusto.rg }}'
   subscription: '{{ .global.subscription.key }}'
@@ -86,6 +96,11 @@ resourceGroups:
         resourceGroup: global
         step: output
         name: globalMSIId
+    - name: serviceKeyVaultSubscription
+      input:
+        resourceGroup: svcKV
+        step: output
+        name: subscriptionId
   - name: infra-output
     action: ARM
     template: templates/svc-infra-lookup.bicep
@@ -95,6 +110,12 @@ resourceGroups:
     dependsOn:
     - resourceGroup: service
       step: infra
+    variables:
+    - name: serviceKeyVaultSubscription
+      input:
+        resourceGroup: svcKV
+        step: output
+        name: subscriptionId
   # Configure certificate issuers for the SVC KV
   - name: oncert-private-kv-issuer
     action: SetCertificateIssuer
@@ -163,6 +184,11 @@ resourceGroups:
         resourceGroup: auditLogs
         step: output
         name: auditLogsEventHubAuthRuleId
+    - name: serviceKeyVaultSubscription
+      input:
+        resourceGroup: svcKV
+        step: output
+        name: subscriptionId
     dependsOn:
     - resourceGroup: service
       step: oncert-private-kv-issuer

--- a/dev-infrastructure/templates/subscription-lookup.bicep
+++ b/dev-infrastructure/templates/subscription-lookup.bicep
@@ -1,0 +1,1 @@
+output subscriptionId string = subscription().subscriptionId

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -264,6 +264,9 @@ param serviceKeyVaultName string
 @description('The name of the resourcegroup for the service keyvault')
 param serviceKeyVaultResourceGroup string = resourceGroup().name
 
+@description('The subscription ID where the service keyvault resource group lives. Defaults to the current subscription. Set when the keyvault is shared across subscriptions.')
+param serviceKeyVaultSubscription string = subscription().subscriptionId
+
 @description('OIDC Storage Account name')
 param oidcStorageAccountName string
 
@@ -458,7 +461,7 @@ param sessiongateIngressCertIssuer string
 
 resource serviceKeyVault 'Microsoft.KeyVault/vaults@2024-04-01-preview' existing = {
   name: serviceKeyVaultName
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
 }
 
 //
@@ -798,6 +801,7 @@ module maestroServer '../modules/maestro/maestro-server.bicep' = {
     mqttClientName: maestroServerMqttClientName
     certKeyVaultName: serviceKeyVaultName
     certKeyVaultResourceGroup: serviceKeyVaultResourceGroup
+    certKeyVaultSubscription: serviceKeyVaultSubscription
     keyVaultOfficerManagedIdentityName: globalMSIId
     maestroCertificateDomain: effectiveMaestroCertDomain
     maestroCertificateIssuer: maestroCertIssuer
@@ -874,7 +878,7 @@ module cs '../modules/cluster-service.bicep' = {
 
 module serviceKeyVaultSecretsUserAccess '../modules/keyvault/keyvault-secret-access.bicep' = {
   name: 'kv-sec-user-${uniqueString(resourceGroup().name)}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
     roleName: 'Key Vault Secrets User'
@@ -884,7 +888,7 @@ module serviceKeyVaultSecretsUserAccess '../modules/keyvault/keyvault-secret-acc
 
 module serviceKeyVaultCertUserAccess '../modules/keyvault/keyvault-secret-access.bicep' = {
   name: 'kv-cert-user-${uniqueString(resourceGroup().name)}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
     roleName: 'Key Vault Certificate User'
@@ -987,7 +991,7 @@ var frontendDnsFQDN = '${frontendDnsName}.${regionalSvcDNSZoneName}'
 
 module frontendIngressCert '../modules/keyvault/key-vault-cert.bicep' = {
   name: 'frontend-cert-${uniqueString(resourceGroup().name)}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
     subjectName: 'CN=${frontendDnsFQDN}'
@@ -1002,7 +1006,7 @@ module frontendIngressCert '../modules/keyvault/key-vault-cert.bicep' = {
 
 module frontendIngressCertCSIAccess '../modules/keyvault/keyvault-secret-access.bicep' = {
   name: 'aks-svc-kv-access-${frontendIngressCertName}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
     roleName: 'Key Vault Secrets User'
@@ -1031,7 +1035,7 @@ var adminApiDnsFQDN = '${adminApiDnsName}.${regionalSvcDNSZoneName}'
 
 module adminApiCert '../modules/keyvault/key-vault-cert.bicep' = {
   name: 'admin-api-cert-${uniqueString(resourceGroup().name)}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
     subjectName: 'CN=${adminApiDnsFQDN}'
@@ -1046,7 +1050,7 @@ module adminApiCert '../modules/keyvault/key-vault-cert.bicep' = {
 
 module adminApiIngressCertCSIAccess '../modules/keyvault/keyvault-secret-access.bicep' = {
   name: 'aks-svc-kv-access-${adminApiIngressCertName}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
     roleName: 'Key Vault Secrets User'
@@ -1076,7 +1080,7 @@ var sessiongateDnsFQDN = '${sessiongateDnsName}.${regionalSvcDNSZoneName}'
 
 module sessiongateCert '../modules/keyvault/key-vault-cert.bicep' = {
   name: 'sessiongate-cert-${uniqueString(resourceGroup().name)}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
     subjectName: 'CN=${sessiongateDnsFQDN}'
@@ -1091,7 +1095,7 @@ module sessiongateCert '../modules/keyvault/key-vault-cert.bicep' = {
 
 module sessiongateIngressCertCSIAccess '../modules/keyvault/keyvault-secret-access.bicep' = {
   name: 'aksSPCRead-${sessiongateIngressCertName}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
     roleName: 'Key Vault Secrets User'
@@ -1119,7 +1123,7 @@ var fpaCertificateSNI = '${fpaCertificateName}.${svcDNSZoneName}'
 
 module fpaCertificate '../modules/keyvault/key-vault-cert.bicep' = if (manageFpaCertificate) {
   name: 'fpa-certificate-${uniqueString(resourceGroup().name)}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
     subjectName: 'CN=${fpaCertificateSNI}'
@@ -1138,7 +1142,7 @@ module fpaCertificate '../modules/keyvault/key-vault-cert.bicep' = if (manageFpa
 
 module genevaRPCertificate '../modules/keyvault/key-vault-cert-with-access.bicep' = if (genevaManageCertificates) {
   name: 'geneva-rp-certificate-${uniqueString(resourceGroup().name)}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
     kvCertOfficerManagedIdentityResourceId: globalMSIId

--- a/dev-infrastructure/templates/svc-infra-lookup.bicep
+++ b/dev-infrastructure/templates/svc-infra-lookup.bicep
@@ -4,6 +4,9 @@ param serviceKeyVaultName string
 @description('The name of the resource group for the service keyvault')
 param serviceKeyVaultResourceGroup string = resourceGroup().name
 
+@description('The subscription ID where the service keyvault resource group lives. Defaults to the current subscription. Set when the keyvault is shared across subscriptions.')
+param serviceKeyVaultSubscription string = subscription().subscriptionId
+
 // this is mostly a situation where multiple svc-infra pipelines run towards
 // a shared svc keyvault resource group ${serviceKeyVaultResourceGroup}. while
 // the individual modules will not conflict with each other, the existence
@@ -12,7 +15,7 @@ var deploymentNameSuffix = uniqueString(resourceGroup().id)
 
 module serviceKeyVault '../modules/keyvault/lookup.bicep' = {
   name: 'svc-kv-${deploymentNameSuffix}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
   }

--- a/dev-infrastructure/templates/svc-infra.bicep
+++ b/dev-infrastructure/templates/svc-infra.bicep
@@ -4,6 +4,9 @@ param serviceKeyVaultName string
 @description('The name of the resource group for the service keyvault')
 param serviceKeyVaultResourceGroup string = resourceGroup().name
 
+@description('The subscription ID where the service keyvault resource group lives. Defaults to the current subscription. Set when the keyvault is shared across subscriptions.')
+param serviceKeyVaultSubscription string = subscription().subscriptionId
+
 @description('The location of the resource group for the service keyvault')
 param serviceKeyVaultLocation string = resourceGroup().location
 
@@ -53,7 +56,7 @@ var deploymentNameSuffix = uniqueString(resourceGroup().id)
 
 module serviceKeyVault '../modules/keyvault/keyvault.bicep' = {
   name: 'svc-kv-${deploymentNameSuffix}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     location: serviceKeyVaultLocation
     keyVaultName: serviceKeyVaultName
@@ -66,7 +69,7 @@ module serviceKeyVault '../modules/keyvault/keyvault.bicep' = {
 
 module serviceKeyVaultCertOfficer '../modules/keyvault/keyvault-secret-access.bicep' = {
   name: 'svc-kv-cert-officer-${deploymentNameSuffix}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
     roleName: 'Key Vault Certificates Officer'
@@ -79,7 +82,7 @@ module serviceKeyVaultCertOfficer '../modules/keyvault/keyvault-secret-access.bi
 
 module serviceKeyVaultSecretsOfficer '../modules/keyvault/keyvault-secret-access.bicep' = {
   name: 'svc-kv-secret-officer-${deploymentNameSuffix}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
     roleName: 'Key Vault Secrets Officer'
@@ -92,7 +95,7 @@ module serviceKeyVaultSecretsOfficer '../modules/keyvault/keyvault-secret-access
 
 module serviceKeyVaultDevopsSecretsOfficer '../modules/keyvault/keyvault-secret-access.bicep' = {
   name: 'svc-kv-devops-secret-officer-${deploymentNameSuffix}'
-  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
     roleName: 'Key Vault Secrets Officer'

--- a/test/util/verifiers/must_gather_cli.go
+++ b/test/util/verifiers/must_gather_cli.go
@@ -197,16 +197,19 @@ func infraClusterNames() (svcCluster, mgmtCluster string) {
 		return "", ""
 	}
 
-	// regionShort = "j" + last 7 chars of BUILD_ID
+	deployEnv := os.Getenv("DEPLOY_ENV")
+	if deployEnv == "" {
+		deployEnv = "prow"
+	}
+
 	suffix := buildID
 	if len(suffix) > 7 {
 		suffix = suffix[len(suffix)-7:]
 	}
 	regionShort := "j" + suffix
 
-	// naming convention from config/config.yaml lines 1468/1488
-	svcCluster = fmt.Sprintf("prow-%s-svc", regionShort)
-	mgmtCluster = fmt.Sprintf("prow-%s-mgmt-1", regionShort)
+	svcCluster = fmt.Sprintf("%s-%s-svc", deployEnv, regionShort)
+	mgmtCluster = fmt.Sprintf("%s-%s-mgmt-1", deployEnv, regionShort)
 	return svcCluster, mgmtCluster
 }
 

--- a/tooling/templatize/settings.yaml
+++ b/tooling/templatize/settings.yaml
@@ -30,7 +30,16 @@ environments:
     regionShortSuffix: "${USER:0:4}"
 - name: prow
   description: |
-    Used for PR end-to-end tests in Prow.
+    CI infra shard0 - PR end-to-end tests.
+  defaults:
+    region: westus3
+    cloud: dev
+    ev2Cloud: public
+    cxStamp: 1
+    regionShortOverride: "j${BUILD_ID: -7}"
+- name: ci01
+  description: |
+    CI infra shard1 - PR end-to-end tests.
   defaults:
     region: westus3
     cloud: dev


### PR DESCRIPTION
## Enable cross-subscription infrastructure deployment for dev environments

### Summary

Adds support for deploying SVC and MGMT cluster infrastructure into a different Azure subscription from the one hosting global shared resources (Key Vault, ACR, DNS, Kusto). This enables subscription sharding to work around Azure resource and quota limits in CI.

A new ci01 environment is defined to deploy its regional infrastructure into the dedicated "ARO HCP E2E Infrastructure (EA Subscription)" subscription, while global resources remain in "ARO Hosted Control Planes (EA Subscription 1)". Even though we might want to use dedicated global resources for CI in the future and fully isolate CI, this is not the concern of the current PR.

### Changes

 
**Commit 1: Cross-subscription infrastructure support**
  
When SVC/MGMT clusters are deployed into a different subscription from the one hosting global shared resources, Bicep's `resourceGroup(name)` scoping breaks because it assumes the current subscription. The main resource affected is the **service Key Vault**, which lives in the global subscription's shared resource group but is referenced extensively from templates deployed in the SVC subscription:
  
- `svc-cluster.bicep` — references the Key Vault for frontend, admin API, sessiongate, and FPA TLS certificates, Geneva certificates, Maestro Event Grid client certificates, and secrets/cert reader RBAC for AKS workload identities
- `svc-infra.bicep` — creates the Key Vault itself and assigns Certificates/Secrets Officer roles
- `svc-infra-lookup.bicep` — reads Key Vault properties for downstream steps
- `maestro-server.bicep` — accesses the Key Vault to provision the Event Grid client certificate
  
Fix: add a `serviceKeyVaultSubscription` parameter (defaulting to the current subscription for backward compatibility) and switch all Key Vault scoping from `resourceGroup(rgName)` to `resourceGroup(subscriptionId, rgName)`.
  
The pipeline (`svc-pipeline.yaml`) resolves this parameter at runtime via a new `svcKV` resource group entry that runs a `subscription-lookup.bicep` output step against the Key Vault's subscription, feeding the subscription ID into the templates that need it.
  
Additionally: grant the openshift-release-bot the AKS RBAC Cluster Admin role on the new subscription so templatize shell steps can access freshly-created AKS clusters.

**Commit 2: Add ci01 environment to dev cloud**
- Register `ci01` as a new environment in `tooling/templatize/settings.yaml` alongside the existing `prow` environment, and update the `prow` description to reflect it is shard0. The reasoning behind adding a new environment for the new subscription is that each subscription has specific AZ mappings and SKU restrictions that make the config for one subscription not work for a different one. As an example, the DDsv5 VM family is restricted in AZ 1 in "ARO HCP E2E Infrastructure (EA Subscription)" so the config for this sub uses the DDsv6 family instead.
- Relax the `sourceEnvironmentIdentifier` schema pattern to allow digits (e.g. `ci01`) in addition to lowercase letters
- Add the full `ci01` environment overlay in `config/config.yaml` deploying into the "ARO HCP E2E Infrastructure" subscription, with `svc.subscription.key` and `mgmt.subscription.key` pointing to that subscription

### Dependencies

- [openshift/release#78202](https://github.com/openshift/release/pull/78202) (merged) — added initial infrastructure subscription sharding support to e2e workflow
- [openshift/release#78619](https://github.com/openshift/release/pull/78619) (merged) — drops `INFRA_SHARD` env var in favor of `ARO_HCP_DEPLOY_ENV`, renames Vault keys to `infra-{env}-subscription-id`