### PR TITLE
fix: increase desired version resolution timeout from 29s to 5m (AROSLSRE-858)

### DIFF
--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
@@ -217,21 +217,24 @@ func (c *operationClusterUpdate) desiredVersionResolutionOperationState(ctx cont
 	if intentFailedCondition == nil || intentFailedCondition.Status != metav1.ConditionTrue || intentFailedCondition.Reason != api.VersionUpgradeNotAcceptedReason {
 		// Customer desired minor differs from the service provider resolved version, and the
 		// ControlPlaneDesiredVersion controller has not yet set IntentFailed (VersionUpgradeNotAccepted).
-		// Stay Accepted while resolution runs; fail once elapsed exceeds 29s from the first
+		// Stay Accepted while resolution runs; fail once elapsed exceeds the timeout from the first
 		// time this process observed the mismatch for this operation, so a
 		// controller restart does not immediately fail long-running operations.
+		// The timeout must be long enough for the ControlPlaneDesiredVersion controller
+		// (which runs every 5 minutes) to reconcile and resolve the version.
+		const desiredVersionResolutionTimeout = 5 * time.Minute
 		pending := newOperationState(arm.ProvisioningStateAccepted, "customer desired version does not match resolved desired version")
 		firstSeen, ok := c.desiredVersionMismatchFirstSeen.Get(operation.ResourceID.String())
 		if !ok {
 			c.desiredVersionMismatchFirstSeen.Add(operation.ResourceID.String(), c.clock.Now())
 			return pending, nil
 		}
-		if c.clock.Since(firstSeen.(time.Time)) <= 29*time.Second {
+		if c.clock.Since(firstSeen.(time.Time)) <= desiredVersionResolutionTimeout {
 			return pending, nil
 		}
 		msg := fmt.Sprintf(
-			"timed out after 29s waiting for resolution of desired version from '%s' cluster version",
-			existingCluster.CustomerProperties.Version.ID,
+			"timed out after %s waiting for resolution of desired version from '%s' cluster version",
+			desiredVersionResolutionTimeout, existingCluster.CustomerProperties.Version.ID,
 		)
 		c.desiredVersionMismatchFirstSeen.Remove(operation.ResourceID.String())
 		return newOperationState(arm.ProvisioningStateFailed, msg), nil

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
@@ -154,10 +154,10 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:                    "customer minor mismatch without ControlPlaneDesiredVersion IntentFailed leaves operation accepted when first seen within 29s",
+			name:                    "customer minor mismatch without ControlPlaneDesiredVersion IntentFailed leaves operation accepted when first seen within 5m",
 			clusterState:            arohcpv1alpha1.ClusterStateReady,
 			customerVersionID:       "4.20",
-			seedMismatchFirstSeenAt: testClockNow.Add(-20 * time.Second),
+			seedMismatchFirstSeenAt: testClockNow.Add(-4 * time.Minute),
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
@@ -171,10 +171,10 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:                    "customer minor mismatch without IntentFailed fails when mismatch first seen exceeds 29s",
+			name:                    "customer minor mismatch without IntentFailed fails when mismatch first seen exceeds 5m",
 			clusterState:            arohcpv1alpha1.ClusterStateReady,
 			customerVersionID:       "4.20",
-			seedMismatchFirstSeenAt: testClockNow.Add(-30 * time.Second),
+			seedMismatchFirstSeenAt: testClockNow.Add(-6 * time.Minute),
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				require.NoError(t, err)
 				wantMsg := fmt.Sprintf(
-					"timed out after 29s waiting for resolution of desired version from '%s' cluster version",
+					"timed out after 5m0s waiting for resolution of desired version from '%s' cluster version",
 					cluster.CustomerProperties.Version.ID,
 				)
 				assert.Equal(t, wantMsg, op.Error.Message)


### PR DESCRIPTION
[AROSLSRE-858](https://redhat.atlassian.net/browse/AROSLSRE-858)

### What

Increase the desired version resolution timeout from 29s to 5 minutes in the `operationClusterUpdate` controller.

### Why

The `ControlPlaneDesiredVersion` controller runs every 5 minutes to query Cincinnati and resolve the customer's desired minor version (e.g. `4.21`) into a target z-stream (e.g. `4.21.15`). The operation controller polls the result and fails the operation if the resolved version hasn't been written within the timeout.

The 29s timeout was too tight for a flow that depends on an async controller with a 5-minute reconcile interval. When multiple clusters upgrade in parallel (E2E runs ~13 clusters), cold Cincinnati cache hits and controller queue congestion cause the resolution to take longer than 29s.

This caused cross-environment E2E failures (11 dev, 2 INT, 1 prod) on the `Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor` test with:

```
timed out after 29s waiting for resolution of desired version from '4.21.15' cluster version
```

Cincinnati is healthy. The version and upgrade edges exist. The issue is purely timing.

### Changes

- `operation_cluster_update.go`: Bump timeout from `29*time.Second` to `5*time.Minute`, extracted to a named constant `desiredVersionResolutionTimeout`
- `operation_cluster_update_test.go`: Updated test cases to match the new timeout (4m within window, 6m exceeds window)

### Testing

- `go test ./backend/pkg/controllers/operationcontrollers/...` passes
- E2E: the affected test should stop timing out since the resolution controller has enough time to reconcile within the 5-minute window