### PR TITLE
test: re-parallelize nodepool scaling operations in nodepool_update_nodes E2E with node status diagnostics on failure

### DIFF
--- a/test/e2e/nodepool_update_nodes.go
+++ b/test/e2e/nodepool_update_nodes.go
@@ -16,12 +16,18 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"golang.org/x/sync/errgroup"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
@@ -37,12 +43,29 @@ var _ = Describe("Customer", func() {
 		labels.High,
 		labels.Positive,
 		labels.AroRpApiCompatible,
-		labels.Slow,
 		func(ctx context.Context) {
 			const (
-				customerClusterName  = "np-update-nodes-hcp-cluster"
-				customerNodePoolName = "np-update-nodes"
-				oneNodePoolName      = "np-one-node"
+				customerClusterName = "hcp-cluster"
+
+				scaleDownNodePoolName = "np-scale-down"
+				scaleUpNodePoolName   = "np-scale-up"
+				autoscaleNodePoolName = "np-autoscale"
+
+				deployedNodePoolsNumber = 3
+
+				scaleDownNodePoolInitialReplicas = 2
+				scaleDownNodePoolUpdatedReplicas = scaleDownNodePoolInitialReplicas - 1
+
+				scaleUpNodePoolInitialReplicas = 1
+				scaleUpNodePoolUpdatedReplicas = scaleUpNodePoolInitialReplicas + 1
+
+				autoscaleNodePoolInitialReplicas = 1
+				autoscaleNodePoolUpdatedReplicas = 0
+				autoscaleNodePoolMinReplicas     = 1
+				autoscaleNodePoolMaxReplicas     = 2
+
+				clusterInitialNodeCount = scaleDownNodePoolInitialReplicas + scaleUpNodePoolInitialReplicas + autoscaleNodePoolInitialReplicas
+				clusterFinalNodeCount   = scaleDownNodePoolUpdatedReplicas + scaleUpNodePoolUpdatedReplicas + autoscaleNodePoolMinReplicas
 			)
 
 			tc := framework.NewTestContext()
@@ -53,10 +76,9 @@ var _ = Describe("Customer", func() {
 			}
 
 			By("creating a resource group")
-			resourceGroup, err := tc.NewResourceGroup(ctx, "nodepool-update-nodes", tc.Location())
+			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-update-nodes", tc.Location())
 			Expect(err).NotTo(HaveOccurred())
 
-			By("creating cluster parameters")
 			clusterParams := framework.NewDefaultClusterParams()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
@@ -91,24 +113,26 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("creating the node pools in parallel")
-			mainNodeCount := 2
-			oneNodeCount := 1
+			By(fmt.Sprintf("creating %d node pools in parallel", deployedNodePoolsNumber))
+			scaleDownParams := framework.NewDefaultNodePoolParams()
+			scaleDownParams.NodePoolName = scaleDownNodePoolName
+			scaleDownParams.Replicas = scaleDownNodePoolInitialReplicas
 
-			mainNodePoolParams := framework.NewDefaultNodePoolParams()
-			mainNodePoolParams.NodePoolName = customerNodePoolName
-			mainNodePoolParams.Replicas = int32(mainNodeCount)
+			scaleUpParams := framework.NewDefaultNodePoolParams()
+			scaleUpParams.NodePoolName = scaleUpNodePoolName
+			scaleUpParams.Replicas = scaleUpNodePoolInitialReplicas
 
-			oneNodePoolParams := framework.NewDefaultNodePoolParams()
-			oneNodePoolParams.NodePoolName = oneNodePoolName
-			oneNodePoolParams.Replicas = int32(oneNodeCount)
+			autoscaleParams := framework.NewDefaultNodePoolParams()
+			autoscaleParams.NodePoolName = autoscaleNodePoolName
+			autoscaleParams.Replicas = autoscaleNodePoolInitialReplicas
 
-			errCh := make(chan error, 2)
-			group, groupCtx := errgroup.WithContext(ctx)
-			for _, nodePoolParams := range []framework.NodePoolParams{mainNodePoolParams, oneNodePoolParams} {
-				group.Go(func() error {
+			allNodePoolParams := []framework.NodePoolParams{scaleDownParams, scaleUpParams, autoscaleParams}
+			nodePoolCreationErrCh := make(chan error, deployedNodePoolsNumber)
+			nodePoolCreateErrGroup, nodePoolCreateGroupCtx := errgroup.WithContext(ctx)
+			for _, nodePoolParams := range allNodePoolParams {
+				nodePoolCreateErrGroup.Go(func() error {
 					createErr := tc.CreateNodePoolFromParam(
-						groupCtx,
+						nodePoolCreateGroupCtx,
 						GinkgoLogr,
 						*resourceGroup.Name,
 						managedResourceGroupName,
@@ -117,106 +141,166 @@ var _ = Describe("Customer", func() {
 						45*time.Minute,
 					)
 					if createErr != nil {
-						errCh <- createErr
+						nodePoolCreationErrCh <- createErr
 					}
 					return createErr
 				})
 			}
-			_ = group.Wait()
-			close(errCh)
-			var creationErrors []error
-			for createErr := range errCh {
-				creationErrors = append(creationErrors, createErr)
+			_ = nodePoolCreateErrGroup.Wait() // ignoring error here, will collect all node pool creation errors in the nodePoolCreationErrCh channel
+			close(nodePoolCreationErrCh)
+			var nodePoolCreationErrors []error
+			for nodePoolCreationErr := range nodePoolCreationErrCh {
+				nodePoolCreationErrors = append(nodePoolCreationErrors, nodePoolCreationErr)
 			}
-			Expect(creationErrors).To(BeEmpty(), "nodepool creation errors: %v", creationErrors)
+			Expect(nodePoolCreationErrors).To(BeEmpty(), "node pool creation errors: %v", nodePoolCreationErrors)
 
-			By("verifying nodes count and ready status")
-			totalNodeCount := mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
+			By("verifying nodes count")
+			Expect(verifiers.VerifyNodeCount(customerClusterName, clusterInitialNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
+
+			By("verifying nodes ready statuses")
 			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
 
-			By("scaling up the nodepool replicas from 2 to 3 replicas")
-			mainNodeCount = 3
-			update := hcpsdk20240610preview.NodePoolUpdate{
-				Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
-					Replicas: to.Ptr(int32(mainNodeCount)),
-				},
-			}
-			scaleUpResp, err := framework.UpdateNodePoolAndWait(ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
-				*resourceGroup.Name,
-				customerClusterName,
-				customerNodePoolName,
-				update,
-				20*time.Minute,
-			)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(scaleUpResp.Properties).NotTo(BeNil(), "scale up response Properties was nil")
-			Expect(scaleUpResp.Properties.Replicas).NotTo(BeNil(), "scale up response Properties.Replicas was nil")
-			Expect(*scaleUpResp.Properties.Replicas).To(Equal(int32(mainNodeCount)))
-
-			By("verifying nodes count and ready status")
-			totalNodeCount = mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
-
+			By("scaling down, scaling up, and enabling node pool autoscaling in parallel")
 			nodePoolsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
 
-			By("scaling down the nodepool replicas from 3 to 2 replicas")
-			mainNodeCount = 2
-			update = hcpsdk20240610preview.NodePoolUpdate{
-				Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
-					Replicas: to.Ptr(int32(mainNodeCount)),
-				},
-			}
-			scaleDownResp, err := framework.UpdateNodePoolAndWait(ctx,
-				nodePoolsClient,
-				*resourceGroup.Name,
-				customerClusterName,
-				customerNodePoolName,
-				update,
-				20*time.Minute,
-			)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(scaleDownResp.Properties).NotTo(BeNil(), "scale down response Properties was nil")
-			Expect(scaleDownResp.Properties.Replicas).NotTo(BeNil(), "scale down response Properties.Replicas was nil")
-			Expect(*scaleDownResp.Properties.Replicas).To(Equal(int32(mainNodeCount)))
+			// will verify these responses after updates
+			var scaleDownNodePoolResp, scaleUpNodePoolResp, autoscaleNodePoolResp *hcpsdk20240610preview.NodePool
 
-			By("verifying nodes count and ready status")
-			totalNodeCount = mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
+			nodePoolUpdateErrCh := make(chan error, deployedNodePoolsNumber)
+			nodePoolUpdateErrGroup, nodePoolUpdateGroupCtx := errgroup.WithContext(ctx)
 
-			By("updating the one-replica nodepool replicas to 0 and enabling autoscaling with a PATCH")
-			update = hcpsdk20240610preview.NodePoolUpdate{
-				Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
-					Replicas: to.Ptr(int32(0)),
-					AutoScaling: &hcpsdk20240610preview.NodePoolAutoScaling{
-						Min: to.Ptr(int32(2)),
-						Max: to.Ptr(int32(3)),
+			// scale down
+			nodePoolUpdateErrGroup.Go(func() error {
+				var scaleDownNodePoolUpdateErr error
+				scaleDownNodePoolUpdate := hcpsdk20240610preview.NodePoolUpdate{
+					Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
+						Replicas: to.Ptr(int32(scaleDownNodePoolUpdatedReplicas)),
 					},
-				},
-			}
-			autoscaleResp, err := framework.UpdateNodePoolAndWait(ctx,
-				nodePoolsClient,
-				*resourceGroup.Name,
-				customerClusterName,
-				oneNodePoolName,
-				update,
-				20*time.Minute,
-			)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(autoscaleResp.Properties).NotTo(BeNil(), "autoscale response Properties was nil")
-			Expect(autoscaleResp.Properties.AutoScaling).NotTo(BeNil(), "autoscale response Properties.AutoScaling was nil")
-			Expect(autoscaleResp.Properties.AutoScaling.Min).NotTo(BeNil(), "autoscale response Properties.AutoScaling.Min was nil")
-			Expect(autoscaleResp.Properties.AutoScaling.Max).NotTo(BeNil(), "autoscale response Properties.AutoScaling.Max was nil")
-			Expect(*autoscaleResp.Properties.AutoScaling.Min).To(Equal(int32(2)))
-			Expect(*autoscaleResp.Properties.AutoScaling.Max).To(Equal(int32(3)))
+				}
+				scaleDownNodePoolResp, scaleDownNodePoolUpdateErr = framework.UpdateNodePoolAndWait(nodePoolUpdateGroupCtx,
+					nodePoolsClient,
+					*resourceGroup.Name,
+					customerClusterName,
+					scaleDownNodePoolName,
+					scaleDownNodePoolUpdate,
+					20*time.Minute,
+				)
+				if scaleDownNodePoolUpdateErr != nil {
+					nodePoolUpdateErrCh <- scaleDownNodePoolUpdateErr
+				}
+				return scaleDownNodePoolUpdateErr
+			})
 
-			By("verifying nodes count and ready status")
-			oneNodeCount = 2
-			totalNodeCount = mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
+			// scale up
+			nodePoolUpdateErrGroup.Go(func() error {
+				var scaleUpNodePoolUpdateErr error
+				scaleUpNodePoolUpdate := hcpsdk20240610preview.NodePoolUpdate{
+					Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
+						Replicas: to.Ptr(int32(scaleUpNodePoolUpdatedReplicas)),
+					},
+				}
+				scaleUpNodePoolResp, scaleUpNodePoolUpdateErr = framework.UpdateNodePoolAndWait(nodePoolUpdateGroupCtx,
+					nodePoolsClient,
+					*resourceGroup.Name,
+					customerClusterName,
+					scaleUpNodePoolName,
+					scaleUpNodePoolUpdate,
+					20*time.Minute,
+				)
+				if scaleUpNodePoolUpdateErr != nil {
+					nodePoolUpdateErrCh <- scaleUpNodePoolUpdateErr
+				}
+				return scaleUpNodePoolUpdateErr
+			})
+
+			// enable autoscaling
+			nodePoolUpdateErrGroup.Go(func() error {
+				var autoscaleNodePoolUpdateErr error
+				autoscaleNodePoolUpdate := hcpsdk20240610preview.NodePoolUpdate{
+					Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
+						Replicas: to.Ptr(int32(autoscaleNodePoolUpdatedReplicas)),
+						AutoScaling: &hcpsdk20240610preview.NodePoolAutoScaling{
+							Min: to.Ptr(int32(autoscaleNodePoolMinReplicas)),
+							Max: to.Ptr(int32(autoscaleNodePoolMaxReplicas)),
+						},
+					},
+				}
+				autoscaleNodePoolResp, autoscaleNodePoolUpdateErr = framework.UpdateNodePoolAndWait(nodePoolUpdateGroupCtx,
+					nodePoolsClient,
+					*resourceGroup.Name,
+					customerClusterName,
+					autoscaleNodePoolName,
+					autoscaleNodePoolUpdate,
+					20*time.Minute,
+				)
+				if autoscaleNodePoolUpdateErr != nil {
+					nodePoolUpdateErrCh <- autoscaleNodePoolUpdateErr
+				}
+				return autoscaleNodePoolUpdateErr
+			})
+
+			_ = nodePoolUpdateErrGroup.Wait() // ignoring error here, will collect all node pool update errors in the nodePoolUpdateErrCh channel
+			close(nodePoolUpdateErrCh)
+			var nodePoolUpdateErrors []error
+			for nodePoolUpdateErr := range nodePoolUpdateErrCh {
+				nodePoolUpdateErrors = append(nodePoolUpdateErrors, nodePoolUpdateErr)
+			}
+			Expect(nodePoolUpdateErrors).To(BeEmpty(), "node pool update errors: %v", nodePoolUpdateErrors)
+
+			By("verifying scale down node pool state")
+			Expect(scaleDownNodePoolResp).NotTo(BeNil(), "scale down node pool response is nil")
+			Expect(scaleDownNodePoolResp.Properties).NotTo(BeNil(), "scale down node pool 'Properties' field is nil")
+			Expect(scaleDownNodePoolResp.Properties.Replicas).NotTo(BeNil(), "scale down node pool 'Properties.Replicas' field is nil")
+			Expect(*scaleDownNodePoolResp.Properties.Replicas).To(Equal(int32(scaleDownNodePoolUpdatedReplicas)))
+
+			By("verifying scale up node pool state")
+			Expect(scaleUpNodePoolResp).NotTo(BeNil(), "scale up node pool response is nil")
+			Expect(scaleUpNodePoolResp.Properties).NotTo(BeNil(), "scale up node pool 'Properties' field is nil")
+			Expect(scaleUpNodePoolResp.Properties.Replicas).NotTo(BeNil(), "scale up node pool 'Properties.Replicas' field is nil")
+			Expect(*scaleUpNodePoolResp.Properties.Replicas).To(Equal(int32(scaleUpNodePoolUpdatedReplicas)))
+
+			By("verifying autoscale node pool state")
+			Expect(autoscaleNodePoolResp).NotTo(BeNil(), "autoscale node pool response is nil")
+			Expect(autoscaleNodePoolResp.Properties).NotTo(BeNil(), "autoscale node pool 'Properties' field is nil")
+			Expect(autoscaleNodePoolResp.Properties.AutoScaling).NotTo(BeNil(), "autoscale node pool 'Properties.AutoScaling' field is nil")
+			Expect(autoscaleNodePoolResp.Properties.AutoScaling.Min).NotTo(BeNil(), "autoscale node pool 'Properties.AutoScaling.Min' field is nil")
+			Expect(autoscaleNodePoolResp.Properties.AutoScaling.Max).NotTo(BeNil(), "autoscale node pool 'Properties.AutoScaling.Max' field is nil")
+			Expect(*autoscaleNodePoolResp.Properties.AutoScaling.Min).To(Equal(int32(autoscaleNodePoolMinReplicas)))
+			Expect(*autoscaleNodePoolResp.Properties.AutoScaling.Max).To(Equal(int32(autoscaleNodePoolMaxReplicas)))
+
+			By("verifying nodes count")
+			if err := verifiers.VerifyNodeCount(customerClusterName, clusterFinalNodeCount).Verify(ctx, adminRESTConfig); err != nil {
+				// if nodes count verifier fails, logging ready and schedulable statuses of all nodes
+				kubeClient, clientErr := kubernetes.NewForConfig(adminRESTConfig)
+				if clientErr != nil {
+					err = fmt.Errorf("%w; failed to create kube client for node details: %v", err, clientErr)
+				} else {
+					nodes, listErr := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+					if listErr != nil {
+						err = fmt.Errorf("%w; failed to list nodes for node details: %v", err, listErr)
+					} else {
+						nodeStatuses := make([]string, 0, len(nodes.Items))
+						for _, node := range nodes.Items {
+							readyStr := "NotReady"
+							for _, c := range node.Status.Conditions {
+								if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
+									readyStr = "Ready"
+									break
+								}
+							}
+							schedulableStr := "Schedulable"
+							if node.Spec.Unschedulable {
+								schedulableStr = "Unschedulable"
+							}
+							nodeStatuses = append(nodeStatuses, fmt.Sprintf("%s (%s, %s)", node.Name, readyStr, schedulableStr))
+						}
+						err = fmt.Errorf("%w; node details: %s", err, strings.Join(nodeStatuses, "; "))
+					}
+				}
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("verifying nodes ready statuses")
 			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
 		})
 })

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -64,6 +64,7 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
+Customer should be able to update nodepool replicas and autoscaling
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -63,6 +63,7 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
+Customer should be able to update nodepool replicas and autoscaling
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -60,6 +60,7 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
+Customer should be able to update nodepool replicas and autoscaling
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -63,6 +63,7 @@ Customer should be able to create a cluster with default autoscaling and a nodep
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
+Customer should be able to update nodepool replicas and autoscaling
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest


### PR DESCRIPTION
[ARO-26082](https://redhat.atlassian.net/browse/ARO-26082)

### What

Re-applies the parallel node pool scaling approach from #4645 (reverted in #4887)
with improved failure diagnostics to investigate the non-deterministic failures
tracked in [ARO-26082](https://redhat.atlassian.net/browse/ARO-26082).


### Why

Changes:
- **Parallel mutations restored**: scale-down (2→1 replicas), scale-up (1→2 replicas), and
  enable-autoscaling (1→0 replicas, min=1, max=2) run concurrently
  on 3 dedicated nodepools (`np-scale-down`, `np-scale-up`, `np-autoscale`).
- **Node status dump on count mismatch**: when the final `VerifyNodeCount` fails,
  the test now lists every node with its name, Ready/NotReady condition, and
  Schedulable/Unschedulable state. This makes it possible to identify which
  node pool contributed the extraneous node.
- Removed `labels.Slow` label.


### Testing

`nodepool_update_nodes.go` test was executed 11 times in personal development environment in order to catch the same error described in [ARO-26082](https://redhat.atlassian.net/browse/ARO-26082) in order to understand which node pool has extraneous node, but the test was passing all the time.