### PR TITLE
test: log duration of cluster operator availability check                                                                                 

### DIFF
--- a/test/util/verifiers/clusteroperator.go
+++ b/test/util/verifiers/clusteroperator.go
@@ -43,6 +43,7 @@ func (v verifyAllClusterOperatorsAvailableImpl) Verify(ctx context.Context, admi
 		return fmt.Errorf("failed to create config client: %w", err)
 	}
 
+	start := time.Now()
 	var lastErr error
 	verifyErr := wait.PollUntilContextTimeout(ctx, 20*time.Second, 30*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		clusterOperators, err := configClient.ClusterOperators().List(ctx, metav1.ListOptions{})
@@ -80,6 +81,7 @@ func (v verifyAllClusterOperatorsAvailableImpl) Verify(ctx context.Context, admi
 	})
 
 	if verifyErr == nil {
+		ginkgo.GinkgoLogr.Info("All cluster operators available", "duration", time.Since(start))
 		return nil
 	}
 


### PR DESCRIPTION
[ARO-24684](https://redhat.atlassian.net/browse/ARO-24684)

### What

Add timing to measure cluster operator availability times. 

### Why

Measure the time it takes for operators to become available to be able to set timeouts based on observed durations. 
[Kusto queries](https://dataexplorer.azure.com/clusters/hcp-dev-us-2.eastus2/databases/HostedControlPlaneLogs?query=H4sIAAAAAAAAA7WTzWrDMBCE732KwRfb4EB6aS91oCTHlj6CkeWNLbCkIK3zU%2FrwlRMnNU1KoWl0W0bSfDsrSWtYKEPuxdYed8AHNg05AitNnoVeYQZR2%2BSxSkeqPB4rjNCEPEck284zucmanFfWTOyKnGDrItxkjWBaW6MRHpG2RgVHZWooD2MZnpj7khtCfCSKMTBG%2B0t8p7Vw6p2wVM5z4YkMcmhlklMIaYZWjDSxHWkod%2Bhj8Csh6RDInzuiLZOpUHWBNBAWgaJj8sGzEky9Z1Gp5TKJD0I84spG%2FOk%2FxnvGMssxhbhE%2BZTjYXqt9Q8wX2OStjOc7GMvw5C%2BU2S4v7r932Csq8j1AGcRCC9vaH4RxoUXE2ikbTttZCMcY6O4QXii3FIezV%2Ff8LwWqhWlahXvsBigsVCenSq7fZFMJ2F4oY80yrAdzp62JkODvbg7Xnz48pj3A4nST5HUuQpMBAAA) show only duration since CVO starts up until CMO is available, which does not directly relate to the set timeout. 

### Testing

This PR adds observability, no behaviour changes.


### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
