### PR TITLE
feat: add Prometheus alerts for FSI image registry policy violations

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1653,6 +1653,73 @@ resource kubeNodeRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-
   }
 }
 
+resource imageRegistryPolicy 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'image-registry-policy'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'ImageRegistryPolicyDenied'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'ImageRegistryPolicyDenied/{{ $labels.cluster }}'
+          description: 'The image-registry-allowlist-policy on cluster {{ $labels.cluster }} has denied {{ $value }} pod admission(s) in the last 15 minutes. This means pods with images from non-approved registries were blocked from running.'
+          info: 'The image-registry-allowlist-policy on cluster {{ $labels.cluster }} has denied {{ $value }} pod admission(s) in the last 15 minutes. This means pods with images from non-approved registries were blocked from running.'
+          runbook_url: 'TBD'
+          summary: 'Image registry policy denied pod admission'
+          title: 'Image registry policy denied pod admission'
+        }
+        expression: 'sum by (cluster, policy, policy_binding) ( increase(apiserver_validating_admission_policy_check_total{ policy="image-registry-allowlist-policy", enforcement_action="deny", validation_result="denied" }[15m]) ) > 0'
+        for: 'PT1M'
+        severity: 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'ImageRegistryPolicyAuditViolation'
+        enabled: true
+        labels: {
+          severity: 'info'
+        }
+        annotations: {
+          correlationId: 'ImageRegistryPolicyAuditViolation/{{ $labels.cluster }}'
+          description: 'The image-registry-allowlist-policy on cluster {{ $labels.cluster }} has logged {{ $value }} audit violation(s) in the last 15 minutes. Pods with images from non-approved registries are running but not blocked. Review kubernetesEvents in Kusto for details.'
+          info: 'The image-registry-allowlist-policy on cluster {{ $labels.cluster }} has logged {{ $value }} audit violation(s) in the last 15 minutes. Pods with images from non-approved registries are running but not blocked. Review kubernetesEvents in Kusto for details.'
+          runbook_url: 'TBD'
+          summary: 'Image registry policy audit violation detected'
+          title: 'Image registry policy audit violation detected'
+        }
+        expression: 'sum by (cluster, policy, policy_binding) ( increase(apiserver_validating_admission_policy_check_total{ policy="image-registry-allowlist-policy", enforcement_action="audit", validation_result="denied" }[15m]) ) > 0'
+        for: 'PT5M'
+        severity: 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
 resource kustoLogsAgeRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
   name: 'kusto-logs-age-rules'
   location: location

--- a/observability/alerts-sl-services.yaml
+++ b/observability/alerts-sl-services.yaml
@@ -12,6 +12,7 @@ prometheusRules:
   - ../observability/alerts/HCPdeletionStuck-prometheusRule.yaml
   - ../observability/alerts/kubeContainerOOM-prometheusRule.yaml
   - ../observability/alerts/kubeNode-prometheusRule.yaml
+  - ../observability/alerts/imageRegistryPolicy-prometheusRule.yaml
   - alerts/kusto-logs-age-prometheusRule.yaml
   untestedRules: []
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep

--- a/observability/alerts/imageRegistryPolicy-prometheusRule.yaml
+++ b/observability/alerts/imageRegistryPolicy-prometheusRule.yaml
@@ -1,0 +1,44 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: image-registry-policy
+  namespace: monitoring
+spec:
+  groups:
+  - name: image-registry-policy
+    interval: 1m
+    rules:
+    - alert: ImageRegistryPolicyDenied
+      expr: |
+        sum by (cluster, policy, policy_binding) (
+          increase(apiserver_validating_admission_policy_check_total{
+            policy="image-registry-allowlist-policy",
+            enforcement_action="deny",
+            validation_result="denied"
+          }[15m])
+        ) > 0
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Image registry policy denied pod admission"
+        description: "The image-registry-allowlist-policy on cluster {{ $labels.cluster }} has denied {{ $value }} pod admission(s) in the last 15 minutes. This means pods with images from non-approved registries were blocked from running."
+        runbook_url: TBD
+        correlationId: "ImageRegistryPolicyDenied/{{ $labels.cluster }}"
+    - alert: ImageRegistryPolicyAuditViolation
+      expr: |
+        sum by (cluster, policy, policy_binding) (
+          increase(apiserver_validating_admission_policy_check_total{
+            policy="image-registry-allowlist-policy",
+            enforcement_action="audit",
+            validation_result="denied"
+          }[15m])
+        ) > 0
+      for: 5m
+      labels:
+        severity: info
+      annotations:
+        summary: "Image registry policy audit violation detected"
+        description: "The image-registry-allowlist-policy on cluster {{ $labels.cluster }} has logged {{ $value }} audit violation(s) in the last 15 minutes. Pods with images from non-approved registries are running but not blocked. Review kubernetesEvents in Kusto for details."
+        runbook_url: TBD
+        correlationId: "ImageRegistryPolicyAuditViolation/{{ $labels.cluster }}"

--- a/observability/alerts/imageRegistryPolicy-prometheusRule_test.yaml
+++ b/observability/alerts/imageRegistryPolicy-prometheusRule_test.yaml
@@ -1,0 +1,60 @@
+rule_files:
+- imageRegistryPolicy-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# Test 1: Deny mode — policy denies pods, alert fires
+- interval: 1m
+  input_series:
+  - series: 'apiserver_validating_admission_policy_check_total{cluster="svc-1",policy="image-registry-allowlist-policy",policy_binding="image-registry-allowlist-policy-binding",enforcement_action="deny",validation_result="denied"}'
+    values: '0+3x20'
+  alert_rule_test:
+  - eval_time: 16m
+    alertname: ImageRegistryPolicyDenied
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        cluster: svc-1
+        policy: image-registry-allowlist-policy
+        policy_binding: image-registry-allowlist-policy-binding
+      exp_annotations:
+        summary: "Image registry policy denied pod admission"
+        description: "The image-registry-allowlist-policy on cluster svc-1 has denied 45 pod admission(s) in the last 15 minutes. This means pods with images from non-approved registries were blocked from running."
+        runbook_url: TBD
+        correlationId: "ImageRegistryPolicyDenied/svc-1"
+# Test 2: Deny mode — no denials, no alert
+- interval: 1m
+  input_series:
+  - series: 'apiserver_validating_admission_policy_check_total{cluster="svc-1",policy="image-registry-allowlist-policy",policy_binding="image-registry-allowlist-policy-binding",enforcement_action="deny",validation_result="allowed"}'
+    values: '0+10x20'
+  alert_rule_test:
+  - eval_time: 16m
+    alertname: ImageRegistryPolicyDenied
+    exp_alerts: []
+# Test 3: Audit mode — violations logged, alert fires after 5m
+- interval: 1m
+  input_series:
+  - series: 'apiserver_validating_admission_policy_check_total{cluster="mgmt-1",policy="image-registry-allowlist-policy",policy_binding="image-registry-allowlist-policy-binding",enforcement_action="audit",validation_result="denied"}'
+    values: '0+2x20'
+  alert_rule_test:
+  - eval_time: 20m
+    alertname: ImageRegistryPolicyAuditViolation
+    exp_alerts:
+    - exp_labels:
+        severity: info
+        cluster: mgmt-1
+        policy: image-registry-allowlist-policy
+        policy_binding: image-registry-allowlist-policy-binding
+      exp_annotations:
+        summary: "Image registry policy audit violation detected"
+        description: "The image-registry-allowlist-policy on cluster mgmt-1 has logged 30 audit violation(s) in the last 15 minutes. Pods with images from non-approved registries are running but not blocked. Review kubernetesEvents in Kusto for details."
+        runbook_url: TBD
+        correlationId: "ImageRegistryPolicyAuditViolation/mgmt-1"
+# Test 4: Audit mode — no violations, no alert
+- interval: 1m
+  input_series:
+  - series: 'apiserver_validating_admission_policy_check_total{cluster="mgmt-1",policy="image-registry-allowlist-policy",policy_binding="image-registry-allowlist-policy-binding",enforcement_action="audit",validation_result="allowed"}'
+    values: '0+5x20'
+  alert_rule_test:
+  - eval_time: 20m
+    alertname: ImageRegistryPolicyAuditViolation
+    exp_alerts: []


### PR DESCRIPTION
[AROSLSRE-860](https://redhat.atlassian.net/browse/AROSLSRE-860) | Parent: [ARO-22152](https://redhat.atlassian.net/browse/ARO-22152)

### What

Add two Prometheus alerting rules for the FSI `ValidatingAdmissionPolicy` deployed by #4690:

| Alert | Severity | Fires when |
|---|---|---|
| `ImageRegistryPolicyDenied` | warning (sev3) | VAP blocks pods with non-approved images in **Deny** mode |
| `ImageRegistryPolicyAuditViolation` | info (sev4) | VAP logs violations in **Audit** mode (pods allowed but non-compliant) |

Both query `apiserver_validating_admission_policy_check_total` (K8s 1.30+, clusters run 1.35.1).

### Why

[ARO-22152](https://redhat.atlassian.net/browse/ARO-22152)'s definition of done requires \"Compliance monitoring and reporting in place.\" Without these alerts, VAP denials go uninvestigated in Deny mode and audit violations go unnoticed in Audit mode. This is the last gap in the epic's acceptance criteria.

### Testing

- 4 promtool unit test scenarios (firing + non-firing for each alert) — all pass via `make -C observability alerts`
- Bicep auto-regenerated and formatted
- Alerts deploy to all environments via the existing `monitoring-pipeline.yaml` → `service-rules.bicep` path with no env-specific changes needed
- AMA scrapes `apiserver` with no metric filtering (`minimalingestionprofile = false`) across all environments

### Special notes for your reviewer

- These alerts depend on #4690 (which deploys the VAP). Without the VAP, the metric counter stays at zero and alerts never fire — safe to merge in either order.
- Alerts route to the **SL-SRE** ICM action group via `slActionGroups` in `monitoring.bicep:105`.
- `runbook_url` is set to `TBD` — will be updated once the runbook is written.
- No changes needed in `sdp-pipelines` — the ARO-HCP repo's `generatedPrometheusAlertingRules.bicep` deploys independently via the `Microsoft.Azure.ARO.HCP.Monitoring` service group.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the \"Why\" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — N/A, alerting rules only
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide) — Draft, pending CI
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge">
</invoke>