### PR TITLE
Fixed broken eng hub links to use correct path

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -1384,7 +1384,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
           correlationId: 'ClusterCredentialExpiringSoon/{{ $labels.cluster }}'
           description: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} are expiring in less than 30 days.'
           info: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} are expiring in less than 30 days.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/doc/tsgs/credential-refresher-expiring-cert'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
           summary: 'Customer cluster credential expiring in less than 30 days'
           title: 'Customer cluster credential expiring in less than 30 days'
         }
@@ -1411,7 +1411,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
           correlationId: 'ClusterCredentialExpired/{{ $labels.cluster }}'
           description: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} have expired.'
           info: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} have expired.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/doc/tsgs/credential-refresher-expiring-cert'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
           summary: 'Customer cluster credential has expired'
           title: 'Customer cluster credential has expired'
         }

--- a/observability/alerts/msi-credential-refresher-prometheusRule.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         description: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} are expiring in less than 30 days.'
         summary: 'Customer cluster credential expiring in less than 30 days'
-        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/doc/tsgs/credential-refresher-expiring-cert'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
         correlationId: 'ClusterCredentialExpiringSoon/{{ $labels.cluster }}'
     - alert: ClusterCredentialExpired
       expr: increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="0"}[30m]) > 0
@@ -26,5 +26,5 @@ spec:
       annotations:
         description: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} have expired.'
         summary: 'Customer cluster credential has expired'
-        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/doc/tsgs/credential-refresher-expiring-cert'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
         correlationId: 'ClusterCredentialExpired/{{ $labels.cluster }}'

--- a/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
@@ -21,7 +21,7 @@ tests:
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster are expiring in less than 30 days.'
         summary: 'Customer cluster credential expiring in less than 30 days'
-        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/doc/tsgs/credential-refresher-expiring-cert'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
         correlationId: 'ClusterCredentialExpiringSoon/test-cluster'
 - interval: 1m
   input_series:
@@ -51,7 +51,7 @@ tests:
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster have expired.'
         summary: 'Customer cluster credential has expired'
-        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/doc/tsgs/credential-refresher-expiring-cert'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
         correlationId: 'ClusterCredentialExpired/test-cluster'
 - interval: 1m
   input_series:


### PR DESCRIPTION
Some broken eng.hub links with "/docs/" path updated to use "/troubleshooting/"