### PR TITLE
operator logging and diagnostic improvements

### DIFF
--- a/test/e2e/cluster_pullsecret.go
+++ b/test/e2e/cluster_pullsecret.go
@@ -33,33 +33,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
 )
-
-// eventuallyVerify is a helper to reduce boilerplate when waiting for verifiers.
-// It tracks the previous error string and only logs when the error changes
-// between poll iterations. Based on the HyperShift EventuallyObject pattern
-// of delta-only logging.  Returns deterministic error strings so that identical
-// state across polls produces identical strings.
-func eventuallyVerify(ctx context.Context, verifier verifiers.HostedClusterVerifier,
-	adminRESTConfig *rest.Config, timeout, interval time.Duration, message string) {
-	var previousError string
-	Eventually(func() error {
-		err := verifier.Verify(ctx, adminRESTConfig)
-		if err != nil {
-			currentError := err.Error()
-			if currentError != previousError {
-				GinkgoLogr.Info("Verifier check", "name", verifier.Name(), "status", "failed", "error", currentError)
-				previousError = currentError
-			}
-		}
-		return err
-	}, timeout, interval).Should(Succeed(), message)
-}
 
 var _ = Describe("Customer", func() {
 	BeforeEach(func() {
@@ -183,12 +161,12 @@ var _ = Describe("Customer", func() {
 
 			By("waiting for HCCO to merge the additional pull secret with the global pull secret")
 			verifier := verifiers.VerifyPullSecretMergedIntoGlobal(testPullSecretHost)
-			eventuallyVerify(ctx, verifier, adminRESTConfig, pullSecretMergeTimeout, verifierPollInterval,
+			verifiers.EventuallyVerify(ctx, verifier, adminRESTConfig, pullSecretMergeTimeout, verifierPollInterval,
 				"additional pull secret should be merged into global-pull-secret by HCCO")
 
 			By("verifying the DaemonSet for global pull secret synchronization is created")
 			verifier = verifiers.VerifyGlobalPullSecretSyncer()
-			eventuallyVerify(ctx, verifier, adminRESTConfig, daemonSetSyncTimeout, verifierPollInterval,
+			verifiers.EventuallyVerify(ctx, verifier, adminRESTConfig, daemonSetSyncTimeout, verifierPollInterval,
 				"global-pull-secret-syncer DaemonSet should be created")
 
 			By("verifying the pull secret was merged into the global pull secret")
@@ -244,12 +222,12 @@ var _ = Describe("Customer", func() {
 
 			By("waiting for HCCO to merge the updated pull secret (with registry.redhat.io) into global pull secret")
 			verifier = verifiers.VerifyPullSecretMergedIntoGlobal(redhatRegistryHost)
-			eventuallyVerify(ctx, verifier, adminRESTConfig, pullSecretMergeTimeout, verifierPollInterval,
+			verifiers.EventuallyVerify(ctx, verifier, adminRESTConfig, pullSecretMergeTimeout, verifierPollInterval,
 				"registry.redhat.io pull secret should be merged into global-pull-secret by HCCO")
 
 			By("waiting for global-pull-secret-syncer DaemonSet to sync updated secret to all nodes")
 			verifier = verifiers.VerifyGlobalPullSecretSyncer()
-			eventuallyVerify(ctx, verifier, adminRESTConfig, daemonSetSyncTimeout, verifierPollInterval,
+			verifiers.EventuallyVerify(ctx, verifier, adminRESTConfig, daemonSetSyncTimeout, verifierPollInterval,
 				"global-pull-secret-syncer should have synced pull secret to all nodes")
 
 			By("verifying both test registries are now in the global pull secret")
@@ -267,7 +245,7 @@ var _ = Describe("Customer", func() {
 
 			By("verifying redhat-operators catalog source is ready")
 			verifier = verifiers.VerifyCatalogSourceReady(catalogSourceNamespace, catalogSourceName)
-			eventuallyVerify(ctx, verifier, adminRESTConfig, catalogSourceTimeout, verifierPollInterval,
+			verifiers.EventuallyVerify(ctx, verifier, adminRESTConfig, catalogSourceTimeout, verifierPollInterval,
 				"redhat-operators catalog source should be ready before creating subscription")
 
 			By("creating dynamic client for operator installation")
@@ -332,7 +310,7 @@ var _ = Describe("Customer", func() {
 
 			By("waiting for NFD operator to be installed")
 			verifier = verifiers.VerifyOperatorInstalled(nfdNamespace, "nfd")
-			eventuallyVerify(ctx, verifier, adminRESTConfig, operatorInstallTimeout, verifierPollInterval,
+			verifiers.EventuallyVerify(ctx, verifier, adminRESTConfig, operatorInstallTimeout, verifierPollInterval,
 				"NFD operator should be installed successfully")
 
 			By("creating NodeFeatureDiscovery CR to deploy NFD worker")
@@ -379,7 +357,7 @@ var _ = Describe("Customer", func() {
 
 			By("waiting for NFD worker pods to be created and verify images from registry.redhat.io can be pulled")
 			verifier = verifiers.VerifyImagePulled(nfdNamespace, "registry.redhat.io", "ose-node-feature-discovery")
-			eventuallyVerify(ctx, verifier, adminRESTConfig, operatorInstallTimeout, verifierPollInterval,
+			verifiers.EventuallyVerify(ctx, verifier, adminRESTConfig, operatorInstallTimeout, verifierPollInterval,
 				"NFD worker images from registry.redhat.io should be pulled successfully with the added pull secret")
 		})
 })

--- a/test/util/verifiers/basic.go
+++ b/test/util/verifiers/basic.go
@@ -31,6 +31,13 @@ type HostedClusterVerifier interface {
 	Verify(ctx context.Context, restConfig *rest.Config) error
 }
 
+// DiagnosticVerifier is an optional interface that verifiers can implement to
+// provide additional context when EventuallyVerify times out. The returned
+// string is logged alongside the timeout error.
+type DiagnosticVerifier interface {
+	DiagnoseFailure(ctx context.Context, restConfig *rest.Config) string
+}
+
 // ExpectForbidden returns a verifier that runs inner and succeeds only when inner.Verify
 // returns a forbidden (403) error. Use it to assert that an identity must not be able
 // to perform the action implemented by inner, without defining separate "Cannot" verifiers.

--- a/test/util/verifiers/eventually.go
+++ b/test/util/verifiers/eventually.go
@@ -1,0 +1,74 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verifiers
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"k8s.io/client-go/rest"
+)
+
+// EventuallyVerify polls a HostedClusterVerifier until it succeeds or the
+// timeout expires. It uses delta-only logging: failure details are logged only
+// when the error message changes between polls, reducing noise from repeated
+// identical states. Elapsed duration is logged on both success and failure.
+//
+// If the verifier implements DiagnosticVerifier and the poll times out,
+// DiagnoseFailure is called and its output is logged to provide additional
+// context for debugging.
+func EventuallyVerify(ctx context.Context, verifier HostedClusterVerifier,
+	restConfig *rest.Config, timeout, interval time.Duration, message string) {
+
+	logger := ginkgo.GinkgoLogr
+	var previousError string
+	startTime := time.Now()
+
+	succeeded := false
+	defer func() {
+		elapsed := time.Since(startTime)
+		if succeeded {
+			logger.Info("Verifier succeeded", "name", verifier.Name(), "elapsed", elapsed.String())
+		} else {
+			logger.Info("Verifier timed out", "name", verifier.Name(), "elapsed", elapsed.String())
+			if dv, ok := verifier.(DiagnosticVerifier); ok {
+				diagCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				diagnostics := dv.DiagnoseFailure(diagCtx, restConfig)
+				if diagnostics != "" {
+					logger.Info("Failure diagnostics", "name", verifier.Name(), "details", diagnostics)
+				}
+			}
+		}
+	}()
+
+	Eventually(func() error {
+		err := verifier.Verify(ctx, restConfig)
+		if err != nil {
+			currentError := err.Error()
+			if currentError != previousError {
+				logger.Info("Verifier check", "name", verifier.Name(), "status", "failed", "error", currentError)
+				previousError = currentError
+			}
+		}
+		return err
+	}, timeout, interval).Should(Succeed(), message)
+
+	succeeded = true
+}

--- a/test/util/verifiers/operator.go
+++ b/test/util/verifiers/operator.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +30,21 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
+
+var (
+	subscriptionGVR = schema.GroupVersionResource{
+		Group:    "operators.coreos.com",
+		Version:  "v1alpha1",
+		Resource: "subscriptions",
+	}
+	catalogSourceGVR = schema.GroupVersionResource{
+		Group:    "operators.coreos.com",
+		Version:  "v1alpha1",
+		Resource: "catalogsources",
+	}
+)
+
+var _ DiagnosticVerifier = verifyOperatorInstalled{}
 
 // imagePullErrorReasons lists all container waiting reasons that indicate an
 // image pull problem.  Values come from k8s.io/kubernetes/pkg/kubelet/images/types.go.
@@ -142,13 +158,6 @@ func (v verifyOperatorInstalled) Verify(ctx context.Context, adminRESTConfig *re
 	kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
-	}
-
-	// Check if Subscription exists
-	subscriptionGVR := schema.GroupVersionResource{
-		Group:    "operators.coreos.com",
-		Version:  "v1alpha1",
-		Resource: "subscriptions",
 	}
 
 	subscription, err := dynamicClient.Resource(subscriptionGVR).Namespace(v.namespace).Get(ctx, v.subscriptionName, metav1.GetOptions{})
@@ -309,15 +318,9 @@ func (v verifyOperatorInstalled) collectCatalogSourceErrors(ctx context.Context,
 		return nil
 	}
 
-	catalogSourceGVR := schema.GroupVersionResource{
-		Group:    "operators.coreos.com",
-		Version:  "v1alpha1",
-		Resource: "catalogsources",
-	}
-
 	cs, err := dynamicClient.Resource(catalogSourceGVR).Namespace(catalogSourceNS).Get(ctx, catalogSource, metav1.GetOptions{})
 	if err != nil {
-		return []string{fmt.Sprintf("failed to get catalog source %s/%s: %s", catalogSourceNS, catalogSource, err)}
+		return []string{fmt.Sprintf("failed to get catalog source %s/%s: %v", catalogSourceNS, catalogSource, err)}
 	}
 
 	var errs []string
@@ -356,6 +359,173 @@ func formatInstallPlanConditions(conditions []any) string {
 		}
 	}
 	return strings.Join(formatted, "\n")
+}
+
+func (v verifyOperatorInstalled) DiagnoseFailure(ctx context.Context, restConfig *rest.Config) string {
+	var sections []string
+
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Sprintf("failed to create dynamic client for diagnostics: %v", err)
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Sprintf("failed to create kubernetes client for diagnostics: %v", err)
+	}
+
+	sub, err := dynamicClient.Resource(subscriptionGVR).Namespace(v.namespace).Get(ctx, v.subscriptionName, metav1.GetOptions{})
+	if err != nil {
+		sections = append(sections, fmt.Sprintf("[subscription] failed to get: %v", err))
+	} else {
+		sections = append(sections, formatSubscriptionStatus(sub))
+	}
+
+	// Catalog source health re-check
+	if sub != nil {
+		sections = append(sections, v.diagnoseCatalogSource(ctx, sub, dynamicClient)...)
+	}
+
+	// OLM pod health
+	sections = append(sections, diagnoseOLMPods(ctx, kubeClient)...)
+
+	// Recent events in subscription namespace and marketplace
+	for _, ns := range []string{v.namespace, "openshift-marketplace"} {
+		sections = append(sections, diagnoseEvents(ctx, kubeClient, ns)...)
+	}
+
+	return strings.Join(sections, "\n")
+}
+
+func formatSubscriptionStatus(sub *unstructured.Unstructured) string {
+	status, _, _ := unstructured.NestedMap(sub.Object, "status")
+	if status == nil {
+		return "[subscription] status: <nil>"
+	}
+
+	state, _ := status["state"].(string)
+	currentCSV, _ := status["currentCSV"].(string)
+	installedCSV, _ := status["installedCSV"].(string)
+
+	var lines []string
+	lines = append(lines, fmt.Sprintf("[subscription] state=%q currentCSV=%q installedCSV=%q", state, currentCSV, installedCSV))
+
+	if planRef, ok, _ := unstructured.NestedString(sub.Object, "status", "installplan", "name"); ok {
+		lines = append(lines, fmt.Sprintf("[subscription] installPlanRef=%q", planRef))
+	}
+
+	conditions, found, _ := unstructured.NestedSlice(sub.Object, "status", "conditions")
+	if found {
+		for _, cond := range conditions {
+			condMap, ok := cond.(map[string]any)
+			if !ok {
+				continue
+			}
+			lines = append(lines, fmt.Sprintf("[subscription] condition type=%s status=%s reason=%s message=%s lastTransitionTime=%s",
+				condMap["type"], condMap["status"], condMap["reason"], condMap["message"], condMap["lastTransitionTime"]))
+		}
+	}
+
+	catalogHealth, found, _ := unstructured.NestedSlice(sub.Object, "status", "catalogHealth")
+	if found {
+		for _, ch := range catalogHealth {
+			chMap, ok := ch.(map[string]any)
+			if !ok {
+				continue
+			}
+			ref, _ := chMap["catalogSourceRef"].(map[string]any)
+			if ref == nil {
+				continue
+			}
+			healthy, _ := chMap["healthy"].(bool)
+			lastUpdated, _ := chMap["lastUpdated"].(string)
+			lines = append(lines, fmt.Sprintf("[subscription] catalogHealth source=%s/%s healthy=%t lastUpdated=%s",
+				ref["namespace"], ref["name"], healthy, lastUpdated))
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (v verifyOperatorInstalled) diagnoseCatalogSource(ctx context.Context, sub *unstructured.Unstructured,
+	dynamicClient dynamic.Interface) []string {
+
+	catalogSource, _, _ := unstructured.NestedString(sub.Object, "spec", "source")
+	catalogSourceNS, _, _ := unstructured.NestedString(sub.Object, "spec", "sourceNamespace")
+	if catalogSource == "" || catalogSourceNS == "" {
+		return nil
+	}
+
+	cs, err := dynamicClient.Resource(catalogSourceGVR).Namespace(catalogSourceNS).Get(ctx, catalogSource, metav1.GetOptions{})
+	if err != nil {
+		return []string{fmt.Sprintf("[catalogsource] failed to get %s/%s: %v", catalogSourceNS, catalogSource, err)}
+	}
+
+	state, _, _ := unstructured.NestedString(cs.Object, "status", "connectionState", "lastObservedState")
+	lastConnect, _, _ := unstructured.NestedString(cs.Object, "status", "connectionState", "lastConnectTime")
+	return []string{fmt.Sprintf("[catalogsource] %s/%s connectionState=%q lastConnectTime=%s", catalogSourceNS, catalogSource, state, lastConnect)}
+}
+
+func diagnoseOLMPods(ctx context.Context, kubeClient kubernetes.Interface) []string {
+	pods, err := kubeClient.CoreV1().Pods("openshift-operator-lifecycle-manager").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return []string{fmt.Sprintf("[olm-pods] failed to list: %v", err)}
+	}
+
+	var lines []string
+	for _, pod := range pods.Items {
+		var restarts int32
+		allStatuses := append(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses...)
+		for _, cs := range allStatuses {
+			restarts += cs.RestartCount
+		}
+		lines = append(lines, fmt.Sprintf("[olm-pods] %s phase=%s restarts=%d", pod.Name, pod.Status.Phase, restarts))
+		for _, cs := range allStatuses {
+			if cs.State.Waiting != nil {
+				lines = append(lines, fmt.Sprintf("[olm-pods]   container %s: waiting reason=%s message=%s",
+					cs.Name, cs.State.Waiting.Reason, cs.State.Waiting.Message))
+			}
+			if cs.State.Terminated != nil {
+				lines = append(lines, fmt.Sprintf("[olm-pods]   container %s: terminated reason=%s exitCode=%d",
+					cs.Name, cs.State.Terminated.Reason, cs.State.Terminated.ExitCode))
+			}
+		}
+	}
+
+	if len(lines) == 0 {
+		lines = append(lines, "[olm-pods] no pods found in openshift-operator-lifecycle-manager")
+	}
+
+	return lines
+}
+
+func diagnoseEvents(ctx context.Context, kubeClient kubernetes.Interface, namespace string) []string {
+	events, err := kubeClient.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return []string{fmt.Sprintf("[events] failed to list events in %s: %v", namespace, err)}
+	}
+
+	cutoff := time.Now().Add(-15 * time.Minute)
+	var lines []string
+	for _, event := range events.Items {
+		eventTime := event.LastTimestamp.Time
+		if eventTime.IsZero() {
+			eventTime = event.CreationTimestamp.Time
+		}
+		if eventTime.Before(cutoff) {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("[events] %s %s/%s: %s (reason=%s, count=%d, age=%s)",
+			namespace, event.InvolvedObject.Kind, event.InvolvedObject.Name,
+			event.Message, event.Reason, event.Count,
+			time.Since(eventTime).Truncate(time.Second)))
+	}
+
+	if len(lines) == 0 {
+		lines = append(lines, fmt.Sprintf("[events] no recent events in %s", namespace))
+	}
+
+	return lines
 }
 
 func VerifyOperatorInstalled(namespace, subscriptionName string) HostedClusterVerifier {
@@ -430,13 +600,6 @@ func (v verifyCatalogSourceReady) Verify(ctx context.Context, adminRESTConfig *r
 	kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
-	}
-
-	// Check connection state
-	catalogSourceGVR := schema.GroupVersionResource{
-		Group:    "operators.coreos.com",
-		Version:  "v1alpha1",
-		Resource: "catalogsources",
 	}
 
 	cs, err := dynamicClient.Resource(catalogSourceGVR).Namespace(v.namespace).Get(ctx, v.catalogSource, metav1.GetOptions{})


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-26756

### What

Gather more diagnostic info when operator installation fails, add timing metrics. Move EventuallyVerify() into framework.

### Why

Currently if an operator fails to install due to timeout we get no useful debugging information beyond the timeout. Also we currently do not have an accurate picture of how long the operator installation takes. 