### PR TITLE
initial commit of pko orphaned resources cleanup

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -503,7 +503,20 @@ resourceGroups:
       - "Internal error occurred"
       maximumRetryCount: 3
       durationBetweenRetries: 1m
-  # TODO: Remove this step once all management clusters have been cleaned up (ARO-23308)
+  # TODO: Remove these PKO cleanup steps once all management clusters have been cleaned up (ARO-23308)
+  - name: cleanup-pko-resources
+    aksCluster: '{{ .mgmt.aks.name }}'
+    action: Shell
+    command: ./scripts/cleanup-pko-resources.sh
+    workingDir: .
+    shellIdentity:
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: management
+      step: cluster
   - name: cleanup-pko
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell

--- a/dev-infrastructure/scripts/cleanup-pko-resources.sh
+++ b/dev-infrastructure/scripts/cleanup-pko-resources.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+# Cleanup script for Package Operator custom resources and CRDs.
+#
+# Delete all CRs in the package-operator.run API group and rely on ownerRef
+# cascading deletion (blockOwnerDeletion: true)
+# to clean up child resources. Once all CRs are gone, remove the CRDs.
+#
+# Idempotent — safe to run on clusters that never had PKO installed.
+#
+# Tracks: ARO-23308 / AROSLSRE-686
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TIMEOUT="${PKO_CLEANUP_TIMEOUT:-120s}"
+
+echo "=== Package Operator CR + CRD cleanup ==="
+
+# 1. Discover all CRDs in the package-operator.run group, extracting
+#    plural name, full API group, and scope from each CRD's spec.
+mapfile -t PKO_CRD_INFO < <(
+  kubectl get crds -o jsonpath='{range .items[*]}{.metadata.name} {.spec.names.plural} {.spec.group} {.spec.scope}{"\n"}{end}' \
+    | grep ' \(.*\.\)\{0,1\}package-operator\.run ' || true
+)
+
+if [[ ${#PKO_CRD_INFO[@]} -eq 0 ]]; then
+  echo "No package-operator.run CRDs found. Nothing to do."
+  exit 0
+fi
+
+echo "Found ${#PKO_CRD_INFO[@]} CRD(s):"
+printf '  %s\n' "${PKO_CRD_INFO[@]}"
+
+delete_crs() {
+  local plural="$1" group="$2" scope="$3"
+  local resource="${plural}.${group}"
+
+  echo ""
+  echo "--- Deleting all ${resource} CRs (${scope}) ---"
+  if [[ "${scope}" == "Namespaced" ]]; then
+    kubectl delete "${resource}" --all-namespaces --all --timeout="${TIMEOUT}" 2>/dev/null || true
+  else
+    kubectl delete "${resource}" --all --timeout="${TIMEOUT}" 2>/dev/null || true
+  fi
+}
+
+count_crs() {
+  local plural="$1" group="$2" scope="$3"
+  local resource="${plural}.${group}"
+
+  if [[ "${scope}" == "Namespaced" ]]; then
+    kubectl get "${resource}" --all-namespaces -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | wc -l
+  else
+    kubectl get "${resource}" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | wc -l
+  fi
+}
+
+strip_finalizers() {
+  local plural="$1" group="$2" scope="$3"
+  local resource="${plural}.${group}"
+
+  if [[ "${scope}" == "Namespaced" ]]; then
+    while IFS= read -r entry; do
+      [[ -z "${entry}" ]] && continue
+      local ns name
+      ns=$(echo "${entry}" | cut -d' ' -f1)
+      name=$(echo "${entry}" | cut -d' ' -f2)
+      echo "  Patching finalizers on ${resource}/${name} -n ${ns}"
+      kubectl patch "${resource}" "${name}" -n "${ns}" \
+        --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+    done < <(kubectl get "${resource}" --all-namespaces \
+               -o jsonpath='{range .items[*]}{.metadata.namespace} {.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+  else
+    while IFS= read -r name; do
+      [[ -z "${name}" ]] && continue
+      echo "  Patching finalizers on ${resource}/${name}"
+      kubectl patch "${resource}" "${name}" \
+        --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+    done < <(kubectl get "${resource}" \
+               -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+  fi
+}
+
+# 2. Delete all CRs for each CRD
+for info in "${PKO_CRD_INFO[@]}"; do
+  read -r _crd plural group scope <<< "${info}"
+  delete_crs "${plural}" "${group}" "${scope}"
+done
+
+# 3. Wait for cascading deletion — poll until no CRs remain or we time out
+echo ""
+echo "Waiting for cascading deletion to complete..."
+max_wait=180
+elapsed=0
+remaining=1
+while [[ $elapsed -lt $max_wait ]]; do
+  remaining=0
+  for info in "${PKO_CRD_INFO[@]}"; do
+    read -r _crd plural group scope <<< "${info}"
+    count=$(count_crs "${plural}" "${group}" "${scope}")
+    remaining=$((remaining + count))
+  done
+
+  if [[ $remaining -eq 0 ]]; then
+    echo "All package-operator CRs have been deleted."
+    break
+  fi
+
+  echo "  ${remaining} CR(s) still remaining, waiting... (${elapsed}s / ${max_wait}s)"
+  sleep 10
+  elapsed=$((elapsed + 10))
+done
+
+# 4. Force-remove stuck resources by patching out finalizers.
+#    The PKO operator is already uninstalled, so nothing will process
+#    these finalizers — we have to strip them ourselves.
+if [[ $remaining -gt 0 ]]; then
+  echo ""
+  echo "WARNING: ${remaining} CR(s) stuck after ${max_wait}s — removing finalizers."
+  for info in "${PKO_CRD_INFO[@]}"; do
+    read -r _crd plural group scope <<< "${info}"
+    strip_finalizers "${plural}" "${group}" "${scope}"
+  done
+
+  echo "Waiting for finalizerless resources to terminate..."
+  sleep 10
+
+  final_remaining=0
+  for info in "${PKO_CRD_INFO[@]}"; do
+    read -r _crd plural group scope <<< "${info}"
+    count=$(count_crs "${plural}" "${group}" "${scope}")
+    final_remaining=$((final_remaining + count))
+  done
+
+  if [[ $final_remaining -gt 0 ]]; then
+    echo "ERROR: ${final_remaining} CR(s) still remain after finalizer removal."
+    exit 1
+  fi
+  echo "All stuck CRs removed."
+fi
+
+# 5. Delete the CRDs themselves
+echo ""
+echo "Removing package-operator.run CRDs..."
+for info in "${PKO_CRD_INFO[@]}"; do
+  read -r crd _plural _group _scope <<< "${info}"
+  echo "  Deleting CRD: ${crd}"
+  kubectl delete crd "${crd}" --timeout="${TIMEOUT}" --ignore-not-found
+done
+
+echo ""
+echo "=== PKO resource cleanup complete ==="

--- a/dev-infrastructure/scripts/cleanup-pko-resources.sh
+++ b/dev-infrastructure/scripts/cleanup-pko-resources.sh
@@ -49,11 +49,24 @@ delete_crs() {
 count_crs() {
   local plural="$1" group="$2" scope="$3"
   local resource="${plural}.${group}"
+  local output
 
   if [[ "${scope}" == "Namespaced" ]]; then
-    kubectl get "${resource}" --all-namespaces -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | wc -l
+    output=$(kubectl get "${resource}" --all-namespaces -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}') || {
+      echo "ERROR: kubectl get ${resource} --all-namespaces failed" >&2
+      return 1
+    }
   else
-    kubectl get "${resource}" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | wc -l
+    output=$(kubectl get "${resource}" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}') || {
+      echo "ERROR: kubectl get ${resource} failed" >&2
+      return 1
+    }
+  fi
+
+  if [[ -z "${output}" ]]; then
+    echo 0
+  else
+    echo "${output}" | wc -l
   fi
 }
 


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Manually cleans up orphaned PKO resources

- Discover all CRDs in the package-operator.run API group (including subgroups like manifests.package-operator.run), extracting plural name, group, and scope from each CRD spec                                                                                           
- Delete all CRs for each CRD, handling cluster-scoped and namespaced resources appropriately
- Poll up to 3 minutes for cascading deletion (via blockOwnerDeletion: true owner refs) to clean up child resources                                                                                                                                                        
- If any CRs are stuck, force-remove their finalizers — the PKO operator is already uninstalled so nothing will process them                                                                                                                                               
- Once all CRs are gone, delete the CRDs themselves                                                                                                                                                                                                                        
- Idempotent and safe to run on clusters that never had PKO installed                                                                                                                                                                                                      
- Wired into mgmt-pipeline.yaml as a new cleanup-pko-resources step, running independently of the existing cleanup-pko step

### Why

Orphaned resources are blocking deletion of clusters that were provisioned while PKO was installed.

### Testing

Wrote a dry-run version of the script that only echo'd and didn't delete and dry-ran it against INT cluster which has orphaned resources:

```
=== Package Operator cleanup — DRY RUN ===

CRDs that would be deleted:
  clusterobjectdeployments.package-operator.run (Cluster)
  clusterobjectsetphases.package-operator.run (Cluster)
  clusterobjectsets.package-operator.run (Cluster)
  clusterobjectslices.package-operator.run (Cluster)
  clusterobjecttemplates.package-operator.run (Cluster)
  clusterpackages.package-operator.run (Cluster)
  objectdeployments.package-operator.run (Namespaced)
  objectsetphases.package-operator.run (Namespaced)
  objectsets.package-operator.run (Namespaced)
  objectslices.package-operator.run (Namespaced)
  objecttemplates.package-operator.run (Namespaced)
  packages.package-operator.run (Namespaced)

--- clusterobjectdeployments.package-operator.run (Cluster) ---
  package-operator  finalizers=

--- clusterobjectsetphases.package-operator.run (Cluster) ---
  (none)

--- clusterobjectsets.package-operator.run (Cluster) ---
  package-operator-7798f7865  finalizers=["package-operator.run/cached","package-operator.run/metrics"]

--- clusterobjectslices.package-operator.run (Cluster) ---
  (none)

--- clusterobjecttemplates.package-operator.run (Cluster) ---
  (none)

--- clusterpackages.package-operator.run (Cluster) ---
  package-operator  finalizers=["package-operator.run/metrics"]

--- objectdeployments.package-operator.run (Namespaced) ---
  (none)

--- objectsetphases.package-operator.run (Namespaced) ---
  (none)

--- objectsets.package-operator.run (Namespaced) ---
  ocm-arohcpint-2pq2015v02n1i0hnqfapfc0kup7se9bf-p9z6i6f2w6p2c6e/remote-phase-84df7849c7  finalizers=["package-operator.run/cached","package-operator.run/metrics"]
  ocm-arohcpint-2pq20f6gu9enf835klvaooivaq359dln-j6p1f9l1e6a9p7y/remote-phase-84df7849c7  finalizers=["package-operator.run/cached","package-operator.run/metrics"]

--- objectslices.package-operator.run (Namespaced) ---
  (none)

--- objecttemplates.package-operator.run (Namespaced) ---
  (none)

--- packages.package-operator.run (Namespaced) ---
  ocm-arohcpint-2pq2015v02n1i0hnqfapfc0kup7se9bf-p9z6i6f2w6p2c6e/remote-phase  finalizers=["package-operator.run/metrics"]
  ocm-arohcpint-2pq20f6gu9enf835klvaooivaq359dln-j6p1f9l1e6a9p7y/remote-phase  finalizers=["package-operator.run/metrics"]

=== Total: 7 CR(s) across 12 CRD(s) would be deleted ===
```


### Special notes for your reviewer

<!-- optional -->
