### PR TITLE
istio: phase 3 - complete canary asm-1-28 in dev

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1226,11 +1226,6 @@ clouds:
         # this is the integrated DEV environment
         defaults:
           regionRG: hcp-underlay-{{ .ctx.environment }}-{{ .ctx.region }}
-          svc:
-            # Temporary override during the asm-1-28 rollout; remove once versions is asm-1-28 only.
-            istio:
-              targetVersion: "asm-1-28"
-              versions: "asm-1-26,asm-1-28"
           mgmt:
             aks:
               systemAgentPool:
@@ -1277,10 +1272,6 @@ clouds:
             svcWorkspaceName: 'services-{{ .ctx.environment }}-{{ .ctx.regionShort }}'
             hcpWorkspaceName: 'hcps-{{ .ctx.environment }}-{{ .ctx.regionShort }}'
           svc:
-            # Temporary override during the asm-1-28 rollout; remove once versions is asm-1-28 only.
-            istio:
-              targetVersion: "asm-1-28"
-              versions: "asm-1-26,asm-1-28"
             aks:
               # MC AKS nodepools
               # big enough for multiple CS instances during PR checks
@@ -1455,10 +1446,6 @@ clouds:
           # SVC
           svc:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
-            # Temporary override during the asm-1-28 rollout; remove once versions is asm-1-28 only.
-            istio:
-              targetVersion: "asm-1-28"
-              versions: "asm-1-26,asm-1-28"
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
           mgmt:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -879,7 +879,7 @@ svc:
     istioctlVersion: 1.29.2
     tag: prod-stable
     targetVersion: asm-1-28
-    versions: asm-1-26,asm-1-28
+    versions: asm-1-28
   nsp:
     accessMode: Learning
     name: nsp-usw3-svc

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -879,7 +879,7 @@ svc:
     istioctlVersion: 1.29.2
     tag: prod-stable
     targetVersion: asm-1-28
-    versions: asm-1-26,asm-1-28
+    versions: asm-1-28
   nsp:
     accessMode: Learning
     name: nsp-usw3-svc

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -879,7 +879,7 @@ svc:
     istioctlVersion: 1.29.2
     tag: prod-stable
     targetVersion: asm-1-28
-    versions: asm-1-26,asm-1-28
+    versions: asm-1-28
   nsp:
     accessMode: Learning
     name: nsp-usw3ptest-svc

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_istio.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_istio.yaml
@@ -4,30 +4,6 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   labels:
-    istio.io/rev: 'asm-1-26'
-  name: istio-shared-configmap-asm-1-26
-  namespace: aks-istio-system
-data:
-  mesh: |-
-    extensionProviders:
-    - name: "ext-authz"
-      envoyExtAuthzHttp:
-        service: "mise/mise.mise.svc.cluster.local"
-        port: "8080"
-        includeRequestHeadersInCheck: ["x-ext-authz", "mise-inbound-policies-to-filter", "x-ms-mise-version"]
-        pathPrefix: "/v1/EnvoyValidateRequest"
-    - name: "ext-authz-misev2"
-      envoyExtAuthzHttp:
-        service: "mise/misev2.mise.svc.cluster.local"
-        port: "8080"
-        includeRequestHeadersInCheck: ["x-ext-authz", "mise-inbound-policies-to-filter", "x-ms-mise-version"]
-        pathPrefix: "/v1/EnvoyValidateRequest"
----
-# Source: istio/templates/istio-shared-configmap.yml
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  labels:
     istio.io/rev: 'asm-1-28'
   name: istio-shared-configmap-asm-1-28
   namespace: aks-istio-system

--- a/istio/testdata/zz_fixture_TestHelmTemplate_istio_mise_enabled.yaml
+++ b/istio/testdata/zz_fixture_TestHelmTemplate_istio_mise_enabled.yaml
@@ -97,30 +97,6 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   labels:
-    istio.io/rev: 'asm-1-26'
-  name: istio-shared-configmap-asm-1-26
-  namespace: aks-istio-system
-data:
-  mesh: |-
-    extensionProviders:
-    - name: "ext-authz"
-      envoyExtAuthzHttp:
-        service: "mise/mise.mise.svc.cluster.local"
-        port: "8080"
-        includeRequestHeadersInCheck: ["x-ext-authz", "mise-inbound-policies-to-filter", "x-ms-mise-version"]
-        pathPrefix: "/v1/EnvoyValidateRequest"
-    - name: "ext-authz-misev2"
-      envoyExtAuthzHttp:
-        service: "mise/misev2.mise.svc.cluster.local"
-        port: "8080"
-        includeRequestHeadersInCheck: ["x-ext-authz", "mise-inbound-policies-to-filter", "x-ms-mise-version"]
-        pathPrefix: "/v1/EnvoyValidateRequest"
----
-# Source: istio/templates/istio-shared-configmap.yml
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  labels:
     istio.io/rev: 'asm-1-28'
   name: istio-shared-configmap-asm-1-28
   namespace: aks-istio-system


### PR DESCRIPTION
Complete canary upgrade of asm-1-28 in dev
Cleanup overrides as asm-1-28 is now set as the default.