### PR TITLE
observability: register user-journey folder so its dashboards deploy

### DIFF
--- a/observability/observability.yaml
+++ b/observability/observability.yaml
@@ -54,3 +54,5 @@ grafana-dashboards:
     path: ./grafana-dashboards/kas-monitor
   - name: HCP Kube API Server KSM
     path: ./grafana-dashboards/kas-ksm-monitor
+  - name: User Journey
+    path: ./grafana-dashboards/user-journey


### PR DESCRIPTION
### What

Register the `./grafana-dashboards/user-journey` folder in `observability.yaml`'s `dashboardFolders` list.

### Why

PR #4095 added `observability/grafana-dashboards/user-journey/etcd-availability.json` (Feb 2026) but the folder was never wired into the deploy config. The dashboard JSON has been sitting in the repo unused since merge; Grafana never receives it.

This change registers the folder so the existing etcd-availability dashboard ships, and pre-wires the path for upcoming user-journey dashboards (e.g. PR #4987 cluster-provisioning-slo).

### Testing

- `make -C observability verify` passes (grafanactl validates dashboards in the folder)
- `make verify-yamlfmt` passes
- `make verify` passes