### PR TITLE
Tune fluent-bit forwarder config for memory optimization

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -120,7 +120,7 @@ defaults:
           cpu: 100m
           memory: 256Mi
         limits:
-          memory: 1Gi
+          memory: 1248Mi
     kusto:
       enabled: false
       buffering: true

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -70,7 +70,7 @@ arobit:
       repository: oss/v2/fluent/fluent-bit
     resources:
       limits:
-        memory: 1Gi
+        memory: 1248Mi
       requests:
         cpu: 100m
         memory: 256Mi

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -70,7 +70,7 @@ arobit:
       repository: oss/v2/fluent/fluent-bit
     resources:
       limits:
-        memory: 1Gi
+        memory: 1248Mi
       requests:
         cpu: 100m
         memory: 256Mi

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -70,7 +70,7 @@ arobit:
       repository: oss/v2/fluent/fluent-bit
     resources:
       limits:
-        memory: 1Gi
+        memory: 1248Mi
       requests:
         cpu: 100m
         memory: 256Mi

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -70,7 +70,7 @@ arobit:
       repository: oss/v2/fluent/fluent-bit
     resources:
       limits:
-        memory: 1Gi
+        memory: 1248Mi
       requests:
         cpu: 100m
         memory: 256Mi

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -70,7 +70,7 @@ arobit:
       repository: oss/v2/fluent/fluent-bit
     resources:
       limits:
-        memory: 1Gi
+        memory: 1248Mi
       requests:
         cpu: 100m
         memory: 256Mi

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -70,7 +70,7 @@ arobit:
       repository: oss/v2/fluent/fluent-bit
     resources:
       limits:
-        memory: 1Gi
+        memory: 1248Mi
       requests:
         cpu: 100m
         memory: 256Mi

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -37,13 +37,11 @@ data:
         Plugins_File              /fluent-bit/etc/plugins.conf
         HTTP_Server               On
         storage.path              /var/fluent-bit/flb-storage
-        # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
-        # (default: 128)
-        storage.max_chunks_up     256
-        # This option configure a hint of maximum value of memory to use when processing the backlog data.
-        # (default: 5M)
-        storage.backlog.mem_limit 50M
+        storage.max_chunks_up     128
+        storage.backlog.mem_limit 15M
         storage.metrics           on
+        storage.delete_irrecoverable_chunks on
+        scheduler.cap             600
         Grace                     30
         # Based on the HC_Period, if the error number > HC_Errors_Count or the retry failure > HC_Retry_Failure_Count, fluent bit is considered as unhealthy.
         Health_Check              On
@@ -73,8 +71,8 @@ data:
         DB.locking        true
         Refresh_Interval  15
         Read_from_Head    On
-        Buffer_Chunk_Size 128K
-        Buffer_Max_Size   2M
+        Buffer_Chunk_Size 32K
+        Buffer_Max_Size   256K
         Skip_Long_Lines   On
         storage.type      filesystem
         Threaded          On
@@ -99,6 +97,7 @@ data:
         Alias  otlp
         Listen 0.0.0.0
         Port   4318
+        Mem_Buf_Limit 50M
 
     [INPUT]
         Name            systemd
@@ -133,6 +132,7 @@ data:
         Kube_Tag_Prefix     kubernetes.var.log.containers.
         Annotations         Off
         K8S-Logging.Exclude On
+        Kube_Meta_Cache_TTL 300
         Buffer_Size         64k
 
     [FILTER]
@@ -176,6 +176,7 @@ data:
     [OUTPUT]
         Match ocm.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -200,6 +201,7 @@ data:
     [OUTPUT]
         Match aro-hcp-frontend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -224,6 +226,7 @@ data:
     [OUTPUT]
         Match aro-hcp-backend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -248,6 +251,7 @@ data:
     [OUTPUT]
         Match clusters-service.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -271,6 +275,7 @@ data:
     [OUTPUT]
         Match kubernetes.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -295,6 +300,7 @@ data:
     [OUTPUT]
         Match kube-events.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -329,6 +335,7 @@ data:
     [OUTPUT]
         Match systemd.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -444,7 +451,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 6cd105a5d137e52af9da24c7962786df326951dd5c98f24e2c93839bdc0a3e36
+        checksum/configmap: daa48c40fc3f117b2650ffc65f9606a93231c8ba30f24e21bb4f8b598167c84b
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
@@ -501,7 +508,7 @@ spec:
               cpu: 100m
               memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 1248Mi
           volumeMounts:
             - name: var-kusto
               mountPath: /var/kusto

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -37,13 +37,11 @@ data:
         Plugins_File              /fluent-bit/etc/plugins.conf
         HTTP_Server               On
         storage.path              /var/fluent-bit/flb-storage
-        # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
-        # (default: 128)
-        storage.max_chunks_up     256
-        # This option configure a hint of maximum value of memory to use when processing the backlog data.
-        # (default: 5M)
-        storage.backlog.mem_limit 50M
+        storage.max_chunks_up     128
+        storage.backlog.mem_limit 15M
         storage.metrics           on
+        storage.delete_irrecoverable_chunks on
+        scheduler.cap             600
         Grace                     30
         # Based on the HC_Period, if the error number > HC_Errors_Count or the retry failure > HC_Retry_Failure_Count, fluent bit is considered as unhealthy.
         Health_Check              On
@@ -73,8 +71,8 @@ data:
         DB.locking        true
         Refresh_Interval  15
         Read_from_Head    On
-        Buffer_Chunk_Size 128K
-        Buffer_Max_Size   2M
+        Buffer_Chunk_Size 32K
+        Buffer_Max_Size   256K
         Skip_Long_Lines   On
         storage.type      filesystem
         Threaded          On
@@ -99,6 +97,7 @@ data:
         Alias  otlp
         Listen 0.0.0.0
         Port   4318
+        Mem_Buf_Limit 50M
 
     [INPUT]
         Name            systemd
@@ -133,6 +132,7 @@ data:
         Kube_Tag_Prefix     kubernetes.var.log.containers.
         Annotations         Off
         K8S-Logging.Exclude On
+        Kube_Meta_Cache_TTL 300
         Buffer_Size         64k
 
     [FILTER]
@@ -177,6 +177,7 @@ data:
     [OUTPUT]
         Match aro-hcp-frontend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -201,6 +202,7 @@ data:
     [OUTPUT]
         Match aro-hcp-backend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -225,6 +227,7 @@ data:
     [OUTPUT]
         Match clusters-service.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -248,6 +251,7 @@ data:
     [OUTPUT]
         Match kubernetes.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -272,6 +276,7 @@ data:
     [OUTPUT]
         Match kube-events.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -306,6 +311,7 @@ data:
     [OUTPUT]
         Match systemd.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -421,7 +427,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 5b6688244d10cbd8adb28880185ad51d63fafef5c567c47310c38d90500760cc
+        checksum/configmap: 2a4cfa99e01402601797b5e385a0c40bcef5ef8a62a1266d2ac2589a62874f97
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
@@ -478,7 +484,7 @@ spec:
               cpu: 100m
               memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 1248Mi
           volumeMounts:
             - name: var-kusto
               mountPath: /var/kusto

--- a/observability/arobit/deploy/templates/forwarder-configmap.yaml
+++ b/observability/arobit/deploy/templates/forwarder-configmap.yaml
@@ -43,13 +43,11 @@ data:
         Plugins_File              /fluent-bit/etc/plugins.conf
         HTTP_Server               On
         storage.path              /var/fluent-bit/flb-storage
-        # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
-        # (default: 128)
-        storage.max_chunks_up     256
-        # This option configure a hint of maximum value of memory to use when processing the backlog data.
-        # (default: 5M)
-        storage.backlog.mem_limit 50M
+        storage.max_chunks_up     128
+        storage.backlog.mem_limit 15M
         storage.metrics           on
+        storage.delete_irrecoverable_chunks on
+        scheduler.cap             600
         Grace                     30
         # Based on the HC_Period, if the error number > HC_Errors_Count or the retry failure > HC_Retry_Failure_Count, fluent bit is considered as unhealthy.
         Health_Check              On
@@ -79,8 +77,8 @@ data:
         DB.locking        true
         Refresh_Interval  15
         Read_from_Head    On
-        Buffer_Chunk_Size 128K
-        Buffer_Max_Size   2M
+        Buffer_Chunk_Size 32K
+        Buffer_Max_Size   256K
         Skip_Long_Lines   On
         storage.type      filesystem
         Threaded          On
@@ -105,6 +103,7 @@ data:
         Alias  otlp
         Listen 0.0.0.0
         Port   4318
+        Mem_Buf_Limit 50M
 
     [INPUT]
         Name            systemd
@@ -139,6 +138,7 @@ data:
         Kube_Tag_Prefix     kubernetes.var.log.containers.
         Annotations         Off
         K8S-Logging.Exclude On
+        Kube_Meta_Cache_TTL 300
         Buffer_Size         64k
 
     [FILTER]
@@ -330,6 +330,7 @@ data:
     [OUTPUT]
         Match ocm.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id {{ .Values.forwarder.tenantId }}
         client_id {{ .Values.forwarder.msiClientId }}
@@ -348,6 +349,7 @@ data:
     [OUTPUT]
         Match aro-hcp-frontend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id {{ .Values.forwarder.tenantId }}
         client_id {{ .Values.forwarder.msiClientId }}
@@ -365,6 +367,7 @@ data:
     [OUTPUT]
         Match aro-hcp-backend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id {{ .Values.forwarder.tenantId }}
         client_id {{ .Values.forwarder.msiClientId }}
@@ -382,6 +385,7 @@ data:
     [OUTPUT]
         Match clusters-service.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id {{ .Values.forwarder.tenantId }}
         client_id {{ .Values.forwarder.msiClientId }}
@@ -398,6 +402,7 @@ data:
     [OUTPUT]
         Match kubernetes.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id {{ .Values.forwarder.tenantId }}
         client_id {{ .Values.forwarder.msiClientId }}
@@ -415,6 +420,7 @@ data:
     [OUTPUT]
         Match kube-events.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id {{ .Values.forwarder.tenantId }}
         client_id {{ .Values.forwarder.msiClientId }}
@@ -442,6 +448,7 @@ data:
     [OUTPUT]
         Match systemd.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id {{ .Values.forwarder.tenantId }}
         client_id {{ .Values.forwarder.msiClientId }}

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
@@ -37,13 +37,11 @@ data:
         Plugins_File              /fluent-bit/etc/plugins.conf
         HTTP_Server               On
         storage.path              /var/fluent-bit/flb-storage
-        # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
-        # (default: 128)
-        storage.max_chunks_up     256
-        # This option configure a hint of maximum value of memory to use when processing the backlog data.
-        # (default: 5M)
-        storage.backlog.mem_limit 50M
+        storage.max_chunks_up     128
+        storage.backlog.mem_limit 15M
         storage.metrics           on
+        storage.delete_irrecoverable_chunks on
+        scheduler.cap             600
         Grace                     30
         # Based on the HC_Period, if the error number > HC_Errors_Count or the retry failure > HC_Retry_Failure_Count, fluent bit is considered as unhealthy.
         Health_Check              On
@@ -73,8 +71,8 @@ data:
         DB.locking        true
         Refresh_Interval  15
         Read_from_Head    On
-        Buffer_Chunk_Size 128K
-        Buffer_Max_Size   2M
+        Buffer_Chunk_Size 32K
+        Buffer_Max_Size   256K
         Skip_Long_Lines   On
         storage.type      filesystem
         Threaded          On
@@ -99,6 +97,7 @@ data:
         Alias  otlp
         Listen 0.0.0.0
         Port   4318
+        Mem_Buf_Limit 50M
 
     [INPUT]
         Name            systemd
@@ -133,6 +132,7 @@ data:
         Kube_Tag_Prefix     kubernetes.var.log.containers.
         Annotations         Off
         K8S-Logging.Exclude On
+        Kube_Meta_Cache_TTL 300
         Buffer_Size         64k
 
     [FILTER]
@@ -177,6 +177,7 @@ data:
     [OUTPUT]
         Match aro-hcp-frontend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -190,6 +191,7 @@ data:
     [OUTPUT]
         Match aro-hcp-backend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -204,6 +206,7 @@ data:
     [OUTPUT]
         Match clusters-service.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -217,6 +220,7 @@ data:
     [OUTPUT]
         Match kubernetes.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -231,6 +235,7 @@ data:
     [OUTPUT]
         Match kube-events.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -255,6 +260,7 @@ data:
     [OUTPUT]
         Match systemd.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -360,7 +366,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 49ad24d064241d58dbdcf15dded3d32901f320110de9a827f2ed85bfe2946764
+        checksum/configmap: 0125c22a6f97225ef8815fec4a047ee67b7f0dff1b518abcf3232fc8d1a39f1d
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
@@ -417,7 +423,7 @@ spec:
               cpu: 100m
               memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 1248Mi
           volumeMounts:
             - name: var-kusto
               mountPath: /var/kusto

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -36,13 +36,11 @@ data:
         Plugins_File              /fluent-bit/etc/plugins.conf
         HTTP_Server               On
         storage.path              /var/fluent-bit/flb-storage
-        # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
-        # (default: 128)
-        storage.max_chunks_up     256
-        # This option configure a hint of maximum value of memory to use when processing the backlog data.
-        # (default: 5M)
-        storage.backlog.mem_limit 50M
+        storage.max_chunks_up     128
+        storage.backlog.mem_limit 15M
         storage.metrics           on
+        storage.delete_irrecoverable_chunks on
+        scheduler.cap             600
         Grace                     30
         # Based on the HC_Period, if the error number > HC_Errors_Count or the retry failure > HC_Retry_Failure_Count, fluent bit is considered as unhealthy.
         Health_Check              On
@@ -72,8 +70,8 @@ data:
         DB.locking        true
         Refresh_Interval  15
         Read_from_Head    On
-        Buffer_Chunk_Size 128K
-        Buffer_Max_Size   2M
+        Buffer_Chunk_Size 32K
+        Buffer_Max_Size   256K
         Skip_Long_Lines   On
         storage.type      filesystem
         Threaded          On
@@ -98,6 +96,7 @@ data:
         Alias  otlp
         Listen 0.0.0.0
         Port   4318
+        Mem_Buf_Limit 50M
 
     [INPUT]
         Name            systemd
@@ -132,6 +131,7 @@ data:
         Kube_Tag_Prefix     kubernetes.var.log.containers.
         Annotations         Off
         K8S-Logging.Exclude On
+        Kube_Meta_Cache_TTL 300
         Buffer_Size         64k
 
     [FILTER]
@@ -176,6 +176,7 @@ data:
     [OUTPUT]
         Match aro-hcp-frontend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -200,6 +201,7 @@ data:
     [OUTPUT]
         Match aro-hcp-backend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -224,6 +226,7 @@ data:
     [OUTPUT]
         Match clusters-service.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -247,6 +250,7 @@ data:
     [OUTPUT]
         Match kubernetes.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -271,6 +275,7 @@ data:
     [OUTPUT]
         Match kube-events.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -305,6 +310,7 @@ data:
     [OUTPUT]
         Match systemd.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -420,7 +426,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: fe3b7004c2bdd1d39da1fbc08d996aa6db2276b40255fe44b79815bef46a7f7d
+        checksum/configmap: 6596e05b3e7afcd127f75c1de0a178a0ef2338ad9b6c8d19c9671095345c1deb
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
@@ -477,7 +483,7 @@ spec:
               cpu: 100m
               memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 1248Mi
           volumeMounts:
             - name: var-kusto
               mountPath: /var/kusto

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
@@ -37,13 +37,11 @@ data:
         Plugins_File              /fluent-bit/etc/plugins.conf
         HTTP_Server               On
         storage.path              /var/fluent-bit/flb-storage
-        # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
-        # (default: 128)
-        storage.max_chunks_up     256
-        # This option configure a hint of maximum value of memory to use when processing the backlog data.
-        # (default: 5M)
-        storage.backlog.mem_limit 50M
+        storage.max_chunks_up     128
+        storage.backlog.mem_limit 15M
         storage.metrics           on
+        storage.delete_irrecoverable_chunks on
+        scheduler.cap             600
         Grace                     30
         # Based on the HC_Period, if the error number > HC_Errors_Count or the retry failure > HC_Retry_Failure_Count, fluent bit is considered as unhealthy.
         Health_Check              On
@@ -73,8 +71,8 @@ data:
         DB.locking        true
         Refresh_Interval  15
         Read_from_Head    On
-        Buffer_Chunk_Size 128K
-        Buffer_Max_Size   2M
+        Buffer_Chunk_Size 32K
+        Buffer_Max_Size   256K
         Skip_Long_Lines   On
         storage.type      filesystem
         Threaded          On
@@ -99,6 +97,7 @@ data:
         Alias  otlp
         Listen 0.0.0.0
         Port   4318
+        Mem_Buf_Limit 50M
 
     [INPUT]
         Name            systemd
@@ -133,6 +132,7 @@ data:
         Kube_Tag_Prefix     kubernetes.var.log.containers.
         Annotations         Off
         K8S-Logging.Exclude On
+        Kube_Meta_Cache_TTL 300
         Buffer_Size         64k
 
     [FILTER]
@@ -177,6 +177,7 @@ data:
     [OUTPUT]
         Match aro-hcp-frontend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -201,6 +202,7 @@ data:
     [OUTPUT]
         Match aro-hcp-backend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -225,6 +227,7 @@ data:
     [OUTPUT]
         Match clusters-service.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -248,6 +251,7 @@ data:
     [OUTPUT]
         Match kubernetes.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -272,6 +276,7 @@ data:
     [OUTPUT]
         Match kube-events.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -306,6 +311,7 @@ data:
     [OUTPUT]
         Match systemd.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -421,7 +427,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 6281184d4b8f16c0df6b6fa090f68155462edc356a0aaaaeb32da041e68d2b7a
+        checksum/configmap: d0af69bf42ceeb8edd628b7ced7cfd5834bdb283b5fd6525fbad4d0e75977eda
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -39,13 +39,11 @@ data:
         Plugins_File              /fluent-bit/etc/plugins.conf
         HTTP_Server               On
         storage.path              /var/fluent-bit/flb-storage
-        # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
-        # (default: 128)
-        storage.max_chunks_up     256
-        # This option configure a hint of maximum value of memory to use when processing the backlog data.
-        # (default: 5M)
-        storage.backlog.mem_limit 50M
+        storage.max_chunks_up     128
+        storage.backlog.mem_limit 15M
         storage.metrics           on
+        storage.delete_irrecoverable_chunks on
+        scheduler.cap             600
         Grace                     30
         # Based on the HC_Period, if the error number > HC_Errors_Count or the retry failure > HC_Retry_Failure_Count, fluent bit is considered as unhealthy.
         Health_Check              On
@@ -75,8 +73,8 @@ data:
         DB.locking        true
         Refresh_Interval  15
         Read_from_Head    On
-        Buffer_Chunk_Size 128K
-        Buffer_Max_Size   2M
+        Buffer_Chunk_Size 32K
+        Buffer_Max_Size   256K
         Skip_Long_Lines   On
         storage.type      filesystem
         Threaded          On
@@ -101,6 +99,7 @@ data:
         Alias  otlp
         Listen 0.0.0.0
         Port   4318
+        Mem_Buf_Limit 50M
 
     [INPUT]
         Name            systemd
@@ -135,6 +134,7 @@ data:
         Kube_Tag_Prefix     kubernetes.var.log.containers.
         Annotations         Off
         K8S-Logging.Exclude On
+        Kube_Meta_Cache_TTL 300
         Buffer_Size         64k
 
     [FILTER]
@@ -323,6 +323,7 @@ data:
     [OUTPUT]
         Match ocm.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -347,6 +348,7 @@ data:
     [OUTPUT]
         Match aro-hcp-frontend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -371,6 +373,7 @@ data:
     [OUTPUT]
         Match aro-hcp-backend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -395,6 +398,7 @@ data:
     [OUTPUT]
         Match clusters-service.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -418,6 +422,7 @@ data:
     [OUTPUT]
         Match kubernetes.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -442,6 +447,7 @@ data:
     [OUTPUT]
         Match kube-events.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -476,6 +482,7 @@ data:
     [OUTPUT]
         Match systemd.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -591,7 +598,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 1bcf41031ddd939fc7fda8e95915cce0382741abc5ff4e73a4047e9ef9569141
+        checksum/configmap: bcc43b17958a9e5ecb2765877be2145fc8deb5f8e3c2974fe0beb84ee0d34694
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
@@ -648,7 +655,7 @@ spec:
               cpu: 100m
               memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 1248Mi
           volumeMounts:
             - name: var-kusto
               mountPath: /var/kusto

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -37,13 +37,11 @@ data:
         Plugins_File              /fluent-bit/etc/plugins.conf
         HTTP_Server               On
         storage.path              /var/fluent-bit/flb-storage
-        # If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory.
-        # (default: 128)
-        storage.max_chunks_up     256
-        # This option configure a hint of maximum value of memory to use when processing the backlog data.
-        # (default: 5M)
-        storage.backlog.mem_limit 50M
+        storage.max_chunks_up     128
+        storage.backlog.mem_limit 15M
         storage.metrics           on
+        storage.delete_irrecoverable_chunks on
+        scheduler.cap             600
         Grace                     30
         # Based on the HC_Period, if the error number > HC_Errors_Count or the retry failure > HC_Retry_Failure_Count, fluent bit is considered as unhealthy.
         Health_Check              On
@@ -73,8 +71,8 @@ data:
         DB.locking        true
         Refresh_Interval  15
         Read_from_Head    On
-        Buffer_Chunk_Size 128K
-        Buffer_Max_Size   2M
+        Buffer_Chunk_Size 32K
+        Buffer_Max_Size   256K
         Skip_Long_Lines   On
         storage.type      filesystem
         Threaded          On
@@ -99,6 +97,7 @@ data:
         Alias  otlp
         Listen 0.0.0.0
         Port   4318
+        Mem_Buf_Limit 50M
 
     [INPUT]
         Name            systemd
@@ -133,6 +132,7 @@ data:
         Kube_Tag_Prefix     kubernetes.var.log.containers.
         Annotations         Off
         K8S-Logging.Exclude On
+        Kube_Meta_Cache_TTL 300
         Buffer_Size         64k
 
     [FILTER]
@@ -177,6 +177,7 @@ data:
     [OUTPUT]
         Match aro-hcp-frontend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -201,6 +202,7 @@ data:
     [OUTPUT]
         Match aro-hcp-backend.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -225,6 +227,7 @@ data:
     [OUTPUT]
         Match clusters-service.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -248,6 +251,7 @@ data:
     [OUTPUT]
         Match kubernetes.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -272,6 +276,7 @@ data:
     [OUTPUT]
         Match kube-events.logs
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -306,6 +311,7 @@ data:
     [OUTPUT]
         Match systemd.*
         Name azure_kusto
+        Retry_Limit 5
         auth_type workload_identity
         tenant_id __tenantId__
         client_id __msiClientId__
@@ -421,7 +427,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: ecfea847f2164f8937eb5cd3e0a8237769dccd75842f35fa428546ae5ea66d0c
+        checksum/configmap: adfb75e40455e9c78550952a0d0c570120d30fdc28229331d9ccf1bf4e20d489
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
@@ -478,7 +484,7 @@ spec:
               cpu: 100m
               memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 1248Mi
           volumeMounts:
             - name: var-kusto
               mountPath: /var/kusto


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-680

## Summary

Apply fluent-bit memory optimization best practices to the arobit forwarder configmap. These changes bound previously-unlimited buffer growth, reduce peak RSS, and add missing safety limits across all input/filter/output sections.

## Changes

### SERVICE section

| Parameter | Before | After | Why |
|---|---|---|---|
| `storage.max_chunks_up` | 256 | 128 | Each chunk is ~2MB. 256 chunks = 512MB potential in-memory chunk data. 128 (the default) = 256MB. Was doubled from the default with no clear justification. |
| `storage.backlog.mem_limit` | 50M | 15M | Controls how much memory the backlog processor uses when reloading chunks from disk after a restart. 50M can cause a memory spike at pod startup if there's a large backlog on disk. 15M is still generous while limiting restart-time spikes. |
| `storage.delete_irrecoverable_chunks` | (missing) | on | When enabled, corrupted filesystem chunks are deleted on load instead of blocking the pipeline. Prevents memory waste from repeatedly trying to process bad chunks. Default is off. |
| `scheduler.cap` | (missing, default 2000ms) | 600 | Caps the maximum retry backoff at 600ms. Failed chunks are retried sooner, freed from memory sooner on success. Reduces how long failed chunks sit in memory during the exponential backoff window. |

Removed 4 comments that stated incorrect defaults (e.g. "default: 5M" for backlog.mem_limit — actual source code default is 100M).

### tail INPUT (container logs)

| Parameter | Before | After | Why |
|---|---|---|---|
| `Buffer_Chunk_Size` | 128K | 32K | Per-file read buffer allocated for every tracked log file. 128K is 4x the default (32K). With hundreds of container log files, this multiplies: 500 files × 128K = 62MB vs 500 × 32K = 15MB. |
| `Buffer_Max_Size` | 2M | 256K | Maximum buffer size a single file can grow to for a long line. 2M per file is excessive — CRI log format already splits long entries. 256K handles all reasonable structured log lines. Lines exceeding this are skipped (`Skip_Long_Lines On` is already set). |


### opentelemetry INPUT

| Parameter | Before | After | Why |
|---|---|---|---|
| `Mem_Buf_Limit` | (missing, unlimited) | 50M | Network input (listens on port 4318) with no buffer limit — could buffer without bound under backpressure. Network inputs are especially vulnerable to memory bursts because they can't control the sender's rate. 50M matches the forward input's limit. |

### kubernetes FILTER

| Parameter | Before | After | Why |
|---|---|---|---|
| `Kube_Meta_Cache_TTL` | 0 (infinite) | 300 | Default is 0 (never expires). Metadata for deleted/evicted pods stays cached in memory forever. With pod churn, this causes unbounded cache growth. 300s (5 min) expires stale entries for pods that no longer exist. |

### azure_kusto OUTPUTs (all 7 instances)

| Parameter | Before | After | Why |
|---|---|---|---|
| `Retry_Limit` | (missing, default 1) | 5 | Gives a reasonable number of retry attempts for transient Kusto ingestion errors before dropping the chunk. Prevents indefinite retry accumulation during extended outages while still allowing recovery from brief blips. |

### Forwarder container resource limits

| Parameter | Before | After | Why |
|---|---|---|---|
| `resources.limits.memory` | 1Gi | 1248Mi | Bumped by ~224Mi to give more headroom. Observation of running processes indicates it needs more memory to run properly with the current workload. |


🤖 Generated with [Claude Code](https://claude.com/claude-code)