### PR TITLE
add registryOverride for control-plane-operator images (AROSLSRE-777)

### DIFF
--- a/hypershiftoperator/values.yaml
+++ b/hypershiftoperator/values.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to manage Hypershift Operator and dependencies for ARO
 name: aro-hcp-hypershift-operator
 image: "{{ .acr.svc.name }}.azurecr.io/{{ .hypershift.image.repository }}"
 imageDigest: "{{ .hypershift.image.digest }}"
-registryOverrides: "quay.io/openshift-release-dev/ocp-v4.0-art-dev={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat={{ .acr.ocp.name }}.azurecr.io/redhat"
+registryOverrides: "quay.io/openshift-release-dev/ocp-v4.0-art-dev={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat={{ .acr.ocp.name }}.azurecr.io/redhat,quay.io/redhat-user-workloads/crt-redhat-acm-tenant={{ .acr.ocp.name }}.azurecr.io/quay-cache/redhat-user-workloads/crt-redhat-acm-tenant"
 azureKeyVaultClientId: "__csiSecretStoreClientId__"
 additionalArgs: "{{ .hypershift.additionalInstallArg }}"
 operatorEnvVars:

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -720,7 +720,7 @@ spec:
             --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
             --aro-hcp-key-vault-users-client-id __csiSecretStoreClientId__ \
-            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat" \
+            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat,quay.io/redhat-user-workloads/crt-redhat-acm-tenant=arohcpocpdev.azurecr.io/quay-cache/redhat-user-workloads/crt-redhat-acm-tenant" \
             --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890 \
             --platform-monitoring=None \
             --metrics-set=SRE \


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-777

/hold Depends on #5137 (ACR cache rule) being deployed to global infra first.

### What

Add `quay.io/redhat-user-workloads/crt-redhat-acm-tenant` to HyperShift `registryOverrides` in `hypershiftoperator/values.yaml`, mapping to the OCP ACR.

### Why

The HyperShift control-plane-operator image (`quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-XX`) is injected by HyperShift as a sidecar in HCP pods. Without a registry override, HyperShift pulls it directly from quay.io, which is blocked by the FSI ValidatingAdmissionPolicy (#4690).

With this override, HyperShift rewrites CPO image references to use the OCP ACR, where the pull-through cache rule (#5137) transparently fetches and caches the image from quay.io.

### Merge order

1. #5137: ACR pull-through cache rule (merge and deploy first)
2. **This PR**: registryOverride (merge after cache rule is live)
3. #4690: FSI ValidatingAdmissionPolicy (merge after both are deployed)

### Related

- [AROSLSRE-777](https://redhat.atlassian.net/browse/AROSLSRE-777): fix tracking
- [AROSLSRE-768](https://redhat.atlassian.net/browse/AROSLSRE-768): root cause investigation
- #5137: ACR cache rule (step 1)
- #5139: combined test PR (DO NOT MERGE)
- #4690: FSI ValidatingAdmissionPolicy (blocked)