### PR TITLE
fix: add centralus to cleanup-sweeper exclusions

### DIFF
--- a/tooling/cleanup-sweeper/resourcegroups.policy.yaml
+++ b/tooling/cleanup-sweeper/resourcegroups.policy.yaml
@@ -13,6 +13,7 @@ rgOrdered:
   - global
   - hcp-kusto-us
   - westus3-shared-resources
+  - centralus-shared-resources
   discovery:
     # Rules are evaluated in order; first match wins.
     rules:


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

adds centralus-shared-resoureces to cleanup sweeper exclusions

### Why

the new centralus-shared-resources rg will be deleted by the cleaner once it's 2 days old if it's not excluded.

### Testing

e2e in pr

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
