### PR TITLE
dev-infrastructure: fix template crash for optional serviceKeyVault.subscription

### DIFF
--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -62,7 +62,7 @@ resourceGroups:
     outputOnly: true
 - name: svcKV
   resourceGroup: '{{ .serviceKeyVault.rg }}'
-  subscription: '{{ if .serviceKeyVault.subscription.key }}{{ .serviceKeyVault.subscription.key }}{{ else }}{{ .svc.subscription.key }}{{ end }}'
+  subscription: '{{ with index .serviceKeyVault "subscription" }}{{ .key }}{{ else }}{{ $.svc.subscription.key }}{{ end }}'
   steps:
   - name: output
     action: ARM


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-773

### What

Use `index` function instead of direct map access for the optional `serviceKeyVault.subscription` key in `svc-pipeline.yaml`.

### Why

The INT bumper is blocked. Commit 68e4da8c4 added:

```yaml
subscription: '{{ if .serviceKeyVault.subscription.key }}...'
```

Go templates with `missingkey=error` crash on `.serviceKeyVault.subscription.key` when `subscription` doesn't exist as a map key — even inside an `if`. The `serviceKeyVault.subscription` key only exists in the dev cloud config overlay, not in public (INT/STG/PROD).

### Fix

```yaml
# Before (crashes when subscription key missing)
subscription: '{{ if .serviceKeyVault.subscription.key }}{{ .serviceKeyVault.subscription.key }}{{ else }}{{ .svc.subscription.key }}{{ end }}'

# After (index returns nil for missing key, with treats nil as false)
subscription: '{{ with index .serviceKeyVault "subscription" }}{{ .key }}{{ else }}{{ $.svc.subscription.key }}{{ end }}'
```

`index` is a function call — `missingkey=error` only applies to dot-access, not to `index`. Returns nil for missing keys, `with` treats nil as false, falls through to `$.svc.subscription.key`.

### Testing

- Template-only change, no functional impact when key exists (dev cloud)
- Unblocks INT/STG/PROD manifest generation where key is absent