### PR TITLE
fix: use quay-cache/ target prefix for CPO ACR cache rule (AROSLSRE-777)

### DIFF
--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -80,7 +80,7 @@ module ocpPublicCaching '../modules/acr/public-cache.bicep' = {
       {
         ruleName: 'redhat-user-workloads-crt-redhat-acm-tenant'
         sourceRepo: 'quay.io/redhat-user-workloads/crt-redhat-acm-tenant/*'
-        targetRepo: 'redhat-user-workloads/crt-redhat-acm-tenant/*'
+        targetRepo: 'quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/*'
       }
     ]
   }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-777

### What

Change the ACR pull-through cache rule target from `redhat-user-workloads/crt-redhat-acm-tenant/*` to `quay-cache/redhat-user-workloads/crt-redhat-acm-tenant/*`.

### Why

#5137 failed to deploy because the OCP ACR already has images at `redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main` (from the HyperShift pipeline's `mirror-shared-ingress-image` step). ACR rejects cache rules when existing repositories match the target path prefix:

```
TargetRepositoryPrefixMatchesExistingRegistries: There are one or more target
repositories in the registry which match the target repository prefix
'redhat-user-workloads/crt-redhat-acm-tenant/*'.
```

The `quay-cache/` prefix avoids the conflict. This is the same pattern used by the SVC ACR for shared-ingress caching.

### Impact on other PRs

#5162 (registryOverride) needs to be updated to map to the `quay-cache/` path:
```
quay.io/redhat-user-workloads/crt-redhat-acm-tenant=<acr>.azurecr.io/quay-cache/redhat-user-workloads/crt-redhat-acm-tenant
```

### ACR pull access

Verified in code (`dev-infrastructure/modules/aks-cluster-base.bicep`):
- MGMT cluster has `AcrPull` on both OCP and SVC ACRs
- SVC cluster has `AcrPull` on SVC ACR only
- CPO images run on MGMT cluster (HCP control plane pods), so OCP ACR access is confirmed

### Related

- [AROSLSRE-777](https://redhat.atlassian.net/browse/AROSLSRE-777): CPO image mirroring fix
- #5137: initial cache rule (merged, failed to deploy)
- #5162: registryOverride (needs update after this merges)
- #5166: switch to authenticated cache (needs update after this merges)