### PR TITLE
fix(observability): rebuild etcd-availability as fleet summary

### DIFF
--- a/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
+++ b/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
@@ -316,7 +316,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Highest regional p99 WAL fsync duration across the fleet (max of per-region p99s). NOTE: this is NOT a true cross-region p99; PromQL cannot aggregate histograms across independent Prometheus workspaces. Use this as a \"any region degraded?\" signal. SLO target per region: < 10ms.",
+      "description": "Worst per-cluster p99 WAL fsync duration across the fleet. Computes p99 per cluster, then takes the max across all clusters and regions. Use this as a \"any cluster degraded?\" signal. SLO target: < 10ms.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -383,7 +383,7 @@
           "refId": "A"
         }
       ],
-      "title": "Worst Regional P99 WAL Fsync (5m)",
+      "title": "Worst Cluster P99 WAL Fsync (5m)",
       "transformations": [
         {
           "id": "merge",
@@ -406,7 +406,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Highest regional p99 backend commit duration across the fleet. NOT a true cross-region p99 (see WAL Fsync panel description). SLO target per region: < 25ms.",
+      "description": "Worst per-cluster p99 backend commit duration across the fleet. Computes p99 per cluster, then takes the max across all clusters and regions. SLO target: < 25ms.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -473,7 +473,7 @@
           "refId": "A"
         }
       ],
-      "title": "Worst Regional P99 Backend Commit (5m)",
+      "title": "Worst Cluster P99 Backend Commit (5m)",
       "transformations": [
         {
           "id": "merge",
@@ -496,7 +496,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Highest regional p99 etcd peer network RTT across the fleet. NOT a true cross-region p99 (see WAL Fsync panel description). SLO target per region: < 50ms.",
+      "description": "Worst per-cluster p99 etcd peer network RTT across the fleet. Computes p99 per cluster, then takes the max across all clusters and regions. SLO target: < 50ms.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -563,7 +563,7 @@
           "refId": "A"
         }
       ],
-      "title": "Worst Regional P99 Peer RTT (5m)",
+      "title": "Worst Cluster P99 Peer RTT (5m)",
       "transformations": [
         {
           "id": "merge",

--- a/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
+++ b/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
@@ -754,6 +754,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "P99 Fsync (ms)",
+              "cluster": "Cluster"
+            }
+          }
         }
       ],
       "type": "table"
@@ -841,6 +855,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "P99 Commit (ms)",
+              "cluster": "Cluster"
+            }
+          }
         }
       ],
       "type": "table"
@@ -928,6 +956,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "P99 RTT (ms)",
+              "cluster": "Cluster"
+            }
+          }
         }
       ],
       "type": "table"
@@ -1020,6 +1062,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Changes/Hour",
+              "cluster": "Cluster"
+            }
+          }
         }
       ],
       "type": "table"
@@ -1120,6 +1176,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Leader Changes (24h)",
+              "cluster": "Cluster Name"
+            }
+          }
         }
       ],
       "type": "table"
@@ -1220,6 +1290,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Leader Changes (24h)",
+              "cluster": "Cluster Name"
+            }
+          }
         }
       ],
       "type": "table"
@@ -1380,6 +1464,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Stable (\u22645 changes/24h)",
+              "Value #B": "High Churn (>10 changes/24h)",
+              "Value #C": "Unstable (>5 changes/24h)"
+            }
+          }
         }
       ],
       "type": "table"
@@ -1688,6 +1786,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "DB Size (bytes)",
+              "cluster": "Cluster Name"
+            }
+          }
         }
       ],
       "type": "table"

--- a/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
+++ b/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
@@ -113,7 +113,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "count(max by (cluster) (changes(etcd_server_leader_changes_seen_total[1d])) <= 5) or vector(0)",
+          "expr": "count(max by (cluster) (increase(etcd_server_leader_changes_seen_total[1d])) <= 5) or vector(0)",
           "instant": true,
           "legendFormat": "Stable Clusters",
           "range": false,
@@ -204,7 +204,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(max by (cluster) (changes(etcd_server_leader_changes_seen_total[1d])))",
+          "expr": "sum(max by (cluster) (increase(etcd_server_leader_changes_seen_total[1d])))",
           "instant": true,
           "legendFormat": "Total Leader Changes",
           "range": false,
@@ -376,7 +376,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster!=\"\"}[5m])) by (le)) * 1000",
+          "expr": "max(histogram_quantile(0.99, sum by (cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster!=\"\"}[5m])))) * 1000",
           "instant": true,
           "legendFormat": "P99 WAL Fsync",
           "range": false,
@@ -466,7 +466,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster!=\"\"}[5m])) by (le)) * 1000",
+          "expr": "max(histogram_quantile(0.99, sum by (cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster!=\"\"}[5m])))) * 1000",
           "instant": true,
           "legendFormat": "P99 Backend Commit",
           "range": false,
@@ -556,7 +556,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_network_peer_round_trip_time_seconds_bucket{cluster!=\"\"}[5m])) by (le)) * 1000",
+          "expr": "max(histogram_quantile(0.99, sum by (cluster, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket{cluster!=\"\"}[5m])))) * 1000",
           "instant": true,
           "legendFormat": "P99 Peer RTT",
           "range": false,
@@ -1007,7 +1007,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max by (cluster) (changes(etcd_server_leader_changes_seen_total[1h])) > 3",
+          "expr": "max by (cluster) (increase(etcd_server_leader_changes_seen_total[1h])) > 3",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -1107,7 +1107,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max by (cluster) (changes(etcd_server_leader_changes_seen_total[1d])) > 10",
+          "expr": "max by (cluster) (increase(etcd_server_leader_changes_seen_total[1d])) > 10",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -1207,7 +1207,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max by (cluster) (changes(etcd_server_leader_changes_seen_total{cluster!=\"\"}[1d])) > 5",
+          "expr": "max by (cluster) (increase(etcd_server_leader_changes_seen_total{cluster!=\"\"}[1d])) > 5",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -1258,7 +1258,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "Stable (≤5 changes/24h)"
+                "value": "Stable (\u22645 changes/24h)"
               },
               {
                 "id": "color",
@@ -1337,7 +1337,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(max by (cluster) (changes(etcd_server_leader_changes_seen_total[1d])) <= 5) or vector(0)",
+          "expr": "count(max by (cluster) (increase(etcd_server_leader_changes_seen_total[1d])) <= 5) or vector(0)",
           "format": "table",
           "instant": true,
           "legendFormat": "Stable",
@@ -1351,7 +1351,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(max by (cluster) (changes(etcd_server_leader_changes_seen_total[1d])) > 10) or vector(0)",
+          "expr": "count(max by (cluster) (increase(etcd_server_leader_changes_seen_total[1d])) > 10) or vector(0)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1366,7 +1366,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(max by (cluster) (changes(etcd_server_leader_changes_seen_total{cluster!=\"\"}[1d])) > 5) or vector(0)",
+          "expr": "count(max by (cluster) (increase(etcd_server_leader_changes_seen_total{cluster!=\"\"}[1d])) > 5) or vector(0)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1582,7 +1582,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "max by (cluster) (changes(etcd_server_leader_changes_seen_total{cluster!=\"\"}[1h]))",
+          "expr": "max by (cluster) (increase(etcd_server_leader_changes_seen_total{cluster!=\"\"}[1h]))",
           "instant": false,
           "legendFormat": "{{cluster}}",
           "range": true,

--- a/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
+++ b/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
@@ -58,7 +58,7 @@
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 1,
+          "decimals": 0,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -149,7 +149,7 @@
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 1,
+          "decimals": 0,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -249,7 +249,8 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "decimals": 0
         },
         "overrides": []
       },
@@ -949,7 +950,7 @@
             },
             "inspect": false
           },
-          "decimals": 2,
+          "decimals": 0,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",

--- a/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
+++ b/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
@@ -40,7 +40,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "### Etcd Availability Dashboard\n\nMonitors etcd availability and performance across all HCP clusters.\n\n**Health Targets:**\n- Leader stability: < 5 changes per 24h\n- No excessive leader churn (> 3 changes/hour)\n\n**Performance SLOs (99th percentile):**\n- WAL fsync duration: < 10ms\n- Backend commit duration: < 25ms\n- Peer network RTT: < 50ms\n\n**Note:** Leader health is inferred from leader change stability (available metrics).",
+        "content": "### Etcd Availability - Fleet Summary\n\nThis dashboard summarizes etcd availability across **all** HCP regional Prometheus workspaces.\n\n**Aggregation methodology:**\n- **Counts and totals** (clusters monitored, total leader changes, stable cluster count, total/worst DB size): mathematically correct fleet-wide sum/max via Grafana's `Mixed` datasource + `Reduce` transform.\n- **Latency percentiles** (`Worst Regional P99 ...`): show the **highest p99 observed in any single region**, NOT a true cross-region p99. PromQL cannot reconstruct a histogram across independent Prometheus workspaces. Use these tiles as an \"is any region degraded?\" signal. A true fleet p99 requires observability infrastructure work (Thanos / Mimir / federated workspace).\n- **Violator tables**: concatenated rows from every regional workspace; each row is one offending cluster.\n- **Per-cluster timeseries**: lines from every cluster in every region overlaid on one chart.\n\n**Health Targets:**\n- Leader stability: < 5 changes per 24h\n- No excessive leader churn (> 3 changes/hour)\n\n**Performance SLOs (per region, 99th percentile):**\n- WAL fsync duration: < 10ms\n- Backend commit duration: < 25ms\n- Peer network RTT: < 50ms\n",
         "mode": "markdown"
       },
       "pluginVersion": "11.6.9",
@@ -52,7 +52,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Percentage of clusters with stable leadership - Target: > 95% - Shows what percentage of clusters have ≤5 leader changes in the last 24 hours, indicating healthy etcd leader stability.",
+      "description": "Total number of HCP clusters across the fleet with stable etcd leadership in the last 24 hours (<=5 leader changes). Computed by summing per-region stable-cluster counts.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -64,19 +64,20 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": null
               },
               {
                 "color": "yellow",
-                "value": 90
+                "value": 1
               },
               {
                 "color": "green",
-                "value": 95
+                "value": 5
               }
             ]
           },
-          "unit": "percent"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -95,7 +96,7 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "sum"
           ],
           "fields": "",
           "values": false
@@ -112,14 +113,14 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "((count(max by (cluster) (changes(etcd_server_leader_changes_seen_total[1d])) <= 5) or vector(0)) / count(count by (cluster) (etcd_server_leader_changes_seen_total))) * 100",
+          "expr": "count(max by (cluster) (changes(etcd_server_leader_changes_seen_total[1d])) <= 5) or vector(0)",
           "instant": true,
-          "legendFormat": "Stable Leadership",
+          "legendFormat": "Stable Clusters",
           "range": false,
           "refId": "A"
         }
       ],
-      "title": "Fleet Leader Stability (24h)",
+      "title": "Fleet Total Stable Clusters (24h)",
       "transformations": [
         {
           "id": "merge",
@@ -128,8 +129,9 @@
         {
           "id": "reduce",
           "options": {
+            "mode": "reduceFields",
             "reducers": [
-              "mean"
+              "sum"
             ]
           }
         }
@@ -141,7 +143,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Average leader changes across fleet - Target: < 5 per 24h - Average number of leader elections across all clusters in the last 24 hours. High values indicate instability.",
+      "description": "Total etcd leader changes observed across the entire fleet in the last 24 hours. Sum across regions of per-cluster max leader-change counts.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -153,15 +155,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "yellow",
-                "value": 3
+                "value": 50
               },
               {
                 "color": "red",
-                "value": 5
+                "value": 200
               }
             ]
           },
@@ -184,7 +187,7 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "sum"
           ],
           "fields": "",
           "values": false
@@ -201,14 +204,14 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg(max by (cluster) (changes(etcd_server_leader_changes_seen_total[1d])))",
+          "expr": "sum(max by (cluster) (changes(etcd_server_leader_changes_seen_total[1d])))",
           "instant": true,
-          "legendFormat": "Avg Leader Changes",
+          "legendFormat": "Total Leader Changes",
           "range": false,
           "refId": "A"
         }
       ],
-      "title": "Avg Leader Changes (24h)",
+      "title": "Fleet Total Leader Changes (24h)",
       "transformations": [
         {
           "id": "merge",
@@ -217,8 +220,9 @@
         {
           "id": "reduce",
           "options": {
+            "mode": "reduceFields",
             "reducers": [
-              "mean"
+              "sum"
             ]
           }
         }
@@ -230,7 +234,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Total clusters monitored - Shows the total number of HCP clusters with etcd metrics being collected and available for monitoring.",
+      "description": "Total number of HCP clusters across the fleet currently emitting etcd metrics. Sum of per-region cluster counts.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -264,7 +268,7 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "sum"
           ],
           "fields": "",
           "values": false
@@ -288,7 +292,7 @@
           "refId": "A"
         }
       ],
-      "title": "Total Clusters Monitored",
+      "title": "Fleet Clusters Monitored",
       "transformations": [
         {
           "id": "merge",
@@ -297,8 +301,9 @@
         {
           "id": "reduce",
           "options": {
+            "mode": "reduceFields",
             "reducers": [
-              "lastNotNull"
+              "sum"
             ]
           }
         }
@@ -310,7 +315,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Fleet-wide 99th percentile WAL fsync duration - SLO target: < 10ms - Measures how long it takes to sync write-ahead log to disk. Critical for write performance.",
+      "description": "Highest regional p99 WAL fsync duration across the fleet (max of per-region p99s). NOTE: this is NOT a true cross-region p99; PromQL cannot aggregate histograms across independent Prometheus workspaces. Use this as a \"any region degraded?\" signal. SLO target per region: < 10ms.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -353,7 +358,7 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "max"
           ],
           "fields": "",
           "values": false
@@ -377,7 +382,7 @@
           "refId": "A"
         }
       ],
-      "title": "Fleet P99 WAL Fsync Duration",
+      "title": "Worst Regional P99 WAL Fsync (5m)",
       "transformations": [
         {
           "id": "merge",
@@ -386,8 +391,9 @@
         {
           "id": "reduce",
           "options": {
+            "mode": "reduceFields",
             "reducers": [
-              "lastNotNull"
+              "max"
             ]
           }
         }
@@ -399,7 +405,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Fleet-wide 99th percentile backend commit duration - SLO target: < 25ms - Measures how long it takes to commit data to the backend database. Impacts overall write latency.",
+      "description": "Highest regional p99 backend commit duration across the fleet. NOT a true cross-region p99 (see WAL Fsync panel description). SLO target per region: < 25ms.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -442,7 +448,7 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "max"
           ],
           "fields": "",
           "values": false
@@ -466,7 +472,7 @@
           "refId": "A"
         }
       ],
-      "title": "Fleet P99 Backend Commit Duration",
+      "title": "Worst Regional P99 Backend Commit (5m)",
       "transformations": [
         {
           "id": "merge",
@@ -475,8 +481,9 @@
         {
           "id": "reduce",
           "options": {
+            "mode": "reduceFields",
             "reducers": [
-              "lastNotNull"
+              "max"
             ]
           }
         }
@@ -488,7 +495,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Fleet-wide 99th percentile peer network round-trip time - SLO target: < 50ms - Tracks network latency between etcd nodes (peers). High values cause slow replication and leader instability.",
+      "description": "Highest regional p99 etcd peer network RTT across the fleet. NOT a true cross-region p99 (see WAL Fsync panel description). SLO target per region: < 50ms.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -531,7 +538,7 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "max"
           ],
           "fields": "",
           "values": false
@@ -555,7 +562,7 @@
           "refId": "A"
         }
       ],
-      "title": "Fleet P99 Peer Network RTT",
+      "title": "Worst Regional P99 Peer RTT (5m)",
       "transformations": [
         {
           "id": "merge",
@@ -564,8 +571,9 @@
         {
           "id": "reduce",
           "options": {
+            "mode": "reduceFields",
             "reducers": [
-              "lastNotNull"
+              "max"
             ]
           }
         }
@@ -577,7 +585,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Average etcd database size across fleet - Warning: > 6GB - Shows average DB size. Large databases may need compaction and can impact performance.",
+      "description": "Largest etcd DB size observed on any cluster in any region. Useful for capacity / outlier detection.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -601,7 +609,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -620,7 +628,7 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "max"
           ],
           "fields": "",
           "values": false
@@ -637,14 +645,14 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg(max by (cluster) (etcd_mvcc_db_total_size_in_bytes))",
+          "expr": "max(max by (cluster) (etcd_mvcc_db_total_size_in_bytes))",
           "instant": true,
-          "legendFormat": "Avg DB Size",
+          "legendFormat": "Worst Cluster DB Size",
           "range": false,
           "refId": "A"
         }
       ],
-      "title": "Fleet Avg DB Size",
+      "title": "Fleet Worst Cluster DB Size",
       "transformations": [
         {
           "id": "merge",
@@ -653,8 +661,9 @@
         {
           "id": "reduce",
           "options": {
+            "mode": "reduceFields",
             "reducers": [
-              "lastNotNull"
+              "max"
             ]
           }
         }
@@ -718,7 +727,7 @@
         "sortBy": [
           {
             "desc": true,
-            "displayName": "P99 Fsync (ms)"
+            "displayName": "Value"
           }
         ]
       },
@@ -744,32 +753,6 @@
         {
           "id": "merge",
           "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true
-            },
-            "includeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "Value": "P99 Fsync (ms)",
-              "cluster": "Cluster"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": true,
-                "field": "P99 Fsync (ms)"
-              }
-            ]
-          }
         }
       ],
       "type": "table"
@@ -831,7 +814,7 @@
         "sortBy": [
           {
             "desc": true,
-            "displayName": "P99 Commit (ms)"
+            "displayName": "Value"
           }
         ]
       },
@@ -857,32 +840,6 @@
         {
           "id": "merge",
           "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true
-            },
-            "includeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "Value": "P99 Commit (ms)",
-              "cluster": "Cluster"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": true,
-                "field": "P99 Commit (ms)"
-              }
-            ]
-          }
         }
       ],
       "type": "table"
@@ -944,7 +901,7 @@
         "sortBy": [
           {
             "desc": true,
-            "displayName": "P99 RTT (ms)"
+            "displayName": "Value"
           }
         ]
       },
@@ -970,32 +927,6 @@
         {
           "id": "merge",
           "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true
-            },
-            "includeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "Value": "P99 RTT (ms)",
-              "cluster": "Cluster"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": true,
-                "field": "P99 RTT (ms)"
-              }
-            ]
-          }
         }
       ],
       "type": "table"
@@ -1024,15 +955,20 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "yellow"
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
               },
               {
                 "color": "red",
-                "value": 2
+                "value": 10
               }
             ]
           },
-          "unit": "percent"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -1057,7 +993,7 @@
         "sortBy": [
           {
             "desc": true,
-            "displayName": "Changes/Hour"
+            "displayName": "Value"
           }
         ]
       },
@@ -1083,32 +1019,6 @@
         {
           "id": "merge",
           "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true
-            },
-            "includeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "Value": "Changes/Hour",
-              "cluster": "Cluster"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": true,
-                "field": "Failure Rate (%)"
-              }
-            ]
-          }
         }
       ],
       "type": "table"
@@ -1183,7 +1093,7 @@
         "sortBy": [
           {
             "desc": true,
-            "displayName": "Leader Changes (24h)"
+            "displayName": "Value"
           }
         ]
       },
@@ -1209,32 +1119,6 @@
         {
           "id": "merge",
           "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true
-            },
-            "includeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "Value": "Leader Changes (24h)",
-              "cluster": "Cluster Name"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": true,
-                "field": "Leader Changes (24h)"
-              }
-            ]
-          }
         }
       ],
       "type": "table"
@@ -1309,7 +1193,7 @@
         "sortBy": [
           {
             "desc": true,
-            "displayName": "Leader Changes (24h)"
+            "displayName": "Value"
           }
         ]
       },
@@ -1335,32 +1219,6 @@
         {
           "id": "merge",
           "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true
-            },
-            "includeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "Value": "Leader Changes (24h)",
-              "cluster": "Cluster Name"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": true,
-                "field": "Leader Changes (24h)"
-              }
-            ]
-          }
         }
       ],
       "type": "table"
@@ -1521,20 +1379,6 @@
         {
           "id": "merge",
           "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true
-            },
-            "indexByName": {},
-            "renameByName": {
-              "Value #A": "Stable (≤5 changes/24h)",
-              "Value #B": "High Churn (>10 changes/24h)",
-              "Value #C": "Unstable (>5 changes/24h)"
-            }
-          }
         }
       ],
       "type": "table"
@@ -1817,7 +1661,7 @@
         "sortBy": [
           {
             "desc": true,
-            "displayName": "DB Size (bytes)"
+            "displayName": "Value"
           }
         ]
       },
@@ -1843,32 +1687,6 @@
         {
           "id": "merge",
           "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true
-            },
-            "includeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "Value": "DB Size (bytes)",
-              "cluster": "Cluster Name"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": true,
-                "field": "DB Size (bytes)"
-              }
-            ]
-          }
         }
       ],
       "type": "table"
@@ -1878,7 +1696,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Fleet disk performance trends (P99) - Shows WAL fsync and backend commit latency trends over time. SLO thresholds displayed as reference lines.",
+      "description": "Per-cluster p99 disk latency (WAL fsync and backend commit) across the fleet, one line per cluster. Cluster IDs are unique fleet-wide.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2024,9 +1842,9 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster!=\"\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster!=\"\"}[5m])) by (le, cluster)) * 1000",
           "instant": false,
-          "legendFormat": "WAL Fsync P99",
+          "legendFormat": "{{cluster}} WAL Fsync P99",
           "range": true,
           "refId": "A"
         },
@@ -2036,21 +1854,15 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster!=\"\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster!=\"\"}[5m])) by (le, cluster)) * 1000",
           "hide": false,
           "instant": false,
-          "legendFormat": "Backend Commit P99",
+          "legendFormat": "{{cluster}} Backend Commit P99",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Fleet Disk Performance (P99)",
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {}
-        }
-      ],
+      "title": "Fleet Disk Performance P99 (per-cluster lines)",
       "type": "timeseries"
     },
     {
@@ -2058,7 +1870,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Fleet network performance trends (P99) - Shows peer-to-peer network latency trends over time. Spikes indicate network issues affecting raft consensus.",
+      "description": "Per-cluster p99 etcd peer-network RTT across the fleet, one line per cluster.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2145,20 +1957,14 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_network_peer_round_trip_time_seconds_bucket{cluster!=\"\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_network_peer_round_trip_time_seconds_bucket{cluster!=\"\"}[5m])) by (le, cluster)) * 1000",
           "instant": false,
-          "legendFormat": "Peer RTT P99",
+          "legendFormat": "{{cluster}} Peer RTT P99",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Fleet Network Performance (P99)",
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {}
-        }
-      ],
+      "title": "Fleet Network Performance P99 (per-cluster lines)",
       "type": "timeseries"
     },
     {
@@ -2296,9 +2102,9 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(rate(etcd_server_proposals_failed_total{cluster!=\"\"}[5m]))",
+          "expr": "sum by (cluster) (rate(etcd_server_proposals_failed_total{cluster!=\"\"}[5m]))",
           "instant": false,
-          "legendFormat": "Failed",
+          "legendFormat": "{{cluster}} Failed",
           "range": true,
           "refId": "A"
         },
@@ -2308,10 +2114,10 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(rate(etcd_server_proposals_committed_total{cluster!=\"\"}[5m]))",
+          "expr": "sum by (cluster) (rate(etcd_server_proposals_committed_total{cluster!=\"\"}[5m]))",
           "hide": false,
           "instant": false,
-          "legendFormat": "Committed",
+          "legendFormat": "{{cluster}} Committed",
           "range": true,
           "refId": "B"
         },
@@ -2321,21 +2127,15 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(rate(etcd_server_proposals_applied_total{cluster!=\"\"}[5m]))",
+          "expr": "sum by (cluster) (rate(etcd_server_proposals_applied_total{cluster!=\"\"}[5m]))",
           "hide": false,
           "instant": false,
-          "legendFormat": "Applied",
+          "legendFormat": "{{cluster}} Applied",
           "range": true,
           "refId": "C"
         }
       ],
-      "title": "Fleet Proposal Metrics",
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {}
-        }
-      ],
+      "title": "Fleet Proposal Metrics (per-cluster lines)",
       "type": "timeseries"
     }
   ],
@@ -2344,7 +2144,8 @@
   "tags": [
     "etcd",
     "fleet",
-    "health"
+    "health",
+    "summary"
   ],
   "templating": {
     "list": [
@@ -2360,7 +2161,8 @@
         "query": "prometheus",
         "refresh": 1,
         "regex": "^Managed_Prometheus_hcps-.*$",
-        "type": "datasource"
+        "type": "datasource",
+        "multi": true
       }
     ]
   },

--- a/observability/observability.yaml
+++ b/observability/observability.yaml
@@ -55,7 +55,5 @@ grafana-dashboards:
     path: ./grafana-dashboards/kas-monitor
   - name: HCP Kube API Server KSM
     path: ./grafana-dashboards/kas-ksm-monitor
-  - name: User Journey
-    path: ./grafana-dashboards/user-journey
   - name: SRE User Journey
     path: ./grafana-dashboards/sre/user-journey


### PR DESCRIPTION
### What

Rebuild `etcd-availability` as a fleet summary and move it to `observability/grafana-dashboards/sre/user-journey/`.

### Why

Each stat panel rendered as N unlabeled tiles in prod (one per regional HCP Prom workspace) because Mixed datasource + multi-select All fanned queries out with no reduction step.

- Stat panels: `[merge, reduce reduceFields <sum|max>]` collapses N regional frames into one tile.
- Tables: `merge` unions per-region rows; sort fields fixed.
- Timeseries: `{{cluster}}` legend; p99 panels aggregate `by (le, cluster)`.
- Stale per-region thresholds and legendFormats recalibrated.
- Worst Regional P99 documented honestly (not a true fleet p99; PromQL cannot federate histograms across independent workspaces).
- `observability.yaml` retargets the User Journey folder to the new path.

### Testing

`make -C observability verify` passes. JSON valid at schemaVersion 41. Confirmed in dev Grafana that each stat tile renders as a single number; warning triangles in dev are the documented stale-datasource hazard, not a dashboard issue.

### Special notes for your reviewer

The Worst Regional P99 tiles use Reduce(max) across per-region p99s. This is the only mathematically defensible single-number representation without federation infra (Thanos/Mimir). Called out in the Dashboard Info panel.
