### PR TITLE
Retry AddPassword on untyped transient Graph SDK errors

### DIFF
--- a/internal/graph/util/applications.go
+++ b/internal/graph/util/applications.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -103,16 +104,18 @@ func (c *Client) AddPassword(ctx context.Context, appID, displayName string, sta
 		result, err = c.graphClient.Applications().ByApplicationId(appID).AddPassword().Post(ctx, reqBody, nil)
 		if err != nil {
 			lastErr = err
-			// Only retry on transient errors (404, 429, 5xx)
+			// Retry on known transient errors (404, 429, 5xx). For unknown
+			// error shapes returned by the Graph SDK, also retry to tolerate
+			// eventual-consistency propagation delays.
 			var odataErr *odataerrors.ODataError
 			if errors.As(err, &odataErr) {
 				code := odataErr.ResponseStatusCode
-				if code == 404 || code == 429 || code >= 500 {
-					return false, nil
+				if code != http.StatusNotFound && code != http.StatusTooManyRequests && code < http.StatusInternalServerError {
+					// Non-transient typed OData error, stop retrying.
+					return false, err
 				}
 			}
-			// Non-transient or unknown error, stop retrying
-			return false, err
+			return false, nil
 		}
 		return true, nil
 	})


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-26567

### What

Retry AddPassword on untyped transient Graph SDK errors

### Why

This fix updates the Graph AddPassword retry behavior so transient failures no longer fail fast when the SDK returns an untyped error shape: instead of only retrying recognized OData transient codes (404, 429, 5xx) and immediately aborting everything else, it now only stops early for clearly non-transient typed OData errors and retries unknown/untyped errors within the existing polling window, which makes app-registration password creation resilient to Microsoft Graph eventual-consistency delays that were causing the external-auth e2e test to fail after a single attempt.

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
