### PR TITLE
Remove Cincinnati upgrade-graph validation for nodepool upgrades

### DIFF
--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
@@ -260,7 +260,8 @@ func prependActiveVersionIfChanged(currentVersions []api.HCPNodePoolActiveVersio
 //   - The desired version exists in Cincinnati
 //
 // Cincinnati upgrade-edge validation is intentionally skipped — HCP nodepools use the Replace
-// strategy (destroy + recreate), so only version existence matters. See OCM-16815, ARO-26792.
+// strategy (destroy + recreate), so only version existence matters.
+// See https://hypershift.pages.dev/reference/nodepool-rollouts/#upgrade-types
 //
 // Returns nil if the desired version is valid, or an error describing why it's invalid.
 func (c *nodePoolVersionSyncer) validateDesiredNodePoolVersion(

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
@@ -100,7 +100,7 @@ func NewNodePoolVersionController(
 //   - Not less than the highest active version (no downgrades)
 //   - Not greater than the lowest control plane version (node pools cannot exceed CP)
 //   - Not skip minor versions (only z-stream or +1 minor allowed)
-//   - Have a valid upgrade path in Cincinnati from the current version
+//   - Exist as a known version in Cincinnati
 //   - If valid, stores it in ServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion
 //
 // If the desired version is already among the active versions, validation is skipped
@@ -251,13 +251,16 @@ func prependActiveVersionIfChanged(currentVersions []api.HCPNodePoolActiveVersio
 	return newVersions
 }
 
-// validateDesiredNodePoolVersion checks that the desired node pool version is a valid upgrade path.
+// validateDesiredNodePoolVersion checks that the desired node pool version is a valid upgrade.
 // It validates:
 //   - The desired version is not less than the highest active node pool version (no downgrades)
 //   - The desired version is not greater than the lowest control plane version
 //   - No major version changes (unless FeatureExperimentalReleaseFeatures is registered)
 //   - No minor versions are skipped
-//   - An upgrade path exists from the current version (all the activeVersions) to the desired version (via Cincinnati)
+//   - The desired version exists in Cincinnati
+//
+// Cincinnati upgrade-edge validation is intentionally skipped — HCP nodepools use the Replace
+// strategy (destroy + recreate), so only version existence matters. See OCM-16815, ARO-26792.
 //
 // Returns nil if the desired version is valid, or an error describing why it's invalid.
 func (c *nodePoolVersionSyncer) validateDesiredNodePoolVersion(
@@ -290,22 +293,19 @@ func (c *nodePoolVersionSyncer) validateDesiredNodePoolVersion(
 		return err
 	}
 
-	// Validate upgrade path exists in Cincinnati for ALL active node pool versions
-	for _, activeVersion := range nodePoolActiveVersions {
-		if activeVersion.Version != nil && !desiredVersion.EQ(*activeVersion.Version) {
-			if err := c.validateUpgradePathAvailable(ctx, activeVersion.Version, desiredVersion, channelGroup, clusterUUID); err != nil {
-				return fmt.Errorf("no valid upgrade path from active version %s: %w", activeVersion.Version.String(), err)
-			}
-		}
+	// Validate the desired version exists in Cincinnati (not that an edge exists from the current version).
+	if err := c.validateVersionExistsInCincinnati(ctx, desiredVersion, channelGroup, clusterUUID); err != nil {
+		return err
 	}
 
 	return nil
 }
 
-// validateUpgradePathAvailable checks that an upgrade path exists from current to desired version.
-func (c *nodePoolVersionSyncer) validateUpgradePathAvailable(
+// validateVersionExistsInCincinnati checks that the desired version exists as a node in the
+// Cincinnati update graph.
+func (c *nodePoolVersionSyncer) validateVersionExistsInCincinnati(
 	ctx context.Context,
-	currentVersion, desiredVersion *semver.Version,
+	version *semver.Version,
 	channelGroup string,
 	clusterUUID uuid.UUID,
 ) error {
@@ -314,23 +314,17 @@ func (c *nodePoolVersionSyncer) validateUpgradePathAvailable(
 		return fmt.Errorf("failed to get Cincinnati URI: %w", err)
 	}
 
-	targetMinorString := fmt.Sprintf("%d.%d", desiredVersion.Major, desiredVersion.Minor)
-	cincinnatiChannel := fmt.Sprintf("%s-%s", channelGroup, targetMinorString)
-
+	cincinnatiChannel := fmt.Sprintf("%s-%d.%d", channelGroup, version.Major, version.Minor)
 	cincinnatiClient := c.cincinnatiClientCache.GetOrCreateClient(clusterUUID)
-	// Get updates for the current version
-	// TODO: for nodePools we should use the arch of that nodePool
-	_, candidates, _, err := cincinnatiClient.GetUpdates(ctx, cincinnatiURI, "multi", "multi", cincinnatiChannel, *currentVersion)
+
+	// GetUpdates returns VersionNotFound if the version doesn't exist in the channel.
+	_, _, _, err = cincinnatiClient.GetUpdates(ctx, cincinnatiURI, "multi", "multi", cincinnatiChannel, *version)
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to query Cincinnati for upgrade path: %w", err))
-	}
-
-	for _, candidate := range candidates {
-		candidateVersion := semver.MustParse(candidate.Version)
-		if candidateVersion.EQ(*desiredVersion) {
-			return nil
+		if cincinnati.IsCincinnatiVersionNotFoundError(err) {
+			return utils.TrackError(fmt.Errorf("version %s not found in Cincinnati channel %s", version, cincinnatiChannel))
 		}
+		return utils.TrackError(fmt.Errorf("failed to query Cincinnati for version existence: %w", err))
 	}
 
-	return utils.TrackError(fmt.Errorf("no upgrade path available from %s to %s in channel %s", currentVersion, desiredVersion, cincinnatiChannel))
+	return nil
 }

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
@@ -919,7 +919,7 @@ func TestNodePoolVersionSyncer_SyncOnce_DowngradeFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot downgrade")
 }
 
-func TestNodePoolVersionSyncer_SyncOnce_UpgradePathExistsSucceeds(t *testing.T) {
+func TestNodePoolVersionSyncer_SyncOnce_ValidUpgradeSucceeds(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
@@ -34,6 +34,7 @@ import (
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
+	cvocincinnati "github.com/openshift/cluster-version-operator/pkg/cincinnati"
 	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
@@ -743,7 +744,7 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredExceedsControlPlaneFails(t *testi
 	assert.Contains(t, err.Error(), "cannot exceed control plane version")
 }
 
-func TestNodePoolVersionSyncer_SyncOnce_NoUpgradePathInCincinnatiFails(t *testing.T) {
+func TestNodePoolVersionSyncer_SyncOnce_SucceedsWithoutCincinnatiEdge(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 
@@ -757,6 +758,9 @@ func TestNodePoolVersionSyncer_SyncOnce_NoUpgradePathInCincinnatiFails(t *testin
 	// Create ServiceProviderCluster with control plane at 4.20.0 (allows the desired version)
 	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
 
+	// Create ServiceProviderNodePool with active version 4.19.7
+	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
+
 	// CS returns node pool with current version 4.19.7
 	csNodePool := newCSNodePoolWithVersion(t, "4.19.7")
 	mockCS.EXPECT().
@@ -764,12 +768,12 @@ func TestNodePoolVersionSyncer_SyncOnce_NoUpgradePathInCincinnatiFails(t *testin
 		Return(csNodePool, nil).
 		Times(1)
 
-	// Setup Cincinnati mock to return NO upgrade path (empty candidates)
+	// Cincinnati: version exists, no candidates
 	mockCincinnati.EXPECT().
-		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.10"))).
 		Return(
-			configv1.Release{Version: "4.19.7"},
-			[]configv1.Release{}, // Empty - no upgrade path available
+			configv1.Release{Version: "4.19.10"},
+			[]configv1.Release{},
 			nil,
 			nil,
 		).
@@ -796,8 +800,76 @@ func TestNodePoolVersionSyncer_SyncOnce_NoUpgradePathInCincinnatiFails(t *testin
 	ctx = utils.ContextWithLogger(ctx, logr.Discard())
 	err := syncer.SyncOnce(ctx, testKey)
 
+	require.NoError(t, err)
+
+	// Verify the ServiceProviderNodePool DesiredVersion was updated
+	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
+		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
+	).Get(ctx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+	require.NotNil(t, spnp.Spec.NodePoolVersion.DesiredVersion)
+	expectedDesiredVersion := semver.MustParse("4.19.10")
+	require.True(t, expectedDesiredVersion.EQ(*spnp.Spec.NodePoolVersion.DesiredVersion))
+}
+
+func TestNodePoolVersionSyncer_SyncOnce_VersionNotInCincinnatiFails(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+	mockCincinnati := cincinnati.NewMockClient(ctrl)
+
+	// Create node pool with desired version 4.19.99 (does not exist in Cincinnati)
+	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.99")
+
+	// Create ServiceProviderCluster with control plane at 4.20.0
+	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
+
+	// Create ServiceProviderNodePool with active version 4.19.7
+	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
+
+	// CS returns node pool with current version 4.19.7
+	csNodePool := newCSNodePoolWithVersion(t, "4.19.7")
+	mockCS.EXPECT().
+		GetNodePool(gomock.Any(), gomock.Any()).
+		Return(csNodePool, nil).
+		Times(1)
+
+	// Cincinnati returns VersionNotFound for the desired version
+	mockCincinnati.EXPECT().
+		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.99"))).
+		Return(
+			configv1.Release{},
+			nil,
+			nil,
+			&cvocincinnati.Error{Reason: "VersionNotFound", Message: "version 4.19.99 not found"},
+		).
+		Times(1)
+
+	mockClientCache := cincinnati.NewMockClientCache(ctrl)
+	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
+
+	syncer := &nodePoolVersionSyncer{
+		cooldownChecker:                       &alwaysSyncCooldownChecker{},
+		clusterManagementClusterContentLister: newValidHostedClusterContentLister(t),
+		resourcesDBClient:                     mockResourcesDBClient,
+		clusterServiceClient:                  mockCS,
+		cincinnatiClientCache:                 mockClientCache,
+	}
+
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	ctx = utils.ContextWithLogger(ctx, logr.Discard())
+	err := syncer.SyncOnce(ctx, testKey)
+
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no upgrade path available")
+	assert.Contains(t, err.Error(), "not found in Cincinnati")
 }
 
 func TestNodePoolVersionSyncer_SyncOnce_DowngradeFails(t *testing.T) {
@@ -868,16 +940,12 @@ func TestNodePoolVersionSyncer_SyncOnce_UpgradePathExistsSucceeds(t *testing.T) 
 		Return(csNodePool, nil).
 		Times(1)
 
-	// Setup Cincinnati mock to return valid upgrade path including desired version
+	// Cincinnati returns success for the desired version (version exists in the graph)
 	mockCincinnati.EXPECT().
 		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(
-			configv1.Release{Version: "4.19.10"},
-			[]configv1.Release{
-				{Version: "4.19.12"},
-				{Version: "4.19.15"}, // Desired version is in candidates
-				{Version: "4.19.18"},
-			},
+			configv1.Release{Version: "4.19.15"},
+			[]configv1.Release{},
 			nil,
 			nil,
 		).
@@ -934,13 +1002,13 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 		Return(csNodePool, nil).
 		Times(1)
 
-	// Phase 1: Cincinnati mock returns valid upgrade path
+	// Phase 1: Cincinnati confirms the desired version exists
 	mockCincinnati := cincinnati.NewMockClient(ctrl)
 	mockCincinnati.EXPECT().
 		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(
-			configv1.Release{Version: "4.19.10"},
-			[]configv1.Release{{Version: "4.19.15"}},
+			configv1.Release{Version: "4.19.15"},
+			[]configv1.Release{},
 			nil,
 			nil,
 		).
@@ -989,13 +1057,13 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	require.True(t, expectedDesiredVersion.EQ(*spnp.Spec.NodePoolVersion.DesiredVersion),
 		"DesiredVersion should match customer version %s, got %s", "4.19.15", spnp.Spec.NodePoolVersion.DesiredVersion)
 
-	// --- Phase 2: Change version, Cincinnati fails, desired should NOT change ---
+	// --- Phase 2: Change to non-existent version, Cincinnati fails, desired should NOT change ---
 
-	// Update the HCPNodePool with a new desired version
+	// Update the HCPNodePool with a version that doesn't exist in Cincinnati
 	nodePool, err := mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).
 		NodePools(testClusterName).Get(ctx, testNodePoolName)
 	require.NoError(t, err)
-	nodePool.Properties.Version.ID = "4.19.20"
+	nodePool.Properties.Version.ID = "4.19.99"
 	_, err = mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).
 		NodePools(testClusterName).Replace(ctx, nodePool, nil)
 	require.NoError(t, err)
@@ -1006,22 +1074,23 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 		Return(csNodePool, nil).
 		Times(1)
 
+	// Cincinnati returns VersionNotFound — version doesn't exist
 	mockCincinnatiFailing := cincinnati.NewMockClient(ctrl)
 	mockCincinnatiFailing.EXPECT().
 		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(
-			configv1.Release{Version: "4.19.10"},
-			[]configv1.Release{}, // Empty - no upgrade path available
+			configv1.Release{},
 			nil,
 			nil,
+			&cvocincinnati.Error{Reason: "VersionNotFound", Message: "version 4.19.99 not found"},
 		).
 		AnyTimes()
 	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnatiFailing).Times(1)
 
-	// SyncOnce should fail because Cincinnati doesn't have upgrade path
+	// SyncOnce should fail because the version doesn't exist in Cincinnati
 	err = syncer.SyncOnce(ctx, testKey)
-	require.Error(t, err, "SyncOnce should fail when Cincinnati has no upgrade path")
-	assert.Contains(t, err.Error(), "no upgrade path available")
+	require.Error(t, err, "SyncOnce should fail when version doesn't exist in Cincinnati")
+	assert.Contains(t, err.Error(), "not found in Cincinnati")
 
 	// Verify that DesiredVersion was NOT changed (still 4.19.15)
 	spnp, err = mockResourcesDBClient.ServiceProviderNodePools(
@@ -1034,7 +1103,16 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 		"DesiredVersion should NOT have changed after failed validation, expected %s, got %s",
 		"4.19.15", spnp.Spec.NodePoolVersion.DesiredVersion)
 
-	// --- Phase 3: Cincinnati succeeds, desired should change ---
+	// --- Phase 3: Change to existing version, should succeed ---
+
+	// Update the HCPNodePool with a version that exists in Cincinnati
+	nodePool, err = mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).
+		NodePools(testClusterName).Get(ctx, testNodePoolName)
+	require.NoError(t, err)
+	nodePool.Properties.Version.ID = "4.19.20"
+	_, err = mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).
+		NodePools(testClusterName).Replace(ctx, nodePool, nil)
+	require.NoError(t, err)
 
 	// Setup CS mocks for third sync
 	mockCS.EXPECT().
@@ -1042,12 +1120,13 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 		Return(csNodePool, nil).
 		Times(1)
 
+	// Cincinnati confirms the version exists
 	mockCincinnatiSucceeding := cincinnati.NewMockClient(ctrl)
 	mockCincinnatiSucceeding.EXPECT().
 		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(
-			configv1.Release{Version: "4.19.10"},
-			[]configv1.Release{{Version: "4.19.20"}}, // Valid upgrade path
+			configv1.Release{Version: "4.19.20"},
+			[]configv1.Release{},
 			nil,
 			nil,
 		).
@@ -1056,7 +1135,7 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 
 	// SyncOnce should succeed now
 	err = syncer.SyncOnce(ctx, testKey)
-	require.NoError(t, err, "SyncOnce should succeed when Cincinnati has valid upgrade path")
+	require.NoError(t, err, "SyncOnce should succeed when version exists in Cincinnati")
 
 	// Verify that DesiredVersion HAS changed to 4.19.20
 	spnp, err = mockResourcesDBClient.ServiceProviderNodePools(

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -239,5 +240,138 @@ var _ = Describe("Customer", func() {
 		Entry("from 4.20.z to 4.20.zLatest",
 			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible,
 			"4.20", "4.20"),
+	)
+
+	// Nodepool upgrade without Cincinnati edge: proves the no-edge scenario works for forward
+	// upgrades. HCP nodepools use Replace strategy — nodes are recreated, not upgraded in-place —
+	// so Cincinnati upgrade edges are irrelevant. The backend only validates that the target
+	// version exists in Cincinnati, not that an edge exists from the current version.
+	DescribeTable("should upgrade a nodepool to a version without Cincinnati upgrade edge",
+		func(ctx context.Context, minor string) {
+			Skip("skipped until PR #5184 is merged and deployed")
+
+			channelGroup := framework.DefaultOpenshiftChannelGroup()
+
+			fromVersion, toVersion, err := framework.GetVersionPairWithoutUpgradeEdge(ctx, channelGroup, minor)
+			if errors.Is(err, framework.ErrNoNoEdgePairFound) {
+				Skip(fmt.Sprintf("no version pair without upgrade edge in minor %s on channel %s", minor, channelGroup))
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			clusterInstallVersion, err := framework.GetLatestVersionInMinor(ctx, channelGroup, minor)
+			if cincinnati.IsCincinnatiVersionNotFoundError(err) {
+				Skip(fmt.Sprintf("Cincinnati returned version not found for minor %s on channel %s", minor, channelGroup))
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			clusterVersion := api.Must(semver.ParseTolerant(clusterInstallVersion))
+			Expect(toVersion.LTE(clusterVersion)).To(BeTrue(),
+				"target version %s must not exceed control plane version %s", toVersion, clusterVersion)
+
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			suffix := rand.String(6)
+			clusterName := "np-noedge-" + suffix
+
+			By("creating resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-np-noedge-"+suffix, tc.Location())
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating cluster parameters at control plane version")
+			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams.ClusterName = clusterName
+			clusterParams.OpenshiftVersionId = clusterInstallVersion
+			clusterParams.ChannelGroup = channelGroup
+			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name+"-np-ne-"+suffix, "-managed", 64)
+
+			By("creating customer resources")
+			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{
+					"customerNsgName":        "customer-nsg-np-noedge-" + suffix,
+					"customerVnetName":       "customer-vnet-np-noedge-" + suffix,
+					"customerVnetSubnetName": "customer-vnet-subnet-np-noedge-" + suffix,
+				},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("creating the HCP cluster with version %s", clusterInstallVersion))
+			err = tc.CreateHCPClusterFromParam(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				45*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("creating nodepool at version %s (no Cincinnati edge to %s)", fromVersion, toVersion))
+			customerNodePoolName := fmt.Sprintf("npnoedge-%s", strings.ReplaceAll(minor, ".", "-"))
+			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams.NodePoolName = customerNodePoolName
+			nodePoolParams.OpenshiftVersionId = fromVersion.String()
+			nodePoolParams.ChannelGroup = channelGroup
+			nodePoolParams.NodeDrainTimeoutMinutes = to.Ptr(int32(10))
+			err = tc.CreateNodePoolFromParam(
+				ctx,
+				*resourceGroup.Name,
+				clusterName,
+				nodePoolParams,
+				45*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("getting admin credentials")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				clusterName,
+				10*time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("capturing node release images before upgrade")
+			previousReleaseImages, err := framework.NodePoolReleaseImages(ctx, adminRESTConfig, customerNodePoolName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(previousReleaseImages).NotTo(BeEmpty(), "expected node pool nodes to report at least one release image ref before upgrade")
+
+			By(fmt.Sprintf("triggering nodepool upgrade from %s to %s (no Cincinnati edge)", fromVersion, toVersion))
+			nodePoolsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
+			update := hcpsdk20240610preview.NodePoolUpdate{
+				Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
+					Version: &hcpsdk20240610preview.NodePoolVersionProfile{
+						ID:           to.Ptr(toVersion.String()),
+						ChannelGroup: to.Ptr(channelGroup),
+					},
+				},
+			}
+			_, err = framework.UpdateNodePoolAndWait(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName, update, 45*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying nodes are recreated at the target version")
+			Eventually(func() error {
+				return verifiers.VerifyNodePoolUpgrade(toVersion.String(), customerNodePoolName, previousReleaseImages).Verify(ctx, adminRESTConfig)
+			}, 45*time.Minute, 2*time.Minute).Should(Succeed())
+
+			By("verifying node pool GET reflects the target version")
+			npGetResponse, err := framework.GetNodePool(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(npGetResponse.Properties).NotTo(BeNil())
+			Expect(npGetResponse.Properties.Version).NotTo(BeNil())
+			Expect(npGetResponse.Properties.Version.ID).NotTo(BeNil())
+			Expect(*npGetResponse.Properties.Version.ID).To(Equal(toVersion.String()))
+		},
+		Entry("z-stream upgrade without Cincinnati edge in 4.20",
+			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible,
+			"4.20"),
 	)
 })

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -253,7 +253,7 @@ var _ = Describe("Customer", func() {
 			channelGroup := framework.DefaultOpenshiftChannelGroup()
 
 			fromVersion, toVersion, err := framework.GetVersionPairWithoutUpgradeEdge(ctx, channelGroup, minor)
-			if errors.Is(err, framework.ErrNoNoEdgePairFound) {
+			if errors.Is(err, framework.ErrNoEdgePairFound) {
 				Skip(fmt.Sprintf("no version pair without upgrade edge in minor %s on channel %s", minor, channelGroup))
 			}
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -322,7 +322,9 @@ var _ = Describe("Customer", func() {
 			nodePoolParams.NodeDrainTimeoutMinutes = to.Ptr(int32(10))
 			err = tc.CreateNodePoolFromParam(
 				ctx,
+				GinkgoLogr,
 				*resourceGroup.Name,
+				clusterParams.ManagedResourceGroupName,
 				clusterName,
 				nodePoolParams,
 				45*time.Minute,

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -256,13 +256,13 @@ var _ = Describe("Customer", func() {
 			if errors.Is(err, framework.ErrNoEdgePairFound) {
 				Skip(fmt.Sprintf("no version pair without upgrade edge in minor %s on channel %s", minor, channelGroup))
 			}
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "failed to get version pair without upgrade edge for minor %s", minor)
 
 			clusterInstallVersion, err := framework.GetLatestVersionInMinor(ctx, channelGroup, minor)
 			if cincinnati.IsCincinnatiVersionNotFoundError(err) {
 				Skip(fmt.Sprintf("Cincinnati returned version not found for minor %s on channel %s", minor, channelGroup))
 			}
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "failed to get latest version in minor %s", minor)
 
 			clusterVersion := api.Must(semver.ParseTolerant(clusterInstallVersion))
 			Expect(toVersion.LTE(clusterVersion)).To(BeTrue(),
@@ -272,7 +272,7 @@ var _ = Describe("Customer", func() {
 
 			if tc.UsePooledIdentities() {
 				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 
 			suffix := rand.String(6)
@@ -280,7 +280,7 @@ var _ = Describe("Customer", func() {
 
 			By("creating resource group")
 			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-np-noedge-"+suffix, tc.Location())
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group")
 
 			By("creating cluster parameters at control plane version")
 			clusterParams := framework.NewDefaultClusterParams()
@@ -301,7 +301,7 @@ var _ = Describe("Customer", func() {
 				TestArtifactsFS,
 				framework.RBACScopeResourceGroup,
 			)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
 
 			By(fmt.Sprintf("creating the HCP cluster with version %s", clusterInstallVersion))
 			err = tc.CreateHCPClusterFromParam(
@@ -311,7 +311,7 @@ var _ = Describe("Customer", func() {
 				clusterParams,
 				45*time.Minute,
 			)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %s", clusterName)
 
 			By(fmt.Sprintf("creating nodepool at version %s (no Cincinnati edge to %s)", fromVersion, toVersion))
 			customerNodePoolName := fmt.Sprintf("npnoedge-%s", strings.ReplaceAll(minor, ".", "-"))
@@ -329,7 +329,7 @@ var _ = Describe("Customer", func() {
 				nodePoolParams,
 				45*time.Minute,
 			)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "failed to create nodepool %s at version %s", customerNodePoolName, fromVersion)
 
 			By("getting admin credentials")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
@@ -339,11 +339,11 @@ var _ = Describe("Customer", func() {
 				clusterName,
 				10*time.Minute,
 			)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %s", clusterName)
 
 			By("capturing node release images before upgrade")
 			previousReleaseImages, err := framework.NodePoolReleaseImages(ctx, adminRESTConfig, customerNodePoolName)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "failed to capture node release images for nodepool %s", customerNodePoolName)
 			Expect(previousReleaseImages).NotTo(BeEmpty(), "expected node pool nodes to report at least one release image ref before upgrade")
 
 			By(fmt.Sprintf("triggering nodepool upgrade from %s to %s (no Cincinnati edge)", fromVersion, toVersion))
@@ -357,7 +357,7 @@ var _ = Describe("Customer", func() {
 				},
 			}
 			_, err = framework.UpdateNodePoolAndWait(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName, update, 45*time.Minute)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "failed to upgrade nodepool %s from %s to %s", customerNodePoolName, fromVersion, toVersion)
 
 			By("verifying nodes are recreated at the target version")
 			Eventually(func() error {
@@ -366,11 +366,11 @@ var _ = Describe("Customer", func() {
 
 			By("verifying node pool GET reflects the target version")
 			npGetResponse, err := framework.GetNodePool(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(npGetResponse.Properties).NotTo(BeNil())
-			Expect(npGetResponse.Properties.Version).NotTo(BeNil())
-			Expect(npGetResponse.Properties.Version.ID).NotTo(BeNil())
-			Expect(*npGetResponse.Properties.Version.ID).To(Equal(toVersion.String()))
+			Expect(err).NotTo(HaveOccurred(), "failed to GET nodepool %s", customerNodePoolName)
+			Expect(npGetResponse.Properties).NotTo(BeNil(), "nodepool %s response Properties was nil", customerNodePoolName)
+			Expect(npGetResponse.Properties.Version).NotTo(BeNil(), "nodepool %s Properties.Version was nil", customerNodePoolName)
+			Expect(npGetResponse.Properties.Version.ID).NotTo(BeNil(), "nodepool %s Properties.Version.ID was nil", customerNodePoolName)
+			Expect(*npGetResponse.Properties.Version.ID).To(Equal(toVersion.String()), "nodepool %s version should be %s but got %s", customerNodePoolName, toVersion, *npGetResponse.Properties.Version.ID)
 		},
 		Entry("z-stream upgrade without Cincinnati edge in 4.20",
 			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible,

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -66,4 +66,5 @@ Customer should be able to update nodepool replicas and autoscaling
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
+Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should be able to use workload identity via the cluster OIDC issuer URL

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -68,5 +68,6 @@ Customer should be able to update node pool labels and taints
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
+Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -67,6 +67,7 @@ Customer should be able to update node pool labels and taints
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
+Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings
 Customer should not be able to perform various invalid operations on cluster resources

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -70,5 +70,6 @@ Customer should be able to update nodepool replicas and autoscaling
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
+Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -63,5 +63,6 @@ Customer should be able to update node pool labels and taints
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
+Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -67,6 +67,7 @@ Customer should be able to update node pool labels and taints
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
+Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings
 Customer should not be able to perform various invalid operations on cluster resources

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -41,6 +41,7 @@ var (
 	ErrNoAcceptedNightlyTags        = errors.New("no accepted nightly tags found")
 	ErrNoParseableNightlyTags       = errors.New("no parseable nightly tags found")
 	ErrVersionNotFound              = errors.New("no graph nodes found")
+	ErrNoNoEdgePairFound            = errors.New("no version pair without upgrade edge found")
 )
 
 const (
@@ -80,7 +81,8 @@ func isRetryableVersionError(err error) bool {
 	if errors.Is(err, ErrVersionNotFound) ||
 		errors.Is(err, ErrNightlyReleaseStreamNotFound) ||
 		errors.Is(err, ErrNoAcceptedNightlyTags) ||
-		errors.Is(err, ErrNoParseableNightlyTags) {
+		errors.Is(err, ErrNoParseableNightlyTags) ||
+		errors.Is(err, ErrNoNoEdgePairFound) {
 		return false
 	}
 	if cincinnati.IsCincinnatiVersionNotFoundError(err) {
@@ -283,6 +285,98 @@ func GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx context.Context, channelGr
 		return out[i].LT(out[j])
 	})
 	return out, nil
+}
+
+// GetVersionPairWithoutUpgradeEdge finds two versions A < B in the given minor where Cincinnati
+// has no upgrade edge from A to B. This is useful for testing that nodepool upgrades succeed
+// even without a Cincinnati upgrade path (HCP nodepools use Replace strategy).
+// Returns ErrNoNoEdgePairFound if all version pairs in the minor have edges.
+func GetVersionPairWithoutUpgradeEdge(ctx context.Context, channelGroup string, minor string) (from, to semver.Version, err error) {
+	type versionPair struct {
+		from, to semver.Version
+	}
+	pair, err := retryOnTransientError(ctx, func() (versionPair, error) {
+		f, t, err := getVersionPairWithoutUpgradeEdge(ctx, channelGroup, minor)
+		return versionPair{f, t}, err
+	})
+	return pair.from, pair.to, err
+}
+
+func getVersionPairWithoutUpgradeEdge(ctx context.Context, channelGroup string, minor string) (from, to semver.Version, err error) {
+	channel := fmt.Sprintf("%s-%s", channelGroup, minor)
+	graphURL := fmt.Sprintf("https://api.openshift.com/api/upgrades_info/v1/graph?channel=%s", url.QueryEscape(channel))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, graphURL, nil)
+	if err != nil {
+		return semver.Version{}, semver.Version{}, fmt.Errorf("create graph request for %s: %w", channel, err)
+	}
+
+	client := &http.Client{Timeout: graphAPIRequestTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return semver.Version{}, semver.Version{}, fmt.Errorf("query graph for %s: %w", channel, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return semver.Version{}, semver.Version{}, fmt.Errorf("query graph for %s returned %s: %s", channel, resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var payload struct {
+		Nodes []struct {
+			Version string `json:"version"`
+		} `json:"nodes"`
+		// Directed edges: [from_index, to_index] means upgrade path from nodes[from] to nodes[to].
+		Edges [][]int `json:"edges"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return semver.Version{}, semver.Version{}, fmt.Errorf("decode graph response for %s: %w", channel, err)
+	}
+	if len(payload.Nodes) < 2 {
+		return semver.Version{}, semver.Version{}, fmt.Errorf("%w: fewer than 2 nodes in %s", ErrNoNoEdgePairFound, channel)
+	}
+
+	requestedMinor, err := semver.ParseTolerant(minor)
+	if err != nil {
+		return semver.Version{}, semver.Version{}, fmt.Errorf("parse minor %q: %w", minor, err)
+	}
+
+	type indexedVersion struct {
+		index   int
+		version semver.Version
+	}
+	var versions []indexedVersion
+	for i, node := range payload.Nodes {
+		v, parseErr := semver.ParseTolerant(node.Version)
+		if parseErr != nil {
+			continue
+		}
+		if v.Major != requestedMinor.Major || v.Minor != requestedMinor.Minor {
+			continue
+		}
+		versions = append(versions, indexedVersion{index: i, version: v})
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].version.LT(versions[j].version)
+	})
+
+	edgeSet := make(map[[2]int]bool, len(payload.Edges))
+	for _, edge := range payload.Edges {
+		if len(edge) == 2 {
+			edgeSet[[2]int{edge[0], edge[1]}] = true
+		}
+	}
+
+	for i := 0; i < len(versions)-1; i++ {
+		for j := i + 1; j < len(versions); j++ {
+			if !edgeSet[[2]int{versions[i].index, versions[j].index}] {
+				return versions[i].version, versions[j].version, nil
+			}
+		}
+	}
+
+	return semver.Version{}, semver.Version{}, fmt.Errorf("%w in %s", ErrNoNoEdgePairFound, channel)
 }
 
 // GetLatestInstallVersion returns the latest install version for the given channel group and version.

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -41,7 +41,7 @@ var (
 	ErrNoAcceptedNightlyTags        = errors.New("no accepted nightly tags found")
 	ErrNoParseableNightlyTags       = errors.New("no parseable nightly tags found")
 	ErrVersionNotFound              = errors.New("no graph nodes found")
-	ErrNoNoEdgePairFound            = errors.New("no version pair without upgrade edge found")
+	ErrNoEdgePairFound              = errors.New("no version pair without upgrade edge found")
 )
 
 const (
@@ -82,7 +82,7 @@ func isRetryableVersionError(err error) bool {
 		errors.Is(err, ErrNightlyReleaseStreamNotFound) ||
 		errors.Is(err, ErrNoAcceptedNightlyTags) ||
 		errors.Is(err, ErrNoParseableNightlyTags) ||
-		errors.Is(err, ErrNoNoEdgePairFound) {
+		errors.Is(err, ErrNoEdgePairFound) {
 		return false
 	}
 	if cincinnati.IsCincinnatiVersionNotFoundError(err) {
@@ -290,7 +290,7 @@ func GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx context.Context, channelGr
 // GetVersionPairWithoutUpgradeEdge finds two versions A < B in the given minor where Cincinnati
 // has no upgrade edge from A to B. This is useful for testing that nodepool upgrades succeed
 // even without a Cincinnati upgrade path (HCP nodepools use Replace strategy).
-// Returns ErrNoNoEdgePairFound if all version pairs in the minor have edges.
+// Returns ErrNoEdgePairFound if all version pairs in the minor have edges.
 func GetVersionPairWithoutUpgradeEdge(ctx context.Context, channelGroup string, minor string) (from, to semver.Version, err error) {
 	type versionPair struct {
 		from, to semver.Version
@@ -303,7 +303,12 @@ func GetVersionPairWithoutUpgradeEdge(ctx context.Context, channelGroup string, 
 }
 
 func getVersionPairWithoutUpgradeEdge(ctx context.Context, channelGroup string, minor string) (from, to semver.Version, err error) {
-	channel := fmt.Sprintf("%s-%s", channelGroup, minor)
+	requestedMinor, err := semver.ParseTolerant(minor)
+	if err != nil {
+		return semver.Version{}, semver.Version{}, fmt.Errorf("parse minor %q: %w", minor, err)
+	}
+
+	channel := fmt.Sprintf("%s-%d.%d", channelGroup, requestedMinor.Major, requestedMinor.Minor)
 	graphURL := fmt.Sprintf("https://api.openshift.com/api/upgrades_info/v1/graph?channel=%s", url.QueryEscape(channel))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, graphURL, nil)
@@ -334,12 +339,7 @@ func getVersionPairWithoutUpgradeEdge(ctx context.Context, channelGroup string, 
 		return semver.Version{}, semver.Version{}, fmt.Errorf("decode graph response for %s: %w", channel, err)
 	}
 	if len(payload.Nodes) < 2 {
-		return semver.Version{}, semver.Version{}, fmt.Errorf("%w: fewer than 2 nodes in %s", ErrNoNoEdgePairFound, channel)
-	}
-
-	requestedMinor, err := semver.ParseTolerant(minor)
-	if err != nil {
-		return semver.Version{}, semver.Version{}, fmt.Errorf("parse minor %q: %w", minor, err)
+		return semver.Version{}, semver.Version{}, fmt.Errorf("%w: fewer than 2 nodes in %s", ErrNoEdgePairFound, channel)
 	}
 
 	type indexedVersion struct {
@@ -356,6 +356,9 @@ func getVersionPairWithoutUpgradeEdge(ctx context.Context, channelGroup string, 
 			continue
 		}
 		versions = append(versions, indexedVersion{index: i, version: v})
+	}
+	if len(versions) < 2 {
+		return semver.Version{}, semver.Version{}, fmt.Errorf("%w: fewer than 2 parseable versions in minor %d.%d on channel %s", ErrNoEdgePairFound, requestedMinor.Major, requestedMinor.Minor, channel)
 	}
 	sort.Slice(versions, func(i, j int) bool {
 		return versions[i].version.LT(versions[j].version)
@@ -376,7 +379,7 @@ func getVersionPairWithoutUpgradeEdge(ctx context.Context, channelGroup string, 
 		}
 	}
 
-	return semver.Version{}, semver.Version{}, fmt.Errorf("%w in %s", ErrNoNoEdgePairFound, channel)
+	return semver.Version{}, semver.Version{}, fmt.Errorf("%w in %s", ErrNoEdgePairFound, channel)
 }
 
 // GetLatestInstallVersion returns the latest install version for the given channel group and version.


### PR DESCRIPTION
Fixes: [ARO-26792](https://redhat.atlassian.net/browse/ARO-26792)

(updated)

 ### What

  Replace Cincinnati upgrade-edge validation with a version existence check in the nodepool version controller. The backend now verifies the desired version exists in
  Cincinnati but no longer requires an upgrade edge from the current version. Static Kubernetes version skew constraints remain enforced (nodepool ≤ CP version, no downgrade,
   within minor+1).

  Per @deads2k suggestion, this work is split into two PRs:
  1. **(this PR)** Remove edge requirement, keep version existence check
  2. Remove downgrade restriction for nodepool versions (#5184)

  ### Why

  HCP nodepools use the Replace upgrade strategy — nodes are destroyed and recreated at the target version, not upgraded in-place. Cincinnati upgrade edges are irrelevant for
   this strategy.

  The controller was querying Cincinnati for every nodepool upgrade and requiring an edge from the current to the desired version. When no edge existed (e.g. 4.20.8 →
  4.21.1), it entered a permanent error-retry loop. ARM reported `Succeeded` while the upgrade never progressed, leaving customers with no visibility into the failure.

  ### Testing

  - **Unit tests**: Replaced edge-check mocks with existence-check mocks. Added `SucceedsWithoutCincinnatiEdge` (version exists but no edge → succeeds) and
  `VersionNotInCincinnatiFails` (version doesn't exist → fails). Updated `DesiredVersionUnchangedOnFailure` to test VersionNotFound instead of missing edges.
  - **E2E**: Existing y-stream upgrade test (4.20.z → 4.21.zLatest) validates the fix end-to-end. Verified locally against a dev cluster — nodepool upgraded from 4.20.20 to
  4.21.14 successfully.

  ### Special notes for your reviewer

  **Depends on CS [MR !322](https://gitlab.cee.redhat.com/service/aro-hcp-clusters-service/-/merge_requests/322)** — CS also validates upgrade edges via `AvailableUpgrades`
  in `ValidateNodePoolUpgradeVersion()`. Without the CS change, the backend accepts the version but CS blocks the upgrade policy. Safe to deploy in any order — neither change
   alone creates a regression.

  A rationale comment in `validateDesiredNodePoolVersion` notes that if an InPlace upgrade strategy is introduced in the future, strategy-specific upgrade validation should
  be added.

