### PR TITLE
delete red hat openshift SALs during RG clean up

### DIFF
--- a/docs/ci/cleanup.md
+++ b/docs/ci/cleanup.md
@@ -130,6 +130,18 @@ In DEV and other `no-rp` situations, that owner may already be gone or unavailab
 
 So the difference is not "DEV is special" for its own sake. The difference is whether there is still a live owner for managed resource-group deletion.
 
+### Why dev cleanup actively deletes service association links but public-cloud cleanup does not
+
+Service association links (SALs) are created by Azure when a subnet is delegated to a service. When a cluster uses a delegated customer subnet, Azure creates a SAL linking the subnet to the cluster resource.
+
+In public cloud, SALs are part of the cluster lifecycle owned by the RP. The correct behavior is to delete the cluster through the RP and expect Azure to remove the SAL as a consequence of that deletion.
+
+If SALs are left behind in public cloud, that is a signal that the RP did not complete deletion correctly. The cleanup framework treats that as meaningful signal, not something to silently clean up.
+
+In dev and other `no-rp` situations, the RP may already be torn down. In dev e2e CI, each job spins up a fresh RP and tears it down after the run. If a SAL is orphaned and there is no RP left to clean it up, it blocks resource-group deletion with `InUseSubnetCannotBeDeleted` errors.
+
+That is why the `no-rp` cleanup mode includes an optional FPA-authenticated SAL deletion step. When the RP is unavailable, cleanup deletes orphaned SALs directly before deleting the resource group. This requires FPA credentials because standard service principals lack permission to delete SALs.
+
 ## How Each Path Works
 
 ### E2E test teardown

--- a/test/cmd/aro-hcp-tests/cleanup/cmd.go
+++ b/test/cmd/aro-hcp-tests/cleanup/cmd.go
@@ -128,6 +128,9 @@ func newCleanupResourceGroupsCommand() *cobra.Command {
 	cmd.Flags().StringArrayVar(&rawOpt.ExcludeLocations, "exclude-location", rawOpt.ExcludeLocations, "Do not delete resource groups in these Azure locations (repeatable)")
 	cmd.Flags().BoolVar(&rawOpt.Tracked, "tracked", rawOpt.Tracked, "Use tracked resource groups")
 	cmd.Flags().StringVar(&rawOpt.SharedDir, "shared-dir", rawOpt.SharedDir, "Shared directory to use for tracked resource groups")
+	cmd.Flags().StringVar(&rawOpt.FPAClientID, "fpa-client-id", rawOpt.FPAClientID, "Client ID of the FPA used to delete Red Hat OpenShift service association links")
+	cmd.Flags().StringVar(&rawOpt.FPATenantID, "fpa-tenant-id", rawOpt.FPATenantID, "Tenant ID of the FPA used to delete Red Hat OpenShift service association links")
+	cmd.Flags().StringVar(&rawOpt.FPACertPath, "fpa-cert-path", rawOpt.FPACertPath, "Certificate path of the FPA used to delete Red Hat OpenShift service association links")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)

--- a/test/cmd/aro-hcp-tests/cleanup/cmd.go
+++ b/test/cmd/aro-hcp-tests/cleanup/cmd.go
@@ -129,7 +129,6 @@ func newCleanupResourceGroupsCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&rawOpt.Tracked, "tracked", rawOpt.Tracked, "Use tracked resource groups")
 	cmd.Flags().StringVar(&rawOpt.SharedDir, "shared-dir", rawOpt.SharedDir, "Shared directory to use for tracked resource groups")
 	cmd.Flags().StringVar(&rawOpt.FPAClientID, "fpa-client-id", rawOpt.FPAClientID, "Client ID of the FPA used to delete Red Hat OpenShift service association links")
-	cmd.Flags().StringVar(&rawOpt.FPATenantID, "fpa-tenant-id", rawOpt.FPATenantID, "Tenant ID of the FPA used to delete Red Hat OpenShift service association links")
 	cmd.Flags().StringVar(&rawOpt.FPACertPath, "fpa-cert-path", rawOpt.FPACertPath, "Certificate path of the FPA used to delete Red Hat OpenShift service association links")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/test/util/cleanup/resourcegroups/options.go
+++ b/test/util/cleanup/resourcegroups/options.go
@@ -37,6 +37,9 @@ type RawOptions struct {
 	ExcludeLocations []string
 	Tracked          bool
 	SharedDir        string
+	FPAClientID      string
+	FPATenantID      string
+	FPACertPath      string
 }
 
 // validatedOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
@@ -59,6 +62,9 @@ type completedOptions struct {
 	CleanupWorkflow  framework.CleanupWorkflow
 	DeleteExpired    bool
 	EvaluationTime   time.Time
+	FPAClientID      string
+	FPATenantID      string
+	FPACertPath      string
 }
 
 type Options struct {
@@ -78,6 +84,9 @@ func DefaultOptions() *RawOptions {
 		ExcludeLocations: []string{},
 		Tracked:          false,
 		SharedDir:        framework.SharedDir(),
+		FPAClientID:      "",
+		FPATenantID:      "",
+		FPACertPath:      "",
 	}
 }
 
@@ -141,6 +150,30 @@ func (o *RawOptions) Validate() (*ValidatedOptions, error) {
 		if group.oneOfGroup && group.seenFlags.Len() == 0 {
 			return nil, fmt.Errorf("one of %s is required", group.memberFlags.UnsortedList())
 		}
+	}
+
+	fpaFlags := []struct {
+		flag  string
+		value string
+	}{
+		{flag: "--fpa-client-id", value: o.FPAClientID},
+		{flag: "--fpa-tenant-id", value: o.FPATenantID},
+		{flag: "--fpa-cert-path", value: o.FPACertPath},
+	}
+
+	var seenFPAFlags []string
+	var missingFPAFlags []string
+
+	for _, item := range fpaFlags {
+		if item.value != "" {
+			seenFPAFlags = append(seenFPAFlags, item.flag)
+		} else {
+			missingFPAFlags = append(missingFPAFlags, item.flag)
+		}
+	}
+
+	if len(seenFPAFlags) > 0 && len(missingFPAFlags) > 0 {
+		return nil, fmt.Errorf("%v must be provided together; got %v, missing %v", []string{"--fpa-client-id", "--fpa-tenant-id", "--fpa-cert-path"}, seenFPAFlags, missingFPAFlags)
 	}
 
 	return &ValidatedOptions{
@@ -211,6 +244,9 @@ func (o *ValidatedOptions) Complete() (*Options, error) {
 			ExcludeLocations: sets.New(o.ExcludeLocations...),
 			DeleteExpired:    o.DeleteExpired,
 			EvaluationTime:   evalTime,
+			FPAClientID:      o.FPAClientID,
+			FPATenantID:      o.FPATenantID,
+			FPACertPath:      o.FPACertPath,
 		},
 	}, nil
 }

--- a/test/util/cleanup/resourcegroups/options.go
+++ b/test/util/cleanup/resourcegroups/options.go
@@ -38,7 +38,6 @@ type RawOptions struct {
 	Tracked          bool
 	SharedDir        string
 	FPAClientID      string
-	FPATenantID      string
 	FPACertPath      string
 }
 
@@ -63,7 +62,6 @@ type completedOptions struct {
 	DeleteExpired    bool
 	EvaluationTime   time.Time
 	FPAClientID      string
-	FPATenantID      string
 	FPACertPath      string
 }
 
@@ -85,7 +83,6 @@ func DefaultOptions() *RawOptions {
 		Tracked:          false,
 		SharedDir:        framework.SharedDir(),
 		FPAClientID:      "",
-		FPATenantID:      "",
 		FPACertPath:      "",
 	}
 }
@@ -157,7 +154,6 @@ func (o *RawOptions) Validate() (*ValidatedOptions, error) {
 		value string
 	}{
 		{flag: "--fpa-client-id", value: o.FPAClientID},
-		{flag: "--fpa-tenant-id", value: o.FPATenantID},
 		{flag: "--fpa-cert-path", value: o.FPACertPath},
 	}
 
@@ -173,7 +169,7 @@ func (o *RawOptions) Validate() (*ValidatedOptions, error) {
 	}
 
 	if len(seenFPAFlags) > 0 && len(missingFPAFlags) > 0 {
-		return nil, fmt.Errorf("%v must be provided together; got %v, missing %v", []string{"--fpa-client-id", "--fpa-tenant-id", "--fpa-cert-path"}, seenFPAFlags, missingFPAFlags)
+		return nil, fmt.Errorf("%v must be provided together; got %v, missing %v", []string{"--fpa-client-id", "--fpa-cert-path"}, seenFPAFlags, missingFPAFlags)
 	}
 
 	return &ValidatedOptions{
@@ -245,7 +241,6 @@ func (o *ValidatedOptions) Complete() (*Options, error) {
 			DeleteExpired:    o.DeleteExpired,
 			EvaluationTime:   evalTime,
 			FPAClientID:      o.FPAClientID,
-			FPATenantID:      o.FPATenantID,
 			FPACertPath:      o.FPACertPath,
 		},
 	}, nil

--- a/test/util/cleanup/resourcegroups/run.go
+++ b/test/util/cleanup/resourcegroups/run.go
@@ -102,7 +102,6 @@ func (o *Options) Run(ctx context.Context) error {
 		CleanupWorkflow:    o.CleanupWorkflow,
 		FPACredentials: framework.FPACredentials{
 			ClientID: o.FPAClientID,
-			TenantID: o.FPATenantID,
 			CertPath: o.FPACertPath,
 		},
 	}

--- a/test/util/cleanup/resourcegroups/run.go
+++ b/test/util/cleanup/resourcegroups/run.go
@@ -100,6 +100,11 @@ func (o *Options) Run(ctx context.Context) error {
 		ResourceGroupNames: resourceGroupsToDelete,
 		Timeout:            o.Timeout,
 		CleanupWorkflow:    o.CleanupWorkflow,
+		FPACredentials: framework.FPACredentials{
+			ClientID: o.FPAClientID,
+			TenantID: o.FPATenantID,
+			CertPath: o.FPACertPath,
+		},
 	}
 
 	err := tc.CleanupResourceGroups(

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -318,12 +318,11 @@ func isIgnorableResourceGroupCleanupError(err error) bool {
 
 type FPACredentials struct {
 	ClientID string
-	TenantID string
 	CertPath string
 }
 
 func (c FPACredentials) IsConfigured() bool {
-	return c.ClientID != "" && c.TenantID != "" && c.CertPath != ""
+	return c.ClientID != "" && c.CertPath != ""
 }
 
 type CleanupWorkflow string

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -554,13 +554,6 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 		ginkgo.GinkgoLogr.Info("no left behind managed resource groups found", "resourceGroup", resourceGroupName)
 	}
 
-	if fpaCredentials.IsConfigured() {
-		ginkgo.GinkgoLogr.Info("deleting any remaining RedHatOpenShift service association links in resource group", "resourceGroup", resourceGroupName)
-		if err := tc.deleteRedHatOpenShiftServiceAssociationLinks(ctx, resourceGroupName, fpaCredentials); err != nil {
-			return fmt.Errorf("failed to delete RedHatOpenShift service association links in %q: %w", resourceGroupName, err)
-		}
-	}
-
 	ginkgo.GinkgoLogr.Info("deleting resource group", "resourceGroup", resourceGroupName)
 	if err := DeleteResourceGroup(ctx, resourceClientFactory.NewResourceGroupsClient(), networkClientFactory, resourceGroupName, false, timeout); err != nil {
 		return fmt.Errorf("failed to cleanup resource group: %w", err)

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -352,7 +352,7 @@ func (tc *perItOrDescribeTestContext) CleanupResourceGroups(ctx context.Context,
 
 			switch opts.CleanupWorkflow {
 			case CleanupWorkflowStandard:
-				if err := tc.cleanupResourceGroup(ctx, currResourceGroupName, opts.Timeout, opts.FPACredentials); err != nil {
+				if err := tc.cleanupResourceGroup(ctx, currResourceGroupName, opts.Timeout); err != nil {
 					errCh <- err
 				}
 			case CleanupWorkflowNoRP:
@@ -500,7 +500,7 @@ func (tc *perItOrDescribeTestContext) waitForManagedResourceGroupsDeletion(ctx c
 // 1. delete all HCP clusters via the RP and wait for success
 // 2. wait for any managed resource groups to be deleted
 // 3. delete the resource group
-func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, resourceGroupName string, timeout time.Duration, fpaCredentials FPACredentials) error {
+func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, resourceGroupName string, timeout time.Duration) error {
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -316,6 +316,16 @@ func isIgnorableResourceGroupCleanupError(err error) bool {
 	return isResourceGroupNotFoundError(err)
 }
 
+type FPACredentials struct {
+	ClientID string
+	TenantID string
+	CertPath string
+}
+
+func (c FPACredentials) IsConfigured() bool {
+	return c.ClientID != "" && c.TenantID != "" && c.CertPath != ""
+}
+
 type CleanupWorkflow string
 
 const (
@@ -327,6 +337,7 @@ type CleanupResourceGroupsOptions struct {
 	ResourceGroupNames []string
 	Timeout            time.Duration
 	CleanupWorkflow    CleanupWorkflow
+	FPACredentials     FPACredentials
 }
 
 func (tc *perItOrDescribeTestContext) CleanupResourceGroups(ctx context.Context, opts CleanupResourceGroupsOptions) error {
@@ -342,11 +353,11 @@ func (tc *perItOrDescribeTestContext) CleanupResourceGroups(ctx context.Context,
 
 			switch opts.CleanupWorkflow {
 			case CleanupWorkflowStandard:
-				if err := tc.cleanupResourceGroup(ctx, currResourceGroupName, opts.Timeout); err != nil {
+				if err := tc.cleanupResourceGroup(ctx, currResourceGroupName, opts.Timeout, opts.FPACredentials); err != nil {
 					errCh <- err
 				}
 			case CleanupWorkflowNoRP:
-				if err := tc.cleanupResourceGroupNoRP(ctx, currResourceGroupName, opts.Timeout); err != nil {
+				if err := tc.cleanupResourceGroupNoRP(ctx, currResourceGroupName, opts.Timeout, opts.FPACredentials); err != nil {
 					errCh <- err
 				}
 			}
@@ -490,7 +501,7 @@ func (tc *perItOrDescribeTestContext) waitForManagedResourceGroupsDeletion(ctx c
 // 1. delete all HCP clusters via the RP and wait for success
 // 2. wait for any managed resource groups to be deleted
 // 3. delete the resource group
-func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, resourceGroupName string, timeout time.Duration) error {
+func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, resourceGroupName string, timeout time.Duration, fpaCredentials FPACredentials) error {
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
@@ -544,6 +555,13 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 		ginkgo.GinkgoLogr.Info("no left behind managed resource groups found", "resourceGroup", resourceGroupName)
 	}
 
+	if fpaCredentials.IsConfigured() {
+		ginkgo.GinkgoLogr.Info("deleting any remaining RedHatOpenShift service association links in resource group", "resourceGroup", resourceGroupName)
+		if err := tc.deleteRedHatOpenShiftServiceAssociationLinks(ctx, resourceGroupName, fpaCredentials); err != nil {
+			return fmt.Errorf("failed to delete RedHatOpenShift service association links in %q: %w", resourceGroupName, err)
+		}
+	}
+
 	ginkgo.GinkgoLogr.Info("deleting resource group", "resourceGroup", resourceGroupName)
 	if err := DeleteResourceGroup(ctx, resourceClientFactory.NewResourceGroupsClient(), networkClientFactory, resourceGroupName, false, timeout); err != nil {
 		return fmt.Errorf("failed to cleanup resource group: %w", err)
@@ -559,7 +577,7 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 //  1. discovers any "managed" resource groups whose ManagedBy references a resource in the parent
 //     resource group and deletes them (using 'force' to speed up VM/VMSS deletion).
 //  2. deletes the parent resource group itself.
-func (tc *perItOrDescribeTestContext) cleanupResourceGroupNoRP(ctx context.Context, resourceGroupName string, timeout time.Duration) error {
+func (tc *perItOrDescribeTestContext) cleanupResourceGroupNoRP(ctx context.Context, resourceGroupName string, timeout time.Duration, fpaCredentials FPACredentials) error {
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
@@ -589,6 +607,13 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroupNoRP(ctx context.Conte
 			} else {
 				return fmt.Errorf("failed to cleanup managed resource group %q: %w", managedRG, err)
 			}
+		}
+	}
+
+	if fpaCredentials.IsConfigured() {
+		ginkgo.GinkgoLogr.Info("deleting any remaining RedHatOpenShift service association links in resource group", "resourceGroup", resourceGroupName)
+		if err := tc.deleteRedHatOpenShiftServiceAssociationLinks(ctx, resourceGroupName, fpaCredentials); err != nil {
+			return fmt.Errorf("failed to delete RedHatOpenShift service association links in %q: %w", resourceGroupName, err)
 		}
 	}
 

--- a/test/util/framework/serviceassociationlink_helper.go
+++ b/test/util/framework/serviceassociationlink_helper.go
@@ -1,0 +1,182 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+
+	"github.com/Azure/ARO-HCP/internal/certificate"
+	"github.com/Azure/ARO-HCP/internal/fpa"
+)
+
+const (
+	redHatOpenShiftSALName           = "RedHatOpenShift"
+	redHatOpenShiftLinkedResource    = "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+	serviceAssociationLinkAPIVersion = "2021-08-01"
+)
+
+func (tc *perItOrDescribeTestContext) deleteRedHatOpenShiftServiceAssociationLinks(
+	ctx context.Context,
+	resourceGroupName string,
+	creds FPACredentials,
+) error {
+	if !creds.IsConfigured() {
+		return nil
+	}
+
+	networkClientFactory, err := tc.GetARMNetworkClientFactory(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get ARM network client factory: %w", err)
+	}
+
+	fpaResourcesClient, err := tc.newFPAResourcesClient(ctx, creds)
+	if err != nil {
+		return fmt.Errorf("failed to create FPA resources client: %w", err)
+	}
+
+	return deleteRedHatOpenShiftSALs(ctx, networkClientFactory, fpaResourcesClient, resourceGroupName)
+}
+
+func (tc *perItOrDescribeTestContext) newFPAResourcesClient(
+	ctx context.Context,
+	creds FPACredentials,
+) (*armresources.Client, error) {
+	certReader := certificate.NewAzureIdentityFileReader(creds.CertPath)
+	clientOptions := tc.perBinaryInvocationTestContext.getClientFactoryOptions()
+
+	credentialRetriever, err := fpa.NewFirstPartyApplicationTokenCredentialRetriever(
+		creds.ClientID,
+		certReader,
+		clientOptions.ClientOptions,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create FPA credential retriever: %w", err)
+	}
+
+	credential, err := credentialRetriever.RetrieveCredential(creds.TenantID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve FPA credential: %w", err)
+	}
+
+	subscriptionID, err := tc.SubscriptionID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get subscription ID: %w", err)
+	}
+
+	clientFactory, err := armresources.NewClientFactory(
+		subscriptionID,
+		credential,
+		clientOptions,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create FPA ARM resources client factory: %w", err)
+	}
+
+	return clientFactory.NewClient(), nil
+}
+
+func deleteRedHatOpenShiftSALs(
+	ctx context.Context,
+	networkClientFactory *armnetwork.ClientFactory,
+	fpaResourcesClient *armresources.Client,
+	resourceGroupName string,
+) error {
+	vnetClient := networkClientFactory.NewVirtualNetworksClient()
+	subnetClient := networkClientFactory.NewSubnetsClient()
+
+	vnetPager := vnetClient.NewListPager(resourceGroupName, nil)
+	for vnetPager.More() {
+		vnetPage, err := vnetPager.NextPage(ctx)
+		if err != nil {
+			if isResourceGroupNotFoundError(err) {
+				return nil
+			}
+			return fmt.Errorf("failed listing VNets in resource group %q: %w", resourceGroupName, err)
+		}
+
+		for _, vnet := range vnetPage.Value {
+			if vnet == nil || vnet.Name == nil {
+				continue
+			}
+
+			subnetsPager := subnetClient.NewListPager(resourceGroupName, *vnet.Name, nil)
+			for subnetsPager.More() {
+				subnetPage, err := subnetsPager.NextPage(ctx)
+				if err != nil {
+					return fmt.Errorf("failed listing subnets in resource group %q VNet %q: %w", resourceGroupName, *vnet.Name, err)
+				}
+
+				for _, subnet := range subnetPage.Value {
+					if subnet == nil || subnet.ID == nil || subnet.Name == nil || subnet.Properties == nil {
+						continue
+					}
+
+					for _, sal := range subnet.Properties.ServiceAssociationLinks {
+						if sal == nil || sal.ID == nil {
+							continue
+						}
+
+						if !isRedHatOpenShiftServiceAssociationLink(sal) {
+							continue
+						}
+
+						ginkgo.GinkgoLogr.Info(
+							"deleting RedHatOpenShift service association link",
+							"resourceGroup", resourceGroupName,
+							"vnet", *vnet.Name,
+							"subnet", *subnet.Name,
+							"serviceAssociationLink", *sal.ID,
+						)
+
+						if err := deleteResourceByID(ctx, fpaResourcesClient, *sal.ID, serviceAssociationLinkAPIVersion); err != nil {
+							return fmt.Errorf("failed deleting service association link %q: %w", *sal.ID, err)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func isRedHatOpenShiftServiceAssociationLink(sal *armnetwork.ServiceAssociationLink) bool {
+	if sal == nil {
+		return false
+	}
+
+	if sal.Name != nil && strings.EqualFold(*sal.Name, redHatOpenShiftSALName) {
+		return true
+	}
+
+	if sal.Properties != nil &&
+		sal.Properties.LinkedResourceType != nil &&
+		strings.EqualFold(*sal.Properties.LinkedResourceType, redHatOpenShiftLinkedResource) {
+		return true
+	}
+
+	return false
+}
+
+func deleteResourceByID(
+	ctx context.Context,
+	client *armresources.Client,
+	resourceID string,
+	apiVersion string,
+) error {
+	poller, err := client.BeginDeleteByID(ctx, resourceID, apiVersion, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
+		Frequency: StandardPollInterval,
+	})
+	return err
+}

--- a/test/util/framework/serviceassociationlink_helper.go
+++ b/test/util/framework/serviceassociationlink_helper.go
@@ -16,11 +16,14 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -40,10 +43,6 @@ func (tc *perItOrDescribeTestContext) deleteRedHatOpenShiftServiceAssociationLin
 	resourceGroupName string,
 	creds FPACredentials,
 ) error {
-	if !creds.IsConfigured() {
-		return nil
-	}
-
 	networkClientFactory, err := tc.GetARMNetworkClientFactory(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get ARM network client factory: %w", err)
@@ -181,6 +180,19 @@ func isRedHatOpenShiftServiceAssociationLink(sal *armnetwork.ServiceAssociationL
 	return false
 }
 
+func isResourceNotFoundError(err error) bool {
+	var responseErr *azcore.ResponseError
+	if errors.As(err, &responseErr) {
+		if responseErr.StatusCode == http.StatusNotFound {
+			return true
+		}
+		if responseErr.ErrorCode == "ResourceNotFound" {
+			return true
+		}
+	}
+	return false
+}
+
 func deleteResourceByID(
 	ctx context.Context,
 	client *armresources.Client,
@@ -189,11 +201,19 @@ func deleteResourceByID(
 ) error {
 	poller, err := client.BeginDeleteByID(ctx, resourceID, apiVersion, nil)
 	if err != nil {
+		// If the resource is already deleted (404), treat as success
+		if isResourceNotFoundError(err) {
+			return nil
+		}
 		return err
 	}
 
 	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
 		Frequency: StandardPollInterval,
 	})
+	if err != nil && isResourceNotFoundError(err) {
+		// Resource was deleted during polling
+		return nil
+	}
 	return err
 }

--- a/test/util/framework/serviceassociationlink_helper.go
+++ b/test/util/framework/serviceassociationlink_helper.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package framework
 
 import (
@@ -109,6 +123,9 @@ func deleteRedHatOpenShiftSALs(
 			for subnetsPager.More() {
 				subnetPage, err := subnetsPager.NextPage(ctx)
 				if err != nil {
+					if isResourceGroupNotFoundError(err) {
+						return nil
+					}
 					return fmt.Errorf("failed listing subnets in resource group %q VNet %q: %w", resourceGroupName, *vnet.Name, err)
 				}
 

--- a/test/util/framework/serviceassociationlink_helper.go
+++ b/test/util/framework/serviceassociationlink_helper.go
@@ -73,7 +73,7 @@ func (tc *perItOrDescribeTestContext) newFPAResourcesClient(
 		return nil, fmt.Errorf("failed to create FPA credential retriever: %w", err)
 	}
 
-	credential, err := credentialRetriever.RetrieveCredential(creds.TenantID)
+	credential, err := credentialRetriever.RetrieveCredential(tc.TenantID())
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve FPA credential: %w", err)
 	}


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://redhat.atlassian.net/browse/ARO-26088

### What

<!-- Briefly describe what this PR does -->
Adds optional FPA authenticated cleanup for dangling Red Hat OpenShift service association links before deleting resource groups.

When the new FPA flags are provided, resource group cleanup discovers Red Hat OpenShift SALs under VNets/subnets and deletes them using an FPA authenticated ARM client before continuing with the existing resource group deletion flow.

When the FPA flags are not provided, cleanup behavior remains unchanged.

### Why

<!-- Briefly explain why this change is needed -->
Expired e2e/dev resource group cleanup can fail when a customer integration subnet still contains a dangling `RedHatOpenShift` service association link. Azure then blocks subnet/VNet/RG deletion with `InUseSubnetCannotBeDeleted`.

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->
```bash
go test -run '^$' -v \
  ./test/util/framework/... \
  ./test/util/cleanup/resourcegroups/... \
  ./test/cmd/aro-hcp-tests/cleanup/...

go run ./test/cmd/aro-hcp-tests cleanup resource-groups --help | grep fpa
```

### Special notes for your reviewer

<!-- optional -->

After this ARO-HCP PR is up, the next PR is the `openshift/release` wiring:

```text
download firstPartyCert2 to a temp file
pass --fpa-client-id
pass --fpa-tenant-id
pass --fpa-cert-path
```

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
