### PR TITLE
Set maestro server and agent deployment replicas to 1

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -814,7 +814,7 @@ defaults:
       loglevel: 2
       managedIdentityName: maestro-server
       k8s:
-        replicas: 3
+        replicas: 1
         namespace: maestro
         serviceAccountName: maestro
         resources:
@@ -828,7 +828,7 @@ defaults:
       loglevel: 2
       managedIdentityName: maestro-consumer
       k8s:
-        replicas: 3
+        replicas: 1
         namespace: maestro
         serviceAccountName: maestro
       sidecar:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -472,7 +472,7 @@ maestro:
     consumerName: hcp-underlay-usw3-mgmt-1
     k8s:
       namespace: maestro
-      replicas: 3
+      replicas: 1
       serviceAccountName: maestro
     loglevel: 2
     managedIdentityName: maestro-consumer
@@ -512,7 +512,7 @@ maestro:
   server:
     k8s:
       namespace: maestro
-      replicas: 3
+      replicas: 1
       resources:
         limits:
           memory: unlimited

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -472,7 +472,7 @@ maestro:
     consumerName: hcp-underlay-usw3-mgmt-1
     k8s:
       namespace: maestro
-      replicas: 3
+      replicas: 1
       serviceAccountName: maestro
     loglevel: 2
     managedIdentityName: maestro-consumer
@@ -512,7 +512,7 @@ maestro:
   server:
     k8s:
       namespace: maestro
-      replicas: 3
+      replicas: 1
       resources:
         limits:
           memory: unlimited

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -472,7 +472,7 @@ maestro:
     consumerName: hcp-underlay-usw3ptest-mgmt-1
     k8s:
       namespace: maestro
-      replicas: 3
+      replicas: 1
       serviceAccountName: maestro
     loglevel: 2
     managedIdentityName: maestro-consumer
@@ -512,7 +512,7 @@ maestro:
   server:
     k8s:
       namespace: maestro
-      replicas: 3
+      replicas: 1
       resources:
         limits:
           memory: unlimited

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -472,7 +472,7 @@ maestro:
     consumerName: hcp-underlay-usw3test-mgmt-1
     k8s:
       namespace: maestro
-      replicas: 3
+      replicas: 1
       serviceAccountName: maestro
     loglevel: 2
     managedIdentityName: maestro-consumer
@@ -512,7 +512,7 @@ maestro:
   server:
     k8s:
       namespace: maestro
-      replicas: 3
+      replicas: 1
       resources:
         limits:
           memory: unlimited

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -472,7 +472,7 @@ maestro:
     consumerName: hcp-underlay-j7654321-mgmt-1
     k8s:
       namespace: maestro
-      replicas: 3
+      replicas: 1
       serviceAccountName: maestro
     loglevel: 2
     managedIdentityName: maestro-consumer
@@ -512,7 +512,7 @@ maestro:
   server:
     k8s:
       namespace: maestro
-      replicas: 3
+      replicas: 1
       resources:
         limits:
           memory: unlimited

--- a/maestro/agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_maestro_agent.yaml
+++ b/maestro/agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_maestro_agent.yaml
@@ -285,7 +285,7 @@ metadata:
   name: maestro-agent
   namespace: 'maestro'
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: maestro-agent
@@ -348,7 +348,7 @@ spec:
         - --workload-source-driver=mqtt
         - --workload-source-config=/secrets/maestro/config.yaml
         - --cloudevents-client-id=hcp-underlay-usw3-mgmt-1-work-agent
-        - --disable-leader-election=false
+        - --disable-leader-election=true
         - --appliedmanifestwork-eviction-grace-period=876000h
         - -v=2
         image: "arohcpsvcdev.azurecr.io/redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro@sha256:1234567890"

--- a/maestro/server/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_maestro_server.yaml
+++ b/maestro/server/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_maestro_server.yaml
@@ -120,7 +120,7 @@ spec:
   selector:
     matchLabels:
       app: maestro
-  replicas: 3
+  replicas: 1
   strategy:
     rollingUpdate:
       maxSurge: 0


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What
Scale maestro-agent and maestro-server pod replicas to 1

### Why

There are some leadership election issues with maestro that appear to be race conditions.  Additionally, we're only running a single management cluster right now, so having multiple replicas doesn't make sense.  


### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
