### PR TITLE
test: fix version resolution and improve reliability of fetching OCP versions

### DIFF
--- a/test/util/framework/deployment_params.go
+++ b/test/util/framework/deployment_params.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -85,21 +86,39 @@ type NetworkConfig struct {
 	HostPrefix  int32
 }
 
-func DefaultOpenshiftControlPlaneVersionId() string {
-	version := os.Getenv("ARO_HCP_OPENSHIFT_CONTROLPLANE_VERSION")
-	if len(version) == 0 {
-		version = DefaultOCPVersionId
-		channelGroup := DefaultOpenshiftChannelGroup()
-		if channelGroup != "stable" {
-			var err error
-			version, err = GetLatestInstallVersion(context.Background(), channelGroup, version)
-			if err != nil {
-				if errors.Is(err, ErrNightlyReleaseStreamNotFound) || errors.Is(err, ErrNoAcceptedNightlyTags) || errors.Is(err, ErrVersionNotFound) {
-					Skip(fmt.Sprintf("No install version found for %s in %s channel (%s)", version, channelGroup, err.Error()))
-				} else {
-					Fail(fmt.Sprintf("failed to get latest install version for %s channel: %s", channelGroup, err.Error()))
+var (
+	defaultCPVersion     string
+	defaultCPVersionErr  error
+	defaultCPVersionOnce sync.Once
+)
+
+func resolveDefaultControlPlaneVersion() (string, error) {
+	defaultCPVersionOnce.Do(func() {
+		version := os.Getenv("ARO_HCP_OPENSHIFT_CONTROLPLANE_VERSION")
+		if len(version) == 0 {
+			version = DefaultOCPVersionId
+			channelGroup := DefaultOpenshiftChannelGroup()
+			if channelGroup != "stable" {
+				resolved, err := GetLatestInstallVersion(context.Background(), channelGroup, version)
+				if err != nil {
+					defaultCPVersionErr = err
+					return
 				}
+				version = resolved
 			}
+		}
+		defaultCPVersion = version
+	})
+	return defaultCPVersion, defaultCPVersionErr
+}
+
+func DefaultOpenshiftControlPlaneVersionId() string {
+	version, err := resolveDefaultControlPlaneVersion()
+	if err != nil {
+		if errors.Is(err, ErrNightlyReleaseStreamNotFound) || errors.Is(err, ErrNoAcceptedNightlyTags) || errors.Is(err, ErrVersionNotFound) {
+			Skip(fmt.Sprintf("No install version found for %s in %s channel (%s)", DefaultOCPVersionId, DefaultOpenshiftChannelGroup(), err.Error()))
+		} else {
+			Fail(fmt.Sprintf("failed to get latest install version for %s channel: %s", DefaultOpenshiftChannelGroup(), err.Error()))
 		}
 	}
 	return version
@@ -117,6 +136,9 @@ func DefaultOpenshiftNodePoolVersionId() string {
 	version := os.Getenv("ARO_HCP_OPENSHIFT_NODEPOOL_VERSION")
 	if len(version) == 0 {
 		channelGroup := DefaultOpenshiftNodePoolChannelGroup()
+		if channelGroup == DefaultOpenshiftChannelGroup() {
+			return DefaultOpenshiftControlPlaneVersionId()
+		}
 		if channelGroup != "stable" {
 			var err error
 			version, err = GetLatestInstallVersion(context.Background(), channelGroup, DefaultOCPVersionId)

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -29,6 +29,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
 
+	configv1 "github.com/openshift/api/config/v1"
 	cvocincinnati "github.com/openshift/cluster-version-operator/pkg/cincinnati"
 
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -42,7 +43,51 @@ var (
 	ErrVersionNotFound              = errors.New("no graph nodes found")
 )
 
-const graphAPIRequestTimeout = 30 * time.Second
+const (
+	graphAPIRequestTimeout     = 30 * time.Second
+	versionFetchMaxRetries     = 3
+	versionFetchRetryBaseDelay = 1 * time.Second
+)
+
+func retryOnTransientError[T any](ctx context.Context, f func() (T, error)) (T, error) {
+	var zero T
+	var lastErr error
+	for attempt := range versionFetchMaxRetries + 1 {
+		if attempt > 0 {
+			backoff := versionFetchRetryBaseDelay * time.Duration(1<<(attempt-1))
+			select {
+			case <-ctx.Done():
+				return zero, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+		result, err := f()
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		if !isRetryableVersionError(err) {
+			return zero, err
+		}
+	}
+	return zero, fmt.Errorf("after %d attempts: %w", versionFetchMaxRetries+1, lastErr)
+}
+
+func isRetryableVersionError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if errors.Is(err, ErrVersionNotFound) ||
+		errors.Is(err, ErrNightlyReleaseStreamNotFound) ||
+		errors.Is(err, ErrNoAcceptedNightlyTags) ||
+		errors.Is(err, ErrNoParseableNightlyTags) {
+		return false
+	}
+	if cincinatti.IsCincinnatiVersionNotFoundError(err) {
+		return false
+	}
+	return true
+}
 
 // GetInstallVersionForZStreamUpgrade returns the version to install the cluster with when testing
 // a z-stream upgrade, and whether that version has an available z-stream upgrade path. It uses
@@ -101,7 +146,10 @@ func GetAllVersionsInMinorStartingWith(ctx context.Context, channelGroup string,
 	client := cvocincinnati.NewClient(uuid.NameSpaceDNS, transport, "ARO-HCP", cincinatti.NewAlwaysConditionRegistry())
 	channel := fmt.Sprintf("%s-%d.%d", channelGroup, fromVersion.Major, fromVersion.Minor)
 
-	_, possibleUpgradeCandidates, _, err := client.GetUpdates(ctx, cincinnatiURI, "multi", "multi", channel, fromVersion)
+	possibleUpgradeCandidates, err := retryOnTransientError(ctx, func() ([]configv1.Release, error) {
+		_, updates, _, err := client.GetUpdates(ctx, cincinnatiURI, "multi", "multi", channel, fromVersion)
+		return updates, err
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +229,10 @@ func GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx context.Context, channelGr
 	}
 	client := cvocincinnati.NewClient(uuid.NameSpaceDNS, transport, "ARO-HCP", cincinatti.NewAlwaysConditionRegistry())
 
-	_, possibleCandidates, _, err := client.GetUpdates(ctx, cincinnatiURI, "multi", "multi", channel, fromVer)
+	possibleCandidates, err := retryOnTransientError(ctx, func() ([]configv1.Release, error) {
+		_, candidates, _, err := client.GetUpdates(ctx, cincinnatiURI, "multi", "multi", channel, fromVer)
+		return candidates, err
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -202,18 +253,21 @@ func GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx context.Context, channelGr
 	return out, nil
 }
 
-// GetLatestInstallVersion returns the latest install version for the given channel group and version
+// GetLatestInstallVersion returns the latest install version for the given channel group and version.
 // For nightly channels, it returns the latest accepted nightly tag.
 // For all other channels, it returns the latest version in the minor.
+// Transient HTTP/DNS errors are retried with exponential backoff.
 func GetLatestInstallVersion(ctx context.Context, channelGroup string, version string) (string, error) {
-	if channelGroup == "nightly" {
-		return GetLatestInstallVersionForNightlyChannel(version)
-	}
-	return GetLatestInstallVersionForGraphChannel(ctx, channelGroup, version)
+	return retryOnTransientError(ctx, func() (string, error) {
+		if channelGroup == "nightly" {
+			return getLatestInstallVersionForNightlyChannel(ctx, version)
+		}
+		return getLatestInstallVersionForGraphChannel(ctx, channelGroup, version)
+	})
 }
 
 // Note that this function is different from GetLatestVersionInMinor because it will return also engineering candidate versions.
-func GetLatestInstallVersionForGraphChannel(ctx context.Context, channelGroup string, version string) (string, error) {
+func getLatestInstallVersionForGraphChannel(ctx context.Context, channelGroup string, version string) (string, error) {
 	channel := fmt.Sprintf("%s-%s", channelGroup, version)
 	graphURL := fmt.Sprintf("https://api.openshift.com/api/upgrades_info/v1/graph?channel=%s", url.QueryEscape(channel))
 
@@ -271,19 +325,19 @@ func GetLatestInstallVersionForGraphChannel(ctx context.Context, channelGroup st
 	}
 
 	if latestVersionID == "" {
-		return "", fmt.Errorf("no %s versions found in %s for requested minor %s", channelGroup, channel, version)
+		return "", fmt.Errorf("%w: no %s versions in %s for requested minor %s", ErrVersionNotFound, channelGroup, channel, version)
 	}
 
 	return latestVersionID, nil
 }
 
-// GetLatestInstallVersionForNightlyChannel returns the latest accepted nightly tag for the given minor version
+// getLatestInstallVersionForNightlyChannel returns the latest accepted nightly tag for the given minor version
 // (for example "4.19" -> "4.19.0-0.nightly-multi-YYYY-MM-DD-HHMMSS").
-func GetLatestInstallVersionForNightlyChannel(version string) (string, error) {
+func getLatestInstallVersionForNightlyChannel(ctx context.Context, version string) (string, error) {
 	releaseStream := fmt.Sprintf("%s.0-0.nightly-multi", version)
 	releaseTagsURL := fmt.Sprintf("https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/%s/tags?phase=Accepted", url.PathEscape(releaseStream))
 
-	req, err := http.NewRequest(http.MethodGet, releaseTagsURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releaseTagsURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("create nightly tags request for %s: %w", releaseStream, err)
 	}


### PR DESCRIPTION
[ARO-26732](https://redhat.atlassian.net/browse/ARO-26732)
[ARO-26733](https://redhat.atlassian.net/browse/ARO-26733)

### What

- Control plane version is cached with `sync.Once` and resolved only once per process 
- `DefaultOpenshiftNodePoolVersionId()` now reuses the cached control plane version when channel group matches the cluster's
- Add generic retry helper with exponential back-off - `retryOnTransientError()` 
- Enable the retry for `GetLatestInstallVersion()`, `GetAllVersionsInMinorStartingWith()` and `GetUpgradeCandidatesInMaxMinorFromCincinnati()`
- Make `GetLatestInstallVersionForGraphChannel()` and `GetLatestInstallVersionForNightlyChannel()` private. To be called only through the retry wrapper
- Propagate context to nightly channel function for context cancellation support

### Why

This is a fix for 2 bugs:

1. Version race condition: NewDefaultClusterParams() and NewDefaultNodePoolParams() each independently query Cincinnati for the latest OCP version. Since cluster creation can take more than 30 minutes, a new candidate version can be published between the two queries, causing node pool creation to fail.
2. Transient HTTP failures: The second, and in this case redundant, Cincinnati query can fail due to various network errors, failing the test even though the first query succeeded. 

### Testing

PR modifies framework helper functions used broadly across tests. 
