### PR TITLE
Dump sub-documents even when parent document is missing

### DIFF
--- a/internal/serverutils/dump_data.go
+++ b/internal/serverutils/dump_data.go
@@ -36,7 +36,7 @@ func DumpDataToLogger(ctx context.Context, cosmosClient database.DBClient, resou
 	}
 	startingCosmosRecord, err := cosmosCRUD.Get(ctx, resourceID)
 	if database.IsNotFoundError(err) {
-		logger.Info(fmt.Sprintf("dumping resourceID %v — document not found, dumping sub-documents only", resourceID),
+		logger.Info(fmt.Sprintf("dumping resourceID %v - document not found, dumping sub-documents only", resourceID),
 			"currentResourceID", resourceID.String(),
 		)
 	} else if err != nil {

--- a/internal/serverutils/dump_data.go
+++ b/internal/serverutils/dump_data.go
@@ -35,13 +35,18 @@ func DumpDataToLogger(ctx context.Context, cosmosClient database.DBClient, resou
 		return utils.TrackError(err)
 	}
 	startingCosmosRecord, err := cosmosCRUD.Get(ctx, resourceID)
-	if err != nil {
+	if database.IsNotFoundError(err) {
+		logger.Info(fmt.Sprintf("dumping resourceID %v — document not found, dumping sub-documents only", resourceID),
+			"currentResourceID", resourceID.String(),
+		)
+	} else if err != nil {
 		return utils.TrackError(err)
+	} else {
+		logger.Info(fmt.Sprintf("dumping resourceID %v", startingCosmosRecord.ResourceID),
+			"currentResourceID", startingCosmosRecord.ResourceID.String(),
+			"content", startingCosmosRecord,
+		)
 	}
-	logger.Info(fmt.Sprintf("dumping resourceID %v", startingCosmosRecord.ResourceID),
-		"currentResourceID", startingCosmosRecord.ResourceID.String(),
-		"content", startingCosmosRecord,
-	)
 
 	allCosmosRecords, err := cosmosCRUD.ListRecursive(ctx, nil)
 	if err != nil {


### PR DESCRIPTION
### What

sub document dumping is not skipped anymore if the parent document does not exist in cosmosdb.
this allows us to get a picture of what is in the database if the parent is not present or can't be found (potential bugs).

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
