### PR TITLE
feat: forward cluster-autoscaler and capi provider logs to shoebox

### DIFF
--- a/observability/arobit/deploy/templates/forwarder-configmap.yaml
+++ b/observability/arobit/deploy/templates/forwarder-configmap.yaml
@@ -272,7 +272,8 @@ data:
         Name            rewrite_tag
         Alias           filter.shoebox_router
         Match           ocm.logs
-        Rule            $kubernetes['container_name'] ^(audit-logs|kube-apiserver|kube-controller-manager|kube-scheduler|cloud-controller-manager|csi-driver|snapshot-controller)$ shoeboxlogs true
+        Rule            $kubernetes['container_name'] ^(audit-logs|kube-apiserver|kube-controller-manager|kube-scheduler|cloud-controller-manager|csi-driver|snapshot-controller|cluster-autoscaler)$ shoeboxlogs true
+        Rule            $kubernetes['pod_name'] ^capi-provider.* shoeboxlogs true
         Emitter_Name    re_emitted_shoebox
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -297,7 +298,7 @@ data:
 
   transform-shoebox.lua: |
     -- Lua script for transforming Kubernetes control plane logs to Shoebox format.
-    -- Supports all 9 log categories defined in the Shoebox manifest.
+    -- Supports all 11 log categories defined in the Shoebox manifest.
 
     -- Cache for resourceId lookups (namespace -> resourceId)
     -- ResourceIds are immutable per cluster, so we cache forever
@@ -310,7 +311,8 @@ data:
         ["kube-controller-manager"] = "kube-controller-manager",
         ["kube-scheduler"] = "kube-scheduler",
         ["cloud-controller-manager"] = "cloud-controller-manager",
-        ["snapshot-controller"] = "csi-snapshot-controller"
+        ["snapshot-controller"] = "csi-snapshot-controller",
+        ["cluster-autoscaler"] = "cluster-autoscaler"
     }
 
     -- Get resourceId for a namespace by reading the corresponding file
@@ -342,6 +344,12 @@ data:
                 return "kube-audit-admin"
             else
                 return "kube-audit"
+            end
+        end
+
+        if container_name == "manager" then
+            if pod_name and pod_name:match("^capi%-provider") then
+                return "capi-provider"
             end
         end
 

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -122,16 +122,6 @@ data:
         Tag             systemd.*
         Systemd_Filter  _SYSTEMD_UNIT=containerd.service
         Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
-        # AROSLSRE-1465: capture kernel ring-buffer (kmsg) messages so we can see
-        # the guest kernel stack (hung_task/soft-lockup/panic) in the seconds
-        # before a userswft node hard-freezes into NodeNotReady. Kernel journal
-        # records carry no _SYSTEMD_UNIT; they are matched by _TRANSPORT=kernel.
-        # Systemd_Filter entries are OR'd, so this only adds kernel lines. They
-        # flow to the existing systemdLogs Kusto table (no schema change): the
-        # full record is preserved in the `log` dynamic column, so _TRANSPORT /
-        # SYSLOG_IDENTIFIER / PRIORITY stay queryable, and `message` maps from
-        # $.log.MESSAGE. systemd_unit is simply empty for kernel lines.
-        Systemd_Filter  _TRANSPORT=kernel
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
@@ -152,24 +142,6 @@ data:
         Alias   filter.drop_kube_proxy_topology_noise
         Match   kubernetes.var.log.containers.kube-proxy*
         Exclude log Ignoring same-(node|zone) topology hints
-
-    [FILTER]
-        # AROSLSRE-1465: the kernel journal (_TRANSPORT=kernel, captured by the
-        # systemd input above) carries SELinux/audit-subsystem records that are
-        # routed through kmsg: lines beginning with "audit:" (audit types such as
-        # 1300/1325/1327/1130/1131 -- syscall, netfilter and service-state audit
-        # events) and the "kauditd_printk_skb: N callbacks suppressed" throttle
-        # notices. These are process/security audit events, NOT kernel-health
-        # signals, and they account for ~87% of kernel-transport log volume. They
-        # are useless for diagnosing node hard-freezes (hung_task, soft lockup,
-        # RCU stall, OOM, MCE, kernel panic), so we drop them here and keep only
-        # actionable kernel diagnostics. kubelet/containerd systemd records and
-        # all non-audit kernel lines are unaffected (their MESSAGE never starts
-        # with these prefixes).
-        Name    grep
-        Alias   filter.drop_kernel_audit_noise
-        Match   systemd.*
-        Exclude MESSAGE ^(audit:|kauditd_printk_skb:)
 
     [FILTER]
         Name modify
@@ -267,7 +239,8 @@ data:
         Name            rewrite_tag
         Alias           filter.shoebox_router
         Match           ocm.logs
-        Rule            $kubernetes['container_name'] ^(audit-logs|kube-apiserver|kube-controller-manager|kube-scheduler|cloud-controller-manager|csi-driver|snapshot-controller)$ shoeboxlogs true
+        Rule            $kubernetes['container_name'] ^(audit-logs|kube-apiserver|kube-controller-manager|kube-scheduler|cloud-controller-manager|csi-driver|snapshot-controller|cluster-autoscaler)$ shoeboxlogs true
+        Rule            $kubernetes['pod_name'] ^capi-provider.* shoeboxlogs true
         Emitter_Name    re_emitted_shoebox
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -292,7 +265,7 @@ data:
 
   transform-shoebox.lua: |
     -- Lua script for transforming Kubernetes control plane logs to Shoebox format.
-    -- Supports all 9 log categories defined in the Shoebox manifest.
+    -- Supports all 11 log categories defined in the Shoebox manifest.
 
     -- Cache for resourceId lookups (namespace -> resourceId)
     -- ResourceIds are immutable per cluster, so we cache forever
@@ -305,7 +278,8 @@ data:
         ["kube-controller-manager"] = "kube-controller-manager",
         ["kube-scheduler"] = "kube-scheduler",
         ["cloud-controller-manager"] = "cloud-controller-manager",
-        ["snapshot-controller"] = "csi-snapshot-controller"
+        ["snapshot-controller"] = "csi-snapshot-controller",
+        ["cluster-autoscaler"] = "cluster-autoscaler"
     }
 
     -- Get resourceId for a namespace by reading the corresponding file
@@ -337,6 +311,12 @@ data:
                 return "kube-audit-admin"
             else
                 return "kube-audit"
+            end
+        end
+
+        if container_name == "manager" then
+            if pod_name and pod_name:match("^capi%-provider") then
+                return "capi-provider"
             end
         end
 
@@ -808,7 +788,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 11ab5ef382c815cd496dd5ac1ea47145094ed1a3d3519bf4e62bf5a331800a56
+        checksum/configmap: 1ba57d93251384d398b848200bbe7903ad82e1c7e59473376238ce9de6aa7af4
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -122,6 +122,16 @@ data:
         Tag             systemd.*
         Systemd_Filter  _SYSTEMD_UNIT=containerd.service
         Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+        # AROSLSRE-1465: capture kernel ring-buffer (kmsg) messages so we can see
+        # the guest kernel stack (hung_task/soft-lockup/panic) in the seconds
+        # before a userswft node hard-freezes into NodeNotReady. Kernel journal
+        # records carry no _SYSTEMD_UNIT; they are matched by _TRANSPORT=kernel.
+        # Systemd_Filter entries are OR'd, so this only adds kernel lines. They
+        # flow to the existing systemdLogs Kusto table (no schema change): the
+        # full record is preserved in the `log` dynamic column, so _TRANSPORT /
+        # SYSLOG_IDENTIFIER / PRIORITY stay queryable, and `message` maps from
+        # $.log.MESSAGE. systemd_unit is simply empty for kernel lines.
+        Systemd_Filter  _TRANSPORT=kernel
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
@@ -142,6 +152,24 @@ data:
         Alias   filter.drop_kube_proxy_topology_noise
         Match   kubernetes.var.log.containers.kube-proxy*
         Exclude log Ignoring same-(node|zone) topology hints
+
+    [FILTER]
+        # AROSLSRE-1465: the kernel journal (_TRANSPORT=kernel, captured by the
+        # systemd input above) carries SELinux/audit-subsystem records that are
+        # routed through kmsg: lines beginning with "audit:" (audit types such as
+        # 1300/1325/1327/1130/1131 -- syscall, netfilter and service-state audit
+        # events) and the "kauditd_printk_skb: N callbacks suppressed" throttle
+        # notices. These are process/security audit events, NOT kernel-health
+        # signals, and they account for ~87% of kernel-transport log volume. They
+        # are useless for diagnosing node hard-freezes (hung_task, soft lockup,
+        # RCU stall, OOM, MCE, kernel panic), so we drop them here and keep only
+        # actionable kernel diagnostics. kubelet/containerd systemd records and
+        # all non-audit kernel lines are unaffected (their MESSAGE never starts
+        # with these prefixes).
+        Name    grep
+        Alias   filter.drop_kernel_audit_noise
+        Match   systemd.*
+        Exclude MESSAGE ^(audit:|kauditd_printk_skb:)
 
     [FILTER]
         Name modify
@@ -788,7 +816,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 1ba57d93251384d398b848200bbe7903ad82e1c7e59473376238ce9de6aa7af4
+        checksum/configmap: 133a0e0fd47a7579ffef2d31dc95ed2ebd5310a55af3c0a8675ddf76f949f4d2
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-26491

### What

This PR allows us to forward two new log categories to from the ocm namespace, capi provider and cluster autoscaler to shoebox.

### Why
Customer request.

### Testing

Tested in personal dev env. Emitted logs in the comments.


[] Need to update the shoebox manifest(with the new manifest) in all regions before we can promote this to stage or prod.

