### PR TITLE
ci: add label guard to prevent manual lgtm/approved labels

### DIFF
--- a/.github/workflows/label-guard.yml
+++ b/.github/workflows/label-guard.yml
@@ -1,0 +1,21 @@
+name: PR Label Guard
+on:
+  pull_request_target:
+    types: [labeled]
+jobs:
+  revert-label:
+    if: (github.event.label.name == 'lgtm' || github.event.label.name == 'approved') && github.event.sender.login != 'openshift-ci[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - name: Remove unauthorized label
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        LABEL: ${{ github.event.label.name }}
+        SENDER: ${{ github.event.sender.login }}
+      run: |
+        echo "Removing '$LABEL' label added by $SENDER (not openshift-ci[bot])"
+        gh pr edit "$PR_NUMBER" --remove-label "$LABEL"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that removes `lgtm` and `approved` labels when added by anyone other than `openshift-ci[bot]`
- Uses `pull_request_target` with `labeled` event type so it fires immediately and has write permissions
- Prevents humans from bypassing the prow review process by manually slapping labels on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)