### PR TITLE
Revert CSPR SVC cluster aks version

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1282,6 +1282,8 @@ clouds:
               targetVersion: "asm-1-28"
               versions: "asm-1-26,asm-1-28"
             aks:
+              # Temporary override: revert to 1.34.4 until asm-1-26 is removed
+              kubernetesVersion: 1.34.4
               # MC AKS nodepools
               # big enough for multiple CS instances during PR checks
               userAgentPool:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -848,7 +848,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: 1.34.4
     name: cspr-westus3-svc-1
     networkDataplane: cilium
     networkPolicy: cilium


### PR DESCRIPTION
### What

Reverts CSPR env's service cluster aks version from 1.35 to 1.34

### Why

ASM 1.26 is not supported with AKS version 1.35.

Error message:  https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-cspr-pipeline-postsubmit/2052113889994215424

Preflight validation check for resource(s) for container service cspr-westus3-svc-1 in resource group hcp-underlay-cspr-westus3-svc failed. Message: Service mesh revision asm-1-26 is not compatible with cluster version 1.35.1. To find information about mesh-cluster compatibility, use 'az aks mesh get-upgrades


### Testing

Just a revert in the code to not try a upgrade. AKS remains in the same version as is which is no-op