### PR TITLE
backend: Add a doc comment to controller constructors

### DIFF
--- a/backend/pkg/controllers/operationcontrollers/dispatch_request_credential.go
+++ b/backend/pkg/controllers/operationcontrollers/dispatch_request_credential.go
@@ -36,6 +36,15 @@ type dispatchRequestCredential struct {
 	clustersServiceClient ocm.ClusterServiceClientSpec
 }
 
+// NewDispatchRequestCredentialController returns a new Controller instance that
+// initiates an asynchronous admin credential request operation in Clusters Service.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters
+//	     Request: RequestCredential
+//	      Status: Accepted
+//	  InternalID: an empty value
 func NewDispatchRequestCredentialController(
 	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,

--- a/backend/pkg/controllers/operationcontrollers/dispatch_revoke_credentials.go
+++ b/backend/pkg/controllers/operationcontrollers/dispatch_revoke_credentials.go
@@ -42,6 +42,14 @@ type dispatchRevokeCredentials struct {
 	clustersServiceClient ocm.ClusterServiceClientSpec
 }
 
+// NewDispatchRevokeCredentialsController returns a new Controller instance that
+// initiates an asynchronous credential revocation operation in Clusters Service.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters
+//	     Request: RevokeCredentials
+//	      Status: Accepted
 func NewDispatchRevokeCredentialsController(
 	clock utilsclock.PassiveClock,
 	cosmosClient database.DBClient,

--- a/backend/pkg/controllers/operationcontrollers/doc.go
+++ b/backend/pkg/controllers/operationcontrollers/doc.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The controllers in the operationcontrollers package provide the glue between
+// Clusters Service and asynchronous operations initiated by RP frontend pods in
+// response to client requests.
+//
+// For background reading about Azure's asynchronous operation contract for
+// Resource Providers, see the [Resource Provider Contract].
+//
+// The ARO-HCP RP uses type api.Operation to represent an asynchronous operation.
+// These structs get converted to JSON format and stored in Cosmos DB as so-called
+// "operation documents".
+//
+// At the time of this writing the RP backend defers most of the actual work involved
+// in an operation to Clusters Service. The controllers in this package merely update
+// operation documents in Cosmos DB to reflect the status of the actual operation in
+// Clusters Service.
+//
+// Generally speaking, the lifecycle of an operation document is as follows:
+//
+//  1. A frontend pod creates the operation document in Cosmos DB before responding
+//     to the client requesting the operation.
+//
+//  2. On the backend, the new operation document is first noticed by a "dispatch
+//     controller" that is dedicated to the operation's particular request type and
+//     resource type, such as "create cluster" or "delete node pool". The dispatch
+//     controller makes the appropriate calls to dispatch the operation to Clusters
+//     Service.
+//
+//  3. Once the operation is dispatched to Clusters Service, an "operation controller"
+//     begins polling the Clusters Service resource associated with the operation for
+//     status changes, and updates the operation document in Cosmos DB accordingly.
+//
+//  4. Meanwhile, the frontend will have exposed a status endpoint for this operation
+//     for the client to poll. (The endpoint is returned to the client as a header in
+//     the initial response.) The response body format of this endpoint is defined by
+//     Azure, but the operation document in Cosmos DB has all the required details to
+//     build a compliant response.
+//
+//  5. Operation documents in Cosmos DB are transient by way of a time-to-live (TTL)
+//     value. Once this TTL period (currently 7 days) expires, the Cosmos DB service
+//     will automatically delete the operation document.
+//
+// [Resource Provider Contract]: https://github.com/cloud-and-ai-microsoft/resource-provider-contract/blob/master/v1.0/async-api-reference.md
+package operationcontrollers

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -50,7 +50,20 @@ type operationClusterCreate struct {
 	notificationClient                    *http.Client
 }
 
-// NewOperationClusterCreateController periodically lists all clusters and for each out when the cluster was created and its state.
+// NewOperationClusterCreateController returns a new Controller instance that
+// follows an asynchronous cluster creation operation to completion and updates
+// the corresponding operation document in Cosmos DB.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters
+//	     Request: Create
+//	      Status: any non-terminal value
+//
+// Note that "to completion" does not imply success. An operation is considered
+// complete when its status field reaches what Azure defines as a terminal value;
+// any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
+// a terminal value, there will be no further updates to the operation document.
 func NewOperationClusterCreateController(
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
@@ -41,7 +41,20 @@ type operationClusterDelete struct {
 	notificationClient   *http.Client
 }
 
-// NewOperationClusterDeleteController periodically lists all clusters and for each out when the cluster was deleted and its state.
+// NewOperationClusterDeleteController returns a new Controller instance that
+// follows an asynchronous cluster deletion operation to completion and updates
+// the corresponding operation document in Cosmos DB.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters
+//	     Request: Delete
+//	      Status: any non-terminal value
+//
+// Note that "to completion" does not imply success. An operation is considered
+// complete when its status field reaches what Azure defines as a terminal value;
+// any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
+// a terminal value, there will be no further updates to the operation document.
 func NewOperationClusterDeleteController(
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
@@ -36,7 +36,20 @@ type operationClusterUpdate struct {
 	notificationClient   *http.Client
 }
 
-// NewOperationClusterUpdateController periodically lists all clusters and for each out when the cluster was created and its state.
+// NewOperationClusterUpdateController returns a new Controller instance that
+// follows an asynchronous cluster update operation to completion and updates
+// the corresponding operation document in Cosmos DB.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters
+//	     Request: Update
+//	      Status: any non-terminal value
+//
+// Note that "to completion" does not imply success. An operation is considered
+// complete when its status field reaches what Azure defines as a terminal value;
+// any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
+// a terminal value, there will be no further updates to the operation document.
 func NewOperationClusterUpdateController(
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_create.go
@@ -36,6 +36,20 @@ type operationExternalAuthCreate struct {
 	notificationClient   *http.Client
 }
 
+// NewOperationExternalAuthCreateController returns a new Controller instance that
+// follows an asynchronous external auth creation operation to completion and updates
+// the corresponding operation document in Cosmos DB.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths
+//	     Request: Create
+//	      Status: any non-terminal value
+//
+// Note that "to completion" does not imply success. An operation is considered
+// complete when its status field reaches what Azure defines as a terminal value;
+// any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
+// a terminal value, there will be no further updates to the operation document.
 func NewOperationExternalAuthCreateController(
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_delete.go
@@ -39,7 +39,20 @@ type operationExternalAuthDelete struct {
 	notificationClient   *http.Client
 }
 
-// NewOperationExternalAuthDeleteController periodically lists all clusters and for each out when the cluster was deleted and its state.
+// NewOperationExternalAuthDeleteController returns a new Controller instance that
+// follows an asynchronous external auth deletion operation to completion and updates
+// the corresponding operation document in Cosmos DB.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths
+//	     Request: Delete
+//	      Status: any non-terminal value
+//
+// Note that "to completion" does not imply success. An operation is considered
+// complete when its status field reaches what Azure defines as a terminal value;
+// any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
+// a terminal value, there will be no further updates to the operation document.
 func NewOperationExternalAuthDeleteController(
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_update.go
@@ -36,6 +36,20 @@ type operationExternalAuthUpdate struct {
 	notificationClient   *http.Client
 }
 
+// NewOperationExternalAuthUpdateController returns a new Controller instance that
+// follows an asynchronous external auth update operation to completion and updates
+// the corresponding operation document in Cosmos DB.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths
+//	     Request: Update
+//	      Status: any non-terminal value
+//
+// Note that "to completion" does not imply success. An operation is considered
+// complete when its status field reaches what Azure defines as a terminal value;
+// any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
+// a terminal value, there will be no further updates to the operation document.
 func NewOperationExternalAuthUpdateController(
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_create.go
@@ -36,6 +36,20 @@ type operationNodePoolCreate struct {
 	notificationClient   *http.Client
 }
 
+// NewOperationNodePoolCreateController returns a new Controller instance that
+// follows an asynchronous node pool creation operation to completion and updates
+// the corresponding operation document in Cosmos DB.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools
+//	     Request: Create
+//	      Status: any non-terminal value
+//
+// Note that "to completion" does not imply success. An operation is considered
+// complete when its status field reaches what Azure defines as a terminal value;
+// any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
+// a terminal value, there will be no further updates to the operation document.
 func NewOperationNodePoolCreateController(
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete.go
@@ -39,7 +39,20 @@ type operationNodePoolDelete struct {
 	notificationClient   *http.Client
 }
 
-// NewOperationNodePoolDeleteController periodically lists all clusters and for each out when the cluster was deleted and its state.
+// NewOperationNodePoolDeleteController returns a new Controller instance that
+// follows an asynchronous node pool deletion operation to completion and updates
+// the corresponding operation document in Cosmos DB.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools
+//	     Request: Delete
+//	      Status: any non-terminal value
+//
+// Note that "to completion" does not imply success. An operation is considered
+// complete when its status field reaches what Azure defines as a terminal value;
+// any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
+// a terminal value, there will be no further updates to the operation document.
 func NewOperationNodePoolDeleteController(
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
@@ -36,6 +36,20 @@ type operationNodePoolUpdate struct {
 	notificationClient   *http.Client
 }
 
+// NewOperationNodePoolUpdateController returns a new Controller instance that
+// follows an asynchronous node pool update operation to completion and updates
+// the corresponding operation document in Cosmos DB.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools
+//	     Request: Update
+//	      Status: any non-terminal value
+//
+// Note that "to completion" does not imply success. An operation is considered
+// complete when its status field reaches what Azure defines as a terminal value;
+// any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
+// a terminal value, there will be no further updates to the operation document.
 func NewOperationNodePoolUpdateController(
 	cosmosClient database.DBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,

--- a/backend/pkg/controllers/operationcontrollers/operation_request_credential.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_request_credential.go
@@ -38,6 +38,21 @@ type operationRequestCredential struct {
 	notificationClient    *http.Client
 }
 
+// NewOperationRequestCredentialController returns a new Controller instance that
+// follows an asynchronous admin credential request operation to completion and
+// updates the corresponding operation document in Cosmos DB.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters
+//	     Request: RequestCredential
+//	      Status: any non-terminal value
+//	  InternalID: a Clusters Service HREF value
+//
+// Note that "to completion" does not imply success. An operation is considered
+// complete when its status field reaches what Azure defines as a terminal value;
+// any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
+// a terminal value, there will be no further updates to the operation document.
 func NewOperationRequestCredentialController(
 	cosmosClient database.DBClient,
 	clustersServiceClient ocm.ClusterServiceClientSpec,

--- a/backend/pkg/controllers/operationcontrollers/operation_revoke_credentials.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_revoke_credentials.go
@@ -38,6 +38,20 @@ type operationRevokeCredentials struct {
 	notificationClient    *http.Client
 }
 
+// NewOperationRevokeCredentialsController returns a new Controller instance that
+// follows an asynchronous credential revocation operation to completion and updates
+// the corresponding operation document in Cosmos DB.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters
+//	     Request: RevokeCredentials
+//	      Status: Deleting
+//
+// Note that "to completion" does not imply success. An operation is considered
+// complete when its status field reaches what Azure defines as a terminal value;
+// any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
+// a terminal value, there will be no further updates to the operation document.
 func NewOperationRevokeCredentialsController(
 	cosmosClient database.DBClient,
 	clustersServiceClient ocm.ClusterServiceClientSpec,


### PR DESCRIPTION
### What

Add doc comments to constructor functions in the `operationcontrollers` package, as well as a preamble in `doc.go`.

### Why

IOU for @tmstff 