### PR TITLE
Adding Microsoft.Quota Resource Provider

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -395,6 +395,8 @@ defaults:
           poll: true
         'Microsoft.Kusto':
           poll: true
+        'Microsoft.Quota':
+          poll: true
     rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.region }}-svc"
     nsp:
       name: nsp-{{ .ctx.regionShort }}-svc
@@ -527,6 +529,8 @@ defaults:
           features:
           - name: IstioNativeSidecarModePreview
             poll: true
+        'Microsoft.Quota':
+          poll: true
     rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.region }}-mgmt-{{ .ctx.stamp }}"
     applyKubeletFixes: true
     nsp:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -652,6 +652,8 @@ mgmt:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
         poll: true
+      Microsoft.Quota:
+        poll: true
       Microsoft.Storage:
         poll: true
     usePlannedQuota: true
@@ -961,6 +963,8 @@ svc:
         features:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
+        poll: true
+      Microsoft.Quota:
         poll: true
     usePlannedQuota: true
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -652,6 +652,8 @@ mgmt:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
         poll: true
+      Microsoft.Quota:
+        poll: true
       Microsoft.Storage:
         poll: true
     usePlannedQuota: true
@@ -961,6 +963,8 @@ svc:
         features:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
+        poll: true
+      Microsoft.Quota:
         poll: true
     usePlannedQuota: true
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -652,6 +652,8 @@ mgmt:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
         poll: true
+      Microsoft.Quota:
+        poll: true
       Microsoft.Storage:
         poll: true
     usePlannedQuota: true
@@ -961,6 +963,8 @@ svc:
         features:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
+        poll: true
+      Microsoft.Quota:
         poll: true
     usePlannedQuota: true
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -654,6 +654,8 @@ mgmt:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
         poll: true
+      Microsoft.Quota:
+        poll: true
       Microsoft.Storage:
         poll: true
     usePlannedQuota: true
@@ -965,6 +967,8 @@ svc:
         features:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
+        poll: true
+      Microsoft.Quota:
         poll: true
     usePlannedQuota: true
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -654,6 +654,8 @@ mgmt:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
         poll: true
+      Microsoft.Quota:
+        poll: true
       Microsoft.Storage:
         poll: true
     usePlannedQuota: true
@@ -965,6 +967,8 @@ svc:
         features:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
+        poll: true
+      Microsoft.Quota:
         poll: true
     usePlannedQuota: true
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Adding Microsoft.Quota Resource Provider to Service and Management Clusters

### Why

This resource provider is required to use the Group Quota API to automatically request quota as demand increases.

### Testing

Tested by e2e parallel PR gate

### Special notes for your reviewer

<!-- optional -->
