### PR TITLE
Fix warm-loop updates

### DIFF
--- a/backend/pkg/controllers/controllerutils/needs_update.go
+++ b/backend/pkg/controllers/controllerutils/needs_update.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerutils
+
+import (
+	"bytes"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+// needsUpdateEqualities is a copy of equality.Semantic with extra equality functions for types
+// that have multiple Go-level representations of the same persisted value, plus a CosmosMetadata
+// equality that ignores the cosmos-managed CosmosETag and the in-memory-only ExistingCosmosUID.
+//
+// We need our own copy because equality.Semantic.DeepEqual sees two documents as different when:
+//   - CosmosMetadata.CosmosETag is server-assigned on every write, so existing has a value and
+//     desired typically does not (or has a different one).
+//   - CosmosMetadata.ExistingCosmosUID is `json:"-"` and is filled in by the read conversion on
+//     existing but is empty on a freshly-built desired.
+//   - runtime.RawExtension can be carrying its data in either Raw or Object - reads populate Raw,
+//     freshly-built desired values populate Object.
+//   - *azcorearm.ResourceID has a parent pointer chain whose addresses differ between two
+//     independently-parsed instances even though the represented ARM IDs are equal.
+var needsUpdateEqualities = func() conversion.Equalities {
+	e := equality.Semantic.Copy()
+	if err := e.AddFuncs(
+		// arm.CosmosMetadata: only compare ResourceID. CosmosETag is server-assigned and
+		// ExistingCosmosUID is an in-memory bridge.
+		func(a, b arm.CosmosMetadata) bool {
+			return resourceIDStringsEqual(a.ResourceID, b.ResourceID)
+		},
+		// *azcorearm.ResourceID: compare by string so unrelated parent pointer chains don't
+		// cause spurious inequality.
+		func(a, b *azcorearm.ResourceID) bool {
+			return resourceIDStringsEqual(a, b)
+		},
+		// azcorearm.ResourceID (value): same reason as the pointer form.
+		func(a, b azcorearm.ResourceID) bool {
+			return a.String() == b.String()
+		},
+		// runtime.RawExtension: compare via canonical JSON. RawExtension can carry data either as
+		// Raw bytes or as a typed Object; both forms need to round-trip to the same JSON for our
+		// purposes.
+		func(a, b runtime.RawExtension) bool {
+			aBytes, err := a.MarshalJSON()
+			if err != nil {
+				return false
+			}
+			bBytes, err := b.MarshalJSON()
+			if err != nil {
+				return false
+			}
+			return bytes.Equal(aBytes, bBytes)
+		},
+	); err != nil {
+		panic(err)
+	}
+	return e
+}()
+
+func resourceIDStringsEqual(a, b *azcorearm.ResourceID) bool {
+	var aStr, bStr string
+	if a != nil {
+		aStr = a.String()
+	}
+	if b != nil {
+		bStr = b.String()
+	}
+	return aStr == bStr
+}
+
+// NeedsUpdate reports whether `desired` differs from `existing` in any way that should cause us to
+// write `desired` back to Cosmos. It is a strict-but-server-managed-fields-aware semantic equality
+// check: all the fields that actually persist must match, but cosmos-managed values like the
+// document etag are ignored, as are Go-level representation differences (RawExtension Raw vs
+// Object, parent pointer chains in ResourceID, etc.).
+func NeedsUpdate(existing, desired any) bool {
+	return !needsUpdateEqualities.DeepEqual(existing, desired)
+}

--- a/backend/pkg/controllers/controllerutils/needs_update_test.go
+++ b/backend/pkg/controllers/controllerutils/needs_update_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerutils
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+func mustParseRID(t *testing.T, s string) *azcorearm.ResourceID {
+	t.Helper()
+	rid, err := azcorearm.ParseResourceID(s)
+	require.NoError(t, err)
+	return rid
+}
+
+func TestNeedsUpdate_CosmosMetadata_IgnoresEtag(t *testing.T) {
+	ridStr := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/c"
+	a := arm.CosmosMetadata{
+		ResourceID: mustParseRID(t, ridStr),
+		CosmosETag: azcore.ETag("etag-1"),
+	}
+	b := arm.CosmosMetadata{
+		ResourceID: mustParseRID(t, ridStr),
+		CosmosETag: azcore.ETag("etag-2"),
+	}
+	assert.False(t, NeedsUpdate(a, b), "differing etags should not trigger an update")
+}
+
+func TestNeedsUpdate_CosmosMetadata_IgnoresExistingCosmosUID(t *testing.T) {
+	ridStr := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/c"
+	a := arm.CosmosMetadata{
+		ResourceID:        mustParseRID(t, ridStr),
+		ExistingCosmosUID: "uid-from-cosmos",
+	}
+	b := arm.CosmosMetadata{
+		ResourceID: mustParseRID(t, ridStr),
+		// freshly built desired - no UID yet
+	}
+	assert.False(t, NeedsUpdate(a, b), "ExistingCosmosUID is internal-only and must not trigger an update")
+}
+
+func TestNeedsUpdate_CosmosMetadata_DetectsResourceIDDifference(t *testing.T) {
+	a := arm.CosmosMetadata{
+		ResourceID: mustParseRID(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/a"),
+	}
+	b := arm.CosmosMetadata{
+		ResourceID: mustParseRID(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/b"),
+	}
+	assert.True(t, NeedsUpdate(a, b), "different ResourceIDs must trigger an update")
+}
+
+func TestNeedsUpdate_ResourceID_ComparedByString(t *testing.T) {
+	// Two independently-parsed ResourceIDs share string form but have different parent pointer
+	// chains. equality.Semantic would report them as different; NeedsUpdate must not.
+	ridStr := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/c"
+	a := mustParseRID(t, ridStr)
+	b := mustParseRID(t, ridStr)
+	assert.NotSame(t, a, b, "test fixture: instances should be distinct pointers")
+	assert.False(t, NeedsUpdate(a, b), "ResourceIDs with the same string form should not trigger an update")
+}
+
+func TestNeedsUpdate_RawExtension_NormalizesRawAndObject(t *testing.T) {
+	// runtime.RawExtension can carry data either in Raw bytes or as a typed Object. Both forms
+	// produce identical persisted JSON, so they must compare equal for our purposes.
+	hc := map[string]any{
+		"apiVersion": "hypershift.openshift.io/v1beta1",
+		"kind":       "HostedCluster",
+		"metadata":   map[string]any{"name": "hc1", "namespace": "ns1"},
+	}
+	rawBytes, err := json.Marshal(hc)
+	require.NoError(t, err)
+
+	rawForm := runtime.RawExtension{Raw: rawBytes}
+	objForm := runtime.RawExtension{Object: &unstructured.Unstructured{Object: hc}}
+
+	assert.False(t, NeedsUpdate(rawForm, objForm), "Raw and Object forms with the same content must be equal")
+}
+
+func TestNeedsUpdate_ManagementClusterContent_RoundTripUnchanged(t *testing.T) {
+	// End-to-end check: a ManagementClusterContent built fresh and then marshalled+unmarshalled
+	// (the path through cosmos read) must compare as not needing an update.
+	rid := mustParseRID(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/c/managementClusterContents/readonlyHypershiftHostedCluster")
+	desired := &api.ManagementClusterContent{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: rid},
+		ResourceID:     *rid,
+		Status: api.ManagementClusterContentStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:    "Degraded",
+					Status:  metav1.ConditionFalse,
+					Reason:  "NoErrors",
+					Message: "As expected.",
+				},
+			},
+			KubeContent: &metav1.List{
+				Items: []runtime.RawExtension{
+					{Object: &unstructured.Unstructured{Object: map[string]any{
+						"apiVersion": "hypershift.openshift.io/v1beta1",
+						"kind":       "HostedCluster",
+						"metadata":   map[string]any{"name": "hc1"},
+					}}},
+				},
+			},
+		},
+	}
+
+	// Round-trip through JSON to mimic the read path which fills RawExtension.Raw and assigns a
+	// new etag/UID.
+	bytes, err := json.Marshal(desired)
+	require.NoError(t, err)
+	roundTripped := &api.ManagementClusterContent{}
+	require.NoError(t, json.Unmarshal(bytes, roundTripped))
+	roundTripped.CosmosETag = azcore.ETag("server-assigned-etag")
+	roundTripped.ExistingCosmosUID = "server-assigned-uid"
+
+	assert.False(t, NeedsUpdate(roundTripped, desired), "round-tripped existing should compare equal to a freshly-built desired")
+}

--- a/backend/pkg/controllers/maestro_readonly_bundle_helpers.go
+++ b/backend/pkg/controllers/maestro_readonly_bundle_helpers.go
@@ -20,7 +20,6 @@ import (
 
 	workv1 "open-cluster-management.io/api/work/v1"
 
-	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -322,7 +321,7 @@ func readAndPersistMaestroReadonlyBundleContent(
 	}
 	desired.Status.Conditions = mergedConditions
 
-	if equality.Semantic.DeepEqual(existing, desired) {
+	if !controllerutils.NeedsUpdate(existing, desired) {
 		return nil
 	}
 

--- a/backend/pkg/controllers/maestro_readonly_bundle_helpers_test.go
+++ b/backend/pkg/controllers/maestro_readonly_bundle_helpers_test.go
@@ -242,6 +242,27 @@ func TestMaestroReadonlyBundleHelpers_getSingleResourceStatusFeedbackRawJSONFrom
 	}
 }
 
+// callCountingMCCCRUD wraps ManagementClusterContentCRUD to count calls to Replace and Create
+// so tests can assert that no unnecessary writes happen when the desired and existing documents
+// match.
+type callCountingMCCCRUD struct {
+	database.ManagementClusterContentCRUD
+	replaceCount int
+	createCount  int
+}
+
+func (c *callCountingMCCCRUD) Replace(ctx context.Context, obj *api.ManagementClusterContent, opts *azcosmos.ItemOptions) (*api.ManagementClusterContent, error) {
+	c.replaceCount++
+	return c.ManagementClusterContentCRUD.Replace(ctx, obj, opts)
+}
+
+func (c *callCountingMCCCRUD) Create(ctx context.Context, obj *api.ManagementClusterContent, opts *azcosmos.ItemOptions) (*api.ManagementClusterContent, error) {
+	c.createCount++
+	return c.ManagementClusterContentCRUD.Create(ctx, obj, opts)
+}
+
+var _ database.ManagementClusterContentCRUD = &callCountingMCCCRUD{}
+
 // errorInjectingMCCCRUD wraps ManagementClusterContentCRUD to allow error injection for testing.
 type errorInjectingMCCCRUD struct {
 	database.ManagementClusterContentCRUD
@@ -544,6 +565,38 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		require.NoError(t, err)
 		require.NotNil(t, got.Status.KubeContent)
 		require.Len(t, got.Status.KubeContent.Items, 1)
+	})
+
+	t.Run("Replace is not called when desired matches existing", func(t *testing.T) {
+		// Regression test: when readAndPersistMaestroReadonlyBundleContent is invoked repeatedly
+		// against unchanged content, it should not write to Cosmos. Previously the equality check
+		// compared `existing` (which has CosmosMetadata.ExistingCosmosUID populated by the read
+		// conversion) with a freshly-built `desired` (where ExistingCosmosUID is empty). Because
+		// equality.Semantic.DeepEqual sees those struct fields differ, Replace was called every
+		// iteration even when the document content was identical, generating churn (new etag /
+		// timestamp on each write).
+		ctrl := gomock.NewController(t)
+		mockMaestro := maestro.NewMockClient(ctrl)
+		b := buildTestMaestroBundleWithStatusFeedback("bundle-name", "ns", validHCJSON)
+		// Get is called once when building desired for pre-create, and once inside readAndPersistMaestroReadonlyBundleContent.
+		mockMaestro.EXPECT().Get(gomock.Any(), "bundle-name", gomock.Any()).Return(b, nil).Times(2)
+
+		mockDB := databasetesting.NewMockDBClient()
+		baseMCCCRUD := mockDB.HCPClusters("sub", "rg").ManagementClusterContents("cluster")
+		desired, err := calculateManagementClusterContentFromMaestroBundle(ctx, cluster.ID, ref, mockMaestro)
+		require.NoError(t, err)
+		require.NotNil(t, desired)
+		// Pre-create the same content via the underlying CRUD (so the counter wrapper isn't
+		// charged for setup work).
+		_, err = baseMCCCRUD.Create(ctx, desired, nil)
+		require.NoError(t, err)
+
+		counter := &callCountingMCCCRUD{ManagementClusterContentCRUD: baseMCCCRUD}
+		err = readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, counter)
+		require.NoError(t, err)
+
+		assert.Equal(t, 0, counter.replaceCount, "expected no Replace calls when desired matches existing; CosmosMetadata.ExistingCosmosUID populated by the read conversion is not copied to desired and trips equality.Semantic.DeepEqual")
+		assert.Equal(t, 0, counter.createCount, "Create should not be called when the document already exists")
 	})
 
 	t.Run("error occurs when object has been modified in Cosmos since we retrieved it", func(t *testing.T) {

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -106,8 +105,13 @@ func (c *controlPlaneActiveVersionSyncer) SyncOnce(ctx context.Context, key cont
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
 	}
+	// Use NeedsUpdate (semantic equality) instead of slices.Equal: HCPClusterActiveVersion holds
+	// *semver.Version, and Go's `==` (which slices.Equal relies on) compares those pointers, not
+	// the represented version. Two independent reads/parses of the same version produce different
+	// pointer addresses, which previously caused a Replace on every reconciliation cycle even
+	// when the active versions were semantically identical.
 	oldActiveVersions := existingServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions
-	if slices.Equal(oldActiveVersions, newActiveVersions) {
+	if !controllerutils.NeedsUpdate(oldActiveVersions, newActiveVersions) {
 		return nil
 	}
 	logger := utils.LoggerFromContext(ctx)

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller_test.go
@@ -238,6 +238,42 @@ func TestControlPlaneActiveVersionSyncer_SyncOnce(t *testing.T) {
 	}
 }
 
+// TestControlPlaneActiveVersionSyncer_NoReplaceWhenVersionsUnchanged is a regression test for
+// unnecessary writes against ServiceProviderClusters/default. The previous comparison used
+// slices.Equal on []HCPClusterActiveVersion, where each element holds a *semver.Version. Two
+// independently-parsed semver pointers compare unequal under Go's `==` even when the represented
+// versions are identical, so every reconciliation produced a Replace whose only effect was a new
+// _etag / _ts / properties.cosmosMetadata.etag.
+func TestControlPlaneActiveVersionSyncer_NoReplaceWhenVersionsUnchanged(t *testing.T) {
+	runCtx := utils.ContextWithLogger(context.Background(), logr.Discard())
+	mockDB := databasetesting.NewMockDBClient()
+
+	createTestHCPCluster(t, runCtx, mockDB)
+	createServiceProviderClusterWithVersion(t, runCtx, mockDB, "4.19.15")
+	createManagementClusterContentWithHostedClusterHistory(t, runCtx, mockDB, []configv1.UpdateHistory{
+		{Version: "4.19.15", State: configv1.CompletedUpdate},
+	})
+
+	spcCRUD := mockDB.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName)
+	before, err := spcCRUD.Get(runCtx, api.ServiceProviderClusterResourceName)
+	require.NoError(t, err)
+	beforeETag := before.CosmosETag
+
+	syncer := &controlPlaneActiveVersionSyncer{
+		cooldownChecker: &alwaysSyncCooldownChecker{},
+		cosmosClient:    mockDB,
+	}
+	require.NoError(t, syncer.SyncOnce(runCtx, controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}))
+
+	after, err := spcCRUD.Get(runCtx, api.ServiceProviderClusterResourceName)
+	require.NoError(t, err)
+	assert.Equal(t, beforeETag, after.CosmosETag, "ServiceProviderCluster.CosmosETag changed despite identical ActiveVersions; the syncer wrote unnecessarily")
+}
+
 // createTestHCPCluster creates an HCP cluster in the mock database (no node pools).
 // Used as the parent resource for control plane active version sync.
 func createTestHCPCluster(t *testing.T, ctx context.Context, mockDB *databasetesting.MockDBClient) {


### PR DESCRIPTION
Found a datadump with many entries for
    
        UPDATED:
          _ts: 1.777650056e+09
          properties.cosmosMetadata.etag: "\"0c002e6a-0000-4d00-0000-69f4c97d0000\""
          _etag: "\"0c00ef6a-0000-4d00-0000-69f4c9880000\""
    
This fixes them
