### PR TITLE
fix: skip TLS verification in VerifySimpleWebApp with timebomb (AROSLSRE-841)

### DIFF
--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -36,8 +36,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-
-	"github.com/Azure/ARO-HCP/test/util/framework"
 )
 
 //go:embed artifacts
@@ -164,14 +162,17 @@ func (v verifySimpleWebApp) Verify(ctx context.Context, adminRESTConfig *rest.Co
 	lastErr = nil
 	url := "https://" + host
 
-	// Create HTTP client with TLS skip for development environments
-	client := &http.Client{}
-	if framework.IsDevelopmentEnvironment() {
-		client.Transport = &http.Transport{
+	// AROSLSRE-836: skip TLS verification unconditionally until the backend
+	// blocks cluster Succeeded on ingress cert readiness. Remove after 2026-06-12.
+	if time.Now().After(time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)) {
+		ginkgo.Fail("AROSLSRE-836 timebomb: TLS skip mitigation expired. Fix the backend or extend the deadline.")
+	}
+	client := &http.Client{
+		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 			},
-		}
+		},
 	}
 	startTime := time.Now()
 	logged5Min := false

--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -165,14 +165,14 @@ func (v verifySimpleWebApp) Verify(ctx context.Context, adminRESTConfig *rest.Co
 	// AROSLSRE-836: skip TLS verification unconditionally until the backend
 	// blocks cluster Succeeded on ingress cert readiness. Remove after 2026-06-12.
 	if time.Now().After(time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)) {
-		ginkgo.Fail("AROSLSRE-836 timebomb: TLS skip mitigation expired. Fix the backend or extend the deadline.")
+		return fmt.Errorf("AROSLSRE-836 timebomb: TLS skip mitigation expired. Fix the backend or extend the deadline")
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
 	}
 	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-		},
+		Transport: transport,
 	}
 	startTime := time.Now()
 	logged5Min := false


### PR DESCRIPTION
## Summary

Temporary mitigation for intermittent x509 E2E flakes in `VerifySimpleWebApp` ([AROSLSRE-836](https://redhat.atlassian.net/browse/AROSLSRE-836)).

## Problem

The ingress cert provisioning chain (OneCert -> Azure Key Vault -> mgmt cluster secret -> ACM policy -> HCP IngressController) has variable latency. Clusters can report `Succeeded` while routes still serve HyperShift's default self-signed cert. The test's HTTP client rejects the self-signed cert with `x509: certificate signed by unknown authority` and times out after 25 minutes.

This is intermittent: when OneCert is fast, the cert is in place before the test reaches the route check. When it's slow, the test exhausts its timeout. 14 instances across 6 jobs in the last 2 weeks ([dptools search](https://search.dptools.openshift.org/?search=tls%3A+failed+to+verify+certificate%3A+x509%3A+certificate+signed+by+unknown+authority&maxAge=336h&context=1&type=build-log&name=ARO-HCP&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)).

## Fix

Skip TLS verification unconditionally in `VerifySimpleWebApp`. This test verifies app reachability via a route, not certificate validity. There's a dedicated `cluster_tls_endpoints.go` test that covers cert chain validation.

Timebombed to **2026-06-12**. After that date, the test will fail with a message pointing to [AROSLSRE-836](https://redhat.atlassian.net/browse/AROSLSRE-836), forcing the proper backend fix (blocking cluster `Succeeded` on ingress cert readiness) or a conscious deadline extension.

## Test plan

- [ ] Verify `VerifySimpleWebApp` passes in all environments (dev, INT, STG, PROD)
- [ ] Verify `cluster_tls_endpoints` test continues to validate cert chains independently
- [ ] Monitor dptools for x509 regressions after merge