### PR TITLE
dev-infrastructure: use nullable type for postgres admin password (AROSLSRE-636)

### DIFF
--- a/dev-infrastructure/modules/postgres/postgres.bicep
+++ b/dev-infrastructure/modules/postgres/postgres.bicep
@@ -82,8 +82,8 @@ param subnetId string = ''
 param vnetId string = ''
 
 @secure()
-@description('The administrator login password (required for server creation).')
-param administratorLoginPassword string = ''
+@description('The administrator login password. Nullable to avoid sending an empty string on updates, which triggers an FSPG RP bug in some regions (AROSLSRE-636).')
+param administratorLoginPassword string?
 
 resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview' = {
   name: name


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-636

### What

Change `administratorLoginPassword` parameter in `postgres.bicep` from `string = ''` (default empty string) to `string?` (nullable, no default).

### Why

The FSPG RP in Brazil South has a regression ([IcM 779612318](https://portal.microsofticm.com/imp/v5/incidents/details/779612318/summary), open 20+ days) where an empty string password triggers a `NullArgumentException` in `SetUpDataResidencyForWorkflow → StoreEncrypted → AesTextEncryptor.Encrypt`. This blocks all `maestro-postgres-deployment` PUTs in Brazil South, which cascades to fail the entire `Service.Infra.service.cluster` EV2 step.

The bug only affects empty strings — `null` is handled correctly. By making the parameter nullable instead of defaulting to `''`, ARM omits the property from the PUT body entirely, bypassing the broken encryption path.

### Root cause (Microsoft side)

A new data residency feature deployed to Brazil South tries to encrypt the admin password on every PUT, but doesn't handle empty strings:

```
System.ArgumentNullException: Value cannot be null.
Parameter name: plainBytes
   at AesTextEncryptor.Encrypt(Byte[] plainBytes, ...)
   at SetUpDataResidencyForWorkflow(...)
   at UpsertServer(...)
```

Microsoft confirmed the regression (Cesar Martinez Macias, Apr 16) and said a fix would ship in M61, but it's still not deployed as of May 6. Steve Kuznetsov re-escalated to Sev2 on Apr 30.

### Impact

- Every other region works fine (empty string is only encrypted in regions with the new data residency feature)
- The PostgreSQL server in Brazil South already exists and is functional
- Password auth is disabled (`passwordAuth: 'Disabled'`) — only Entra AD auth is used
- This is a no-op PUT that shouldn't touch the password at all

### Change

```diff
-param administratorLoginPassword string = ''
+param administratorLoginPassword string?
```

One line. No callers explicitly pass this parameter — they all rely on the default. With `string?`, ARM treats it as `null` and omits it from the PUT body.

### Testing

- `az bicep build` compiles successfully
- ARM template output shows `"nullable": true` for the parameter
- No functional change for regions where empty string already works (null is equally valid)