### PR TITLE
resilient datadumper + migratecosmosordie timeout bump

### DIFF
--- a/frontend/deploy/templates/_helpers.tpl
+++ b/frontend/deploy/templates/_helpers.tpl
@@ -94,6 +94,12 @@ spec:
           - name: mdsd-asa-run-vol
             mountPath: /var/run/mdsd
         {{- end }}
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+          periodSeconds: 10
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz

--- a/frontend/pipeline.yaml
+++ b/frontend/pipeline.yaml
@@ -61,6 +61,7 @@ resourceGroups:
   - name: deploy
     aksCluster: '{{ .svc.aks.name }}'
     action: Helm
+    timeout: 10m
     releaseName: 'aro-hcp-frontend-dev'
     releaseNamespace: '{{ .frontend.k8s.namespace }}'
     chartDir: ./deploy

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
@@ -187,6 +187,12 @@ spec:
         volumeMounts:
           - name: mdsd-asa-run-vol
             mountPath: /var/run/mdsd
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+          periodSeconds: 10
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
@@ -298,6 +304,12 @@ spec:
         volumeMounts:
           - name: mdsd-asa-run-vol
             mountPath: /var/run/mdsd
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+          periodSeconds: 10
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
@@ -184,6 +184,12 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+          periodSeconds: 10
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
@@ -287,6 +293,12 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+          periodSeconds: 10
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz

--- a/frontend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
+++ b/frontend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
@@ -184,6 +184,12 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+          periodSeconds: 10
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
@@ -287,6 +293,12 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+          periodSeconds: 10
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz

--- a/internal/serverutils/dump_data.go
+++ b/internal/serverutils/dump_data.go
@@ -69,7 +69,7 @@ func DumpDataToLogger(ctx context.Context, resourcesDBClient database.ResourcesD
 		currOperationTarget := strings.ToLower(operation.ExternalID.String())
 		if strings.HasPrefix(currOperationTarget, resourceIDString) {
 			logger.Info(fmt.Sprintf("dumping resourceID %v", operation.ResourceID),
-				"currentResourceID", operation.ResourceID.String(),
+				"currentResourceID", resourceIDToString(operation.ResourceID),
 				"content", operation,
 			)
 		}
@@ -79,6 +79,13 @@ func DumpDataToLogger(ctx context.Context, resourcesDBClient database.ResourcesD
 	}
 
 	return utils.TrackError(errors.Join(errs...))
+}
+
+func resourceIDToString(id *azcorearm.ResourceID) string {
+	if id == nil {
+		return "<missing>"
+	}
+	return id.String()
 }
 
 // DumpBillingToLogger dumps active billing documents for the given cluster resource ID to the logger.


### PR DESCRIPTION
### What

* Fix nil-pointer panic in datadumper: Operations without a ResourceID cause a nil dereference when calling .String() during data dumping. Added a nil-safe helper that returns a placeholder string instead of panicking.
* add MigrateCosmosOrDie timeout  by adding a startup probe

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
