### PR TITLE
deps: bump @azure-tools/typespec-client-generator-core to 0.67.4

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,7 +9,7 @@
         "@azure-tools/typespec-azure-core": "^0.67.1",
         "@azure-tools/typespec-azure-resource-manager": "^0.67.1",
         "@azure-tools/typespec-azure-rulesets": "0.67.0",
-        "@azure-tools/typespec-client-generator-core": "^0.67.3",
+        "@azure-tools/typespec-client-generator-core": "^0.67.4",
         "@typespec/http": "~1.11.0",
         "@typespec/openapi": "~1.11.0",
         "@typespec/openapi3": "~1.11.0",
@@ -234,9 +234,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.67.3",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.67.3.tgz",
-      "integrity": "sha512-hK+1juRH2kWPCVfqsVYKFw8RbhLJY4ioh6OTZA4JmPXwQ4zz0/nsaGHG6K+tZ9D7yRyYd06GNxJoAbWabFfDYA==",
+      "version": "0.67.4",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.67.4.tgz",
+      "integrity": "sha512-Q9mlU5wZzPCFtdwVKKgqb6Nw4PM0taOeRsr7Aj9WkRYx7n9B8Y+ITtMLYaJWd3OQVkpZoiFOgq+0ZnrcC3IjCw==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -248,14 +248,14 @@
       },
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": "^0.67.1",
-        "@typespec/compiler": "~1.11.0",
+        "@typespec/compiler": "^1.11.0",
         "@typespec/events": "^0.81.0",
-        "@typespec/http": "~1.11.0",
-        "@typespec/openapi": "~1.11.0",
-        "@typespec/rest": "~0.81.0",
+        "@typespec/http": "^1.11.0",
+        "@typespec/openapi": "^1.11.0",
+        "@typespec/rest": "^0.81.0",
         "@typespec/sse": "^0.81.0",
         "@typespec/streams": "^0.81.0",
-        "@typespec/versioning": "~0.81.0",
+        "@typespec/versioning": "^0.81.0",
         "@typespec/xml": "^0.81.0"
       }
     },

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
     "@azure-tools/typespec-azure-core": "^0.67.1",
     "@azure-tools/typespec-azure-resource-manager": "^0.67.1",
     "@azure-tools/typespec-azure-rulesets": "0.67.0",
-    "@azure-tools/typespec-client-generator-core": "^0.67.3",
+    "@azure-tools/typespec-client-generator-core": "^0.67.4",
     "@typespec/http": "~1.11.0",
     "@typespec/openapi": "~1.11.0",
     "@typespec/openapi3": "~1.11.0",
@@ -23,9 +23,9 @@
     "testsdk": "autorest testsdk.md --verbose --tag=${VERSION}"
   },
   "devDependencies": {
-    "@typespec/compiler": "~1.11.0",
     "@microsoft.azure/openapi-validator": "2.2.4",
     "@microsoft.azure/openapi-validator-rulesets": "2.2.6",
+    "@typespec/compiler": "~1.11.0",
     "autorest": "^3.7.2"
   },
   "overrides": {


### PR DESCRIPTION
[AROSLSRE-762](https://redhat.atlassian.net/browse/AROSLSRE-762)

### What

Bump `@azure-tools/typespec-client-generator-core` from `0.67.3` to `0.67.4` in `/api` (typespec group).

### Why

Dependency update.

### Testing

- [x] `npm install` passes

Closes #5098