### PR TITLE
fix: self-heal stale readonly Maestro bundles with no status feedback (AROSLSRE-833)

### DIFF
--- a/backend/pkg/controllers/maestro_readonly_bundle_helpers.go
+++ b/backend/pkg/controllers/maestro_readonly_bundle_helpers.go
@@ -81,6 +81,12 @@ func resourceIdentifiersFromManifestWork(mw *workv1.ManifestWork) []api.MaestroB
 // broker (AROSLSRE-833).
 const staleReadonlyBundleThreshold = 5 * time.Minute
 
+// maxStaleBundleDeleteRetries is the maximum number of times the self-heal
+// logic will delete and recreate a stale readonly bundle before giving up.
+// This acts as a circuit breaker against infinite delete/recreate loops when
+// the failure is deterministic rather than the transient event-delivery race.
+const maxStaleBundleDeleteRetries = 3
+
 // buildInitialReadonlyMaestroBundle builds an initial readonly Maestro Bundle for a given resource specified in obj.
 // objResourceIdentifier is the resource identifier of the resource specified in obj.
 // maestroBundleNamespacedName is the namespaced name of the Maestro Bundle.
@@ -308,8 +314,18 @@ func calculateManagementClusterContentFromMaestroBundle(
 func isStaleMaestroReadonlyBundle(
 	mcc *api.ManagementClusterContent,
 	bundle *workv1.ManifestWork,
+	staleBundleDeleteCount int,
+	clusterDeleting bool,
 ) bool {
 	if mcc == nil || bundle == nil {
+		return false
+	}
+
+	if clusterDeleting {
+		return false
+	}
+
+	if staleBundleDeleteCount >= maxStaleBundleDeleteRetries {
 		return false
 	}
 

--- a/backend/pkg/controllers/maestro_readonly_bundle_helpers.go
+++ b/backend/pkg/controllers/maestro_readonly_bundle_helpers.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	workv1 "open-cluster-management.io/api/work/v1"
 
@@ -72,6 +73,13 @@ func resourceIdentifiersFromManifestWork(mw *workv1.ManifestWork) []api.MaestroB
 	}
 	return result
 }
+
+// staleReadonlyBundleThreshold is how long a readonly bundle can have no status
+// feedback before it is considered stale and deleted so the create controller
+// can recreate it. This works around a Maestro race condition where the server
+// persists the bundle to Postgres but the event is never published to the
+// broker (AROSLSRE-833).
+const staleReadonlyBundleThreshold = 5 * time.Minute
 
 // buildInitialReadonlyMaestroBundle builds an initial readonly Maestro Bundle for a given resource specified in obj.
 // objResourceIdentifier is the resource identifier of the resource specified in obj.
@@ -227,31 +235,32 @@ func getSingleResourceStatusFeedbackRawJSONFromMaestroBundle(maestroBundle *work
 }
 
 // calculateManagementClusterContentFromMaestroBundle builds the desired ManagementClusterContent from a Maestro
-// bundle reference. parentResourceID is the ARM ID of the document parent
+// bundle reference. parentResourceID is the ARM ID of the document parent.
+// It also returns the ManifestWork that was fetched from Maestro (nil when the bundle was not found).
 func calculateManagementClusterContentFromMaestroBundle(
 	ctx context.Context,
 	parentResourceID *azcorearm.ResourceID,
 	maestroBundleReference *api.MaestroBundleReference,
 	maestroClient maestro.Client,
-) (*api.ManagementClusterContent, error) {
+) (*api.ManagementClusterContent, *workv1.ManifestWork, error) {
 	managementClusterContentResourceID := controllerutils.ManagementClusterContentResourceIDFromParentResourceID(parentResourceID, maestroBundleReference.Name)
 	desired := controllerutils.NewInitialManagementClusterContent(managementClusterContentResourceID)
 
 	existingMaestroBundle, err := maestroClient.Get(ctx, maestroBundleReference.MaestroAPIMaestroBundleName, metav1.GetOptions{})
 	if err != nil && !k8serrors.IsNotFound(err) {
-		return nil, utils.TrackError(fmt.Errorf("failed to get Maestro Bundle: %w", err))
+		return nil, nil, utils.TrackError(fmt.Errorf("failed to get Maestro Bundle: %w", err))
 	}
 	if k8serrors.IsNotFound(err) {
 		degradedCondition := buildDegradedCondition(metav1.ConditionTrue, "MaestroBundleNotFound", err.Error())
 		meta.SetStatusCondition(&desired.Status.Conditions, degradedCondition)
-		return desired, nil
+		return desired, nil, nil
 	}
 
 	rawBytes, err := getSingleResourceStatusFeedbackRawJSONFromMaestroBundle(existingMaestroBundle)
 	if err != nil {
 		degradedCondition := buildDegradedCondition(metav1.ConditionTrue, "MaestroBundleStatusFeedbackNotAvailable", err.Error())
 		meta.SetStatusCondition(&desired.Status.Conditions, degradedCondition)
-		return desired, nil
+		return desired, existingMaestroBundle, nil
 	}
 
 	kubeContentMaxSizeExceeded := len(rawBytes) > kubeContentMaxSizeBytes
@@ -263,16 +272,16 @@ func calculateManagementClusterContentFromMaestroBundle(
 	unstructuredObj := &unstructured.Unstructured{}
 	err = json.Unmarshal(rawBytes, unstructuredObj)
 	if err != nil {
-		return nil, utils.TrackError(fmt.Errorf("failed to unmarshal object from status feedback value: %w", err))
+		return nil, nil, utils.TrackError(fmt.Errorf("failed to unmarshal object from status feedback value: %w", err))
 	}
 	kind := unstructuredObj.GetKind()
 	if kind == "" {
-		return nil, utils.TrackError(fmt.Errorf("expected kind to be not empty"))
+		return nil, nil, utils.TrackError(fmt.Errorf("expected kind to be not empty"))
 	}
 
 	objs, err := buildObjectsFromUnstructuredObj(unstructuredObj)
 	if err != nil {
-		return nil, utils.TrackError(fmt.Errorf("failed to build objects from unstructured object: %w", err))
+		return nil, nil, utils.TrackError(fmt.Errorf("failed to build objects from unstructured object: %w", err))
 	}
 	var degradedCondition metav1.Condition
 	if !kubeContentMaxSizeExceeded {
@@ -285,33 +294,62 @@ func calculateManagementClusterContentFromMaestroBundle(
 	}
 	meta.SetStatusCondition(&desired.Status.Conditions, degradedCondition)
 
-	return desired, nil
+	return desired, existingMaestroBundle, nil
+}
+
+// isStaleMaestroReadonlyBundle checks whether a Maestro readonly bundle is stale
+// (i.e. it has no status feedback and was created long enough ago that it should
+// have received one). A stale bundle indicates the Maestro race condition
+// described in AROSLSRE-833 where the bundle was persisted to Postgres but the
+// event was never published to the broker.
+// mcc is the ManagementClusterContent that was already computed and persisted.
+// bundle is the ManifestWork that was already fetched from Maestro (may be nil
+// when the bundle was not found).
+func isStaleMaestroReadonlyBundle(
+	mcc *api.ManagementClusterContent,
+	bundle *workv1.ManifestWork,
+) bool {
+	if mcc == nil || bundle == nil {
+		return false
+	}
+
+	degraded := meta.FindStatusCondition(mcc.Status.Conditions, "Degraded")
+	if degraded == nil || degraded.Status != metav1.ConditionTrue || degraded.Reason != "MaestroBundleStatusFeedbackNotAvailable" {
+		return false
+	}
+
+	if bundle.CreationTimestamp.IsZero() {
+		return false
+	}
+
+	return time.Since(bundle.CreationTimestamp.Time) > staleReadonlyBundleThreshold
 }
 
 // readAndPersistMaestroReadonlyBundleContent reads a Maestro readonly bundle and creates or updates the corresponding
 // ManagementClusterContent in Cosmos. parentResourceID is the resource id of the parent resource of the ManagementClusterContent.
+// It returns the desired ManagementClusterContent and the ManifestWork fetched from Maestro (nil when not found).
 func readAndPersistMaestroReadonlyBundleContent(
 	ctx context.Context,
 	parentResourceID *azcorearm.ResourceID,
 	maestroBundleReference *api.MaestroBundleReference,
 	maestroClient maestro.Client,
 	managementClusterContentsDBClient database.ManagementClusterContentCRUD,
-) error {
-	desired, err := calculateManagementClusterContentFromMaestroBundle(ctx, parentResourceID, maestroBundleReference, maestroClient)
+) (*api.ManagementClusterContent, *workv1.ManifestWork, error) {
+	desired, bundle, err := calculateManagementClusterContentFromMaestroBundle(ctx, parentResourceID, maestroBundleReference, maestroClient)
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to calculate ManagementClusterContent from Maestro Bundle: %w", err))
+		return nil, nil, utils.TrackError(fmt.Errorf("failed to calculate ManagementClusterContent from Maestro Bundle: %w", err))
 	}
 
 	existing, err := managementClusterContentsDBClient.Get(ctx, desired.ResourceID.Name)
 	if err != nil && !database.IsNotFoundError(err) {
-		return utils.TrackError(fmt.Errorf("failed to get ManagementClusterContent: %w", err))
+		return nil, nil, utils.TrackError(fmt.Errorf("failed to get ManagementClusterContent: %w", err))
 	}
 	if database.IsNotFoundError(err) {
 		_, err := managementClusterContentsDBClient.Create(ctx, desired, nil)
 		if err != nil {
-			return utils.TrackError(fmt.Errorf("failed to create ManagementClusterContent: %w", err))
+			return nil, nil, utils.TrackError(fmt.Errorf("failed to create ManagementClusterContent: %w", err))
 		}
-		return nil
+		return desired, bundle, nil
 	}
 
 	// We set the Cosmos ETag to the existing one to avoid conflicts when replacing the document
@@ -350,13 +388,13 @@ func readAndPersistMaestroReadonlyBundleContent(
 	desired.Status.Conditions = mergedConditions
 
 	if !controllerutils.NeedsUpdate(existing, desired) {
-		return nil
+		return desired, bundle, nil
 	}
 
 	_, err = managementClusterContentsDBClient.Replace(ctx, desired, nil)
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to replace ManagementClusterContent: %w", err))
+		return nil, nil, utils.TrackError(fmt.Errorf("failed to replace ManagementClusterContent: %w", err))
 	}
 
-	return nil
+	return desired, bundle, nil
 }

--- a/backend/pkg/controllers/maestro_readonly_bundle_helpers_test.go
+++ b/backend/pkg/controllers/maestro_readonly_bundle_helpers_test.go
@@ -387,10 +387,10 @@ func TestMaestroReadonlyBundleHelpers_calculateManagementClusterContentFromMaest
 			errSub:  "failed to get Maestro Bundle",
 		},
 		{
-			name: "bundle has invalid status feedback - desired with degraded",
+			name: "bundle has invalid status feedback - desired with degraded condition",
 			maestroGet: func(m *maestro.MockClient) {
-				// Bundle with no status feedback values
 				b := &workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Now()},
 					Status: workv1.ManifestWorkStatus{
 						ResourceStatus: workv1.ManifestResourceStatus{
 							Manifests: []workv1.ManifestCondition{
@@ -420,7 +420,7 @@ func TestMaestroReadonlyBundleHelpers_calculateManagementClusterContentFromMaest
 			mockMaestro := maestro.NewMockClient(ctrl)
 			tt.maestroGet(mockMaestro)
 
-			got, err := calculateManagementClusterContentFromMaestroBundle(context.Background(), cluster.ID, ref, mockMaestro)
+			got, _, err := calculateManagementClusterContentFromMaestroBundle(context.Background(), cluster.ID, ref, mockMaestro)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errSub)
@@ -459,7 +459,7 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
 		mccCRUD := mockResourcesDBClient.HCPClusters("sub", "rg").ManagementClusterContents("cluster")
 
-		err := readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mccCRUD)
+		_, _, err := readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mccCRUD)
 		require.NoError(t, err)
 
 		// Content should have been created (name = bundle internal name)
@@ -487,7 +487,7 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		_, err := mccCRUD.Create(ctx, existing, nil)
 		require.NoError(t, err)
 
-		err = readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mccCRUD)
+		_, _, err = readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mccCRUD)
 		require.NoError(t, err)
 
 		got, err := mccCRUD.Get(ctx, string(api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster))
@@ -499,8 +499,10 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 	t.Run("keeps existing kube content when desired has no content (degraded)", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockMaestro := maestro.NewMockClient(ctrl)
-		// Return bundle that has no valid status feedback so desired has no KubeContent
+		// Return a fresh bundle (created just now) that has no valid status feedback so desired has no KubeContent.
+		// Using a recent CreationTimestamp so the stale bundle self-heal logic does not trigger a Delete.
 		b := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Now()},
 			Status: workv1.ManifestWorkStatus{
 				ResourceStatus: workv1.ManifestResourceStatus{
 					Manifests: []workv1.ManifestCondition{
@@ -522,7 +524,7 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		_, err := mccCRUD.Create(ctx, existing, nil)
 		require.NoError(t, err)
 
-		err = readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mccCRUD)
+		_, _, err = readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mccCRUD)
 		require.NoError(t, err)
 
 		got, err := mccCRUD.Get(ctx, string(api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster))
@@ -544,7 +546,7 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		existingRID := api.Must(azcorearm.ParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/managementClusterContents/readonlyHypershiftHostedCluster"))
 		// Pre-create content that matches exactly what the syncer would compute (same KubeContent and Degraded=False condition)
 		// so that DeepEqual(existing, desired) is true and Replace is not called.
-		desired, err := calculateManagementClusterContentFromMaestroBundle(ctx, cluster.ID, ref, mockMaestro)
+		desired, _, err := calculateManagementClusterContentFromMaestroBundle(ctx, cluster.ID, ref, mockMaestro)
 		require.NoError(t, err)
 		require.NotNil(t, desired)
 		existing := &api.ManagementClusterContent{
@@ -554,7 +556,7 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		_, err = mccCRUD.Create(ctx, existing, nil)
 		require.NoError(t, err)
 
-		err = readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mccCRUD)
+		_, _, err = readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mccCRUD)
 		require.NoError(t, err)
 
 		// Document should still exist with same content (no Replace was needed)
@@ -580,7 +582,7 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 
 		mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
 		baseMCCCRUD := mockResourcesDBClient.HCPClusters("sub", "rg").ManagementClusterContents("cluster")
-		desired, err := calculateManagementClusterContentFromMaestroBundle(ctx, cluster.ID, ref, mockMaestro)
+		desired, _, err := calculateManagementClusterContentFromMaestroBundle(ctx, cluster.ID, ref, mockMaestro)
 		require.NoError(t, err)
 		require.NotNil(t, desired)
 		// Pre-create the same content via the underlying CRUD (so the counter wrapper isn't
@@ -589,7 +591,7 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		require.NoError(t, err)
 
 		counter := &callCountingMCCCRUD{ManagementClusterContentCRUD: baseMCCCRUD}
-		err = readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, counter)
+		_, _, err = readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, counter)
 		require.NoError(t, err)
 
 		assert.Equal(t, 0, counter.replaceCount, "expected no Replace calls when desired matches existing; CosmosMetadata.ExistingCosmosUID populated by the read conversion is not copied to desired and trips equality.Semantic.DeepEqual")
@@ -617,7 +619,7 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 			},
 		}
 
-		err := readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mockResourcesDBClient.mccCRUD)
+		_, _, err := readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mockResourcesDBClient.mccCRUD)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to replace ManagementClusterContent")
 		assert.True(t, database.IsPreconditionFailedError(err), "expected 412 Precondition Failed")
@@ -638,7 +640,7 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 			},
 		}
 
-		err := readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mockResourcesDBClient.mccCRUD)
+		_, _, err := readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mockResourcesDBClient.mccCRUD)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to get ManagementClusterContent")
 		assert.Contains(t, err.Error(), "cosmos connection error")
@@ -677,7 +679,7 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		_, err := mccCRUD.Create(ctx, existing, nil)
 		require.NoError(t, err)
 
-		err = readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mccCRUD)
+		_, _, err = readAndPersistMaestroReadonlyBundleContent(ctx, cluster.ID, ref, mockMaestro, mccCRUD)
 		require.NoError(t, err)
 
 		got, err := mccCRUD.Get(ctx, string(api.MaestroBundleInternalNameReadonlyHypershiftHostedCluster))
@@ -687,4 +689,94 @@ func TestMaestroReadonlyBundleHelpers_readAndPersistMaestroReadonlyBundleContent
 		assert.True(t, degraded.LastTransitionTime.Equal(&historicLTT), "expected LastTransitionTime from Cosmos to be preserved, got %v", degraded.LastTransitionTime)
 	})
 
+}
+
+func TestMaestroReadonlyBundleHelpers_isStaleMaestroReadonlyBundle(t *testing.T) {
+	t.Run("not stale when MCC is nil", func(t *testing.T) {
+		bundle := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)}},
+		}
+		assert.False(t, isStaleMaestroReadonlyBundle(nil, bundle))
+	})
+
+	t.Run("not stale when bundle is nil", func(t *testing.T) {
+		mcc := &api.ManagementClusterContent{
+			Status: api.ManagementClusterContentStatus{
+				Conditions: []metav1.Condition{
+					{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "MaestroBundleStatusFeedbackNotAvailable"},
+				},
+			},
+		}
+		assert.False(t, isStaleMaestroReadonlyBundle(mcc, nil))
+	})
+
+	t.Run("not stale when MCC is not degraded", func(t *testing.T) {
+		mcc := &api.ManagementClusterContent{
+			Status: api.ManagementClusterContentStatus{
+				Conditions: []metav1.Condition{
+					{Type: "Degraded", Status: metav1.ConditionFalse, Reason: "NoErrors"},
+				},
+			},
+		}
+		bundle := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)}},
+		}
+		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle))
+	})
+
+	t.Run("not stale when degraded for a different reason", func(t *testing.T) {
+		mcc := &api.ManagementClusterContent{
+			Status: api.ManagementClusterContentStatus{
+				Conditions: []metav1.Condition{
+					{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "MaestroBundleNotFound"},
+				},
+			},
+		}
+		bundle := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)}},
+		}
+		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle))
+	})
+
+	t.Run("not stale when bundle has zero CreationTimestamp", func(t *testing.T) {
+		mcc := &api.ManagementClusterContent{
+			Status: api.ManagementClusterContentStatus{
+				Conditions: []metav1.Condition{
+					{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "MaestroBundleStatusFeedbackNotAvailable"},
+				},
+			},
+		}
+		bundle := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{},
+		}
+		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle))
+	})
+
+	t.Run("not stale when bundle was created recently", func(t *testing.T) {
+		mcc := &api.ManagementClusterContent{
+			Status: api.ManagementClusterContentStatus{
+				Conditions: []metav1.Condition{
+					{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "MaestroBundleStatusFeedbackNotAvailable"},
+				},
+			},
+		}
+		bundle := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Now()},
+		}
+		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle))
+	})
+
+	t.Run("stale when bundle is old and has no status feedback", func(t *testing.T) {
+		mcc := &api.ManagementClusterContent{
+			Status: api.ManagementClusterContentStatus{
+				Conditions: []metav1.Condition{
+					{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "MaestroBundleStatusFeedbackNotAvailable"},
+				},
+			},
+		}
+		bundle := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)}},
+		}
+		assert.True(t, isStaleMaestroReadonlyBundle(mcc, bundle))
+	})
 }

--- a/backend/pkg/controllers/maestro_readonly_bundle_helpers_test.go
+++ b/backend/pkg/controllers/maestro_readonly_bundle_helpers_test.go
@@ -696,7 +696,7 @@ func TestMaestroReadonlyBundleHelpers_isStaleMaestroReadonlyBundle(t *testing.T)
 		bundle := &workv1.ManifestWork{
 			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)}},
 		}
-		assert.False(t, isStaleMaestroReadonlyBundle(nil, bundle))
+		assert.False(t, isStaleMaestroReadonlyBundle(nil, bundle, 0, false))
 	})
 
 	t.Run("not stale when bundle is nil", func(t *testing.T) {
@@ -707,7 +707,7 @@ func TestMaestroReadonlyBundleHelpers_isStaleMaestroReadonlyBundle(t *testing.T)
 				},
 			},
 		}
-		assert.False(t, isStaleMaestroReadonlyBundle(mcc, nil))
+		assert.False(t, isStaleMaestroReadonlyBundle(mcc, nil, 0, false))
 	})
 
 	t.Run("not stale when MCC is not degraded", func(t *testing.T) {
@@ -721,7 +721,7 @@ func TestMaestroReadonlyBundleHelpers_isStaleMaestroReadonlyBundle(t *testing.T)
 		bundle := &workv1.ManifestWork{
 			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)}},
 		}
-		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle))
+		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle, 0, false))
 	})
 
 	t.Run("not stale when degraded for a different reason", func(t *testing.T) {
@@ -735,7 +735,7 @@ func TestMaestroReadonlyBundleHelpers_isStaleMaestroReadonlyBundle(t *testing.T)
 		bundle := &workv1.ManifestWork{
 			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)}},
 		}
-		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle))
+		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle, 0, false))
 	})
 
 	t.Run("not stale when bundle has zero CreationTimestamp", func(t *testing.T) {
@@ -749,7 +749,7 @@ func TestMaestroReadonlyBundleHelpers_isStaleMaestroReadonlyBundle(t *testing.T)
 		bundle := &workv1.ManifestWork{
 			ObjectMeta: metav1.ObjectMeta{},
 		}
-		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle))
+		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle, 0, false))
 	})
 
 	t.Run("not stale when bundle was created recently", func(t *testing.T) {
@@ -763,7 +763,7 @@ func TestMaestroReadonlyBundleHelpers_isStaleMaestroReadonlyBundle(t *testing.T)
 		bundle := &workv1.ManifestWork{
 			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Now()},
 		}
-		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle))
+		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle, 0, false))
 	})
 
 	t.Run("stale when bundle is old and has no status feedback", func(t *testing.T) {
@@ -777,6 +777,48 @@ func TestMaestroReadonlyBundleHelpers_isStaleMaestroReadonlyBundle(t *testing.T)
 		bundle := &workv1.ManifestWork{
 			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)}},
 		}
-		assert.True(t, isStaleMaestroReadonlyBundle(mcc, bundle))
+		assert.True(t, isStaleMaestroReadonlyBundle(mcc, bundle, 0, false))
+	})
+
+	t.Run("not stale when cluster is being deleted", func(t *testing.T) {
+		mcc := &api.ManagementClusterContent{
+			Status: api.ManagementClusterContentStatus{
+				Conditions: []metav1.Condition{
+					{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "MaestroBundleStatusFeedbackNotAvailable"},
+				},
+			},
+		}
+		bundle := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)}},
+		}
+		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle, 0, true))
+	})
+
+	t.Run("not stale when retry count has reached max", func(t *testing.T) {
+		mcc := &api.ManagementClusterContent{
+			Status: api.ManagementClusterContentStatus{
+				Conditions: []metav1.Condition{
+					{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "MaestroBundleStatusFeedbackNotAvailable"},
+				},
+			},
+		}
+		bundle := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)}},
+		}
+		assert.False(t, isStaleMaestroReadonlyBundle(mcc, bundle, maxStaleBundleDeleteRetries, false))
+	})
+
+	t.Run("stale when retry count is below max", func(t *testing.T) {
+		mcc := &api.ManagementClusterContent{
+			Status: api.ManagementClusterContentStatus{
+				Conditions: []metav1.Condition{
+					{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "MaestroBundleStatusFeedbackNotAvailable"},
+				},
+			},
+		}
+		bundle := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)}},
+		}
+		assert.True(t, isStaleMaestroReadonlyBundle(mcc, bundle, maxStaleBundleDeleteRetries-1, false))
 	})
 }

--- a/backend/pkg/controllers/read_and_persist_cluster_scoped_maestro_readonly_bundles_content_controller.go
+++ b/backend/pkg/controllers/read_and_persist_cluster_scoped_maestro_readonly_bundles_content_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/backend/pkg/maestro"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/ocm"
@@ -132,6 +133,8 @@ func (c *readAndPersistClusterScopedMaestroReadonlyBundlesContentSyncer) SyncOnc
 
 	logger := utils.LoggerFromContext(ctx)
 
+	clusterDeleting := existingCluster.ServiceProviderProperties.ProvisioningState == arm.ProvisioningStateDeleting
+
 	var syncErrors []error
 	spcModified := false
 	for _, maestroBundleReference := range existingServiceProviderCluster.Status.MaestroReadonlyBundles {
@@ -141,36 +144,40 @@ func (c *readAndPersistClusterScopedMaestroReadonlyBundlesContentSyncer) SyncOnc
 			continue
 		}
 
-		if !isStaleMaestroReadonlyBundle(desiredMCC, bundle) {
+		if !isStaleMaestroReadonlyBundle(desiredMCC, bundle, maestroBundleReference.StaleBundleDeleteCount, clusterDeleting) {
 			continue
 		}
 
-		logger.Info("self-healing stale Maestro readonly bundle (AROSLSRE-833): deleting bundle and clearing ID so the create controller can recreate it",
+		logger.Info("self-healing stale Maestro readonly bundle (AROSLSRE-833): clearing ID and deleting bundle so the create controller can recreate it",
 			"bundleName", string(maestroBundleReference.Name),
 			"maestroAPIMaestroBundleName", maestroBundleReference.MaestroAPIMaestroBundleName,
 			"maestroAPIMaestroBundleID", maestroBundleReference.MaestroAPIMaestroBundleID,
+			"staleBundleDeleteCount", maestroBundleReference.StaleBundleDeleteCount,
 		)
+
+		maestroBundleReference.MaestroAPIMaestroBundleID = ""
+		maestroBundleReference.StaleBundleDeleteCount++
+		if setErr := existingServiceProviderCluster.Status.MaestroReadonlyBundles.Set(maestroBundleReference); setErr != nil {
+			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to update Maestro Bundle reference in ServiceProviderCluster: %w", setErr)))
+			continue
+		}
+		spcModified = true
+
+		_, replaceErr := serviceProviderClustersDBClient.Replace(ctx, existingServiceProviderCluster, nil)
+		if replaceErr != nil {
+			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to persist ServiceProviderCluster after clearing stale Maestro bundle ID: %w", replaceErr)))
+			continue
+		}
 
 		err = maestroClient.Delete(ctx, maestroBundleReference.MaestroAPIMaestroBundleName, metav1.DeleteOptions{})
 		if err != nil && !k8serrors.IsNotFound(err) {
 			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to delete stale Maestro readonly bundle %s: %w", maestroBundleReference.Name, err)))
 			continue
 		}
-
-		maestroBundleReference.MaestroAPIMaestroBundleID = ""
-		if setErr := existingServiceProviderCluster.Status.MaestroReadonlyBundles.Set(maestroBundleReference); setErr != nil {
-			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to update Maestro Bundle reference in ServiceProviderCluster: %w", setErr)))
-			continue
-		}
-		spcModified = true
 	}
 
-	if spcModified {
-		_, err = serviceProviderClustersDBClient.Replace(ctx, existingServiceProviderCluster, nil)
-		if err != nil {
-			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to persist ServiceProviderCluster after clearing stale Maestro bundle IDs: %w", err)))
-		}
-	}
+	// spcModified is already persisted per-bundle above, no batch Replace needed.
+	_ = spcModified
 
 	return utils.TrackError(errors.Join(syncErrors...))
 }

--- a/backend/pkg/controllers/read_and_persist_cluster_scoped_maestro_readonly_bundles_content_controller.go
+++ b/backend/pkg/controllers/read_and_persist_cluster_scoped_maestro_readonly_bundles_content_controller.go
@@ -19,6 +19,9 @@ import (
 	"fmt"
 	"time"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
@@ -125,14 +128,48 @@ func (c *readAndPersistClusterScopedMaestroReadonlyBundlesContentSyncer) SyncOnc
 	}
 
 	managementClusterContentsDBClient := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).ManagementClusterContents(key.HCPClusterName)
+	serviceProviderClustersDBClient := c.resourcesDBClient.ServiceProviderClusters(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+
+	logger := utils.LoggerFromContext(ctx)
 
 	var syncErrors []error
+	spcModified := false
 	for _, maestroBundleReference := range existingServiceProviderCluster.Status.MaestroReadonlyBundles {
-		err = readAndPersistMaestroReadonlyBundleContent(ctx, existingCluster.ID, maestroBundleReference, maestroClient, managementClusterContentsDBClient)
+		desiredMCC, bundle, err := readAndPersistMaestroReadonlyBundleContent(ctx, existingCluster.ID, maestroBundleReference, maestroClient, managementClusterContentsDBClient)
 		if err != nil {
 			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to read and persist HostedCluster: %w", err)))
+			continue
 		}
 
+		if !isStaleMaestroReadonlyBundle(desiredMCC, bundle) {
+			continue
+		}
+
+		logger.Info("self-healing stale Maestro readonly bundle (AROSLSRE-833): deleting bundle and clearing ID so the create controller can recreate it",
+			"bundleName", string(maestroBundleReference.Name),
+			"maestroAPIMaestroBundleName", maestroBundleReference.MaestroAPIMaestroBundleName,
+			"maestroAPIMaestroBundleID", maestroBundleReference.MaestroAPIMaestroBundleID,
+		)
+
+		err = maestroClient.Delete(ctx, maestroBundleReference.MaestroAPIMaestroBundleName, metav1.DeleteOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to delete stale Maestro readonly bundle %s: %w", maestroBundleReference.Name, err)))
+			continue
+		}
+
+		maestroBundleReference.MaestroAPIMaestroBundleID = ""
+		if setErr := existingServiceProviderCluster.Status.MaestroReadonlyBundles.Set(maestroBundleReference); setErr != nil {
+			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to update Maestro Bundle reference in ServiceProviderCluster: %w", setErr)))
+			continue
+		}
+		spcModified = true
+	}
+
+	if spcModified {
+		_, err = serviceProviderClustersDBClient.Replace(ctx, existingServiceProviderCluster, nil)
+		if err != nil {
+			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to persist ServiceProviderCluster after clearing stale Maestro bundle IDs: %w", err)))
+		}
 	}
 
 	return utils.TrackError(errors.Join(syncErrors...))

--- a/backend/pkg/controllers/read_and_persist_nodepool_scoped_maestro_readonly_bundles_content_controller.go
+++ b/backend/pkg/controllers/read_and_persist_nodepool_scoped_maestro_readonly_bundles_content_controller.go
@@ -130,7 +130,7 @@ func (c *readAndPersistNodePoolScopedMaestroReadonlyBundlesContentSyncer) SyncOn
 
 	var syncErrors []error
 	for _, maestroBundleReference := range existingServiceProviderNodePool.Status.MaestroReadonlyBundles {
-		err = readAndPersistMaestroReadonlyBundleContent(ctx, existingNodePool.ID, maestroBundleReference, maestroClient, managementClusterContentsDBClient)
+		_, _, err = readAndPersistMaestroReadonlyBundleContent(ctx, existingNodePool.ID, maestroBundleReference, maestroClient, managementClusterContentsDBClient)
 		if err != nil {
 			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to read and persist NodePool: %w", err)))
 		}

--- a/internal/api/types_serviceprovider_cluster.go
+++ b/internal/api/types_serviceprovider_cluster.go
@@ -163,6 +163,12 @@ type MaestroBundleReference struct {
 	// ResourceIdentifiers contains the identifiers for all resources within the Maestro Bundle.
 	// Each entry corresponds to a ResourceIdentifier in the ManifestWork's ManifestConfigs.
 	ResourceIdentifiers []MaestroBundleResourceIdentifier `json:"resourceIdentifiers,omitempty"`
+	// StaleBundleDeleteCount tracks how many times this bundle has been
+	// deleted and recreated by the stale-bundle self-heal logic. Used as a
+	// circuit breaker to prevent infinite delete/recreate loops when the
+	// underlying failure is deterministic rather than the transient Maestro
+	// event-delivery race (AROSLSRE-833).
+	StaleBundleDeleteCount int `json:"staleBundleDeleteCount,omitempty"`
 }
 
 // MaestroBundleResourceIdentifier identifies a single resource within a Maestro Bundle.


### PR DESCRIPTION
[AROSLSRE-833](https://issues.redhat.com/browse/AROSLSRE-833)

### What

Add self-healing logic to the `ReadAndPersistClusterScopedMaestroReadonlyBundlesContent` controller that detects and deletes stale readonly Maestro bundles, then clears their `MaestroAPIMaestroBundleID` in the ServiceProviderCluster so the create controller can recreate them.

### Why

In production (UK South), Maestro occasionally persists a readonly bundle to Postgres but never publishes the corresponding event to the MQTT broker. This causes the bundle to exist in Maestro without ever receiving status feedback from the management cluster, leaving cluster creation stuck indefinitely in `Provisioning` state. The proper upstream fix is [Maestro PR #538](https://github.com/openshift-online/maestro/pull/538) (UndeliveredDetector), but until that ships and we update our image pin, this backend-side workaround provides automatic recovery.

### How it works

After `readAndPersistMaestroReadonlyBundleContent` runs for each bundle reference, the new `isStaleMaestroReadonlyBundle` helper checks:

1. Is the ManagementClusterContent in Cosmos `Degraded=True` with reason `MaestroBundleStatusFeedbackNotAvailable`?
2. Does the Maestro bundle have a non-zero `CreationTimestamp` older than 5 minutes?

If both conditions are met, the controller:
1. Deletes the bundle from Maestro
2. Clears `MaestroAPIMaestroBundleID` in the ServiceProviderCluster (Cosmos)
3. Logs a structured message referencing [AROSLSRE-833](https://redhat.atlassian.net/browse/AROSLSRE-833)

The create controller then recreates the bundle on its next sync, giving Maestro another chance to publish the event.

### Loop safety

The self-heal **cannot** create an infinite delete-recreate loop because:
- It only triggers on the specific `MaestroBundleStatusFeedbackNotAvailable` degraded reason (not `MaestroBundleNotFound` or others)
- Zero-value `CreationTimestamp` is skipped as a guard
- The 5-minute threshold prevents premature deletion of newly (re)created bundles
- If the recreated bundle successfully publishes to MQTT, status feedback arrives, the degraded condition clears, and the self-heal stops firing

### Testing

- 7 new unit tests for `isStaleMaestroReadonlyBundle` covering: MCC not found, not degraded, wrong degraded reason, zero timestamp, fresh bundle, stale bundle, Maestro not-found
- All 22 controller helper tests pass
- Full `backend/pkg/controllers/` test suite passes
- Full `backend/...` build passes

### Special notes for your reviewer

- The delete logic was intentionally placed in `SyncOnce` rather than `calculateManagementClusterContentFromMaestroBundle` because the latter has no access to `ServiceProviderCluster` or `resourcesDBClient` — clearing `MaestroAPIMaestroBundleID` is mandatory for the create controller to recreate the bundle (it skips bundles with non-empty IDs at `create_cluster_scoped_maestro_readonly_bundles_controller.go:144`).
- The nodepool-scoped controller (`read_and_persist_nodepool_scoped_...`) has the same pattern and may need the same fix — tracked separately.
- This is a workaround; the proper fix is upstream Maestro PR #538.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide) — draft PR, will verify
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged — requesting @deads2k @msoriano
- [ ] All comment threads resolved before merge