### PR TITLE
tooling/hcpctl: fix PKI operator query

### DIFF
--- a/tooling/hcpctl/pkg/snapshot/queries.go
+++ b/tooling/hcpctl/pkg/snapshot/queries.go
@@ -291,10 +291,10 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryResourceDiscovery,
 		ready: func(d queryData) bool {
-			return d.ResourceGroup != "" && d.ResourceName != "" && strings.EqualFold(d.ResourceType, "microsoft.redhatopenshift/hcpopenshiftclusters")
+			return d.ResourceGroup != "" && d.ClusterResourceName != ""
 		},
-		prerequisites: "ResourceGroup, ResourceName, ResourceType is cluster",
-		requiredWhen:  isClusterType,
+		prerequisites: "ResourceGroup, ClusterResourceName",
+		requiredWhen:  func(d queryData) bool { return d.ClusterResourceName != "" },
 		storeResult: func(d *queryData, rows []resultRow) {
 			d.HostedClusterNamespace = rows[0].values[0]
 			d.HostedControlPlaneNamespace = rows[0].values[0] + "-" + rows[0].values[1]


### PR DESCRIPTION
We were only fetching the hosted control plane namespace for clusters, but we needed it for PKI operator logs, so the previous query would never fire.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->
