### PR TITLE
add ACR cache rule for HyperShift control-plane-operator images (AROSLSRE-777)

### DIFF
--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -72,6 +72,23 @@ module ocpCaching '../modules/acr/cache.bicep' = {
   ]
 }
 
+module ocpPublicCaching '../modules/acr/public-cache.bicep' = {
+  name: '${ocpAcrName}-public-caching'
+  params: {
+    acrName: ocpAcrName
+    publicRepositoriesToCache: [
+      {
+        ruleName: 'redhat-user-workloads-cpo'
+        sourceRepo: 'quay.io/redhat-user-workloads/crt-redhat-acm-tenant/*'
+        targetRepo: 'redhat-user-workloads/crt-redhat-acm-tenant/*'
+      }
+    ]
+  }
+  dependsOn: [
+    ocpAcr
+  ]
+}
+
 module ocpRedhatProdCaching '../modules/acr/cache.bicep' = {
   name: '${ocpAcrName}-redhat-prod-caching'
   params: {

--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -78,7 +78,7 @@ module ocpPublicCaching '../modules/acr/public-cache.bicep' = {
     acrName: ocpAcrName
     publicRepositoriesToCache: [
       {
-        ruleName: 'redhat-user-workloads-cpo'
+        ruleName: 'redhat-user-workloads-crt-redhat-acm-tenant'
         sourceRepo: 'quay.io/redhat-user-workloads/crt-redhat-acm-tenant/*'
         targetRepo: 'redhat-user-workloads/crt-redhat-acm-tenant/*'
       }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-777

### What

Add a public pull-through cache rule on the OCP ACR for `quay.io/redhat-user-workloads/crt-redhat-acm-tenant/*`.

### Why

The HyperShift control-plane-operator image (`quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-XX`) is injected by HyperShift as a sidecar in HCP pods. It is not mirrored to ACR and not covered by `registryOverrides`.

This is step 1 of 2 to unblock #4690 (FSI ValidatingAdmissionPolicy). Once the cache rule is deployed, the follow-up PR adds a `registryOverride` to HyperShift so it pulls CPO images from ACR instead of quay.io.

Root cause: [AROSLSRE-768](https://redhat.atlassian.net/browse/AROSLSRE-768)

### How it works

ACR pull-through cache automatically proxies and caches images on first pull. When HyperShift (after the registryOverride in step 2) requests `arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:xxx`, ACR transparently fetches it from `quay.io` and caches it. No manual mirroring, no digest tracking, all versions handled automatically.

### Merge order

1. **This PR** (cache rule) - merge and deploy to global infra first
2. **Follow-up PR** (registryOverride in `hypershiftoperator/values.yaml`) - merge after cache rule is deployed

### Testing

After deploying, verify:
```bash
az acr cache list --registry arohcpocpdev -o table | grep redhat-user-workloads
```