### PR TITLE
Update ci01 and prow envs to align with current CI overrides

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1595,15 +1595,15 @@ clouds:
               systemAgentPool:
                 maxCount: 4
                 osDiskSizeGB: 32
-                vmSize: Standard_D4ds_v5
+                vmSize: Standard_D4ds_v6
               userAgentPool:
                 maxCount: 14
                 minCount: 3
                 osDiskSizeGB: 100
-                vmSize: Standard_D16ds_v5
+                vmSize: Standard_D16ds_v6
                 secondaryNicCount: 7
               infraAgentPool:
-                vmSize: Standard_D4ds_v5
+                vmSize: Standard_D4ds_v6
                 osDiskSizeGB: 64
               enableSwiftV2Nodepools: true
               enableSwiftV2Vnet: true
@@ -1615,12 +1615,14 @@ clouds:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
+              systemAgentPool:
+                vmSize: Standard_D4ds_v6
               userAgentPool:
-                name: 'u64d8dsv5'
-                vmSize: 'Standard_D8ds_v5'
+                name: 'u64d8dsv6'
+                vmSize: Standard_D8ds_v6
                 osDiskSizeGB: 64
               infraAgentPool:
-                vmSize: Standard_D4ds_v5
+                vmSize: Standard_D4ds_v6
             jaeger:
               deploy: true
         regions:
@@ -1688,15 +1690,15 @@ clouds:
               systemAgentPool:
                 maxCount: 4
                 osDiskSizeGB: 32
-                vmSize: Standard_D4ads_v6
+                vmSize: Standard_D4ds_v6
               userAgentPool:
                 maxCount: 14
                 minCount: 3
                 osDiskSizeGB: 100
-                vmSize: Standard_D16ads_v6
+                vmSize: Standard_D16ds_v6
                 secondaryNicCount: 7
               infraAgentPool:
-                vmSize: Standard_D4ads_v6
+                vmSize: Standard_D4ds_v6
                 osDiskSizeGB: 64
               enableSwiftV2Nodepools: true
               enableSwiftV2Vnet: true
@@ -1711,13 +1713,13 @@ clouds:
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
               systemAgentPool:
-                vmSize: Standard_D4ads_v6
+                vmSize: Standard_D4ds_v6
               userAgentPool:
-                name: 'u8adsv6'
-                vmSize: Standard_D8ads_v6
+                name: 'u64d8dsv6'
+                vmSize: Standard_D8ds_v6
                 osDiskSizeGB: 64
               infraAgentPool:
-                vmSize: Standard_D4ads_v6
+                vmSize: Standard_D4ds_v6
             jaeger:
               deploy: true
         regions:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -88,13 +88,13 @@ auditLogsEventHub:
   authRuleName: SendRule
   enabled: false
   kustoConsumerGroupName: AuditLogsToKusto
-  kustoDataConnectionName: ci01-westus3-auditlogs
+  kustoDataConnectionName: ci01-centralus-auditlogs
   name: aks-auditlogs
-  namespace: hcp-ci01-westus3-auditlogs-eh
-  rg: westus3-shared-resources
+  namespace: hcp-ci01-centralus-auditlogs-eh
+  rg: centralus-shared-resources
 automationDryRun: false
 azureGeoShortId: us
-azureRegionAvailabilityZoneCount: 4
+azureRegionAvailabilityZoneCount: 3
 backend:
   azureRuntimeConfig:
     tlsCertificatesIssuer: Self
@@ -303,7 +303,7 @@ geneva:
       issuer: Self
       manage: true
       name: genevaAction
-    endpointName: westus3
+    endpointName: centralus
     endpointUrl: ""
     genevaActionsPrincipalId: ""
     keyVault:
@@ -320,7 +320,7 @@ geneva:
       buildId: 0
       packageName: empty-sentinel
     serviceTag: GenevaActions
-    targetRegion: West US 3
+    targetRegion: Central US
   logs:
     adminCertName: geneva-logs-admin
     adminCertificateDomain: geneva.keyvault.aro-hcp-global.azure.com
@@ -482,7 +482,7 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
-  location: westus3
+  location: centralus
   manageInstance: true
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs
@@ -579,7 +579,7 @@ mgmt:
       name: infra
       osDiskSizeGB: 64
       poolCount: 2
-      vmSize: Standard_D4ads_v6
+      vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.35.1
@@ -594,7 +594,7 @@ mgmt:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ads_v6
+      vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
     userAgentPool:
@@ -604,7 +604,7 @@ mgmt:
       osDiskSizeGB: 100
       poolCount: 3
       secondaryNicCount: 7
-      vmSize: Standard_D16ads_v6
+      vmSize: Standard_D16ds_v6
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14
@@ -671,7 +671,7 @@ mgmt:
     certificateDomains:
     - '*.hcp.osadev.cloud'
     - '*.hcpsvc.osadev.cloud'
-    displayName: Azure Red Hat OpenShift HCP - West US 3 - MGMT - 1
+    displayName: Azure Red Hat OpenShift HCP - Central US - MGMT - 1
     key: ARO HCP E2E Infrastructure (EA Subscription)
     providers:
       Microsoft.Compute:
@@ -824,7 +824,7 @@ oidc:
     useManagedCertificates: true
   storageAccount:
     name: arohcpci01oidcj7654321
-    privateLinkLocation: westus3
+    privateLinkLocation: centralus
     public: true
     zoneRedundantMode: Auto
 quotaizer:
@@ -834,9 +834,9 @@ quotaizer:
     repository: empty-sentinel
   managedIdentityName: aro-quotaizer
   quotaGroup:
-    displayName: HCP - ci01 westus3
-    id: aro-ci01-westus3
-region: westus3
+    displayName: HCP - ci01 centralus
+    id: aro-ci01-centralus
+region: centralus
 regionRG: hcp-underlay-ci01-j7654321
 routeMonitorOperator:
   blackboxExporterImage:
@@ -905,7 +905,7 @@ svc:
       name: infra
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ads_v6
+      vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.35.1
@@ -920,16 +920,16 @@ svc:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ads_v6
+      vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
     userAgentPool:
       maxCount: 3
       minCount: 1
-      name: u8adsv6
+      name: u64d8dsv6
       osDiskSizeGB: 64
       poolCount: 3
-      vmSize: Standard_D8ads_v6
+      vmSize: Standard_D8ds_v6
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14
@@ -999,7 +999,7 @@ svc:
   subscription:
     certificateDomains:
     - '*.hcpsvc.osadev.cloud'
-    displayName: Azure Red Hat OpenShift HCP - West US 3 - SVC
+    displayName: Azure Red Hat OpenShift HCP - Central US - SVC
     key: ARO HCP E2E Infrastructure (EA Subscription)
     providers:
       Microsoft.Compute:

--- a/config/rendered/dev/prow/centralus.yaml
+++ b/config/rendered/dev/prow/centralus.yaml
@@ -88,13 +88,13 @@ auditLogsEventHub:
   authRuleName: SendRule
   enabled: true
   kustoConsumerGroupName: AuditLogsToKusto
-  kustoDataConnectionName: prow-westus3-auditlogs
+  kustoDataConnectionName: prow-centralus-auditlogs
   name: aks-auditlogs
-  namespace: hcp-prow-westus3-auditlogs-eh
-  rg: westus3-shared-resources
+  namespace: hcp-prow-centralus-auditlogs-eh
+  rg: centralus-shared-resources
 automationDryRun: false
 azureGeoShortId: us
-azureRegionAvailabilityZoneCount: 4
+azureRegionAvailabilityZoneCount: 3
 backend:
   azureRuntimeConfig:
     tlsCertificatesIssuer: Self
@@ -303,7 +303,7 @@ geneva:
       issuer: Self
       manage: true
       name: genevaAction
-    endpointName: westus3
+    endpointName: centralus
     endpointUrl: ""
     genevaActionsPrincipalId: ""
     keyVault:
@@ -320,7 +320,7 @@ geneva:
       buildId: 0
       packageName: empty-sentinel
     serviceTag: GenevaActions
-    targetRegion: West US 3
+    targetRegion: Central US
   logs:
     adminCertName: geneva-logs-admin
     adminCertificateDomain: geneva.keyvault.aro-hcp-global.azure.com
@@ -482,7 +482,7 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
-  location: westus3
+  location: centralus
   manageInstance: false
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs
@@ -579,7 +579,7 @@ mgmt:
       name: infra
       osDiskSizeGB: 64
       poolCount: 2
-      vmSize: Standard_D4ds_v5
+      vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.35.1
@@ -594,7 +594,7 @@ mgmt:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ds_v5
+      vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
     userAgentPool:
@@ -604,7 +604,7 @@ mgmt:
       osDiskSizeGB: 100
       poolCount: 3
       secondaryNicCount: 7
-      vmSize: Standard_D16ds_v5
+      vmSize: Standard_D16ds_v6
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14
@@ -671,7 +671,7 @@ mgmt:
     certificateDomains:
     - '*.hcp.osadev.cloud'
     - '*.hcpsvc.osadev.cloud'
-    displayName: Azure Red Hat OpenShift HCP - West US 3 - MGMT - 1
+    displayName: Azure Red Hat OpenShift HCP - Central US - MGMT - 1
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:
       Microsoft.Compute:
@@ -824,7 +824,7 @@ oidc:
     useManagedCertificates: true
   storageAccount:
     name: arohcpprowoidcj7654321
-    privateLinkLocation: westus3
+    privateLinkLocation: centralus
     public: true
     zoneRedundantMode: Auto
 quotaizer:
@@ -834,9 +834,9 @@ quotaizer:
     repository: empty-sentinel
   managedIdentityName: aro-quotaizer
   quotaGroup:
-    displayName: HCP - prow westus3
-    id: aro-prow-westus3
-region: westus3
+    displayName: HCP - prow centralus
+    id: aro-prow-centralus
+region: centralus
 regionRG: hcp-underlay-prow-j7654321
 routeMonitorOperator:
   blackboxExporterImage:
@@ -905,7 +905,7 @@ svc:
       name: infra
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ds_v5
+      vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: 1.35.1
@@ -920,16 +920,16 @@ svc:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D2s_v3
+      vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
     userAgentPool:
       maxCount: 3
       minCount: 1
-      name: u64d8dsv5
+      name: u64d8dsv6
       osDiskSizeGB: 64
       poolCount: 3
-      vmSize: Standard_D8ds_v5
+      vmSize: Standard_D8ds_v6
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14
@@ -999,7 +999,7 @@ svc:
   subscription:
     certificateDomains:
     - '*.hcpsvc.osadev.cloud'
-    displayName: Azure Red Hat OpenShift HCP - West US 3 - SVC
+    displayName: Azure Red Hat OpenShift HCP - Central US - SVC
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:
       Microsoft.Compute:

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -20,7 +20,7 @@ All E2E tests are triggered through Prow by commenting on a pull request in the 
 
 | Command | Environment | Runs Automatically | Notes |
 |---------|-------------|-------------------|-------|
-| `/test e2e-parallel` | Dev (westus3) | Yes (on every PR) | Optional, does not block merge |
+| `/test e2e-parallel` | Dev (centralus) | Yes (on every PR) | Optional, does not block merge. Deploys to dedicated subscription. |
 | `/test integration-e2e-parallel` | Int (uksouth) | No | Must be triggered manually |
 | `/test stage-e2e-parallel` | Stage (uksouth) | No | Must be triggered manually |
 | `/test prod-e2e-parallel` | Prod (uksouth) | No | Use with caution |

--- a/docs/prow.md
+++ b/docs/prow.md
@@ -54,7 +54,7 @@ Presubmit jobs run automatically or on-demand for pull requests to the main bran
 | image-updater-images | Yes | Yes | - |
 | periodic-images | Yes | Yes | - |
 | frontend-simulation | Yes | Yes | - |
-| e2e-parallel | Yes | No | Dev (westus3) |
+| e2e-parallel | Yes | No | Dev (centralus) |
 | integration-e2e-parallel | No | No | Int (uksouth) |
 | stage-e2e-parallel | No | No | Stage (uksouth) |
 | prod-e2e-parallel | No | No | Prod (uksouth) |
@@ -87,7 +87,8 @@ Presubmit jobs run automatically or on-demand for pull requests to the main bran
 |----------|-------|
 | **Job Name** | [pull-ci-Azure-ARO-HCP-main-e2e-parallel](https://prow.ci.openshift.org/?job=pull-ci-Azure-ARO-HCP-main-e2e-parallel) |
 | **Status** | Always runs, but optional (does not block merge) |
-| **Environment** | Dev (westus3) |
+| **Environment** | Dev (centralus) |
+| **Subscription** | ARO HCP E2E Infrastructure (EA Subscription) |
 | **Cluster** | build07 |
 | **Step Registry** | [e2e-parallel](https://steps.ci.openshift.org/job?org=Azure&repo=ARO-HCP&branch=main&test=e2e-parallel) |
 | **Purpose** | Runs end-to-end tests in parallel mode against the dev environment. This job always runs on PRs but is marked optional, meaning failures won't block the PR from merging. |

--- a/tooling/templatize/settings.yaml
+++ b/tooling/templatize/settings.yaml
@@ -30,9 +30,9 @@ environments:
     regionShortSuffix: "${USER:0:4}"
 - name: prow
   description: |
-    CI infra shard0 - PR end-to-end tests.
+    CI infra shard0 - PR end-to-end tests (fallback).
   defaults:
-    region: westus3
+    region: centralus
     cloud: dev
     ev2Cloud: public
     cxStamp: 1
@@ -41,7 +41,7 @@ environments:
   description: |
     CI infra shard1 - PR end-to-end tests.
   defaults:
-    region: westus3
+    region: centralus
     cloud: dev
     ev2Cloud: public
     cxStamp: 1


### PR DESCRIPTION
[<!-- Link to Jira issue -->](https://redhat.atlassian.net/browse/ARO-26089)

Provision of CI environments has been moved to subscription "ARO HCP E2E Infrastructure (EA Subscription)".
E2E parallel job has been moved to centralus due to westus3 allocation issues and capacity constraints.

This PR formalizes those two changes in the environment configuration/defaults so the overrides can be removed from the CI job.
