### PR TITLE
feat(tooling): Add --cluster-id/--cluster-name HCP filter and sanitize KQL inputs to must-gather

### DIFF
--- a/tooling/hcpctl/cmd/must-gather/query_options.go
+++ b/tooling/hcpctl/cmd/must-gather/query_options.go
@@ -35,6 +35,7 @@ type RawQueryOptions struct {
 	ResourceGroup              string   // Resource group
 	ResourceId                 string   // Resource ID
 	ClusterIds                 []string // Explicit HCP cluster IDs to filter on
+	ClusterNames               []string // HCP cluster names to resolve to IDs and filter on
 	SkipHostedControlPlaneLogs bool     // Skip hosted control plane logs
 	SkipKubernetesEventsLogs   bool     // Skip Kubernetes events logs
 	CollectSystemdLogs         bool     // Collect Systemd logs
@@ -57,7 +58,8 @@ func BindQueryOptions(opts *RawQueryOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.SubscriptionID, "subscription-id", opts.SubscriptionID, "subscription ID")
 	cmd.Flags().StringVar(&opts.ResourceGroup, "resource-group", opts.ResourceGroup, "resource group")
 	cmd.Flags().StringVar(&opts.ResourceId, "resource-id", opts.ResourceId, "resource ID")
-	cmd.Flags().StringArrayVar(&opts.ClusterIds, "cluster-id", opts.ClusterIds, "filter by HCP cluster ID (repeatable; narrows HCP-specific and service log queries, but shared infrastructure queries may still be resource-group scoped)")
+	cmd.Flags().StringArrayVar(&opts.ClusterIds, "cluster-id", opts.ClusterIds, "filter by HCP cluster ID (repeatable, combinable with --cluster-name; custom queries may still be resource-group scoped)")
+	cmd.Flags().StringArrayVar(&opts.ClusterNames, "cluster-name", opts.ClusterNames, "filter by HCP cluster name (repeatable, resolved to cluster IDs via Kusto)")
 	cmd.Flags().BoolVar(&opts.SkipHostedControlPlaneLogs, "skip-hcp-logs", opts.SkipHostedControlPlaneLogs, "Do not gather customer (ocm namespaces) logs")
 	cmd.Flags().BoolVar(&opts.SkipKubernetesEventsLogs, "skip-kubernetes-events-logs", opts.SkipKubernetesEventsLogs, "Do not gather Kubernetes events logs")
 	cmd.Flags().BoolVar(&opts.CollectSystemdLogs, "collect-systemd-logs", opts.CollectSystemdLogs, "Collect Systemd logs")
@@ -102,6 +104,11 @@ func (o *RawQueryOptions) Validate(ctx context.Context) (*ValidatedQueryOptions,
 			return nil, fmt.Errorf("--cluster-id was specified with an empty value")
 		}
 	}
+	for _, name := range o.ClusterNames {
+		if name == "" {
+			return nil, fmt.Errorf("--cluster-name was specified with an empty value")
+		}
+	}
 
 	subscriptionID := o.SubscriptionID
 	resourceGroupName := o.ResourceGroup
@@ -122,6 +129,7 @@ func (o *RawQueryOptions) Validate(ctx context.Context) (*ValidatedQueryOptions,
 			SubscriptionId:    subscriptionID,
 			ResourceGroupName: resourceGroupName,
 			ClusterIds:        o.ClusterIds,
+			ClusterNames:      o.ClusterNames,
 			TimestampMin:      o.TimestampMin,
 			TimestampMax:      o.TimestampMax,
 			Limit:             o.Limit,

--- a/tooling/hcpctl/cmd/must-gather/query_options.go
+++ b/tooling/hcpctl/cmd/must-gather/query_options.go
@@ -31,13 +31,14 @@ import (
 // RawQueryOptions represents the initial, unvalidated configuration for query operations.
 type RawQueryOptions struct {
 	BaseGatherOptions
-	SubscriptionID             string // Subscription ID
-	ResourceGroup              string // Resource group
-	ResourceId                 string // Resource ID
-	SkipHostedControlPlaneLogs bool   // Skip hosted control plane logs
-	SkipKubernetesEventsLogs   bool   // Skip Kubernetes events logs
-	CollectSystemdLogs         bool   // Collect Systemd logs
-	SkipCustomLogs             bool   // Skip Custom logs
+	SubscriptionID             string   // Subscription ID
+	ResourceGroup              string   // Resource group
+	ResourceId                 string   // Resource ID
+	ClusterIds                 []string // Explicit HCP cluster IDs to filter on
+	SkipHostedControlPlaneLogs bool     // Skip hosted control plane logs
+	SkipKubernetesEventsLogs   bool     // Skip Kubernetes events logs
+	CollectSystemdLogs         bool     // Collect Systemd logs
+	SkipCustomLogs             bool     // Skip Custom logs
 }
 
 // DefaultQueryOptions returns a new RawQueryOptions struct initialized with sensible defaults.
@@ -56,6 +57,7 @@ func BindQueryOptions(opts *RawQueryOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.SubscriptionID, "subscription-id", opts.SubscriptionID, "subscription ID")
 	cmd.Flags().StringVar(&opts.ResourceGroup, "resource-group", opts.ResourceGroup, "resource group")
 	cmd.Flags().StringVar(&opts.ResourceId, "resource-id", opts.ResourceId, "resource ID")
+	cmd.Flags().StringArrayVar(&opts.ClusterIds, "cluster-id", opts.ClusterIds, "filter by HCP cluster ID (repeatable; narrows HCP-specific and service log queries, but shared infrastructure queries may still be resource-group scoped)")
 	cmd.Flags().BoolVar(&opts.SkipHostedControlPlaneLogs, "skip-hcp-logs", opts.SkipHostedControlPlaneLogs, "Do not gather customer (ocm namespaces) logs")
 	cmd.Flags().BoolVar(&opts.SkipKubernetesEventsLogs, "skip-kubernetes-events-logs", opts.SkipKubernetesEventsLogs, "Do not gather Kubernetes events logs")
 	cmd.Flags().BoolVar(&opts.CollectSystemdLogs, "collect-systemd-logs", opts.CollectSystemdLogs, "Collect Systemd logs")
@@ -95,6 +97,12 @@ func (o *RawQueryOptions) Validate(ctx context.Context) (*ValidatedQueryOptions,
 		logger.Info("warning: both resource-id and resource-group/subscription-id are provided, will use resource-id to gather cluster ID")
 	}
 
+	for _, id := range o.ClusterIds {
+		if id == "" {
+			return nil, fmt.Errorf("--cluster-id was specified with an empty value")
+		}
+	}
+
 	subscriptionID := o.SubscriptionID
 	resourceGroupName := o.ResourceGroup
 
@@ -113,6 +121,7 @@ func (o *RawQueryOptions) Validate(ctx context.Context) (*ValidatedQueryOptions,
 		QueryOptions: kusto.QueryOptions{
 			SubscriptionId:    subscriptionID,
 			ResourceGroupName: resourceGroupName,
+			ClusterIds:        o.ClusterIds,
 			TimestampMin:      o.TimestampMin,
 			TimestampMax:      o.TimestampMax,
 			Limit:             o.Limit,

--- a/tooling/hcpctl/cmd/must-gather/query_options_test.go
+++ b/tooling/hcpctl/cmd/must-gather/query_options_test.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mustgather
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidate_ClusterIds_RejectsEmpty(t *testing.T) {
+	opts := &RawQueryOptions{
+		BaseGatherOptions: BaseGatherOptions{
+			Kusto:        "test-kusto",
+			Region:       "eastus",
+			QueryTimeout: 5 * time.Minute,
+			TimestampMin: time.Now().Add(-1 * time.Hour),
+			TimestampMax: time.Now(),
+		},
+		SubscriptionID: "test-sub",
+		ResourceGroup:  "test-rg",
+		ClusterIds:     []string{"valid-id", ""},
+	}
+
+	_, err := opts.Validate(t.Context())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--cluster-id was specified with an empty value")
+}
+
+func TestValidate_ClusterIds_AcceptsValid(t *testing.T) {
+	opts := &RawQueryOptions{
+		BaseGatherOptions: BaseGatherOptions{
+			Kusto:        "test-kusto",
+			Region:       "eastus",
+			QueryTimeout: 5 * time.Minute,
+			TimestampMin: time.Now().Add(-1 * time.Hour),
+			TimestampMax: time.Now(),
+		},
+		SubscriptionID: "test-sub",
+		ResourceGroup:  "test-rg",
+		ClusterIds:     []string{"cluster-abc-123", "cluster-def-456"},
+	}
+
+	validated, err := opts.Validate(t.Context())
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"cluster-abc-123", "cluster-def-456"}, validated.QueryOptions.ClusterIds)
+}

--- a/tooling/hcpctl/cmd/must-gather/query_options_test.go
+++ b/tooling/hcpctl/cmd/must-gather/query_options_test.go
@@ -40,6 +40,65 @@ func TestValidate_ClusterIds_RejectsEmpty(t *testing.T) {
 	assert.Contains(t, err.Error(), "--cluster-id was specified with an empty value")
 }
 
+func TestValidate_ClusterNames_RejectsEmpty(t *testing.T) {
+	opts := &RawQueryOptions{
+		BaseGatherOptions: BaseGatherOptions{
+			Kusto:        "test-kusto",
+			Region:       "eastus",
+			QueryTimeout: 5 * time.Minute,
+			TimestampMin: time.Now().Add(-1 * time.Hour),
+			TimestampMax: time.Now(),
+		},
+		SubscriptionID: "test-sub",
+		ResourceGroup:  "test-rg",
+		ClusterNames:   []string{"valid-name", ""},
+	}
+
+	_, err := opts.Validate(t.Context())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--cluster-name was specified with an empty value")
+}
+
+func TestValidate_ClusterNames_AcceptsValid(t *testing.T) {
+	opts := &RawQueryOptions{
+		BaseGatherOptions: BaseGatherOptions{
+			Kusto:        "test-kusto",
+			Region:       "eastus",
+			QueryTimeout: 5 * time.Minute,
+			TimestampMin: time.Now().Add(-1 * time.Hour),
+			TimestampMax: time.Now(),
+		},
+		SubscriptionID: "test-sub",
+		ResourceGroup:  "test-rg",
+		ClusterNames:   []string{"my-cluster", "other-cluster"},
+	}
+
+	validated, err := opts.Validate(t.Context())
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"my-cluster", "other-cluster"}, validated.QueryOptions.ClusterNames)
+}
+
+func TestValidate_CombinedClusterIdAndName(t *testing.T) {
+	opts := &RawQueryOptions{
+		BaseGatherOptions: BaseGatherOptions{
+			Kusto:        "test-kusto",
+			Region:       "eastus",
+			QueryTimeout: 5 * time.Minute,
+			TimestampMin: time.Now().Add(-1 * time.Hour),
+			TimestampMax: time.Now(),
+		},
+		SubscriptionID: "test-sub",
+		ResourceGroup:  "test-rg",
+		ClusterIds:     []string{"explicit-cid"},
+		ClusterNames:   []string{"my-cluster"},
+	}
+
+	validated, err := opts.Validate(t.Context())
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"explicit-cid"}, validated.QueryOptions.ClusterIds)
+	assert.Equal(t, []string{"my-cluster"}, validated.QueryOptions.ClusterNames)
+}
+
 func TestValidate_ClusterIds_AcceptsValid(t *testing.T) {
 	opts := &RawQueryOptions{
 		BaseGatherOptions: BaseGatherOptions{

--- a/tooling/hcpctl/pkg/kusto/query.go
+++ b/tooling/hcpctl/pkg/kusto/query.go
@@ -78,12 +78,17 @@ func (q *templateQuery) String() string {
 	return q.query.String()
 }
 
+// kqlEscStr escapes a single string as a KQL string literal to avoid KQL injection
+func kqlEscStr(str string) string {
+	return strings.ReplaceAll(str, "'", "''")
+}
+
 // kqlEscStrList escapes each element of a string slice as a KQL string literal
 // and joins them with commas, suitable for use in has_any() or similar operators.
 func kqlEscStrList(items []string) string {
 	quoted := make([]string, len(items))
 	for i, item := range items {
-		quoted[i] = "'" + strings.ReplaceAll(item, "'", "''") + "'"
+		quoted[i] = "'" + kqlEscStr(item) + "'"
 	}
 	return strings.Join(quoted, ", ")
 }
@@ -121,7 +126,7 @@ func WithTable(table string) TemplateDataOptions {
 
 func WithClusterId(clusterId string) TemplateDataOptions {
 	return func(d *TemplateData) {
-		d.ClusterId = clusterId
+		d.ClusterId = kqlEscStr(clusterId)
 	}
 }
 
@@ -133,13 +138,13 @@ func WithClusterIds(clusterIds []string) TemplateDataOptions {
 
 func WithHCPNamespacePrefix(hcpNamespacePrefix string) TemplateDataOptions {
 	return func(d *TemplateData) {
-		d.HCPNamespacePrefix = hcpNamespacePrefix
+		d.HCPNamespacePrefix = kqlEscStr(hcpNamespacePrefix)
 	}
 }
 
 func WithClusterName(clusterName string) TemplateDataOptions {
 	return func(d *TemplateData) {
-		d.ClusterName = clusterName
+		d.ClusterName = kqlEscStr(clusterName)
 	}
 }
 
@@ -165,8 +170,8 @@ func NewTemplateDataFromOptions(queryOptions QueryOptions, options ...TemplateDa
 	templateData := TemplateData{
 		NoTruncation:       queryOptions.Limit < 0,
 		Limit:              max(queryOptions.Limit, 0),
-		SubResourceGroupId: fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", queryOptions.SubscriptionId, queryOptions.ResourceGroupName),
-		ResourceGroupName:  queryOptions.ResourceGroupName,
+		SubResourceGroupId: fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", kqlEscStr(queryOptions.SubscriptionId), kqlEscStr(queryOptions.ResourceGroupName)),
+		ResourceGroupName:  kqlEscStr(queryOptions.ResourceGroupName),
 		SplitByPod:         queryOptions.SplitByPod,
 	}
 	defaults := []TemplateDataOptions{

--- a/tooling/hcpctl/pkg/kusto/query.go
+++ b/tooling/hcpctl/pkg/kusto/query.go
@@ -29,6 +29,7 @@ type QueryOptions struct {
 	SubscriptionId    string
 	ResourceGroupName string
 	InfraClusterName  string
+	ClusterIds        []string
 	TimestampMin      time.Time
 	TimestampMax      time.Time
 	Limit             int

--- a/tooling/hcpctl/pkg/kusto/query.go
+++ b/tooling/hcpctl/pkg/kusto/query.go
@@ -30,6 +30,7 @@ type QueryOptions struct {
 	ResourceGroupName string
 	InfraClusterName  string
 	ClusterIds        []string
+	ClusterNames      []string
 	TimestampMin      time.Time
 	TimestampMax      time.Time
 	Limit             int
@@ -112,6 +113,7 @@ type TemplateData struct {
 	ResourceGroupName  string
 	ClusterId          string
 	ClusterIds         string
+	FilterClusterName  string
 	HCPNamespacePrefix string
 	SplitByPod         bool
 }
@@ -133,6 +135,12 @@ func WithClusterId(clusterId string) TemplateDataOptions {
 func WithClusterIds(clusterIds []string) TemplateDataOptions {
 	return func(d *TemplateData) {
 		d.ClusterIds = kqlEscStrList(clusterIds)
+	}
+}
+
+func WithFilterClusterName(name string) TemplateDataOptions {
+	return func(d *TemplateData) {
+		d.FilterClusterName = kqlEscStr(name)
 	}
 }
 

--- a/tooling/hcpctl/pkg/kusto/query_test.go
+++ b/tooling/hcpctl/pkg/kusto/query_test.go
@@ -214,6 +214,19 @@ func TestClusterNamesQuery(t *testing.T) {
 	testutil.CompareWithFixture(t, queryToFixture(queries[0]))
 }
 
+func TestClusterIdByNameQuery(t *testing.T) {
+	f, err := NewQueryFactory()
+	require.NoError(t, err)
+	opts := baseOptions()
+	def, err := f.GetBuiltinQueryDefinition("clusterIdByName")
+	require.NoError(t, err)
+	queries, err := f.Build(*def, NewTemplateDataFromOptions(opts, WithFilterClusterName("test-hcp")))
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+
+	testutil.CompareWithFixture(t, queryToFixture(queries[0]))
+}
+
 func TestBuildMerged_SingleTemplate(t *testing.T) {
 	f, err := NewQueryFactory()
 	require.NoError(t, err)

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/discovery/cluster_id_by_name.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/discovery/cluster_id_by_name.kql.gotmpl
@@ -1,0 +1,6 @@
+clustersServiceLogs
+| where resource_id has '{{.SubResourceGroupId}}'
+| extend _cluster_name = extract(@"hcpOpenShiftClusters/([^/""]+)", 1, tostring(resource_id))
+| where _cluster_name =~ '{{.FilterClusterName}}'
+| where isnotempty(cid)
+| distinct cid

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/queries.yaml
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/queries.yaml
@@ -30,6 +30,10 @@
   queryType: must-gather-internal
   database: ServiceLogs
   templatePath: templates/builtin/discovery/cluster_id.kql.gotmpl
+- name: clusterIdByName
+  queryType: must-gather-internal
+  database: ServiceLogs
+  templatePath: templates/builtin/discovery/cluster_id_by_name.kql.gotmpl
 - name: clusterNamesSvc
   queryType: must-gather-internal
   database: ServiceLogs

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/services/service_logs.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/services/service_logs.kql.gotmpl
@@ -1,17 +1,18 @@
 {{- if .NoTruncation}}set notruncation;
 {{end -}}
 {{.Table}}
+| where timestamp between({{ .TimestampMin }} .. {{ .TimestampMax }})
+{{- if .ClusterIds }}
+| where column_ifexists("cid", "") in ({{.ClusterIds}})
+    or (log has '{{.SubResourceGroupId}}' and log has_any ({{.ClusterIds}}))
+{{- else}}
+| where log has '{{.SubResourceGroupId}}'
+{{- end}}
 {{- if .SplitByPod}}
 | extend pod_name = column_ifexists("pod_name", "")
 | project timestamp, log, cluster, namespace_name, container_name, pod_name
 {{- else}}
 | project timestamp, log, cluster, namespace_name, container_name
-{{- end}}
-| where timestamp between({{ .TimestampMin }} .. {{ .TimestampMax }})
-{{- if .ClusterIds }}
-| where log has '{{.SubResourceGroupId}}' or log has_any ({{.ClusterIds}})
-{{- else}}
-| where log has '{{.SubResourceGroupId}}'
 {{- end}}
 {{- if gt .Limit 0}}
 | limit {{.Limit}}

--- a/tooling/hcpctl/pkg/mustgather/gather.go
+++ b/tooling/hcpctl/pkg/mustgather/gather.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -341,12 +342,37 @@ func (g *Gatherer) GatherLogs(ctx context.Context) error {
 
 	logger.V(1).Info("Query options", "queryOptions", g.GetQueryOptions())
 
-	// Get cluster IDs: use explicit IDs if provided, otherwise discover them
+	// Get cluster IDs: merge explicit IDs, resolved names, or discover all from RG
 	var clusterIds []string
 	if len(g.opts.QueryOptions.ClusterIds) > 0 {
-		clusterIds = g.opts.QueryOptions.ClusterIds
-		logger.V(1).Info("Using explicitly provided clusterIDs", "clusterIds", strings.Join(clusterIds, ", "))
-	} else {
+		clusterIds = append(clusterIds, g.opts.QueryOptions.ClusterIds...)
+		logger.V(1).Info("Using explicitly provided clusterIDs", "clusterIds", strings.Join(g.opts.QueryOptions.ClusterIds, ", "))
+	}
+	if len(g.opts.QueryOptions.ClusterNames) > 0 {
+		clusterIdByNameDef, err := queryFactory.GetBuiltinQueryDefinition("clusterIdByName")
+		if err != nil {
+			return fmt.Errorf("failed to get clusterIdByName query definition: %w", err)
+		}
+		for _, name := range g.opts.QueryOptions.ClusterNames {
+			templateData := kusto.NewTemplateDataFromOptions(g.GetQueryOptions(), kusto.WithFilterClusterName(name))
+			nameQueries, err := queryFactory.Build(*clusterIdByNameDef, templateData)
+			if err != nil {
+				return fmt.Errorf("failed to build clusterIdByName query for %q: %w", name, err)
+			}
+			resolvedIds, err := executeQueryAndConvert[ClusterIdRow](ctx, g, nameQueries[0])
+			if err != nil {
+				return fmt.Errorf("failed to resolve cluster name %q to ID: %w", name, err)
+			}
+			if len(resolvedIds) == 0 {
+				return fmt.Errorf("cluster name %q did not resolve to any cluster ID", name)
+			}
+			for _, row := range resolvedIds {
+				clusterIds = append(clusterIds, row.ClusterId)
+			}
+		}
+		logger.V(1).Info("Resolved cluster names to IDs", "clusterNames", strings.Join(g.opts.QueryOptions.ClusterNames, ", "), "resolvedIds", strings.Join(clusterIds, ", "))
+	}
+	if len(clusterIds) == 0 {
 		clusterIdDef, err := queryFactory.GetBuiltinQueryDefinition("clusterId")
 		if err != nil {
 			return fmt.Errorf("failed to get cluster id query definition: %w", err)
@@ -362,7 +388,14 @@ func (g *Gatherer) GatherLogs(ctx context.Context) error {
 		for _, row := range allClusterIds {
 			clusterIds = append(clusterIds, row.ClusterId)
 		}
-		logger.V(1).Info("Obtained following clusterIDs", "clusterIds", strings.Join(clusterIds, ", "))
+		logger.V(1).Info("Discovered clusterIDs from resource group", "clusterIds", strings.Join(clusterIds, ", "))
+	}
+
+	slices.Sort(clusterIds)
+	clusterIds = slices.Compact(clusterIds)
+	clusterIds = slices.DeleteFunc(clusterIds, func(s string) bool { return s == "" })
+	if len(clusterIds) == 0 && (len(g.opts.QueryOptions.ClusterIds) > 0 || len(g.opts.QueryOptions.ClusterNames) > 0) {
+		return fmt.Errorf("no valid cluster IDs found for resource group %q", g.opts.QueryOptions.ResourceGroupName)
 	}
 
 	// Gather service logs

--- a/tooling/hcpctl/pkg/mustgather/gather.go
+++ b/tooling/hcpctl/pkg/mustgather/gather.go
@@ -341,24 +341,29 @@ func (g *Gatherer) GatherLogs(ctx context.Context) error {
 
 	logger.V(1).Info("Query options", "queryOptions", g.GetQueryOptions())
 
-	// First, get all cluster IDs
-	clusterIds := make([]string, 0)
-	clusterIdDef, err := queryFactory.GetBuiltinQueryDefinition("clusterId")
-	if err != nil {
-		return fmt.Errorf("failed to get cluster id query definition: %w", err)
+	// Get cluster IDs: use explicit IDs if provided, otherwise discover them
+	var clusterIds []string
+	if len(g.opts.QueryOptions.ClusterIds) > 0 {
+		clusterIds = g.opts.QueryOptions.ClusterIds
+		logger.V(1).Info("Using explicitly provided clusterIDs", "clusterIds", strings.Join(clusterIds, ", "))
+	} else {
+		clusterIdDef, err := queryFactory.GetBuiltinQueryDefinition("clusterId")
+		if err != nil {
+			return fmt.Errorf("failed to get cluster id query definition: %w", err)
+		}
+		clusterIdQueries, err := queryFactory.Build(*clusterIdDef, kusto.NewTemplateDataFromOptions(g.GetQueryOptions()))
+		if err != nil {
+			return fmt.Errorf("failed to build cluster id query: %w", err)
+		}
+		allClusterIds, err := executeQueryAndConvert[ClusterIdRow](ctx, g, clusterIdQueries[0])
+		if err != nil {
+			return fmt.Errorf("failed to execute cluster id query: %w", err)
+		}
+		for _, row := range allClusterIds {
+			clusterIds = append(clusterIds, row.ClusterId)
+		}
+		logger.V(1).Info("Obtained following clusterIDs", "clusterIds", strings.Join(clusterIds, ", "))
 	}
-	clusterIdQueries, err := queryFactory.Build(*clusterIdDef, kusto.NewTemplateDataFromOptions(g.GetQueryOptions()))
-	if err != nil {
-		return fmt.Errorf("failed to build cluster id query: %w", err)
-	}
-	allClusterIds, err := executeQueryAndConvert[ClusterIdRow](ctx, g, clusterIdQueries[0])
-	if err != nil {
-		return fmt.Errorf("failed to execute cluster id query: %w", err)
-	}
-	for _, row := range allClusterIds {
-		clusterIds = append(clusterIds, row.ClusterId)
-	}
-	logger.V(1).Info("Obtained following clusterIDs", "clusterIds", strings.Join(clusterIds, ", "))
 
 	// Gather service logs
 	servicesQueries, err := serviceLogs(queryFactory, "serviceLogs", g.GetQueryOptions(), clusterIds)

--- a/tooling/hcpctl/pkg/mustgather/gather_test.go
+++ b/tooling/hcpctl/pkg/mustgather/gather_test.go
@@ -140,6 +140,35 @@ func TestGatherer_GatherLogs(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestGatherer_GatherLogs_ExplicitClusterIds(t *testing.T) {
+	mockQueryClient := &MockQueryClient{}
+	gatherer := &Gatherer{
+		QueryClient: mockQueryClient,
+		opts: GathererOptions{
+			SkipKubernetesEventsLogs: true,
+			QueryOptions: &kusto.QueryOptions{
+				SubscriptionId:    "test-sub",
+				ResourceGroupName: "test-rg",
+				ClusterIds:        []string{"cluster-abc-123", "cluster-def-456"},
+			},
+		},
+		outputFunc:    mockOutputFunc,
+		outputOptions: RowOutputOptions{"outputPath": "/test"},
+	}
+
+	// With explicit cluster IDs, ExecutePreconfiguredQuery should only be called
+	// for cluster names discovery (not cluster ID discovery)
+	mockQueryClient.On("ExecutePreconfiguredQuery", mock.Anything, mock.Anything, mock.Anything).Return(&kusto.QueryResult{}, nil)
+	mockQueryClient.On("ConcurrentQueries", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	err := gatherer.GatherLogs(t.Context())
+	assert.NoError(t, err)
+
+	// ExecutePreconfiguredQuery should NOT be called for cluster ID discovery,
+	// only for cluster names (2 calls: clusterNamesSvc + clusterNamesHcp)
+	mockQueryClient.AssertNumberOfCalls(t, "ExecutePreconfiguredQuery", 2)
+}
+
 func TestGatherer_GatherLogs_WithKubernetesEventsAndSystemdLogs(t *testing.T) {
 	mockQueryClient := &MockQueryClient{}
 	gatherer := &Gatherer{

--- a/tooling/hcpctl/testdata/zz_fixture_TestClusterIdByNameQuery.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestClusterIdByNameQuery.yaml
@@ -1,0 +1,10 @@
+database: ServiceLogs
+kql: |
+  clustersServiceLogs
+  | where resource_id has '/subscriptions/test-sub/resourceGroups/test-rg'
+  | extend _cluster_name = extract(@"hcpOpenShiftClusters/([^/""]+)", 1, tostring(resource_id))
+  | where _cluster_name =~ 'test-hcp'
+  | where isnotempty(cid)
+  | distinct cid
+name: clusterIdByName
+unlimited: false

--- a/tooling/hcpctl/testdata/zz_fixture_TestServiceLogs.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestServiceLogs.yaml
@@ -1,9 +1,10 @@
 database: ServiceLogs
-kql: |-
+kql: |
   containerLogs
-  | project timestamp, log, cluster, namespace_name, container_name
   | where timestamp between(datetime(0001-01-01T00:00:00.0000000Z) .. datetime(0001-01-01T00:00:00.0000000Z))
-  | where log has '/subscriptions/sub/resourceGroups/rg' or log has_any ('cid1')
+  | where column_ifexists("cid", "") in ('cid1')
+      or (log has '/subscriptions/sub/resourceGroups/rg' and log has_any ('cid1'))
+  | project timestamp, log, cluster, namespace_name, container_name
   | limit 10
   | order by timestamp asc
 name: serviceLogs

--- a/tooling/hcpctl/testdata/zz_fixture_TestServiceLogs_NoClusterIds.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestServiceLogs_NoClusterIds.yaml
@@ -1,9 +1,9 @@
 database: ServiceLogs
-kql: |-
+kql: |
   containerLogs
-  | project timestamp, log, cluster, namespace_name, container_name
   | where timestamp between(datetime(0001-01-01T00:00:00.0000000Z) .. datetime(0001-01-01T00:00:00.0000000Z))
   | where log has '/subscriptions/sub/resourceGroups/rg'
+  | project timestamp, log, cluster, namespace_name, container_name
   | limit 10
   | order by timestamp asc
 name: serviceLogs

--- a/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions.yaml
@@ -2,6 +2,7 @@ ClusterId: cid1
 ClusterIds: '''cid1'', ''cid2'''
 ClusterName: my-cluster
 ClusterNames: '''cluster-a'', ''cluster-b'''
+FilterClusterName: ""
 HCPNamespacePrefix: ocm-arohcp
 Limit: 100
 NoTruncation: false

--- a/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions_NoTruncation.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions_NoTruncation.yaml
@@ -2,6 +2,7 @@ ClusterId: ""
 ClusterIds: ""
 ClusterName: ""
 ClusterNames: ''''''
+FilterClusterName: ""
 HCPNamespacePrefix: ""
 Limit: 0
 NoTruncation: true


### PR DESCRIPTION
Implements [AROSLSRE-539](https://redhat.atlassian.net/browse/AROSLSRE-539)

### What

- Adds a repeatable `--cluster-id` and `--cluster-name` flags to `hcpctl must-gather query` that scopes HCP and service log queries to specific hosted control plane cluster IDs, bypassing the automatic cluster ID discovery query. Shared infrastructure queries (custom logs, service cluster k8s events) are not scoped by this flag since they operate on infra cluster names rather than HCP IDs. Management cluster k8s events retain all infra-namespace events but scope HCP-namespace events to the requested cluster IDs.
- `--cluster-name` flag performs cluster id lookup for 
- Hardens KQL template inputs against injection by introducing a `kqlEscStr` helper and applying it to `WithClusterId`, `WithClusterName`, and `WithHCPNamespacePrefix`.

### Why

Must-gather currently collects logs for every cluster in a resource group. When troubleshooting a specific HCP, this is slow and noisy. The --cluster-id and --cluster-name flags let operators target specific HCPs directly.

### Testing

- Unit tests: Run `make test` from `./tooling/hcpctl` directory
- Validation: Build new hcpctl executable (`make build`), then run must-gather against an RG with multiple HCPs.  Verify logs in `{{ output_directory }}/services` are now split by pod names:

```sh
./hcpctl must-gather query \
  --kusto {{ kusto_name }} \
  --region {{ kusto_region }} \
  --subscription-id {{ subscription_id }} \
  --resource-group {{ resource_group }} \
  --output-path {{ output_directory }} \
  --timestamp-min "{{ start_timestamp }}" \
  --timestamp-max "{{ end_timestamp }}" \
  --cluster-id "{{ cluster_id }}" \
  --limit 100 \
  -v 3
```

Also test with:
  - `--cluster-id ""` (should fail)
  - `--cluster-id "{{ cluster1_id }}" --cluster-id "{{ cluster2_id }}"` (validate param works with multiple clusters)
  - `--cluster-id "{{ cluster1_id }}" --cluster-name "{{ cluster2_name }}" (validate mixed cluster_id/cluster_name flags

