### PR TITLE
fix: add Swift V2 delegate IP allocation tags to agent pool VMSS

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -250,6 +250,8 @@ var advancedNetworking = networkDataplane == 'cilium'
 var swiftNodepoolTags = enableSwiftV2Nodepools
   ? {
       'aks-nic-enable-multi-tenancy': 'true'
+      'delegate-ip-allocation-for-nics-without-subnet': 'true'
+      'delegate-ip-allocation-nic-prefix': 'delegate'
     }
   : null
 

--- a/dev-infrastructure/modules/aks/pool.bicep
+++ b/dev-infrastructure/modules/aks/pool.bicep
@@ -75,9 +75,13 @@ var swiftNodepoolTags = enableSwiftV2
       ? {
           'aks-nic-enable-multi-tenancy': 'true'
           'aks-nic-secondary-count': string(secondaryNicCount)
+          'delegate-ip-allocation-for-nics-without-subnet': 'true'
+          'delegate-ip-allocation-nic-prefix': 'delegate'
         }
       : {
           'aks-nic-enable-multi-tenancy': 'true'
+          'delegate-ip-allocation-for-nics-without-subnet': 'true'
+          'delegate-ip-allocation-nic-prefix': 'delegate'
         })
   : null
 


### PR DESCRIPTION
ICM 797752695

The PR is a contingency plan, see [Slack](https://redhat-internal.slack.com/archives/C0B4P8WRYTA/p1778804621531479).

**Before Merge:** AKS confirmation on whether the system pool needs these tags; if not, a follow-up will narrow to user pools only and if the `delegate` tag is required.

### What

Adds two Swift V2 NIC delegation tags to all agent pool tag sets (system and user pools) when Swift V2 is enabled:

- `delegate-ip-allocation-for-nics-without-subnet`: `true`
- `delegate-ip-allocation-nic-prefix`: `delegate`

Tags are added to three call sites:
- `dev-infrastructure/modules/aks-cluster-base.bicep` (system pool)
- `dev-infrastructure/modules/aks/pool.bicep` (user pools, both `secondaryNicCount > 0` and `== 0` branches)

Infra pools are unaffected (they pass `enableSwiftV2: false`, so the tag set resolves to `null`).

### Why

ICM 797752695: eastus2 Swift NIC allocation failures. The delegate IP allocation tags are missing from our VMSS. AKS RP propagates agent pool tags to the backing VMSS at creation time; adding them here ensures new and reconciled pools get the correct tag set.

### Constraints and follow-ups

1. **Existing VMSS are not healed by this Bicep change alone.** The tags are applied at pool creation/reconciliation time. Existing eastus2 agent pools will need a nodepool image upgrade or rolling reimage after this deploys to pick up the new tags.

2. **System pool inclusion.** Both tags are applied to the system pool as well as user pools. If AKS confirms the system pool does not need them, a follow-up can narrow the scope.

3. **Swift tag duplication.** The Swift NIC tag set is now maintained in three call sites across two files. A follow-up could extract it into a shared Bicep variable or module to reduce drift risk.

### Testing

- `az bicep lint` passes on both modified files (only pre-existing warnings)
- `az bicep format` shows no drift
- `make -C config/ detect-change` confirms no rendered config changes needed
- No unit tests exist for the Swift tag set (infra-only change; tag correctness is validated at deploy time by AKS RP)

### Special notes for your reviewer

- Confirm with AKS team on the two asks:
  - System pool required or only user pool.
  - If the `delegate` tag is required as well.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge