### PR TITLE
extended maxCount of MC userAgentPool

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1247,7 +1247,7 @@ clouds:
             maxCount: 4
             poolCount: 1
           userAgentPool:
-            maxCount: 14
+            maxCount: 15
             vmSize: 'Standard_D4s_v3'
             osDiskSizeGB: 100
             secondaryNicCount: 1
@@ -1606,7 +1606,7 @@ clouds:
                 osDiskSizeGB: 32
                 vmSize: Standard_D4ds_v6
               userAgentPool:
-                maxCount: 14
+                maxCount: 15
                 minCount: 3
                 osDiskSizeGB: 100
                 vmSize: Standard_D16ds_v6
@@ -1701,7 +1701,7 @@ clouds:
                 osDiskSizeGB: 32
                 vmSize: Standard_D4ds_v6
               userAgentPool:
-                maxCount: 14
+                maxCount: 15
                 minCount: 3
                 osDiskSizeGB: 100
                 vmSize: Standard_D16ds_v6

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -609,7 +609,7 @@ mgmt:
       zoneRedundantMode: Auto
       zones: ""
     userAgentPool:
-      maxCount: 14
+      maxCount: 15
       minCount: 3
       name: userswft
       osDiskSizeGB: 100

--- a/config/rendered/dev/prow/centralus.yaml
+++ b/config/rendered/dev/prow/centralus.yaml
@@ -609,7 +609,7 @@ mgmt:
       zoneRedundantMode: Auto
       zones: ""
     userAgentPool:
-      maxCount: 14
+      maxCount: 15
       minCount: 3
       name: userswft
       osDiskSizeGB: 100


### PR DESCRIPTION
To support swiftv2 networking for ARO-HCP

### What

Extend maxCount of userAgentPool to 15 per region, so it can scale up to 45 nodes for HCP.

### Why

- With Swift networking in ARO-HCP, each node is limited to a maximum of 7 NICs, which effectively limits it to hosting up to 7 router pods per node.
- Each HCP deploys 3 router replicas, so 100 HCPs result in 300 router pods.
- With a placement limit of 7 router pods per node, this requires approximately 300 / 7 ≈ 43 nodes.
- Therefore, we need more than 14 replicas per region in the userAgentPool to accommodate the router pod distribution safely.

For this - https://redhat.atlassian.net/browse/ARO-27392

cc: @geoberle @stevekuznetsov 