### PR TITLE
Switch ci01 SKUs to Standard_D*ads variant

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1631,15 +1631,15 @@ clouds:
               systemAgentPool:
                 maxCount: 4
                 osDiskSizeGB: 32
-                vmSize: Standard_D4ds_v6
+                vmSize: Standard_D4ads_v6
               userAgentPool:
                 maxCount: 14
                 minCount: 3
                 osDiskSizeGB: 100
-                vmSize: Standard_D16ds_v6
+                vmSize: Standard_D16ads_v6
                 secondaryNicCount: 7
               infraAgentPool:
-                vmSize: Standard_D4ds_v6
+                vmSize: Standard_D4ads_v6
                 osDiskSizeGB: 64
               enableSwiftV2Nodepools: true
               enableSwiftV2Vnet: true
@@ -1654,13 +1654,13 @@ clouds:
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
               systemAgentPool:
-                vmSize: Standard_D4ds_v6
+                vmSize: Standard_D4ads_v6
               userAgentPool:
-                name: 'u64d8dsv6'
-                vmSize: Standard_D8ds_v6
+                name: 'u8adsv6'
+                vmSize: Standard_D8ads_v6
                 osDiskSizeGB: 64
               infraAgentPool:
-                vmSize: Standard_D4ds_v6
+                vmSize: Standard_D4ads_v6
             jaeger:
               deploy: true
         regions:

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -549,7 +549,7 @@ mgmt:
       name: infra
       osDiskSizeGB: 64
       poolCount: 2
-      vmSize: Standard_D4ds_v6
+      vmSize: Standard_D4ads_v6
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.35.1
@@ -564,7 +564,7 @@ mgmt:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ds_v6
+      vmSize: Standard_D4ads_v6
       zoneRedundantMode: Auto
       zones: ""
     userAgentPool:
@@ -574,7 +574,7 @@ mgmt:
       osDiskSizeGB: 100
       poolCount: 3
       secondaryNicCount: 7
-      vmSize: Standard_D16ds_v6
+      vmSize: Standard_D16ads_v6
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14
@@ -856,7 +856,7 @@ svc:
       name: infra
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ds_v6
+      vmSize: Standard_D4ads_v6
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.35.1
@@ -871,16 +871,16 @@ svc:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ds_v6
+      vmSize: Standard_D4ads_v6
       zoneRedundantMode: Auto
       zones: ""
     userAgentPool:
       maxCount: 3
       minCount: 1
-      name: u64d8dsv6
+      name: u8adsv6
       osDiskSizeGB: 64
       poolCount: 3
-      vmSize: Standard_D8ds_v6
+      vmSize: Standard_D8ads_v6
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14


### PR DESCRIPTION
Part of https://redhat.atlassian.net/browse/ARO-26089

`Standard_D16ds` consistently fails with a `OverconstrainedZonalAllocationRequest` error in AZ3. `Standard_D16ads` allocates properly in all AZs.