### PR TITLE
fix: block cluster Succeeded until ingress cert is configured (AROSLSRE-836)

### DIFF
--- a/backend/pkg/controllers/create_cluster_scoped_maestro_readonly_bundles_controller.go
+++ b/backend/pkg/controllers/create_cluster_scoped_maestro_readonly_bundles_controller.go
@@ -22,6 +22,8 @@ import (
 	workv1 "open-cluster-management.io/api/work/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
@@ -122,6 +124,7 @@ func (c *createClusterScopedMaestroReadonlyBundlesSyncer) SyncOnce(ctx context.C
 	// controller and reported as an error.
 	recognizedMaestroBundles := []api.MaestroBundleInternalName{
 		api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster,
+		api.MaestroBundleInternalNameReadonlyIngressController,
 	}
 
 	var maestroBundlesToSync []api.MaestroBundleInternalName
@@ -258,6 +261,8 @@ func (c *createClusterScopedMaestroReadonlyBundlesSyncer) syncMaestroBundle(
 	switch maestroBundleInternalName {
 	case api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster:
 		desiredMaestroBundle = c.buildInitialReadonlyMaestroBundleForHostedCluster(existingCluster, csClusterDomainPrefix, maestroBundleNamespacedName)
+	case api.MaestroBundleInternalNameReadonlyIngressController:
+		desiredMaestroBundle = c.buildInitialReadonlyMaestroBundleForIngressController(maestroBundleNamespacedName)
 	default:
 		return lastPersistedSPC, utils.TrackError(fmt.Errorf("unrecognized Maestro Bundle internal name: %s", maestroBundleInternalName))
 	}
@@ -342,6 +347,27 @@ func (c *createClusterScopedMaestroReadonlyBundlesSyncer) buildInitialReadonlyMa
 // Internally in CS this is the "CDNamespace" attribute associated to the cluster.
 func (c *createClusterScopedMaestroReadonlyBundlesSyncer) getHostedClusterNamespace(envName string, csClusterID string) string {
 	return fmt.Sprintf("ocm-%s-%s", envName, csClusterID)
+}
+
+// buildInitialReadonlyMaestroBundleForIngressController builds an initial readonly Maestro Bundle for the
+// default IngressController in the HCP cluster's openshift-ingress-operator namespace.
+func (c *createClusterScopedMaestroReadonlyBundlesSyncer) buildInitialReadonlyMaestroBundleForIngressController(maestroBundleNamespacedName types.NamespacedName) *workv1.ManifestWork {
+	ingressController := &unstructured.Unstructured{}
+	ingressController.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operator.openshift.io",
+		Version: "v1",
+		Kind:    "IngressController",
+	})
+	ingressController.SetName("default")
+	ingressController.SetNamespace("openshift-ingress-operator")
+
+	resourceIdentifier := workv1.ResourceIdentifier{
+		Group:     "operator.openshift.io",
+		Resource:  "ingresscontrollers",
+		Name:      "default",
+		Namespace: "openshift-ingress-operator",
+	}
+	return buildInitialReadonlyMaestroBundle(maestroBundleNamespacedName, resourceIdentifier, ingressController, readonlyBundleManagedByK8sLabelValueClusterScoped)
 }
 
 func (c *createClusterScopedMaestroReadonlyBundlesSyncer) CooldownChecker() controllerutils.CooldownChecker {

--- a/backend/pkg/controllers/create_cluster_scoped_maestro_readonly_bundles_controller_test.go
+++ b/backend/pkg/controllers/create_cluster_scoped_maestro_readonly_bundles_controller_test.go
@@ -611,6 +611,11 @@ func TestCreateClusterScopedMaestroReadonlyBundlesSyncer_SyncOnce_AllBundlesAlre
 					MaestroAPIMaestroBundleID:   "bundle-id",
 				},
 				{
+					Name:                        api.MaestroBundleInternalNameReadonlyIngressController,
+					MaestroAPIMaestroBundleName: "bundle-name-ingress",
+					MaestroAPIMaestroBundleID:   "bundle-id-ingress",
+				},
+				{
 					Name:                        syncMaestroBundleTestOtherBundleName,
 					MaestroAPIMaestroBundleName: "bundle-nameother",
 					MaestroAPIMaestroBundleID:   "bundle-idother",

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -27,6 +27,7 @@ import (
 	"github.com/blang/semver/v4"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -175,6 +176,11 @@ func (c *operationClusterCreate) determineOperationStatus(ctx context.Context, o
 	} else {
 		operationStates = append(operationStates, currState)
 	}
+	if currState, err := c.ingressCertOperationStatus(ctx, operation); err != nil {
+		errs = append(errs, utils.TrackError(err))
+	} else {
+		operationStates = append(operationStates, currState)
+	}
 
 	if err := errors.Join(errs...); err != nil {
 		return nil, err
@@ -304,5 +310,35 @@ func (c *operationClusterCreate) hostedClusterOperationStatus(ctx context.Contex
 	// 1. the hosted cluster is available via condition
 	// 2. the hosted cluster has successfully installed at least one version
 	// 3. the hosted cluster has a control plane endpoint host and port
+	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+}
+
+func (c *operationClusterCreate) ingressCertOperationStatus(ctx context.Context, operation *api.Operation) (*operationState, error) {
+	ingressControllerContent, err := c.clusterManagementClusterContentLister.GetForCluster(
+		ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Name,
+		string(api.MaestroBundleInternalNameReadonlyIngressController),
+	)
+	if database.IsNotFoundError(err) {
+		return newOperationState(arm.ProvisioningStateProvisioning, "ingress controller readonly bundle not yet available"), nil
+	}
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	if !meta.IsStatusConditionFalse(ingressControllerContent.Status.Conditions, "Degraded") {
+		return newOperationState(arm.ProvisioningStateProvisioning, "ingress controller readonly bundle is degraded"), nil
+	}
+	if ingressControllerContent.Status.KubeContent == nil || len(ingressControllerContent.Status.KubeContent.Items) == 0 {
+		return newOperationState(arm.ProvisioningStateProvisioning, "ingress controller readonly bundle has no content"), nil
+	}
+
+	obj := &unstructured.Unstructured{}
+	if err := json.Unmarshal(ingressControllerContent.Status.KubeContent.Items[0].Raw, obj); err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to decode IngressController: %w", err))
+	}
+	certName, found, _ := unstructured.NestedString(obj.Object, "spec", "defaultCertificate", "name")
+	if !found || certName != "cluster-ingress-cert" {
+		return newOperationState(arm.ProvisioningStateProvisioning, "ingress certificate not yet configured on IngressController"), nil
+	}
+
 	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -325,17 +325,30 @@ func (c *operationClusterCreate) ingressCertOperationStatus(ctx context.Context,
 		return nil, utils.TrackError(err)
 	}
 	if !meta.IsStatusConditionFalse(ingressControllerContent.Status.Conditions, "Degraded") {
-		return newOperationState(arm.ProvisioningStateProvisioning, "ingress controller readonly bundle is degraded"), nil
+		message := "ingress controller maestro bundle is degraded, degraded condition missing"
+		if degradedCondition := meta.FindStatusCondition(ingressControllerContent.Status.Conditions, "Degraded"); degradedCondition != nil {
+			message = fmt.Sprintf("ingress controller maestro bundle is degraded: %s: %s", degradedCondition.Reason, degradedCondition.Message)
+		}
+		return newOperationState(arm.ProvisioningStateProvisioning, message), nil
 	}
-	if ingressControllerContent.Status.KubeContent == nil || len(ingressControllerContent.Status.KubeContent.Items) == 0 {
-		return newOperationState(arm.ProvisioningStateProvisioning, "ingress controller readonly bundle has no content"), nil
+	if ingressControllerContent.Status.KubeContent == nil {
+		return newOperationState(arm.ProvisioningStateProvisioning, "ingress controller maestro bundle has no kube content"), nil
+	}
+	if len(ingressControllerContent.Status.KubeContent.Items) == 0 {
+		return newOperationState(arm.ProvisioningStateProvisioning, "ingress controller maestro bundle has no items in kube content"), nil
+	}
+	if len(ingressControllerContent.Status.KubeContent.Items) > 1 {
+		return nil, utils.TrackError(fmt.Errorf("unexpected number of kube content items for IngressController: %d", len(ingressControllerContent.Status.KubeContent.Items)))
 	}
 
 	obj := &unstructured.Unstructured{}
 	if err := json.Unmarshal(ingressControllerContent.Status.KubeContent.Items[0].Raw, obj); err != nil {
 		return nil, utils.TrackError(fmt.Errorf("failed to decode IngressController: %w", err))
 	}
-	certName, found, _ := unstructured.NestedString(obj.Object, "spec", "defaultCertificate", "name")
+	certName, found, err := unstructured.NestedString(obj.Object, "spec", "defaultCertificate", "name")
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to read spec.defaultCertificate.name from IngressController: %w", err))
+	}
 	if !found || certName != "cluster-ingress-cert" {
 		return newOperationState(arm.ProvisioningStateProvisioning, "ingress certificate not yet configured on IngressController"), nil
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
@@ -130,7 +130,7 @@ func TestOperationClusterCreate_SynchronizeOperation(t *testing.T) {
 					Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
 				},
 				clusterManagementClusterContentLister: &listertesting.SliceManagementClusterContentLister{
-					Contents: []*api.ManagementClusterContent{succeededContent},
+					Contents: []*api.ManagementClusterContent{succeededContent, newIngressControllerContent(t, "cluster-ingress-cert")},
 				},
 			}
 
@@ -212,6 +212,50 @@ func newHostedClusterContent(t *testing.T, hostedCluster *v1beta1.HostedCluster,
 	}
 }
 
+func newIngressControllerContent(t *testing.T, certName string, conditions ...metav1.Condition) *api.ManagementClusterContent {
+	t.Helper()
+	obj := map[string]any{
+		"apiVersion": "operator.openshift.io/v1",
+		"kind":       "IngressController",
+		"metadata": map[string]any{
+			"name":      "default",
+			"namespace": "openshift-ingress-operator",
+		},
+	}
+	if certName != "" {
+		obj["spec"] = map[string]any{
+			"defaultCertificate": map[string]any{
+				"name": certName,
+			},
+		}
+	}
+	raw, err := json.Marshal(obj)
+	require.NoError(t, err)
+	if conditions == nil {
+		conditions = []metav1.Condition{
+			{Type: "Degraded", Status: metav1.ConditionFalse},
+		}
+	}
+
+	contentResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/managementClusterContents/" + string(api.MaestroBundleInternalNameReadonlyIngressController)))
+
+	return &api.ManagementClusterContent{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID: contentResourceID,
+		},
+		Status: api.ManagementClusterContentStatus{
+			Conditions: conditions,
+			KubeContent: &metav1.List{
+				Items: []kruntime.RawExtension{{Raw: raw}},
+			},
+		},
+	}
+}
+
 func newClusterWithAPIURL(url string) *api.HCPOpenShiftCluster {
 	fixture := newClusterTestFixture()
 	cluster := fixture.newCluster(nil)
@@ -233,7 +277,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 		errContains     string
 	}{
 		{
-			name: "both checks succeed → Succeeded",
+			name: "all checks succeed → Succeeded",
 			clusterLister: &listertesting.SliceClusterLister{
 				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
 			},
@@ -255,6 +299,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 							},
 						},
 					}),
+										newIngressControllerContent(t, "cluster-ingress-cert"),
 				},
 			},
 			expectedState:   arm.ProvisioningStateSucceeded,
@@ -283,6 +328,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 							},
 						},
 					}),
+										newIngressControllerContent(t, "cluster-ingress-cert"),
 				},
 			},
 			expectedState:   arm.ProvisioningStateProvisioning,
@@ -317,6 +363,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 							},
 						},
 					}),
+										newIngressControllerContent(t, "cluster-ingress-cert"),
 				},
 			},
 			expectError: true,
@@ -369,6 +416,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 							},
 						},
 					}),
+										newIngressControllerContent(t, "cluster-ingress-cert"),
 				},
 			},
 			expectedState:   arm.ProvisioningStateProvisioning,
@@ -393,6 +441,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 							},
 						},
 					}),
+										newIngressControllerContent(t, "cluster-ingress-cert"),
 				},
 			},
 			expectedState:   arm.ProvisioningStateProvisioning,
@@ -420,6 +469,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 							},
 						},
 					}),
+										newIngressControllerContent(t, "cluster-ingress-cert"),
 				},
 			},
 			expectedState:   arm.ProvisioningStateProvisioning,
@@ -448,6 +498,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 							},
 						},
 					}),
+										newIngressControllerContent(t, "cluster-ingress-cert"),
 				},
 			},
 			expectedState:   arm.ProvisioningStateProvisioning,

--- a/internal/api/types_serviceprovider_cluster.go
+++ b/internal/api/types_serviceprovider_cluster.go
@@ -216,4 +216,8 @@ const (
 	// MaestroBundleInternalNameReadonlyHypershiftHostedCluster is the internal name of the Maestro Bundle that represents
 	// the Cluster's Hypershift's HostedCluster K8s resource.
 	MaestroBundleInternalNameReadonlyHypershiftHostedCluster MaestroBundleInternalName = "readonlyHypershiftHostedCluster"
+
+	// MaestroBundleInternalNameReadonlyIngressController is the internal name of the Maestro Bundle that represents
+	// the default IngressController in the HCP cluster's openshift-ingress-operator namespace.
+	MaestroBundleInternalNameReadonlyIngressController MaestroBundleInternalName = "readonlyIngressController"
 )


### PR DESCRIPTION
## Summary

Clusters report `Succeeded` before the OneCert ingress certificate is delivered to the HCP cluster, causing intermittent `x509: certificate signed by unknown authority` errors when accessing routes. This affects E2E tests ([dptools search](https://search.dptools.openshift.org/?search=tls%3A+failed+to+verify+certificate%3A+x509%3A+certificate+signed+by+unknown+authority&maxAge=336h&context=1&type=build-log&name=ARO-HCP&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)) and customers.

## Root cause

The ingress cert provisioning chain has multiple async hops after the cluster is installed:

1. OneCert issues cert in Azure Key Vault (variable latency)
2. SecretSync copies cert from Key Vault to K8s secret on mgmt cluster
3. ACM policy copies cert to HCP's `openshift-ingress/cluster-ingress-cert` (polls every 45s)
4. IngressController reloads with the new cert

The backend marks the cluster `Succeeded` based on HostedCluster availability + API URL, without checking whether the ingress cert has been delivered. Until the chain completes, the ingress serves HyperShift's default self-signed cert.

## Fix

Add a maestro readonly bundle for the `IngressController/default` resource in the HCP cluster's `openshift-ingress-operator` namespace. The backend reads this via the existing maestro -> Cosmos pipeline and checks `spec.defaultCertificate.name == "cluster-ingress-cert"` before allowing `Succeeded`.

This follows the same pattern as the existing HostedCluster readonly bundle. The new check participates in `determineOperationStatus()` alongside `hostedClusterOperationStatus` and `clusterOperationStatus`, using the worst-state merge.

### Changes

- `internal/api/types_serviceprovider_cluster.go` -- new `MaestroBundleInternalNameReadonlyIngressController` constant
- `backend/pkg/controllers/create_cluster_scoped_maestro_readonly_bundles_controller.go` -- register bundle, add builder using `unstructured.Unstructured` (avoids new typed dependency)
- `backend/pkg/controllers/operationcontrollers/operation_cluster_create.go` -- add `ingressCertOperationStatus` check

## Test plan

- [ ] `go build ./backend/...` compiles clean
- [ ] Existing backend unit tests pass
- [ ] Deploy to dev -- cluster creation still succeeds (Self issuer certs are fast)
- [ ] Monitor INT/STG/PROD E2E for x509 flake elimination
- [ ] Check cluster creation time metrics for impact of added wait