### PR TITLE
backend: delete orphaned CosmosDB records by raw ID

### DIFF
--- a/backend/pkg/controllers/mismatchcontrollers/delete_orphaned_cosmos.go
+++ b/backend/pkg/controllers/mismatchcontrollers/delete_orphaned_cosmos.go
@@ -28,8 +28,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 
-	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -87,9 +85,20 @@ func (c *deleteOrphanedCosmosResources) synchronizeSubscription(ctx context.Cont
 
 	errs := []error{}
 	// while the number of items is large, but we can paginate through
-	allSubscriptionResourceIDs := map[string]*azcorearm.ResourceID{}
+	allSubscriptionResourceIDs := map[string]*database.TypedDocument{}
 	for _, subscriptionResource := range subscriptionResourceIterator.Items(ctx) {
-		allSubscriptionResourceIDs[strings.ToLower(subscriptionResource.ResourceID.String())] = subscriptionResource.ResourceID
+		if subscriptionResource.ResourceID == nil {
+			// n.b. our listers pass all data through a Cosmos -> internal representation mapping, which attempts to ensure
+			// that document.resourceID is a comprehensible value - however:
+			// - first, if/when we retire that, we don't want this controller to panic and blow up if we encounter a record where
+			//   that has not happened, and we need to make sure that errant values are visible through logs
+			// - during the migration period when records in the database exist with old pipe-delimited identifiers, or during any future
+			//   migrations, we need to be deleting from cosmos with the raw partition and document ID
+			localLogger := logger.WithValues(utils.LogValues{}.AddCosmosResourceID(subscriptionResource.CosmosResourceID))
+			localLogger.Error(errors.New("cosmos document has no resource ID"), "found invalid document")
+			continue
+		}
+		allSubscriptionResourceIDs[strings.ToLower(subscriptionResource.ResourceID.String())] = subscriptionResource
 	}
 	if err := subscriptionResourceIterator.GetError(); err != nil {
 		return utils.TrackError(err)
@@ -110,16 +119,16 @@ func (c *deleteOrphanedCosmosResources) synchronizeSubscription(ctx context.Cont
 	// at this point we have every resourceID under the subscription that is under a resourcegroup
 	resourceGroupPrefix := subscriptionResourceID.String() + "/resourcegroups/"
 	for _, currResourceIDString := range resourceIDStrings {
-		currResourceID := allSubscriptionResourceIDs[currResourceIDString]
+		currResource := allSubscriptionResourceIDs[currResourceIDString]
 		switch {
-		case strings.EqualFold(currResourceID.ResourceType.String(), api.ClusterResourceType.String()):
+		case strings.EqualFold(currResource.ResourceID.ResourceType.String(), api.ClusterResourceType.String()):
 			// clusters have an owning cluster by definition (themselves)
 			continue
 		case !strings.HasPrefix(strings.ToLower(currResourceIDString), strings.ToLower(resourceGroupPrefix)):
 			// skip anything outside a resourcegroup (operations for instance).  These have TTLs and logically need to live past clusters.
 			// For instance, a DNSReservation must exist for a week after the cluster using it is gone to avoid unexpected reuse.
 			continue
-		case !strings.EqualFold(currResourceID.ResourceType.Namespace, api.ProviderNamespace):
+		case !strings.EqualFold(currResource.ResourceID.ResourceType.Namespace, api.ProviderNamespace):
 			// any resources outside our namespace we shouldn't delete. Subscriptions exist outside our namespace for instance.
 			continue
 		}
@@ -127,20 +136,20 @@ func (c *deleteOrphanedCosmosResources) synchronizeSubscription(ctx context.Cont
 		localLogger := logger.WithValues(
 			utils.LogValues{}.
 				AddCosmosResourceID(currResourceIDString).
-				AddLogValuesForResourceID(currResourceID)...)
+				AddLogValuesForResourceID(currResource.ResourceID)...)
 		ctxWithLocalLogger := utils.ContextWithLogger(ctx, localLogger) // setting so that other calls down the chain will show correctly in kusto for the delete
 
-		if currResourceID.Parent == nil {
+		if currResource.ResourceID.Parent == nil {
 			// this is an unexpected state, so we'll log it and hope it is rare.
 			localLogger.Error(nil, "cosmos resource has no parent", "cosmosResourceID", currResourceIDString)
 			continue
 		}
-		_, parentExists := allSubscriptionResourceIDs[strings.ToLower(currResourceID.Parent.String())]
+		_, parentExists := allSubscriptionResourceIDs[strings.ToLower(currResource.ResourceID.Parent.String())]
 		if !parentExists {
-			localLogger.Info("deleting orphaned cosmos resource")
-			if err := untypedSubscriptionCRUD.Delete(ctxWithLocalLogger, currResourceID); err != nil {
-				localLogger.Error(err, "unable to delete orphaned cosmos resource") // logged here so we a log line with a filterable context.
-				errs = append(errs, utils.TrackError(fmt.Errorf("unable to delete %v in %v: %w", currResourceIDString, currResourceID.Parent.String(), err)))
+			localLogger.Info("deleting orphaned cosmos resource by cosmos ID")
+			if err := untypedSubscriptionCRUD.DeleteByCosmosID(ctxWithLocalLogger, currResource.PartitionKey, currResource.ID); err != nil {
+				localLogger.Error(err, "unable to delete orphaned cosmos resource") // logged here so we emit a log line with a filterable context.
+				errs = append(errs, utils.TrackError(fmt.Errorf("unable to delete %v in %v: %w", currResourceIDString, currResource.ResourceID.Parent.String(), err)))
 			}
 		}
 	}

--- a/internal/databasetesting/mock_crud.go
+++ b/internal/databasetesting/mock_crud.go
@@ -762,7 +762,7 @@ func (m *mockUntypedCRUD) listInternal(ctx context.Context, opts *database.DBCli
 			continue
 		}
 
-		if !strings.HasPrefix(strings.ToLower(typedDoc.ResourceID.String()), strings.ToLower(prefix)) {
+		if typedDoc.ResourceID != nil && !strings.HasPrefix(strings.ToLower(typedDoc.ResourceID.String()), strings.ToLower(prefix)) {
 			continue
 		}
 

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/pipe_style_ids_deleted/00-load-initial-state/controller.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/pipe_style_ids_deleted/00-load-initial-state/controller.json
@@ -1,0 +1,29 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"4a0036e3-0000-1100-0000-69f35f960000\"",
+	"_rid": "vr4qAP3+YBM3FAQAAAAAAA==",
+	"_self": "dbs/vr4qAA==/colls/vr4qAP3+YBM=/docs/vr4qAP3+YBM3FAQAAAAAAA==/",
+	"_ts": 1777557398,
+	"id": "718f75e1-6967-5ce1-ab3c-4f991504b7eb",
+	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
+	"properties": {
+		"cosmosMetadata": {
+			"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/microsoft.redhatopenshift/hcpopenshiftclusters/monstrousPrecinct/hcpOpenShiftControllers/CreateBillingDoc"
+		},
+		"externalId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/microsoft.redhatopenshift/hcpopenshiftclusters/monstrousPrecinct",
+		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/microsoft.redhatopenshift/hcpopenshiftclusters/monstrousPrecinct/hcpOpenShiftControllers/CreateBillingDoc",
+		"status": {
+			"conditions": [
+				{
+					"lastTransitionTime": "2026-04-30T13:56:38Z",
+					"message": "As expected.",
+					"reason": "NoErrors",
+					"status": "False",
+					"type": "Degraded"
+				}
+			]
+		}
+	},
+	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/microsoft.redhatopenshift/hcpopenshiftclusters/monstrousPrecinct/hcpOpenShiftControllers/CreateBillingDoc",
+	"resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters/hcpOpenShiftControllers"
+}

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/pipe_style_ids_deleted/00-load-initial-state/serviceprovidercluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/pipe_style_ids_deleted/00-load-initial-state/serviceprovidercluster.json
@@ -1,0 +1,25 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"a503428e-0000-1100-0000-69807fa40000\"",
+	"_rid": "vr4qAP3+YBNMBQEAAAAAAA==",
+	"_self": "dbs/vr4qAA==/colls/vr4qAP3+YBM=/docs/vr4qAP3+YBNMBQEAAAAAAA==/",
+	"_ts": 1770028964,
+	"id": "|subscriptions|a433a095-1277-44f1-8453-8d61a4d848c2|resourcegroups|unimportantPostponement|providers|microsoft.redhatopenshift|hcpopenshiftclusters|monstrousPrecinct|serviceproviderclusters|default",
+	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
+	"properties": {
+		"cosmosMetadata": {
+			"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct/serviceProviderClusters/default"
+		},
+		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct/serviceProviderClusters/default",
+		"validations": [
+			{
+				"lastTransitionTime": "2026-02-02T10:42:44.390858444Z",
+				"message": "Validation succeeded",
+				"reason": "Succeeded",
+				"status": "True",
+				"type": "AlwaysSuccessValidation"
+			}
+		]
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/serviceProviderClusters"
+}

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/pipe_style_ids_deleted/00-load-initial-state/subscription.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/pipe_style_ids_deleted/00-load-initial-state/subscription.json
@@ -1,0 +1,35 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"f100ce4d-0000-1100-0000-69f87b380000\"",
+	"_rid": "vr4qAP3+YBMVQQEAAAAAAA==",
+	"_self": "dbs/vr4qAA==/colls/vr4qAP3+YBM=/docs/vr4qAP3+YBMVQQEAAAAAAA==/",
+	"_ts": 1777892152,
+	"id": "b1e87a41-1eeb-51ba-8155-cd118688d9d2",
+	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
+	"properties": {
+		"cosmosMetadata": {
+			"etag": "\"f100af4d-0000-1100-0000-69f87b380000\"",
+			"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2"
+		},
+		"properties": {
+			"registeredFeatures": [
+				{
+					"name": "Microsoft.RedHatOpenShift/HcpPrivatePreview",
+					"state": "Registered"
+				},
+				{
+					"name": "Microsoft.RedHatOpenShift/PreconfiguredNSG",
+					"state": "Registered"
+				},
+				{
+					"name": "Microsoft.RedHatOpenShift/ExperimentalReleaseFeatures",
+					"state": "Registered"
+				}
+			]
+		},
+		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2",
+		"state": "Registered"
+	},
+	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2",
+	"resourceType": "Microsoft.Resources/subscriptions"
+}

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/pipe_style_ids_deleted/99-cosmosCompare-end-state/subscription.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/pipe_style_ids_deleted/99-cosmosCompare-end-state/subscription.json
@@ -1,0 +1,35 @@
+{
+	"_attachments": "attachments/",
+	"_etag": "\"f100ce4d-0000-1100-0000-69f87b380000\"",
+	"_rid": "vr4qAP3+YBMVQQEAAAAAAA==",
+	"_self": "dbs/vr4qAA==/colls/vr4qAP3+YBM=/docs/vr4qAP3+YBMVQQEAAAAAAA==/",
+	"_ts": 1777892152,
+	"id": "b1e87a41-1eeb-51ba-8155-cd118688d9d2",
+	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
+	"properties": {
+		"cosmosMetadata": {
+			"etag": "\"f100af4d-0000-1100-0000-69f87b380000\"",
+			"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2"
+		},
+		"properties": {
+			"registeredFeatures": [
+				{
+					"name": "Microsoft.RedHatOpenShift/HcpPrivatePreview",
+					"state": "Registered"
+				},
+				{
+					"name": "Microsoft.RedHatOpenShift/PreconfiguredNSG",
+					"state": "Registered"
+				},
+				{
+					"name": "Microsoft.RedHatOpenShift/ExperimentalReleaseFeatures",
+					"state": "Registered"
+				}
+			]
+		},
+		"resourceId": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2",
+		"state": "Registered"
+	},
+	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2",
+	"resourceType": "Microsoft.Resources/subscriptions"
+}

--- a/test-integration/backend/controllers/mismatches/delete_orphaned_cosmos_test.go
+++ b/test-integration/backend/controllers/mismatches/delete_orphaned_cosmos_test.go
@@ -55,38 +55,6 @@ func testDeleteOrphanedCosmosResourcesController(t *testing.T, withMock bool) {
 			},
 		},
 		{
-			Name: "old_style_id_deleted",
-			ControllerKey: controllerutils.HCPClusterKey{
-				SubscriptionID:    "a433a095-1277-44f1-8453-8d61a4d848c2",
-				ResourceGroupName: "unimportantPostponement",
-				HCPClusterName:    "monstrousPrecinct",
-			},
-			ArtifactDir: api.Must(fs.Sub(artifacts, path.Join("artifacts/delete_orphaned_cosmos"))),
-			ControllerInitializerFn: func(ctx context.Context, t *testing.T, input *controllertesthelpers.ControllerInitializationInput) (controller controllerutils.Controller, testMemory map[string]any) {
-				return newSubscriptionKeyWrapper(
-					mismatchcontrollers.NewDeleteOrphanedCosmosResourcesController(input.CosmosClient, input.SubscriptionLister),
-				), map[string]any{}
-			},
-			ControllerVerifierFn: func(ctx context.Context, t *testing.T, controller controllerutils.Controller, testMemory map[string]any, input *controllertesthelpers.ControllerInitializationInput) {
-				// The old-style ID document should be deleted
-				subscriptionResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2"))
-				crud, err := input.CosmosClient.UntypedCRUD(*subscriptionResourceID)
-				require.NoError(t, err)
-
-				allItems, err := crud.ListRecursive(ctx, nil)
-				require.NoError(t, err)
-
-				for _, item := range allItems.Items(ctx) {
-					if item.ID == "718f75e1-6967-5ce1-ab3c-4f991504b7eb" ||
-						item.ID == "f7583c84-ae03-56f3-b91d-55bbb849164d" {
-						continue
-					}
-					t.Errorf("unexpected resource found: %v", item.ID)
-				}
-				require.NoError(t, allItems.GetError())
-			},
-		},
-		{
 			Name: "controller_under_missing_nodepool_deleted",
 			ControllerKey: controllerutils.HCPClusterKey{
 				SubscriptionID:    "a433a095-1277-44f1-8453-8d61a4d848c2",

--- a/test-integration/backend/controllers/mismatches/delete_orphaned_cosmos_test.go
+++ b/test-integration/backend/controllers/mismatches/delete_orphaned_cosmos_test.go
@@ -119,6 +119,37 @@ func testDeleteOrphanedCosmosResourcesController(t *testing.T, withMock bool) {
 				require.NoError(t, allItems.GetError())
 			},
 		},
+		{
+			Name: "pipe_style_ids_deleted",
+			ControllerKey: controllerutils.HCPClusterKey{
+				SubscriptionID:    "a433a095-1277-44f1-8453-8d61a4d848c2",
+				ResourceGroupName: "unimportantPostponement",
+				HCPClusterName:    "monstrousPrecinct",
+			},
+			ArtifactDir: api.Must(fs.Sub(artifacts, path.Join("artifacts/delete_orphaned_cosmos"))),
+			ControllerInitializerFn: func(ctx context.Context, t *testing.T, input *controllertesthelpers.ControllerInitializationInput) (controller controllerutils.Controller, testMemory map[string]any) {
+				return newSubscriptionKeyWrapper(
+					mismatchcontrollers.NewDeleteOrphanedCosmosResourcesController(input.CosmosClient, input.SubscriptionLister),
+				), map[string]any{}
+			},
+			ControllerVerifierFn: func(ctx context.Context, t *testing.T, controller controllerutils.Controller, testMemory map[string]any, input *controllertesthelpers.ControllerInitializationInput) {
+				// The old-style ID document should be deleted
+				subscriptionResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2"))
+				crud, err := input.CosmosClient.UntypedCRUD(*subscriptionResourceID)
+				require.NoError(t, err)
+
+				allItems, err := crud.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				for _, item := range allItems.Items(ctx) {
+					if item.ID == "b1e87a41-1eeb-51ba-8155-cd118688d9d2" {
+						continue
+					}
+					t.Errorf("unexpected resource found: %v", item.ID)
+				}
+				require.NoError(t, allItems.GetError())
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/test-integration/utils/controllertesthelpers/basic_controller.go
+++ b/test-integration/utils/controllertesthelpers/basic_controller.go
@@ -64,6 +64,9 @@ func (tc *BasicControllerTest) RunTest(t *testing.T) {
 	testDir, err := fs.Sub(tc.ArtifactDir, tc.Name)
 	require.NoError(t, err)
 
+	_, err = fs.Lstat(tc.ArtifactDir, tc.Name)
+	require.NoError(t, err)
+
 	ctx = utils.ContextWithLogger(ctx, integrationutils.DefaultLogger(t))
 	logger := utils.LoggerFromContext(ctx)
 	logger = tc.ControllerKey.AddLoggerValues(logger)


### PR DESCRIPTION
test-integration: correctly fail when per-test artifacts are missing

The previous code intended to enforce that each test had an artifact
directory on disk, but the `fs.Sub()` call does not error when there's
nothing at the root, as it does not actually interact with the
filesystem.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

test-integration: clean up orphaned test code

The data directories for this test was already removed, but the test
remained on accident.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

internal: allow missing resource IDs in mock lister

Our actual listers against CosmosDB don't try to parse the record as a
typed document during this call, so we need our mocks to be faithful to
that as we will be writing tests that assert over malformed data.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

backend: delete orphaned CosmosDB records by raw ID

When we determine that a record in CosmosDB is orphaned and should be
cleaned up, previously we were issuing a delete using the new ID scheme
and a typed CRUD client. Our Cosmos -> internal logic would backfill
coherent resource IDs for records that were missing one, so this code
would attempt to delete them by their new-style ID, which had no effect,
as the deletion client would not map backwards. Instead, we can delete
by the raw CosmosDB partition and ID.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

test-integration: add a test for orphaned data with pipe-style IDs

We saw these kinds of orphaned records in UKSouth production.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

