### PR TITLE
fix: add retry for grafana datasource step on UpdateConflict

### DIFF
--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -53,6 +53,11 @@ resourceGroups:
   - name: add-grafana-datasource
     action: GrafanaDatasources
     omitFromServiceGroupCompletion: true
+    automatedRetry:
+      errorContainsAny:
+      - "UpdateConflict"
+      maximumRetryCount: 3
+      durationBetweenRetries: 1m
     grafanaName: "{{ .monitoring.grafanaName }}"
     identityFrom:
       resourceGroup: global


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Adds a retry step on 409's to the add-grafana-datasource step in the regional pipeline

### Why

e2e occasionally fails when the add-grafana-datasource hits a conflict.  

### Testing

e2e in PR

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
