### PR TITLE
Enable cleanup-sweeper policy-driven rg-ordered workflow for ci01

### DIFF
--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -88,7 +88,13 @@ Today that periodic layer includes:
 - Kusto role-assignment cleanup
 - `cleanup-sweeper` jobs for policy-driven resource-group cleanup and shared leftovers
 
-This path is intentionally best-effort. If one run leaves something behind, the next run can pick it up.
+For `cleanup-sweeper` `rg-ordered` workflow, candidate resource groups are chosen using `tooling/cleanup-sweeper/resourcegroups.policy.yaml`. Discovery treats the `createdAt` tag (RFC3339 timestamp on the resource group) as required for any `action: delete` rule: groups without a parseable tag are not candidates.
+
+Azure does not set that tag by default. Subscriptions where `rg-ordered` should run must apply an Azure Policy (or equivalent) that stamps `tags['createdAt']` when a resource group is created, using `[utcNow()]` in the policy rule.
+
+Use `tooling/cleanup-sweeper/scripts/create-createdat-policy-assignment.sh` to create or update the subscription-scoped definition and assignment. The rule body lives in `tooling/cleanup-sweeper/scripts/rg-createdat-policy-rule.json` next to that script.
+
+Background hygiene of this kind is intentionally best-effort. If one run leaves something behind, the next run can pick it up.
 
 ## Why They Behave Differently
 
@@ -179,6 +185,7 @@ If you need to change behavior, start here:
 
 - consolidated periodic jobs: `openshift/release: ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic-cleanup.yaml`
 - `cleanup-sweeper` CLI: `tooling/cleanup-sweeper/cmd/root/options.go`
+- `rg-ordered` resource group `createdAt` tag policy (Azure): `tooling/cleanup-sweeper/scripts/create-createdat-policy-assignment.sh`
 - ordered cleanup engine: `tooling/cleanup-sweeper/pkg/engine/resourcegroup_ordered_cleanup.go`
 - templatize cleanup: `tooling/templatize/cmd/entrypoint/cleanup/`
 - e2e teardown: `test/util/framework/per_test_framework.go`

--- a/tooling/cleanup-sweeper/resourcegroups.policy.yaml
+++ b/tooling/cleanup-sweeper/resourcegroups.policy.yaml
@@ -1,11 +1,12 @@
-# This policy implements the cleanup-sweeper behavior:
-# - Global default: delete RGs older than 2 days.
-# - Always skip managed resource groups (ManagedBy is set).
-# - persist=true normally protects RGs from 2-day deletion.
-# - Exception for hcp-underlay-pers-*:
-#   - delete after 2 days when persist != true
-#   - delete after 15 days when persist == true
-# - hcp-underlay-prow-* groups are deleted after 6 hours.
+# cleanup-sweeper rg-ordered discovery policy (first matching rule wins).
+# - excludedResourceGroups: never candidates (global, hcp-kusto-us, westus3-shared-resources).
+# - Skip managed RGs (managedBy set).
+# - hcp-underlay-pers-*: delete after 15d if persist=true; after 2d if persist is absent or not "true".
+# - hcp-underlay-prow-*: delete after 6h.
+# - Name prefix hcp-underlay-ci*: delete after 6h (covers ci01, etc.).
+# - Skip any RG with persist=true (after pers-* and CI rules).
+# - Default: delete any other RG after 2d.
+# Delete rules need a parseable tags.createdAt; see docs/cleanup.md and scripts/ for Azure Policy.
 rgOrdered:
   # Keep known long-lived/shared groups out of rg-ordered deletion candidates.
   excludedResourceGroups:
@@ -41,6 +42,11 @@ rgOrdered:
       action: delete
       match:
         namePrefix: "hcp-underlay-prow-"
+      olderThan: "6h"
+    - name: ci-delete-after-6h
+      action: delete
+      match:
+        namePrefix: "hcp-underlay-ci"
       olderThan: "6h"
     - name: skip-persist-true-globally
       action: skip

--- a/tooling/cleanup-sweeper/scripts/create-createdat-policy-assignment.sh
+++ b/tooling/cleanup-sweeper/scripts/create-createdat-policy-assignment.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Copyright 2026 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Creates or updates a subscription-scoped Azure Policy definition and assignment
+# that appends tags.createdAt on new resource groups. Required for cleanup-sweeper
+# rg-ordered discovery (see docs/cleanup.md).
+#
+# Usage:
+#   ./create-createdat-policy-assignment.sh [SUBSCRIPTION_ID]
+#
+# If SUBSCRIPTION_ID is omitted, uses the current default from `az account show`.
+#
+# Environment overrides:
+#   POLICY_DEF_NAME     policy definition resource name (default: aro-rg-createdat-tag)
+#   POLICY_ASSIGN_NAME  assignment resource name (default: aro-createdat-rg)
+#   POLICY_DISPLAY_NAME display name for definition and assignment (default: ARO-CreatedAt Tag)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULE_FILE="${SCRIPT_DIR}/rg-createdat-policy-rule.json"
+
+usage() {
+	echo "Usage: $0 [SUBSCRIPTION_ID]" >&2
+	echo "  SUBSCRIPTION_ID  Azure subscription GUID (optional if az default account is set)" >&2
+	exit 2
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+fi
+
+if ! command -v az >/dev/null 2>&1; then
+	echo "error: az (Azure CLI) not found in PATH" >&2
+	exit 1
+fi
+
+SUBSCRIPTION_ID="${1:-${AZURE_SUBSCRIPTION_ID:-}}"
+if [[ -z "${SUBSCRIPTION_ID}" ]]; then
+	SUBSCRIPTION_ID="$(az account show --query id -o tsv)"
+fi
+
+if [[ -z "${SUBSCRIPTION_ID}" ]]; then
+	echo "error: no subscription id; pass one as argv[1] or run az account set" >&2
+	exit 1
+fi
+
+if [[ ! -f "${RULE_FILE}" ]]; then
+	echo "error: policy rule file missing: ${RULE_FILE}" >&2
+	exit 1
+fi
+
+DEF_NAME="${POLICY_DEF_NAME:-aro-rg-createdat-tag}"
+ASSIGN_NAME="${POLICY_ASSIGN_NAME:-aro-createdat-rg}"
+DISPLAY_NAME="${POLICY_DISPLAY_NAME:-ARO-CreatedAt Tag}"
+DESCRIPTION="Append tags.createdAt on resource groups when missing (append + utcNow). mode=All for rg-ordered cleanup-sweeper discovery."
+
+DEF_ID="/subscriptions/${SUBSCRIPTION_ID}/providers/Microsoft.Authorization/policyDefinitions/${DEF_NAME}"
+SCOPE="/subscriptions/${SUBSCRIPTION_ID}"
+
+echo "Subscription: ${SUBSCRIPTION_ID}"
+echo "Definition:   ${DEF_NAME}"
+echo "Assignment: ${ASSIGN_NAME}"
+
+if az policy definition show --subscription "${SUBSCRIPTION_ID}" --name "${DEF_NAME}" &>/dev/null; then
+	echo "Updating policy definition ${DEF_NAME}..."
+	az policy definition update \
+		--subscription "${SUBSCRIPTION_ID}" \
+		--name "${DEF_NAME}" \
+		--display-name "${DISPLAY_NAME}" \
+		--description "${DESCRIPTION}" \
+		--mode All \
+		--rules @"${RULE_FILE}"
+else
+	echo "Creating policy definition ${DEF_NAME}..."
+	az policy definition create \
+		--subscription "${SUBSCRIPTION_ID}" \
+		--name "${DEF_NAME}" \
+		--display-name "${DISPLAY_NAME}" \
+		--description "${DESCRIPTION}" \
+		--mode All \
+		--rules @"${RULE_FILE}"
+fi
+
+if az policy assignment show --subscription "${SUBSCRIPTION_ID}" --name "${ASSIGN_NAME}" &>/dev/null; then
+	echo "Policy assignment ${ASSIGN_NAME} already exists; leaving it unchanged."
+	echo "To re-point or recreate it, delete the assignment in the portal or:"
+	echo "  az policy assignment delete --subscription ${SUBSCRIPTION_ID} --name ${ASSIGN_NAME}"
+else
+	echo "Creating policy assignment ${ASSIGN_NAME}..."
+	az policy assignment create \
+		--subscription "${SUBSCRIPTION_ID}" \
+		--name "${ASSIGN_NAME}" \
+		--display-name "${DISPLAY_NAME}" \
+		--policy "${DEF_ID}" \
+		--scope "${SCOPE}"
+fi

--- a/tooling/cleanup-sweeper/scripts/rg-createdat-policy-rule.json
+++ b/tooling/cleanup-sweeper/scripts/rg-createdat-policy-rule.json
@@ -1,0 +1,23 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "equals": "Microsoft.Resources/subscriptions/resourceGroups",
+        "field": "type"
+      },
+      {
+        "exists": "false",
+        "field": "tags['createdAt']"
+      }
+    ]
+  },
+  "then": {
+    "details": [
+      {
+        "field": "tags['createdAt']",
+        "value": "[utcNow()]"
+      }
+    ],
+    "effect": "append"
+  }
+}


### PR DESCRIPTION
* Add the rule to match ci01 resource groups
* Document the requirement for a policy that sets the createdAt tag on resource groups.
* Add a script to deploy the "ARO-CreatedAt Tag" policy in a subscription.

https://redhat.atlassian.net/browse/ARO-26089