### PR TITLE
feat: ensure maestro readonly bundle is recreated if it is deleted externally

### DIFF
--- a/backend/pkg/controllers/create_cluster_scoped_maestro_readonly_bundles_controller.go
+++ b/backend/pkg/controllers/create_cluster_scoped_maestro_readonly_bundles_controller.go
@@ -124,30 +124,9 @@ func (c *createClusterScopedMaestroReadonlyBundlesSyncer) SyncOnce(ctx context.C
 		api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster,
 	}
 
-	var maestroBundlesToSync []api.MaestroBundleInternalName
-	// We first check if there's any recognized Maestro Bundle reference that needs to be synced.
-	for _, maestroBundleInternalName := range recognizedMaestroBundles {
-		currentMaestroBundleReference, err := existingServiceProviderCluster.Status.MaestroReadonlyBundles.Get(maestroBundleInternalName)
-		if err != nil {
-			return utils.TrackError(fmt.Errorf("failed to get Maestro Bundle reference: %w", err))
-		}
-
-		if currentMaestroBundleReference == nil {
-			maestroBundlesToSync = append(maestroBundlesToSync, maestroBundleInternalName)
-			continue
-		}
-		if len(currentMaestroBundleReference.MaestroAPIMaestroBundleName) == 0 {
-			maestroBundlesToSync = append(maestroBundlesToSync, maestroBundleInternalName)
-			continue
-		}
-		if len(currentMaestroBundleReference.MaestroAPIMaestroBundleID) == 0 {
-			maestroBundlesToSync = append(maestroBundlesToSync, maestroBundleInternalName)
-			continue
-		}
-	}
-	if len(maestroBundlesToSync) == 0 {
-		return nil
-	}
+	// We always sync all recognized Maestro Bundles every cycle. This ensures that
+	// if a bundle is deleted from the Maestro API side, it gets recreated.
+	maestroBundlesToSync := recognizedMaestroBundles
 
 	serviceProviderClustersDBClient := c.cosmosClient.ServiceProviderClusters(
 		key.SubscriptionID,
@@ -267,8 +246,15 @@ func (c *createClusterScopedMaestroReadonlyBundlesSyncer) syncMaestroBundle(
 		return lastPersistedSPC, utils.TrackError(fmt.Errorf("failed to get or create Maestro Bundle: %w", err))
 	}
 
-	// If the Maestro API MaestroBundle ID is not set we store the returned Maestro Bundle ID in the corresponding Maestro Bundle reference of the ServiceProviderCluster in Cosmos.
-	if len(existingMaestroBundleRef.MaestroAPIMaestroBundleID) == 0 {
+	// If the stored Maestro Bundle ID differs from the one returned by the Maestro API, update it.
+	// This handles initial creation (empty -> new UID) and recreation after external deletion (old UID -> new UID).
+	if existingMaestroBundleRef.MaestroAPIMaestroBundleID != string(resultMaestroBundle.UID) {
+		// If the Maestro Bundle we retrieved from the Maestro API is not managed by the controller, we return an error.
+		if resultMaestroBundle.Labels[readonlyBundleManagedByK8sLabelKey] != readonlyBundleManagedByK8sLabelValueClusterScoped {
+			return lastPersistedSPC, utils.TrackError(
+				fmt.Errorf("maestro readonly bundle retrieved from maestro API with maestro bundle name '%s' and maestro bundle UID '%s' is not managed by the controller", maestroBundleNamespacedName.Name, resultMaestroBundle.UID),
+			)
+		}
 		bundleID := string(resultMaestroBundle.UID)
 		existingMaestroBundleRef.MaestroAPIMaestroBundleID = bundleID
 		err = existingServiceProviderCluster.Status.MaestroReadonlyBundles.Set(existingMaestroBundleRef)

--- a/backend/pkg/controllers/create_cluster_scoped_maestro_readonly_bundles_controller_test.go
+++ b/backend/pkg/controllers/create_cluster_scoped_maestro_readonly_bundles_controller_test.go
@@ -199,7 +199,14 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *te
 			},
 			maestroClientSetupMock: func(m *maestro.MockClient) {
 				createdBundle := &workv1.ManifestWork{
-					ObjectMeta: metav1.ObjectMeta{Name: "existing-bundle-name", Namespace: "test-consumer", UID: "new-bundle-uid"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-bundle-name",
+						Namespace: "test-consumer",
+						UID:       "new-bundle-uid",
+						Labels: map[string]string{
+							readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped,
+						},
+					},
 				}
 				m.EXPECT().Get(gomock.Any(), "existing-bundle-name", gomock.Any()).Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "not-found"))
 				m.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Return(createdBundle, nil)
@@ -250,6 +257,47 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *te
 			},
 		},
 		{
+			name: "bundle deleted and recreated - UID updated",
+			initialSPC: &api.ServiceProviderCluster{
+				CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
+				ResourceID:     *spcResourceID,
+				Status: api.ServiceProviderClusterStatus{
+					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+						{
+							Name:                        api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster,
+							MaestroAPIMaestroBundleName: "recreated-bundle-name",
+							MaestroAPIMaestroBundleID:   "old-bundle-uid",
+						},
+					},
+				},
+			},
+			maestroClientSetupMock: func(m *maestro.MockClient) {
+				m.EXPECT().Get(gomock.Any(), "recreated-bundle-name", gomock.Any()).Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "not-found"))
+				recreatedBundle := &workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "recreated-bundle-name",
+						Namespace: "test-consumer",
+						UID:       "new-recreated-uid",
+						Labels: map[string]string{
+							readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped,
+						},
+					},
+				}
+				m.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Return(recreatedBundle, nil)
+			},
+			wantServiceProviderCluster: &api.ServiceProviderCluster{
+				Status: api.ServiceProviderClusterStatus{
+					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+						{
+							Name:                        api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster,
+							MaestroAPIMaestroBundleName: "recreated-bundle-name",
+							MaestroAPIMaestroBundleID:   "new-recreated-uid",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "multiple refs - only synced ref is updated, other refs unchanged",
 			initialSPC: &api.ServiceProviderCluster{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
@@ -271,7 +319,14 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *te
 			},
 			maestroClientSetupMock: func(m *maestro.MockClient) {
 				createdBundle := &workv1.ManifestWork{
-					ObjectMeta: metav1.ObjectMeta{Name: "hosted-cluster-bundle-name", Namespace: "test-consumer", UID: "hosted-cluster-bundle-uid"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hosted-cluster-bundle-name",
+						Namespace: "test-consumer",
+						UID:       "hosted-cluster-bundle-uid",
+						Labels: map[string]string{
+							readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped,
+						},
+					},
 				}
 				m.EXPECT().Get(gomock.Any(), "hosted-cluster-bundle-name", gomock.Any()).Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "not-found"))
 				m.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Return(createdBundle, nil)
@@ -337,7 +392,14 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *te
 			maestroClientSetupMock: func(m *maestro.MockClient) {
 				deterministicName := syncMaestroBundleTestDeterministicUUID.String()
 				createdBundle := &workv1.ManifestWork{
-					ObjectMeta: metav1.ObjectMeta{Name: deterministicName, Namespace: "test-consumer", UID: "new-bundle-uid"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      deterministicName,
+						Namespace: "test-consumer",
+						UID:       "new-bundle-uid",
+						Labels: map[string]string{
+							readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped,
+						},
+					},
 				}
 				m.EXPECT().Get(gomock.Any(), deterministicName, gomock.Any()).Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "not-found"))
 				m.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -391,6 +453,88 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *te
 			wantErr:       true,
 			wantErrSubstr: "failed to get or create Maestro Bundle",
 		},
+		{
+			name: "bundle from API has wrong managed-by label - rejects UID update",
+			initialSPC: &api.ServiceProviderCluster{
+				CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
+				ResourceID:     *spcResourceID,
+				Status: api.ServiceProviderClusterStatus{
+					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+						{
+							Name:                        api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster,
+							MaestroAPIMaestroBundleName: "wrong-label-bundle",
+							MaestroAPIMaestroBundleID:   "",
+						},
+					},
+				},
+			},
+			maestroClientSetupMock: func(m *maestro.MockClient) {
+				existingBundle := &workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "wrong-label-bundle",
+						Namespace: "test-consumer",
+						UID:       "foreign-uid",
+						Labels: map[string]string{
+							readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueNodePoolScoped,
+						},
+					},
+				}
+				m.EXPECT().Get(gomock.Any(), "wrong-label-bundle", gomock.Any()).Return(existingBundle, nil)
+			},
+			wantServiceProviderCluster: &api.ServiceProviderCluster{
+				Status: api.ServiceProviderClusterStatus{
+					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+						{
+							Name:                        api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster,
+							MaestroAPIMaestroBundleName: "wrong-label-bundle",
+							MaestroAPIMaestroBundleID:   "",
+						},
+					},
+				},
+			},
+			wantErr:       true,
+			wantErrSubstr: "not managed by the controller",
+		},
+		{
+			name: "bundle from API has no managed-by label - rejects UID update",
+			initialSPC: &api.ServiceProviderCluster{
+				CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
+				ResourceID:     *spcResourceID,
+				Status: api.ServiceProviderClusterStatus{
+					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+						{
+							Name:                        api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster,
+							MaestroAPIMaestroBundleName: "no-managed-by-label-bundle",
+							MaestroAPIMaestroBundleID:   "",
+						},
+					},
+				},
+			},
+			maestroClientSetupMock: func(m *maestro.MockClient) {
+				existingBundle := &workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "no-managed-by-label-bundle",
+						Namespace: "test-consumer",
+						UID:       "unlabeled-uid",
+						Labels:    nil,
+					},
+				}
+				m.EXPECT().Get(gomock.Any(), "no-managed-by-label-bundle", gomock.Any()).Return(existingBundle, nil)
+			},
+			wantServiceProviderCluster: &api.ServiceProviderCluster{
+				Status: api.ServiceProviderClusterStatus{
+					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+						{
+							Name:                        api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster,
+							MaestroAPIMaestroBundleName: "no-managed-by-label-bundle",
+							MaestroAPIMaestroBundleID:   "",
+						},
+					},
+				},
+			},
+			wantErr:       true,
+			wantErrSubstr: "not managed by the controller",
+		},
 	}
 
 	for _, tt := range tests {
@@ -431,6 +575,10 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *te
 			)
 
 			assert.Equal(t, tt.wantErr, err != nil)
+			if tt.wantErr && tt.wantErrSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSubstr)
+			}
 			require.NotNil(t, result)
 
 			wantList := tt.wantServiceProviderCluster.Status.MaestroReadonlyBundles
@@ -576,11 +724,19 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_SyncOnce_GetServiceProv
 }
 
 func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_SyncOnce_AllBundlesAlreadySynced(t *testing.T) {
+	ctrl := gomock.NewController(t)
 	ctx := context.Background()
+
 	mockDBClient := databasetesting.NewMockDBClient()
+	mockClusterService := ocm.NewMockClusterServiceClientSpec(ctrl)
+	mockMaestroBuilder := maestro.NewMockMaestroClientBuilder(ctrl)
+	mockMaestroClient := maestro.NewMockClient(ctrl)
+
 	syncer := &createClusterScopedMaestroReadonlyBundlesSyncer{
 		cooldownChecker:                      &alwaysSyncCooldownChecker{},
 		cosmosClient:                         mockDBClient,
+		clusterServiceClient:                 mockClusterService,
+		maestroClientBuilder:                 mockMaestroBuilder,
 		maestroSourceEnvironmentIdentifier:   "test-env",
 		maestroAPIMaestroBundleNameGenerator: maestro.NewMaestroAPIMaestroBundleNameGenerator(),
 	}
@@ -604,7 +760,6 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_SyncOnce_AllBundlesAlre
 	_, err := clustersCRUD.Create(ctx, cluster, nil)
 	require.NoError(t, err)
 
-	var syncMaestroBundleTestOtherBundleName api.MaestroBundleInternalName = "otherReadonlyBundle"
 	// SPC with all bundles already synced (both name and ID populated)
 	spcResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/serviceProviderClusters/default"))
 	spc := &api.ServiceProviderCluster{
@@ -617,11 +772,6 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_SyncOnce_AllBundlesAlre
 					MaestroAPIMaestroBundleName: "bundle-name",
 					MaestroAPIMaestroBundleID:   "bundle-id",
 				},
-				{
-					Name:                        syncMaestroBundleTestOtherBundleName,
-					MaestroAPIMaestroBundleName: "bundle-nameother",
-					MaestroAPIMaestroBundleID:   "bundle-idother",
-				},
 			},
 		},
 	}
@@ -629,9 +779,44 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_SyncOnce_AllBundlesAlre
 	_, err = spcCRUD.Create(ctx, spc, nil)
 	require.NoError(t, err)
 
-	// Since all bundles are synced, no other calls should be made (no cluster service or maestro calls)
+	// Even though all bundles are synced, the controller now reconciles every cycle
+	provisionShard := buildTestProvisionShard("test-consumer")
+	mockClusterService.EXPECT().
+		GetClusterProvisionShard(gomock.Any(), *cluster.ServiceProviderProperties.ClusterServiceID).
+		Return(provisionShard, nil)
+
+	csCluster, err := arohcpv1alpha1.NewCluster().
+		DomainPrefix("test-domain").
+		Build()
+	require.NoError(t, err)
+	mockClusterService.EXPECT().
+		GetCluster(gomock.Any(), *cluster.ServiceProviderProperties.ClusterServiceID).
+		Return(csCluster, nil)
+
+	restEndpoint := provisionShard.MaestroConfig().RestApiConfig().Url()
+	grpcEndpoint := provisionShard.MaestroConfig().GrpcApiConfig().Url()
+	consumerName := provisionShard.MaestroConfig().ConsumerName()
+	sourceID := maestro.GenerateMaestroSourceID("test-env", provisionShard.ID())
+	mockMaestroBuilder.EXPECT().
+		NewClient(gomock.Any(), restEndpoint, grpcEndpoint, consumerName, sourceID).
+		Return(mockMaestroClient, nil)
+
+	// Bundle already exists in Maestro with matching UID - steady state, no DB write
+	existingBundle := &workv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{Name: "bundle-name", Namespace: "test-consumer", UID: "bundle-id"},
+	}
+	mockMaestroClient.EXPECT().Get(gomock.Any(), "bundle-name", gomock.Any()).Return(existingBundle, nil)
+
 	err = syncer.SyncOnce(ctx, key)
 	assert.NoError(t, err)
+
+	// Verify SPC is unchanged (no DB write for matching UID)
+	updatedSPC, err := spcCRUD.Get(ctx, "default")
+	require.NoError(t, err)
+	bundleRef, err := updatedSPC.Status.MaestroReadonlyBundles.Get(api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster)
+	require.NoError(t, err)
+	assert.Equal(t, "bundle-name", bundleRef.MaestroAPIMaestroBundleName)
+	assert.Equal(t, "bundle-id", bundleRef.MaestroAPIMaestroBundleID)
 }
 
 func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_SyncOnce_SyncLoopExecutesWithBundleCreation(t *testing.T) {
@@ -727,6 +912,9 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_SyncOnce_SyncLoopExecut
 			Name:      "new-bundle-name",
 			Namespace: "test-consumer",
 			UID:       "new-bundle-id",
+			Labels: map[string]string{
+				readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped,
+			},
 		},
 	}
 	mockMaestroClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Return(createdBundle, nil)

--- a/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller.go
@@ -123,30 +123,9 @@ func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) SyncOnce(ctx context.
 		api.MaestroBundleInternalNameReadonlyHypershiftNodePool,
 	}
 
-	var maestroBundlesToSync []api.MaestroBundleInternalName
-	// We first check if there's any recognized Maestro Bundle reference that needs to be synced.
-	for _, maestroBundleInternalName := range recognizedMaestroBundles {
-		currentMaestroBundleReference, err := existingServiceProviderNodePool.Status.MaestroReadonlyBundles.Get(maestroBundleInternalName)
-		if err != nil {
-			return utils.TrackError(fmt.Errorf("failed to get Maestro Bundle reference: %w", err))
-		}
-
-		if currentMaestroBundleReference == nil {
-			maestroBundlesToSync = append(maestroBundlesToSync, maestroBundleInternalName)
-			continue
-		}
-		if len(currentMaestroBundleReference.MaestroAPIMaestroBundleName) == 0 {
-			maestroBundlesToSync = append(maestroBundlesToSync, maestroBundleInternalName)
-			continue
-		}
-		if len(currentMaestroBundleReference.MaestroAPIMaestroBundleID) == 0 {
-			maestroBundlesToSync = append(maestroBundlesToSync, maestroBundleInternalName)
-			continue
-		}
-	}
-	if len(maestroBundlesToSync) == 0 {
-		return nil
-	}
+	// We always sync all recognized Maestro Bundles every cycle. This ensures that
+	// if a bundle is deleted from the Maestro API side, it gets recreated.
+	maestroBundlesToSync := recognizedMaestroBundles
 
 	serviceProviderNodePoolsDBClient := c.cosmosClient.ServiceProviderNodePools(
 		key.SubscriptionID,
@@ -271,8 +250,15 @@ func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) syncMaestroBundle(
 		return lastPersistedSPNP, utils.TrackError(fmt.Errorf("failed to get or create Maestro Bundle: %w", err))
 	}
 
-	// If the Maestro API MaestroBundle ID is not set we store the returned Maestro Bundle ID in the corresponding Maestro Bundle reference of the ServiceProviderNodePool in Cosmos.
-	if len(existingMaestroBundleRef.MaestroAPIMaestroBundleID) == 0 {
+	// If the stored Maestro Bundle ID differs from the one returned by the Maestro API, update it.
+	// This handles initial creation (empty -> new UID) and recreation after external deletion (old UID -> new UID).
+	if existingMaestroBundleRef.MaestroAPIMaestroBundleID != string(resultMaestroBundle.UID) {
+		// If the Maestro Bundle we retrieved from the Maestro API is not managed by the controller, we return an error.
+		if resultMaestroBundle.Labels[readonlyBundleManagedByK8sLabelKey] != readonlyBundleManagedByK8sLabelValueNodePoolScoped {
+			return lastPersistedSPNP, utils.TrackError(
+				fmt.Errorf("maestro readonly bundle retrieved from maestro API with maestro bundle name '%s' and maestro bundle UID '%s' is not managed by the controller", maestroBundleNamespacedName.Name, resultMaestroBundle.UID),
+			)
+		}
 		bundleID := string(resultMaestroBundle.UID)
 		existingMaestroBundleRef.MaestroAPIMaestroBundleID = bundleID
 		err = existingServiceProviderNodePool.Status.MaestroReadonlyBundles.Set(existingMaestroBundleRef)

--- a/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller_test.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller_test.go
@@ -221,7 +221,14 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *t
 			},
 			maestroClientSetupMock: func(m *maestro.MockClient) {
 				createdBundle := &workv1.ManifestWork{
-					ObjectMeta: metav1.ObjectMeta{Name: "existing-bundle-name", Namespace: "test-consumer", UID: "new-bundle-uid"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-bundle-name",
+						Namespace: "test-consumer",
+						UID:       "new-bundle-uid",
+						Labels: map[string]string{
+							readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueNodePoolScoped,
+						},
+					},
 				}
 				m.EXPECT().Get(gomock.Any(), "existing-bundle-name", gomock.Any()).Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "not-found"))
 				m.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Return(createdBundle, nil)
@@ -272,6 +279,47 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *t
 			},
 		},
 		{
+			name: "bundle deleted and recreated - UID updated",
+			initialSPNP: &api.ServiceProviderNodePool{
+				CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
+				ResourceID:     *spnpResourceID,
+				Status: api.ServiceProviderNodePoolStatus{
+					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+						{
+							Name:                        bundleInternalName,
+							MaestroAPIMaestroBundleName: "recreated-bundle-name",
+							MaestroAPIMaestroBundleID:   "old-bundle-uid",
+						},
+					},
+				},
+			},
+			maestroClientSetupMock: func(m *maestro.MockClient) {
+				m.EXPECT().Get(gomock.Any(), "recreated-bundle-name", gomock.Any()).Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "not-found"))
+				recreatedBundle := &workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "recreated-bundle-name",
+						Namespace: "test-consumer",
+						UID:       "new-recreated-uid",
+						Labels: map[string]string{
+							readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueNodePoolScoped,
+						},
+					},
+				}
+				m.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Return(recreatedBundle, nil)
+			},
+			wantServiceProviderNodePool: &api.ServiceProviderNodePool{
+				Status: api.ServiceProviderNodePoolStatus{
+					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+						{
+							Name:                        bundleInternalName,
+							MaestroAPIMaestroBundleName: "recreated-bundle-name",
+							MaestroAPIMaestroBundleID:   "new-recreated-uid",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "multiple refs - only synced ref is updated, other refs unchanged",
 			initialSPNP: &api.ServiceProviderNodePool{
 				CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
@@ -293,7 +341,14 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *t
 			},
 			maestroClientSetupMock: func(m *maestro.MockClient) {
 				createdBundle := &workv1.ManifestWork{
-					ObjectMeta: metav1.ObjectMeta{Name: "nodepool-bundle-name", Namespace: "test-consumer", UID: "nodepool-bundle-uid"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nodepool-bundle-name",
+						Namespace: "test-consumer",
+						UID:       "nodepool-bundle-uid",
+						Labels: map[string]string{
+							readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueNodePoolScoped,
+						},
+					},
 				}
 				m.EXPECT().Get(gomock.Any(), "nodepool-bundle-name", gomock.Any()).Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "not-found"))
 				m.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Return(createdBundle, nil)
@@ -359,7 +414,14 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *t
 			maestroClientSetupMock: func(m *maestro.MockClient) {
 				deterministicName := syncMaestroBundleTestDeterministicUUID.String()
 				createdBundle := &workv1.ManifestWork{
-					ObjectMeta: metav1.ObjectMeta{Name: deterministicName, Namespace: "test-consumer", UID: "new-bundle-uid"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      deterministicName,
+						Namespace: "test-consumer",
+						UID:       "new-bundle-uid",
+						Labels: map[string]string{
+							readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueNodePoolScoped,
+						},
+					},
 				}
 				m.EXPECT().Get(gomock.Any(), deterministicName, gomock.Any()).Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "not-found"))
 				m.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -412,6 +474,88 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *t
 			wantErr:       true,
 			wantErrSubstr: "failed to get or create Maestro Bundle",
 		},
+		{
+			name: "bundle from API has wrong managed-by label - rejects UID update",
+			initialSPNP: &api.ServiceProviderNodePool{
+				CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
+				ResourceID:     *spnpResourceID,
+				Status: api.ServiceProviderNodePoolStatus{
+					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+						{
+							Name:                        bundleInternalName,
+							MaestroAPIMaestroBundleName: "wrong-label-bundle",
+							MaestroAPIMaestroBundleID:   "",
+						},
+					},
+				},
+			},
+			maestroClientSetupMock: func(m *maestro.MockClient) {
+				existingBundle := &workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "wrong-label-bundle",
+						Namespace: "test-consumer",
+						UID:       "foreign-uid",
+						Labels: map[string]string{
+							readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueClusterScoped,
+						},
+					},
+				}
+				m.EXPECT().Get(gomock.Any(), "wrong-label-bundle", gomock.Any()).Return(existingBundle, nil)
+			},
+			wantServiceProviderNodePool: &api.ServiceProviderNodePool{
+				Status: api.ServiceProviderNodePoolStatus{
+					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+						{
+							Name:                        bundleInternalName,
+							MaestroAPIMaestroBundleName: "wrong-label-bundle",
+							MaestroAPIMaestroBundleID:   "",
+						},
+					},
+				},
+			},
+			wantErr:       true,
+			wantErrSubstr: "not managed by the controller",
+		},
+		{
+			name: "bundle from API has no managed-by label - rejects UID update",
+			initialSPNP: &api.ServiceProviderNodePool{
+				CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
+				ResourceID:     *spnpResourceID,
+				Status: api.ServiceProviderNodePoolStatus{
+					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+						{
+							Name:                        bundleInternalName,
+							MaestroAPIMaestroBundleName: "no-managed-by-label-bundle",
+							MaestroAPIMaestroBundleID:   "",
+						},
+					},
+				},
+			},
+			maestroClientSetupMock: func(m *maestro.MockClient) {
+				existingBundle := &workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "no-managed-by-label-bundle",
+						Namespace: "test-consumer",
+						UID:       "unlabeled-uid",
+						Labels:    nil,
+					},
+				}
+				m.EXPECT().Get(gomock.Any(), "no-managed-by-label-bundle", gomock.Any()).Return(existingBundle, nil)
+			},
+			wantServiceProviderNodePool: &api.ServiceProviderNodePool{
+				Status: api.ServiceProviderNodePoolStatus{
+					MaestroReadonlyBundles: api.MaestroBundleReferenceList{
+						{
+							Name:                        bundleInternalName,
+							MaestroAPIMaestroBundleName: "no-managed-by-label-bundle",
+							MaestroAPIMaestroBundleID:   "",
+						},
+					},
+				},
+			},
+			wantErr:       true,
+			wantErrSubstr: "not managed by the controller",
+		},
 	}
 
 	for _, tt := range tests {
@@ -455,7 +599,8 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_syncMaestroBundle(t *t
 			)
 
 			assert.Equal(t, tt.wantErr, err != nil)
-			if tt.wantErr {
+			if tt.wantErr && tt.wantErrSubstr != "" {
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErrSubstr)
 			}
 			require.NotNil(t, result)
@@ -609,11 +754,19 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_GetServicePro
 }
 
 func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_AllBundlesAlreadySynced(t *testing.T) {
+	ctrl := gomock.NewController(t)
 	ctx := context.Background()
+
 	mockDBClient := databasetesting.NewMockDBClient()
+	mockClusterService := ocm.NewMockClusterServiceClientSpec(ctrl)
+	mockMaestroBuilder := maestro.NewMockMaestroClientBuilder(ctrl)
+	mockMaestroClient := maestro.NewMockClient(ctrl)
+
 	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{
 		cooldownChecker:                      &alwaysSyncCooldownChecker{},
 		cosmosClient:                         mockDBClient,
+		clusterServiceClient:                 mockClusterService,
+		maestroClientBuilder:                 mockMaestroBuilder,
 		maestroSourceEnvironmentIdentifier:   "test-env",
 		maestroAPIMaestroBundleNameGenerator: maestro.NewMaestroAPIMaestroBundleNameGenerator(),
 	}
@@ -660,9 +813,44 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_AllBundlesAlr
 	_, err = spnpCRUD.Create(ctx, spnp, nil)
 	require.NoError(t, err)
 
-	// Since all bundles are synced, no cluster service or maestro calls should be made
+	// Even though all bundles are synced, the controller now reconciles every cycle
+	provisionShard := buildTestProvisionShard("test-consumer")
+	mockClusterService.EXPECT().
+		GetClusterProvisionShard(gomock.Any(), nodepool.ServiceProviderProperties.ClusterServiceID).
+		Return(provisionShard, nil)
+
+	csCluster, err := arohcpv1alpha1.NewCluster().
+		DomainPrefix("test-domain").
+		Build()
+	require.NoError(t, err)
+	mockClusterService.EXPECT().
+		GetCluster(gomock.Any(), nodepool.ServiceProviderProperties.ClusterServiceID).
+		Return(csCluster, nil)
+
+	restEndpoint := provisionShard.MaestroConfig().RestApiConfig().Url()
+	grpcEndpoint := provisionShard.MaestroConfig().GrpcApiConfig().Url()
+	consumerName := provisionShard.MaestroConfig().ConsumerName()
+	sourceID := maestro.GenerateMaestroSourceID("test-env", provisionShard.ID())
+	mockMaestroBuilder.EXPECT().
+		NewClient(gomock.Any(), restEndpoint, grpcEndpoint, consumerName, sourceID).
+		Return(mockMaestroClient, nil)
+
+	// Bundle already exists in Maestro with matching UID - steady state, no DB write
+	existingBundle := &workv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{Name: "bundle-name", Namespace: "test-consumer", UID: "bundle-id"},
+	}
+	mockMaestroClient.EXPECT().Get(gomock.Any(), "bundle-name", gomock.Any()).Return(existingBundle, nil)
+
 	err = syncer.SyncOnce(ctx, key)
 	assert.NoError(t, err)
+
+	// Verify SPNP is unchanged (no DB write for matching UID)
+	updatedSPNP, err := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+	bundleRef, err := updatedSPNP.Status.MaestroReadonlyBundles.Get(bundleInternalName)
+	require.NoError(t, err)
+	assert.Equal(t, "bundle-name", bundleRef.MaestroAPIMaestroBundleName)
+	assert.Equal(t, "bundle-id", bundleRef.MaestroAPIMaestroBundleID)
 }
 
 func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_SyncLoopExecutesWithBundleCreation(t *testing.T) {
@@ -747,6 +935,9 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_SyncLoopExecu
 			Name:      "new-bundle-name",
 			Namespace: "test-consumer",
 			UID:       "new-bundle-id",
+			Labels: map[string]string{
+				readonlyBundleManagedByK8sLabelKey: readonlyBundleManagedByK8sLabelValueNodePoolScoped,
+			},
 		},
 	}
 	mockMaestroClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Return(createdBundle, nil)


### PR DESCRIPTION
We update the cluster-scoped and nodepool-scoped maestro readonly bundle creation controllers to ensure the bundle is recreated if it has been deleted in the Maestro API side directly for some reason.

The controllers have also been updated to return an error if the retrieved bundle from the Maestro API has a different UID and it does not have the aro-hcp.azure.com/readonly-bundle-managed-by K8s label to the corresponding scope of the controller. This ensures that we don't start considering a bundle created by something or someone else that happens to have the same maestro bundle name.
