### PR TITLE
switch CPO ACR cache rule from public to authenticated (AROSLSRE-809)

### DIFF
--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -64,25 +64,16 @@ module ocpCaching '../modules/acr/cache.bicep' = {
         passwordIdentifier: 'quay-password'
         loginServer: 'quay.io'
       }
-    ]
-    keyVaultName: globalKeyVaultName
-  }
-  dependsOn: [
-    ocpAcr
-  ]
-}
-
-module ocpPublicCaching '../modules/acr/public-cache.bicep' = {
-  name: '${ocpAcrName}-public-caching'
-  params: {
-    acrName: ocpAcrName
-    publicRepositoriesToCache: [
       {
         ruleName: 'redhat-user-workloads-crt-redhat-acm-tenant'
         sourceRepo: 'quay.io/redhat-user-workloads/crt-redhat-acm-tenant/*'
         targetRepo: 'quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/*'
+        userIdentifier: 'quay-username'
+        passwordIdentifier: 'quay-password'
+        loginServer: 'quay.io'
       }
     ]
+    keyVaultName: globalKeyVaultName
   }
   dependsOn: [
     ocpAcr


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-809

### What

Switch the ACR pull-through cache rule for `quay.io/redhat-user-workloads/crt-redhat-acm-tenant/*` from `public-cache.bicep` to `cache.bicep` with authenticated quay.io credentials.

### Why

The initial cache rule (#5137) uses public cache (no auth) because the repo is public today. If `redhat-user-workloads` moves behind auth on quay.io, pulls would silently break. Using authenticated cache with the existing `quay-username`/`quay-password` credentials is safer and consistent with the `openshift-release-dev` cache rule pattern.

### Implementation

Remove the separate `ocpPublicCaching` module and add the CPO entry to the existing `ocpCaching` module, reusing the same quay.io credentials from Key Vault.

### Merge order

1. #5137 (public cache rule) - merge and deploy first
2. **This PR** - merge after #5137 is deployed, switches to authenticated
3. #5162 (registryOverride) - merge after cache is live
4. #4690 (FSI VAP) - merge after all above

### Related

- Epic: [AROSLSRE-807](https://redhat.atlassian.net/browse/AROSLSRE-807)
- [AROSLSRE-777](https://redhat.atlassian.net/browse/AROSLSRE-777): CPO image mirroring fix
- #5137: initial public cache rule (step 1)
- #5162: registryOverride (step 3)