### PR TITLE
test: revert blanket registry allowlist, use ghcr.io for VAP test

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1196,9 +1196,6 @@ clouds:
       imageRegistryPolicy:
         extraAllowedRegistries:
         - docker.io
-        - quay.io
-        - registry.k8s.io
-        - registry.redhat.io
         - jaegertracing
         - grafana
         - otel

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -408,17 +408,6 @@ hypershift:
     digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
-imageRegistryPolicy:
-  extraAllowedRegistries:
-  - docker.io
-  - quay.io
-  - registry.k8s.io
-  - registry.redhat.io
-  - jaegertracing
-  - grafana
-  - otel
-  validationActions:
-  - Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -411,9 +411,6 @@ hypershift:
 imageRegistryPolicy:
   extraAllowedRegistries:
   - docker.io
-  - quay.io
-  - registry.k8s.io
-  - registry.redhat.io
   - jaegertracing
   - grafana
   - otel

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -411,9 +411,6 @@ hypershift:
 imageRegistryPolicy:
   extraAllowedRegistries:
   - docker.io
-  - quay.io
-  - registry.k8s.io
-  - registry.redhat.io
   - jaegertracing
   - grafana
   - otel

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -411,9 +411,6 @@ hypershift:
 imageRegistryPolicy:
   extraAllowedRegistries:
   - docker.io
-  - quay.io
-  - registry.k8s.io
-  - registry.redhat.io
   - jaegertracing
   - grafana
   - otel

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -411,9 +411,6 @@ hypershift:
 imageRegistryPolicy:
   extraAllowedRegistries:
   - docker.io
-  - quay.io
-  - registry.k8s.io
-  - registry.redhat.io
   - jaegertracing
   - grafana
   - otel

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -411,9 +411,6 @@ hypershift:
 imageRegistryPolicy:
   extraAllowedRegistries:
   - docker.io
-  - quay.io
-  - registry.k8s.io
-  - registry.redhat.io
   - jaegertracing
   - grafana
   - otel

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_image_registry_policy.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_image_registry_policy.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: image-registry-policy
     app.kubernetes.io/managed-by: Helm
 data:
-  allowedRegistries: 'arohcpsvcdev.azurecr.io,arohcpocpdev.azurecr.io,mcr.microsoft.com,kubernetesshared.azurecr.io,docker.io,quay.io,registry.k8s.io,registry.redhat.io,jaegertracing,grafana,otel'
+  allowedRegistries: 'arohcpsvcdev.azurecr.io,arohcpocpdev.azurecr.io,mcr.microsoft.com,kubernetesshared.azurecr.io,docker.io,jaegertracing,grafana,otel'
 ---
 # Source: image-registry-policy/templates/validatingadmissionpolicy.yaml
 # This policy enforces FSI image sourcing requirements by restricting all pod

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_image_registry_policy.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_image_registry_policy.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: image-registry-policy
     app.kubernetes.io/managed-by: Helm
 data:
-  allowedRegistries: 'arohcpsvcdev.azurecr.io,arohcpocpdev.azurecr.io,mcr.microsoft.com,kubernetesshared.azurecr.io,docker.io,quay.io,registry.k8s.io,registry.redhat.io,jaegertracing,grafana,otel'
+  allowedRegistries: 'arohcpsvcdev.azurecr.io,arohcpocpdev.azurecr.io,mcr.microsoft.com,kubernetesshared.azurecr.io,docker.io,jaegertracing,grafana,otel'
 ---
 # Source: image-registry-policy/templates/validatingadmissionpolicy.yaml
 # This policy enforces FSI image sourcing requirements by restricting all pod

--- a/test/e2e/image_registry_policy.go
+++ b/test/e2e/image_registry_policy.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	disallowedImage = "quay.io/library/nginx:latest"
+	disallowedImage = "ghcr.io/library/nginx:latest"
 )
 
 var _ = Describe("Image Registry Policy", func() {


### PR DESCRIPTION
### What

1. Reverts the blanket `quay.io`, `registry.k8s.io`, `registry.redhat.io` addition to the allowlist (from edaabeafe)
2. Changes the VAP test's disallowed image from `quay.io/library/nginx:latest` to `ghcr.io/library/nginx:latest`

### Why

Adding `quay.io` as a blanket allowlist entry defeats the purpose of the image registry policy. All production images should come from ACR via mirroring.

This PR tests whether the E2E failures were caused by the VAP blocking non-mirrored images, or by the rebase onto newer main. If E2E passes, the VAP was never the issue. If it fails, we need to find which specific image is pulling from a non-ACR registry.

### Testing

- E2E validates both the policy enforcement (via the `ghcr.io` test) and cluster creation (without the blanket allowlist)