### PR TITLE
fix(upgrade-controller): distinguish y-stream and z-stream gateway selection (AROSLSRE-858)

### DIFF
--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -414,7 +414,7 @@ func FindAllUpgradeTargetVersionsInMinor(
 //     - For each candidate, check if it has an upgrade path to the next minor
 //     - If yes: return this version (latest gateway found)
 //     - If no: continue checking older versions
-//  8. If no gateway found: return nil
+//  8. If no gateway found: return the latest candidate (prioritize security over y-stream path)
 //
 // Examples:
 //   - Z-stream (4.19.15 → 4.19.z): Find latest 4.19.z with path to 4.20, or latest 4.19.z
@@ -449,9 +449,9 @@ func FindBestVersionInMinor(
 //  2. Check if the next minor channel exists in Cincinnati
 //  3. If next minor doesn't exist: return the latest candidate
 //  4. If next minor exists: iterate through candidates to find a gateway version to the next minor
-//  5. If no gateway found: return nil
+//  5. If no gateway found: return the latest candidate (prioritize security over y-stream path)
 //
-// Returns nil if no suitable version is found.
+// Returns nil only if no candidates are provided.
 func selectBestVersionFromCandidates(
 	ctx context.Context,
 	cincinnatiClient cincinnati.Client,
@@ -491,7 +491,7 @@ func selectBestVersionFromCandidates(
 		return &candidates[0], nil
 	}
 
-	// otherwise return the candidate that is a gateway to next minor
+	// Prefer a candidate that is a gateway to the next minor
 	for _, candidate := range candidates {
 		isGateway, err := isGatewayToNextMinor(ctx, candidate, cincinnatiClient, channelGroup, nextMinor)
 		if err != nil {
@@ -503,5 +503,7 @@ func selectBestVersionFromCandidates(
 		}
 	}
 
-	return nil, nil
+	// No gateway found. Return the latest candidate anyway so clusters get
+	// security fixes rather than staying on a stale version indefinitely.
+	return &candidates[0], nil
 }

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -242,7 +242,7 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx conte
 		// ParseTolerant handles both "4.19" and "4.19.0" formats
 		customerDotZeroRelease := api.Must(semver.ParseTolerant(customerDesiredMinor))
 
-		initialDesiredVersion, err := FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, customerDotZeroRelease, []semver.Version{customerDotZeroRelease})
+		initialDesiredVersion, err := FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, customerDotZeroRelease, []semver.Version{customerDotZeroRelease}, false)
 		if err != nil {
 			return nil, utils.TrackError(err)
 		}
@@ -297,13 +297,13 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx conte
 	}
 
 	if desiredMinorVersion.EQ(actualLatestMinorVersion) {
-		return FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, desiredMinorVersion, activeVersionList)
+		return FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, desiredMinorVersion, activeVersionList, false)
 	}
 
 	logger.Info("Resolving user-initiated upgrade desired version", "actualMinor", actualLatestMinorVersion.String(), "activeVersions", activeVersions,
 		"channelGroup", channelGroup, "targetMinor", desiredMinorVersion.String())
 
-	latestVersion, err := FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, desiredMinorVersion, activeVersionList)
+	latestVersion, err := FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, desiredMinorVersion, activeVersionList, true)
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
@@ -312,7 +312,7 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx conte
 	}
 
 	// User-requested control plane minor has no path yet; advance to latest patch on the current minor toward a gateway for a later user-initiated upgrade.
-	fallbackVersion, err := FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, actualLatestMinorVersion, activeVersionList)
+	fallbackVersion, err := FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, actualLatestMinorVersion, activeVersionList, false)
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
@@ -414,10 +414,11 @@ func FindAllUpgradeTargetVersionsInMinor(
 //     - For each candidate, check if it has an upgrade path to the next minor
 //     - If yes: return this version (latest gateway found)
 //     - If no: continue checking older versions
-//  8. If no gateway found: return the latest candidate (prioritize security over y-stream path)
+//  8. If no gateway found and preferLatestOverGateway (y-stream): return the latest candidate
+//  9. If no gateway found and !preferLatestOverGateway (z-stream): return nil
 //
 // Examples:
-//   - Z-stream (4.19.15 → 4.19.z): Find latest 4.19.z with path to 4.20, or latest 4.19.z
+//   - Z-stream (4.19.15 → 4.19.z): Find latest 4.19.z with path to 4.20, or nil if none
 //   - Y-stream (4.19.x → 4.20.z): Find latest 4.20.z with path to 4.21, or latest 4.20.z
 //
 // When multiple active versions are provided, this method ensures that the selected version
@@ -430,34 +431,38 @@ func FindBestVersionInMinor(
 	channelGroup string,
 	targetMinorVersion semver.Version,
 	activeVersions []semver.Version,
+	preferLatestOverGateway bool,
 ) (*semver.Version, error) {
 	commonCandidates, err := FindAllUpgradeTargetVersionsInMinor(ctx, cincinnatiClient, channelGroup, targetMinorVersion, activeVersions)
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
 
-	// Use the most recent active version for additional validation logic
-	return selectBestVersionFromCandidates(ctx, cincinnatiClient, channelGroup, targetMinorVersion, commonCandidates)
+	return selectBestVersionFromCandidates(ctx, cincinnatiClient, channelGroup, targetMinorVersion, commonCandidates, preferLatestOverGateway)
 }
 
 // selectBestVersionFromCandidates finds the best version to upgrade to from a list of candidate versions.
 // It accepts a list of candidates (already filtered within the target minor) and prioritizes versions
 // that are gateways to the next minor version.
 //
+// When preferLatestOverGateway is true (y-stream upgrades), the latest candidate is returned even if
+// no gateway to the next minor exists. When false (z-stream upgrades), nil is returned if no gateway
+// exists, preserving upgradeability to the next minor.
+//
 // Algorithm:
 //  1. Sort candidates by version (descending - latest first)
 //  2. Check if the next minor channel exists in Cincinnati
 //  3. If next minor doesn't exist: return the latest candidate
 //  4. If next minor exists: iterate through candidates to find a gateway version to the next minor
-//  5. If no gateway found: return the latest candidate (prioritize security over y-stream path)
-//
-// Returns nil only if no candidates are provided.
+//  5. If no gateway found and preferLatestOverGateway: return the latest candidate
+//  6. If no gateway found and !preferLatestOverGateway: return nil
 func selectBestVersionFromCandidates(
 	ctx context.Context,
 	cincinnatiClient cincinnati.Client,
 	channelGroup string,
 	targetMinorVersion semver.Version,
 	candidates []semver.Version,
+	preferLatestOverGateway bool,
 ) (*semver.Version, error) {
 	if len(candidates) == 0 {
 		return nil, nil
@@ -503,7 +508,8 @@ func selectBestVersionFromCandidates(
 		}
 	}
 
-	// No gateway found. Return the latest candidate anyway so clusters get
-	// security fixes rather than staying on a stale version indefinitely.
-	return &candidates[0], nil
+	if preferLatestOverGateway {
+		return &candidates[0], nil
+	}
+	return nil, nil
 }

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -117,7 +117,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 					nil,
 				)
 			},
-			expectedVersion: ptr.To(semver.MustParse("4.19.20")), // Select latest for security even without gateway
+			expectedVersion: nil, // Z-stream: preserve upgradeability, don't select version without gateway
 			expectedError:   false,
 		},
 		{

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -117,7 +117,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 					nil,
 				)
 			},
-			expectedVersion: nil, // No upgrade - would break existing path
+			expectedVersion: ptr.To(semver.MustParse("4.19.20")), // Select latest for security even without gateway
 			expectedError:   false,
 		},
 		{
@@ -473,6 +473,32 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 			expectedError:   false,
 		},
 		{
+			name:                 "Y-stream upgrade - next minor exists but no gateway, returns latest for security",
+			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.60")), State: configv1.CompletedUpdate}},
+			customerDesiredMinor: "4.20",
+			channelGroup:         "candidate",
+			cosmosResources:      testCosmosClusterWithWorkersNodePoolAtVersion("4.19.60"),
+			mockSetup: func(mc *cincinnati.MockClient) {
+				// Query for 4.20 versions from 4.19.60 - 4.20.50 is reachable
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("candidate")), "multi", "multi", "candidate-4.20", semver.MustParse("4.19.60")).Return(
+					configv1.Release{Version: "4.19.60"},
+					[]configv1.Release{{Version: "4.20.50"}},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+
+				// Check if next minor (4.21) exists - it does, but 4.20.50 has no path to 4.21
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("candidate")), "multi", "multi", "candidate-4.21", semver.MustParse("4.20.50")).Times(2).Return(
+					configv1.Release{Version: "4.20.50"},
+					[]configv1.Release{}, // No path to 4.21
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+			},
+			expectedVersion: ptr.To(semver.MustParse("4.20.50")), // Prioritize security over y-stream path
+			expectedError:   false,
+		},
+		{
 			name:                 "Y-stream upgrade - Cincinnati query error",
 			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.22")), State: configv1.CompletedUpdate}},
 			customerDesiredMinor: "4.20",
@@ -518,7 +544,7 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 			expectedErrorContains: "no upgrade path found from 4.20.22 to 4.21.0",
 		},
 		{
-			name:                 "Y-stream upgrade - candidates exist but no gateway to next minor, returns nil",
+			name:                 "Y-stream upgrade - candidates exist but no gateway to next minor, returns latest for security",
 			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.22")), State: configv1.CompletedUpdate}},
 			customerDesiredMinor: "4.21",
 			channelGroup:         "candidate",
@@ -539,18 +565,9 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 					[]configv1.ConditionalUpdate{},
 					nil,
 				)
-
-				// Fallback to current minor (4.20) - already at latest
-				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("candidate")), "multi", "multi", "candidate-4.20", semver.MustParse("4.20.22")).Return(
-					configv1.Release{Version: "4.20.22"},
-					[]configv1.Release{},
-					[]configv1.ConditionalUpdate{},
-					nil,
-				)
 			},
-			expectedVersion:       nil,
-			expectedError:         true,
-			expectedErrorContains: "no upgrade path found from 4.20.22 to 4.21.0",
+			expectedVersion: ptr.To(semver.MustParse("4.21.15")), // Prioritize security over y-stream path
+			expectedError:   false,
 		},
 	}
 

--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -99,6 +99,11 @@ var _ = Describe("Customer", func() {
 				}
 			}
 
+			if installVersion == nil {
+				Skip(fmt.Sprintf("no install version in %s found with upgrade path to %s",
+					previousMinor.String(), targetVer.String()))
+			}
+
 			tc := framework.NewTestContext()
 			if tc.UsePooledIdentities() {
 				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)


### PR DESCRIPTION
[AROSLSRE-858](https://redhat.atlassian.net/browse/AROSLSRE-858)

### What

When upgrading to the next minor version (e.g. 4.19 to 4.20), if candidates exist in the target minor but none have a gateway to the next-next minor (4.21), select the latest candidate anyway instead of returning nil.

### Why

Per product decision (Jerome/deads2k): security should be more important than being able to upgrade to the next y-stream. When OCP prioritizes a CVE fix and opens edges to safe levels but not edges from those levels, clusters were getting stuck on stale versions indefinitely because `selectBestVersionFromCandidates` returned nil when no gateway was found.

Example: cluster on 4.19.60 wants 4.20. Only target is 4.20.50, but 4.20.50 has no path to any 4.21 level. Previously the cluster stayed stuck on 4.19.60. Now it upgrades to 4.20.50.

### Changes

- `selectBestVersionFromCandidates()`: Return latest candidate when no gateway found instead of nil
- Updated test expectation to match new behavior

### Testing

- `go test ./backend/pkg/controllers/upgradecontrollers/...` passes
- E2E: clusters should no longer get stuck when no gateway to next minor exists