### PR TITLE
test: add retry logic to TLS certificate validation in E2E test

### DIFF
--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -94,20 +94,27 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("ensuring the API TLS certificate is signed by a trusted Azure CA")
-			clusterResp, err := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().Get(ctx, *resourceGroup.Name, customerClusterName, nil)
-			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() error {
+				clusterResp, err := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+				if err != nil {
+					return fmt.Errorf("failed to get cluster: %w", err)
+				}
 
-			Expect(clusterResp.Properties).NotTo(BeNil(), "cluster response Properties was nil")
-			Expect(clusterResp.Properties.API).NotTo(BeNil(), "cluster Properties.API was nil")
-			Expect(clusterResp.Properties.API.URL).NotTo(BeNil(), "cluster Properties.API.URL was nil")
+				if clusterResp.Properties == nil || clusterResp.Properties.API == nil || clusterResp.Properties.API.URL == nil {
+					return fmt.Errorf("cluster API URL not yet available")
+				}
 
-			apiServerURL := clusterResp.Properties.API.URL
-			actualAPICerts, err := tlsCertsFromURL(ctx, *apiServerURL)
-			Expect(err).NotTo(HaveOccurred())
+				apiServerURL := clusterResp.Properties.API.URL
+				actualAPICerts, err := tlsCertsFromURL(ctx, *apiServerURL)
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "error fetching API cert: %v\n", err)
+					return err
+				}
 
-			fmt.Fprintf(GinkgoWriter, "Issuer: %v\n", actualAPICerts[0].Issuer)
-			err = verifyCertChain(actualAPICerts, trustedCAs)
-			Expect(err).NotTo(HaveOccurred(), "expect API certificate to be signed by a trusted Azure CA")
+				fmt.Fprintf(GinkgoWriter, "Issuer: %v\n", actualAPICerts[0].Issuer)
+				return verifyCertChain(actualAPICerts, trustedCAs)
+			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
+				"expect API certificate to be signed by a trusted Azure CA")
 
 			By("creating the node pool")
 			nodePoolParams := framework.NewDefaultNodePoolParams()


### PR DESCRIPTION
Wrap API TLS certificate check in Eventually block to allow cluster API endpoint time to become available and serve valid certificates after cluster creation completes. Retries for 5 minutes with 10-second polling.

[ARO-26761](https://redhat.atlassian.net/browse/ARO-26761)

[<!-- Link to Jira issue -->
](https://redhat.atlassian.net/browse/ARO-26761?atlOrigin=eyJpIjoiNGEyMGVlNTA1NDQwNDFkNTgwNWY0OWQ0MDE1ZmY2ZWUiLCJwIjoiaiJ9)

### What

Introduces a retry so TLS checks don't fail because the resources aren't online yet.

### Why

Causing false negative test failures.

### Testing

This was a test change only.  Ran in personal-dev-env to verify.

### Special notes for your reviewer

Wraps the test in an Eventually block and retries every 10 seconds for 5 minutes.