### PR TITLE
Add Kubernetes provisioning diagnostics dashboard (ARO-26753)

### DIFF
--- a/docs/ops/kubernetes-provisioning-diagnostics.md
+++ b/docs/ops/kubernetes-provisioning-diagnostics.md
@@ -1,0 +1,238 @@
+# Kubernetes Provisioning Diagnostics
+
+## Overview
+
+This dashboard provides visibility into Kubernetes-level resource issues that can impact HCP cluster provisioning performance. It tracks pod health, container restarts, node resource pressure, and scheduling delays across management clusters.
+
+**Dashboard:** `HCP Kubernetes Provisioning Diagnostics` (in Grafana under "Performance & Scale" folder)
+
+**Related Jira:** [ARO-26753](https://redhat.atlassian.net/browse/ARO-26753)
+
+## Context
+
+During burst cluster creation (15+ clusters), provisioning times can breach the 20-minute SLO due to resource saturation on management clusters. This dashboard helps diagnose:
+
+- **Pod failures** - Crashes, OOMKills, or image pull failures
+- **Scheduling delays** - Pending pods due to resource constraints
+- **Container restarts** - Crash loops indicating stability issues
+- **Node pressure** - Memory, disk, or PID exhaustion on management cluster nodes
+
+## Dashboard Sections
+
+### 1. Pod Health by Namespace
+
+**Panels:**
+- **Ready Pods per Namespace** - Running pods over time
+- **Failed Pods per Namespace** - Failed pods indicating crashes or errors
+- **Pending Pods per Namespace** - Pods waiting to be scheduled
+- **Pod Phase Distribution** - Stacked view of all pod states
+
+**What to look for:**
+- Sudden drops in running pods during burst provisioning
+- Spikes in failed or pending pods correlating with slow cluster creation
+- Sustained high pending pod counts indicating resource exhaustion
+
+### 2. Pod Restart Analysis
+
+**Panels:**
+- **Container Restarts per Namespace** - Restart rate over 5-minute windows
+- **Top 10 Restarting Pods** - Specific pods with the most restarts in the last hour
+
+**What to look for:**
+- High restart rates (>0.1/sec) indicating crash loops
+- Restarts in critical namespaces (hypershift, OCM, maestro)
+- Specific pods repeatedly restarting during provisioning windows
+
+### 3. Node Resource Pressure
+
+**Panels:**
+- **Nodes Under Memory Pressure** - Count of nodes evicting pods due to memory
+- **Nodes Under Disk Pressure** - Count of nodes with disk space issues
+- **Nodes Under PID Pressure** - Count of nodes with process ID exhaustion
+- **Node Pressure Timeline** - Historical view of pressure conditions
+
+**What to look for:**
+- Any nodes showing pressure (count > 0) during burst provisioning
+- Correlation between node pressure and slow cluster creation times
+- Repeated pressure events indicating undersized nodes or resource leaks
+
+### 4. Scheduling and Resource Correlation
+
+**Panels:**
+- **Unschedulable Pods** - Pods that cannot be scheduled due to constraints
+- **Pod Distribution Heatmap** - Pod distribution across nodes and namespaces
+
+**What to look for:**
+- Unschedulable pods > 0 indicates resource exhaustion
+- Uneven pod distribution suggesting scheduling affinity issues
+- Hot spots on specific nodes during burst creation
+
+## Example Queries
+
+### Show Failed Pods During Provisioning Burst
+
+```promql
+# Failed pods by namespace
+sum(kube_pod_status_phase{cluster="cspr-westus3-mgmt-1", phase="Failed"}) by (namespace)
+```
+
+**Use case:** Set time range to the provisioning burst window (e.g., "April 23, 08:38-09:04") to see which namespaces had pod failures.
+
+### Which Namespaces Had the Most Restarts?
+
+```promql
+# Top 5 namespaces by restart rate over last hour
+topk(5, sum(rate(kube_pod_container_status_restarts_total{cluster="cspr-westus3-mgmt-1"}[1h])) by (namespace))
+```
+
+**Use case:** Identify namespaces with stability issues during or after burst provisioning.
+
+### Are Any Nodes Under Pressure During Provisioning?
+
+```promql
+# Memory pressure by node
+sum(kube_node_status_condition{cluster="cspr-westus3-mgmt-1", condition="MemoryPressure", status="true"}) by (node)
+
+# Disk pressure by node
+sum(kube_node_status_condition{cluster="cspr-westus3-mgmt-1", condition="DiskPressure", status="true"}) by (node)
+
+# PID pressure by node
+sum(kube_node_status_condition{cluster="cspr-westus3-mgmt-1", condition="PIDPressure", status="true"}) by (node)
+```
+
+**Use case:** Check if management cluster nodes are resource-saturated during slow provisioning.
+
+### Unschedulable Pods Indicating Resource Exhaustion
+
+```promql
+# Count of unschedulable pods
+sum(kube_pod_status_unschedulable{cluster="cspr-westus3-mgmt-1"}) by (namespace, pod)
+```
+
+**Use case:** Zero unschedulable pods = healthy. Any value > 0 indicates the cluster cannot schedule new pods.
+
+### Pod Distribution to Identify Hotspots
+
+```promql
+# Pods per node by namespace
+count(kube_pod_info{cluster="cspr-westus3-mgmt-1"}) by (node, namespace)
+```
+
+**Use case:** Check if certain nodes are overloaded during burst creation.
+
+## Correlating with Cluster Provisioning Events
+
+To diagnose slow provisioning, cross-reference this dashboard with cluster service logs:
+
+1. **Identify the time window** - Find the cluster creation timestamps from cluster-service logs
+   - Example: April 23, 08:38 (cluster moves to Installing) → 09:04 (cluster Ready) = 26 min
+
+2. **Set the dashboard time range** - Use the Grafana time picker to focus on that window
+
+3. **Check each section:**
+   - **Pod Health:** Were there failed/pending pods in `ocm-*` or `hypershift` namespaces?
+   - **Restarts:** Were critical pods (maestro-agent, hypershift-operator) restarting?
+   - **Node Pressure:** Were management cluster nodes under memory/disk/PID pressure?
+   - **Scheduling:** Were pods unschedulable due to resource constraints?
+
+4. **Compare to baseline** - Check the same metrics during normal (non-burst) provisioning to identify anomalies
+
+## Troubleshooting Scenarios
+
+### Scenario 1: Cluster Provisioning Takes >20 Minutes
+
+**Symptoms:**
+- Cluster moves to Installing state quickly
+- HostedCluster CR created in management cluster
+- Long delay before cluster reaches Ready state
+
+**Diagnosis Steps:**
+1. Check **Pending Pods per Namespace** - Are HCP control plane pods pending?
+2. Check **Node Pressure** - Is the management cluster resource-saturated?
+3. Check **Unschedulable Pods** - Can new pods even be scheduled?
+4. Check **Pod Distribution Heatmap** - Are nodes unevenly loaded?
+
+**Common Causes:**
+- Management cluster nodes undersized for burst load
+- Too many HCPs on one management cluster (need more shards)
+- Resource requests set too high on HCP components
+
+### Scenario 2: Pods Keep Restarting During Provisioning
+
+**Symptoms:**
+- Cluster eventually provisions but takes long time
+- Intermittent failures in provisioning flow
+
+**Diagnosis Steps:**
+1. Check **Top 10 Restarting Pods** - Which pods are crash-looping?
+2. Check **Container Restarts per Namespace** - Which namespace has the issue?
+3. Check **Node Pressure** - Are restarts due to OOMKills (memory pressure)?
+
+**Common Causes:**
+- Memory limits too low on HCP components (OOMKilled)
+- Liveness probe configured too aggressively
+- External dependency issues (maestro MQTT, postgres)
+
+### Scenario 3: Failed Pods Block Provisioning
+
+**Symptoms:**
+- Provisioning gets stuck
+- Cluster never reaches Ready state
+
+**Diagnosis Steps:**
+1. Check **Failed Pods per Namespace** - Which pods failed?
+2. Check specific pod logs: `kubectl logs -n <namespace> <pod>`
+3. Check pod events: `kubectl describe pod -n <namespace> <pod>`
+
+**Common Causes:**
+- Image pull failures (registry issues, wrong image tag)
+- Init container failures (configuration errors)
+- Insufficient RBAC permissions
+
+## Accessing the Dashboard
+
+### From Grafana UI
+1. Log into Grafana for your target environment (dev/cspr/int/stg/prod)
+2. Navigate to **Dashboards** → **Performance & Scale** folder
+3. Select **HCP Kubernetes Provisioning Diagnostics**
+
+### Direct Link
+```
+https://<grafana-url>/d/hcp-k8s-provisioning-diagnostics
+```
+
+### Variables
+- **Datasource** - Select the Prometheus datasource for your environment
+- **Cluster** - Select the management cluster (e.g., `cspr-westus3-mgmt-1`)
+- **Namespace** - Filter to specific namespaces or use "All"
+  - Common namespaces to monitor:
+    - `ocm-*` - Open Cluster Management (HCP orchestration)
+    - `hypershift` - HCP control plane operator
+    - `maestro` - Event distribution
+    - `clusters-*` - Per-HCP cluster namespaces
+
+## Related Dashboards
+
+- **Cluster Service SLO** - API-level provisioning metrics and SLO tracking
+- **Maestro Server** - Event delivery metrics (MQTT, postgres, gRPC)
+- **AKS Performance** - Management cluster infrastructure metrics
+
+## Metrics Reference
+
+All metrics are sourced from `kube-state-metrics` running in the management cluster:
+
+| Metric | Description | Labels |
+|--------|-------------|--------|
+| `kube_pod_status_phase` | Pod lifecycle phase (Running, Pending, Failed, etc.) | namespace, pod, uid, phase |
+| `kube_pod_container_status_restarts_total` | Container restart count | namespace, pod, uid, container |
+| `kube_node_status_condition` | Node condition states (MemoryPressure, DiskPressure, etc.) | node, condition, status |
+| `kube_pod_status_unschedulable` | Pods that cannot be scheduled | namespace, pod, uid |
+| `kube_pod_info` | Pod metadata for pod counts | namespace, pod, node, uid |
+
+## See Also
+
+- [ARO-26753: Add Kubernetes metrics](https://redhat.atlassian.net/browse/ARO-26753)
+- [ARO-26043: Investigate provisioning duration SLO breach](https://redhat.atlassian.net/browse/ARO-26043)
+- [ARO-26893: Observability metrics epic](https://redhat.atlassian.net/browse/ARO-26893)
+- [Cleanup Stuck Cluster Deletion](./cleanup-stuck-cluster-deletion.md)
+- [HCP Cluster Creation Flow](./hcp-cluster-creation-flow.md)

--- a/docs/ops/kubernetes-provisioning-diagnostics.md
+++ b/docs/ops/kubernetes-provisioning-diagnostics.md
@@ -22,7 +22,7 @@ During burst cluster creation (15+ clusters), provisioning times can breach the 
 ### 1. Pod Health by Namespace
 
 **Panels:**
-- **Ready Pods per Namespace** - Running pods over time
+- **Running Pods per Namespace** - Running pods over time
 - **Failed Pods per Namespace** - Failed pods indicating crashes or errors
 - **Pending Pods per Namespace** - Pods waiting to be scheduled
 - **Pod Phase Distribution** - Stacked view of all pod states

--- a/observability/grafana-dashboards/perfscale-dashboards/kubernetes-provisioning-diagnostics.json
+++ b/observability/grafana-dashboards/perfscale-dashboards/kubernetes-provisioning-diagnostics.json
@@ -1,0 +1,1389 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Kubernetes pod health and node pressure metrics for diagnosing HCP cluster provisioning delays. Tracks pod failures, restarts, scheduling issues, and node resource pressure during burst cluster creation.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Cluster Service SLO Dashboard",
+      "tooltip": "View cluster provisioning SLO metrics",
+      "type": "link",
+      "url": "/d/aro-hcp-cluster-service-slos"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Maestro Server Dashboard",
+      "tooltip": "View Maestro server metrics",
+      "type": "link",
+      "url": "/d/maestro-server"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Pod Health by Namespace",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Number of pods in Running state per namespace. A decrease during provisioning may indicate pod failures or scheduling issues.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Running Pods",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["last", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=~\"$namespace\", phase=\"Running\"}) by (namespace)",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Ready Pods per Namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Number of pods in Failed state per namespace. Failed pods indicate crashes, OOMKills, or image pull failures that impact provisioning.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Failed Pods",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["last", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=~\"$namespace\", phase=\"Failed\"}) by (namespace)",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Pods per Namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Number of pods in Pending state per namespace. Pending pods indicate scheduling delays due to resource constraints or node availability issues.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Pending Pods",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "orange",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["last", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=~\"$namespace\", phase=\"Pending\"}) by (namespace)",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pending Pods per Namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Distribution of pod phases across all selected namespaces. Provides a visual overview of pod health.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Pods",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Running"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Pending"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Succeeded"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Unknown"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=~\"$namespace\"}) by (phase)",
+          "legendFormat": "{{phase}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Phase Distribution",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Pod Restart Analysis",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Container restart rate per namespace over a 5-minute window. High restart rates indicate crash loops, OOMKills, or liveness probe failures.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Restarts/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["last", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(kube_pod_container_status_restarts_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[5m])) by (namespace)",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Container Restarts per Namespace (5m rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Top 10 pods with the most container restarts in the last hour. Use this to identify specific problematic pods.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Restarts (1h)"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 8,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Restarts (1h)"
+          }
+        ]
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(10, sum(increase(kube_pod_container_status_restarts_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[1h])) by (namespace, pod))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Restarting Pods (Last Hour)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Node Resource Pressure",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Number of nodes experiencing memory pressure. When status=true, the node is evicting pods due to memory constraints.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 27
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_node_status_condition{cluster=\"$cluster\", condition=\"MemoryPressure\", status=\"true\"})",
+          "legendFormat": "Nodes Under Memory Pressure",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes Under Memory Pressure",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Number of nodes experiencing disk pressure. When status=true, the node is evicting pods due to disk constraints.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 27
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_node_status_condition{cluster=\"$cluster\", condition=\"DiskPressure\", status=\"true\"})",
+          "legendFormat": "Nodes Under Disk Pressure",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes Under Disk Pressure",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Number of nodes experiencing PID pressure. When status=true, the node has exhausted its process ID space.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 27
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_node_status_condition{cluster=\"$cluster\", condition=\"PIDPressure\", status=\"true\"})",
+          "legendFormat": "Nodes Under PID Pressure",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes Under PID Pressure",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Timeline of node pressure conditions. Spikes during burst provisioning indicate resource saturation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Nodes",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MemoryPressure"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DiskPressure"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PIDPressure"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": ["last", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_node_status_condition{cluster=\"$cluster\", condition=\"MemoryPressure\", status=\"true\"}) by (condition)",
+          "legendFormat": "{{condition}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_node_status_condition{cluster=\"$cluster\", condition=\"DiskPressure\", status=\"true\"}) by (condition)",
+          "hide": false,
+          "legendFormat": "{{condition}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_node_status_condition{cluster=\"$cluster\", condition=\"PIDPressure\", status=\"true\"}) by (condition)",
+          "hide": false,
+          "legendFormat": "{{condition}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Node Pressure Timeline",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Scheduling and Resource Correlation",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Number of pods that cannot be scheduled due to resource constraints. This is a critical indicator of resource exhaustion.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 15,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_pod_status_unschedulable{cluster=\"$cluster\", namespace=~\"$namespace\"})",
+          "legendFormat": "Unschedulable Pods",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unschedulable Pods",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Distribution of pods across nodes and namespaces. Uneven distribution may indicate scheduling affinity issues or node capacity problems.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 16,
+      "options": {
+        "calculate": false,
+        "cellGap": 2,
+        "cellValues": {
+          "decimals": 0
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "max": 50,
+          "min": 0,
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "count(kube_pod_info{cluster=\"$cluster\", namespace=~\"$namespace\"}) by (node, namespace)",
+          "format": "time_series",
+          "legendFormat": "{{node}}/{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Distribution Heatmap (by Node and Namespace)",
+      "type": "heatmap"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": ["kubernetes", "provisioning", "diagnostics", "hcp"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "cspr-westus3-mgmt-1",
+          "value": "cspr-westus3-mgmt-1"
+        },
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kube_pod_info, cluster)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_pod_info, cluster)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "HCP Kubernetes Provisioning Diagnostics",
+  "uid": "hcp-k8s-provisioning-diagnostics",
+  "version": 1,
+  "weekStart": ""
+}

--- a/observability/grafana-dashboards/perfscale-dashboards/kubernetes-provisioning-diagnostics.json
+++ b/observability/grafana-dashboards/perfscale-dashboards/kubernetes-provisioning-diagnostics.json
@@ -1313,7 +1313,11 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",
@@ -1328,14 +1332,14 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "cspr-westus3-mgmt-1",
           "value": "cspr-westus3-mgmt-1"
         },
         "datasource": {
           "uid": "$datasource"
         },
-        "definition": "label_values(kube_pod_info, cluster)",
+        "definition": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
         "hide": 0,
         "includeAll": false,
         "label": "Cluster",
@@ -1353,7 +1357,11 @@
         "type": "query"
       },
       {
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": {
           "uid": "$datasource"
         },
@@ -1380,7 +1388,31 @@
     "from": "now-6h",
     "to": "now"
   },
-  "timepicker": {},
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
   "timezone": "utc",
   "title": "HCP Kubernetes Provisioning Diagnostics",
   "uid": "hcp-k8s-provisioning-diagnostics",

--- a/observability/grafana-dashboards/perfscale-dashboards/kubernetes-provisioning-diagnostics.json
+++ b/observability/grafana-dashboards/perfscale-dashboards/kubernetes-provisioning-diagnostics.json
@@ -153,7 +153,7 @@
           "refId": "A"
         }
       ],
-      "title": "Ready Pods per Namespace",
+      "title": "Running Pods per Namespace",
       "type": "timeseries"
     },
     {
@@ -1250,7 +1250,7 @@
       },
       "id": 16,
       "options": {
-        "calculate": false,
+        "calculate": true,
         "cellGap": 2,
         "cellValues": {
           "decimals": 0
@@ -1343,7 +1343,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, cluster)",
+          "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -1381,7 +1381,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "HCP Kubernetes Provisioning Diagnostics",
   "uid": "hcp-k8s-provisioning-diagnostics",
   "version": 1,


### PR DESCRIPTION
## Summary

Adds a comprehensive Grafana dashboard for diagnosing HCP cluster provisioning performance issues, specifically targeting the root cause analysis work from [ARO-26043](https://redhat.atlassian.net/browse/ARO-26043).

## Changes

### New Grafana Dashboard: `kubernetes-provisioning-diagnostics.json`
- **16 panels** organized into 4 sections:
  1. **Pod Health by Namespace** - Running, failed, and pending pod trends
  2. **Pod Restart Analysis** - Container restart rates and top restarting pods
  3. **Node Resource Pressure** - Memory, disk, and PID pressure indicators
  4. **Scheduling & Correlation** - Unschedulable pods and distribution heatmaps

- **Variables**: Datasource, Cluster (auto-populated), Namespace (multi-select with "All" option)
- **Location**: `observability/grafana-dashboards/perfscale-dashboards/`

### New Documentation: `docs/ops/kubernetes-provisioning-diagnostics.md`
- Dashboard overview and context
- Section-by-section panel descriptions
- Example PromQL queries for common scenarios
- 3 detailed troubleshooting scenarios with diagnosis steps
- Access instructions and metrics reference

## Metrics Used

All metrics sourced from `kube-state-metrics` in management clusters:
- `kube_pod_status_phase` - Pod lifecycle states
- `kube_pod_container_status_restarts_total` - Container restarts
- `kube_node_status_condition` - Node pressure conditions
- `kube_pod_status_unschedulable` - Scheduling failures
- `kube_pod_info` - Pod metadata

Metrics verified available in CSPR management cluster.

## Use Case

During burst cluster creation (15+ clusters), provisioning times can breach the 20-minute SLO. This dashboard helps identify:
- Pod failures blocking provisioning
- Resource exhaustion on management clusters
- Crash loops in critical components (maestro, hypershift, OCM)
- Scheduling delays due to resource constraints

## Testing

- ✅ JSON syntax validated
- ✅ PromQL queries verified against CSPR Prometheus
- ✅ All required metrics confirmed available
- ✅ Dashboard structure matches existing perfscale dashboards
- ⚠️ Full UI testing blocked by CSPR management cluster Prometheus agent issues (separate infrastructure problem)

## Related Issues

- Resolves: [ARO-26753](https://redhat.atlassian.net/browse/ARO-26753)
- Related: [ARO-26043](https://redhat.atlassian.net/browse/ARO-26043) - Provisioning duration SLO breach investigation
- Related: [ARO-26893](https://redhat.atlassian.net/browse/ARO-26893) - Observability metrics epic

## Deployment

Dashboard will be automatically deployed to CSPR via Prow after merge. No manual deployment steps required.