### PR TITLE
test: group node pool verifiers into a single one

### DIFF
--- a/test/e2e/cluster_create_cni_cilium.go
+++ b/test/e2e/cluster_create_cni_cilium.go
@@ -159,8 +159,17 @@ var _ = Describe("Customer", func() {
 			// We delay checking the error on purpose to get more details
 			// about the issue by running the verifiers.
 
-			By("checking that cilium is running and nodes are in Ready state")
-			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodesReady(), verifiers.VerifyCiliumOperational(ciliumNamespace, "k8s-app=cilium"))
+			By("checking that cilium is running and nodes are ready, schedulable, and viable")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
+				append(
+					verifiers.NodePoolVerifiers(
+						tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+						*resourceGroup.Name,
+						customerClusterName,
+					),
+					verifiers.VerifyCiliumOperational(ciliumNamespace, "k8s-app=cilium"),
+				)...,
+			)
 			Expect(errors.Join(err, nodePoolErr)).NotTo(HaveOccurred())
 
 			By("verifying a simple web app can run with cilium")

--- a/test/e2e/cluster_create_complex_cilium_kv.go
+++ b/test/e2e/cluster_create_complex_cilium_kv.go
@@ -188,8 +188,17 @@ var _ = Describe("Customer", func() {
 			// We delay checking the error on purpose to get more details
 			// about the issue by running the verifiers.
 
-			By("verifying nodes become Ready with Cilium CNI")
-			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodesReady(), verifiers.VerifyCiliumOperational("kube-system", "k8s-app=cilium"))
+			By("verifying nodes are ready, schedulable, and viable with Cilium CNI")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
+				append(
+					verifiers.NodePoolVerifiers(
+						tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+						*resourceGroup.Name,
+						customerClusterName,
+					),
+					verifiers.VerifyCiliumOperational("kube-system", "k8s-app=cilium"),
+				)...,
+			)
 			Expect(errors.Join(err, nodePoolErr)).NotTo(HaveOccurred())
 
 			By("verifying a simple web app can run with cilium")

--- a/test/e2e/cluster_create_private_kv.go
+++ b/test/e2e/cluster_create_private_kv.go
@@ -99,12 +99,6 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 				clusterResource,
 				45*time.Minute,
 			)
-			if isAPINotDeployedError(err) {
-				if time.Now().Before(timeBombDeadline) {
-					Skip(fmt.Sprintf("v20251223preview API not yet deployed; skipping until %s", timeBombDeadline.Format(time.RFC3339)))
-				}
-				Fail(fmt.Sprintf("v20251223preview API still not deployed as of %s deadline", timeBombDeadline.Format(time.RFC3339)))
-			}
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying cluster was created with private keyvault visibility")
@@ -164,20 +158,9 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("verifying the cluster is viable and pod logs can be fetched")
-			logVerifier := verifiers.VerifyGetDeploymentLogs("openshift-ingress", "router-default", "router")
-			var previousError string
-			Eventually(func() error {
-				err := logVerifier.Verify(ctx, adminRESTConfig)
-				if err != nil {
-					currentError := err.Error()
-					if currentError != previousError {
-						GinkgoLogr.Info("Verifier check", "name", logVerifier.Name(), "status", "failed", "error", currentError)
-						previousError = currentError
-					}
-				}
-				return err
-			}, 10*time.Minute, 30*time.Second).Should(Succeed(), "router-default deployment logs should be fetchable")
+			By("verifying the cluster is viable: nodes ready and pod logs can be fetched")
+			err = verifiers.VerifyNodeViability().Verify(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "nodes should be ready and router-default deployment logs should be fetchable")
 
 		})
 })

--- a/test/e2e/cluster_create_private_kv.go
+++ b/test/e2e/cluster_create_private_kv.go
@@ -158,9 +158,15 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("verifying the cluster is viable: nodes ready and pod logs can be fetched")
-			err = verifiers.VerifyNodeViability().Verify(ctx, adminRESTConfig)
-			Expect(err).NotTo(HaveOccurred(), "nodes should be ready and router-default deployment logs should be fetchable")
+			By("verifying the cluster is viable: node pool counts, readiness, schedulability, and pod logs")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
+				verifiers.NodePoolVerifiers(
+					tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+					*resourceGroup.Name,
+					customerClusterName,
+				)...,
+			)
+			Expect(err).NotTo(HaveOccurred(), "nodes should be ready, schedulable, and router-default deployment logs should be fetchable")
 
 		})
 })

--- a/test/e2e/nodepool_ephemeral_osdisk.go
+++ b/test/e2e/nodepool_ephemeral_osdisk.go
@@ -184,9 +184,15 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("verifying count and ready status of nodes from the ephemeral nodepool")
-			Expect(verifiers.VerifyNodeCount(customerClusterName, int(nodePoolParams.Replicas)).Verify(ctx, adminRESTConfig)).To(Succeed())
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
+			By("verifying count, readiness, schedulability, and viability of nodes from the ephemeral nodepool")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
+				verifiers.NodePoolVerifiers(
+					tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+					*resourceGroup.Name,
+					customerClusterName,
+				)...,
+			)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying Azure VMs actually have ephemeral OS disks")
 			computeFactory := tc.GetARMComputeClientFactoryOrDie(ctx)

--- a/test/e2e/nodepool_labels_taints.go
+++ b/test/e2e/nodepool_labels_taints.go
@@ -137,10 +137,15 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("waiting for nodes to be ready")
-			Eventually(func(ctx context.Context) error {
-				return verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)
-			}).WithContext(ctx).WithTimeout(10 * time.Minute).Should(Succeed())
+			By("waiting for nodes to be ready, schedulable, and viable")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
+				verifiers.NodePoolVerifiers(
+					tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+					*resourceGroup.Name,
+					customerClusterName,
+				)...,
+			)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying initial labels are present on nodes")
 			k8sClient, err := kubernetes.NewForConfig(adminRESTConfig)

--- a/test/e2e/nodepool_update_nodes.go
+++ b/test/e2e/nodepool_update_nodes.go
@@ -128,10 +128,15 @@ var _ = Describe("Customer", func() {
 			}
 			Expect(creationErrors).To(BeEmpty(), "nodepool creation errors: %v", creationErrors)
 
-			By("verifying nodes count and ready status")
-			totalNodeCount := mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
+			By("verifying nodes count, readiness, schedulability, and viability")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
+				verifiers.NodePoolVerifiers(
+					tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+					*resourceGroup.Name,
+					customerClusterName,
+				)...,
+			)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("scaling up the nodepool replicas from 2 to 3 replicas")
 			mainNodeCount = 3
@@ -153,10 +158,15 @@ var _ = Describe("Customer", func() {
 			Expect(scaleUpResp.Properties.Replicas).NotTo(BeNil(), "scale up response Properties.Replicas was nil")
 			Expect(*scaleUpResp.Properties.Replicas).To(Equal(int32(mainNodeCount)))
 
-			By("verifying nodes count and ready status")
-			totalNodeCount = mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
+			By("verifying nodes count, readiness, schedulability, and viability")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
+				verifiers.NodePoolVerifiers(
+					tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+					*resourceGroup.Name,
+					customerClusterName,
+				)...,
+			)
+			Expect(err).NotTo(HaveOccurred())
 
 			nodePoolsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
 
@@ -180,10 +190,15 @@ var _ = Describe("Customer", func() {
 			Expect(scaleDownResp.Properties.Replicas).NotTo(BeNil(), "scale down response Properties.Replicas was nil")
 			Expect(*scaleDownResp.Properties.Replicas).To(Equal(int32(mainNodeCount)))
 
-			By("verifying nodes count and ready status")
-			totalNodeCount = mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
+			By("verifying nodes count, readiness, schedulability, and viability")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
+				verifiers.NodePoolVerifiers(
+					tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+					*resourceGroup.Name,
+					customerClusterName,
+				)...,
+			)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("updating the one-replica nodepool replicas to 0 and enabling autoscaling with a PATCH")
 			update = hcpsdk20240610preview.NodePoolUpdate{
@@ -211,10 +226,14 @@ var _ = Describe("Customer", func() {
 			Expect(*autoscaleResp.Properties.AutoScaling.Min).To(Equal(int32(2)))
 			Expect(*autoscaleResp.Properties.AutoScaling.Max).To(Equal(int32(3)))
 
-			By("verifying nodes count and ready status")
-			oneNodeCount = 2
-			totalNodeCount = mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
+			By("verifying nodes count, readiness, schedulability, and viability")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
+				verifiers.NodePoolVerifiers(
+					tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+					*resourceGroup.Name,
+					customerClusterName,
+				)...,
+			)
+			Expect(err).NotTo(HaveOccurred())
 		})
 })

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -223,8 +223,15 @@ var _ = Describe("Customer", func() {
 			Expect(npGetResponse.Properties.Version.ID).NotTo(BeNil())
 			Expect(*npGetResponse.Properties.Version.ID).To(Equal(nodePoolDesiredVersion))
 
-			By("verifying number of nodes ready and not draining meet the expected replicas")
-			Expect(verifiers.VerifyNodePoolReadyAndSchedulableNodeCount(customerNodePoolName, updateReplicas).Verify(ctx, adminRESTConfig)).To(Succeed())
+			By("verifying number of nodes ready, schedulable, and viable meet the expected replicas")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
+				verifiers.NodePoolVerifiers(
+					tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+					*resourceGroup.Name,
+					clusterName,
+				)...,
+			)
+			Expect(err).NotTo(HaveOccurred())
 
 		},
 		Entry("from 4.20.z to 4.21.zLatest",

--- a/test/e2e/oidc_issuer_workload_identity.go
+++ b/test/e2e/oidc_issuer_workload_identity.go
@@ -256,9 +256,15 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("verifying nodes count and ready status")
-			Expect(verifiers.VerifyNodeCount(customerClusterName, int(nodePoolParams.Replicas)).Verify(ctx, adminRESTConfig)).To(Succeed())
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
+			By("verifying nodes count, readiness, schedulability, and viability")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
+				verifiers.NodePoolVerifiers(
+					tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+					*resourceGroup.Name,
+					customerClusterName,
+				)...,
+			)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a user-assigned managed identity for the test")
 			subscriptionID, err := tc.SubscriptionID(ctx)

--- a/test/util/verifiers/nodes.go
+++ b/test/util/verifiers/nodes.go
@@ -21,11 +21,14 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/blang/semver/v4"
+	"github.com/onsi/ginkgo/v2"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/set"
@@ -362,4 +365,58 @@ func (v verifyNodePoolUpgrade) nodeReleaseImagesUpdated(node *corev1.Node) strin
 		}
 	}
 	return fmt.Sprintf("%s (release images unchanged: %v)", node.Name, currentImgs)
+}
+
+type verifyNodeViability struct{}
+
+func (v verifyNodeViability) Name() string {
+	return "VerifyNodeViability"
+}
+
+func (v verifyNodeViability) Verify(ctx context.Context, restConfig *rest.Config) error {
+	logger := ginkgo.GinkgoLogr
+
+	nodesVerifier := VerifyNodesReady()
+	logsVerifier := VerifyGetDeploymentLogs("openshift-ingress", "router-default", "router")
+
+	var lastErr error
+	var previousError string
+	err := wait.PollUntilContextTimeout(ctx, 30*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+		if err := nodesVerifier.Verify(ctx, restConfig); err != nil {
+			lastErr = err
+			currentError := err.Error()
+			if currentError != previousError {
+				logger.Info("Verifier check", "name", nodesVerifier.Name(), "status", "failed", "error", currentError)
+				previousError = currentError
+			}
+			return false, nil
+		}
+		if err := logsVerifier.Verify(ctx, restConfig); err != nil {
+			lastErr = err
+			currentError := err.Error()
+			if currentError != previousError {
+				logger.Info("Verifier check", "name", logsVerifier.Name(), "status", "failed", "error", currentError)
+				previousError = currentError
+			}
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		if lastErr != nil {
+			return fmt.Errorf("%s timed out: %w", v.Name(), lastErr)
+		}
+		return fmt.Errorf("%s: %w", v.Name(), err)
+	}
+
+	logger.Info("Node viability verified")
+	return nil
+}
+
+// VerifyNodeViability returns a verifier that polls until all nodes are ready
+// and pod logs can be fetched from the openshift-ingress/router-default deployment,
+// proving the cluster is functional. It polls every 30s for up to 10 minutes
+// with delta-only logging.
+func VerifyNodeViability() HostedClusterVerifier {
+	return verifyNodeViability{}
 }

--- a/test/util/verifiers/nodes.go
+++ b/test/util/verifiers/nodes.go
@@ -17,6 +17,7 @@ package verifiers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -37,6 +38,7 @@ import (
 
 	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
+	hcpsdk "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 )
 
@@ -165,56 +167,6 @@ func formatNodesByPool(nodes []corev1.Node) string {
 		parts = append(parts, fmt.Sprintf("%s: [%s]", nodePoolName, strings.Join(nodeNames, ", ")))
 	}
 	return strings.Join(parts, ", ")
-}
-
-type verifyNodePoolReadyAndSchedulableNodeCount struct {
-	nodePoolName string
-	expected     int
-}
-
-func (v verifyNodePoolReadyAndSchedulableNodeCount) Name() string {
-	return fmt.Sprintf("VerifyNodePoolReadyAndSchedulableNodeCount(nodePool=%s, expected=%d)", v.nodePoolName, v.expected)
-}
-
-func (v verifyNodePoolReadyAndSchedulableNodeCount) Verify(ctx context.Context, adminRESTConfig *rest.Config) error {
-	kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create kubernetes client: %w", err)
-	}
-
-	nodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("can't list nodes in the cluster: %w", err)
-	}
-
-	matchingNodes, err := framework.SelectNodesBelongingToNodePool(nodes.Items, v.nodePoolName)
-	if err != nil {
-		return fmt.Errorf("failed to select nodes for node pool %q: %w", v.nodePoolName, err)
-	}
-
-	readyCount := 0
-	for i := range matchingNodes {
-		if nodeReadyAndSchedulable(&matchingNodes[i]) {
-			readyCount++
-		}
-	}
-
-	if readyCount != v.expected {
-		return fmt.Errorf("expected %d ready (and schedulable) nodes in node pool %q, found %d", v.expected, v.nodePoolName, readyCount)
-	}
-
-	return nil
-}
-
-// VerifyNodePoolReadyAndSchedulableNodeCount verifies that the specified node pool has exactly
-// the expected number of ready and schedulable nodes. This excludes cordoned nodes
-// (Unschedulable=true), which is useful during rolling upgrades when old nodes are
-// being replaced and the total node count may temporarily exceed the target replica count.
-func VerifyNodePoolReadyAndSchedulableNodeCount(nodePoolName string, expected int) HostedClusterVerifier {
-	return verifyNodePoolReadyAndSchedulableNodeCount{
-		nodePoolName: nodePoolName,
-		expected:     expected,
-	}
 }
 
 type verifyNodePoolUpgrade struct {
@@ -367,35 +319,40 @@ func (v verifyNodePoolUpgrade) nodeReleaseImagesUpdated(node *corev1.Node) strin
 	return fmt.Sprintf("%s (release images unchanged: %v)", node.Name, currentImgs)
 }
 
-type verifyNodeViability struct{}
+type verifyNodesSchedulable struct{}
 
-func (v verifyNodeViability) Name() string {
-	return "VerifyNodeViability"
-}
+func (v verifyNodesSchedulable) Name() string { return "VerifyNodesSchedulable" }
 
-func (v verifyNodeViability) Verify(ctx context.Context, restConfig *rest.Config) error {
+func (v verifyNodesSchedulable) Verify(ctx context.Context, restConfig *rest.Config) error {
 	logger := ginkgo.GinkgoLogr
-
-	nodesVerifier := VerifyNodesReady()
-	logsVerifier := VerifyGetDeploymentLogs("openshift-ingress", "router-default", "router")
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
 
 	var lastErr error
 	var previousError string
-	err := wait.PollUntilContextTimeout(ctx, 30*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
-		if err := nodesVerifier.Verify(ctx, restConfig); err != nil {
-			lastErr = err
-			currentError := err.Error()
-			if currentError != previousError {
-				logger.Info("Verifier check", "name", nodesVerifier.Name(), "status", "failed", "error", currentError)
-				previousError = currentError
-			}
+	err = wait.PollUntilContextTimeout(ctx, 30*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+		nodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("can't list nodes: %w", err)
 			return false, nil
 		}
-		if err := logsVerifier.Verify(ctx, restConfig); err != nil {
-			lastErr = err
-			currentError := err.Error()
+		if len(nodes.Items) == 0 {
+			lastErr = fmt.Errorf("no nodes found")
+			return false, nil
+		}
+		var unschedulable []string
+		for i := range nodes.Items {
+			if nodes.Items[i].Spec.Unschedulable {
+				unschedulable = append(unschedulable, nodes.Items[i].Name)
+			}
+		}
+		if len(unschedulable) > 0 {
+			lastErr = fmt.Errorf("%d of %d nodes unschedulable (cordoned): %v", len(unschedulable), len(nodes.Items), unschedulable)
+			currentError := lastErr.Error()
 			if currentError != previousError {
-				logger.Info("Verifier check", "name", logsVerifier.Name(), "status", "failed", "error", currentError)
+				logger.Info("Verifier check", "name", v.Name(), "status", "failed", "error", currentError)
 				previousError = currentError
 			}
 			return false, nil
@@ -408,15 +365,130 @@ func (v verifyNodeViability) Verify(ctx context.Context, restConfig *rest.Config
 		}
 		return fmt.Errorf("%s: %w", v.Name(), err)
 	}
-
-	logger.Info("Node viability verified")
+	logger.Info("All nodes schedulable")
 	return nil
 }
 
-// VerifyNodeViability returns a verifier that polls until all nodes are ready
-// and pod logs can be fetched from the openshift-ingress/router-default deployment,
-// proving the cluster is functional. It polls every 30s for up to 10 minutes
-// with delta-only logging.
-func VerifyNodeViability() HostedClusterVerifier {
-	return verifyNodeViability{}
+// VerifyNodesSchedulable returns a verifier that polls until no nodes are
+// cordoned (Unschedulable=true). Polls every 30s for up to 10 minutes with
+// delta-only logging.
+func VerifyNodesSchedulable() HostedClusterVerifier {
+	return verifyNodesSchedulable{}
+}
+
+type verifyNodePoolNodeCount struct {
+	nodePoolsClient *hcpsdk.NodePoolsClient
+	resourceGroup   string
+	clusterName     string
+}
+
+func (v verifyNodePoolNodeCount) Name() string {
+	return fmt.Sprintf("VerifyNodePoolNodeCount(cluster=%s)", v.clusterName)
+}
+
+func (v verifyNodePoolNodeCount) Verify(ctx context.Context, restConfig *rest.Config) error {
+	logger := ginkgo.GinkgoLogr
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	var lastErr error
+	var previousError string
+	err = wait.PollUntilContextTimeout(ctx, 30*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+		expectedPools := make(map[string]int)
+		pager := v.nodePoolsClient.NewListByParentPager(v.resourceGroup, v.clusterName, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				lastErr = fmt.Errorf("list node pools: %w", err)
+				return false, nil
+			}
+			for _, np := range page.Value {
+				if np.Name == nil || np.Properties == nil {
+					continue
+				}
+				if np.Properties.ProvisioningState == nil || *np.Properties.ProvisioningState != hcpsdk.ProvisioningStateSucceeded {
+					continue
+				}
+				if np.Properties.Replicas == nil {
+					continue
+				}
+				expectedPools[*np.Name] = int(*np.Properties.Replicas)
+			}
+		}
+
+		if len(expectedPools) == 0 {
+			lastErr = fmt.Errorf("no successfully provisioned node pools found for cluster %s", v.clusterName)
+			return false, nil
+		}
+
+		nodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("can't list nodes: %w", err)
+			return false, nil
+		}
+
+		var errs []error
+		expectedTotal := 0
+		for poolName, expectedReplicas := range expectedPools {
+			expectedTotal += expectedReplicas
+			matchingNodes, err := framework.SelectNodesBelongingToNodePool(nodes.Items, poolName)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("pool %q: %w", poolName, err))
+				continue
+			}
+			if len(matchingNodes) != expectedReplicas {
+				errs = append(errs, fmt.Errorf("pool %q: expected %d nodes, found %d",
+					poolName, expectedReplicas, len(matchingNodes)))
+			}
+		}
+		if len(nodes.Items) != expectedTotal {
+			errs = append(errs, fmt.Errorf("expected %d total nodes, found %d; nodes per pool: %s",
+				expectedTotal, len(nodes.Items), formatNodesByPool(nodes.Items)))
+		}
+
+		if len(errs) > 0 {
+			lastErr = errors.Join(errs...)
+			currentError := lastErr.Error()
+			if currentError != previousError {
+				logger.Info("Verifier check", "name", v.Name(), "status", "failed", "error", currentError)
+				previousError = currentError
+			}
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		if lastErr != nil {
+			return fmt.Errorf("%s timed out: %w", v.Name(), lastErr)
+		}
+		return fmt.Errorf("%s: %w", v.Name(), err)
+	}
+	logger.Info("Node pool node counts verified", "cluster", v.clusterName)
+	return nil
+}
+
+// VerifyNodePoolNodeCount returns a verifier that queries the ARM API for
+// successfully provisioned node pools, then polls until the per-pool
+// Kubernetes node counts match the expected replicas. Polls every 30s for
+// up to 10 minutes with delta-only logging.
+func VerifyNodePoolNodeCount(nodePoolsClient *hcpsdk.NodePoolsClient, resourceGroup, clusterName string) HostedClusterVerifier {
+	return verifyNodePoolNodeCount{
+		nodePoolsClient: nodePoolsClient,
+		resourceGroup:   resourceGroup,
+		clusterName:     clusterName,
+	}
+}
+
+// NodePoolVerifiers returns the standard set of node pool verifiers:
+// node readiness, schedulability, per-pool count matching, and deployment
+// log accessibility.
+func NodePoolVerifiers(nodePoolsClient *hcpsdk.NodePoolsClient, resourceGroup, clusterName string) []HostedClusterVerifier {
+	return []HostedClusterVerifier{
+		VerifyNodesReady(),
+		VerifyNodesSchedulable(),
+		VerifyNodePoolNodeCount(nodePoolsClient, resourceGroup, clusterName),
+		VerifyGetDeploymentLogs("openshift-ingress", "router-default", "router"),
+	}
 }


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Groups the various node pool verifiers we have into a single one

### Why

We have duplicated node pool verification.  Additionally, the node pool verification should be consistent across any node pool created.  

Now this verifies: 
- node is ready
- node is scheduable
- can fetch logs on a pod running on the node - router
- node replica count matches nodes in cluster

### Testing

green e2e

### Special notes for your reviewer
This is fallout from the konnectivity pods failing during our swift rollout.  We failed for the kas to dial to kubelet due to konnectivity-agent having the wrong TLS cert bundle as we were setting domains when we shouldn't have been. 

This will test we're always able to get node logs when a node is running.  
