### PR TITLE
deps: bump fast-uri to fix 2 CVEs (AROSLSRE-785)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2698,9 +2698,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/api/package.json
+++ b/api/package.json
@@ -41,6 +41,7 @@
     "@tootallnate/once": "^3.0.1",
     "@azure/ms-rest-js": {
       "uuid": "^14.0.0"
-    }
+    },
+    "fast-uri": "^3.1.2"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `fast-uri` from 3.1.0 to 3.1.2 via npm override in `api/package.json`

## Security fixes

| CVE | Severity | Description |
|---|---|---|
| CVE-2026-6321 | High | Path traversal via percent-encoded dot segments |
| CVE-2026-6322 | High | Host confusion via percent-encoded authority delimiters |

## Dependabot alerts resolved
- #235 (CVE-2026-6321)
- #236 (CVE-2026-6322)

## JIRA
https://redhat.atlassian.net/browse/AROSLSRE-785