### PR TITLE
test: add retry logic for TLS certificate verification (ARO-26761)

### DIFF
--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -111,12 +111,12 @@ var _ = Describe("Customer", func() {
 					return fmt.Errorf("failed to fetch TLS certificate from %s: %w", *apiServerURL, err)
 				}
 
-				GinkgoLogr.Info("API certificate issuer", "issuer", actualAPICerts[0].Issuer)
 				err = verifyCertChain(actualAPICerts, trustedCAs)
 				if err != nil {
 					return fmt.Errorf("certificate verification failed for %s (issuer: %v): %w",
 						*apiServerURL, actualAPICerts[0].Issuer, err)
 				}
+				GinkgoLogr.Info("API certificate issuer", "issuer", actualAPICerts[0].Issuer)
 				return nil
 			}).WithContext(ctx).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"expect API certificate to be signed by a trusted Azure CA")

--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -111,7 +111,7 @@ var _ = Describe("Customer", func() {
 					return fmt.Errorf("failed to fetch TLS certificate from %s: %w", *apiServerURL, err)
 				}
 
-				fmt.Fprintf(GinkgoWriter, "Issuer: %v\n", actualAPICerts[0].Issuer)
+				GinkgoLogr.Info("API certificate issuer", "issuer", actualAPICerts[0].Issuer)
 				err = verifyCertChain(actualAPICerts, trustedCAs)
 				if err != nil {
 					return fmt.Errorf("certificate verification failed for %s (issuer: %v): %w",

--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -95,7 +95,7 @@ var _ = Describe("Customer", func() {
 
 			By("ensuring the API TLS certificate is signed by a trusted Azure CA")
 			clusterClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				clusterResp, err := clusterClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
 				if err != nil {
 					return fmt.Errorf("failed to get cluster: %w", err)
@@ -118,7 +118,7 @@ var _ = Describe("Customer", func() {
 						*apiServerURL, actualAPICerts[0].Issuer, err)
 				}
 				return nil
-			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
+			}).WithContext(ctx).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"expect API certificate to be signed by a trusted Azure CA")
 
 			By("creating the node pool")

--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -94,20 +94,32 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("ensuring the API TLS certificate is signed by a trusted Azure CA")
-			clusterResp, err := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().Get(ctx, *resourceGroup.Name, customerClusterName, nil)
-			Expect(err).NotTo(HaveOccurred())
+			clusterClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			Eventually(func() error {
+				clusterResp, err := clusterClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+				if err != nil {
+					return fmt.Errorf("failed to get cluster: %w", err)
+				}
 
-			Expect(clusterResp.Properties).NotTo(BeNil(), "cluster response Properties was nil")
-			Expect(clusterResp.Properties.API).NotTo(BeNil(), "cluster Properties.API was nil")
-			Expect(clusterResp.Properties.API.URL).NotTo(BeNil(), "cluster Properties.API.URL was nil")
+				if clusterResp.Properties == nil || clusterResp.Properties.API == nil || clusterResp.Properties.API.URL == nil {
+					return fmt.Errorf("cluster API URL not yet available")
+				}
 
-			apiServerURL := clusterResp.Properties.API.URL
-			actualAPICerts, err := tlsCertsFromURL(ctx, *apiServerURL)
-			Expect(err).NotTo(HaveOccurred())
+				apiServerURL := clusterResp.Properties.API.URL
+				actualAPICerts, err := tlsCertsFromURL(ctx, *apiServerURL)
+				if err != nil {
+					return fmt.Errorf("failed to fetch TLS certificate from %s: %w", *apiServerURL, err)
+				}
 
-			fmt.Fprintf(GinkgoWriter, "Issuer: %v\n", actualAPICerts[0].Issuer)
-			err = verifyCertChain(actualAPICerts, trustedCAs)
-			Expect(err).NotTo(HaveOccurred(), "expect API certificate to be signed by a trusted Azure CA")
+				fmt.Fprintf(GinkgoWriter, "Issuer: %v\n", actualAPICerts[0].Issuer)
+				err = verifyCertChain(actualAPICerts, trustedCAs)
+				if err != nil {
+					return fmt.Errorf("certificate verification failed for %s (issuer: %v): %w",
+						*apiServerURL, actualAPICerts[0].Issuer, err)
+				}
+				return nil
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
+				"expect API certificate to be signed by a trusted Azure CA")
 
 			By("creating the node pool")
 			nodePoolParams := framework.NewDefaultNodePoolParams()

--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -146,7 +146,7 @@ var _ = Describe("Customer", func() {
 				}
 				Expect(resp.Properties.Console.URL).NotTo(BeNil(), "cluster Properties.Console.URL was nil")
 				consoleURL = *resp.Properties.Console.URL
-				fmt.Fprintln(GinkgoWriter, "Console URL found:", consoleURL)
+				GinkgoLogr.Info("Console URL found", "url", consoleURL)
 				return true
 			}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
 
@@ -157,10 +157,10 @@ var _ = Describe("Customer", func() {
 			Eventually(func() error {
 				certs, err := tlsCertsFromURL(ctx, consoleUrlWithPort)
 				if err != nil {
-					fmt.Fprintf(GinkgoWriter, "error fetching cert: %v\n", err)
+					GinkgoLogr.Info("Ingress certificate check", "status", "failed", "error", err.Error())
 					return err
 				}
-				fmt.Fprintf(GinkgoWriter, "Issuer: %v\n", certs[0].Issuer)
+				GinkgoLogr.Info("Ingress certificate issuer", "issuer", certs[0].Issuer.String())
 				return verifyCertChain(certs, trustedCAs)
 			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"expect ingress certificate to be signed by a trusted Azure CA")


### PR DESCRIPTION
## Summary

Fix race condition where TLS endpoint test fails because API URL is not immediately available after cluster creation. The API URL can take up to 9 minutes to become available after cluster provisioning completes.

## Changes

- Wrap API certificate verification in `Eventually` block with 10-minute timeout
- Add proper error handling for missing API URL
- Keep ingress certificate timeout at 10 minutes
- Improve error messages for debugging

## Jira

Fixes: [ARO-26761](https://issues.redhat.com/browse/ARO-26761)

## Test Plan

- [x] Run TLS endpoints e2e test in personal dev environment
- [x] Verify test passes with retry logic
- [x] Confirm timeouts are appropriate for typical cluster creation timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)