### PR TITLE
test/e2e: bump TLS ingress cert poll timeout to 10m

### DIFF
--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -150,7 +150,7 @@ var _ = Describe("Customer", func() {
 				}
 				fmt.Fprintf(GinkgoWriter, "Issuer: %v\n", certs[0].Issuer)
 				return verifyCertChain(certs, trustedCAs)
-			}).WithTimeout(4*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"expect ingress certificate to be signed by a trusted Azure CA")
 		})
 })


### PR DESCRIPTION
The "Customer should create an HCP cluster and validate TLS certificates" e2e test was flaky in **centralindia** due to a too-tight 4-minute `Eventually` timeout for ingress certificate verification.

After NodePool reaches Ready, the cluster still needs to schedule `router-default` pods, bring up console, run the cert-manager DNS-01 challenge, replace the `router-certs-default` Secret, and let external-dns publish the apps wildcard CNAME. 4 minutes is not enough budget, so the test repeatedly observes the built-in self-signed router cert (`CN=root-ca, OU=openshift`) until it times out.

Bump the timeout to 10 minutes to align with the existing 15-minute Console URL wait above it.

Jira: [AROSLSRE-816](https://redhat.atlassian.net/browse/AROSLSRE-816)