### PR TITLE
Fix E2E minor upgrade test to account for y+2 gateway logic

### DIFF
--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -77,7 +77,14 @@ var _ = Describe("Customer", func() {
 				Skip(fmt.Sprintf("no Cincinnati upgrade candidates from install %s within target minor %s; cannot exercise control plane y-stream upgrade",
 					installVersion, targetVer.String()))
 			}
-			desiredVersion := candidates[len(candidates)-1].String()
+
+			gatewayCandidates, err := framework.FilterCandidatesToGatewayVersions(ctx, channelGroup, targetVer, candidates)
+			Expect(err).NotTo(HaveOccurred())
+			if len(gatewayCandidates) == 0 {
+				Skip(fmt.Sprintf("no gateway candidates in target minor %s to next minor %d.%d on channel %s; controller will not perform y-stream upgrade",
+					targetVer.String(), targetVer.Major, targetVer.Minor+1, channelGroup))
+			}
+			desiredVersion := gatewayCandidates[len(gatewayCandidates)-1].String()
 
 			tc := framework.NewTestContext()
 			if tc.UsePooledIdentities() {

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -253,6 +253,64 @@ func GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx context.Context, channelGr
 	return out, nil
 }
 
+// FilterCandidatesToGatewayVersions filters candidates to those with an upgrade path
+// to the next minor version (targetMinor.Minor+1). If the next minor channel does not
+// exist in Cincinnati, all candidates are returned unfiltered. This mirrors the
+// controller's selectBestVersionFromCandidates gateway logic.
+// Input candidates should be sorted ascending (lowest first).
+func FilterCandidatesToGatewayVersions(ctx context.Context, channelGroup string, targetMinor semver.Version, candidates []semver.Version) ([]semver.Version, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	nextMinor := fmt.Sprintf("%d.%d", targetMinor.Major, targetMinor.Minor+1)
+	nextMinorChannel := fmt.Sprintf("%s-%s", channelGroup, nextMinor)
+
+	cincinnatiURI, err := cincinnati.GetCincinnatiURI(channelGroup)
+	if err != nil {
+		return nil, fmt.Errorf("get Cincinnati URI for channel %s: %w", channelGroup, err)
+	}
+	transport, _ := http.DefaultTransport.(*http.Transport)
+	if transport == nil {
+		transport = &http.Transport{}
+	}
+	client := cvocincinnati.NewClient(uuid.NameSpaceDNS, transport, "ARO-HCP", cincinnati.NewAlwaysConditionRegistry())
+
+	latestCandidate := candidates[len(candidates)-1]
+	_, probeErr := retryOnTransientError(ctx, func() ([]configv1.Release, error) {
+		_, updates, _, err := client.GetUpdates(ctx, cincinnatiURI, "multi", "multi", nextMinorChannel, latestCandidate)
+		return updates, err
+	})
+	if probeErr != nil {
+		if cincinnati.IsCincinnatiVersionNotFoundError(probeErr) {
+			return candidates, nil
+		}
+		return nil, fmt.Errorf("probe next minor channel %s: %w", nextMinorChannel, probeErr)
+	}
+
+	var gateways []semver.Version
+	for _, candidate := range candidates {
+		updates, err := retryOnTransientError(ctx, func() ([]configv1.Release, error) {
+			_, u, _, err := client.GetUpdates(ctx, cincinnatiURI, "multi", "multi", nextMinorChannel, candidate)
+			return u, err
+		})
+		if err != nil {
+			if cincinnati.IsCincinnatiVersionNotFoundError(err) {
+				continue
+			}
+			return nil, fmt.Errorf("check gateway for %s: %w", candidate, err)
+		}
+
+		for _, release := range updates {
+			if strings.Contains(release.Version, nextMinor+".") {
+				gateways = append(gateways, candidate)
+				break
+			}
+		}
+	}
+	return gateways, nil
+}
+
 // GetLatestInstallVersion returns the latest install version for the given channel group and version.
 // For nightly channels, it returns the latest accepted nightly tag.
 // For all other channels, it returns the latest version in the minor.


### PR DESCRIPTION
The controller's selectBestVersionFromCandidates only upgrades to a target minor version if gateway candidates to y+2 exist (when the y+2 channel is present). The E2E test did not account for this, which could cause it to hang waiting for an upgrade the controller will never perform. Filter candidates through the same gateway logic and skip the test when no gateways are available.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Green e2e
### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
