### PR TITLE
Fix CSPR orphaned-namespace-cleaner image to use allowed registry

### DIFF
--- a/cluster-service/cspr/orphaned-namespace-cleaner.yaml
+++ b/cluster-service/cspr/orphaned-namespace-cleaner.yaml
@@ -9,8 +9,8 @@ parameters:
 - name: ORPHANED_NAMESPACE_CLEANER_CLUSTERROLE_NAME
   value: orphaned-namespace-cleaner
 - name: KUBECTL_IMAGE
-  description: An image which have the `kubectl` binary in it.
-  value: quay.io/rhn_support_ansverma/ubi8-minimal-kubectl:latest
+  description: An image which has the `kubectl` binary in it.
+  value: mcr.microsoft.com/aks/command/runtime@sha256:a249d179ee44de7951020ebf0f141e689dadd7207c228b355734b35b772c3333
 objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole


### PR DESCRIPTION
[ARO-26305](https://redhat.atlassian.net/browse/ARO-26305)

### What

Update the CSPR orphaned-namespace-cleaner CronJob to use an image from an allowed registry.

### Why

The CronJob has been failing for 19+ days because the image `quay.io/rhn_support_ansverma/ubi8-minimal-kubectl:latest` is blocked by the `image-registry-allowlist-policy` ValidatingAdmissionPolicy.

The new image `mcr.microsoft.com/aks/command/runtime` (using digest) is already used in the repo for similar kubectl operations (mitigations CronJob) and includes both kubectl and jq.

### Testing

Manual testing:
- Verified the image has required tools: `docker run --rm mcr.microsoft.com/aks/command/runtime@sha256:a249d179ee44de7951020ebf0f141e689dadd7207c228b355734b35b772c3333 sh -c "kubectl version --client && jq --version"`
- Apply to cluster and trigger manual job to verify it completes successfully
 
  ```
  oc process -f cluster-service/cspr/orphaned-namespace-cleaner.yaml | oc apply -f - 
  cronjob.batch/orphaned-namespace-cleaner configured
  ```

  ```
  kubectl create job --from=cronjob/orphaned-namespace-cleaner manual-test -n orphaned-namespace-cleaner                                                                            
  job.batch/manual-test created
  ```
    ```
  kubectl get jobs -n orphaned-namespace-cleaner
  NAME                                  STATUS     COMPLETIONS   DURATION   AGE
  manual-test                           Running    0/1           6s         6s
  ```
  After some seconds
  ```
  kubectl get jobs -n orphaned-namespace-cleaner 
  NAME                                  STATUS     COMPLETIONS   DURATION   AGE
  manual-test                           Complete   1/1           7s         12s
  ```

  Pod looks good as well
  ```
  kubectl get pods -n orphaned-namespace-cleaner 
  NAME                READY   STATUS      RESTARTS   AGE
  manual-test-l6z4r   0/1     Completed   0          6m35s
  ```

  Reverted the configuration to the old one.

### Special notes for your reviewer

