### PR TITLE
refactor: no need to trigger control plane upgrade if cluster is still installing i.e no active version set

### DIFF
--- a/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
@@ -105,14 +105,16 @@ func (c *triggerControlPlaneUpgradeSyncer) SyncOnce(ctx context.Context, key con
 		return nil // No desired version set
 	}
 
-	// Get latest actual version from active versions
-	var actualLatestVersion *semver.Version
-	if len(existingServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions) > 0 {
-		actualLatestVersion = existingServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions[0].Version
+	// No active version yet (installation ongoing); skip upgrade trigger.
+	if len(existingServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions) == 0 {
+		return nil
 	}
 
+	// Get latest actual version from active versions
+	actualLatestVersion := existingServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions[0].Version
+
 	// If desired version matches latest actual version, nothing to do
-	if actualLatestVersion != nil && desiredVersion.EQ(*actualLatestVersion) {
+	if desiredVersion.EQ(*actualLatestVersion) {
 		return nil
 	}
 


### PR DESCRIPTION
### What

refactor: no need to trigger control plane upgrade if cluster is still installing i.e no active version set

### Why

If cluster is still installing there is no point in triggering an upgrade via CS;
- This saves some few API calls between systems
- And avoid cases where an upgrade is triggered for the same version as observed in

https://dataexplorer.azure.com/clusters/hcp-dev-us-2.eastus2/databases/ServiceLogs?query=H4sIAAAAAAAAA03LwQ2DMBBE0VamAqiALrhHlhnslcCG8RpEqs8JKccvvT%2BOmLM1nJ16EErYni8b4tabU%2BhHUlgIl6VEccFtnnFRzWr5rKr79IZX2PBP1yp4JmKXWBwhul185x%2B9sCk0egAAAA%3D%3D
```
count_
1,036
```


### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
