### PR TITLE
test(helmtest): add policy check to detect resource limits in Helm charts

### DIFF
--- a/tooling/helmtest/internal/type.go
+++ b/tooling/helmtest/internal/type.go
@@ -54,9 +54,10 @@ func (h *HelmStepWithPath) ChartDirFromRoot(topologyDir string) string {
 }
 
 type Settings struct {
-	ConfigPath  string
-	TopologyDir string
-	Replace     []Replace
+	ConfigPath              string
+	TopologyDir             string
+	Replace                 []Replace
+	ResourceLimitsAllowlist []string
 }
 
 type Replace struct {

--- a/tooling/helmtest/settings.yaml
+++ b/tooling/helmtest/settings.yaml
@@ -3,3 +3,7 @@ TopologyDir: ../..
 Replace:
 - Regex: 'sha256.[a-fA-F0-9]{64}'
   Replacement: 'sha256:1234567890'
+ResourceLimitsAllowlist:
+- Deployment/acrpull/acrpull-controller # upstream chart sets limits
+- DaemonSet/arobit-forwarder/fluentbit # upstream fluent-bit chart sets limits
+- Deployment/multicluster-engine-operator/backplane-operator # third-party MCE chart, not ours to modify

--- a/tooling/helmtest/settings.yaml
+++ b/tooling/helmtest/settings.yaml
@@ -6,4 +6,7 @@ Replace:
 ResourceLimitsAllowlist:
 - Deployment/acrpull/acrpull-controller # upstream chart sets limits
 - DaemonSet/arobit-forwarder/fluentbit # upstream fluent-bit chart sets limits
+- DaemonSet/arobit-forwarder/mdsd-cert-watchdog # upstream arobit chart sets limits
 - Deployment/multicluster-engine-operator/backplane-operator # third-party MCE chart, not ours to modify
+- Deployment/fleet-controller/fleet-controller # fleet controller chart sets limits
+- Job/*/fleet-registration # fleet registration job name varies by environment

--- a/tooling/helmtest/testrunner/policy_checks.go
+++ b/tooling/helmtest/testrunner/policy_checks.go
@@ -1,0 +1,106 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testrunner
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+type workloadMeta struct {
+	Kind     string `json:"kind"`
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		Template corev1.PodTemplateSpec `json:"template"`
+		// CronJob nesting
+		JobTemplate struct {
+			Spec struct {
+				Template corev1.PodTemplateSpec `json:"template"`
+			} `json:"spec"`
+		} `json:"jobTemplate"`
+	} `json:"spec"`
+}
+
+var workloadKinds = sets.New[string](
+	"Deployment",
+	"StatefulSet",
+	"DaemonSet",
+	"Job",
+	"CronJob",
+)
+
+func checkPolicyViolations(manifest string, resourceLimitsAllowlist sets.Set[string]) []string {
+	var violations []string
+
+	decoder := utilyaml.NewYAMLToJSONDecoder(strings.NewReader(manifest))
+	for {
+		var w workloadMeta
+		if err := decoder.Decode(&w); err != nil {
+			// if we've reached the end of the manifest, break
+			if err == io.EOF {
+				break
+			}
+
+			// if we failed to decode the manifest document, add a violation
+			violations = append(violations, fmt.Sprintf("failed to decode manifest document: %v", err))
+			continue
+		}
+
+		if !workloadKinds.Has(w.Kind) {
+			continue
+		}
+
+		// get pod spec from workload (or job template for CronJob)
+		podSpec := w.Spec.Template.Spec
+		if w.Kind == "CronJob" {
+			podSpec = w.Spec.JobTemplate.Spec.Template.Spec
+		}
+
+		violations = append(violations, checkPodSpecHasNoResourceLimits(w.Kind, w.Metadata.Name, podSpec, resourceLimitsAllowlist)...)
+	}
+
+	return violations
+}
+
+func checkPodSpecHasNoResourceLimits(kind, name string, podSpec corev1.PodSpec, allowlist sets.Set[string]) []string {
+	var violations []string
+	for _, c := range slices.Concat(podSpec.InitContainers, podSpec.Containers) {
+		if len(c.Resources.Limits) > 0 {
+			key := fmt.Sprintf("%s/%s/%s", kind, name, c.Name)
+			if allowlist.Has(key) {
+				continue
+			}
+			violations = append(violations, fmt.Sprintf("%s has resource limits set (add to ResourceLimitsAllowlist if intentional)", key))
+		}
+	}
+	for _, ec := range podSpec.EphemeralContainers {
+		if len(ec.Resources.Limits) > 0 {
+			key := fmt.Sprintf("%s/%s/%s", kind, name, ec.Name)
+			if allowlist.Has(key) {
+				continue
+			}
+			violations = append(violations, fmt.Sprintf("%s has resource limits set (add to ResourceLimitsAllowlist if intentional)", key))
+		}
+	}
+	return violations
+}

--- a/tooling/helmtest/testrunner/policy_checks.go
+++ b/tooling/helmtest/testrunner/policy_checks.go
@@ -17,6 +17,7 @@ package testrunner
 import (
 	"fmt"
 	"io"
+	"path"
 	"slices"
 	"strings"
 
@@ -49,7 +50,20 @@ var workloadKinds = sets.New[string](
 	"CronJob",
 )
 
-func checkPolicyViolations(manifest string, resourceLimitsAllowlist sets.Set[string]) []string {
+func matchesAllowlist(key string, patterns []string) (bool, error) {
+	for _, p := range patterns {
+		matched, err := path.Match(p, key)
+		if err != nil {
+			return false, fmt.Errorf("invalid allowlist pattern %q: %w", p, err)
+		}
+		if matched {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func checkPolicyViolations(manifest string, resourceLimitsAllowlist []string) []string {
 	var violations []string
 
 	decoder := utilyaml.NewYAMLToJSONDecoder(strings.NewReader(manifest))
@@ -82,12 +96,17 @@ func checkPolicyViolations(manifest string, resourceLimitsAllowlist sets.Set[str
 	return violations
 }
 
-func checkPodSpecHasNoResourceLimits(kind, name string, podSpec corev1.PodSpec, allowlist sets.Set[string]) []string {
+func checkPodSpecHasNoResourceLimits(kind, name string, podSpec corev1.PodSpec, allowlist []string) []string {
 	var violations []string
 	for _, c := range slices.Concat(podSpec.InitContainers, podSpec.Containers) {
 		if len(c.Resources.Limits) > 0 {
 			key := fmt.Sprintf("%s/%s/%s", kind, name, c.Name)
-			if allowlist.Has(key) {
+			matched, err := matchesAllowlist(key, allowlist)
+			if err != nil {
+				violations = append(violations, err.Error())
+				continue
+			}
+			if matched {
 				continue
 			}
 			violations = append(violations, fmt.Sprintf("%s has resource limits set (add to ResourceLimitsAllowlist if intentional)", key))
@@ -96,7 +115,12 @@ func checkPodSpecHasNoResourceLimits(kind, name string, podSpec corev1.PodSpec, 
 	for _, ec := range podSpec.EphemeralContainers {
 		if len(ec.Resources.Limits) > 0 {
 			key := fmt.Sprintf("%s/%s/%s", kind, name, ec.Name)
-			if allowlist.Has(key) {
+			matched, err := matchesAllowlist(key, allowlist)
+			if err != nil {
+				violations = append(violations, err.Error())
+				continue
+			}
+			if matched {
 				continue
 			}
 			violations = append(violations, fmt.Sprintf("%s has resource limits set (add to ResourceLimitsAllowlist if intentional)", key))

--- a/tooling/helmtest/testrunner/policy_checks_test.go
+++ b/tooling/helmtest/testrunner/policy_checks_test.go
@@ -18,15 +18,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-var emptyAllowlist = sets.New[string]()
+var emptyAllowlist []string
 
-var testAllowlist = sets.New[string](
+var testAllowlist = []string{
 	"DaemonSet/test-allowlisted-ds/test-container",
-)
+}
 
 func TestCheckPolicyViolations_DeploymentWithLimits(t *testing.T) {
 	manifest := `
@@ -220,6 +218,67 @@ spec:
 `
 	violations := checkPolicyViolations(manifest, emptyAllowlist)
 	assert.Empty(t, violations)
+}
+
+func TestCheckPolicyViolations_WildcardAllowlist(t *testing.T) {
+	manifest := `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dev-westus3-svc-1-fleet-reg
+spec:
+  template:
+    spec:
+      containers:
+      - name: fleet-registration
+        resources:
+          limits:
+            memory: "256Mi"
+`
+	wildcardAllowlist := []string{"Job/*/fleet-registration"}
+	violations := checkPolicyViolations(manifest, wildcardAllowlist)
+	assert.Empty(t, violations)
+}
+
+func TestCheckPolicyViolations_WildcardNoMatch(t *testing.T) {
+	manifest := `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dev-westus3-svc-1-fleet-reg
+spec:
+  template:
+    spec:
+      containers:
+      - name: some-other-container
+        resources:
+          limits:
+            memory: "256Mi"
+`
+	wildcardAllowlist := []string{"Job/*/fleet-registration"}
+	violations := checkPolicyViolations(manifest, wildcardAllowlist)
+	assert.Equal(t, []string{`Job/dev-westus3-svc-1-fleet-reg/some-other-container has resource limits set (add to ResourceLimitsAllowlist if intentional)`}, violations)
+}
+
+func TestCheckPolicyViolations_MalformedPattern(t *testing.T) {
+	manifest := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: web
+        resources:
+          limits:
+            memory: "128Mi"
+`
+	badAllowlist := []string{"Deployment/my-app/[bad"}
+	violations := checkPolicyViolations(manifest, badAllowlist)
+	assert.Len(t, violations, 1)
+	assert.Contains(t, violations[0], "invalid allowlist pattern")
 }
 
 func TestCheckPolicyViolations_MixedAllowlistedAndViolating(t *testing.T) {

--- a/tooling/helmtest/testrunner/policy_checks_test.go
+++ b/tooling/helmtest/testrunner/policy_checks_test.go
@@ -1,0 +1,246 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testrunner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var emptyAllowlist = sets.New[string]()
+
+var testAllowlist = sets.New[string](
+	"DaemonSet/test-allowlisted-ds/test-container",
+)
+
+func TestCheckPolicyViolations_DeploymentWithLimits(t *testing.T) {
+	manifest := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: web
+        resources:
+          limits:
+            memory: "128Mi"
+`
+	violations := checkPolicyViolations(manifest, emptyAllowlist)
+	assert.Equal(t, []string{`Deployment/my-app/web has resource limits set (add to ResourceLimitsAllowlist if intentional)`}, violations)
+}
+
+func TestCheckPolicyViolations_DeploymentWithoutLimits(t *testing.T) {
+	manifest := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: web
+        resources:
+          requests:
+            memory: "64Mi"
+`
+	violations := checkPolicyViolations(manifest, emptyAllowlist)
+	assert.Empty(t, violations)
+}
+
+func TestCheckPolicyViolations_InitContainerWithLimits(t *testing.T) {
+	manifest := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: init
+        resources:
+          limits:
+            cpu: "500m"
+      containers:
+      - name: web
+`
+	violations := checkPolicyViolations(manifest, emptyAllowlist)
+	assert.Equal(t, []string{`Deployment/my-app/init has resource limits set (add to ResourceLimitsAllowlist if intentional)`}, violations)
+}
+
+func TestCheckPolicyViolations_CronJobWithLimits(t *testing.T) {
+	manifest := `
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cleanup
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: cleaner
+            resources:
+              limits:
+                memory: "256Mi"
+`
+	violations := checkPolicyViolations(manifest, emptyAllowlist)
+	assert.Equal(t, []string{`CronJob/cleanup/cleaner has resource limits set (add to ResourceLimitsAllowlist if intentional)`}, violations)
+}
+
+func TestCheckPolicyViolations_DaemonSetWithLimits(t *testing.T) {
+	manifest := `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: agent
+spec:
+  template:
+    spec:
+      containers:
+      - name: collector
+        resources:
+          limits:
+            memory: "512Mi"
+`
+	violations := checkPolicyViolations(manifest, emptyAllowlist)
+	assert.Equal(t, []string{`DaemonSet/agent/collector has resource limits set (add to ResourceLimitsAllowlist if intentional)`}, violations)
+}
+
+func TestCheckPolicyViolations_NonWorkloadSkipped(t *testing.T) {
+	manifest := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+data:
+  key: value
+`
+	violations := checkPolicyViolations(manifest, emptyAllowlist)
+	assert.Empty(t, violations)
+}
+
+func TestCheckPolicyViolations_MultiDocument(t *testing.T) {
+	manifest := `
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-svc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: web
+        resources:
+          limits:
+            memory: "128Mi"
+`
+	violations := checkPolicyViolations(manifest, emptyAllowlist)
+	assert.Equal(t, []string{`Deployment/my-app/web has resource limits set (add to ResourceLimitsAllowlist if intentional)`}, violations)
+}
+
+func TestCheckPolicyViolations_AllowlistedSkipped(t *testing.T) {
+	manifest := `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-allowlisted-ds
+spec:
+  template:
+    spec:
+      containers:
+      - name: test-container
+        resources:
+          limits:
+            memory: "1Gi"
+`
+	violations := checkPolicyViolations(manifest, testAllowlist)
+	assert.Empty(t, violations)
+}
+
+func TestCheckPolicyViolations_EphemeralContainerWithLimits(t *testing.T) {
+	manifest := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: web
+      ephemeralContainers:
+      - name: debugger
+        resources:
+          limits:
+            memory: "256Mi"
+`
+	violations := checkPolicyViolations(manifest, emptyAllowlist)
+	assert.Equal(t, []string{`Deployment/my-app/debugger has resource limits set (add to ResourceLimitsAllowlist if intentional)`}, violations)
+}
+
+func TestCheckPolicyViolations_EphemeralContainerWithoutLimits(t *testing.T) {
+	manifest := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: web
+      ephemeralContainers:
+      - name: debugger
+`
+	violations := checkPolicyViolations(manifest, emptyAllowlist)
+	assert.Empty(t, violations)
+}
+
+func TestCheckPolicyViolations_MixedAllowlistedAndViolating(t *testing.T) {
+	manifest := `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-allowlisted-ds
+spec:
+  template:
+    spec:
+      containers:
+      - name: test-container
+        resources:
+          limits:
+            memory: "1Gi"
+      - name: not-allowlisted
+        resources:
+          limits:
+            cpu: "100m"
+`
+	violations := checkPolicyViolations(manifest, testAllowlist)
+	assert.Equal(t, []string{`DaemonSet/test-allowlisted-ds/not-allowlisted has resource limits set (add to ResourceLimitsAllowlist if intentional)`}, violations)
+}

--- a/tooling/helmtest/testrunner/test_runner.go
+++ b/tooling/helmtest/testrunner/test_runner.go
@@ -25,11 +25,14 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/chart/common"
 	"helm.sh/helm/v4/pkg/chart/loader"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/release"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/yaml"
 
@@ -151,6 +154,7 @@ func RunTestHelmTemplate(t *testing.T, settingsPath string) {
 	assert.NoError(t, err)
 	assert.NotNil(t, helmSteps)
 
+	resourceLimitsAllowlist := sets.New[string](settings.ResourceLimitsAllowlist...)
 	chartDirsVisited := make(map[string]bool)
 
 	for _, helmStep := range helmSteps {
@@ -174,7 +178,12 @@ func RunTestHelmTemplate(t *testing.T, settingsPath string) {
 		for _, testCase := range allCases {
 			t.Run(testCase.Name, func(t *testing.T) {
 				manifest, err := runTest(t.Context(), settings, testCase)
-				assert.NoError(t, err)
+				require.NoError(t, err)
+
+				for _, v := range checkPolicyViolations(manifest, resourceLimitsAllowlist) {
+					t.Error(v)
+				}
+
 				// we want to place implicit test cases by the pipelines that created them, not the chart they happened to render.
 				// n.b. a more correct implementation would keep track of *where* the custom test case came from and use that dir
 				// exactly as the output directory - an exercise left for the future

--- a/tooling/helmtest/testrunner/test_runner.go
+++ b/tooling/helmtest/testrunner/test_runner.go
@@ -32,8 +32,6 @@ import (
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/release"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"sigs.k8s.io/yaml"
 
 	"github.com/Azure/ARO-Tools/config"
@@ -154,7 +152,7 @@ func RunTestHelmTemplate(t *testing.T, settingsPath string) {
 	assert.NoError(t, err)
 	assert.NotNil(t, helmSteps)
 
-	resourceLimitsAllowlist := sets.New[string](settings.ResourceLimitsAllowlist...)
+	resourceLimitsAllowlist := settings.ResourceLimitsAllowlist
 	chartDirsVisited := make(map[string]bool)
 
 	for _, helmStep := range helmSteps {


### PR DESCRIPTION

Implements [AROSLSRE-573](https://redhat.atlassian.net/browse/AROSLSRE-573)

### What
Adds an automated and extendable policy check to `helmtest` that flags workloads with `resources.limits` set, supporting the goal of removing resource limits from services we deploy (#4581). The check runs inline with `TestHelmTemplate` on every rendered manifest, inspecting Deployments, StatefulSets, DaemonSets, Jobs, and CronJobs for container-level resource limits.

Known exceptions (acrpull, arobit/fluentbit, mce) are allowlisted since they have limits set intentionally or are third-party charts.

Future manifest policy check functions can easily be added to the overarching manifest test loop.

### Why

Resource limits can cause services to be OOMKilled under load, as seen with the backend crashes that motivated #4641.  This test ensures we don't regress by accidentally reintroducing limits on services where they've been deliberately removed.

### Testing

- [x] `go test . -run TestHelmTemplate` passes with allowlisted exceptions
- [ ] Verify that adding `resources.limits` to a non-allowlisted chart causes a test failure

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
