### PR TITLE
e2e: add timeout and frequency to remaining unprotected PollUntilDone…

### DIFF
--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -414,7 +415,11 @@ var _ = Describe("Authorized CIDRs", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				_, err = poller.PollUntilDone(ctx, nil)
+				pollCtx, pollCancel := context.WithTimeout(ctx, 10*time.Minute)
+				defer pollCancel()
+				_, err = poller.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
+					Frequency: framework.StandardPollInterval,
+				})
 				Expect(err).NotTo(HaveOccurred())
 
 				By("verifying VM is now blocked from API access")

--- a/test/util/cleanup/kusto-role-assignments/run.go
+++ b/test/util/cleanup/kusto-role-assignments/run.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/sync/errgroup"
@@ -74,8 +75,12 @@ func pageAssignmentsAndDeleteInvalid(ctx context.Context, pager *runtime.Pager[a
 				if err != nil {
 					return fmt.Errorf("failed to delete role assignment: %w", err)
 				}
+				pollCtx, pollCancel := context.WithTimeout(ctx, 5*time.Minute)
+				defer pollCancel()
 				var resp any
-				if resp, err = poller.PollUntilDone(ctx, nil); err != nil {
+				if resp, err = poller.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
+					Frequency: 10 * time.Second,
+				}); err != nil {
 					return fmt.Errorf("failed to delete role assignment: %w", err)
 				}
 				switch m := resp.(type) {


### PR DESCRIPTION
… calls

Prevents indefinite polling in cluster_authorized_cidrs_connectivity and kusto-role-assignment cleanup by adding context timeouts and poll frequency options. Without these, a stalled ARM operation causes PollUntilDone to block until CI's external timeout kills the process, producing a misleading "deserialization error" instead of a clear timeout message.

Extends the fix from PR #4611 which only covered clusters_sharing_resgroup.

Ref: [ARO-25369](https://redhat.atlassian.net/browse/ARO-25369)

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
