### PR TITLE
ARO-26795: derive operation metric resource_id from op.ExternalID

### DIFF
--- a/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller.go
+++ b/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller.go
@@ -90,7 +90,7 @@ func (h *operationPhaseMetricsHandler) Sync(ctx context.Context, op *api.Operati
 		// alerting a hook.
 		logger := utils.LoggerFromContext(ctx)
 		logger.Info("operation has no ExternalID; skipping metric emission",
-			"operation_resource_id", resourceIDMetricLabel(op.GetResourceID()))
+			"cosmos_doc_id", resourceIDMetricLabel(op.GetResourceID()))
 		return
 	}
 	subscriptionID := subscriptionIDMetricLabel(op.MetricResourceID())
@@ -113,7 +113,7 @@ func (h *operationPhaseMetricsHandler) Sync(ctx context.Context, op *api.Operati
 	labels := prometheus.Labels{
 		"resource_id":     resourceID,
 		"subscription_id": subscriptionID,
-		"resource_type":   resourceIDToTypeMetricLabel(op.ExternalID),
+		"resource_type":   resourceIDToTypeMetricLabel(op.MetricResourceID()),
 		"operation_type":  operationTypeMetricLabel(op.Request),
 		"phase":           phaseMetricLabel(op.Status),
 	}
@@ -129,12 +129,16 @@ func (h *operationPhaseMetricsHandler) Sync(ctx context.Context, op *api.Operati
 
 // Delete is intentionally a no-op for operation phase metrics.
 //
-// Multiple operation documents can share one resource_id label (the
-// ARM resource id from op.ExternalID), so deleting by resource_id
-// when one operation is removed would also blank any sibling
-// operation's currently-emitted series. Sync's pre-emit
-// DeletePartialMatch implicitly cleans up obsolete labels whenever
-// any operation for a resource is processed.
+// The controller framework calls handler.Delete with the indexer key,
+// which for Operations is the lowercased Cosmos document id. That key
+// no longer matches the resource_id metric label after this PR
+// (resource_id is now derived from op.ExternalID, the ARM resource id).
+// Deleting by the cosmos key would not find any series; deleting by
+// resource_id would blank any sibling operation's currently-emitted
+// series for the same ARM resource (multiple operation documents can
+// share one resource_id label). Sync's pre-emit DeletePartialMatch
+// implicitly cleans up obsolete labels whenever any operation for
+// a resource is processed, so explicit Delete is unnecessary.
 //
 // The trade-off: when the LAST operation for a resource ages out of
 // the Cosmos TTL with no surviving sibling, the series persists in

--- a/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller.go
+++ b/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller.go
@@ -21,10 +21,35 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 var operationMetricLabelNames = []string{"resource_id", "subscription_id", "resource_type", "operation_type", "phase"}
 
+// operationPhaseMetricsHandler emits and clears the
+// backend_resource_operation_* metric family.
+//
+// resource_id derivation:
+//
+// resource_id is the lowercased ARM resource id of the cluster /
+// nodepool / external auth this operation targets (op.ExternalID, via
+// op.MetricResourceID()). It is NOT the cosmos doc id stored in
+// op.ResourceID, which exists only for unique cosmos addressing and
+// has no meaning to operators correlating metrics with customer ARM
+// resources. This matches the format already used by the sibling
+// backend_resource_provision_state metric family.
+//
+// Multiple operations on the same ARM resource id collapse to one
+// series. On the AllOperations() informer's unordered iteration
+// (every relist / resync, or backend restart) whichever operation
+// is processed last wins for that resource_id; this may temporarily
+// or persistently reflect an older terminal op until a later emit
+// for that resource supersedes it. If the resource is idle, the stale
+// labels can persist indefinitely. Separate limitation: when the
+// last operation for a resource ages out of the Cosmos TTL, its
+// series persists until process restart (Delete is a no-op; see
+// Delete doc-comment for the rationale). Resource-level conditions
+// are the longer-term direction.
 type operationPhaseMetricsHandler struct {
 	phaseInfo          *prometheus.GaugeVec
 	startTime          *prometheus.GaugeVec
@@ -51,21 +76,39 @@ func NewOperationPhaseMetricsHandler(r prometheus.Registerer) Handler[*api.Opera
 	return h
 }
 
-func (h *operationPhaseMetricsHandler) Sync(_ context.Context, op *api.Operation) {
-	resourceID := resourceIDMetricLabel(op.GetResourceID())
+func (h *operationPhaseMetricsHandler) Sync(ctx context.Context, op *api.Operation) {
+	resourceID := resourceIDMetricLabel(op.MetricResourceID())
 	if len(resourceID) == 0 {
+		// op.ExternalID is expected to always be populated for production
+		// operations (every frontend construction site passes the target
+		// resource ID into database.NewOperation). Surface a warning when
+		// the invariant breaks so an operator notices instead of staring
+		// at a silently missing metric. This logs once per Sync event
+		// for the offending op; if an operation persists with nil
+		// ExternalID across resyncs the log will repeat per reconcile,
+		// which is bounded by the op count and gives count-based
+		// alerting a hook.
+		logger := utils.LoggerFromContext(ctx)
+		logger.Info("operation has no ExternalID; skipping metric emission",
+			"operation_resource_id", resourceIDMetricLabel(op.GetResourceID()))
 		return
 	}
-	subscriptionID := subscriptionIDMetricLabel(op.GetResourceID())
+	subscriptionID := subscriptionIDMetricLabel(op.MetricResourceID())
 	if op.OperationID == nil {
-		h.Delete(resourceID)
+		// Implicit operation (e.g. child-resource cleanup along with
+		// parent). Don't emit a metric series for it, and don't
+		// deleteByResourceID either: a sibling operation with the
+		// same ExternalID may already own the emitted series for
+		// this resource_id and we must not blank it. Same rationale
+		// as Delete being a no-op (see Delete doc-comment).
 		return
 	}
 
 	// Clear any previous series for this resource before writing the current labels.
 	// Phase and operation labels are part of the metric identity, so updates would
-	// otherwise leave stale series behind for older label combinations.
-	h.Delete(resourceID)
+	// otherwise leave stale series behind for older label combinations. Multiple
+	// operations sharing this resource_id collapse to the latest-emitted labels.
+	h.deleteByResourceID(resourceID)
 
 	labels := prometheus.Labels{
 		"resource_id":     resourceID,
@@ -84,12 +127,34 @@ func (h *operationPhaseMetricsHandler) Sync(_ context.Context, op *api.Operation
 	}
 }
 
+// Delete is intentionally a no-op for operation phase metrics.
+//
+// Multiple operation documents can share one resource_id label (the
+// ARM resource id from op.ExternalID), so deleting by resource_id
+// when one operation is removed would also blank any sibling
+// operation's currently-emitted series. Sync's pre-emit
+// DeletePartialMatch implicitly cleans up obsolete labels whenever
+// any operation for a resource is processed.
+//
+// The trade-off: when the LAST operation for a resource ages out of
+// the Cosmos TTL with no surviving sibling, the series persists in
+// the in-memory prom registry until process restart / pod replacement;
+// affects only resources that go fully idle. The alternative
+// (per-resource active-op counting) reintroduces handler-local
+// bookkeeping, which is disproportionate for an operation-phase
+// metric whose longer-term direction is resource-level conditions.
 func (h *operationPhaseMetricsHandler) Delete(key string) {
-	if len(key) == 0 {
+	// no-op; see doc-comment above
+}
+
+// deleteByResourceID is used by Sync to clear stale labels before
+// writing new ones. Delete intentionally does not call this; see
+// the Delete doc-comment.
+func (h *operationPhaseMetricsHandler) deleteByResourceID(resourceID string) {
+	if len(resourceID) == 0 {
 		return
 	}
-
-	deleteSelector := prometheus.Labels{"resource_id": key}
+	deleteSelector := prometheus.Labels{"resource_id": resourceID}
 	h.phaseInfo.DeletePartialMatch(deleteSelector)
 	h.startTime.DeletePartialMatch(deleteSelector)
 	h.lastTransitionTime.DeletePartialMatch(deleteSelector)

--- a/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller.go
+++ b/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller.go
@@ -81,16 +81,16 @@ func (h *operationPhaseMetricsHandler) Sync(ctx context.Context, op *api.Operati
 	if len(resourceID) == 0 {
 		// op.ExternalID is expected to always be populated for production
 		// operations (every frontend construction site passes the target
-		// resource ID into database.NewOperation). Surface a warning when
-		// the invariant breaks so an operator notices instead of staring
-		// at a silently missing metric. This logs once per Sync event
-		// for the offending op; if an operation persists with nil
-		// ExternalID across resyncs the log will repeat per reconcile,
-		// which is bounded by the op count and gives count-based
-		// alerting a hook.
+		// resource ID into database.NewOperation). Log when the invariant
+		// breaks so an operator notices instead of staring at a silently
+		// missing metric. This logs once per Sync event for the offending
+		// op; if an operation persists with nil ExternalID across resyncs
+		// the log will repeat per reconcile, which is bounded by the op
+		// count and gives count-based alerting a hook.
 		logger := utils.LoggerFromContext(ctx)
-		logger.Info("WARNING: operation has no ExternalID; skipping metric emission",
-			"cosmos_resource_id", resourceIDMetricLabel(op.GetResourceID()))
+		logger.Info("operation has no ExternalID; skipping metric emission",
+			"missing_external_id", true,
+			"cosmos_doc_id", resourceIDMetricLabel(op.GetResourceID()))
 		return
 	}
 	subscriptionID := subscriptionIDMetricLabel(op.ExternalID)

--- a/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller.go
+++ b/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller.go
@@ -32,8 +32,8 @@ var operationMetricLabelNames = []string{"resource_id", "subscription_id", "reso
 // resource_id derivation:
 //
 // resource_id is the lowercased ARM resource id of the cluster /
-// nodepool / external auth this operation targets (op.ExternalID, via
-// op.MetricResourceID()). It is NOT the cosmos doc id stored in
+// nodepool / external auth this operation targets (op.ExternalID).
+// It is NOT the cosmos doc id stored in
 // op.ResourceID, which exists only for unique cosmos addressing and
 // has no meaning to operators correlating metrics with customer ARM
 // resources. This matches the format already used by the sibling
@@ -77,7 +77,7 @@ func NewOperationPhaseMetricsHandler(r prometheus.Registerer) Handler[*api.Opera
 }
 
 func (h *operationPhaseMetricsHandler) Sync(ctx context.Context, op *api.Operation) {
-	resourceID := resourceIDMetricLabel(op.MetricResourceID())
+	resourceID := resourceIDMetricLabel(op.ExternalID)
 	if len(resourceID) == 0 {
 		// op.ExternalID is expected to always be populated for production
 		// operations (every frontend construction site passes the target
@@ -93,7 +93,7 @@ func (h *operationPhaseMetricsHandler) Sync(ctx context.Context, op *api.Operati
 			"cosmos_resource_id", resourceIDMetricLabel(op.GetResourceID()))
 		return
 	}
-	subscriptionID := subscriptionIDMetricLabel(op.MetricResourceID())
+	subscriptionID := subscriptionIDMetricLabel(op.ExternalID)
 	if op.OperationID == nil {
 		// Implicit operation (e.g. child-resource cleanup along with
 		// parent). Don't emit a metric series for it, and don't
@@ -113,7 +113,7 @@ func (h *operationPhaseMetricsHandler) Sync(ctx context.Context, op *api.Operati
 	labels := prometheus.Labels{
 		"resource_id":     resourceID,
 		"subscription_id": subscriptionID,
-		"resource_type":   resourceIDToTypeMetricLabel(op.MetricResourceID()),
+		"resource_type":   resourceIDToTypeMetricLabel(op.ExternalID),
 		"operation_type":  operationTypeMetricLabel(op.Request),
 		"phase":           phaseMetricLabel(op.Status),
 	}

--- a/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller.go
+++ b/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller.go
@@ -89,8 +89,8 @@ func (h *operationPhaseMetricsHandler) Sync(ctx context.Context, op *api.Operati
 		// which is bounded by the op count and gives count-based
 		// alerting a hook.
 		logger := utils.LoggerFromContext(ctx)
-		logger.Info("operation has no ExternalID; skipping metric emission",
-			"cosmos_doc_id", resourceIDMetricLabel(op.GetResourceID()))
+		logger.Info("WARNING: operation has no ExternalID; skipping metric emission",
+			"cosmos_resource_id", resourceIDMetricLabel(op.GetResourceID()))
 		return
 	}
 	subscriptionID := subscriptionIDMetricLabel(op.MetricResourceID())

--- a/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller_test.go
+++ b/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller_test.go
@@ -203,8 +203,8 @@ func TestOperationPhaseMetricsHandler_PhaseTransitionDeletesOldSeries(t *testing
 	op.LastTransitionTime = now.Add(5 * time.Minute)
 	handler.Sync(context.Background(), op)
 
-	resourceID := resourceIDMetricLabel(op.MetricResourceID())
-	subscriptionID := subscriptionIDMetricLabel(op.MetricResourceID())
+	resourceID := resourceIDMetricLabel(op.ExternalID)
+	subscriptionID := subscriptionIDMetricLabel(op.ExternalID)
 	expected := fmt.Sprintf(`# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
 # TYPE backend_resource_operation_phase_info gauge
 backend_resource_operation_phase_info{operation_type="create",phase="provisioning",resource_id="%s",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="%s"} 1
@@ -240,8 +240,8 @@ func TestOperationControllerSyncResource_SetsMetricsFromIndexer(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, controller.syncResource(context.Background(), key))
 
-	resourceID := resourceIDMetricLabel(op.MetricResourceID())
-	subscriptionID := subscriptionIDMetricLabel(op.MetricResourceID())
+	resourceID := resourceIDMetricLabel(op.ExternalID)
+	subscriptionID := subscriptionIDMetricLabel(op.ExternalID)
 	expected := fmt.Sprintf(`# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
 # TYPE backend_resource_operation_phase_info gauge
 backend_resource_operation_phase_info{operation_type="create",phase="accepted",resource_id="%s",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="%s"} 1
@@ -395,8 +395,8 @@ func TestOperationPhaseMetricsHandler_VerifiesLabelValues(t *testing.T) {
 	handler, reg := newTestOperationHandler(t)
 	handler.Sync(context.Background(), op)
 
-	resourceID := resourceIDMetricLabel(op.MetricResourceID())
-	subscriptionID := subscriptionIDMetricLabel(op.MetricResourceID())
+	resourceID := resourceIDMetricLabel(op.ExternalID)
+	subscriptionID := subscriptionIDMetricLabel(op.ExternalID)
 	expected := fmt.Sprintf(`# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
 # TYPE backend_resource_operation_phase_info gauge
 backend_resource_operation_phase_info{operation_type="create",phase="provisioning",resource_id="%s",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="%s"} 1
@@ -430,9 +430,9 @@ func TestOperationPhaseMetricsHandler_ResourceIDIsExternalIDNotCosmosID(t *testi
 	require.Contains(t, cosmosID, "hcpoperationstatuses",
 		"sanity: cosmos id should be the operationstatuses-prefixed string")
 
-	armID := resourceIDMetricLabel(op.MetricResourceID())
+	armID := resourceIDMetricLabel(op.ExternalID)
 	require.Equal(t, strings.ToLower(armResourceID), armID,
-		"MetricResourceID should be the lowercased ARM id of op.ExternalID")
+		"ExternalID should be the lowercased ARM id")
 	require.NotEqual(t, cosmosID, armID,
 		"sanity: cosmos id and ARM id must differ for this test to be meaningful")
 

--- a/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller_test.go
+++ b/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller_test.go
@@ -203,8 +203,8 @@ func TestOperationPhaseMetricsHandler_PhaseTransitionDeletesOldSeries(t *testing
 	op.LastTransitionTime = now.Add(5 * time.Minute)
 	handler.Sync(context.Background(), op)
 
-	resourceID := resourceIDMetricLabel(op.GetResourceID())
-	subscriptionID := subscriptionIDMetricLabel(op.GetResourceID())
+	resourceID := resourceIDMetricLabel(op.MetricResourceID())
+	subscriptionID := subscriptionIDMetricLabel(op.MetricResourceID())
 	expected := fmt.Sprintf(`# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
 # TYPE backend_resource_operation_phase_info gauge
 backend_resource_operation_phase_info{operation_type="create",phase="provisioning",resource_id="%s",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="%s"} 1
@@ -240,8 +240,8 @@ func TestOperationControllerSyncResource_SetsMetricsFromIndexer(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, controller.syncResource(context.Background(), key))
 
-	resourceID := resourceIDMetricLabel(op.GetResourceID())
-	subscriptionID := subscriptionIDMetricLabel(op.GetResourceID())
+	resourceID := resourceIDMetricLabel(op.MetricResourceID())
+	subscriptionID := subscriptionIDMetricLabel(op.MetricResourceID())
 	expected := fmt.Sprintf(`# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
 # TYPE backend_resource_operation_phase_info gauge
 backend_resource_operation_phase_info{operation_type="create",phase="accepted",resource_id="%s",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="%s"} 1
@@ -249,7 +249,12 @@ backend_resource_operation_phase_info{operation_type="create",phase="accepted",r
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "backend_resource_operation_phase_info"))
 }
 
-func TestOperationControllerSyncResource_DeletesMetricsWhenOperationRemoved(t *testing.T) {
+// TestOperationControllerSyncResource_DeleteIsNoOp documents that
+// the controller framework calls handler.Delete when an operation
+// is removed from the indexer, but the operation handler's Delete
+// is intentionally a no-op (see Delete doc-comment). The previously-
+// emitted series persists until process restart.
+func TestOperationControllerSyncResource_DeleteIsNoOp(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	op := newTestOperation(
 		t,
@@ -264,7 +269,7 @@ func TestOperationControllerSyncResource_DeletesMetricsWhenOperationRemoved(t *t
 	indexer := cache.NewIndexer(resourceIDStoreKeyForObject, cache.Indexers{})
 	require.NoError(t, indexer.Add(op))
 
-	handler, reg := newTestOperationHandler(t)
+	handler, _ := newTestOperationHandler(t)
 	controller := &Controller[*api.Operation]{
 		name:    "OperationPhaseMetrics",
 		indexer: indexer,
@@ -274,10 +279,13 @@ func TestOperationControllerSyncResource_DeletesMetricsWhenOperationRemoved(t *t
 	key, err := resourceIDStoreKeyForObject(op)
 	require.NoError(t, err)
 	require.NoError(t, controller.syncResource(context.Background(), key))
+	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
+
 	require.NoError(t, indexer.Delete(op))
 	require.NoError(t, controller.syncResource(context.Background(), key))
 
-	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(""), "backend_resource_operation_phase_info", "backend_resource_operation_start_time_seconds", "backend_resource_operation_last_transition_time_seconds"))
+	// Series persists after Delete (no-op behavior).
+	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
 }
 
 func TestResourceIDStoreKeyForObject_MatchesMetaNamespaceKeyFuncForOperation(t *testing.T) {
@@ -387,11 +395,273 @@ func TestOperationPhaseMetricsHandler_VerifiesLabelValues(t *testing.T) {
 	handler, reg := newTestOperationHandler(t)
 	handler.Sync(context.Background(), op)
 
-	resourceID := resourceIDMetricLabel(op.GetResourceID())
-	subscriptionID := subscriptionIDMetricLabel(op.GetResourceID())
+	resourceID := resourceIDMetricLabel(op.MetricResourceID())
+	subscriptionID := subscriptionIDMetricLabel(op.MetricResourceID())
 	expected := fmt.Sprintf(`# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
 # TYPE backend_resource_operation_phase_info gauge
 backend_resource_operation_phase_info{operation_type="create",phase="provisioning",resource_id="%s",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="%s"} 1
 `, resourceID, subscriptionID)
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "backend_resource_operation_phase_info"))
+}
+
+// TestOperationPhaseMetricsHandler_ResourceIDIsExternalIDNotCosmosID asserts
+// that the resource_id label is the ARM resource id from op.ExternalID,
+// not the cosmos doc id from op.GetResourceID(). This is the headline
+// behavior change introduced by ARO-26795.
+func TestOperationPhaseMetricsHandler_ResourceIDIsExternalIDNotCosmosID(t *testing.T) {
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	armResourceID := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-1"
+	op := newTestOperation(
+		t,
+		"op-1",
+		api.OperationRequestCreate,
+		arm.ProvisioningStateProvisioning,
+		armResourceID,
+		now,
+		now,
+	)
+
+	handler, reg := newTestOperationHandler(t)
+	handler.Sync(context.Background(), op)
+
+	// op.GetResourceID() returns the cosmos doc id, NOT the ARM id.
+	// The new metric label must NOT match this.
+	cosmosID := resourceIDMetricLabel(op.GetResourceID())
+	require.Contains(t, cosmosID, "hcpoperationstatuses",
+		"sanity: cosmos id should be the operationstatuses-prefixed string")
+
+	armID := resourceIDMetricLabel(op.MetricResourceID())
+	require.Equal(t, strings.ToLower(armResourceID), armID,
+		"MetricResourceID should be the lowercased ARM id of op.ExternalID")
+	require.NotEqual(t, cosmosID, armID,
+		"sanity: cosmos id and ARM id must differ for this test to be meaningful")
+
+	expected := fmt.Sprintf(`# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
+# TYPE backend_resource_operation_phase_info gauge
+backend_resource_operation_phase_info{operation_type="create",phase="provisioning",resource_id="%s",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="sub-1"} 1
+`, armID)
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "backend_resource_operation_phase_info"))
+}
+
+// TestOperationPhaseMetricsHandler_SkipsWhenExternalIDNil verifies that an
+// operation with no ExternalID (which would happen if the always-set
+// invariant ever broke) does not emit a metric series. The skip is
+// silent at the metric layer; the controller logs a warning to surface
+// the unexpected state to operators.
+func TestOperationPhaseMetricsHandler_SkipsWhenExternalIDNil(t *testing.T) {
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	resourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub-1/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/op-no-ext-id"))
+	op := &api.Operation{
+		CosmosMetadata:     api.CosmosMetadata{ResourceID: resourceID},
+		ResourceID:         resourceID,
+		OperationID:        api.Must(azcorearm.ParseResourceID("/subscriptions/sub-1/providers/Microsoft.RedHatOpenShift/locations/eastus/hcpOperationStatuses/op-no-ext-id")),
+		Request:            api.OperationRequestCreate,
+		Status:             arm.ProvisioningStateAccepted,
+		StartTime:          now,
+		LastTransitionTime: now,
+		// ExternalID intentionally nil
+	}
+
+	handler, _ := newTestOperationHandler(t)
+	handler.Sync(context.Background(), op)
+
+	require.Equal(t, 0, testutil.CollectAndCount(handler.phaseInfo))
+	require.Equal(t, 0, testutil.CollectAndCount(handler.startTime))
+	require.Equal(t, 0, testutil.CollectAndCount(handler.lastTransitionTime))
+}
+
+// TestOperationPhaseMetricsHandler_LowercasesResourceID verifies that ARM
+// ids with mixed case (e.g. Microsoft.RedHatOpenShift) are emitted
+// lowercased to match the convention used by the sibling resource state
+// metrics.
+func TestOperationPhaseMetricsHandler_LowercasesResourceID(t *testing.T) {
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	mixedCase := "/Subscriptions/SUB-1/ResourceGroups/RG/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/Cluster-MixedCase"
+	op := newTestOperation(
+		t,
+		"op-1",
+		api.OperationRequestCreate,
+		arm.ProvisioningStateAccepted,
+		mixedCase,
+		now,
+		now,
+	)
+
+	handler, reg := newTestOperationHandler(t)
+	handler.Sync(context.Background(), op)
+
+	expected := fmt.Sprintf(`# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
+# TYPE backend_resource_operation_phase_info gauge
+backend_resource_operation_phase_info{operation_type="create",phase="accepted",resource_id="%s",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="sub-1"} 1
+`, strings.ToLower(mixedCase))
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "backend_resource_operation_phase_info"))
+}
+
+// TestOperationPhaseMetricsHandler_SubscriptionIDFromExternalID verifies
+// that subscription_id co-switches to op.ExternalID.SubscriptionID
+// alongside resource_id. This is benign in production (cosmos doc and
+// ARM id share a subscription) but the test pins the invariant so a
+// future code path that breaks it surfaces here.
+func TestOperationPhaseMetricsHandler_SubscriptionIDFromExternalID(t *testing.T) {
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	op := newTestOperation(
+		t,
+		"op-1",
+		api.OperationRequestCreate,
+		arm.ProvisioningStateAccepted,
+		"/subscriptions/sub-target/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-1",
+		now,
+		now,
+	)
+
+	handler, reg := newTestOperationHandler(t)
+	handler.Sync(context.Background(), op)
+
+	// Both resource_id and subscription_id come from op.ExternalID,
+	// not from op.GetResourceID() (whose subscription would be sub-1
+	// from the cosmos doc id, which can differ from ExternalID's
+	// subscription in malformed fixtures).
+	expected := `# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
+# TYPE backend_resource_operation_phase_info gauge
+backend_resource_operation_phase_info{operation_type="create",phase="accepted",resource_id="/subscriptions/sub-target/resourcegroups/rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/cluster-1",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="sub-target"} 1
+`
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "backend_resource_operation_phase_info"))
+}
+
+// TestOperationPhaseMetricsHandler_DeleteIsNoOp verifies that
+// handler.Delete does NOT remove series for the operation. See the
+// Delete doc-comment for the rationale: Delete is intentionally a
+// no-op because deleting by resource_id can blank a sibling
+// operation's currently-emitted series.
+func TestOperationPhaseMetricsHandler_DeleteIsNoOp(t *testing.T) {
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	op := newTestOperation(
+		t,
+		"op-1",
+		api.OperationRequestCreate,
+		arm.ProvisioningStateAccepted,
+		"/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-1",
+		now,
+		now,
+	)
+
+	handler, _ := newTestOperationHandler(t)
+	handler.Sync(context.Background(), op)
+	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
+
+	cosmosKey, err := resourceIDStoreKeyForObject(op)
+	require.NoError(t, err)
+
+	handler.Delete(cosmosKey)
+
+	// Series persists after Delete (no-op behavior).
+	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
+}
+
+// TestOperationPhaseMetricsHandler_MultipleOpsSameExternalIDCollapseToOneSeries
+// documents the design decision that multiple operations sharing one
+// ARM resource id collapse to a single Prometheus series. The handler
+// emits one series per resource (last-emitted-labels-win); operation_id
+// is intentionally not in the label set.
+//
+// This test exercises natural processing order (older op first, newer
+// op second) and asserts the resulting collapse to one series with
+// the second op's labels. It does NOT assert "newest by
+// LastTransitionTime wins" under adversarial / relist iteration order
+// where the newer op might be processed first; that property is not
+// provided by the handler. See the handler doc-comment for the flutter
+// limitation.
+func TestOperationPhaseMetricsHandler_MultipleOpsSameExternalIDCollapseToOneSeries(t *testing.T) {
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	armID := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-1"
+
+	op1 := newTestOperation(t, "op-1", api.OperationRequestCreate, arm.ProvisioningStateSucceeded, armID, now, now)
+	op2 := newTestOperation(t, "op-2", api.OperationRequestUpdate, arm.ProvisioningStateProvisioning, armID, now.Add(time.Hour), now.Add(time.Hour))
+
+	handler, reg := newTestOperationHandler(t)
+
+	// Two ops on the same ARM id, processed in order. After both Syncs,
+	// the second emission's labels are the only ones present because
+	// DeletePartialMatch wipes by resource_id before each emit.
+	handler.Sync(context.Background(), op1)
+	handler.Sync(context.Background(), op2)
+
+	expected := `# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
+# TYPE backend_resource_operation_phase_info gauge
+backend_resource_operation_phase_info{operation_type="update",phase="provisioning",resource_id="/subscriptions/sub-1/resourcegroups/rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/cluster-1",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="sub-1"} 1
+`
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "backend_resource_operation_phase_info"))
+	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
+}
+
+// TestOperationPhaseMetricsHandler_DeleteOnSiblingDoesNotBlankActiveSeries
+// is the direct regression guard for the bug a previous iteration of
+// this PR introduced: when two operations share an ExternalID
+// (collapsed to one series), Delete on the older terminal operation
+// must NOT blank the newer operation's currently-emitted series.
+// The fix is that Delete is a no-op; this test pins it.
+func TestOperationPhaseMetricsHandler_DeleteOnSiblingDoesNotBlankActiveSeries(t *testing.T) {
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	armID := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-1"
+
+	// op1: completed Create still in cosmos TTL window.
+	op1 := newTestOperation(t, "op-1", api.OperationRequestCreate, arm.ProvisioningStateSucceeded, armID, now, now)
+	// op2: fresh Update on the same cluster, currently in flight.
+	op2 := newTestOperation(t, "op-2", api.OperationRequestUpdate, arm.ProvisioningStateProvisioning, armID, now.Add(time.Hour), now.Add(time.Hour))
+
+	handler, reg := newTestOperationHandler(t)
+	handler.Sync(context.Background(), op1)
+	handler.Sync(context.Background(), op2)
+
+	// op2's labels currently own the shared series.
+	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
+
+	// op1 ages out of cosmos TTL: the controller framework calls
+	// handler.Delete with op1's cosmos doc id. This must NOT blank
+	// op2's series.
+	op1CosmosKey, err := resourceIDStoreKeyForObject(op1)
+	require.NoError(t, err)
+	handler.Delete(op1CosmosKey)
+
+	// op2's series is still emitted.
+	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
+	expected := `# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
+# TYPE backend_resource_operation_phase_info gauge
+backend_resource_operation_phase_info{operation_type="update",phase="provisioning",resource_id="/subscriptions/sub-1/resourcegroups/rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/cluster-1",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="sub-1"} 1
+`
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "backend_resource_operation_phase_info"))
+}
+
+// TestOperationPhaseMetricsHandler_NilOperationIDDoesNotBlankSibling
+// guards against future regressions of the nil-OperationID branch
+// in Sync. The branch must NOT call deleteByResourceID, because a
+// sibling operation may already own the emitted series for the
+// shared ExternalID. Implicit child-resource cleanups (parent
+// Delete cascades) produce nil-OperationID ops on child ARM ids in
+// production cosmos shape.
+func TestOperationPhaseMetricsHandler_NilOperationIDDoesNotBlankSibling(t *testing.T) {
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	armID := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-1"
+
+	// op-A: explicit operation, owns the emitted series.
+	opA := newTestOperation(t, "op-a", api.OperationRequestUpdate, arm.ProvisioningStateProvisioning, armID, now, now)
+
+	// op-B: implicit operation (nil OperationID) on the same ARM resource.
+	opB := newTestOperation(t, "op-b", api.OperationRequestDelete, arm.ProvisioningStateDeleting, armID, now.Add(time.Minute), now.Add(time.Minute))
+	opB.OperationID = nil
+
+	handler, reg := newTestOperationHandler(t)
+	handler.Sync(context.Background(), opA)
+	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
+
+	// Sync op-B (nil OperationID, same ExternalID) must NOT blank
+	// op-A's series.
+	handler.Sync(context.Background(), opB)
+
+	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
+	expected := `# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
+# TYPE backend_resource_operation_phase_info gauge
+backend_resource_operation_phase_info{operation_type="update",phase="provisioning",resource_id="/subscriptions/sub-1/resourcegroups/rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/cluster-1",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="sub-1"} 1
+`
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "backend_resource_operation_phase_info"))
 }

--- a/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller_test.go
+++ b/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller_test.go
@@ -453,7 +453,6 @@ func TestOperationPhaseMetricsHandler_SkipsWhenExternalIDNil(t *testing.T) {
 	resourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub-1/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/op-no-ext-id"))
 	op := &api.Operation{
 		CosmosMetadata:     api.CosmosMetadata{ResourceID: resourceID},
-		ResourceID:         resourceID,
 		OperationID:        api.Must(azcorearm.ParseResourceID("/subscriptions/sub-1/providers/Microsoft.RedHatOpenShift/locations/eastus/hcpOperationStatuses/op-no-ext-id")),
 		Request:            api.OperationRequestCreate,
 		Status:             arm.ProvisioningStateAccepted,

--- a/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller_test.go
+++ b/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
@@ -280,12 +281,16 @@ func TestOperationControllerSyncResource_DeleteIsNoOp(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, controller.syncResource(context.Background(), key))
 	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
+	require.Equal(t, 1, testutil.CollectAndCount(handler.startTime))
+	require.Equal(t, 1, testutil.CollectAndCount(handler.lastTransitionTime))
 
 	require.NoError(t, indexer.Delete(op))
 	require.NoError(t, controller.syncResource(context.Background(), key))
 
-	// Series persists after Delete (no-op behavior).
+	// All three metric vectors persist after Delete (no-op behavior).
 	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
+	require.Equal(t, 1, testutil.CollectAndCount(handler.startTime))
+	require.Equal(t, 1, testutil.CollectAndCount(handler.lastTransitionTime))
 }
 
 func TestResourceIDStoreKeyForObject_MatchesMetaNamespaceKeyFuncForOperation(t *testing.T) {
@@ -446,7 +451,7 @@ backend_resource_operation_phase_info{operation_type="create",phase="provisionin
 // TestOperationPhaseMetricsHandler_SkipsWhenExternalIDNil verifies that an
 // operation with no ExternalID (which would happen if the always-set
 // invariant ever broke) does not emit a metric series. The skip is
-// silent at the metric layer; the controller logs a warning to surface
+// silent at the metric layer; the controller logs an info entry to surface
 // the unexpected state to operators.
 func TestOperationPhaseMetricsHandler_SkipsWhenExternalIDNil(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -462,7 +467,8 @@ func TestOperationPhaseMetricsHandler_SkipsWhenExternalIDNil(t *testing.T) {
 	}
 
 	handler, _ := newTestOperationHandler(t)
-	handler.Sync(context.Background(), op)
+	ctx := logr.NewContext(context.Background(), logr.Discard())
+	handler.Sync(ctx, op)
 
 	require.Equal(t, 0, testutil.CollectAndCount(handler.phaseInfo))
 	require.Equal(t, 0, testutil.CollectAndCount(handler.startTime))

--- a/internal/api/types_operation.go
+++ b/internal/api/types_operation.go
@@ -83,3 +83,15 @@ func (o *Operation) ComputeLogicalResourceID() *azcorearm.ResourceID {
 				o.OperationID.Name,
 			))))
 }
+
+// MetricResourceID returns the ARM resource id used as the resource_id
+// label on this operation's Prometheus metrics. It is op.ExternalID,
+// the ARM resource id of the cluster / nodepool / external auth this
+// operation targets, rather than the synthetic cosmos doc id stored
+// in op.ResourceID. Centralizing the choice here means metric handlers
+// do not need to know the cosmos-vs-ARM distinction inline. Returns
+// nil when ExternalID is unset; callers should handle that as the
+// "skip emission" case (see operation_phase_metrics_controller.go).
+func (o *Operation) MetricResourceID() *azcorearm.ResourceID {
+	return o.ExternalID
+}

--- a/internal/api/types_operation.go
+++ b/internal/api/types_operation.go
@@ -90,8 +90,7 @@ func (o *Operation) ComputeLogicalResourceID() *azcorearm.ResourceID {
 // operation targets, rather than the synthetic cosmos doc id stored
 // in op.ResourceID. Centralizing the choice here means metric handlers
 // do not need to know the cosmos-vs-ARM distinction inline. Returns
-// nil when ExternalID is unset; callers should handle that as the
-// "skip emission" case (see operation_phase_metrics_controller.go).
+// nil when ExternalID is unset; nil means no metric should be emitted.
 func (o *Operation) MetricResourceID() *azcorearm.ResourceID {
 	return o.ExternalID
 }

--- a/internal/api/types_operation.go
+++ b/internal/api/types_operation.go
@@ -85,12 +85,13 @@ func (o *Operation) ComputeLogicalResourceID() *azcorearm.ResourceID {
 }
 
 // MetricResourceID returns the ARM resource id used as the resource_id
-// label on this operation's Prometheus metrics. It is op.ExternalID,
+// label on this operation's Prometheus metrics. It is o.ExternalID,
 // the ARM resource id of the cluster / nodepool / external auth this
 // operation targets, rather than the synthetic cosmos doc id stored
-// in op.ResourceID. Centralizing the choice here means metric handlers
-// do not need to know the cosmos-vs-ARM distinction inline. Returns
-// nil when ExternalID is unset; nil means no metric should be emitted.
+// in CosmosMetadata.ResourceID. Centralizing the choice here means
+// metric handlers do not need to know the cosmos-vs-ARM distinction
+// inline. Returns nil when ExternalID is unset; nil means no metric
+// should be emitted.
 func (o *Operation) MetricResourceID() *azcorearm.ResourceID {
 	return o.ExternalID
 }

--- a/internal/api/types_operation.go
+++ b/internal/api/types_operation.go
@@ -83,15 +83,3 @@ func (o *Operation) ComputeLogicalResourceID() *azcorearm.ResourceID {
 				o.OperationID.Name,
 			))))
 }
-
-// MetricResourceID returns the ARM resource id used as the resource_id
-// label on this operation's Prometheus metrics. It is o.ExternalID,
-// the ARM resource id of the cluster / nodepool / external auth this
-// operation targets, rather than the synthetic cosmos doc id stored
-// in CosmosMetadata.ResourceID. Centralizing the choice here means
-// metric handlers do not need to know the cosmos-vs-ARM distinction
-// inline. Returns nil when ExternalID is unset; nil means no metric
-// should be emitted.
-func (o *Operation) MetricResourceID() *azcorearm.ResourceID {
-	return o.ExternalID
-}

--- a/test-integration/backend/launch/metrics_test.go
+++ b/test-integration/backend/launch/metrics_test.go
@@ -133,9 +133,9 @@ func TestBackendExposesMetrics(t *testing.T) {
 		)
 		operationMetricLine := fmt.Sprintf(
 			`backend_resource_operation_phase_info{operation_type="create",phase="succeeded",resource_id="%s",resource_type="%s",subscription_id="%s"} 1`,
-			strings.ToLower(operation.GetResourceID().String()),
+			strings.ToLower(operation.MetricResourceID().String()),
 			strings.ToLower(clusterResourceID.ResourceType.String()),
-			strings.ToLower(operation.GetResourceID().SubscriptionID),
+			strings.ToLower(operation.MetricResourceID().SubscriptionID),
 		)
 
 		require.Eventually(t, func() bool {

--- a/test-integration/backend/launch/metrics_test.go
+++ b/test-integration/backend/launch/metrics_test.go
@@ -131,11 +131,13 @@ func TestBackendExposesMetrics(t *testing.T) {
 			strings.ToLower(clusterResourceID.String()),
 			strings.ToLower(clusterResourceID.SubscriptionID),
 		)
+		metricResourceID := operation.MetricResourceID()
+		require.NotNil(t, metricResourceID, "operation.MetricResourceID() must not be nil")
 		operationMetricLine := fmt.Sprintf(
 			`backend_resource_operation_phase_info{operation_type="create",phase="succeeded",resource_id="%s",resource_type="%s",subscription_id="%s"} 1`,
-			strings.ToLower(operation.MetricResourceID().String()),
+			strings.ToLower(metricResourceID.String()),
 			strings.ToLower(clusterResourceID.ResourceType.String()),
-			strings.ToLower(operation.MetricResourceID().SubscriptionID),
+			strings.ToLower(metricResourceID.SubscriptionID),
 		)
 
 		require.Eventually(t, func() bool {

--- a/test-integration/backend/launch/metrics_test.go
+++ b/test-integration/backend/launch/metrics_test.go
@@ -131,13 +131,12 @@ func TestBackendExposesMetrics(t *testing.T) {
 			strings.ToLower(clusterResourceID.String()),
 			strings.ToLower(clusterResourceID.SubscriptionID),
 		)
-		metricResourceID := operation.MetricResourceID()
-		require.NotNil(t, metricResourceID, "operation.MetricResourceID() must not be nil")
+		require.NotNil(t, operation.ExternalID, "operation.ExternalID must not be nil")
 		operationMetricLine := fmt.Sprintf(
 			`backend_resource_operation_phase_info{operation_type="create",phase="succeeded",resource_id="%s",resource_type="%s",subscription_id="%s"} 1`,
-			strings.ToLower(metricResourceID.String()),
+			strings.ToLower(operation.ExternalID.String()),
 			strings.ToLower(clusterResourceID.ResourceType.String()),
-			strings.ToLower(metricResourceID.SubscriptionID),
+			strings.ToLower(operation.ExternalID.SubscriptionID),
 		)
 
 		require.Eventually(t, func() bool {


### PR DESCRIPTION
[ARO-26795](https://redhat.atlassian.net/browse/ARO-26795)

### What

Switches the `resource_id` and `subscription_id` labels on the `backend_resource_operation_*` metric family from the cosmos doc id to the ARM resource id of the cluster / nodepool / external auth the operation targets.

Adds `(*Operation).MetricResourceID()` helper returning `op.ExternalID` so callers don't have to know the cosmos-vs-ARM distinction inline.

### Why

Engineers triaging customer-impacting incidents can correlate Prometheus metrics with the customer's actual ARM resource id directly. The cosmos doc id stored in `op.ResourceID` has no meaning to operators and required a translation step to find anything useful.

This matches the format already used by the sibling `backend_resource_provision_state` (cluster / nodepool / external auth) metric family.

### Testing

- Unit: existing tests updated for the new label format. New tests cover the relabel, lowercase, subscription_id co-switch, nil-ExternalID skip, sibling-preservation regression guards (Delete-on-sibling, nil-OperationID-on-sibling), and the multi-op same-ExternalID collapse.
- Integration: `test-integration/backend/launch/metrics_test.go` updated to expect ARM-format labels.
- `make lint` passes (0 issues).
- Manual: `/metrics` scrape on a backend pod will show `resource_id="/subscriptions/.../microsoft.redhatopenshift/hcpopenshiftclusters/..."` (lowercased ARM id) instead of the previous `hcpoperationstatuses/<uuid-ish>` cosmos format.

### Special notes for your reviewer

- **Multi-op collapse + Delete is a no-op:** multiple operations on the same ARM resource id share one series. Sync's pre-emit `DeletePartialMatch` handles label transitions for active ops. `Delete` is intentionally a no-op so deleting one operation doesn't blank a sibling's currently-emitted series; the trade-off is a series leak when the LAST operation for a resource ages out (clears at process restart).
- **Resource-level conditions are the longer-term direction;** the limitations of operation-phase metrics (relist-iteration-order flutter, last-op-leaks-until-restart) are documented in the handler doc-comment.
- **`op.OperationID == nil` branch was also made non-destructive** alongside Delete, so implicit child-resource cleanups can't blank a sibling's series.