### PR TITLE
Remove dynamic pod names from alert summaries to reduce incident noise

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1031,8 +1031,8 @@ Retries occur when the azure_kusto output encounters a recoverable error (e.g. t
 Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
 '''
           runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html'
-          summary: 'High Kusto output retry rate (> 3/s for 5 min).'
-          title: 'High Kusto output retry rate (> 3/s for 5 min).'
+          summary: 'High Kusto output retries'
+          title: 'High Kusto output retries'
         }
         expression: 'sum(increase(fluentbit_output_retries_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 3'
         for: 'PT5M'

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -982,39 +982,6 @@ resource arobitRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01
             }
           }
         ]
-        alert: 'LowOutputBytesProcessed'
-        enabled: true
-        labels: {
-          severity: 'warning'
-        }
-        annotations: {
-          correlationId: 'LowOutputBytesProcessed/{{ $labels.cluster }}/{{ $labels.pod }}'
-          description: '''Fluent Bit pod {{ $labels.pod }} on cluster {{ $labels.cluster }} output is low.
-The metric fluentbit_output_proc_bytes_total only counts bytes from chunks that were sent successfully, this indicates a problem with the output plugin or low input.
-Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-'''
-          info: '''Fluent Bit pod {{ $labels.pod }} on cluster {{ $labels.cluster }} output is low.
-The metric fluentbit_output_proc_bytes_total only counts bytes from chunks that were sent successfully, this indicates a problem with the output plugin or low input.
-Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-'''
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html'
-          summary: 'No log data delivered to Kusto by {{ $labels.pod }} for 15 minutes.'
-          title: 'No log data delivered to Kusto by {{ $labels.pod }} for 15 minutes.'
-        }
-        expression: 'sum(rate(fluentbit_output_proc_bytes_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) < 50'
-        for: 'PT15M'
-        severity: 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
         alert: 'FluentBitIngestionPaused'
         enabled: true
         labels: {
@@ -1031,8 +998,8 @@ Ingestion pauses when Fluent Bit\'s internal memory or storage buffers are full,
 Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
 '''
           runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html'
-          summary: 'Fluent Bit input ingestion paused on {{ $labels.pod }} due to backpressure.'
-          title: 'Fluent Bit input ingestion paused on {{ $labels.pod }} due to backpressure.'
+          summary: 'Fluent Bit input ingestion paused due to backpressure.'
+          title: 'Fluent Bit input ingestion paused due to backpressure.'
         }
         expression: 'sum(fluentbit_input_ingestion_paused) by (cluster, pod) > 0'
         for: 'PT5M'
@@ -1064,10 +1031,10 @@ Retries occur when the azure_kusto output encounters a recoverable error (e.g. t
 Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
 '''
           runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html'
-          summary: 'High Kusto output retry rate on {{ $labels.pod }} (> 3/s for 5 min).'
-          title: 'High Kusto output retry rate on {{ $labels.pod }} (> 3/s for 5 min).'
+          summary: 'High Kusto output retry rate (> 3/s for 5 min).'
+          title: 'High Kusto output retry rate (> 3/s for 5 min).'
         }
-        expression: 'sum(rate(fluentbit_output_retries_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 3'
+        expression: 'sum(increase(fluentbit_output_retries_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 3'
         for: 'PT5M'
         severity: 3
       }
@@ -1095,10 +1062,10 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
 Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
 '''
           runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html'
-          summary: 'Unrecoverable Kusto output errors on {{ $labels.pod }} - log data is being dropped.'
-          title: 'Unrecoverable Kusto output errors on {{ $labels.pod }} - log data is being dropped.'
+          summary: 'Unrecoverable Kusto output errors - log data is being dropped.'
+          title: 'Unrecoverable Kusto output errors - log data is being dropped.'
         }
-        expression: 'sum(rate(fluentbit_output_errors_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 0'
+        expression: 'sum(increase(fluentbit_output_errors_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 0'
         for: 'PT5M'
         severity: 3
       }
@@ -1126,10 +1093,10 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
 Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
 '''
           runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html'
-          summary: 'Kusto output retries exhausted on {{ $labels.pod }} - chunks discarded after max retries.'
-          title: 'Kusto output retries exhausted on {{ $labels.pod }} - chunks discarded after max retries.'
+          summary: 'Kusto output retries exhausted - chunks discarded after max retries.'
+          title: 'Kusto output retries exhausted - chunks discarded after max retries.'
         }
-        expression: 'sum(rate(fluentbit_output_retries_failed_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 0'
+        expression: 'sum(increase(fluentbit_output_retries_failed_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 0'
         for: 'PT5M'
         severity: 3
       }
@@ -1473,8 +1440,8 @@ This may indicate that finalizers are stuck or resources are failing to cleanup.
 This may indicate that finalizers are stuck or resources are failing to cleanup.
 '''
           runbook_url: 'TBD'
-          summary: 'Cluster {{ $labels.exported_namespace }} stuck deleting'
-          title: 'Cluster {{ $labels.exported_namespace }} stuck deleting'
+          summary: 'Cluster stuck deleting'
+          title: 'Cluster stuck deleting'
         }
         expression: 'sum by (cluster, exported_namespace, name) (hypershift_cluster_deleting_duration_seconds) > 7200'
         for: 'PT5M'
@@ -1513,8 +1480,8 @@ resource kubeContainerOomRules 'Microsoft.AlertsManagement/prometheusRuleGroups@
           description: 'Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} on cluster {{ $labels.cluster }} has been OOMKilled. This indicates the container exceeded its memory limit and was terminated by the kernel.'
           info: 'Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} on cluster {{ $labels.cluster }} has been OOMKilled. This indicates the container exceeded its memory limit and was terminated by the kernel.'
           runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/service-lifecycle.html'
-          summary: 'Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} was OOMKilled'
-          title: 'Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} was OOMKilled'
+          summary: 'Container {{ $labels.container }} was OOMKilled'
+          title: 'Container {{ $labels.container }} was OOMKilled'
         }
         expression: 'kube_pod_container_status_last_terminated_reason{reason="OOMKilled", job="kube-state-metrics"} == 1'
         severity: 3

--- a/observability/alerts/HCPdeletionStuck-prometheusRule.yaml
+++ b/observability/alerts/HCPdeletionStuck-prometheusRule.yaml
@@ -14,6 +14,6 @@ spec:
       labels:
         severity: warning
       annotations:
-        summary: "Cluster {{ $labels.exported_namespace }} stuck deleting"
+        summary: "Cluster stuck deleting"
         description: "Cluster {{ $labels.exported_namespace }} has been in a deleting state for more than 2 hours. \nThis may indicate that finalizers are stuck or resources are failing to cleanup.\n"
         runbook_url: TBD

--- a/observability/alerts/HCPdeletionStuck-prometheusRule_test.yaml
+++ b/observability/alerts/HCPdeletionStuck-prometheusRule_test.yaml
@@ -23,6 +23,6 @@ tests:
         exported_namespace: hcp-ns-1
         name: cluster-1
       exp_annotations:
-        summary: "Cluster hcp-ns-1 stuck deleting"
+        summary: "Cluster stuck deleting"
         description: "Cluster hcp-ns-1 has been in a deleting state for more than 2 hours. \nThis may indicate that finalizers are stuck or resources are failing to cleanup.\n"
         runbook_url: TBD

--- a/observability/alerts/arobit-prometheusRule.yaml
+++ b/observability/alerts/arobit-prometheusRule.yaml
@@ -17,18 +17,6 @@ spec:
           The Arobit forwarder metrics endpoint on cluster {{ $labels.cluster }} has been unreachable for 15 minutes.
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html
         summary: Arobit forwarder metrics endpoint is unreachable on cluster {{ $labels.cluster }}.
-    - alert: LowOutputBytesProcessed
-      expr: sum(rate(fluentbit_output_proc_bytes_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) < 50
-      for: 15m
-      labels:
-        severity: warning
-      annotations:
-        runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html
-        description: |
-          Fluent Bit pod {{ $labels.pod }} on cluster {{ $labels.cluster }} output is low.
-          The metric fluentbit_output_proc_bytes_total only counts bytes from chunks that were sent successfully, this indicates a problem with the output plugin or low input.
-          Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-        summary: No log data delivered to Kusto by {{ $labels.pod }} for 15 minutes.
     - alert: FluentBitIngestionPaused
       expr: sum(fluentbit_input_ingestion_paused) by (cluster, pod) > 0
       for: 5m
@@ -40,9 +28,9 @@ spec:
           Fluent Bit pod {{ $labels.pod }} on cluster {{ $labels.cluster }} has paused collecting new log data for at least 5 minutes.
           Ingestion pauses when Fluent Bit's internal memory or storage buffers are full, typically caused by backpressure from a slow or failing output.
           Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-        summary: Fluent Bit input ingestion paused on {{ $labels.pod }} due to backpressure.
+        summary: Fluent Bit input ingestion paused due to backpressure.
     - alert: FluentBitHighOutputRetries
-      expr: sum(rate(fluentbit_output_retries_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 3
+      expr: sum(increase(fluentbit_output_retries_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 3
       for: 5m
       labels:
         severity: warning
@@ -52,9 +40,9 @@ spec:
           Fluent Bit pod {{ $labels.pod }} on cluster {{ $labels.cluster }} is retrying chunk delivery.
           Retries occur when the azure_kusto output encounters a recoverable error (e.g. transient network failure, HTTP 429/5xx from Kusto).
           Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-        summary: High Kusto output retry rate on {{ $labels.pod }} (> 3/s for 5 min).
+        summary: High Kusto output retry rate (> 3/s for 5 min).
     - alert: FluentBitOutputErrors
-      expr: sum(rate(fluentbit_output_errors_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 0
+      expr: sum(increase(fluentbit_output_errors_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 0
       for: 5m
       labels:
         severity: warning
@@ -63,9 +51,9 @@ spec:
         description: |
           Fluent Bit pod {{ $labels.pod }} on cluster {{ $labels.cluster }} is encountering errors sending log chunks to Kusto.
           Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-        summary: Unrecoverable Kusto output errors on {{ $labels.pod }} - log data is being dropped.
+        summary: Unrecoverable Kusto output errors - log data is being dropped.
     - alert: FluentBitOutputRetriesExhausted
-      expr: sum(rate(fluentbit_output_retries_failed_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 0
+      expr: sum(increase(fluentbit_output_retries_failed_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 0
       for: 5m
       labels:
         severity: warning
@@ -74,4 +62,4 @@ spec:
         description: |
           Fluent Bit pod {{ $labels.pod }} on cluster {{ $labels.cluster }} has chunks that exceeded the configured Retry_Limit for the Kusto output.
           Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-        summary: Kusto output retries exhausted on {{ $labels.pod }} - chunks discarded after max retries.
+        summary: Kusto output retries exhausted - chunks discarded after max retries.

--- a/observability/alerts/arobit-prometheusRule.yaml
+++ b/observability/alerts/arobit-prometheusRule.yaml
@@ -40,7 +40,7 @@ spec:
           Fluent Bit pod {{ $labels.pod }} on cluster {{ $labels.cluster }} is retrying chunk delivery.
           Retries occur when the azure_kusto output encounters a recoverable error (e.g. transient network failure, HTTP 429/5xx from Kusto).
           Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-        summary: High Kusto output retry rate (> 3/s for 5 min).
+        summary: High Kusto output retries
     - alert: FluentBitOutputErrors
       expr: sum(increase(fluentbit_output_errors_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 0
       for: 5m

--- a/observability/alerts/arobit-prometheusRule_test.yaml
+++ b/observability/alerts/arobit-prometheusRule_test.yaml
@@ -22,45 +22,6 @@ tests:
           The Arobit forwarder metrics endpoint on cluster test has been unreachable for 15 minutes.
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html
         summary: Arobit forwarder metrics endpoint is unreachable on cluster test.
-# LowOutputBytesProcessed - alert fires for azure_kusto output with low throughput
-- interval: 1m
-  input_series:
-  - series: 'fluentbit_output_proc_bytes_total{pod="arobit-12345",cluster="test",name="azure_kusto.0"}'
-    values: "100+0x20"
-  alert_rule_test:
-  - eval_time: 16m
-    alertname: LowOutputBytesProcessed
-    exp_alerts:
-    - exp_labels:
-        alertname: LowOutputBytesProcessed
-        severity: warning
-        cluster: test
-        pod: arobit-12345
-      exp_annotations:
-        runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html
-        description: |
-          Fluent Bit pod arobit-12345 on cluster test output is low.
-          The metric fluentbit_output_proc_bytes_total only counts bytes from chunks that were sent successfully, this indicates a problem with the output plugin or low input.
-          Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-        summary: No log data delivered to Kusto by arobit-12345 for 15 minutes.
-# LowOutputBytesProcessed - healthy azure_kusto pod, no alert
-- interval: 1m
-  input_series:
-  - series: 'fluentbit_output_proc_bytes_total{pod="arobit-healthy",cluster="test",name="azure_kusto.0"}'
-    values: "100+5000x20"
-  alert_rule_test:
-  - eval_time: 16m
-    alertname: LowOutputBytesProcessed
-    exp_alerts: []
-# LowOutputBytesProcessed - non-kusto output stalled, no alert
-- interval: 1m
-  input_series:
-  - series: 'fluentbit_output_proc_bytes_total{pod="arobit-other",cluster="test",name="stdout.0"}'
-    values: "100+0x20"
-  alert_rule_test:
-  - eval_time: 16m
-    alertname: LowOutputBytesProcessed
-    exp_alerts: []
 # FluentBitIngestionPaused - alert fires
 - interval: 1m
   input_series:
@@ -81,7 +42,7 @@ tests:
           Fluent Bit pod arobit-paused on cluster test has paused collecting new log data for at least 5 minutes.
           Ingestion pauses when Fluent Bit's internal memory or storage buffers are full, typically caused by backpressure from a slow or failing output.
           Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-        summary: Fluent Bit input ingestion paused on arobit-paused due to backpressure.
+        summary: Fluent Bit input ingestion paused due to backpressure.
 # FluentBitIngestionPaused - healthy pod, no alert
 - interval: 1m
   input_series:
@@ -111,7 +72,7 @@ tests:
           Fluent Bit pod arobit-retrying on cluster test is retrying chunk delivery.
           Retries occur when the azure_kusto output encounters a recoverable error (e.g. transient network failure, HTTP 429/5xx from Kusto).
           Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-        summary: High Kusto output retry rate on arobit-retrying (> 3/s for 5 min).
+        summary: High Kusto output retry rate (> 3/s for 5 min).
 # FluentBitHighOutputRetries - low retries, no alert
 - interval: 1m
   input_series:
@@ -149,7 +110,7 @@ tests:
         description: |
           Fluent Bit pod arobit-errors on cluster test is encountering errors sending log chunks to Kusto.
           Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-        summary: Unrecoverable Kusto output errors on arobit-errors - log data is being dropped.
+        summary: Unrecoverable Kusto output errors - log data is being dropped.
 # FluentBitOutputErrors - no errors, no alert
 - interval: 1m
   input_series:
@@ -187,7 +148,7 @@ tests:
         description: |
           Fluent Bit pod arobit-exhausted on cluster test has chunks that exceeded the configured Retry_Limit for the Kusto output.
           Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-        summary: Kusto output retries exhausted on arobit-exhausted - chunks discarded after max retries.
+        summary: Kusto output retries exhausted - chunks discarded after max retries.
 # FluentBitOutputRetriesExhausted - no failed retries, no alert
 - interval: 1m
   input_series:

--- a/observability/alerts/arobit-prometheusRule_test.yaml
+++ b/observability/alerts/arobit-prometheusRule_test.yaml
@@ -72,7 +72,7 @@ tests:
           Fluent Bit pod arobit-retrying on cluster test is retrying chunk delivery.
           Retries occur when the azure_kusto output encounters a recoverable error (e.g. transient network failure, HTTP 429/5xx from Kusto).
           Investigate the Fluent Bit logs for the specific error details and check the Kusto instance health.
-        summary: High Kusto output retry rate (> 3/s for 5 min).
+        summary: High Kusto output retries
 # FluentBitHighOutputRetries - low retries, no alert
 - interval: 1m
   input_series:

--- a/observability/alerts/kubeContainerOOM-prometheusRule.yaml
+++ b/observability/alerts/kubeContainerOOM-prometheusRule.yaml
@@ -13,6 +13,6 @@ spec:
       labels:
         severity: warning
       annotations:
-        summary: "Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} was OOMKilled"
+        summary: "Container {{ $labels.container }} was OOMKilled"
         description: "Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} on cluster {{ $labels.cluster }} has been OOMKilled. This indicates the container exceeded its memory limit and was terminated by the kernel."
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/service-lifecycle.html

--- a/observability/alerts/kubeContainerOOM-prometheusRule_test.yaml
+++ b/observability/alerts/kubeContainerOOM-prometheusRule_test.yaml
@@ -21,7 +21,7 @@ tests:
         reason: OOMKilled
         job: kube-state-metrics
       exp_annotations:
-        summary: "Container frontend in pod aro-hcp/frontend-abc-12345 was OOMKilled"
+        summary: "Container frontend was OOMKilled"
         description: "Container frontend in pod aro-hcp/frontend-abc-12345 on cluster svc-1 has been OOMKilled. This indicates the container exceeded its memory limit and was terminated by the kernel."
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/service-lifecycle.html
 # Scenario 2: Container terminated for a different reason (not OOMKilled) - no alert


### PR DESCRIPTION


<!-- Link to Jira issue -->

### What/Why

Alert summaries are used as incident titles in the triaging system. Dynamic parts like pod names cause separate incidents for the same underlying problem. This removes pod names and other ephemeral identifiers from summaries while keeping them in descriptions.
Remove alert `LowOutputBytesProcessed`, cause we now have exporter providing info if kusto logs are flowing.