### PR TITLE
Add PR standards AI skill and update contributing guidelines

### DIFF
--- a/.claude/skills/pr-standards/SKILL.md
+++ b/.claude/skills/pr-standards/SKILL.md
@@ -7,7 +7,7 @@ description: Use when creating, reviewing, or preparing a pull request — enfor
 
 All PR rules are maintained in a single source of truth. Read and enforce every rule in:
 
-**[CONTRIBUTING.md — Pull Request Standards](../../CONTRIBUTING.md#pull-request-standards)**
+**[CONTRIBUTING.md — Pull Request Standards](../../../CONTRIBUTING.md#pull-request-standards)**
 
 Do not duplicate the rules here. Always read CONTRIBUTING.md before creating or reviewing a PR.
 

--- a/.claude/skills/pr-standards/SKILL.md
+++ b/.claude/skills/pr-standards/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: pr-standards
+description: Use when creating, reviewing, or preparing a pull request — enforces team PR standards including size, summary quality, CI checks, commit hygiene, and review workflow.
+---
+
+# Pull Request Standards
+
+All PR rules are maintained in a single source of truth. Read and enforce every rule in:
+
+**[CONTRIBUTING.md — Pull Request Standards](../../CONTRIBUTING.md#pull-request-standards)**
+
+Do not duplicate the rules here. Always read CONTRIBUTING.md before creating or reviewing a PR.
+
+The PR checklist is built into `.github/PULL_REQUEST_TEMPLATE.md` — it appears automatically on every new PR.
+
+## Workflow
+
+When the user asks to create a PR:
+
+1. **Read rules**: Open `CONTRIBUTING.md` and read the "Pull Request Standards" section in full.
+2. **Pre-flight**: Run `git diff` and review changes. Flag anything that violates the rules.
+3. **Scope check**: If the diff touches unrelated concerns, recommend splitting into separate PRs.
+4. **Generate description**: Write a summary following the rules, include ticket links. The checklist is auto-populated by the PR template.
+5. **Title**: Use Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.).
+6. **CI check**: Run available tests/linting and report status. Ignore Tide — it is not a CI check.
+7. **Draft vs. Ready**: Ask whether to open as Draft if work appears incomplete.
+8. **Reviewers**: Suggest specific reviewers based on file ownership (CODEOWNERS, git blame).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,3 +21,17 @@
 ### Special notes for your reviewer
 
 <!-- optional -->
+
+### PR Checklist
+- [ ] PR is scoped to a single task (no mixed concerns)
+- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
+- [ ] Summary explains the "Why" behind the change
+- [ ] Linked to relevant ticket/issue
+- [ ] Screenshots included (if graph/UI/metrics changes)
+- [ ] Self-reviewed the diff
+- [ ] CI/CD checks are passing (ignore Tide)
+- [ ] Draft PR used for WIP (if applicable)
+- [ ] Commit history is clean (rebased/squashed)
+- [ ] Tricky code blocks are commented
+- [ ] Specific reviewers tagged
+- [ ] All comment threads resolved before merge

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,15 @@
+# Copilot Instructions
+
+## Pull Request Standards
+
+All PR rules are maintained in a single source of truth:
+
+**[CONTRIBUTING.md — Pull Request Standards](../CONTRIBUTING.md#pull-request-standards)**
+
+When creating or reviewing a pull request, read and enforce every rule in that section. Do not duplicate the rules here.
+
+Key points to remember:
+- Use Conventional Commits format for PR titles (`feat:`, `fix:`, `docs:`, etc.).
+- Ignore Tide when evaluating CI/CD status — it is not a CI check.
+- Screenshots are required for graph, UI, metrics, and performance changes.
+- The PR checklist is built into `.github/PULL_REQUEST_TEMPLATE.md` — it appears automatically.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Welcome to the ARO HCP project! We appreciate your interest in contributing. Thi
 ## Table of Contents
 - [Getting Started](#getting-started)
 - [Contributing Guidelines](#contributing-guidelines)
+- [Pull Request Standards](#pull-request-standards)
+- [AI Skills](#ai-skills)
 - [PR and Issue Lifecycle](#pr-and-issue-lifecycle)
 - [Code of Conduct](#code-of-conduct)
 - [License](#license)
@@ -29,11 +31,6 @@ need to create your pull from ARO-HCP repository directly. See
 ## Contributing Guidelines
 Please follow these guidelines when contributing to ARO HCP:
 
-- Please consider, starting with a draft PR, unless you are ready for review. If you want a early feedback,
-  do not hesitate to ping the code owners.
-- Write meaningful commit messages and PR description. The PR will be squashed before merging, unless
-  the splitting into multiple commits is explicitly needed in order to separate changes and allow
-  later `git bisect`.
 - The repository is structured according to the focus areas, e.g. `api` containing all exposed API specs.
   When you contribute, please follow this structure and add your contribution to the appropriate folder.
   When in doubt, open PR early and ask for feedback.
@@ -49,6 +46,80 @@ Please follow these guidelines when contributing to ARO HCP:
   help others to understand the context and decisions made.
 
 Please note, that you might be asked to comply with these guidelines before your PR is accepted.
+
+## Pull Request Standards
+
+All pull requests must follow these standards. Reviewers will check for compliance before approving.
+
+### 1. Keep PRs Small
+- One PR per task — do not mix features with refactors, style fixes, or unrelated bug fixes.
+- If a task requires multiple concerns, split them into separate PRs.
+
+### 2. Use Informative PR Titles
+- Titles should be clear, concise, and follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format where applicable.
+- Use a type prefix: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, etc.
+- Example: `feat: add MISE v2 header-based routing` — not `update routing`.
+- The title becomes the squash-merge commit message, so make it meaningful for `git log`.
+
+### 3. Write a Clear Summary
+- The PR description must explain the **"Why"** behind the change, not just the "What".
+- Example: _"Increased node pool max count from 5 → 10 to handle Black Friday traffic spikes"_ — not _"Changed max count"_.
+- Lead with motivation and business context, then briefly describe the technical approach.
+
+### 4. Link to Relevant Ticket or Issue
+- Every PR must reference its tracking ticket (Jira, GitHub Issue).
+- Use formats like `Fixes #123`, `Closes PROJ-456`, or a direct URL.
+- If no ticket exists, create one first or explain why in the PR body.
+
+### 5. Include Screenshots for Graph/UI/Metrics/Performance Changes
+- Any change that affects dashboards, graphs, metrics visualizations, UI, or performance/metrics must include before/after screenshots.
+- This includes changes to alerting rules, SLOs, monitoring dashboards, and any observable behavioral change.
+- Annotate screenshots when the change is subtle.
+
+### 6. Self-Review Before Requesting Review
+- Run `git diff` and review every changed line yourself before requesting others.
+- Look for: leftover debug code, TODOs, unintended changes, secrets, formatting issues.
+
+### 7. CI/CD Checks Must Pass
+- All tests, linting, and CI/CD pipeline checks must be green before requesting review, **excluding Tide**.
+- Tide is a merge-automation bot and its status is not a CI/CD check — do not wait on it or treat it as a blocker.
+- If a non-Tide check is flaky or unrelated, note it explicitly in the PR description — do not ignore it silently.
+
+### 8. Use Draft PRs for WIP
+- If requesting early feedback or the work is incomplete, open the PR as a **Draft**.
+- Convert to "Ready for Review" only when all checks pass and self-review is done.
+
+### 9. Keep Commit History Clean
+- Use `git rebase` or `git squash` to maintain a clean, logical commit history.
+- Each commit message should be meaningful — no "fix typo" or "wip" commits in the final history.
+- The PR will be squashed before merging, unless splitting into multiple commits is explicitly
+  needed to separate changes and allow later `git bisect`.
+
+### 10. Comment on Tricky Code
+- Add inline comments on any non-obvious logic explaining **why** a particular approach was chosen.
+- Flag performance tradeoffs, workarounds, or temporary solutions.
+
+### 11. Tag Specific Reviewers
+- Tag **specific owners or subject-matter experts** who are most relevant to the changed code.
+- For cross-team changes, tag reviewers from each affected team.
+
+### 12. Resolve All Comment Threads
+- After addressing review feedback, resolve each comment thread.
+- If you disagree with feedback, reply with your reasoning before resolving — do not silently dismiss.
+- A PR should have zero open threads before merging.
+
+
+## AI Skills
+
+This repository includes AI agent skills — structured instructions that coding agents (Claude Code, Crush, Cursor, GitHub Copilot) follow for specific workflows like creating or reviewing PRs.
+
+Skills live in `.claude/skills/` as `SKILL.md` files with YAML frontmatter. Most AI coding tools auto-load skills from this directory — no configuration needed. For GitHub Copilot, a condensed version lives in `.github/copilot-instructions.md`.
+
+### Adding New Skills
+
+1. Create a directory under `.claude/skills/<skill-name>/`.
+2. Add a `SKILL.md` with YAML frontmatter (`name`, `description`) and the full instruction body.
+3. For Copilot compatibility, add the rules to `.github/copilot-instructions.md` as a new section.
 
 
 ## PR and Issue Lifecycle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ All pull requests must follow these standards. Reviewers will check for complian
 - Convert to "Ready for Review" only when all checks pass and self-review is done.
 
 ### 9. Keep Commit History Clean
-- Use `git rebase` or `git squash` to maintain a clean, logical commit history.
+- Use interactive rebase (`git rebase -i`) to squash or fixup commits into a clean, logical history.
 - Each commit message should be meaningful — no "fix typo" or "wip" commits in the final history.
 - The PR will be squashed before merging, unless splitting into multiple commits is explicitly
   needed to separate changes and allow later `git bisect`.
@@ -111,9 +111,9 @@ All pull requests must follow these standards. Reviewers will check for complian
 
 ## AI Skills
 
-This repository includes AI agent skills — structured instructions that coding agents (Claude Code, Crush, Cursor, GitHub Copilot) follow for specific workflows like creating or reviewing PRs.
+This repository includes AI agent skills — structured instructions that coding agents follow for specific workflows like creating or reviewing PRs.
 
-Skills live in `.claude/skills/` as `SKILL.md` files with YAML frontmatter. Most AI coding tools auto-load skills from this directory — no configuration needed. For GitHub Copilot, a condensed version lives in `.github/copilot-instructions.md`.
+Skills live in `.claude/skills/` as `SKILL.md` files with YAML frontmatter. Claude Code, Crush, and Cursor all auto-load skills from this directory — no configuration needed. For GitHub Copilot, a condensed version lives in `.github/copilot-instructions.md`.
 
 ### Adding New Skills
 


### PR DESCRIPTION
<!-- Link to Jira issue -->
[ARO-26762](https://issues.redhat.com/browse/ARO-26762)

### What

Adds a cross-tool AI skill (`pr-standards`) that enforces team PR standards when AI coding agents assist with creating or reviewing pull requests. Also updates CONTRIBUTING.md and AGENTS.md.

### Why

AI coding agents (Crush, Claude Code, Copilot) are increasingly used to create PRs in this repo. Without explicit instructions, they produce inconsistent descriptions and miss team conventions. This codifies our PR standards in a way that both humans (via CONTRIBUTING.md) and AI agents (via auto-loaded skills) follow the same rules.

### Changes

**New files:**
- `.crush/skills/pr-standards/SKILL.md` — Crush auto-load skill
- `.claude/skills/pr-standards/SKILL.md` — Claude Code auto-load skill
- `.github/copilot-instructions.md` — GitHub Copilot instructions

**Updated files:**
- `AGENTS.md` — New "AI Skills" section documenting skill locations, auto-load behavior, and how to add new skills
- `CONTRIBUTING.md` — New "Pull Request Standards" section with 11 enforceable rules replacing scattered PR guidance

### PR Standards Enforced

1. Keep PRs small (one task per PR)
2. Write clear summaries explaining the "Why"
3. Link to relevant Jira/GitHub issue
4. Include screenshots for graph/UI changes
5. Self-review diff before requesting review
6. CI/CD checks must pass
7. Use Draft PRs for WIP
8. Keep commit history clean (rebase/squash)
9. Comment on tricky code blocks
10. Tag specific reviewers/SMEs
11. Resolve all comment threads before merge

### Testing

Documentation-only change. Verified skill files are correctly structured with YAML frontmatter and load in Crush.

### Special notes for your reviewer

Skills are placed in hidden auto-load directories (`.crush/skills/`, `.claude/skills/`) because that is how each tool discovers them without requiring config changes. This is documented in the new AGENTS.md section so contributors understand the pattern.

## PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI changes) — N/A, docs only
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented — N/A, no code
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
