### PR TITLE
add genericdocument compatible serialization of nodepools

### DIFF
--- a/internal/database/convert_nodepool.go
+++ b/internal/database/convert_nodepool.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/ocm"
 )
 
 func InternalToCosmosNodePool(internalObj *api.HCPOpenShiftClusterNodePool) (*NodePool, error) {
@@ -40,6 +39,7 @@ func InternalToCosmosNodePool(internalObj *api.HCPOpenShiftClusterNodePool) (*No
 			ResourceType: internalObj.ID.ResourceType.String(),
 		},
 		NodePoolProperties: NodePoolProperties{
+			HCPOpenShiftClusterNodePool: *internalObj,
 			CosmosMetadata: api.CosmosMetadata{
 				ResourceID: internalObj.ID,
 			},
@@ -57,20 +57,6 @@ func InternalToCosmosNodePool(internalObj *api.HCPOpenShiftClusterNodePool) (*No
 			},
 		},
 	}
-
-	// some pieces of data in the internalNodePool conflict with ResourceDocument fields.  We may evolve over time, but for
-	// now avoid persisting those.
-	cosmosObj.InternalState.InternalAPI.TrackedResource = arm.TrackedResource{
-		Location: internalObj.Location, // this is the only TrackedResource value not present elsewhere in ResourceDcoument
-	}
-	cosmosObj.InternalState.InternalAPI.Identity = nil
-	cosmosObj.InternalState.InternalAPI.Properties.ProvisioningState = ""
-	cosmosObj.InternalState.InternalAPI.SystemData = nil
-	cosmosObj.InternalState.InternalAPI.Tags = nil
-	// we do this to keep serialization the same so that we can go to n-1 where this field isn't a pointer.
-	// on the reading side, we handle the pointer as expected.
-	cosmosObj.InternalState.InternalAPI.ServiceProviderProperties.ClusterServiceID = &ocm.InternalID{}
-	cosmosObj.InternalState.InternalAPI.ServiceProviderProperties.ActiveOperationID = ""
 
 	return cosmosObj, nil
 }
@@ -101,7 +87,7 @@ func CosmosToInternalNodePool(cosmosObj *NodePool) (*api.HCPOpenShiftClusterNode
 	// we carry over the CosmosETag from the cosmos object to the internal object into a
 	// temporary field until we have inlined and serialized CosmosMetadata in
 	// HCPOpenShiftClusterNodePool.
-	internalObj.CosmosETag = cosmosObj.CosmosETag
+	internalObj.CosmosETag = cosmosObj.BaseDocument.CosmosETag
 	internalObj.Identity = resourceDoc.Identity.DeepCopy()
 	internalObj.Properties.ProvisioningState = resourceDoc.ProvisioningState
 	internalObj.SystemData = resourceDoc.SystemData

--- a/internal/database/types_nodepool.go
+++ b/internal/database/types_nodepool.go
@@ -25,8 +25,14 @@ type NodePool struct {
 }
 
 type NodePoolProperties struct {
+	// HCPOpenShiftClusterNodePool is where we're migrating to.  It is compatible with a GenericDocument[api.HCPOpenShiftClusterNodePool]
+	// which is where we want to end up.
+	// * to be compatible with prior versions, we must continue writing all previous fields and this new field
+	// * to be compatible with prior versions, we must continue reading only from previous fields
+	api.HCPOpenShiftClusterNodePool `json:",inline"`
+
 	// when we switch to inlining the internalObj, this will be in the right spot.  We add it now so that we can switch our
-	// queries to select on cosmosMetata.ResourceID instead of resourceId
+	// queries to select on cosmosMetadata.ResourceID instead of resourceId
 	CosmosMetadata api.CosmosMetadata `json:"cosmosMetadata"`
 
 	// IntermediateResourceDoc exists so that we can stop inlining the resource document so that we can directly

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/nodepool-basic.json
@@ -7,6 +7,7 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
+		"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 		"intermediateResourceDoc": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 			"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 				"location": "fake-location",
+				"name": "basic",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/00-load-initial-state/nodepool-basic.json
@@ -2,6 +2,7 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
+		"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 		"intermediateResourceDoc": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 			"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
@@ -16,21 +17,55 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 				"location": "fake-location",
+				"name": "basic",
 				"properties": {
 					"autoRepair": true,
 					"platform": {
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"version": {
 						"channelGroup": "stable"
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic",
+		"properties": {
+			"autoRepair": true,
+			"platform": {
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/99-cosmosCompare-end-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/99-cosmosCompare-end-state/nodepool-basic.json
@@ -2,6 +2,7 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
+		"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 		"intermediateResourceDoc": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 			"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
@@ -16,21 +17,55 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 				"location": "fake-location",
+				"name": "basic",
 				"properties": {
 					"autoRepair": true,
 					"platform": {
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"version": {
 						"channelGroup": "stable"
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic",
+		"properties": {
+			"autoRepair": true,
+			"platform": {
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/nodepool-basic.json
@@ -7,6 +7,7 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
+		"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 		"intermediateResourceDoc": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 				"location": "fake-location",
+				"name": "basic",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/99-cosmosCompare-end-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/99-cosmosCompare-end-state/nodepool-basic.json
@@ -7,6 +7,7 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
+		"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 		"intermediateResourceDoc": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 				"location": "fake-location",
+				"name": "basic",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/00-load-initial-state/nodepool-basic.json
@@ -7,6 +7,7 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
+		"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 		"intermediateResourceDoc": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 			"internalId": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 				"location": "fake-location",
+				"name": "basic",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/99-cosmosCompare-end-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/99-cosmosCompare-end-state/nodepool-basic.json
@@ -7,6 +7,7 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
+		"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 		"intermediateResourceDoc": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 			"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 				"location": "fake-location",
+				"name": "basic",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/nodepool-basic.json
@@ -7,6 +7,7 @@
 	"id": "b3b837bb-154f-5f52-8562-96a8c9d2bb05",
 	"partitionKey": "a433a095-1277-44f1-8453-8d61a4d848c2",
 	"properties": {
+		"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 		"intermediateResourceDoc": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 			"internalId": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 				"location": "fake-location",
+				"name": "basic",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/a433a095-1277-44f1-8453-8d61a4d848c2/resourceGroups/unimportantpostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousprecinct/nodePools/basic",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
@@ -5,6 +5,7 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool"
 		},
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool",
 		"intermediateResourceDoc": {
 			"provisioningState": "Deleting",
 			"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool",
@@ -17,7 +18,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool",
 				"location": "fake-location",
+				"name": "test-nodepool",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -38,6 +41,7 @@
 						"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
 						"vmSize": "large"
 					},
+					"provisioningState": "Deleting",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,9 +56,59 @@
 				},
 				"serviceProviderProperties": {
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "test-nodepool",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-key": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"diskType": "Managed",
+					"sizeGiB": 64
+				},
+				"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+				"vmSize": "large"
+			},
+			"provisioningState": "Deleting",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable",
+				"id": "4.20.8"
+			}
+		},
+		"serviceProviderProperties": {},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-basic-node-pool.json
@@ -7,6 +7,7 @@
 	"id": "2b834a28-7e5b-50e2-9fb9-b6679cdd6a1b",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 		"intermediateResourceDoc": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 				"location": "fake-location",
+				"name": "basic-node-pool",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic-node-pool",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-node-pool-02.json
@@ -7,6 +7,7 @@
 	"id": "9b74accf-0661-53d8-9741-b3aa39f9a53c",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 		"intermediateResourceDoc": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 				"location": "fake-location",
+				"name": "node-pool-02",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "node-pool-02",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-basic-node-pool.json
@@ -10,6 +10,7 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool"
 		},
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 		"intermediateResourceDoc": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
@@ -24,7 +25,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 				"location": "fake-location",
+				"name": "basic-node-pool",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -44,6 +47,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -56,10 +60,62 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic-node-pool",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"diskType": "Managed",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-node-pool-02.json
@@ -10,6 +10,7 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02"
 		},
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 		"intermediateResourceDoc": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
@@ -24,7 +25,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 				"location": "fake-location",
+				"name": "node-pool-02",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -44,6 +47,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -56,10 +60,62 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "node-pool-02",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"diskType": "Managed",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-basic-node-pool.json
@@ -7,6 +7,7 @@
 	"id": "2b834a28-7e5b-50e2-9fb9-b6679cdd6a1b",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 		"intermediateResourceDoc": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 				"location": "fake-location",
+				"name": "basic-node-pool",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic-node-pool",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-node-pool-02.json
@@ -7,6 +7,7 @@
 	"id": "9b74accf-0661-53d8-9741-b3aa39f9a53c",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 		"intermediateResourceDoc": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 				"location": "fake-location",
+				"name": "node-pool-02",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "node-pool-02",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-basic-node-pool.json
@@ -7,6 +7,7 @@
 	"id": "2b834a28-7e5b-50e2-9fb9-b6679cdd6a1b",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 		"intermediateResourceDoc": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 				"location": "fake-location",
+				"name": "basic-node-pool",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic-node-pool",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-node-pool-02.json
@@ -6,6 +6,7 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02"
 		},
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 		"intermediateResourceDoc": {
 			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
 			"provisioningState": "Succeeded",
@@ -19,7 +20,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 				"location": "fake-location",
+				"name": "node-pool-02",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -39,6 +42,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Succeeded",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,9 +56,59 @@
 				},
 				"serviceProviderProperties": {
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "node-pool-02",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"diskType": "Managed",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Succeeded",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-basic-node-pool.json
@@ -10,6 +10,7 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool"
 		},
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 		"intermediateResourceDoc": {
 			"activeOperationId": "bf643e76-55fe-48a0-a752-f5c5a2db72ad",
 			"internalId": "/api/clusters_mgmt/v1/clusters/dl7f9px2f2/node_pools/82npf9hxmk",
@@ -24,7 +25,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 				"location": "fake-location",
+				"name": "basic-node-pool",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -45,6 +48,7 @@
 						"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -58,10 +62,64 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "bf643e76-55fe-48a0-a752-f5c5a2db72ad",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic-node-pool",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"diskType": "Managed",
+					"sizeGiB": 64
+				},
+				"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable",
+				"id": "4.20.8"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "bf643e76-55fe-48a0-a752-f5c5a2db72ad",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/dl7f9px2f2/node_pools/82npf9hxmk"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-node-pool-02.json
@@ -10,6 +10,7 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02"
 		},
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 		"intermediateResourceDoc": {
 			"activeOperationId": "25e4713b-44b5-4799-9e60-894a132c6674",
 			"internalId": "/api/clusters_mgmt/v1/clusters/dl7f9px2f2/node_pools/5zdc9grtvf",
@@ -24,7 +25,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 				"location": "fake-location",
+				"name": "node-pool-02",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -45,6 +48,7 @@
 						"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -58,10 +62,64 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "25e4713b-44b5-4799-9e60-894a132c6674",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "node-pool-02",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"diskType": "Managed",
+					"sizeGiB": 64
+				},
+				"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable",
+				"id": "4.20.8"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "25e4713b-44b5-4799-9e60-894a132c6674",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/dl7f9px2f2/node_pools/5zdc9grtvf"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-basic-node-pool.json
@@ -7,6 +7,7 @@
 	"id": "2b834a28-7e5b-50e2-9fb9-b6679cdd6a1b",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 		"intermediateResourceDoc": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 				"location": "fake-location",
+				"name": "basic-node-pool",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic-node-pool",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-node-pool-02.json
@@ -7,6 +7,7 @@
 	"id": "9b74accf-0661-53d8-9741-b3aa39f9a53c",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 		"intermediateResourceDoc": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 				"location": "fake-location",
+				"name": "node-pool-02",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "node-pool-02",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-02.json
@@ -7,6 +7,7 @@
 	"id": "9b74accf-0661-53d8-9741-b3aa39f9a53c",
 	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 		"intermediateResourceDoc": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
@@ -21,7 +22,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 				"location": "fake-location",
+				"name": "node-pool-02",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -40,6 +43,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -52,10 +56,61 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "node-pool-02",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "valid"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/node-pool-02",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-basic-node-pool.json
@@ -10,6 +10,7 @@
 		"cosmosMetadata": {
 			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool"
 		},
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 		"intermediateResourceDoc": {
 			"activeOperationId": "9e244879-591b-4693-823a-4412b4200f4d",
 			"internalId": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
@@ -24,7 +25,9 @@
 		},
 		"internalState": {
 			"internalAPI": {
+				"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 				"location": "fake-location",
+				"name": "basic-node-pool",
 				"properties": {
 					"autoRepair": true,
 					"autoScaling": {
@@ -44,6 +47,7 @@
 						},
 						"vmSize": "large"
 					},
+					"provisioningState": "Accepted",
 					"taints": [
 						{
 							"effect": "NoExecute",
@@ -56,10 +60,62 @@
 					}
 				},
 				"serviceProviderProperties": {
+					"activeOperationId": "9e244879-591b-4693-823a-4412b4200f4d",
 					"clusterServiceID": ""
-				}
+				},
+				"systemData": {
+					"createdBy": "Unknown-ARO-HCP-frontend",
+					"createdByType": "Application",
+					"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+					"lastModifiedByType": "Application"
+				},
+				"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 			}
-		}
+		},
+		"location": "fake-location",
+		"name": "basic-node-pool",
+		"properties": {
+			"autoRepair": true,
+			"autoScaling": {
+				"max": 5,
+				"min": 1
+			},
+			"labels": {
+				"label-ky": "label-value"
+			},
+			"nodeDrainTimeoutMinutes": 2,
+			"platform": {
+				"enableEncryptionAtHost": false,
+				"osDisk": {
+					"diskStorageAccountType": "Premium_LRS",
+					"diskType": "Managed",
+					"sizeGiB": 64
+				},
+				"vmSize": "large"
+			},
+			"provisioningState": "Accepted",
+			"taints": [
+				{
+					"effect": "NoExecute",
+					"key": "foo.com/key",
+					"value": "other"
+				}
+			],
+			"version": {
+				"channelGroup": "stable"
+			}
+		},
+		"serviceProviderProperties": {
+			"activeOperationId": "9e244879-591b-4693-823a-4412b4200f4d",
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s"
+		},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/create-with-tags/nodePools/basic-node-pool",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"


### PR DESCRIPTION
This stores all the data necessary to switch from custom cluster storage to the generic document storage for nodepools.

Part of a multi-step plan
1. https://github.com/Azure/ARO-HCP/pull/5206
2. https://github.com/Azure/ARO-HCP/pull/5207
3. https://github.com/Azure/ARO-HCP/pull/5208
4. https://github.com/Azure/ARO-HCP/pull/5209