### PR TITLE
feat(tooling): add split-by-pod option to hcpctl must-gather

### DIFF
--- a/docs/sops/gather-logs.md
+++ b/docs/sops/gather-logs.md
@@ -60,6 +60,16 @@ hcpctl must-gather query \
   --limit 1000
 ```
 
+**Split output by pod name (for concurrency/timing debugging):**
+```bash
+hcpctl must-gather query \
+  --kusto my-kusto-cluster \
+  --region eastus \
+  --subscription-id 12345678-1234-1234-1234-123456789012 \
+  --resource-group my-resource-group \
+  --split-by-pod
+```
+
 #### Handling large data
 
 Kusto has limits for what a query can return, in order to overcome these, you can check the `json` files created. These contain information on the datasize queried. You can then use the `limit` and `timestamp` parameters to reduce the number of log rows gathered. These filters are applied per query.

--- a/tooling/hcpctl/README.md
+++ b/tooling/hcpctl/README.md
@@ -135,6 +135,14 @@ What is gathered?
 hcpctl must-gather  query --kusto $kusto --region $region  --subscription-id $subscription_id --resource-group $resource_group
 ```
 
+To split output files by pod name (useful for investigating timing and concurrency issues), add `--split-by-pod`:
+
+```bash
+hcpctl must-gather  query --kusto $kusto --region $region  --subscription-id $subscription_id --resource-group $resource_group --split-by-pod
+```
+
+Without this flag, logs from all pods of the same container are written to a single file (e.g. `cluster_namespace_container.jsonl`). With `--split-by-pod`, each pod gets its own file (e.g. `cluster_namespace_container_pod.jsonl`).
+
 If you get an error like, limit execeeded try reducing the amount of data by setting either limit or timestamps, i.e.:
 
 Set `--limit` fetch the first `$limit` number of rows.

--- a/tooling/hcpctl/cmd/must-gather/query_base_options.go
+++ b/tooling/hcpctl/cmd/must-gather/query_base_options.go
@@ -36,6 +36,7 @@ type BaseGatherOptions struct {
 	TimestampMin time.Time     // Timestamp minimum
 	TimestampMax time.Time     // Timestamp maximum
 	Limit        int           // Limit the number of results
+	SplitByPod   bool          // Split output files by pod name
 }
 
 // DefaultBaseGatherOptions returns BaseGatherOptions initialized with sensible defaults.
@@ -58,6 +59,7 @@ func BindBaseGatherOptions(opts *BaseGatherOptions, cmd *cobra.Command) error {
 	cmd.Flags().TimeVar(&opts.TimestampMin, "timestamp-min", opts.TimestampMin, []string{time.DateTime}, "timestamp minimum")
 	cmd.Flags().TimeVar(&opts.TimestampMax, "timestamp-max", opts.TimestampMax, []string{time.DateTime}, "timestamp maximum")
 	cmd.Flags().IntVar(&opts.Limit, "limit", opts.Limit, "limit the number of results")
+	cmd.Flags().BoolVar(&opts.SplitByPod, "split-by-pod", opts.SplitByPod, "split output files by pod name")
 
 	requiredFlags := []string{"kusto", "region"}
 	for _, flag := range requiredFlags {

--- a/tooling/hcpctl/cmd/must-gather/query_infra_cmd.go
+++ b/tooling/hcpctl/cmd/must-gather/query_infra_cmd.go
@@ -75,6 +75,7 @@ func (opts *CompletedInfraQueryOptions) RunInfra(ctx context.Context) error {
 				TimestampMin:     opts.TimestampMin,
 				TimestampMax:     opts.TimestampMax,
 				Limit:            opts.Limit,
+				SplitByPod:       opts.SplitByPod,
 			},
 		}, true)
 

--- a/tooling/hcpctl/cmd/must-gather/query_options.go
+++ b/tooling/hcpctl/cmd/must-gather/query_options.go
@@ -116,6 +116,7 @@ func (o *RawQueryOptions) Validate(ctx context.Context) (*ValidatedQueryOptions,
 			TimestampMin:      o.TimestampMin,
 			TimestampMax:      o.TimestampMax,
 			Limit:             o.Limit,
+			SplitByPod:        o.SplitByPod,
 		},
 	}, nil
 }

--- a/tooling/hcpctl/pkg/kusto/query.go
+++ b/tooling/hcpctl/pkg/kusto/query.go
@@ -32,6 +32,7 @@ type QueryOptions struct {
 	TimestampMin      time.Time
 	TimestampMax      time.Time
 	Limit             int
+	SplitByPod        bool
 }
 
 // Query represents a ready-to-execute KQL query with all its metadata.
@@ -106,6 +107,7 @@ type TemplateData struct {
 	ClusterId          string
 	ClusterIds         string
 	HCPNamespacePrefix string
+	SplitByPod         bool
 }
 
 type TemplateDataOptions func(*TemplateData)
@@ -164,6 +166,7 @@ func NewTemplateDataFromOptions(queryOptions QueryOptions, options ...TemplateDa
 		Limit:              max(queryOptions.Limit, 0),
 		SubResourceGroupId: fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", queryOptions.SubscriptionId, queryOptions.ResourceGroupName),
 		ResourceGroupName:  queryOptions.ResourceGroupName,
+		SplitByPod:         queryOptions.SplitByPod,
 	}
 	defaults := []TemplateDataOptions{
 		WithClusterName(queryOptions.InfraClusterName),

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/hcp/hcp_logs.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/hcp/hcp_logs.kql.gotmpl
@@ -1,7 +1,12 @@
 {{- if .NoTruncation}}set notruncation;
 {{end -}}
 containerLogs
+{{- if .SplitByPod}}
+| extend pod_name = column_ifexists("pod_name", "")
+| project timestamp, log, cluster, namespace_name, container_name, pod_name
+{{- else}}
 | project timestamp, log, cluster, namespace_name, container_name
+{{- end}}
 | where timestamp between({{ .TimestampMin }} .. {{ .TimestampMax }})
 | where namespace_name has '{{.ClusterId}}'
 {{- if gt .Limit 0}}

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/infra/service_logs.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/infra/service_logs.kql.gotmpl
@@ -1,7 +1,12 @@
 {{- if .NoTruncation}}set notruncation;
 {{end -}}
 {{.Table}}
+{{- if .SplitByPod}}
+| extend pod_name = column_ifexists("pod_name", "")
+| project timestamp, log, cluster, namespace_name, container_name, pod_name
+{{- else}}
 | project timestamp, log, cluster, namespace_name, container_name
+{{- end}}
 | where timestamp between({{ .TimestampMin }} .. {{ .TimestampMax }})
 | where cluster == '{{.ClusterName}}'
 {{- if gt .Limit 0}}

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/services/service_logs.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/services/service_logs.kql.gotmpl
@@ -1,7 +1,12 @@
 {{- if .NoTruncation}}set notruncation;
 {{end -}}
 {{.Table}}
+{{- if .SplitByPod}}
+| extend pod_name = column_ifexists("pod_name", "")
+| project timestamp, log, cluster, namespace_name, container_name, pod_name
+{{- else}}
 | project timestamp, log, cluster, namespace_name, container_name
+{{- end}}
 | where timestamp between({{ .TimestampMin }} .. {{ .TimestampMax }})
 {{- if .ClusterIds }}
 | where log has '{{.SubResourceGroupId}}' or log has_any ({{.ClusterIds}})

--- a/tooling/hcpctl/pkg/mustgather/gather.go
+++ b/tooling/hcpctl/pkg/mustgather/gather.go
@@ -58,27 +58,30 @@ type RowOutputFunc func(ctx context.Context, logLineChan chan *NormalizedLogLine
 // This structure is passed to RowOutputFunc implementations for processing.
 //
 // Fields available for custom output functions:
-//   - Log: The actual log message content as bytes
+//   - Log: Structured map of log fields
 //   - Cluster: The cluster ID where this log originated
 //   - Namespace: The Kubernetes namespace (for HCP logs) or service name
 //   - ContainerName: The container that generated this log
+//   - PodName: The pod that generated this log (only populated when SplitByPod is enabled)
 //   - Timestamp: When the log entry was created
 //
 // Example usage in a custom output function:
 //
 //	for logLine := range logLineChan {
+//		jsonBytes, _ := json.Marshal(logLine.Log)
 //		fmt.Printf("[%s] %s/%s/%s: %s\n",
 //			logLine.Timestamp.Format(time.RFC3339),
 //			logLine.Cluster,
 //			logLine.Namespace,
 //			logLine.ContainerName,
-//			string(logLine.Log))
+//			string(jsonBytes))
 //	}
 type NormalizedLogLine struct {
 	// Log           []byte          `kusto:"log"`
 	Cluster       string    `kusto:"cluster"`
 	Namespace     string    `kusto:"namespace_name"`
 	ContainerName string    `kusto:"container_name"`
+	PodName       string    `kusto:"pod_name"`
 	Timestamp     time.Time `kusto:"timestamp"`
 
 	Log       map[string]any  `kusto:"-"` // Log content, set by the gatherer pipeline
@@ -247,6 +250,7 @@ func NewCliGatherer(queryClient QueryClientInterface, outputPath, serviceLogsDir
 		string(kusto.QueryTypeServices):           serviceLogsDirectory,
 		string(kusto.QueryTypeHostedControlPlane): hostedControlPlaneLogsDirectory,
 		string(kusto.QueryTypeCustomLogs):         customLogsDirectory,
+		"splitByPod":                              opts.QueryOptions.SplitByPod,
 	}
 
 	return &Gatherer{
@@ -260,6 +264,7 @@ func NewCliGatherer(queryClient QueryClientInterface, outputPath, serviceLogsDir
 
 func cliOutputFunc(ctx context.Context, logLineChan chan *NormalizedLogLine, options RowOutputOptions) error {
 	outputPath := options["outputPath"].(string)
+	splitByPod, _ := options["splitByPod"].(bool)
 
 	openedFiles := make(map[string]*os.File)
 
@@ -288,11 +293,15 @@ func cliOutputFunc(ctx context.Context, logLineChan chan *NormalizedLogLine, opt
 			var fileName string
 			switch logLine.QueryType {
 			case kusto.QueryTypeKubernetesEvents, kusto.QueryTypeSystemdLogs:
-				fileName = fmt.Sprintf("%s-%s.jsonl", logLine.Cluster, logLine.QueryType)
+				fileName = fmt.Sprintf("%s_%s.jsonl", logLine.Cluster, logLine.QueryType)
 			case kusto.QueryTypeCustomLogs:
-				fileName = fmt.Sprintf("custom-query-%s.jsonl", logLine.QueryName)
+				fileName = fmt.Sprintf("custom-query_%s.jsonl", logLine.QueryName)
 			default:
-				fileName = fmt.Sprintf("%s-%s-%s.jsonl", logLine.Cluster, logLine.Namespace, logLine.ContainerName)
+				if splitByPod && logLine.PodName != "" {
+					fileName = fmt.Sprintf("%s_%s_%s_%s.jsonl", logLine.Cluster, logLine.Namespace, logLine.ContainerName, logLine.PodName)
+				} else {
+					fileName = fmt.Sprintf("%s_%s_%s.jsonl", logLine.Cluster, logLine.Namespace, logLine.ContainerName)
+				}
 			}
 
 			file, ok := openedFiles[fileName]

--- a/tooling/hcpctl/pkg/mustgather/gather.go
+++ b/tooling/hcpctl/pkg/mustgather/gather.go
@@ -304,15 +304,15 @@ func cliOutputFunc(ctx context.Context, logLineChan chan *NormalizedLogLine, opt
 				}
 			}
 
-			file, ok := openedFiles[fileName]
+			filePath := path.Join(outputPath, directory, fileName)
+			file, ok := openedFiles[filePath]
 			if !ok {
-				filePath := path.Join(outputPath, directory, fileName)
 				newFile, err := os.Create(filePath)
 				if err != nil {
 					allErrors = errors.Join(allErrors, fmt.Errorf("failed to create output file %s: %w", filePath, err))
 					continue
 				}
-				openedFiles[fileName] = newFile
+				openedFiles[filePath] = newFile
 				file = newFile
 			}
 			thisLog, err := json.Marshal(logLine.Log)

--- a/tooling/hcpctl/pkg/mustgather/gather_test.go
+++ b/tooling/hcpctl/pkg/mustgather/gather_test.go
@@ -299,7 +299,7 @@ func TestCliOutputFunc(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify file was created and contains log
-	expectedFile := filepath.Join(tempDir, "services", "cluster1-default-container1.jsonl")
+	expectedFile := filepath.Join(tempDir, "services", "cluster1_default_container1.jsonl")
 	assert.FileExists(t, expectedFile)
 	content, err := os.ReadFile(expectedFile)
 	require.NoError(t, err)
@@ -352,8 +352,8 @@ func TestCliOutputFunc_KubernetesEvents(t *testing.T) {
 	err = cliOutputFunc(t.Context(), logLineChan, options)
 	assert.NoError(t, err)
 
-	// Kubernetes events use cluster-querytype.jsonl naming
-	expectedFile := filepath.Join(tempDir, "cluster", "test-cluster-kubernetes-events.jsonl")
+	// Kubernetes events use cluster_querytype.jsonl naming
+	expectedFile := filepath.Join(tempDir, "cluster", "test-cluster_kubernetes-events.jsonl")
 	assert.FileExists(t, expectedFile)
 	content, err := os.ReadFile(expectedFile)
 	require.NoError(t, err)
@@ -386,7 +386,7 @@ func TestCliOutputFunc_SystemdLogs(t *testing.T) {
 	err = cliOutputFunc(t.Context(), logLineChan, options)
 	assert.NoError(t, err)
 
-	expectedFile := filepath.Join(tempDir, "cluster", "test-cluster-systemd-logs.jsonl")
+	expectedFile := filepath.Join(tempDir, "cluster", "test-cluster_systemd-logs.jsonl")
 	assert.FileExists(t, expectedFile)
 	content, err := os.ReadFile(expectedFile)
 	require.NoError(t, err)
@@ -687,7 +687,7 @@ func TestCliOutputFunc_JSONLFormat(t *testing.T) {
 	err = cliOutputFunc(t.Context(), logLineChan, options)
 	assert.NoError(t, err)
 
-	expectedFile := filepath.Join(tempDir, "services", "cluster1-default-container1.jsonl")
+	expectedFile := filepath.Join(tempDir, "services", "cluster1_default_container1.jsonl")
 	content, err := os.ReadFile(expectedFile)
 	require.NoError(t, err)
 
@@ -711,4 +711,145 @@ func splitNonEmpty(s string) []string {
 		}
 	}
 	return result
+}
+
+func TestCliOutputFunc_SplitByPod(t *testing.T) {
+	tempDir := t.TempDir()
+	err := os.MkdirAll(filepath.Join(tempDir, "services"), 0755)
+	require.NoError(t, err)
+
+	logLineChan := make(chan *NormalizedLogLine, 3)
+	options := RowOutputOptions{
+		"outputPath":                    tempDir,
+		string(kusto.QueryTypeServices): "services",
+		"splitByPod":                    true,
+	}
+
+	logLineChan <- &NormalizedLogLine{
+		Log:           makeLogMap("message", "log from pod-a"),
+		Cluster:       "cluster1",
+		Namespace:     "default",
+		ContainerName: "frontend",
+		PodName:       "frontend-abc123",
+		Timestamp:     time.Now(),
+		QueryType:     kusto.QueryTypeServices,
+	}
+	logLineChan <- &NormalizedLogLine{
+		Log:           makeLogMap("message", "log from pod-b"),
+		Cluster:       "cluster1",
+		Namespace:     "default",
+		ContainerName: "frontend",
+		PodName:       "frontend-def456",
+		Timestamp:     time.Now(),
+		QueryType:     kusto.QueryTypeServices,
+	}
+	logLineChan <- &NormalizedLogLine{
+		Log:           makeLogMap("message", "log from pod-a again"),
+		Cluster:       "cluster1",
+		Namespace:     "default",
+		ContainerName: "frontend",
+		PodName:       "frontend-abc123",
+		Timestamp:     time.Now(),
+		QueryType:     kusto.QueryTypeServices,
+	}
+	close(logLineChan)
+
+	err = cliOutputFunc(t.Context(), logLineChan, options)
+	assert.NoError(t, err)
+
+	// Each pod should get its own file
+	fileA := filepath.Join(tempDir, "services", "cluster1_default_frontend_frontend-abc123.jsonl")
+	fileB := filepath.Join(tempDir, "services", "cluster1_default_frontend_frontend-def456.jsonl")
+	assert.FileExists(t, fileA)
+	assert.FileExists(t, fileB)
+
+	contentA, err := os.ReadFile(fileA)
+	require.NoError(t, err)
+	linesA := splitNonEmpty(string(contentA))
+	assert.Len(t, linesA, 2)
+	assert.Contains(t, linesA[0], "log from pod-a")
+	assert.Contains(t, linesA[1], "log from pod-a again")
+
+	contentB, err := os.ReadFile(fileB)
+	require.NoError(t, err)
+	linesB := splitNonEmpty(string(contentB))
+	assert.Len(t, linesB, 1)
+	assert.Contains(t, linesB[0], "log from pod-b")
+}
+
+func TestCliOutputFunc_SplitByPod_EmptyPodName(t *testing.T) {
+	tempDir := t.TempDir()
+	err := os.MkdirAll(filepath.Join(tempDir, "services"), 0755)
+	require.NoError(t, err)
+
+	logLineChan := make(chan *NormalizedLogLine, 1)
+	options := RowOutputOptions{
+		"outputPath":                    tempDir,
+		string(kusto.QueryTypeServices): "services",
+		"splitByPod":                    true,
+	}
+
+	// When pod_name is empty (e.g. table doesn't have the column), fall back to default naming
+	logLineChan <- &NormalizedLogLine{
+		Log:           makeLogMap("message", "log without pod name"),
+		Cluster:       "cluster1",
+		Namespace:     "default",
+		ContainerName: "backend",
+		PodName:       "",
+		Timestamp:     time.Now(),
+		QueryType:     kusto.QueryTypeServices,
+	}
+	close(logLineChan)
+
+	err = cliOutputFunc(t.Context(), logLineChan, options)
+	assert.NoError(t, err)
+
+	// Should fall back to the default naming without pod name
+	expectedFile := filepath.Join(tempDir, "services", "cluster1_default_backend.jsonl")
+	assert.FileExists(t, expectedFile)
+}
+
+func TestCliOutputFunc_SplitByPod_Disabled(t *testing.T) {
+	tempDir := t.TempDir()
+	err := os.MkdirAll(filepath.Join(tempDir, "services"), 0755)
+	require.NoError(t, err)
+
+	logLineChan := make(chan *NormalizedLogLine, 2)
+	options := RowOutputOptions{
+		"outputPath":                    tempDir,
+		string(kusto.QueryTypeServices): "services",
+		"splitByPod":                    false,
+	}
+
+	// Even with pod names present, they should be grouped when splitByPod is false
+	logLineChan <- &NormalizedLogLine{
+		Log:           makeLogMap("message", "log from pod-a"),
+		Cluster:       "cluster1",
+		Namespace:     "default",
+		ContainerName: "frontend",
+		PodName:       "frontend-abc123",
+		Timestamp:     time.Now(),
+		QueryType:     kusto.QueryTypeServices,
+	}
+	logLineChan <- &NormalizedLogLine{
+		Log:           makeLogMap("message", "log from pod-b"),
+		Cluster:       "cluster1",
+		Namespace:     "default",
+		ContainerName: "frontend",
+		PodName:       "frontend-def456",
+		Timestamp:     time.Now(),
+		QueryType:     kusto.QueryTypeServices,
+	}
+	close(logLineChan)
+
+	err = cliOutputFunc(t.Context(), logLineChan, options)
+	assert.NoError(t, err)
+
+	// Both should go to the same file
+	expectedFile := filepath.Join(tempDir, "services", "cluster1_default_frontend.jsonl")
+	assert.FileExists(t, expectedFile)
+	content, err := os.ReadFile(expectedFile)
+	require.NoError(t, err)
+	lines := splitNonEmpty(string(content))
+	assert.Len(t, lines, 2)
 }

--- a/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions.yaml
@@ -6,6 +6,7 @@ HCPNamespacePrefix: ocm-arohcp
 Limit: 100
 NoTruncation: false
 ResourceGroupName: rg
+SplitByPod: false
 SubResourceGroupId: /subscriptions/sub/resourceGroups/rg
 Table: myTable
 TimestampMax: datetime(0001-01-01T00:00:00.0000000Z)

--- a/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions_NoTruncation.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions_NoTruncation.yaml
@@ -6,6 +6,7 @@ HCPNamespacePrefix: ""
 Limit: 0
 NoTruncation: true
 ResourceGroupName: ""
+SplitByPod: false
 SubResourceGroupId: /subscriptions//resourceGroups/
 Table: ""
 TimestampMax: datetime(0001-01-01T00:00:00.0000000Z)


### PR DESCRIPTION
# Add option to split must-gather logs by pod name

<!-- Link to Jira issue -->

Implements [AROSLSRE-540](https://redhat.atlassian.net/browse/AROSLSRE-540)

### What

Add `--split-by-pod` flag to hcpctl to split must-gather logs by pod name

### Why

Helps with tracing and debugging concurrency issues

### Testing

- Unit tests: Run `make test` from `./tooling/hcpctl` directory
- Validation: Build new hcpctl executable (`make build`), then run must-gather against an active cluster.  Verify logs in `{{ output_directory }}/services` are now split by pod names:

```sh
./hcpctl must-gather query \
  --kusto {{ kusto_name }} \
  --region {{ kusto_region }} \
  --subscription-id {{ subscription_id }} \
  --resource-group {{ resource_group }} \
  --output-path {{ output_directory }} \
  --timestamp-min "{{ start_timestamp }}" \
  --timestamp-max "{{ end_timestamp }}" \
  --split-by-pod \
  --limit 100 \
  -v 3
```

