### PR TITLE
feat: add log verbosity support in backend and frontend and make it configurable per env

### DIFF
--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -504,9 +504,6 @@ func RunRootCmd(cmd *cobra.Command, flags *BackendRootCmdFlags) error {
 	// We use slog.Level(flags.LogVerbosity * -1) to convert the verbosity level to a slog.Level.
 	// A value of 0 is equivalent to INFO. Higher values mean more verbose output.
 	handlerOptions := &slog.HandlerOptions{Level: slog.Level(flags.LogVerbosity * -1), AddSource: true}
-	// Temporary hardcode the log level to -4 to see increased klog logging
-	// verbosity.
-	handlerOptions.Level = slog.Level(-4)
 	slogJSONHandler := slog.NewJSONHandler(os.Stdout, handlerOptions)
 	logger := logr.FromSlogHandler(slogJSONHandler)
 	ctx = utils.ContextWithLogger(ctx, logger)

--- a/backend/deploy/templates/backend.deployment.yaml
+++ b/backend/deploy/templates/backend.deployment.yaml
@@ -66,6 +66,7 @@ spec:
         - "--maestro-source-environment-identifier"
         - "{{ .Values.maestro.sourceEnvironmentIdentifier }}"
         - "--exit-on-panic={{ .Values.exitOnPanic }}"
+        - "--log-verbosity={{ .Values.logVerbosity }}"
        {{- if and .Values.miMock.certName .Values.miMock.clientId .Values.miMock.principalId .Values.miMock.tenantId
                   .Values.armPermissionsManagerIdentity.certName .Values.armPermissionsManagerIdentity.clientId .Values.armPermissionsManagerIdentity.tenantId
         }}

--- a/backend/testdata/zz_fixture_TestHelmTemplate_backend_clstr_scoped_identities_role_set_name_public.yaml
+++ b/backend/testdata/zz_fixture_TestHelmTemplate_backend_clstr_scoped_identities_role_set_name_public.yaml
@@ -167,6 +167,7 @@ spec:
         - "--maestro-source-environment-identifier"
         - "arohcpdev"
         - "--exit-on-panic=true"
+        - "--log-verbosity=4"
         # MI Mock flags. They should only be set in ARO-HCP environments where Microsoft's Managed Identities Dataplane service is not available.
         - "--insecure-ignore-user-azure-managed-identities-that-need-managed-identities-dataplane-available-and-use-mock"
         - "--insecure-azure-managed-identity-mock-certificate-bundle-path"

--- a/backend/testdata/zz_fixture_TestHelmTemplate_backend_mi_mock_and_arm_perms_mgr_identities_unset.yaml
+++ b/backend/testdata/zz_fixture_TestHelmTemplate_backend_mi_mock_and_arm_perms_mgr_identities_unset.yaml
@@ -167,6 +167,7 @@ spec:
         - "--maestro-source-environment-identifier"
         - "arohcpdev"
         - "--exit-on-panic=true"
+        - "--log-verbosity=4"
         - "--azure-cluster-scoped-identities-role-set-name"
         - "dev"
         env:

--- a/backend/values.yaml
+++ b/backend/values.yaml
@@ -84,5 +84,6 @@ exitOnPanic: {{ .backend.exitOnPanic }}
 # This value is used to select the appropriate set of role definitions to be used by the cluster scoped
 # identities. What role definitions are used by each cluster scoped identity for each role set and the role set names
 # themselves are defined as part of application code.
+logVerbosity: {{ .backend.logVerbosity }}
 clusterScopedIdentitiesConfig:
   roleSetName: "{{ .backend.clusterScopedIdentitiesConfig.roleSetName }}"

--- a/backend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_backend_dev.yaml
+++ b/backend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_backend_dev.yaml
@@ -167,6 +167,7 @@ spec:
         - "--maestro-source-environment-identifier"
         - "arohcpdev"
         - "--exit-on-panic=true"
+        - "--log-verbosity=4"
         # MI Mock flags. They should only be set in ARO-HCP environments where Microsoft's Managed Identities Dataplane service is not available.
         - "--insecure-ignore-user-azure-managed-identities-that-need-managed-identities-dataplane-available-and-use-mock"
         - "--insecure-azure-managed-identity-mock-certificate-bundle-path"

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1278,6 +1278,11 @@
           "type": "boolean",
           "description": "If true, backend will exit the process if a panic occurs. As of now it only controls the setting of k8s.io/apimachinery/pkg/util/runtime.ReallyCrash"
         },
+        "logVerbosity": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Log verbosity level for the backend, specified as a go-logr/logr log level. 0 is the default (INFO). Must be >= 0, where higher values produce more verbose output."
+        },
         "clusterScopedIdentitiesConfig": {
           "$ref": "#/definitions/clusterScopedIdentitiesConfig"
         }
@@ -1291,6 +1296,7 @@
         "azureRuntimeConfig",
         "maestro",
         "exitOnPanic",
+        "logVerbosity",
         "clusterScopedIdentitiesConfig"
       ]
     },
@@ -1521,6 +1527,11 @@
         "exitOnPanic": {
           "type": "boolean",
           "description": "If true, frontend will exit the process if a panic occurs. As of now it only controls the setting of k8s.io/apimachinery/pkg/util/runtime.ReallyCrash"
+        },
+        "logVerbosity": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Log verbosity level for the frontend, specified as a go-logr/logr log level. 0 is the default (INFO). Must be >= 0, where higher values produce more verbose output."
         }
       },
       "additionalProperties": false,
@@ -1531,7 +1542,8 @@
         "tracing",
         "k8s",
         "managedIdentityName",
-        "exitOnPanic"
+        "exitOnPanic",
+        "logVerbosity"
       ]
     },
     "billing": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -677,6 +677,7 @@ defaults:
     maestro:
       sourceEnvironmentIdentifier: "arohcp{{ .ctx.environment }}"
     exitOnPanic: true
+    logVerbosity: 4
     clusterScopedIdentitiesConfig:
       roleSetName: "public"
   # Admin API
@@ -757,6 +758,7 @@ defaults:
     cert:
       name: frontend-cert-{{ .ctx.environment }}-{{ .ctx.regionShort }}
     exitOnPanic: true
+    logVerbosity: 0
   # Billing
   billing:
     rg: "placeholder"

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -115,6 +115,7 @@ backend:
         cpu: 100m
         memory: 500Mi
     serviceAccountName: backend
+  logVerbosity: 4
   maestro:
     sourceEnvironmentIdentifier: arohcpci01
   managedIdentityName: backend
@@ -281,6 +282,7 @@ frontend:
         cpu: 100m
         memory: 512Mi
     serviceAccountName: frontend
+  logVerbosity: 0
   managedIdentityName: frontend
   tracing:
     address: http://ingest.observability:4318

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -115,6 +115,7 @@ backend:
         cpu: 100m
         memory: 500Mi
     serviceAccountName: backend
+  logVerbosity: 4
   maestro:
     sourceEnvironmentIdentifier: arohcpcspr
   managedIdentityName: backend
@@ -281,6 +282,7 @@ frontend:
         cpu: 100m
         memory: 512Mi
     serviceAccountName: frontend
+  logVerbosity: 0
   managedIdentityName: frontend
   tracing:
     address: ""

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -115,6 +115,7 @@ backend:
         cpu: 100m
         memory: 500Mi
     serviceAccountName: backend
+  logVerbosity: 4
   maestro:
     sourceEnvironmentIdentifier: arohcpdev
   managedIdentityName: backend
@@ -281,6 +282,7 @@ frontend:
         cpu: 100m
         memory: 512Mi
     serviceAccountName: frontend
+  logVerbosity: 0
   managedIdentityName: frontend
   tracing:
     address: ""

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -115,6 +115,7 @@ backend:
         cpu: 100m
         memory: 500Mi
     serviceAccountName: backend
+  logVerbosity: 4
   maestro:
     sourceEnvironmentIdentifier: arohcpperf
   managedIdentityName: backend
@@ -281,6 +282,7 @@ frontend:
         cpu: 100m
         memory: 512Mi
     serviceAccountName: frontend
+  logVerbosity: 0
   managedIdentityName: frontend
   tracing:
     address: ""

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -115,6 +115,7 @@ backend:
         cpu: 100m
         memory: 500Mi
     serviceAccountName: backend
+  logVerbosity: 4
   maestro:
     sourceEnvironmentIdentifier: arohcppers
   managedIdentityName: backend
@@ -281,6 +282,7 @@ frontend:
         cpu: 100m
         memory: 512Mi
     serviceAccountName: frontend
+  logVerbosity: 0
   managedIdentityName: frontend
   tracing:
     address: http://ingest.observability:4318

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -115,6 +115,7 @@ backend:
         cpu: 100m
         memory: 500Mi
     serviceAccountName: backend
+  logVerbosity: 4
   maestro:
     sourceEnvironmentIdentifier: arohcpprow
   managedIdentityName: backend
@@ -281,6 +282,7 @@ frontend:
         cpu: 100m
         memory: 512Mi
     serviceAccountName: frontend
+  logVerbosity: 0
   managedIdentityName: frontend
   tracing:
     address: http://ingest.observability:4318

--- a/frontend/cmd/cmd.go
+++ b/frontend/cmd/cmd.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -67,7 +66,8 @@ type FrontendOpts struct {
 	cosmosName string
 	cosmosURL  string
 
-	exitOnPanic bool
+	exitOnPanic  bool
+	logVerbosity int
 }
 
 func NewRootCmd() *cobra.Command {
@@ -108,6 +108,9 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.Flags().BoolVar(&opts.exitOnPanic, "exit-on-panic", opts.exitOnPanic,
 		"If set, frontend will exit the process if a panic occurs. As of now it only controls the setting of k8s.io/apimachinery/pkg/util/runtime.ReallyCrash",
 	)
+	rootCmd.Flags().IntVar(&opts.logVerbosity, "log-verbosity", opts.logVerbosity,
+		"Log verbosity, as a go-logr/logr log level. 0 is the default verbosity level (INFO). It must be a value >= 0, where a higher value means more verbose output.",
+	)
 	rootCmd.MarkFlagsRequiredTogether("cosmos-name", "cosmos-url")
 
 	return rootCmd
@@ -141,17 +144,35 @@ func CorrelationIDPolicy(req *policy.Request) (*http.Response, error) {
 	return req.Next()
 }
 
+func (opts *FrontendOpts) Validate() error {
+	if len(opts.location) == 0 {
+		return utils.TrackError(fmt.Errorf("--location is required"))
+	}
+
+	if opts.logVerbosity < 0 {
+		return utils.TrackError(fmt.Errorf("--log-verbosity must be a value >= 0"))
+	}
+
+	return nil
+}
+
 func (opts *FrontendOpts) Run() error {
+	err := opts.Validate()
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("flags validation failed: %w", err))
+	}
+
 	ctx := signal.SetupSignalContext()
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(fmt.Errorf("function returned"))
 
-	logger := utils.DefaultLogger()
+	// Create a logr.Logger and add it to context for use throughout the application.
+	// We use slog.Level(opts.LogVerbosity * -1) to convert the verbosity level to a slog.Level.
+	// A value of 0 is equivalent to INFO. Higher values mean more verbose output.
+	handlerOptions := &slog.HandlerOptions{Level: slog.Level(opts.logVerbosity * -1), AddSource: true}
+	slogJSONHandler := slog.NewJSONHandler(os.Stderr, handlerOptions)
+	logger := logr.FromSlogHandler(slogJSONHandler)
 	ctx = utils.ContextWithLogger(ctx, logger)
-
-	if len(opts.location) == 0 {
-		return errors.New("location is required")
-	}
 
 	logger.Info(fmt.Sprintf(
 		"%s (%s) started in %s",

--- a/frontend/deploy/templates/_helpers.tpl
+++ b/frontend/deploy/templates/_helpers.tpl
@@ -43,7 +43,7 @@ spec:
       - name: {{ .appName }}
         image: '{{ .Values.deployment.imageName }}'
         imagePullPolicy: Always
-        args: ["--clusters-service-url", "http://clusters-service.{{ .Values.clustersService.namespace }}.svc.cluster.local:8000", "--exit-on-panic={{ .Values.exitOnPanic }}"]
+        args: ["--clusters-service-url", "http://clusters-service.{{ .Values.clustersService.namespace }}.svc.cluster.local:8000", "--exit-on-panic={{ .Values.exitOnPanic }}", "--log-verbosity={{ .Values.logVerbosity }}"]
         env:
         - name: DB_NAME
           valueFrom:

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
@@ -142,7 +142,7 @@ spec:
       - name: aro-hcp-frontend-v2
         image: 'arohcpsvcdev.azurecr.io/arohcpfrontend@sha256:1234567890'
         imagePullPolicy: Always
-        args: ["--clusters-service-url", "http://clusters-service.clusters-service.svc.cluster.local:8000", "--exit-on-panic=true"]
+        args: ["--clusters-service-url", "http://clusters-service.clusters-service.svc.cluster.local:8000", "--exit-on-panic=true", "--log-verbosity=0"]
         env:
         - name: DB_NAME
           valueFrom:
@@ -259,7 +259,7 @@ spec:
       - name: aro-hcp-frontend
         image: 'arohcpsvcdev.azurecr.io/arohcpfrontend@sha256:1234567890'
         imagePullPolicy: Always
-        args: ["--clusters-service-url", "http://clusters-service.clusters-service.svc.cluster.local:8000", "--exit-on-panic=true"]
+        args: ["--clusters-service-url", "http://clusters-service.clusters-service.svc.cluster.local:8000", "--exit-on-panic=true", "--log-verbosity=0"]
         env:
         - name: DB_NAME
           valueFrom:

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
@@ -142,7 +142,7 @@ spec:
       - name: aro-hcp-frontend-v2
         image: 'arohcpsvcdev.azurecr.io/arohcpfrontend@sha256:1234567890'
         imagePullPolicy: Always
-        args: ["--clusters-service-url", "http://clusters-service.clusters-service.svc.cluster.local:8000", "--exit-on-panic=true"]
+        args: ["--clusters-service-url", "http://clusters-service.clusters-service.svc.cluster.local:8000", "--exit-on-panic=true", "--log-verbosity=0"]
         env:
         - name: DB_NAME
           valueFrom:
@@ -251,7 +251,7 @@ spec:
       - name: aro-hcp-frontend
         image: 'arohcpsvcdev.azurecr.io/arohcpfrontend@sha256:1234567890'
         imagePullPolicy: Always
-        args: ["--clusters-service-url", "http://clusters-service.clusters-service.svc.cluster.local:8000", "--exit-on-panic=true"]
+        args: ["--clusters-service-url", "http://clusters-service.clusters-service.svc.cluster.local:8000", "--exit-on-panic=true", "--log-verbosity=0"]
         env:
         - name: DB_NAME
           valueFrom:

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -48,3 +48,4 @@ virtualService:
 # here just temporary until we move the gateway to the istio chart
 adminApiHost: "admin.{{ .dns.regionalSubdomain }}.{{ .dns.svcParentZoneName }}"
 exitOnPanic: {{ .frontend.exitOnPanic }}
+logVerbosity: {{ .frontend.logVerbosity }}

--- a/frontend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
+++ b/frontend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
@@ -142,7 +142,7 @@ spec:
       - name: aro-hcp-frontend-v2
         image: 'arohcpsvcdev.azurecr.io/arohcpfrontend@sha256:1234567890'
         imagePullPolicy: Always
-        args: ["--clusters-service-url", "http://clusters-service.clusters-service.svc.cluster.local:8000", "--exit-on-panic=true"]
+        args: ["--clusters-service-url", "http://clusters-service.clusters-service.svc.cluster.local:8000", "--exit-on-panic=true", "--log-verbosity=0"]
         env:
         - name: DB_NAME
           valueFrom:
@@ -251,7 +251,7 @@ spec:
       - name: aro-hcp-frontend
         image: 'arohcpsvcdev.azurecr.io/arohcpfrontend@sha256:1234567890'
         imagePullPolicy: Always
-        args: ["--clusters-service-url", "http://clusters-service.clusters-service.svc.cluster.local:8000", "--exit-on-panic=true"]
+        args: ["--clusters-service-url", "http://clusters-service.clusters-service.svc.cluster.local:8000", "--exit-on-panic=true", "--log-verbosity=0"]
         env:
         - name: DB_NAME
           valueFrom:


### PR DESCRIPTION
This commit introduces the ability to configure the --log-verbosity CLI flag as part of their deployment through the config.schema.json mechanism. This also allows making it configurable per ARO-HCP environment.

Backend already had the --log-verbosity added but was hardcoding it to level 4. This commit removes the hardcoding and makes the necessary changes to provide it as part of its deployment.

Frontend did not have the --log-verbosity flag added, this commit adds it as well as introduces the necessary changes to provide it as part of its deployment. Because it didn't have any flag the logging wasn't specifying any verbosity in particular, which means log level zero was being used. This commit keeps the same behavior by setting it to zero.

The same log verbosity level has been set for all ARO-HCP environments initially.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
