### PR TITLE
Allowing pipeline runs with multiple topologies

### DIFF
--- a/tooling/templatize/cmd/configuration/validate/cmd.go
+++ b/tooling/templatize/cmd/configuration/validate/cmd.go
@@ -26,13 +26,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-func NewCommand(centralRemoteUrl string) (*cobra.Command, error) {
+func NewCommand(centralRemoteUrls ...string) (*cobra.Command, error) {
 	scratchDir := filepath.Join(os.TempDir(), "config-"+rand.String(8))
 	if err := os.MkdirAll(scratchDir, os.ModePerm); err != nil {
 		return nil, fmt.Errorf("failed to create scratch directory: %w", err)
 	}
 
-	opts := DefaultOptions(scratchDir, centralRemoteUrl)
+	opts := DefaultOptions(scratchDir, centralRemoteUrls)
 	cmd := &cobra.Command{
 		Use:           "validate",
 		Short:         "Validate rendered configurations for all clouds, environments, and regions.",

--- a/tooling/templatize/cmd/configuration/validate/options.go
+++ b/tooling/templatize/cmd/configuration/validate/options.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -39,10 +40,10 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/settings"
 )
 
-func DefaultOptions(outputDir string, url string) *RawOptions {
+func DefaultOptions(outputDir string, urls []string) *RawOptions {
 	return &RawOptions{
 		OutputDir:        outputDir,
-		CentralRemoteUrl: url,
+		CentralRemoteUrl: urls,
 	}
 }
 
@@ -51,7 +52,7 @@ func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.DevSettingsFile, "dev-settings-file", opts.DevSettingsFile, "Validate only the combinations present in the settings file, using public production Ev2 contexts.")
 	cmd.Flags().StringVar(&opts.DigestFile, "digest-file", opts.DigestFile, "File holding digests of previously-rendered configurations to validate with.")
 	cmd.Flags().StringVar(&opts.OutputDir, "output-dir", opts.OutputDir, "Directory to output rendered configurations to.")
-	cmd.Flags().StringVar(&opts.CentralRemoteUrl, "central-remote-url", opts.CentralRemoteUrl, "Git URL for the central remote, used to calculate merge-base.")
+	cmd.Flags().StringArrayVar(&opts.CentralRemoteUrl, "central-remote-url", opts.CentralRemoteUrl, "Git URL for the central remote, used to calculate merge-base. Can be specified multiple times.")
 	cmd.Flags().BoolVar(&opts.Update, "update", opts.Update, "Update the digest file.")
 
 	for _, flag := range []string{
@@ -73,7 +74,7 @@ func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
 type RawOptions struct {
 	ServiceConfigFile string
 	DevSettingsFile   string
-	CentralRemoteUrl  string
+	CentralRemoteUrl  []string
 
 	DigestFile string
 	OutputDir  string
@@ -96,7 +97,7 @@ type completedOptions struct {
 	Digests       *Digests
 	DevSettings   *settings.Settings
 
-	CentralRemoteUrl  string
+	CentralRemoteUrl  []string
 	OutputDir         string
 	ServiceConfigFile string
 	DigestFile        string
@@ -259,7 +260,7 @@ func ValidateServiceConfig(
 	outputDir string,
 	update bool,
 	digestFile string,
-	centralRemoteUrl string,
+	centralRemoteUrls []string,
 ) error {
 	logger, err := logr.FromContext(ctx)
 	if err != nil {
@@ -405,7 +406,7 @@ func ValidateServiceConfig(
 							ctx,
 							cloud, environment, *regionCtx,
 							serviceConfigFile, jsonSchemaPath,
-							centralRemoteUrl, outputDir, scratchDir,
+							centralRemoteUrls, outputDir, scratchDir,
 						); err != nil {
 							logger.WithValues("cloud", cloud, "environment", environment, "region", region).Error(err, "Failed to render diff.")
 						}
@@ -449,7 +450,7 @@ func renderDiff(
 	cloud, environment string, regionCtx RegionContext,
 	serviceConfigFile string,
 	jsonSchemaFile string,
-	centralRemoteUrl string,
+	centralRemoteUrls []string,
 	outputDir, scratchDir string,
 ) error {
 	region := regionCtx.Region
@@ -489,7 +490,7 @@ func renderDiff(
 	//
 	// n.b. in GitHub Actions CI, we're in some non-standard git state and are better off consuming
 	// the upstream ref directly
-	mergeBase, err := DetermineMergeBase(ctx, dir, centralRemoteUrl)
+	mergeBase, err := DetermineMergeBase(ctx, dir, centralRemoteUrls)
 	if err != nil {
 		return err
 	}
@@ -564,7 +565,7 @@ func renderDiff(
 }
 
 // DetermineMergeBase determines the merge base between HEAD and what we think the upstream target branch is.
-func DetermineMergeBase(ctx context.Context, dir, centralRemoteUrl string) (string, error) {
+func DetermineMergeBase(ctx context.Context, dir string, centralRemoteUrls []string) (string, error) {
 	var mergeBase string
 	if value, set := os.LookupEnv("MERGE_BASE_REF"); set && value != "" {
 		mergeBase = value
@@ -603,7 +604,7 @@ func DetermineMergeBase(ctx context.Context, dir, centralRemoteUrl string) (stri
 				if err != nil {
 					return "", fmt.Errorf("failed to get git remote URL: %w", err)
 				}
-				if strings.TrimSpace(remoteUrl) == centralRemoteUrl {
+				if slices.Contains(centralRemoteUrls, strings.TrimSpace(remoteUrl)) {
 					upstreamRef = remote + "/main"
 					break
 				}
@@ -611,7 +612,7 @@ func DetermineMergeBase(ctx context.Context, dir, centralRemoteUrl string) (stri
 		}
 
 		if upstreamRef == "" {
-			return "", fmt.Errorf("failed to determine upstream branch - no upstream configured and no remote matches %s", centralRemoteUrl)
+			return "", fmt.Errorf("failed to determine upstream branch - no upstream configured and no remote matches any of: %s", strings.Join(centralRemoteUrls, ", "))
 		}
 
 		mergeBaseFromGit, err := command(ctx, dir, "git", "merge-base", "HEAD", upstreamRef)

--- a/tooling/templatize/cmd/entrypoint/cleanup/options.go
+++ b/tooling/templatize/cmd/entrypoint/cleanup/options.go
@@ -152,7 +152,7 @@ func (o *Options) CleanUpResources(ctx context.Context) error {
 
 	var executionGraph *graph.Graph
 	if o.Entrypoint != nil {
-		executionGraph, err = graph.ForEntrypoint(o.Topo, o.Entrypoint, o.Pipelines)
+		executionGraph, err = graph.ForEntrypoint(&o.Topo.Topology, o.Entrypoint, o.Pipelines)
 	} else {
 		executionGraph, err = graph.ForPipeline(o.Service, o.Pipelines[o.Service.ServiceGroup])
 	}

--- a/tooling/templatize/cmd/entrypoint/entrypointutils/load.go
+++ b/tooling/templatize/cmd/entrypoint/entrypointutils/load.go
@@ -24,9 +24,13 @@ import (
 )
 
 func LoadPipelines(
-	root *topology.Service, topologyDir string, pipelines map[string]*types.Pipeline,
+	root *topology.Service, t *topology.CombinedTopology, pipelines map[string]*types.Pipeline,
 	cfg configtypes.Configuration,
 ) error {
+	topologyDir, err := t.GetTopologyDirForServiceGroup(root.ServiceGroup)
+	if err != nil {
+		return fmt.Errorf("failed to get topology dir for service group %s: %w", root.ServiceGroup, err)
+	}
 	pipelineConfigFilePath := filepath.Join(topologyDir, root.PipelinePath)
 	pipe, err := types.NewPipelineFromFile(pipelineConfigFilePath, cfg)
 	if err != nil {
@@ -39,7 +43,7 @@ func LoadPipelines(
 	pipelines[root.ServiceGroup] = pipe
 
 	for _, child := range root.Children {
-		if err := LoadPipelines(&child, topologyDir, pipelines, cfg); err != nil {
+		if err := LoadPipelines(&child, t, pipelines, cfg); err != nil {
 			return err
 		}
 	}

--- a/tooling/templatize/cmd/entrypoint/entrypointutils/options.go
+++ b/tooling/templatize/cmd/entrypoint/entrypointutils/options.go
@@ -17,12 +17,8 @@ package entrypointutils
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
-
-	"sigs.k8s.io/yaml"
 
 	configtypes "github.com/Azure/ARO-Tools/config/types"
 	"github.com/Azure/ARO-Tools/pipelines/topology"
@@ -56,7 +52,7 @@ func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
 	if err := rollout.BindRolloutOptions(opts.RawRolloutOptions, cmd); err != nil {
 		return err
 	}
-	cmd.Flags().StringVar(&opts.TopologyFile, "topology-config", opts.TopologyFile, "Path to the topology configuration file. The directory holding this file will become the root of the Ev2 content archive.")
+	cmd.Flags().StringArrayVar(&opts.TopologyFiles, "topology-config", opts.TopologyFiles, "Path to a topology configuration file. Can be specified multiple times.")
 	cmd.Flags().StringVar(&opts.Entrypoint, "entrypoint", opts.Entrypoint, "Name of the entrypoint to create Ev2 manifests for. Exclusive with --service-group.")
 	cmd.Flags().StringVar(&opts.ServiceGroup, "service-group", opts.ServiceGroup, "Name of the service group to create Ev2 manifests for. Exclusive with --entrypoint.")
 
@@ -71,9 +67,9 @@ func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
 type RawOptions struct {
 	*rollout.RawRolloutOptions
 
-	TopologyFile string
-	Entrypoint   string
-	ServiceGroup string
+	TopologyFiles []string
+	Entrypoint    string
+	ServiceGroup  string
 }
 
 // validatedOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
@@ -89,8 +85,7 @@ type ValidatedOptions struct {
 
 // completedOptions is a private wrapper that enforces a call of Complete() before config generation can be invoked.
 type completedOptions struct {
-	Topo       *topology.Topology
-	TopoDir    string
+	Topo       *topology.CombinedTopology
 	Service    *topology.Service
 	Entrypoint *topology.Entrypoint
 	Pipelines  map[string]*types.Pipeline
@@ -104,16 +99,8 @@ type Options struct {
 }
 
 func (o *RawOptions) Validate(ctx context.Context) (*ValidatedOptions, error) {
-	for _, item := range []struct {
-		flag  string
-		name  string
-		value *string
-	}{
-		{flag: "topology-config", name: "topology configuration file", value: &o.TopologyFile},
-	} {
-		if item.value == nil || *item.value == "" {
-			return nil, fmt.Errorf("the %s must be provided with --%s", item.name, item.flag)
-		}
+	if len(o.TopologyFiles) == 0 {
+		return nil, fmt.Errorf("the topology configuration file must be provided with --topology-config")
 	}
 
 	if o.ServiceGroup == "" && o.Entrypoint == "" {
@@ -143,14 +130,9 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 		return nil, err
 	}
 
-	rawTopology, err := os.ReadFile(o.TopologyFile)
+	t, err := topology.LoadCombined(o.TopologyFiles)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read input file %s: %w", o.TopologyFile, err)
-	}
-
-	var t topology.Topology
-	if err := yaml.Unmarshal(rawTopology, &t); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal topology: %w", err)
+		return nil, fmt.Errorf("failed to load topology: %w", err)
 	}
 
 	if err := t.Validate(); err != nil {
@@ -184,14 +166,13 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 	}
 
 	pipelines := map[string]*types.Pipeline{}
-	if err := LoadPipelines(service, filepath.Dir(o.TopologyFile), pipelines, completed.Config); err != nil {
-		return nil, fmt.Errorf("failed to load pipelines from %s: %w", o.TopologyFile, err)
+	if err := LoadPipelines(service, t, pipelines, completed.Config); err != nil {
+		return nil, fmt.Errorf("failed to load pipelines: %w", err)
 	}
 
 	return &Options{
 		completedOptions: &completedOptions{
-			Topo:       &t,
-			TopoDir:    filepath.Dir(o.TopologyFile),
+			Topo:       t,
 			Entrypoint: e,
 			Service:    service,
 			Pipelines:  pipelines,

--- a/tooling/templatize/cmd/entrypoint/graph/options.go
+++ b/tooling/templatize/cmd/entrypoint/graph/options.go
@@ -137,7 +137,7 @@ func (o *Options) Run(ctx context.Context) error {
 			return fmt.Errorf("service group only had %d parts: %s", len(parts), o.Entrypoint.Identifier)
 		}
 		title = fmt.Sprintf("entrypoint/%s", strings.Join(parts[4:], "."))
-		executionGraph, err = graph.ForEntrypoint(o.Topo, o.Entrypoint, o.Pipelines)
+		executionGraph, err = graph.ForEntrypoint(&o.Topo.Topology, o.Entrypoint, o.Pipelines)
 	} else {
 		parts := strings.Split(o.Service.ServiceGroup, ".")
 		if len(parts) < 5 {

--- a/tooling/templatize/cmd/entrypoint/run/options.go
+++ b/tooling/templatize/cmd/entrypoint/run/options.go
@@ -162,7 +162,7 @@ func (o *Options) Run(ctx context.Context) error {
 			BicepClient:                          o.BicepClient,
 			SubscriptionIdToAzureConfigDirectory: subscriptionIdToAzureConfigDirectory,
 		},
-		TopologyDir:           o.TopoDir,
+		TopoDirLookupFunc:     o.Topo.GetTopologyDirForServiceGroup,
 		Region:                o.Region,
 		Environment:           o.DeployEnv,
 		Stamp:                 o.Stamp,

--- a/tooling/templatize/cmd/pipeline/inspect/options.go
+++ b/tooling/templatize/cmd/pipeline/inspect/options.go
@@ -128,16 +128,16 @@ func (o *ValidatedInspectOptions) Complete(ctx context.Context) (*InspectOptions
 func (o *InspectOptions) RunInspect(ctx context.Context) error {
 	return pipeline.Inspect(
 		o.PipelineOptions.Pipeline, ctx, &pipeline.InspectOptions{
-			Scope:          o.Scope,
-			ScopeFunctions: pipeline.NewStepInspectScopes(o.PipelineOptions.RolloutOptions.Subscriptions),
-			Format:         o.Format,
-			Step:           o.PipelineOptions.Step,
-			Region:         o.PipelineOptions.RolloutOptions.Region,
-			Configuration:  o.PipelineOptions.RolloutOptions.Config,
-			TopologyDir:    o.PipelineOptions.TopologyDir,
-			Service:        o.PipelineOptions.Service,
-			OutputFile:     o.OutputFile,
-			Concurrency:    o.PipelineOptions.RolloutOptions.Concurrency,
+			Scope:             o.Scope,
+			ScopeFunctions:    pipeline.NewStepInspectScopes(o.PipelineOptions.RolloutOptions.Subscriptions),
+			Format:            o.Format,
+			Step:              o.PipelineOptions.Step,
+			Region:            o.PipelineOptions.RolloutOptions.Region,
+			Configuration:     o.PipelineOptions.RolloutOptions.Config,
+			TopoDirLookupFunc: o.PipelineOptions.TopoDirLookupFunc,
+			Service:           o.PipelineOptions.Service,
+			OutputFile:        o.OutputFile,
+			Concurrency:       o.PipelineOptions.RolloutOptions.Concurrency,
 		},
 	)
 }

--- a/tooling/templatize/cmd/pipeline/options/options.go
+++ b/tooling/templatize/cmd/pipeline/options/options.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/ARO-Tools/pipelines/types"
 
 	options "github.com/Azure/ARO-HCP/tooling/templatize/cmd"
+	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/pipeline"
 )
 
 func DefaultOptions() *RawPipelineOptions {
@@ -39,7 +40,7 @@ func BindOptions(opts *RawPipelineOptions, cmd *cobra.Command) error {
 		return fmt.Errorf("failed to bind options: %w", err)
 	}
 	cmd.Flags().StringVar(&opts.ServiceGroup, "service-group", opts.ServiceGroup, "Service group identifying the pipeline.")
-	cmd.Flags().StringVar(&opts.TopologyFile, "topology-file", opts.TopologyFile, "Path to the topology configuration.")
+	cmd.Flags().StringArrayVar(&opts.TopologyFiles, "topology-file", opts.TopologyFiles, "Path to a topology configuration file. Can be specified multiple times.")
 	cmd.Flags().StringVar(&opts.Step, "step", opts.Step, "run only a specific step in the pipeline")
 
 	for _, flag := range []string{"topology-file"} {
@@ -57,7 +58,7 @@ func BindOptions(opts *RawPipelineOptions, cmd *cobra.Command) error {
 type RawPipelineOptions struct {
 	RolloutOptions *options.RawRolloutOptions
 	ServiceGroup   string
-	TopologyFile   string
+	TopologyFiles  []string
 	Step           string
 }
 
@@ -74,11 +75,11 @@ type ValidatedPipelineOptions struct {
 
 // completedPipelineOptions is a private wrapper that enforces a call of Complete() before config generation can be invoked.
 type completedPipelineOptions struct {
-	RolloutOptions *options.RolloutOptions
-	Service        *topology.Service
-	Pipeline       *types.Pipeline
-	Step           string
-	TopologyDir    string
+	RolloutOptions    *options.RolloutOptions
+	Service           *topology.Service
+	Pipeline          *types.Pipeline
+	Step              string
+	TopoDirLookupFunc pipeline.TopoDirLookup
 }
 
 type PipelineOptions struct {
@@ -106,9 +107,9 @@ func (o *ValidatedPipelineOptions) Complete(ctx context.Context) (*PipelineOptio
 		return nil, err
 	}
 
-	t, err := topology.Load(o.TopologyFile)
+	t, err := topology.LoadCombined(o.TopologyFiles)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load topology file: %w", err)
+		return nil, fmt.Errorf("failed to load topology files: %w", err)
 	}
 	if err := t.Validate(); err != nil {
 		return nil, fmt.Errorf("failed to validate topology: %w", err)
@@ -118,7 +119,11 @@ func (o *ValidatedPipelineOptions) Complete(ctx context.Context) (*PipelineOptio
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve service group: %w", err)
 	}
-	pipelinePath := filepath.Join(filepath.Dir(o.TopologyFile), service.PipelinePath)
+	topologyDir, err := t.GetTopologyDirForServiceGroup(o.ServiceGroup)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get topology dir for service group: %w", err)
+	}
+	pipelinePath := filepath.Join(topologyDir, service.PipelinePath)
 
 	pipeline, err := types.NewPipelineFromFile(pipelinePath, completed.Config)
 	if err != nil {
@@ -127,11 +132,11 @@ func (o *ValidatedPipelineOptions) Complete(ctx context.Context) (*PipelineOptio
 
 	return &PipelineOptions{
 		completedPipelineOptions: &completedPipelineOptions{
-			RolloutOptions: completed,
-			Pipeline:       pipeline,
-			Service:        service,
-			Step:           o.Step,
-			TopologyDir:    filepath.Dir(o.TopologyFile),
+			RolloutOptions:    completed,
+			Pipeline:          pipeline,
+			Service:           service,
+			Step:              o.Step,
+			TopoDirLookupFunc: t.GetTopologyDirForServiceGroup,
 		},
 	}, nil
 }

--- a/tooling/templatize/cmd/pipeline/run/options.go
+++ b/tooling/templatize/cmd/pipeline/run/options.go
@@ -126,7 +126,7 @@ func (o *RunOptions) RunPipeline(ctx context.Context) error {
 		Stamp:                 o.PipelineOptions.RolloutOptions.Stamp,
 		Step:                  o.PipelineOptions.Step,
 		SubsciptionLookupFunc: pipeline.LookupSubscriptionID(o.PipelineOptions.RolloutOptions.Subscriptions),
-		TopologyDir:           o.PipelineOptions.TopologyDir,
+		TopoDirLookupFunc:     o.PipelineOptions.TopoDirLookupFunc,
 		Concurrency:           o.PipelineOptions.RolloutOptions.Concurrency,
 	}, pipeline.RunStep)
 	return err

--- a/tooling/templatize/cmd/pipeline/validate/options.go
+++ b/tooling/templatize/cmd/pipeline/validate/options.go
@@ -34,23 +34,24 @@ import (
 	"github.com/Azure/ARO-Tools/pipelines/types"
 
 	"github.com/Azure/ARO-HCP/tooling/templatize/cmd/configuration/validate"
+	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/pipeline"
 )
 
 func DefaultValidationOptions() *RawValidationOptions {
 	return &RawValidationOptions{
 		DevMode:          false,
 		DevRegion:        "uksouth",
-		CentralRemoteUrl: "https://github.com/Azure/ARO-HCP.git",
+		CentralRemoteUrl: []string{"https://github.com/Azure/ARO-HCP.git"},
 	}
 }
 
 func BindValidationOptions(opts *RawValidationOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.ServiceConfigFile, "service-config-file", opts.ServiceConfigFile, "Path to the service configuration file.")
-	cmd.Flags().StringVar(&opts.TopologyFile, "topology-config-file", opts.TopologyFile, "Path to the topology configuration file.")
+	cmd.Flags().StringArrayVar(&opts.TopologyFiles, "topology-config-file", opts.TopologyFiles, "Path to a topology configuration file. Can be specified multiple times.")
 	cmd.Flags().BoolVar(&opts.DevMode, "dev-mode", opts.DevMode, "Validate just one region, using public production Ev2 contexts.")
 	cmd.Flags().StringVar(&opts.DevRegion, "dev-region", opts.DevRegion, "Region to use for dev mode validation.")
 	cmd.Flags().BoolVar(&opts.OnlyChanged, "only-changed", opts.OnlyChanged, "Validate only pipelines whose files have uncommitted changes.")
-	cmd.Flags().StringVar(&opts.CentralRemoteUrl, "central-remote-url", opts.CentralRemoteUrl, "Central remote URL for the repository.")
+	cmd.Flags().StringArrayVar(&opts.CentralRemoteUrl, "central-remote-url", opts.CentralRemoteUrl, "Central remote URL for the repository. Can be specified multiple times.")
 
 	for _, flag := range []string{
 		"service-config-file",
@@ -66,11 +67,11 @@ func BindValidationOptions(opts *RawValidationOptions, cmd *cobra.Command) error
 // RawValidationOptions holds input values.
 type RawValidationOptions struct {
 	ServiceConfigFile string
-	TopologyFile      string
+	TopologyFiles     []string
 	DevMode           bool
 	DevRegion         string
 	OnlyChanged       bool
-	CentralRemoteUrl  string
+	CentralRemoteUrl  []string
 }
 
 // validatedValidationOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
@@ -85,13 +86,13 @@ type ValidatedValidationOptions struct {
 
 // completedValidationOptions is a private wrapper that enforces a call of Complete() before config generation can be invoked.
 type completedValidationOptions struct {
-	Topology         *topology.Topology
-	TopologyDir      string
+	TopologyFiles    []string
+	Topology         *topology.CombinedTopology
 	Config           config.ConfigProvider
 	DevMode          bool
 	DevRegion        string
 	OnlyChanged      bool
-	CentralRemoteUrl string
+	CentralRemoteUrl []string
 }
 
 type ValidationOptions struct {
@@ -106,12 +107,16 @@ func (o *RawValidationOptions) Validate() (*ValidatedValidationOptions, error) {
 		value *string
 	}{
 		{flag: "service-config-file", name: "service configuration file", value: &o.ServiceConfigFile},
-		{flag: "topology-config-file", name: "topology configuration file", value: &o.TopologyFile},
-		{flag: "central-remote-url", name: "URl for the central git remote", value: &o.CentralRemoteUrl},
 	} {
 		if item.value == nil || *item.value == "" {
 			return nil, fmt.Errorf("the %s must be provided with --%s", item.name, item.flag)
 		}
+	}
+	if len(o.CentralRemoteUrl) == 0 {
+		return nil, fmt.Errorf("the URL for the central git remote must be provided with --central-remote-url")
+	}
+	if len(o.TopologyFiles) == 0 {
+		return nil, fmt.Errorf("the topology configuration file must be provided with --topology-config-file")
 	}
 
 	return &ValidatedValidationOptions{
@@ -122,7 +127,7 @@ func (o *RawValidationOptions) Validate() (*ValidatedValidationOptions, error) {
 }
 
 func (o *ValidatedValidationOptions) Complete() (*ValidationOptions, error) {
-	t, err := topology.Load(o.TopologyFile)
+	t, err := topology.LoadCombined(o.TopologyFiles)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load topology: %w", err)
 	}
@@ -137,8 +142,8 @@ func (o *ValidatedValidationOptions) Complete() (*ValidationOptions, error) {
 
 	return &ValidationOptions{
 		completedValidationOptions: &completedValidationOptions{
+			TopologyFiles:    o.TopologyFiles,
 			Topology:         t,
-			TopologyDir:      filepath.Dir(o.TopologyFile),
 			Config:           c,
 			DevMode:          o.DevMode,
 			DevRegion:        o.DevRegion,
@@ -157,7 +162,7 @@ func (opts *ValidationOptions) ValidatePipelineConfigReferences(ctx context.Cont
 		return true
 	}
 	if opts.OnlyChanged {
-		changedServices, err := DetermineChangedServices(ctx, opts.CentralRemoteUrl, opts.TopologyDir, opts.Topology)
+		changedServices, err := DetermineChangedServicesCombined(ctx, opts.CentralRemoteUrl, opts.TopologyFiles, opts.Topology)
 		if err != nil {
 			return fmt.Errorf("failed to determine changed services: %w", err)
 		}
@@ -231,7 +236,7 @@ func (opts *ValidationOptions) ValidatePipelineConfigReferences(ctx context.Cont
 				}
 
 				for _, service := range opts.Topology.Services {
-					if err := handleService(regionLogger, prefix, group, opts.TopologyDir, service, cfg, shouldHandleService); err != nil {
+					if err := handleService(regionLogger, prefix, group, opts.Topology, service, cfg, shouldHandleService); err != nil {
 						return err
 					}
 				}
@@ -241,10 +246,14 @@ func (opts *ValidationOptions) ValidatePipelineConfigReferences(ctx context.Cont
 	return group.Wait()
 }
 
-func handleService(logger logr.Logger, context string, group *errgroup.Group, baseDir string, service topology.Service, cfg configtypes.Configuration, shouldHandleService func(string) bool) error {
+func handleService(logger logr.Logger, context string, group *errgroup.Group, t *topology.CombinedTopology, service topology.Service, cfg configtypes.Configuration, shouldHandleService func(string) bool) error {
 	group.Go(func() error {
 		if !shouldHandleService(service.ServiceGroup) {
 			return nil
+		}
+		baseDir, err := t.GetTopologyDirForServiceGroup(service.ServiceGroup)
+		if err != nil {
+			return fmt.Errorf("%s: %s: failed to get topology dir: %w", context, service.ServiceGroup, err)
 		}
 		pipeline, err := types.NewPipelineFromFile(filepath.Join(baseDir, service.PipelinePath), cfg)
 		if err != nil {
@@ -442,7 +451,7 @@ func handleService(logger logr.Logger, context string, group *errgroup.Group, ba
 		return nil
 	})
 	for _, child := range service.Children {
-		if err := handleService(logger, context, group, baseDir, child, cfg, shouldHandleService); err != nil {
+		if err := handleService(logger, context, group, t, child, cfg, shouldHandleService); err != nil {
 			return err
 		}
 	}
@@ -450,14 +459,16 @@ func handleService(logger logr.Logger, context string, group *errgroup.Group, ba
 }
 
 // DetermineChangedServices uses `git diff` output to try to guess which services have changes in the working tree.
+// It takes a single topology directory and a *topology.Topology. For multi-topology-file support, use
+// DetermineChangedServicesCombined instead.
+//
 // Couple of notes:
 //   - the topology file itself doesn't have to be at the root of the repo
 //   - paths in the topology file are relative to its dir
 //   - `git diff` output is relative to the repo root
 //
-// Therefore, we first compute the relative path from the repo root to the topology file, so that we can prepend it
-// to the pipeline paths and figure out where each pipeline is relative to the root of the repo, so we can detect
-// diffs that touch it.
+// Therefore, we first determine the absolute path of the topology dir and the git root, then compare each
+// service's pipeline directory (as an absolute path) against the set of changed files.
 //
 // Note as well that this approach will only catch diffs that are directly in the pipeline's directory - any shared
 // files or other dependencies that change won't be captured. This approach is meant to be a nice utility and best-
@@ -465,73 +476,145 @@ func handleService(logger logr.Logger, context string, group *errgroup.Group, ba
 //
 // We may choose to improve this algorithm in the future to look for `.bicep` references to paths outside the dir
 // or relative paths in the `pipeline.yaml` itself.
-func DetermineChangedServices(ctx context.Context, centralRemoteUrl, topologyDir string, t *topology.Topology) (sets.Set[string], error) {
-	mergeBase, err := validate.DetermineMergeBase(ctx, topologyDir, centralRemoteUrl)
+func DetermineChangedServices(ctx context.Context, centralRemoteUrl string, topologyDir string, t *topology.Topology) (sets.Set[string], error) {
+	mergeBase, err := validate.DetermineMergeBase(ctx, topologyDir, []string{centralRemoteUrl})
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine merge base: %w", err)
 	}
 
-	// this will be <repo-root-path>/<topology-relative-path>/topology.yaml
+	// this will be <repo-root-path>/<topology-relative-path>
 	topologyDirAbsPath, err := filepath.Abs(topologyDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine absolute path of topology: %w", err)
 	}
 
 	// this will be <repo-root-path>
-	var gitAbsPath string
-	{
-		cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
-		out, err := cmd.Output()
-		if err != nil {
-			return nil, fmt.Errorf("failed to run git rev-parse: %w; output: %s", err, string(out))
-		}
-		gitAbsPath = strings.TrimSpace(string(out))
-	}
-
-	topologyDirRelPath, err := filepath.Rel(gitAbsPath, topologyDirAbsPath)
+	gitAbsPath, err := getGitRoot(ctx, topologyDirAbsPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to determine relative path of topology: %w", err)
+		return nil, fmt.Errorf("failed to get git root: %w", err)
 	}
 
-	// these will be relative to the <repo-root-path>
-	var files []string
-	{
-		cmd := exec.CommandContext(ctx, "git", "diff", "--name-only", fmt.Sprintf("%s..HEAD", mergeBase))
-		out, err := cmd.Output()
-		if err != nil {
-			return nil, fmt.Errorf("failed to run git diff: %w; output: %s", err, string(out))
-		}
-		for _, line := range strings.Split(string(out), "\n") {
-			files = append(files, strings.TrimSpace(line))
-		}
+	// these will be absolute paths
+	files, err := getGitDiff(ctx, gitAbsPath, mergeBase)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get git diff: %w", err)
 	}
 	w := walker{
-		files:              files,
-		topologyDirRelPath: topologyDirRelPath,
-		changed:            sets.New[string](),
+		files: files,
+		getTopoDirForService: func(_ string) (string, error) {
+			return topologyDirAbsPath, nil
+		},
+		changed: sets.New[string](),
 	}
 	for _, service := range t.Services {
-		w.walk(service)
+		if err := w.walk(service); err != nil {
+			return nil, err
+		}
 	}
 	return w.changed, nil
 }
 
-type walker struct {
-	files              []string
-	topologyDirRelPath string
-	changed            sets.Set[string]
-}
-
-func (w *walker) walk(service topology.Service) {
-	for _, child := range service.Children {
-		w.walk(child)
+// DetermineChangedServicesCombined uses `git diff` output to determine which services have changes in the working tree.
+// It accepts a [topology.CombinedTopology], which may aggregate services from multiple topology files across multiple git repositories.
+// For each unique git root derived from the topology files, it resolves a merge base against the provided central remote URLs,
+// collects the set of changed files, and matches them against each service's pipeline directory.
+func DetermineChangedServicesCombined(ctx context.Context, centralRemoteUrls []string, topologyFiles []string, t *topology.CombinedTopology) (sets.Set[string], error) {
+	gitRoots := sets.New[string]()
+	for _, topoFile := range topologyFiles {
+		topoDirAbs, err := filepath.Abs(filepath.Dir(topoFile))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get absolute path of %s: %w", topoFile, err)
+		}
+		gitRoot, err := getGitRoot(ctx, topoDirAbs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to run git rev-parse in %s: %w", topoDirAbs, err)
+		}
+		gitRoots.Insert(gitRoot)
 	}
 
-	serviceDir := filepath.Join(w.topologyDirRelPath, filepath.Dir(service.PipelinePath))
+	var files []string
+	for gitRoot := range gitRoots {
+		mergeBase, err := validate.DetermineMergeBase(ctx, gitRoot, centralRemoteUrls)
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine merge base in %s: %w", gitRoot, err)
+		}
+		rootFiles, err := getGitDiff(ctx, gitRoot, mergeBase)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get git diff in %s: %w", gitRoot, err)
+		}
+		files = append(files, rootFiles...)
+	}
+
+	w := walker{
+		files: files,
+		getTopoDirForService: func(serviceGroup string) (string, error) {
+			topoDir, err := t.GetTopologyDirForServiceGroup(serviceGroup)
+			if err != nil {
+				return "", fmt.Errorf("failed to get topology dir for service %s: %w", serviceGroup, err)
+			}
+			topoDirAbs, err := filepath.Abs(topoDir)
+			if err != nil {
+				return "", fmt.Errorf("failed to get absolute path of topology dir for service %s: %w", serviceGroup, err)
+			}
+			return topoDirAbs, nil
+		},
+		changed: sets.New[string](),
+	}
+	for _, service := range t.Services {
+		if err := w.walk(service); err != nil {
+			return nil, err
+		}
+	}
+	return w.changed, nil
+}
+
+func getGitRoot(ctx context.Context, path string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", path, "rev-parse", "--show-toplevel")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to run git rev-parse in %s: %w", path, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func getGitDiff(ctx context.Context, path string, mergeBase string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", path, "diff", "--name-only", fmt.Sprintf("%s..HEAD", mergeBase))
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run git diff in %s: %w; output: %s", path, err, string(out))
+	}
+	var files []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			files = append(files, filepath.Join(path, line))
+		}
+	}
+	return files, nil
+}
+
+type walker struct {
+	files                []string // absolute paths
+	getTopoDirForService pipeline.TopoDirLookup
+	changed              sets.Set[string]
+}
+
+func (w *walker) walk(service topology.Service) error {
+	for _, child := range service.Children {
+		if err := w.walk(child); err != nil {
+			return err
+		}
+	}
+
+	topoDir, err := w.getTopoDirForService(service.ServiceGroup)
+	if err != nil {
+		return err
+	}
+	serviceDir := filepath.Join(topoDir, filepath.Dir(service.PipelinePath))
 
 	for _, file := range w.files {
 		if strings.HasPrefix(file, serviceDir) {
 			w.changed.Insert(service.ServiceGroup)
 		}
 	}
+	return nil
 }

--- a/tooling/templatize/internal/well_formed_test.go
+++ b/tooling/templatize/internal/well_formed_test.go
@@ -15,12 +15,9 @@
 package internal
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"sigs.k8s.io/yaml"
 
 	"github.com/Azure/ARO-Tools/config"
 	"github.com/Azure/ARO-Tools/config/ev2config"
@@ -62,14 +59,9 @@ func TestStepsWellFormed(t *testing.T) {
 	}
 
 	topologyFile := filepath.Join(repoRootDir, "topology.yaml")
-	rawTopology, err := os.ReadFile(topologyFile)
+	topo, err := topology.LoadCombined([]string{topologyFile})
 	if err != nil {
-		t.Fatalf("failed to read input file %s: %v", topologyFile, err)
-	}
-
-	var topo topology.Topology
-	if err := yaml.Unmarshal(rawTopology, &topo); err != nil {
-		t.Fatalf("failed to unmarshal topology: %v", err)
+		t.Fatalf("failed to load topology from %s: %v", topologyFile, err)
 	}
 
 	if err := topo.Validate(); err != nil {
@@ -84,11 +76,11 @@ func TestStepsWellFormed(t *testing.T) {
 			}
 
 			pipelines := map[string]*types.Pipeline{}
-			if err := entrypointutils.LoadPipelines(service, repoRootDir, pipelines, cfg); err != nil {
+			if err := entrypointutils.LoadPipelines(service, topo, pipelines, cfg); err != nil {
 				t.Fatalf("failed to load pipelines: %v", err)
 			}
 
-			executionGraph, graphConstructionErr := graph.ForEntrypoint(&topo, &entrypoint, pipelines)
+			executionGraph, graphConstructionErr := graph.ForEntrypoint(&topo.Topology, &entrypoint, pipelines)
 			if graphConstructionErr != nil {
 				t.Fatalf("failed to construct graph: %v", graphConstructionErr)
 			}

--- a/tooling/templatize/pkg/pipeline/executiontarget.go
+++ b/tooling/templatize/pkg/pipeline/executiontarget.go
@@ -25,6 +25,7 @@ import (
 )
 
 type SubscriptionLookup func(ctx context.Context, subscriptionName string) (string, error)
+type TopoDirLookup func(serviceGroup string) (string, error)
 
 func LookupSubscriptionID(subscriptions map[string]string) SubscriptionLookup {
 	return func(ctx context.Context, subscriptionName string) (string, error) {

--- a/tooling/templatize/pkg/pipeline/inspect.go
+++ b/tooling/templatize/pkg/pipeline/inspect.go
@@ -47,8 +47,8 @@ type InspectOptions struct {
 	OutputFile     io.Writer
 	Concurrency    int
 
-	Service     *topology.Service
-	TopologyDir string
+	Service           *topology.Service
+	TopoDirLookupFunc TopoDirLookup
 }
 
 func Inspect(p *types.Pipeline, ctx context.Context, options *InspectOptions) error {
@@ -135,7 +135,7 @@ func acquireOutputChainingInputs(ctx context.Context, steps []string, pipeline *
 			Step:                  depStep,
 			SubsciptionLookupFunc: LookupSubscriptionID(subscriptions),
 			Concurrency:           options.Concurrency,
-			TopologyDir:           options.TopologyDir,
+			TopoDirLookupFunc:     options.TopoDirLookupFunc,
 		}
 		outputs, err := RunPipeline(options.Service, pipeline, ctx, runOptions, RunStep)
 		if err != nil {

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -63,8 +63,8 @@ type PipelineRunOptions struct {
 	Stamp                 string
 	SubsciptionLookupFunc SubscriptionLookup
 
-	TopologyDir string
-	Concurrency int
+	TopoDirLookupFunc TopoDirLookup
+	Concurrency       int
 
 	TimingOutputFile string
 	JUnitOutputFile  string
@@ -240,9 +240,17 @@ func RunPipeline(service *topology.Service, pipeline *types.Pipeline, ctx contex
 		return nil, err
 	}
 
+	if options.TopoDirLookupFunc == nil {
+		return nil, errors.New("TopoDirLookupFunc is required in PipelineRunOptions")
+	}
+
 	// Execute build step if defined
 	if pipeline.BuildStep != nil {
-		pipelineDir := filepath.Join(options.TopologyDir, filepath.Dir(service.PipelinePath))
+		topologyDir, err := options.TopoDirLookupFunc(service.ServiceGroup)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get topology dir for %s: %w", service.ServiceGroup, err)
+		}
+		pipelineDir := filepath.Join(topologyDir, filepath.Dir(service.PipelinePath))
 		logger.Info("Running build step.", "serviceGroup", service.ServiceGroup, "directory", pipelineDir)
 		if err := runBuildStep(ctx, *pipeline.BuildStep, service.ServiceGroup, pipelineDir); err != nil {
 			return nil, fmt.Errorf("build step execution failed for %s: %w", service.ServiceGroup, err)
@@ -263,10 +271,14 @@ func RunPipeline(service *topology.Service, pipeline *types.Pipeline, ctx contex
 	return runGraph(ctx, logger, executionGraph, options, executor)
 }
 
-func RunEntrypoint(topo *topology.Topology, entrypoint *topology.Entrypoint, pipelines map[string]*types.Pipeline, ctx context.Context, options *PipelineRunOptions, executor Executor) (Outputs, error) {
+func RunEntrypoint(topo *topology.CombinedTopology, entrypoint *topology.Entrypoint, pipelines map[string]*types.Pipeline, ctx context.Context, options *PipelineRunOptions, executor Executor) (Outputs, error) {
 	logger, err := logr.FromContext(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	if options.TopoDirLookupFunc == nil {
+		return nil, errors.New("TopoDirLookupFunc is required in PipelineRunOptions")
 	}
 
 	// Execute build steps for all pipelines in the service tree
@@ -274,12 +286,12 @@ func RunEntrypoint(topo *topology.Topology, entrypoint *topology.Entrypoint, pip
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup service group %s: %w", entrypoint.Identifier, err)
 	}
-	if err := runBuildStepsForService(ctx, service, options.TopologyDir, pipelines); err != nil {
+	if err := runBuildStepsForService(ctx, service, options.TopoDirLookupFunc, pipelines); err != nil {
 		return nil, err
 	}
 
 	logger.Info("Generating execution graph.")
-	executionGraph, err := graph.ForEntrypoint(topo, entrypoint, pipelines)
+	executionGraph, err := graph.ForEntrypoint(&topo.Topology, entrypoint, pipelines)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate execution graph: %w", err)
 	}
@@ -293,10 +305,14 @@ func RunEntrypoint(topo *topology.Topology, entrypoint *topology.Entrypoint, pip
 }
 
 // runBuildStepsForService recursively executes build steps for all pipelines in the service tree.
-func runBuildStepsForService(ctx context.Context, service *topology.Service, topologyDir string, pipelines map[string]*types.Pipeline) error {
+func runBuildStepsForService(ctx context.Context, service *topology.Service, topoDirLookup TopoDirLookup, pipelines map[string]*types.Pipeline) error {
 	logger := logr.FromContextOrDiscard(ctx)
 	pipe, ok := pipelines[service.ServiceGroup]
 	if ok && pipe.BuildStep != nil {
+		topologyDir, err := topoDirLookup(service.ServiceGroup)
+		if err != nil {
+			return fmt.Errorf("failed to get topology dir for service group %s: %w", service.ServiceGroup, err)
+		}
 		pipelineDir := filepath.Join(topologyDir, filepath.Dir(service.PipelinePath))
 		logger.Info("Running build step.", "serviceGroup", service.ServiceGroup, "directory", pipelineDir)
 		if err := runBuildStep(ctx, *pipe.BuildStep, service.ServiceGroup, pipelineDir); err != nil {
@@ -305,7 +321,7 @@ func runBuildStepsForService(ctx context.Context, service *topology.Service, top
 	}
 
 	for _, child := range service.Children {
-		if err := runBuildStepsForService(ctx, &child, topologyDir, pipelines); err != nil {
+		if err := runBuildStepsForService(ctx, &child, topoDirLookup, pipelines); err != nil {
 			return err
 		}
 	}
@@ -675,10 +691,16 @@ func executeNode(logger logr.Logger, executor Executor, graphCtx *graph.Graph, n
 		output = nil
 		stepRunErr = nil
 	} else {
+		var pipelineDirectory string
+		topoDir, err := options.TopoDirLookupFunc(node.ServiceGroup)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to get topology dir for %s: %w", node.ServiceGroup, err)
+		}
+		pipelineDirectory = filepath.Join(topoDir, filepath.Dir(graphCtx.Services[node.ServiceGroup].PipelinePath))
 		for shouldExecuteStep(step, runCount) {
 			output, details, stepRunErr = executor(node, step, logr.NewContext(ctx, logger), target, &StepRunOptions{
 				BaseRunOptions:    options.BaseRunOptions,
-				PipelineDirectory: filepath.Join(options.TopologyDir, filepath.Dir(graphCtx.Services[node.ServiceGroup].PipelinePath)),
+				PipelineDirectory: pipelineDirectory,
 				RetryAttempt:      runCount,
 				Environment:       options.Environment,
 				Stamp:             options.Stamp,

--- a/tooling/templatize/pkg/pipeline/run_test.go
+++ b/tooling/templatize/pkg/pipeline/run_test.go
@@ -150,6 +150,9 @@ func TestMockedPipelineRun(t *testing.T) {
 		SubsciptionLookupFunc: func(_ context.Context, _ string) (string, error) {
 			return "test", nil
 		},
+		TopoDirLookupFunc: func(_ string) (string, error) {
+			return ".", nil
+		},
 	}, executor); err != nil {
 		t.Error(err)
 	}
@@ -305,6 +308,9 @@ func TestMockedPipelineRunError(t *testing.T) {
 		SubsciptionLookupFunc: func(_ context.Context, _ string) (string, error) {
 			return "test", nil
 		},
+		TopoDirLookupFunc: func(_ string) (string, error) {
+			return ".", nil
+		},
 	}, executor); err == nil {
 		t.Errorf("expected an error, got none")
 	}
@@ -369,6 +375,9 @@ func TestPipelineRun(t *testing.T) {
 		Stamp:       "1",
 		SubsciptionLookupFunc: func(_ context.Context, _ string) (string, error) {
 			return "test", nil
+		},
+		TopoDirLookupFunc: func(_ string) (string, error) {
+			return ".", nil
 		},
 	}, RunStep)
 


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Allow pipeline runs that reference multiple topologies

### Why

Allows us to combine the topologies in here and in sdp-pipelines into real global entrypoint.

### Testing

- Tested pipeline runs locally that reference ARO-HCP/topology.yaml and sdp-pipelines/hcp/topology.yaml
- Confirmed that git diffing for changes to services works by running locally
- pointed my local sdp-pipelines at this version to confirm it still builds and `make validate` still runs correctly

### Special notes for your reviewer

<!-- optional -->
