### PR TITLE
tooling/hcpctl: improve maestro bundle queries

### DIFF
--- a/tooling/hcpctl/cmd/must-gather/snapshot/from_prow_job_cmd.go
+++ b/tooling/hcpctl/cmd/must-gather/snapshot/from_prow_job_cmd.go
@@ -87,7 +87,7 @@ func (o *validatedFromProwJobOptions) run(ctx context.Context) error {
 	)
 
 	// Phase 1: Download Prow artifacts and parse config + failed tests.
-	jobConfig, failedTests, err := snapshotpkg.FetchProwJobData(ctx, o.prowInfo)
+	jobConfig, failedTests, _, err := snapshotpkg.FetchProwJobData(ctx, o.prowInfo)
 	if err != nil {
 		return fmt.Errorf("failed to fetch Prow job data: %w", err)
 	}

--- a/tooling/hcpctl/pkg/snapshot/prow.go
+++ b/tooling/hcpctl/pkg/snapshot/prow.go
@@ -128,20 +128,20 @@ func ParseProwURL(rawURL string) (*ProwJobInfo, error) {
 }
 
 // FetchProwJobData downloads config and test results from a Prow job's GCS artifacts.
-// Returns the Kusto config and all failed tests.
-func FetchProwJobData(ctx context.Context, info *ProwJobInfo) (*ProwJobConfig, []FailedTest, error) {
+// Returns the Kusto config, all failed tests, and the full set of test results.
+func FetchProwJobData(ctx context.Context, info *ProwJobInfo) (*ProwJobConfig, []FailedTest, extensiontests.ExtensionTestResults, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	gcsClient, err := storage.NewClient(ctx, option.WithoutAuthentication())
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create GCS client: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to create GCS client: %w", err)
 	}
 	defer gcsClient.Close()
 
 	// Find the artifact directory.
 	artifactDir, err := findArtifactDir(ctx, gcsClient, info.JobName, info.GCSPrefix)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to find artifact directory: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to find artifact directory: %w", err)
 	}
 	logger.Info("Found artifact directory", "dir", artifactDir)
 
@@ -151,12 +151,12 @@ func FetchProwJobData(ctx context.Context, info *ProwJobInfo) (*ProwJobConfig, [
 	configGCSPath := fmt.Sprintf("%s/%s", artifactPrefix, configPath)
 	configData, err := downloadObject(ctx, gcsClient, configGCSPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to download config.yaml: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to download config.yaml: %w", err)
 	}
 
 	jobConfig, err := parseConfig(configData, info.IsPR)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse config.yaml: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to parse config.yaml: %w", err)
 	}
 	logger.Info("Parsed job config",
 		"region", jobConfig.Region,
@@ -173,10 +173,10 @@ func FetchProwJobData(ctx context.Context, info *ProwJobInfo) (*ProwJobConfig, [
 	testResultsPrefix := fmt.Sprintf("%s/%s/artifacts/extension_test_result_e2e_", artifactPrefix, testStep)
 	testResultFiles, err := listObjects(ctx, gcsClient, testResultsPrefix)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list test result files: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to list test result files: %w", err)
 	}
 	if len(testResultFiles) == 0 {
-		return nil, nil, fmt.Errorf("no extension_test_result_e2e_*.json files found under %s", testResultsPrefix)
+		return nil, nil, nil, fmt.Errorf("no extension_test_result_e2e_*.json files found under %s", testResultsPrefix)
 	}
 
 	var allResults extensiontests.ExtensionTestResults
@@ -211,12 +211,12 @@ func FetchProwJobData(ctx context.Context, info *ProwJobInfo) (*ProwJobConfig, [
 		if result.EndTime != nil {
 			ft.EndTime = time.Time(*result.EndTime)
 		}
-		ft.ResourceGroup = extractResourceGroup(result.Output)
+		ft.ResourceGroup = ExtractResourceGroup(result.Output)
 		failed = append(failed, ft)
 	}
 
 	logger.Info("Found test results", "total", len(allResults), "failed", len(failed))
-	return jobConfig, failed, nil
+	return jobConfig, failed, allResults, nil
 }
 
 // resourceGroupRegex matches log lines like:
@@ -224,9 +224,9 @@ func FetchProwJobData(ctx context.Context, info *ProwJobInfo) (*ProwJobConfig, [
 //	"msg"="creating resource group" "resourceGroup"="private-keyvault-gxsj99"
 var resourceGroupRegex = regexp.MustCompile(`"resourceGroup"="([^"]+)"`)
 
-// extractResourceGroup parses the resource group name from test output logs.
+// ExtractResourceGroup parses the resource group name from test output logs.
 // Tests log a line like: "msg"="creating resource group" "resourceGroup"="<name>"
-func extractResourceGroup(output string) string {
+func ExtractResourceGroup(output string) string {
 	matches := resourceGroupRegex.FindStringSubmatch(output)
 	if len(matches) >= 2 {
 		return matches[1]

--- a/tooling/hcpctl/pkg/snapshot/queries.go
+++ b/tooling/hcpctl/pkg/snapshot/queries.go
@@ -268,7 +268,7 @@ var allQueries = []querySpec{
 		prerequisites: "ClusterID",
 		requiredWhen:  func(d queryData) bool { return d.ClusterID != "" },
 		storeResult: func(d *queryData, rows []resultRow) {
-			// Columns: bundleId, bundleName, manifestWork
+			// Columns: bundleId, bundleName, resource, kind
 			for _, row := range rows {
 				if len(row.values) >= 3 {
 					if id := strings.TrimSpace(row.values[0]); id != "" {
@@ -279,6 +279,34 @@ var allQueries = []querySpec{
 					}
 					if mw := strings.TrimSpace(row.values[2]); mw != "" {
 						d.ManifestWorkNames = append(d.ManifestWorkNames, mw)
+					}
+				}
+			}
+		},
+	},
+	{
+		component:    "backend",
+		queryName:    "maestroBundleAssociations",
+		templatePath: "queries/backend/maestroBundleAssociations/query.kql",
+		database:     "service",
+		category:     categoryResourceDiscovery,
+		ready: func(d queryData) bool {
+			return d.ResourceGroup != "" && d.ClusterResourceName != "" && d.ServiceProviderResourceType != ""
+		},
+		prerequisites: "ResourceGroup, ClusterResourceName, ServiceProviderResourceType",
+		requiredWhen:  isClusterOrNodePool,
+		storeResult: func(d *queryData, rows []resultRow) {
+			// Columns: resourceID, name, bundleName, bundleId
+			for _, row := range rows {
+				if len(row.values) >= 4 {
+					if mw := strings.TrimSpace(row.values[1]); mw != "" {
+						d.ManifestWorkNames = append(d.ManifestWorkNames, mw)
+					}
+					if name := strings.TrimSpace(row.values[2]); name != "" {
+						d.BundleNames = append(d.BundleNames, name)
+					}
+					if id := strings.TrimSpace(row.values[3]); id != "" {
+						d.BundleIDs = append(d.BundleIDs, id)
 					}
 				}
 			}
@@ -449,6 +477,20 @@ var allQueries = []querySpec{
 			return len(d.ManifestWorkNames) > 0
 		},
 		prerequisites: "ManifestWorkNames",
+	},
+	{
+		component:    "maestro",
+		queryName:    "transitions",
+		templatePath: "queries/maestro/transitions/query.kql",
+		database:     "service",
+		category:     categoryState,
+		ready: func(d queryData) bool {
+			hasCS := d.ClusterID != ""
+			hasBackend := d.ResourceGroup != "" && d.ClusterResourceName != "" && d.ServiceProviderResourceType != ""
+			return len(d.BundleIDs) > 0 && (hasCS || hasBackend)
+		},
+		prerequisites: "BundleIDs, and one of (ClusterID) or (ResourceGroup, ClusterResourceName, ServiceProviderResourceType)",
+		requiredWhen:  func(d queryData) bool { return len(d.BundleIDs) > 0 },
 	},
 
 	// --- Context: time-windowed, resource-group-scoped ---

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/maestroBundleAssociations/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/maestroBundleAssociations/query.kql
@@ -1,0 +1,11 @@
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
+| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where container_name == 'aro-hcp-backend'
+| where log.controller_name == 'datadump'
+| where log.resource_group == '{{ .ResourceGroup }}'
+| where log.resource_name == '{{ .ClusterResourceName }}'
+| where log.content.resourceType =~ '{{ .ServiceProviderResourceType }}'
+| summarize content = take_any(log.content) by etag = tostring(log.content._etag)
+| extend resourceID = tostring(content.resourceID)
+| mv-expand readOnlyBundle = content.properties.status.maestroReadonlyBundles
+| distinct resourceID, name = tostring(readOnlyBundle.name), bundleName = tostring(readOnlyBundle.maestroAPIMaestroBundleName), bundleId = tostring(readOnlyBundle.maestroAPIMaestroBundleID)

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/maestroBundleAssociations/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/maestroBundleAssociations/query.kql
@@ -4,6 +4,7 @@ cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('clustersS
 | where log.msg has 'successfully sent create request of maestro bundle with maestro bundle id'
 | extend bundleId = extract("bundle id '([^']+)'", 1, tostring(log.msg))
 | extend bundleName = extract("maestro bundle name '([^']+)'", 1, tostring(log.msg))
-| extend manifestWork = extract("containing resource '([^']+)'", 1, tostring(log.msg))
-| where isnotempty(manifestWork)
-| distinct bundleId, bundleName, manifestWork
+| extend resource = extract("containing resource '([^']+)'", 1, tostring(log.msg))
+| extend resource_kind = extract("Kind=([^']+)'", 1, tostring(log.msg))
+| where isnotempty(resource)
+| distinct bundleId, bundleName, resource, resource_kind

--- a/tooling/hcpctl/pkg/snapshot/queries/maestro/transitions/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/maestro/transitions/query.kql
@@ -1,0 +1,92 @@
+{{ if .ClusterID -}}
+let bundleMapCS = cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('clustersServiceLogs')
+| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where cid == '{{ .ClusterID }}'
+| where log.msg has 'successfully sent create request of maestro bundle with maestro bundle id'
+| extend bundleId = extract("bundle id '([^']+)'", 1, tostring(log.msg))
+| extend resource = extract("containing resource '([^']+)'", 1, tostring(log.msg))
+| extend resource_kind = extract("Kind=([^']+)'", 1, tostring(log.msg))
+| where isnotempty(bundleId) and isnotempty(resource)
+| extend resourceNamespace = extract("^([^/]+)/", 1, resource)
+| extend resourceName = extract("/(.+)$", 1, resource)
+| distinct bundleId, resourceNamespace, resourceName, source = 'clustersService', label = strcat(resource_kind, ' ', resource);
+{{ end -}}
+{{ if and .ResourceGroup .ClusterResourceName .ServiceProviderResourceType -}}
+let bundleNameToResourceName = cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
+| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where container_name == 'aro-hcp-backend'
+| where log.controller_name == 'createclusterscopedmaestroreadonlybundles'
+| where log.resource_group == '{{ .ResourceGroup }}'
+| where log.resource_name == '{{ .ClusterResourceName }}'
+| extend bundleName = extract('maestro bundle name ([^ ]+) ', 1, tostring(log.msg))
+| extend resourceName = extract('resource name ([^ ]+)', 1, tostring(log.msg))
+| where bundleName != '' and resourceName != ''
+| distinct bundleName, resourceName;
+let bundleMapBackend = cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
+| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where container_name == 'aro-hcp-backend'
+| where log.controller_name == 'datadump'
+| where log.resource_group == '{{ .ResourceGroup }}'
+| where log.resource_name == '{{ .ClusterResourceName }}'
+| where log.content.resourceType =~ '{{ .ServiceProviderResourceType }}'
+| summarize content = take_any(log.content) by etag = tostring(log.content._etag)
+| extend resourceID = tostring(content.resourceID)
+| mv-expand readOnlyBundle = content.properties.status.maestroReadonlyBundles
+| extend bundleId = tostring(readOnlyBundle.maestroAPIMaestroBundleID)
+| extend bundleName = tostring(readOnlyBundle.name)
+| extend bundleAPIName = tostring(readOnlyBundle.maestroAPIMaestroBundleName)
+| where isnotempty(bundleId)
+| distinct bundleId, bundleName, bundleAPIName, source = 'backend', label = strcat(bundleName, ' (', resourceID, ')')
+| lookup bundleNameToResourceName on $left.bundleAPIName == $right.bundleName;
+{{ end -}}
+let bundleMap = union
+{{ if .ClusterID -}}
+    bundleMapCS{{ if and .ResourceGroup .ClusterResourceName .ServiceProviderResourceType }},{{ end }}
+{{ end -}}
+{{ if and .ResourceGroup .ClusterResourceName .ServiceProviderResourceType -}}
+    bundleMapBackend
+{{ end -}}
+| summarize source = take_any(source), label = take_any(label), resourceNamespace = take_any(resourceNamespace), resourceName = take_any(resourceName) by bundleId;
+let bundleIds = bundleMap | project bundleId;
+let resourceNameToBundleId = bundleMap
+| where isnotempty(resourceName)
+| distinct resourceName, bundleId;
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('containerLogs')
+| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where namespace_name == 'maestro'
+| where container_name in ('maestro-server', 'maestro-agent')
+| extend logs = tostring(log)
+| extend bundleId = extract('("resourceid":|resourceID=)"([^"]+)"', 2, logs)
+| extend resourceName = extract('resourceName="([^"]+)"', 1, logs)
+| lookup resourceNameToBundleId on resourceName
+| extend bundleId = coalesce(bundleId, bundleId1)
+| where isnotempty(bundleId)
+| where bundleId in (bundleIds)
+| extend msg = extract('] "([^"]+)"', 1, logs)
+| extend layer = case(
+    container_name == 'maestro-server' and msg == 'receive the event from client',        '1_server_spec_from_client',
+    container_name == 'maestro-server' and msg == 'Sending event',                        '2_server_spec_to_broker',
+    container_name == 'maestro-agent'  and msg == 'Received event',                       '3_agent_spec_from_broker',
+    container_name == 'maestro-agent'  and msg == 'Server side applied',                  '4_agent_acted_on_cluster',
+    container_name == 'maestro-agent'  and msg == 'Noop because its read-only',           '4_agent_acted_on_cluster',
+    container_name == 'maestro-agent'  and msg == 'Sending event',                        '5_agent_status_to_broker',
+    container_name == 'maestro-server' and msg == 'Updating resource status',             '6_server_status_from_broker',
+    container_name == 'maestro-server' and msg == 'send the event to status subscribers', '7_server_status_to_subscribers',
+    'other')
+| where layer != 'other'
+| lookup bundleMap on bundleId
+| summarize count = count() by source, label, layer
+| union (
+    datatable(source: string, label: string, layer: string, count: long) [
+        '__placeholder__', '__placeholder__', '1_server_spec_from_client', 0,
+        '__placeholder__', '__placeholder__', '2_server_spec_to_broker', 0,
+        '__placeholder__', '__placeholder__', '3_agent_spec_from_broker', 0,
+        '__placeholder__', '__placeholder__', '4_agent_acted_on_cluster', 0,
+        '__placeholder__', '__placeholder__', '5_agent_status_to_broker', 0,
+        '__placeholder__', '__placeholder__', '6_server_status_from_broker', 0,
+        '__placeholder__', '__placeholder__', '7_server_status_to_subscribers', 0
+    ]
+)
+| evaluate pivot(layer, sum(count))
+| where source != '__placeholder__'
+| order by source asc, label asc


### PR DESCRIPTION
tooling/hcpctl: expose Prow data in gather-snapshot

Downstream consumers may want to see data about e.g. passing tests.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

tooling/hcpctl: improve maestro bundle queries

We now have a concise query to track Maestro bundles across the
different layers.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

