### PR TITLE
Upgrade to AKS 1.35

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -412,7 +412,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.34.4
+      kubernetesVersion: 1.35.1
       networkDataplane: "cilium"
       networkPolicy: "cilium"
       systemAgentPool:
@@ -536,7 +536,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.34.4
+      kubernetesVersion: 1.35.1
       networkDataplane: "azure"
       networkPolicy: "azure"
       etcd:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -546,7 +546,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.34.4
+    kubernetesVersion: 1.35.1
     name: cspr-westus3-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -845,7 +845,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.34.4
+    kubernetesVersion: 1.35.1
     name: cspr-westus3-svc-1
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -546,7 +546,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.34.4
+    kubernetesVersion: 1.35.1
     name: dev-westus3-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -845,7 +845,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.34.4
+    kubernetesVersion: 1.35.1
     name: dev-westus3-svc-1
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -546,7 +546,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.34.4
+    kubernetesVersion: 1.35.1
     name: perf-usw3ptest-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -845,7 +845,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.34.4
+    kubernetesVersion: 1.35.1
     name: perf-usw3ptest-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -546,7 +546,7 @@ mgmt:
       vmSize: Standard_D4s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.34.4
+    kubernetesVersion: 1.35.1
     name: pers-usw3test-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -847,7 +847,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.34.4
+    kubernetesVersion: 1.35.1
     name: pers-usw3test-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -546,7 +546,7 @@ mgmt:
       vmSize: Standard_D4ds_v5
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.34.4
+    kubernetesVersion: 1.35.1
     name: prow-j7654321-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -847,7 +847,7 @@ svc:
       vmSize: Standard_D4ds_v5
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.34.4
+    kubernetesVersion: 1.35.1
     name: prow-j7654321-svc
     networkDataplane: cilium
     networkPolicy: cilium


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Upgrade to AKS version 1.35

### Why

To reduce the gap to HyperShift - who test on 1.35

### Testing

- taken care of by the e2e tests

### Special notes for your reviewer

<!-- optional -->
