### PR TITLE
delete orphaned operation documents from cosmos

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -485,6 +485,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		backendInformers,
 	)
 	deleteOrphanedCosmosResourcesController := mismatchcontrollers.NewDeleteOrphanedCosmosResourcesController(b.options.ResourcesDBClient, subscriptionLister)
+	deleteOrphanedOperationsController := mismatchcontrollers.NewDeleteOrphanedOperationsController(b.options.ResourcesDBClient, subscriptionLister)
 	backfillClusterUIDController := controllerutils.NewClusterWatchingController(
 		"BackfillClusterUID", b.options.ResourcesDBClient, backendInformers, 60*time.Minute,
 		mismatchcontrollers.NewBackfillClusterUIDController(utilsclock.RealClock{}, b.options.ResourcesDBClient, b.options.BillingDBClient, clusterLister))
@@ -642,6 +643,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go cosmosMatchingClusterController.Run(ctx, 20)
 				go alwaysSuccessClusterValidationController.Run(ctx, 20)
 				go deleteOrphanedCosmosResourcesController.Run(ctx, 20)
+				go deleteOrphanedOperationsController.Run(ctx, 20)
 				go backfillClusterUIDController.Run(ctx, 20)
 				go orphanedBillingCleanupController.Run(ctx, 20)
 				go createBillingDocController.Run(ctx, 20)

--- a/backend/pkg/controllers/controllerutils/cosmos.go
+++ b/backend/pkg/controllers/controllerutils/cosmos.go
@@ -55,7 +55,22 @@ func DeleteRecursively(ctx context.Context, resourcesDBClient database.Resources
 	if err != nil {
 		return utils.TrackError(err)
 	}
+	logger := utils.LoggerFromContext(ctx)
 	for _, nestedContent := range nestedContentIterator.Items(ctx) {
+		if nestedContent.ResourceID == nil {
+			// Malformed row with no addressable resourceID — we can't go through Delete (it would
+			// .String() a nil pointer). Fall back to DeleteByCosmosID so we still clean up the row
+			// rather than orphaning it under the tree we just deleted.
+			logger.Error(nil, "descendent has no resourceID; deleting by cosmosID",
+				"cosmosID", nestedContent.ID,
+				"partitionKey", nestedContent.PartitionKey,
+				"resourceType", nestedContent.ResourceType,
+			)
+			if err := untypedClient.DeleteByCosmosID(ctx, nestedContent.PartitionKey, nestedContent.ID); err != nil {
+				return utils.TrackError(fmt.Errorf("failed to delete cosmosID %q in partition %q: %w", nestedContent.ID, nestedContent.PartitionKey, err))
+			}
+			continue
+		}
 		if err := untypedClient.Delete(ctx, nestedContent.ResourceID); err != nil {
 			return utils.TrackError(fmt.Errorf("failed to delete resourceID %q: %w", nestedContent.ResourceID, err))
 		}

--- a/backend/pkg/controllers/controllerutils/cosmos_test.go
+++ b/backend/pkg/controllers/controllerutils/cosmos_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerutils
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// TestDeleteRecursively_NilResourceIDChild_DeletedByCosmosID verifies that when a descendent
+// row has no top-level resourceID (so we can't address it via Delete(*ResourceID) — that would
+// panic on the nil pointer), DeleteRecursively falls back to DeleteByCosmosID instead of
+// skipping. Otherwise the malformed row would survive the recursive delete and become an
+// orphan under a tree whose parent is gone.
+func TestDeleteRecursively_NilResourceIDChild_DeletedByCosmosID(t *testing.T) {
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+	const (
+		subscriptionID    = "a433a095-1277-44f1-8453-8d61a4d848c2"
+		resourceGroupName = "unimportantpostponement"
+		clusterName       = "monstrousprecinct"
+		// UUID cosmosID — does NOT parse as a pipe-style resource path, so the lenient convert
+		// surfaces this row with ResourceID == nil rather than back-filling it.
+		malformedChildCosmosID = "07412d96-d4e7-4f4e-a3ab-aa7c0fe7df0f"
+	)
+
+	clusterResourceID := api.Must(api.ToClusterResourceID(subscriptionID, resourceGroupName, clusterName))
+	clusterCosmosID := api.Must(arm.ResourceIDToCosmosID(clusterResourceID))
+
+	healthyChildResourceID := api.Must(azcorearm.ParseResourceID(
+		clusterResourceID.String() + "/" + api.ControllerResourceTypeName + "/healthy",
+	))
+	healthyChildCosmosID := api.Must(arm.ResourceIDToCosmosID(healthyChildResourceID))
+
+	mockClient := databasetesting.NewMockResourcesDBClient()
+
+	// Root: a valid cluster doc.
+	mockClient.StoreDocument(clusterCosmosID, mustMarshalDoc(t, map[string]any{
+		"id":           clusterCosmosID,
+		"partitionKey": subscriptionID,
+		"resourceID":   clusterResourceID.String(),
+		"resourceType": api.ClusterResourceType.String(),
+		"properties":   map[string]any{},
+	}))
+
+	// Healthy child: well-formed resourceID under the cluster. Should be deleted via Delete.
+	mockClient.StoreDocument(healthyChildCosmosID, mustMarshalDoc(t, map[string]any{
+		"id":           healthyChildCosmosID,
+		"partitionKey": subscriptionID,
+		"resourceID":   healthyChildResourceID.String(),
+		"resourceType": api.ClusterControllerResourceType.String(),
+		"properties":   map[string]any{},
+	}))
+
+	// Malformed child: missing top-level resourceID, UUID cosmosID. Must be deleted via DeleteByCosmosID.
+	mockClient.StoreDocument(malformedChildCosmosID, mustMarshalDoc(t, map[string]any{
+		"id":           malformedChildCosmosID,
+		"partitionKey": subscriptionID,
+		"resourceID":   nil,
+		"resourceType": api.ClusterControllerResourceType.String(),
+		"properties":   map[string]any{},
+	}))
+
+	require.NoError(t, DeleteRecursively(ctx, mockClient, clusterResourceID))
+
+	_, healthyStill := mockClient.GetDocument(healthyChildCosmosID)
+	assert.False(t, healthyStill, "healthy child should be deleted via Delete(resourceID)")
+
+	_, malformedStill := mockClient.GetDocument(malformedChildCosmosID)
+	assert.False(t, malformedStill, "malformed child with nil resourceID should be deleted via DeleteByCosmosID fallback")
+
+	_, rootStill := mockClient.GetDocument(clusterCosmosID)
+	assert.False(t, rootStill, "root cluster doc should be deleted last")
+}
+
+func mustMarshalDoc(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return data
+}

--- a/backend/pkg/controllers/mismatchcontrollers/delete_orphaned_operations.go
+++ b/backend/pkg/controllers/mismatchcontrollers/delete_orphaned_operations.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mismatchcontrollers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+type deleteOrphanedOperations struct {
+	name string
+
+	subscriptionLister listers.SubscriptionLister
+	resourcesDBClient  database.ResourcesDBClient
+
+	queue workqueue.TypedRateLimitingInterface[string]
+}
+
+// NewDeleteOrphanedOperationsController periodically scans the resources container under each subscription for
+// operation documents that are missing the top-level resourceID. Such documents cannot be addressed by ARM
+// resource path, so they are unreachable through the typed Operations CRUD; this controller logs the entire
+// document and deletes it by partitionKey + cosmos document ID. We don't know how these arrive in the
+// database, but the data dumper has already had to be made nil-safe to survive them (see DumpDataToLogger),
+// and unreachable rows accrue Cosmos cost and pollute investigation.
+func NewDeleteOrphanedOperationsController(resourcesDBClient database.ResourcesDBClient, subscriptionLister listers.SubscriptionLister) controllerutils.Controller {
+	c := &deleteOrphanedOperations{
+		name:               "DeleteOrphanedOperations",
+		subscriptionLister: subscriptionLister,
+		resourcesDBClient:  resourcesDBClient,
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Name: "DeleteOrphanedOperations",
+			},
+		),
+	}
+
+	return c
+}
+
+func (c *deleteOrphanedOperations) synchronizeSubscription(ctx context.Context, subscription string) error {
+	subscriptionResourceID, err := arm.ToSubscriptionResourceID(subscription)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	untypedSubscriptionCRUD, err := c.resourcesDBClient.UntypedCRUD(*subscriptionResourceID)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	paginatedListOptions := &database.DBClientListResourceDocsOptions{
+		PageSizeHint: ptr.To(int32(500)),
+	}
+	subscriptionResourceIterator, err := untypedSubscriptionCRUD.ListRecursive(ctx, paginatedListOptions)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	errs := []error{}
+	for _, doc := range subscriptionResourceIterator.Items(ctx) {
+		if err := c.processDoc(ctx, untypedSubscriptionCRUD, doc); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := subscriptionResourceIterator.GetError(); err != nil {
+		errs = append(errs, utils.TrackError(err))
+	}
+
+	return errors.Join(errs...)
+}
+
+// processDoc deletes an operation document when either:
+//  1. its top-level resourceID is missing — an unreachable row that the typed Operations CRUD
+//     cannot address, OR
+//  2. its cosmosID is the legacy pipe-delimited form — a pre-migration row. The lenient convert
+//     back-fills a derived ResourceID on read so the doc looks fine to callers, but the row
+//     itself is stale and cheap to recreate; cleaning it up lets the frontend re-write under
+//     the new UUID-cosmosID scheme.
+//
+// Non-operation documents are out of scope here; cluster/nodepool cleanup lives in
+// deleteOrphanedCosmosResources.
+func (c *deleteOrphanedOperations) processDoc(ctx context.Context, untypedCRUD database.UntypedResourceCRUD, doc *database.TypedDocument) error {
+	if !strings.EqualFold(doc.ResourceType, api.OperationStatusResourceType.String()) {
+		return nil
+	}
+
+	missingResourceID := doc.ResourceID == nil
+	preMigrationCosmosID := strings.HasPrefix(doc.ID, "|")
+	if !missingResourceID && !preMigrationCosmosID {
+		return nil
+	}
+
+	logger := utils.LoggerFromContext(ctx)
+	logger = logger.WithValues(
+		utils.LogValues{}.
+			AddSubscriptionID(doc.PartitionKey).
+			AddCosmosResourceID(doc.ID).
+			AddResourceType(doc.ResourceType)...)
+	// Log fields individually rather than passing *doc: logr's reflective formatter calls
+	// .String() on every field, which panics when doc.ResourceID is nil — the exact case we
+	// hit on missingResourceID.
+	logger.Error(nil, "deleting unreachable or pre-migration operation document",
+		"cosmosID", doc.ID,
+		"partitionKey", doc.PartitionKey,
+		"resourceType", doc.ResourceType,
+		"etag", doc.CosmosETag,
+		"missingResourceID", missingResourceID,
+		"preMigrationCosmosID", preMigrationCosmosID,
+		"properties", string(doc.Properties),
+	)
+
+	if err := untypedCRUD.DeleteByCosmosID(ctx, doc.PartitionKey, doc.ID); err != nil {
+		return utils.TrackError(fmt.Errorf("unable to delete orphaned operation %q in partition %q: %w", doc.ID, doc.PartitionKey, err))
+	}
+	return nil
+}
+
+func (c *deleteOrphanedOperations) SyncOnce(ctx context.Context, subscription any) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	syncErr := c.synchronizeSubscription(ctx, subscription.(string))
+	if syncErr != nil {
+		logger.Error(syncErr, "unable to synchronize orphaned operations for subscription")
+	}
+
+	return utils.TrackError(syncErr)
+}
+
+func (c *deleteOrphanedOperations) queueAllSubscriptions(ctx context.Context) {
+	logger := utils.LoggerFromContext(ctx)
+
+	allSubscriptions, err := c.subscriptionLister.List(ctx)
+	if err != nil {
+		logger.Error(err, "unable to list subscriptions")
+	}
+	for _, subscription := range allSubscriptions {
+		c.queue.Add(subscription.ResourceID.SubscriptionID)
+	}
+}
+
+func (c *deleteOrphanedOperations) Run(ctx context.Context, threadiness int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	ctx = utils.ContextWithControllerName(ctx, c.name)
+	logger := utils.LoggerFromContext(ctx)
+	logger = logger.WithValues(utils.LogValues{}.AddControllerName(c.name)...)
+	ctx = utils.ContextWithLogger(ctx, logger)
+	logger.Info("Starting")
+
+	for i := 0; i < threadiness; i++ {
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}
+
+	go wait.JitterUntilWithContext(ctx, c.queueAllSubscriptions, 60*time.Minute, 0.1, true)
+
+	logger.Info("Started workers")
+
+	<-ctx.Done()
+	logger.Info("Shutting down")
+}
+
+func (c *deleteOrphanedOperations) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *deleteOrphanedOperations) processNextWorkItem(ctx context.Context) bool {
+	ref, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.queue.Done(ref)
+
+	logger := utils.LoggerFromContext(ctx)
+	logger = logger.WithValues(utils.LogValues{}.AddSubscriptionID(ref)...)
+	ctx = utils.ContextWithLogger(ctx, logger)
+
+	controllerutils.ReconcileTotal.WithLabelValues(c.name).Inc()
+	err := c.SyncOnce(ctx, ref)
+	if err == nil {
+		c.queue.Forget(ref)
+		return true
+	}
+
+	utilruntime.HandleErrorWithContext(ctx, err, "Error syncing; requeuing for later retry", "objectReference", ref)
+	c.queue.AddRateLimited(ref)
+
+	return true
+}

--- a/backend/pkg/controllers/mismatchcontrollers/delete_orphaned_operations_test.go
+++ b/backend/pkg/controllers/mismatchcontrollers/delete_orphaned_operations_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mismatchcontrollers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	testSubscriptionID = "a433a095-1277-44f1-8453-8d61a4d848c2"
+)
+
+// TestSynchronizeSubscription_BrokenOperation_Deleted drives the controller through its
+// public entry point: an operation document with no top-level resourceID is loaded into the
+// store, synchronizeSubscription is invoked, and we verify the broken row is gone and the
+// healthy row is left alone. The broken row is the case the data-dumper had to be made
+// nil-safe for (commit 6eb9565be) — this controller is what actually deletes it.
+func TestSynchronizeSubscription_BrokenOperation_Deleted(t *testing.T) {
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+	const (
+		brokenCosmosID  = "37332504-70b3-4796-9af6-301a5d47d127"
+		healthyCosmosID = "ab5d298a-2267-432a-ad71-313bbdae0349"
+	)
+
+	mockClient := databasetesting.NewMockResourcesDBClient()
+	mockClient.StoreDocument(brokenCosmosID, brokenOperationDoc(t, brokenCosmosID))
+	mockClient.StoreDocument(healthyCosmosID, healthyOperationDoc(t, healthyCosmosID))
+
+	c := &deleteOrphanedOperations{
+		name:              "DeleteOrphanedOperations",
+		resourcesDBClient: mockClient,
+	}
+
+	require.NoError(t, c.synchronizeSubscription(ctx, testSubscriptionID))
+
+	_, brokenStill := mockClient.GetDocument(brokenCosmosID)
+	assert.False(t, brokenStill, "broken operation must be deleted by synchronizeSubscription")
+
+	_, healthyStill := mockClient.GetDocument(healthyCosmosID)
+	assert.True(t, healthyStill, "healthy operation must survive synchronizeSubscription")
+}
+
+// TestSynchronizeSubscription_StrayNonOperation_LeftAlone confirms scope: a non-operation
+// document with no top-level resourceID is out of scope for this controller and must not
+// be deleted (deleteOrphanedCosmosResources owns those).
+func TestSynchronizeSubscription_StrayNonOperation_LeftAlone(t *testing.T) {
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+	const strayCosmosID = "stray-cluster-with-no-resource-id"
+
+	mockClient := databasetesting.NewMockResourcesDBClient()
+	mockClient.StoreDocument(strayCosmosID, mustMarshal(t, map[string]any{
+		"id":           strayCosmosID,
+		"partitionKey": testSubscriptionID,
+		"resourceID":   nil,
+		"resourceType": api.ClusterResourceType.String(),
+	}))
+
+	c := &deleteOrphanedOperations{
+		name:              "DeleteOrphanedOperations",
+		resourcesDBClient: mockClient,
+	}
+
+	require.NoError(t, c.synchronizeSubscription(ctx, testSubscriptionID))
+
+	_, stillThere := mockClient.GetDocument(strayCosmosID)
+	assert.True(t, stillThere, "non-operation documents are out of scope for this controller")
+}
+
+// TestSynchronizeSubscription_PreMigrationClusterDoc_LeftAlone covers three coexisting cases
+// in the same partition:
+//
+//  1. A pre-migration *cluster* doc (pipe-delimited cosmosID, no top-level resourceID). The
+//     convert back-fills its resourceID on read; the operations controller must leave it alone
+//     because cluster cleanup is out of scope (owned by deleteOrphanedCosmosResources).
+//  2. A pre-migration *operation* doc (pipe-delimited cosmosID, no top-level resourceID). The
+//     convert back-fills its resourceID too, but the row is still stale cruft under the old
+//     cosmosID scheme — the controller deletes it so the frontend can re-write under the new
+//     UUID-cosmosID scheme on next access.
+//  3. A genuinely-broken operation (UUID cosmosID, no top-level resourceID) — unreachable via
+//     resourceID, deleted via DeleteByCosmosID.
+func TestSynchronizeSubscription_PreMigrationClusterDoc_LeftAlone(t *testing.T) {
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+	// Pipe-delimited cosmosIDs — what pre-migration docs look like in cosmos. The convert layer
+	// parses these into a ResourceID by replacing "|" with "/".
+	const (
+		preMigrationClusterCosmosID   = "|subscriptions|a433a095-1277-44f1-8453-8d61a4d848c2|resourcegroups|unimportantpostponement|providers|microsoft.redhatopenshift|hcpopenshiftclusters|monstrousprecinct"
+		preMigrationOperationCosmosID = "|subscriptions|a433a095-1277-44f1-8453-8d61a4d848c2|providers|microsoft.redhatopenshift|hcpoperationstatuses|ab5d298a-2267-432a-ad71-313bbdae0349"
+		brokenOperationCosmosID       = "37332504-70b3-4796-9af6-301a5d47d127"
+	)
+
+	mockClient := databasetesting.NewMockResourcesDBClient()
+
+	mockClient.StoreDocument(preMigrationClusterCosmosID, mustMarshal(t, map[string]any{
+		"id":           preMigrationClusterCosmosID,
+		"partitionKey": testSubscriptionID,
+		// no top-level resourceID — the "not serialized yet" case.
+		"resourceType": api.ClusterResourceType.String(),
+		"properties": map[string]any{
+			"cosmosMetadata": map[string]any{
+				"resourceID": "/subscriptions/" + testSubscriptionID + "/resourceGroups/unimportantPostponement/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/monstrousPrecinct",
+			},
+		},
+	}))
+
+	mockClient.StoreDocument(preMigrationOperationCosmosID, mustMarshal(t, map[string]any{
+		"id":           preMigrationOperationCosmosID,
+		"partitionKey": testSubscriptionID,
+		// no top-level resourceID — convert will back-fill from the pipe-style cosmosID.
+		"resourceType": api.OperationStatusResourceType.String(),
+		"properties": map[string]any{
+			"request": "Create",
+			"status":  "Succeeded",
+		},
+	}))
+
+	mockClient.StoreDocument(brokenOperationCosmosID, brokenOperationDoc(t, brokenOperationCosmosID))
+
+	c := &deleteOrphanedOperations{
+		name:              "DeleteOrphanedOperations",
+		resourcesDBClient: mockClient,
+	}
+
+	require.NoError(t, c.synchronizeSubscription(ctx, testSubscriptionID))
+
+	_, clusterStill := mockClient.GetDocument(preMigrationClusterCosmosID)
+	assert.True(t, clusterStill, "pre-migration cluster doc must not be deleted by the operations controller")
+
+	_, preMigrationOpStill := mockClient.GetDocument(preMigrationOperationCosmosID)
+	assert.False(t, preMigrationOpStill, "pre-migration operation (pipe-style cosmosID) must be deleted")
+
+	_, brokenStill := mockClient.GetDocument(brokenOperationCosmosID)
+	assert.False(t, brokenStill, "broken operation (missing top-level resourceID) must be deleted")
+}
+
+func brokenOperationDoc(t *testing.T, cosmosID string) json.RawMessage {
+	return mustMarshal(t, map[string]any{
+		"id":           cosmosID,
+		"partitionKey": testSubscriptionID,
+		"resourceID":   nil, // <-- the bug we're cleaning up
+		"resourceType": api.OperationStatusResourceType.String(),
+		"properties": map[string]any{
+			"request":            "Create",
+			"status":             "Accepted",
+			"tenantId":           "00000000-0000-0000-0000-000000000000",
+			"startTime":          "2026-05-13T00:00:00Z",
+			"lastTransitionTime": "2026-05-13T00:00:00Z",
+		},
+	})
+}
+
+func healthyOperationDoc(t *testing.T, cosmosID string) json.RawMessage {
+	return mustMarshal(t, map[string]any{
+		"id":           cosmosID,
+		"partitionKey": testSubscriptionID,
+		"resourceID":   api.ToOperationResourceIDString(testSubscriptionID, cosmosID),
+		"resourceType": api.OperationStatusResourceType.String(),
+		"properties": map[string]any{
+			"request": "Create",
+			"status":  "Succeeded",
+		},
+	})
+}
+
+func mustMarshal(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return data
+}

--- a/backend/pkg/controllers/operationcontrollers/utils.go
+++ b/backend/pkg/controllers/operationcontrollers/utils.go
@@ -679,6 +679,7 @@ func SetDeleteOperationAsCompleted(ctx context.Context, resourcesDBClient databa
 	if err != nil {
 		return utils.TrackError(err)
 	}
+	logger := utils.LoggerFromContext(ctx)
 	for _, childResource := range childIterator.Items(ctx) {
 		// clusters, nodepools, and externalauths have special deletion handling, so don't delete them from here.
 		switch strings.ToLower(childResource.ResourceType) {
@@ -694,7 +695,17 @@ func SetDeleteOperationAsCompleted(ctx context.Context, resourcesDBClient databa
 		// CosmosMetadata). The TypedDocument-level ResourceID is preserved across that
 		// migration and is the authoritative ARM ID for the document.
 		if childResource.ResourceID == nil {
-			return utils.TrackError(fmt.Errorf("child resource at cosmosID %q has no resourceID; refusing to delete", childResource.ID))
+			// Malformed row with no addressable resourceID — fall back to DeleteByCosmosID so the
+			// row is still cleaned up alongside its (now-deleted) parent rather than orphaned.
+			logger.Error(nil, "child resource has no resourceID; deleting by cosmosID",
+				"cosmosID", childResource.ID,
+				"partitionKey", childResource.PartitionKey,
+				"resourceType", childResource.ResourceType,
+			)
+			if err := untypedCRUD.DeleteByCosmosID(ctx, childResource.PartitionKey, childResource.ID); err != nil {
+				return utils.TrackError(fmt.Errorf("failed to delete child cosmosID %q in partition %q: %w", childResource.ID, childResource.PartitionKey, err))
+			}
+			continue
 		}
 		if err := untypedCRUD.Delete(ctx, childResource.ResourceID); err != nil {
 			return utils.TrackError(err)

--- a/internal/database/convert_any.go
+++ b/internal/database/convert_any.go
@@ -47,13 +47,13 @@ func CosmosToInternal[InternalAPIType, CosmosAPIType any](obj *CosmosAPIType) (*
 				return any(cosmosObj).(*InternalAPIType), nil
 			}
 
-			// fill in the new ResourceID field for old data that is missing it. This means we didn't migrate something.
-			// this will happen frequently when the new backend is running against an old frontend.
-			resourceIDFromOldCosmosID, err := oldCosmosIDToResourceID(cosmosObj.ID)
-			if err != nil {
-				return nil, utils.TrackError(fmt.Errorf("expected old cosmosID and got %q", castObj.ID))
+			// Best-effort: derive ResourceID from a legacy pipe-delimited cosmosID. When that fails
+			// (e.g. the cosmosID is a bare UUID, as it is for operation documents), surface the doc
+			// with nil ResourceID rather than halting the iterator — cleanup controllers handle the
+			// nil case and need to see these rows to delete them.
+			if resourceIDFromOldCosmosID, err := oldCosmosIDToResourceID(cosmosObj.ID); err == nil {
+				cosmosObj.ResourceID = resourceIDFromOldCosmosID
 			}
-			cosmosObj.ResourceID = resourceIDFromOldCosmosID
 
 			return any(cosmosObj).(*InternalAPIType), nil
 		default:

--- a/internal/serverutils/dump_data.go
+++ b/internal/serverutils/dump_data.go
@@ -39,7 +39,7 @@ func DumpDataToLogger(ctx context.Context, resourcesDBClient database.ResourcesD
 		return utils.TrackError(err)
 	}
 	logger.Info(fmt.Sprintf("dumping resourceID %v", startingCosmosRecord.ResourceID),
-		"currentResourceID", startingCosmosRecord.ResourceID.String(),
+		"currentResourceID", resourceIDToString(startingCosmosRecord.ResourceID),
 		"content", startingCosmosRecord,
 	)
 
@@ -51,7 +51,7 @@ func DumpDataToLogger(ctx context.Context, resourcesDBClient database.ResourcesD
 	errs := []error{}
 	for _, typedDocument := range allCosmosRecords.Items(ctx) {
 		logger.Info(fmt.Sprintf("dumping resourceID %v", typedDocument.ResourceID),
-			"currentResourceID", typedDocument.ResourceID.String(),
+			"currentResourceID", resourceIDToString(typedDocument.ResourceID),
 			"content", typedDocument,
 		)
 	}
@@ -69,7 +69,7 @@ func DumpDataToLogger(ctx context.Context, resourcesDBClient database.ResourcesD
 		currOperationTarget := strings.ToLower(operation.ExternalID.String())
 		if strings.HasPrefix(currOperationTarget, resourceIDString) {
 			logger.Info(fmt.Sprintf("dumping resourceID %v", operation.ResourceID),
-				"currentResourceID", operation.ResourceID.String(),
+				"currentResourceID", resourceIDToString(operation.ResourceID),
 				"content", operation,
 			)
 		}
@@ -79,6 +79,13 @@ func DumpDataToLogger(ctx context.Context, resourcesDBClient database.ResourcesD
 	}
 
 	return utils.TrackError(errors.Join(errs...))
+}
+
+func resourceIDToString(id *azcorearm.ResourceID) string {
+	if id == nil {
+		return "<missing>"
+	}
+	return id.String()
 }
 
 // DumpBillingToLogger dumps active billing documents for the given cluster resource ID to the logger.


### PR DESCRIPTION
Adds a per-subscription mismatch controller that walks the resources container via the untyped CRUD client and deletes operation rows that:

  * are missing the top-level resourceID — unreachable by ARM path, the case the data dumper had to be made nil-safe for (see internal/serverutils/dump_data.go), or
  * carry a legacy pipe-delimited cosmosID — pre-migration cruft whose derived resourceID looks fine on read but whose row is stale; deleting lets the frontend re-write under the new UUID-cosmosID scheme on next access.

To make those rows actually reachable through the iterator, CosmosToInternal for *TypedDocument no longer errors when an old cosmosID can't be back-parsed; it surfaces the row with nil ResourceID and lets cleanup controllers handle it. Three iter consumers had to be hardened against the now-possible nil ResourceID:

  * controllerutils.DeleteRecursively: falls back to DeleteByCosmosID instead of panicking on Delete(nil)
  * operationcontrollers.SetDeleteOperationAsCompleted: same fallback rather than refusing-to-delete an unreachable child
  * serverutils.DumpDataToLogger: routes ResourceID through a nil-safe stringifier (mirrors the fix already on main in commit 6eb9565be)

The controller is wired into backend.go alongside deleteOrphanedCosmosResources at the same threadiness.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
