### PR TITLE
mgmt-fixes: templatize StorageClass SKU for per-region override (AROSLSRE-771)

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -2566,6 +2566,9 @@
         "applyKubeletFixes": {
           "type": "boolean"
         },
+        "defaultStorageClassSkuName": {
+          "type": "string"
+        },
         "hcpBackups": {
           "$ref": "#/definitions/hcpBackups"
         },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -497,6 +497,7 @@ defaults:
           sha: cf3e9b292e4302ad4a4955b56379703aea39516607d382a57604a3d003c35d10
   # MGMT cluster specifics
   mgmt:
+    defaultStorageClassSkuName: "PremiumV2_LRS"
     hcpBackups:
       storageAccount:
         name: "oadp{{ .ctx.environment }}{{ .ctx.regionShort }}{{ .ctx.stamp }}" # [globally-unique]

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -573,6 +573,7 @@ mgmt:
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14
   applyKubeletFixes: true
+  defaultStorageClassSkuName: PremiumV2_LRS
   hcpBackups:
     storageAccount:
       name: oadpcsprusw31

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -573,6 +573,7 @@ mgmt:
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14
   applyKubeletFixes: true
+  defaultStorageClassSkuName: PremiumV2_LRS
   hcpBackups:
     storageAccount:
       name: oadpdevusw31

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -573,6 +573,7 @@ mgmt:
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14
   applyKubeletFixes: true
+  defaultStorageClassSkuName: PremiumV2_LRS
   hcpBackups:
     storageAccount:
       name: oadpperfusw3ptest1

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -573,6 +573,7 @@ mgmt:
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14
   applyKubeletFixes: false
+  defaultStorageClassSkuName: PremiumV2_LRS
   hcpBackups:
     storageAccount:
       name: oadppersusw3test1

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -573,6 +573,7 @@ mgmt:
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14
   applyKubeletFixes: false
+  defaultStorageClassSkuName: PremiumV2_LRS
   hcpBackups:
     storageAccount:
       name: oadpprowj76543211

--- a/mgmt-fixes/default-sc.values.yaml
+++ b/mgmt-fixes/default-sc.values.yaml
@@ -1,1 +1,2 @@
 unannotateJobImage: "{{ .aksCommandRuntime.image.registry }}/{{ .aksCommandRuntime.image.repository }}@{{ .aksCommandRuntime.image.digest }}"
+skuName: "{{ .mgmt.defaultStorageClassSkuName }}"

--- a/mgmt-fixes/deploy/default-sc/templates/managed-csi-premiumv2.storageclass.yaml
+++ b/mgmt-fixes/deploy/default-sc/templates/managed-csi-premiumv2.storageclass.yaml
@@ -5,7 +5,7 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
   name: managed-csi-premiumv2
 parameters:
-  skuname: PremiumV2_LRS
+  skuname: {{ .Values.skuName | default "PremiumV2_LRS" }}
 provisioner: disk.csi.azure.com
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-771

### What

Templatize the `skuname` in the `managed-csi-premiumv2` StorageClass and add a new config parameter `mgmt.defaultStorageClassSkuName` to allow per-region SKU overrides.

### Why

The `PremiumV2_LRS` disk SKU is not available in availability zone 2 in eastus2euap. When etcd pods land on zone 2 nodes, PVC provisioning fails with:

```
SKU 'PremiumV2_LRS' is not available in availability zone '2'.
```

This cascades: etcd can't start -> KAS can't start -> `service-network-admin-kubeconfig` secret never created -> all control plane pods fail with FailedMount -> HostedCluster never reaches Available -> E2E tests time out at 45 minutes.

### Changes

1. `mgmt-fixes/deploy/default-sc/templates/managed-csi-premiumv2.storageclass.yaml` — templatized `skuname` to use `{{ .Values.skuName | default "PremiumV2_LRS" }}`
2. `mgmt-fixes/default-sc.values.yaml` — added `skuName: "{{ .mgmt.defaultStorageClassSkuName }}"`
3. `config/config.yaml` — added `mgmt.defaultStorageClassSkuName: "PremiumV2_LRS"` as default
4. `config/config.schema.json` — added schema entry for the new parameter

### Why not rename the file?

The template file is named `managed-csi-premiumv2.storageclass.yaml` and the Kubernetes StorageClass resource is named `managed-csi-premiumv2`. Both names stay unchanged because:
- The StorageClass name is referenced by existing PVCs and consumers — renaming the resource would break them
- `PremiumV2_LRS` remains the default SKU for all regions except eastus2euap, so the name is still accurate for the primary case
- `Premium_LRS` is only used as a fallback in regions with zone restrictions — renaming the file for a single-region exception would be misleading

### sdp-pipelines follow-up

After this merges, a corresponding sdp-pipelines PR overrides `mgmt.defaultStorageClassSkuName` to `Premium_LRS` for eastus2euap only. All other regions keep the default `PremiumV2_LRS`.

sdp-pipelines PR: https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/sdp-pipelines/pullrequest/15623265

### Testing

- `cd config && make materialize` — configs regenerated
- No functional change for regions using the default `PremiumV2_LRS`