### PR TITLE
feat: add ensureDefaults to nodepool patch and replace

### DIFF
--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -429,6 +429,10 @@ func decodeDesiredNodePoolReplace(ctx context.Context, oldInternalNodePool *api.
 	// TODO we probably update validation to require this field is cleared.
 	//newInternalCluster.Identity.UserAssignedIdentities = nil
 
+	// Backstop for fields unknown to this API version's SetDefaultValues*.
+	// See docs/api-version-defaults-and-storage.md.
+	newInternalNodePool.EnsureDefaults()
+
 	return newInternalNodePool, nil
 }
 
@@ -491,6 +495,10 @@ func decodeDesiredNodePoolPatch(ctx context.Context, oldInternalNodePool *api.HC
 	// TODO we'd like to have the instance complete when we go to validate it.  Right now validation fails if we clear this.
 	// TODO we probably update validation to require this field is cleared.
 	//newInternalCluster.Identity.UserAssignedIdentities = nil
+
+	// Backstop for fields unknown to this API version's SetDefaultValues*.
+	// See docs/api-version-defaults-and-storage.md.
+	newInternalNodePool.EnsureDefaults()
 
 	return newInternalNodePool, nil
 }


### PR DESCRIPTION
To be consistent with what's done for Clusters. Even though not strictly necessary as we read the old value from Cosmos we add it at the end of decodeDesiredNodePoolPatch, decodeDesiredNodePoolReplace to make sure no matter what happens before our calculated new internal nodepool always has the defaults.
