### PR TITLE
Revert "add registryOverride for control-plane-operator images (AROSLSRE-777)"

### DIFF
--- a/hypershiftoperator/values.yaml
+++ b/hypershiftoperator/values.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to manage Hypershift Operator and dependencies for ARO
 name: aro-hcp-hypershift-operator
 image: "{{ .acr.svc.name }}.azurecr.io/{{ .hypershift.image.repository }}"
 imageDigest: "{{ .hypershift.image.digest }}"
-registryOverrides: "quay.io/openshift-release-dev/ocp-v4.0-art-dev={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat={{ .acr.ocp.name }}.azurecr.io/redhat,quay.io/redhat-user-workloads/crt-redhat-acm-tenant={{ .acr.ocp.name }}.azurecr.io/quay-cache/redhat-user-workloads/crt-redhat-acm-tenant"
+registryOverrides: "quay.io/openshift-release-dev/ocp-v4.0-art-dev={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat={{ .acr.ocp.name }}.azurecr.io/redhat"
 azureKeyVaultClientId: "__csiSecretStoreClientId__"
 additionalArgs: "{{ .hypershift.additionalInstallArg }}"
 operatorEnvVars:

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -720,7 +720,7 @@ spec:
             --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
             --aro-hcp-key-vault-users-client-id __csiSecretStoreClientId__ \
-            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat,quay.io/redhat-user-workloads/crt-redhat-acm-tenant=arohcpocpdev.azurecr.io/quay-cache/redhat-user-workloads/crt-redhat-acm-tenant" \
+            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat" \
             --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890 \
             --platform-monitoring=None \
             --metrics-set=SRE \


### PR DESCRIPTION
Reverting #5162 (registryOverride for CPO images) as it causes a node pool re-roll on all customer clusters. Changing registry overrides triggers HyperShift to restart node pools, which is customer-impacting.

Per dffrench: "this cannot go to prod, needs to be reverted." The stance is that Red Hat will never trigger a customer node pool rollout without customer acknowledgement, pending confirmation from Jerome.

This also puts #4690 (FSI ValidatingAdmissionPolicy) on hold, since the VAP would deny CPO images that aren't pulled from ACR — which requires the registryOverride to be in place first.

Next steps:
- Revert #5162 now
- Hold #4690 until we have a plan for the registryOverride that doesn't trigger node pool re-rolls
- Coordinate with [HPSTRAT-22](https://redhat.atlassian.net/browse/HPSTRAT-22) / [ARO-22152](https://redhat.atlassian.net/browse/ARO-22152) on the rollout approach