### PR TITLE
test: add retry logic for TLS certificate verification (ARO-26761)

### DIFF
--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -94,20 +94,32 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("ensuring the API TLS certificate is signed by a trusted Azure CA")
-			clusterResp, err := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().Get(ctx, *resourceGroup.Name, customerClusterName, nil)
-			Expect(err).NotTo(HaveOccurred())
+			clusterClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			Eventually(func() error {
+				clusterResp, err := clusterClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+				if err != nil {
+					return fmt.Errorf("failed to get cluster: %w", err)
+				}
 
-			Expect(clusterResp.Properties).NotTo(BeNil(), "cluster response Properties was nil")
-			Expect(clusterResp.Properties.API).NotTo(BeNil(), "cluster Properties.API was nil")
-			Expect(clusterResp.Properties.API.URL).NotTo(BeNil(), "cluster Properties.API.URL was nil")
+				if clusterResp.Properties == nil || clusterResp.Properties.API == nil || clusterResp.Properties.API.URL == nil {
+					return fmt.Errorf("cluster API URL not yet available")
+				}
 
-			apiServerURL := clusterResp.Properties.API.URL
-			actualAPICerts, err := tlsCertsFromURL(ctx, *apiServerURL)
-			Expect(err).NotTo(HaveOccurred())
+				apiServerURL := clusterResp.Properties.API.URL
+				actualAPICerts, err := tlsCertsFromURL(ctx, *apiServerURL)
+				if err != nil {
+					return fmt.Errorf("failed to fetch TLS certificate from %s: %w", *apiServerURL, err)
+				}
 
-			fmt.Fprintf(GinkgoWriter, "Issuer: %v\n", actualAPICerts[0].Issuer)
-			err = verifyCertChain(actualAPICerts, trustedCAs)
-			Expect(err).NotTo(HaveOccurred(), "expect API certificate to be signed by a trusted Azure CA")
+				fmt.Fprintf(GinkgoWriter, "Issuer: %v\n", actualAPICerts[0].Issuer)
+				err = verifyCertChain(actualAPICerts, trustedCAs)
+				if err != nil {
+					return fmt.Errorf("certificate verification failed for %s (issuer: %v): %w",
+						*apiServerURL, actualAPICerts[0].Issuer, err)
+				}
+				return nil
+			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
+				"expect API certificate to be signed by a trusted Azure CA")
 
 			By("creating the node pool")
 			nodePoolParams := framework.NewDefaultNodePoolParams()
@@ -150,7 +162,7 @@ var _ = Describe("Customer", func() {
 				}
 				fmt.Fprintf(GinkgoWriter, "Issuer: %v\n", certs[0].Issuer)
 				return verifyCertChain(certs, trustedCAs)
-			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
+			}).WithTimeout(4*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"expect ingress certificate to be signed by a trusted Azure CA")
 		})
 })


### PR DESCRIPTION
Fix race condition where TLS endpoint test fails because API URL is not immediately available after cluster creation. The API URL can take up to 9 minutes to become available after cluster provisioning completes.

- Wrap API certificate verification in Eventually block with 5-minute timeout
- Add proper error handling for missing API URL
- Reduce ingress certificate timeout from 10m to 4m
- Improve error messages for debugging

Fixes: [ARO-26761](https://redhat.atlassian.net/browse/ARO-26761)

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
