### PR TITLE
Fix: Add mgmt agent to topology

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -20,6 +20,7 @@ The tree of pipelines making up the ARO HCP service are documented here from the
         - Microsoft.Azure.ARO.HCP.RP.HypershiftOperator ([ref](https://github.com/Azure/ARO-HCP/tree/main/hypershiftoperator/pipeline.yaml)): Deploy the HyperShift operator.
         - Microsoft.Azure.ARO.HCP.Maestro.Agent ([ref](https://github.com/Azure/ARO-HCP/tree/main/maestro/agent/pipeline.yaml)): Deploy the Maestro Agent and register it with the MQTT stream.
         - Microsoft.Azure.ARO.HCP.RouteMonitorOperator ([ref](https://github.com/Azure/ARO-HCP/tree/main/route-monitor-operator/pipeline.yaml)): Deploy the Route Monitor Operator.
+        - Microsoft.Azure.ARO.HCP.MgmtAgent ([ref](https://github.com/Azure/ARO-HCP/tree/main/mgmt-agent/pipeline.yaml)): Deploy the Management Agent.
       - Microsoft.Azure.ARO.HCP.Monitoring ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/monitoring-pipeline.yaml)): Deploy the Monitoring resources
       - Microsoft.Azure.ARO.HCP.E2E ([ref](https://github.com/Azure/ARO-HCP/tree/main/test/e2e-pipeline.yaml)): Run the E2E tests towards a region and gate SDP progression.
 - Microsoft.Azure.ARO.HCP.Management.Delete ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/cleanup/delete.mgmt.pipeline.yaml)): Delete the management resources and management resource group

--- a/mgmt-agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mgmt_agent.yaml
+++ b/mgmt-agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mgmt_agent.yaml
@@ -1,0 +1,187 @@
+---
+# Source: mgmt-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: mgmt-agent
+  annotations:
+    azure.workload.identity/client-id: '__msiClientId__'
+    azure.workload.identity/tenant-id: '__tenantId__'
+  name: mgmt-agent
+  namespace: mgmt-agent
+---
+# Source: mgmt-agent/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: mgmt-agent
+  name: mgmt-agent-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+  - update
+---
+# Source: mgmt-agent/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: mgmt-agent
+  name: mgmt-agent-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mgmt-agent-controller
+subjects:
+- kind: ServiceAccount
+  name: mgmt-agent
+  namespace: mgmt-agent
+---
+# Source: mgmt-agent/templates/leader_election_role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: mgmt-agent
+  name: mgmt-agent-controller-leader-election
+  namespace: mgmt-agent
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# Source: mgmt-agent/templates/leader_election_role_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: mgmt-agent
+  name: mgmt-agent-controller-leader-election
+  namespace: mgmt-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mgmt-agent-controller-leader-election
+subjects:
+- kind: ServiceAccount
+  name: mgmt-agent
+  namespace: mgmt-agent
+---
+# Source: mgmt-agent/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mgmt-agent
+  namespace: 'mgmt-agent'
+  labels:
+    app.kubernetes.io/name: "mgmt-agent"
+spec:
+  selector:
+    app.kubernetes.io/name: mgmt-agent
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+---
+# Source: mgmt-agent/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mgmt-agent
+  namespace: mgmt-agent
+  labels:
+    app.kubernetes.io/name: mgmt-agent
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mgmt-agent
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mgmt-agent
+        azure.workload.identity/use: "true"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - command:
+        - "/mgmt-agent"
+        args:
+        - controller
+        - "--health-address=:8080"
+        - "-v=2"
+        image: "arohcpsvcdev.azurecr.io/mgmt-agent@sha256:1234567890"
+        name: mgmt-agent-controller
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: AZURE_TOKEN_CREDENTIALS
+          value: "WorkloadIdentityCredential"
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+          name: health
+        securityContext:
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+          readOnlyRootFilesystem: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        volumeMounts: []
+      volumes: []
+      serviceAccountName: mgmt-agent
+      terminationGracePeriodSeconds: 10
+      nodeSelector:
+

--- a/topology.yaml
+++ b/topology.yaml
@@ -57,6 +57,9 @@ services:
         - serviceGroup: Microsoft.Azure.ARO.HCP.RouteMonitorOperator
           pipelinePath: route-monitor-operator/pipeline.yaml
           purpose: Deploy the Route Monitor Operator.
+        - serviceGroup: Microsoft.Azure.ARO.HCP.MgmtAgent
+          pipelinePath: mgmt-agent/pipeline.yaml
+          purpose: Deploy the Management Agent.
         pipelinePath: dev-infrastructure/mgmt-pipeline.yaml
         purpose: Deploy a management cluster and backing infrastructure.
       - serviceGroup: Microsoft.Azure.ARO.HCP.Monitoring


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-871

### What

https://github.com/Azure/ARO-HCP/pull/5223 added the mgmt-agent component and registered it in the Makefile's
services_mgmt_pipelines list with service group Microsoft.Azure.ARO.HCP.MgmtAgent, but omitted the
matching entry from topology.yaml. The templatize tool uses the topology file as its service tree registry, so it couldn't resolve the service group at deploy time.

### Why

CSPR is perma failing after https://github.com/Azure/ARO-HCP/pull/5223. 
https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-cspr-pipeline-postsubmit

### Testing

Tested in personal dev

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
