### PR TITLE
mgmt-fixes: add pre-upgrade hook to delete immutable StorageClass

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_default_sc.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_default_sc.yaml
@@ -50,6 +50,58 @@ subjects:
   namespace: 'default-sc'
 
 ---
+# Source: DefaultStorageClass/templates/delete-sc-pre-upgrade.job.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: annotator-cluster-role
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+rules:
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - delete
+---
+# Source: DefaultStorageClass/templates/delete-sc-pre-upgrade.job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-sc-pre-upgrade
+  namespace: 'default-sc'
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  activeDeadlineSeconds: 60
+  backoffLimit: 3
+  template:
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - |
+          CURRENT_SKU=$(kubectl get storageclass managed-csi-premiumv2 -o jsonpath='{.parameters.skuname}' 2>/dev/null || echo "")
+          DESIRED_SKU="PremiumV2_LRS"
+          if [ -z "$CURRENT_SKU" ]; then
+            echo "StorageClass does not exist, nothing to delete"
+          elif [ "$CURRENT_SKU" = "$DESIRED_SKU" ]; then
+            echo "StorageClass skuname already matches ($CURRENT_SKU), skipping delete"
+          else
+            echo "StorageClass skuname mismatch: current=$CURRENT_SKU desired=$DESIRED_SKU, deleting"
+            kubectl delete storageclass managed-csi-premiumv2
+          fi
+        image: "mcr.microsoft.com/aks/command/runtime@sha256:1234567890"
+        name: delete-sc
+      restartPolicy: OnFailure
+      serviceAccountName: annotator
+---
 # Source: DefaultStorageClass/templates/unannotate-default.job.yaml
 apiVersion: batch/v1
 kind: Job

--- a/mgmt-fixes/deploy/default-sc/templates/delete-sc-pre-upgrade.job.yaml
+++ b/mgmt-fixes/deploy/default-sc/templates/delete-sc-pre-upgrade.job.yaml
@@ -1,0 +1,49 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: annotator-cluster-role
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+rules:
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - delete
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-sc-pre-upgrade
+  namespace: '{{ .Release.Namespace }}'
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  activeDeadlineSeconds: 60
+  backoffLimit: 3
+  template:
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - |
+          CURRENT_SKU=$(kubectl get storageclass managed-csi-premiumv2 -o jsonpath='{.parameters.skuname}' 2>/dev/null || echo "")
+          DESIRED_SKU="{{ .Values.skuName | default "PremiumV2_LRS" }}"
+          if [ -z "$CURRENT_SKU" ]; then
+            echo "StorageClass does not exist, nothing to delete"
+          elif [ "$CURRENT_SKU" = "$DESIRED_SKU" ]; then
+            echo "StorageClass skuname already matches ($CURRENT_SKU), skipping delete"
+          else
+            echo "StorageClass skuname mismatch: current=$CURRENT_SKU desired=$DESIRED_SKU, deleting"
+            kubectl delete storageclass managed-csi-premiumv2
+          fi
+        image: "{{ .Values.unannotateJobImage }}"
+        name: delete-sc
+      restartPolicy: OnFailure
+      serviceAccountName: annotator


### PR DESCRIPTION
StorageClass parameters are immutable in Kubernetes. When the SKU is changed (e.g. PremiumV2_LRS to Premium_LRS for EUAP), Helm upgrade fails with `updates to parameters are forbidden`.

Add a pre-upgrade hook Job that deletes the existing StorageClass before Helm applies the update, and grant the delete verb to the existing annotator ClusterRole.

[AROSLSRE-825](https://redhat.atlassian.net/browse/AROSLSRE-825)

<!-- Link to Jira issue -->
https://redhat.atlassian.net/browse/AROSLSRE-825

### What

Add a Helm `pre-upgrade` hook (`delete-sc-pre-upgrade.job.yaml`) that deletes the `managed-csi-premiumv2` StorageClass before Helm tries to update it, and add `delete` verb to the existing `annotator-cluster-role` ClusterRole.

### Why

Kubernetes StorageClass `parameters` are immutable. PR #5124 ([AROSLSRE-771](https://redhat.atlassian.net/browse/AROSLSRE-771)) templatized the `skuname` parameter to allow per-region overrides (e.g. `Premium_LRS` for eastus2euap). However, on clusters where the StorageClass already exists with the old parameter value, Helm upgrade fails because it cannot update `parameters` in-place.

### Testing

Tested end-to-end on personal dev cluster `pers-usw3asna-mgmt-1` (westus3) with an active HCP and 3 etcd PVCs bound to `managed-csi-premiumv2`.

- **Helm template rendering:** Verified `DESIRED_SKU` resolves correctly for both `PremiumV2_LRS` (normal regions) and `Premium_LRS` (eastus2euap)
- **No-op path (matching SKU):** `helm upgrade` with `skuName=PremiumV2_LRS` → hook detected match, skipped delete, upgrade succeeded, SC unchanged
- **Deletion path (mismatching SKU):** `helm upgrade` with `skuName=Premium_LRS` → hook detected mismatch, deleted SC, Helm recreated with `Premium_LRS`. Etcd PVCs remained `Bound`, etcd pods `Running` with 0 restarts — no impact to the HCP

### Special notes for your reviewer

This unblocks the eastus2euap MGMT pipeline which is currently failing at the `storageclass` step. Related to [AROSLSRE-771](https://redhat.atlassian.net/browse/AROSLSRE-771) / PR #5124.