### PR TITLE
Stop migrating operation records

### DIFF
--- a/frontend/pkg/frontend/migrate_cosmos.go
+++ b/frontend/pkg/frontend/migrate_cosmos.go
@@ -164,19 +164,5 @@ func MigrateCosmosOrDie(ctx context.Context, resourcesDBClient database.Resource
 		if err := clusterIterator.GetError(); err != nil {
 			panic(err)
 		}
-
-		operationIterator, err := resourcesDBClient.Operations(subscription.ResourceID.Name).List(ctx, nil)
-		if err != nil {
-			panic(err)
-		}
-		for _, operation := range operationIterator.Items(ctx) {
-			_, err := resourcesDBClient.Operations(operation.ResourceID.SubscriptionID).Get(ctx, operation.ResourceID.Name)
-			if err != nil {
-				panic(err)
-			}
-		}
-		if err := operationIterator.GetError(); err != nil {
-			panic(err)
-		}
 	}
 }


### PR DESCRIPTION
All the ones we care about have been rekeyed. We never rewrite storage since old operations are removed after a week.  Currently have a large enough number that a 3ms latency per is causing a problem.  Remove the stanza.

Operations are already on generic storage, so no more migration expected.