### PR TITLE
deps: bump github/codeql-action to v4.35.3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,15 +36,15 @@ jobs:
         cache-dependency-path: '**/go.sum'
     # Initializes the CodeQL tools for scanning
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+      uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
       with:
         languages: ${{ matrix.language }}
         # Use default CodeQL query packs
         # For custom queries, add: queries: security-and-quality
     # Autobuild attempts to build any compiled languages (Go, C/C++, C#, Java, etc.)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+      uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+      uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
[AROSLSRE-763](https://redhat.atlassian.net/browse/AROSLSRE-763)

### What

Bump `github/codeql-action` from `v4.35.2` to `v4.35.3`.

### Why

Dependency update.

### Testing

- [x] No code changes, GH Actions workflow only

Closes #5097