### PR TITLE
fix: discover EC and RC releases to avoid skipping e2e tests for minor upgrades

### DIFF
--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -24,14 +24,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/blang/semver/v4"
-
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
-	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/cincinnati"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
@@ -53,11 +50,10 @@ var _ = Describe("Service Provider", func() {
 			if len(baseInstallVersion) == 0 {
 				baseInstallVersion = minorVersion // set it to minor so that we defaul to .0 as the patch version
 			}
-			configuredVersionID := api.Must(semver.ParseTolerant(baseInstallVersion))
-			installVersion, hasUpgradePath, err := framework.GetInstallVersionForZStreamUpgrade(ctx, "candidate", configuredVersionID.String())
+			installVersion, hasUpgradePath, err := framework.GetInstallVersionForZStreamUpgrade(ctx, "candidate", baseInstallVersion)
 			if err != nil {
 				if cincinnati.IsCincinnatiVersionNotFoundError(err) {
-					Skip(fmt.Sprintf("Cincinnati returned version not found for configured id %s (minor %s)", configuredVersionID, minorVersion))
+					Skip(fmt.Sprintf("Cincinnati returned version not found for configured id %s (minor %s)", baseInstallVersion, minorVersion))
 				}
 				Expect(err).NotTo(HaveOccurred())
 			}

--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -59,6 +59,11 @@ var _ = Describe("Customer", func() {
 			} else {
 				previousMinor = semver.Version{Major: targetVer.Major, Minor: targetVer.Minor - 1}
 			}
+
+			if previousMinor.Major == 4 && targetVer.Major == 5 {
+				Skip("CS does not support major upgrade yet; skipping until https://redhat.atlassian.net/browse/ARO-25230 is resolved")
+			}
+
 			previousMinorLine := fmt.Sprintf("%d.%d", previousMinor.Major, previousMinor.Minor)
 			targetMinorLine := fmt.Sprintf("%d.%d", targetVer.Major, targetVer.Minor)
 

--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -59,11 +59,13 @@ var _ = Describe("Customer", func() {
 			} else {
 				previousMinor = semver.Version{Major: targetVer.Major, Minor: targetVer.Minor - 1}
 			}
+			previousMinorLine := fmt.Sprintf("%d.%d", previousMinor.Major, previousMinor.Minor)
+			targetMinorLine := fmt.Sprintf("%d.%d", targetVer.Major, targetVer.Minor)
 
 			var installVersion *semver.Version
 			cincinnatiClient := cvocincinnati.NewClient(uuid.NameSpaceDNS, &http.Transport{}, "ARO-HCP", cincinnati.NewAlwaysConditionRegistry())
 
-			possibleInstallVersions, err := framework.GetAllVersionsInMinorStartingWith(ctx, channelGroup, previousMinor.String())
+			possibleInstallVersions, err := framework.GetAllVersionsInMinorStartingWith(ctx, channelGroup, previousMinorLine)
 			if cincinnati.IsCincinnatiVersionNotFoundError(err) {
 				Skip(fmt.Sprintf("Cincinnati returned version not found for previous minor %s on channel %s: %v",
 					previousMinor.String(),
@@ -135,7 +137,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("creating the HCP cluster with install version %s (previous minor %s)", installVersion,
-				previousMinor.String()))
+				previousMinorLine))
 			err = tc.CreateHCPClusterFromParam(
 				ctx,
 				GinkgoLogr,
@@ -184,8 +186,8 @@ var _ = Describe("Customer", func() {
 				return verifiers.VerifyHCPCluster(ctx, adminRESTConfig,
 					verifiers.VerifyKubeAPIServerServerVersionUpgraded(preUpgradeKubeAPIServerVersion),
 					verifiers.VerifyHostedControlPlaneYStreamUpgrade(
-						previousMinor.String(),
-						targetVer.String()))
+						previousMinorLine,
+						targetMinorLine))
 			}, 45*time.Minute, 2*time.Minute).Should(Succeed())
 		},
 		Entry("from 4.20 minor to 4.21 minor", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.21"),

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -95,16 +95,15 @@ func isRetryableVersionError(err error) bool {
 // When no version with an upgrade path is found, it still returns the configured version so the
 // caller can install and optionally skip upgrade assertions.
 func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string, configuredVersionID string) (installVersion string, hasUpgradePath bool, err error) {
-	configuredVersion := api.Must(semver.ParseTolerant(configuredVersionID))
 	candidates, err := GetAllVersionsInMinorStartingWith(ctx, channelGroup, configuredVersionID)
 	if err != nil {
 		return "", false, err
 	}
 	if len(candidates) == 1 {
-		return configuredVersion.String(), false, nil
+		return candidates[0].String(), false, nil
 	}
 
-	nextMinorStr := fmt.Sprintf("%d.%d", configuredVersion.Major, configuredVersion.Minor+1)
+	nextMinorStr := fmt.Sprintf("%d.%d", candidates[0].Major, candidates[0].Minor+1)
 	maxVersion, err := GetLatestVersionInMinor(ctx, channelGroup, nextMinorStr)
 	if err != nil {
 		if !cincinnati.IsCincinnatiVersionNotFoundError(err) {
@@ -127,12 +126,28 @@ func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string
 }
 
 // GetAllVersionsInMinorStartingWith returns all OpenShift versions in the same major.minor as the given version,
-// including that version, from Cincinnati for the given channelGroup. The version string is parse-tolerant
-// (e.g. "4.20", "4.20.0", "4.20.1"). Results are sorted descending (latest first).
+// including that version, from Cincinnati for the given channelGroup. The version string may be strict semver or
+// parse-tolerant (e.g. "4.20", "4.20.0", "4.20.1"). Results are sorted descending (latest first).
+//
+// If semver.Parse succeeds, only that version is used as the Cincinnati graph root for GetUpdates. When semver.Parse
+// fails (major.minor only), discovery queries ParseTolerant dot-zero, X.Y.0-rc.0, and X.Y.0-ec.0 in turn when GA z0 may
+// not yet be a graph node. Each successful response is merged into the result; VersionNotFound skips to the next root;
+// any other error fails immediately.
 func GetAllVersionsInMinorStartingWith(ctx context.Context, channelGroup string, version string) ([]semver.Version, error) {
-	fromVersion, err := semver.ParseTolerant(version)
-	if err != nil {
-		return nil, fmt.Errorf("parse version %q: %w", version, err)
+	var getUpdatesGraphRoots []semver.Version
+	if parsed, err := semver.Parse(version); err != nil {
+		versionToDiscover, err := semver.ParseTolerant(version)
+		if err != nil {
+			return nil, err
+		}
+		// Major.minor only (e.g. "4.20"): discover the minor by querying each dot-zero anchor (GA z0, RC, EC).
+		getUpdatesGraphRoots = []semver.Version{
+			versionToDiscover,
+			semver.MustParse(fmt.Sprintf("%d.%d.0-rc.0", versionToDiscover.Major, versionToDiscover.Minor)),
+			semver.MustParse(fmt.Sprintf("%d.%d.0-ec.0", versionToDiscover.Major, versionToDiscover.Minor)),
+		}
+	} else {
+		getUpdatesGraphRoots = []semver.Version{parsed}
 	}
 
 	cincinnatiURI, err := cincinnati.GetCincinnatiURI(channelGroup)
@@ -144,23 +159,40 @@ func GetAllVersionsInMinorStartingWith(ctx context.Context, channelGroup string,
 		transport = &http.Transport{}
 	}
 	client := cvocincinnati.NewClient(uuid.NameSpaceDNS, transport, "ARO-HCP", cincinnati.NewAlwaysConditionRegistry())
-	channel := fmt.Sprintf("%s-%d.%d", channelGroup, fromVersion.Major, fromVersion.Minor)
+	channel := fmt.Sprintf("%s-%d.%d", channelGroup, getUpdatesGraphRoots[0].Major, getUpdatesGraphRoots[0].Minor)
 
-	possibleUpgradeCandidates, err := retryOnTransientError(ctx, func() ([]configv1.Release, error) {
-		_, updates, _, err := client.GetUpdates(ctx, cincinnatiURI, "multi", "multi", channel, fromVersion)
-		return updates, err
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	candidates := []semver.Version{fromVersion}
-	for _, release := range possibleUpgradeCandidates {
-		candidateVersion := api.Must(semver.ParseTolerant(release.Version))
-		if candidateVersion.Major != fromVersion.Major || candidateVersion.Minor != fromVersion.Minor {
+	maj, min := getUpdatesGraphRoots[0].Major, getUpdatesGraphRoots[0].Minor
+	uniqueVersionsInMinor := make(map[string]semver.Version)
+	for _, root := range getUpdatesGraphRoots {
+		releases, err := retryOnTransientError(ctx, func() ([]configv1.Release, error) {
+			_, updates, _, err := client.GetUpdates(ctx, cincinnatiURI, "multi", "multi", channel, root)
+			return updates, err
+		})
+		if err != nil {
+			if !cincinnati.IsCincinnatiVersionNotFoundError(err) {
+				return nil, err
+			}
 			continue
 		}
-		candidates = append(candidates, candidateVersion)
+		uniqueVersionsInMinor[root.String()] = root
+		for _, release := range releases {
+			candidateVersion := api.Must(semver.ParseTolerant(release.Version))
+			if candidateVersion.Major != maj || candidateVersion.Minor != min {
+				continue
+			}
+			uniqueVersionsInMinor[candidateVersion.String()] = candidateVersion
+		}
+	}
+	if len(uniqueVersionsInMinor) == 0 {
+		return nil, &cvocincinnati.Error{
+			Reason:  "VersionNotFound",
+			Message: fmt.Sprintf("no versions discovered for channel %s (input %q)", channel, version),
+		}
+	}
+
+	candidates := make([]semver.Version, 0, len(uniqueVersionsInMinor))
+	for _, v := range uniqueVersionsInMinor {
+		candidates = append(candidates, v)
 	}
 	sort.Slice(candidates, func(i, j int) bool {
 		return candidates[j].LT(candidates[i])


### PR DESCRIPTION
### What

fix: discover EC and RC releases to avoid skipping e2e tests for minor upgrades

### Why

The E2E e.g "Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor" were skipped because 4.22 isn't GA-ed yet and there are only EC releases for it, it is critical that we are still in a position to perform upgrades verification for these kind of versions to catch any issues and report them upstream.

The fix is to discover these versions using dedicated .RC.0 and .EC.0 anchors.

In doing so; we'll be able to exercise minor upgrades from 4.21.z to 4.22.ec e.g

```
{
  "current": {
    "architecture": "Multi",
    "version": "4.21.14",
    "image": "quay.io/openshift-release-dev/ocp-release@sha256:4b92a67215c370b932f9e9dc3b5d0ccd704903049c1127e00b7fc6a52cee258c",
    "url": "https://access.redhat.com/errata/RHBA-2026:13813",
    "channels": [
      "candidate-4.21",
      "candidate-4.22",
      "fast-4.21",
      "stable-4.21"
    ]
  },
  "updates": [
    {
      "architecture": "Multi",
      "version": "4.22.0-rc.3",
      "image": "quay.io/openshift-release-dev/ocp-release@sha256:31d4f1c5d76c696c34b236610a3ad6858d9d06d25066100c428d6d735b801069",
      "url": "https://access.redhat.com/errata/RHBA-2026:0449",
      "channels": [
        "candidate-4.22",
        "candidate-5.0"
      ]
    }
  ],
  "conditionalUpdates": []
}
```

from 4.21.14 ro 4.22.0-rc.3

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
