### PR TITLE
fix: surface IntentFailed when y-stream upgrade has no path (AROSLSRE-858)

### DIFF
--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -321,7 +321,7 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx conte
 
 	return nil, utils.TrackError(fmt.Errorf(
 		"no upgrade path found from %s to %s: no reachable versions in target minor and no gateway version in current minor",
-		actualLatestMinorVersion.String(), desiredMinorVersion.String(),
+		actualLatestVersion.String(), desiredMinorVersion.String(),
 	))
 }
 
@@ -502,5 +502,7 @@ func selectBestVersionFromCandidates(
 		}
 	}
 
-	return nil, nil
+	// Next minor channel exists but no candidate is a gateway yet.
+	// Return the latest candidate so the upgrade can proceed.
+	return &candidates[0], nil
 }

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -502,7 +502,5 @@ func selectBestVersionFromCandidates(
 		}
 	}
 
-	// Next minor channel exists but no candidate is a gateway yet.
-	// Return the latest candidate so the upgrade can proceed.
-	return &candidates[0], nil
+	return nil, nil
 }

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -311,7 +311,18 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx conte
 	}
 
 	// User-requested control plane minor has no path yet; advance to latest patch on the current minor toward a gateway for a later user-initiated upgrade.
-	return FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, actualLatestMinorVersion, activeVersionList)
+	fallbackVersion, err := FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, actualLatestMinorVersion, activeVersionList)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	if fallbackVersion != nil {
+		return fallbackVersion, nil
+	}
+
+	return nil, utils.TrackError(fmt.Errorf(
+		"no upgrade path found from %s to %s: no reachable versions in target minor and no gateway version in current minor",
+		actualLatestMinorVersion.String(), desiredMinorVersion.String(),
+	))
 }
 
 // FindAllUpgradeTargetVersionsInMinor queries Cincinnati and finds the latest version within the specified target minor.

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -518,7 +518,7 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 			expectedErrorContains: "no upgrade path found from 4.20.22 to 4.21.0",
 		},
 		{
-			name:                 "Y-stream upgrade - next minor exists but no gateway, returns latest candidate",
+			name:                 "Y-stream upgrade - candidates exist but no gateway to next minor, returns nil",
 			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.22")), State: configv1.CompletedUpdate}},
 			customerDesiredMinor: "4.21",
 			channelGroup:         "candidate",
@@ -532,17 +532,25 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 					nil,
 				)
 
-				// Check if next minor (4.22) exists - it does, 4.21.15 is in the graph
-				// but has no 4.22.x edges, so not a gateway. Called twice: once for existence, once for gateway check.
+				// Check if next minor (4.22) exists - it does, but 4.21.15 has no 4.22.x edges
 				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("candidate")), "multi", "multi", "candidate-4.22", semver.MustParse("4.21.15")).Times(2).Return(
 					configv1.Release{Version: "4.21.15"},
-					[]configv1.Release{}, // No 4.22.x reachable
+					[]configv1.Release{},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+
+				// Fallback to current minor (4.20) - already at latest
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("candidate")), "multi", "multi", "candidate-4.20", semver.MustParse("4.20.22")).Return(
+					configv1.Release{Version: "4.20.22"},
+					[]configv1.Release{},
 					[]configv1.ConditionalUpdate{},
 					nil,
 				)
 			},
-			expectedVersion: ptr.To(semver.MustParse("4.21.15")),
-			expectedError:   false,
+			expectedVersion:       nil,
+			expectedError:         true,
+			expectedErrorContains: "no upgrade path found from 4.20.22 to 4.21.0",
 		},
 	}
 

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -490,6 +490,33 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 			expectedError:         true,
 			expectedErrorContains: "example error message",
 		},
+		{
+			name:                 "Y-stream upgrade - no path in target minor and already at latest in current minor",
+			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.22")), State: configv1.CompletedUpdate}},
+			customerDesiredMinor: "4.21",
+			channelGroup:         "candidate",
+			cosmosResources:      testCosmosClusterWithWorkersNodePoolAtVersion("4.20.22"),
+			mockSetup: func(mc *cincinnati.MockClient) {
+				// Query for 4.21 versions from 4.20.22 - no candidates reachable
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("candidate")), "multi", "multi", "candidate-4.21", semver.MustParse("4.20.22")).Return(
+					configv1.Release{Version: "4.20.22"},
+					[]configv1.Release{},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+
+				// Fallback to current minor (4.20) - already at latest, no candidates
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("candidate")), "multi", "multi", "candidate-4.20", semver.MustParse("4.20.22")).Return(
+					configv1.Release{Version: "4.20.22"},
+					[]configv1.Release{},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+			},
+			expectedVersion:       nil,
+			expectedError:         true,
+			expectedErrorContains: "no upgrade path found from 4.20.0 to 4.21.0",
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -515,7 +515,34 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 			},
 			expectedVersion:       nil,
 			expectedError:         true,
-			expectedErrorContains: "no upgrade path found from 4.20.0 to 4.21.0",
+			expectedErrorContains: "no upgrade path found from 4.20.22 to 4.21.0",
+		},
+		{
+			name:                 "Y-stream upgrade - next minor exists but no gateway, returns latest candidate",
+			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.22")), State: configv1.CompletedUpdate}},
+			customerDesiredMinor: "4.21",
+			channelGroup:         "candidate",
+			cosmosResources:      testCosmosClusterWithWorkersNodePoolAtVersion("4.20.22"),
+			mockSetup: func(mc *cincinnati.MockClient) {
+				// Query for 4.21 versions from 4.20.22 - 4.21.15 reachable
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("candidate")), "multi", "multi", "candidate-4.21", semver.MustParse("4.20.22")).Return(
+					configv1.Release{Version: "4.20.22"},
+					[]configv1.Release{{Version: "4.21.15"}},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+
+				// Check if next minor (4.22) exists - it does, 4.21.15 is in the graph
+				// but has no 4.22.x edges, so not a gateway. Called twice: once for existence, once for gateway check.
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("candidate")), "multi", "multi", "candidate-4.22", semver.MustParse("4.21.15")).Times(2).Return(
+					configv1.Release{Version: "4.21.15"},
+					[]configv1.Release{}, // No 4.22.x reachable
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+			},
+			expectedVersion: ptr.To(semver.MustParse("4.21.15")),
+			expectedError:   false,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- When a y-stream upgrade finds no reachable versions and no gateway, `desiredControlPlaneZVersion()` returned `nil, nil`, causing the controller to loop silently. Now returns an explicit error so `IntentFailed` gets persisted.
- Added test coverage for the "candidates exist but no gateway to next minor" scenario, confirming the intentional nil return behavior.

## Context

The E2E minor upgrade test started failing 100% on May 13 (33+ failures across 33 Prow SVC clusters). The controller behavior of returning nil when no gateway exists is intentional (prevents upgrading to a version that can't upgrade further). The E2E test was not accounting for this -- that fix is in #5256.

This PR improves the controller's error reporting: when no path is found at all, the controller now surfaces `IntentFailed` with a clear message instead of looping silently until the 29s operation timeout.

## Changes

1. `control_plane_desired_version_controller.go`: Return error with actual version info when no upgrade path exists
2. `control_plane_desired_version_controller_test.go`: Two new test cases:
   - No path in target minor and already at latest in current minor (expects error)
   - Candidates exist but no gateway to next minor (expects nil, intentional behavior)

## Test plan

- [x] All 9 y-stream upgrade tests pass
- [x] All existing z-stream, validation, cross-major, and initial version tests pass

[AROSLSRE-858](https://redhat.atlassian.net/browse/AROSLSRE-858)

Related: #5256 (E2E test fix by @bennerv)