### PR TITLE
e2e: add timeout and frequency to remaining unprotected PollUntilDone calls

### DIFF
--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -414,7 +415,11 @@ var _ = Describe("Authorized CIDRs", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				_, err = poller.PollUntilDone(ctx, nil)
+				pollCtx, pollCancel := context.WithTimeout(ctx, 10*time.Minute)
+				defer pollCancel()
+				_, err = poller.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
+					Frequency: framework.StandardPollInterval,
+				})
 				Expect(err).NotTo(HaveOccurred())
 
 				By("verifying VM is now blocked from API access")

--- a/test/e2e/shoebox_logs.go
+++ b/test/e2e/shoebox_logs.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
@@ -123,7 +124,11 @@ func createStorageAccount(ctx context.Context, subscriptionID string, creds azco
 		return nil, fmt.Errorf("failed to begin storage account creation: %w", err)
 	}
 
-	storageAccount, err := storagePoller.PollUntilDone(ctx, nil)
+	pollCtx, pollCancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer pollCancel()
+	storageAccount, err := storagePoller.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
+		Frequency: 10 * time.Second,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create storage account: %w", err)
 	}
@@ -163,7 +168,11 @@ func createEventHub(ctx context.Context, subscriptionID string, creds azcore.Tok
 		return nil, fmt.Errorf("failed to begin Event Hub namespace creation: %w", err)
 	}
 
-	_, err = nsPoller.PollUntilDone(ctx, nil)
+	pollCtx, pollCancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer pollCancel()
+	_, err = nsPoller.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
+		Frequency: 10 * time.Second,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Event Hub namespace: %w", err)
 	}

--- a/test/util/cleanup/kusto-role-assignments/run.go
+++ b/test/util/cleanup/kusto-role-assignments/run.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/sync/errgroup"
@@ -74,10 +75,15 @@ func pageAssignmentsAndDeleteInvalid(ctx context.Context, pager *runtime.Pager[a
 				if err != nil {
 					return fmt.Errorf("failed to delete role assignment: %w", err)
 				}
+				pollCtx, pollCancel := context.WithTimeout(ctx, 5*time.Minute)
 				var resp any
-				if resp, err = poller.PollUntilDone(ctx, nil); err != nil {
+				if resp, err = poller.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
+					Frequency: 10 * time.Second,
+				}); err != nil {
+					pollCancel()
 					return fmt.Errorf("failed to delete role assignment: %w", err)
 				}
+				pollCancel()
 				switch m := resp.(type) {
 				case armkusto.DatabasePrincipalAssignmentsClientDeleteResponse:
 					logger.Info("Role assignment deleted", "database", database, "name", name)

--- a/test/util/framework/admin_api_helpers.go
+++ b/test/util/framework/admin_api_helpers.go
@@ -34,6 +34,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 )
@@ -383,7 +384,11 @@ func (tc *perItOrDescribeTestContext) DisableVMBootDiagnostics(ctx context.Conte
 		return fmt.Errorf("failed to begin VM update: %w", err)
 	}
 
-	_, err = poller.PollUntilDone(ctx, nil)
+	pollCtx, pollCancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer pollCancel()
+	_, err = poller.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
+		Frequency: StandardPollInterval,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to disable boot diagnostics: %w", err)
 	}


### PR DESCRIPTION
Adds context timeouts and poll frequency to the remaining `PollUntilDone()` calls that were not covered by #4611. Without these, stalled ARM operations cause the process to hang until CI kills it, producing a misleading deserialization error instead of a clear timeout.

**Call sites fixed:**
- `cluster_authorized_cidrs_connectivity.go` — 10m timeout
- `kusto-role-assignments/run.go` — 5m timeout
- `cluster_authorized_cidrs_connectivity.go` — 10m timeout
- `kusto-role-assignments/run.go` — 5m timeout
- `shoebox_logs.go` (storage account creation) — 10m timeout
- `shoebox_logs.go` (Event Hub namespace creation) — 10m timeout
- `admin_api_helpers.go` (VM boot diagnostics) — 5m timeout

Fixes: [ARO-25369](https://redhat.atlassian.net/browse/ARO-25369)