### PR TITLE
Add Prometheus metrics instrumentation to Maestro GRPC client

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -419,7 +419,8 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 
 	_, controllerLister := backendInformers.Controllers()
 
-	maestroClientBuilder := maestro.NewMaestroClientBuilder()
+	maestroMetrics := maestro.NewMaestroMetrics(b.options.MetricsRegisterer)
+	maestroClientBuilder := maestro.NewMaestroClientBuilder(maestroMetrics)
 
 	subscriptionNonClusterDataDumpController := datadumpcontrollers.NewSubscriptionNonClusterDataDumpController(b.options.ResourcesDBClient, activeOperationLister, backendInformers)
 	clusterRecursiveDataDumpController := datadumpcontrollers.NewClusterRecursiveDataDumpController(b.options.ResourcesDBClient, b.options.KubeApplierDBClients, managementClusterLister, activeOperationLister, backendInformers, unionKubeApplierInformers)

--- a/backend/pkg/maestro/maestro_client.go
+++ b/backend/pkg/maestro/maestro_client.go
@@ -88,14 +88,35 @@ type MaestroClientBuilder interface {
 
 var _ MaestroClientBuilder = (*maestroClientBuilder)(nil)
 
-type maestroClientBuilder struct{}
-
-func (b *maestroClientBuilder) NewClient(ctx context.Context, maestroRESTAPIEndpoint string, maestroGRPCAPIEndpoint string, maestroConsumerName string, maestroSourceID string) (Client, error) {
-	return NewClient(ctx, maestroRESTAPIEndpoint, maestroGRPCAPIEndpoint, maestroConsumerName, maestroSourceID)
+type maestroClientBuilder struct {
+	metrics *MaestroMetrics
 }
 
-func NewMaestroClientBuilder() MaestroClientBuilder {
-	return &maestroClientBuilder{}
+func (b *maestroClientBuilder) NewClient(ctx context.Context, maestroRESTAPIEndpoint string, maestroGRPCAPIEndpoint string, maestroConsumerName string, maestroSourceID string) (Client, error) {
+	client, err := NewClient(ctx, maestroRESTAPIEndpoint, maestroGRPCAPIEndpoint, maestroConsumerName, maestroSourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	if b.metrics != nil {
+		return NewInstrumentedMaestroClient(client, b.metrics), nil
+	}
+
+	return client, nil
+}
+
+// NewMaestroClientBuilder creates a new MaestroClientBuilder.
+//
+// The metrics parameter is optional and can be nil. If provided, all clients
+// created by this builder will be instrumented with Prometheus metrics.
+// If nil, clients will not be instrumented.
+//
+// Breaking change note: This constructor previously took no arguments.
+// The signature change is intentional to enable optional metrics instrumentation.
+func NewMaestroClientBuilder(metrics *MaestroMetrics) MaestroClientBuilder {
+	return &maestroClientBuilder{
+		metrics: metrics,
+	}
 }
 
 // GenerateMaestroSourceID generates a Maestro Source ID of the form "<envName>-<provisionShardID>".

--- a/backend/pkg/maestro/maestro_client_metrics.go
+++ b/backend/pkg/maestro/maestro_client_metrics.go
@@ -44,7 +44,7 @@ func NewMaestroMetrics(r prometheus.Registerer) *MaestroMetrics {
 		errorsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "maestro_grpc_errors_total",
-				Help: "Total number of failed Maestro GRPC operations",
+				Help: "Total number of unexpected Maestro GRPC operation failures (excludes expected errors like NotFound/AlreadyExists)",
 			},
 			[]string{"operation"},
 		),

--- a/backend/pkg/maestro/maestro_client_metrics.go
+++ b/backend/pkg/maestro/maestro_client_metrics.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maestro
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	workv1 "open-cluster-management.io/api/work/v1"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type MaestroMetrics struct {
+	operationsTotal   *prometheus.CounterVec
+	errorsTotal       *prometheus.CounterVec
+	operationDuration *prometheus.HistogramVec
+}
+
+func NewMaestroMetrics(r prometheus.Registerer) *MaestroMetrics {
+	m := &MaestroMetrics{
+		operationsTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "maestro_grpc_operations_total",
+				Help: "Total number of Maestro GRPC operations by operation type",
+			},
+			[]string{"operation"},
+		),
+		errorsTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "maestro_grpc_errors_total",
+				Help: "Total number of failed Maestro GRPC operations",
+			},
+			[]string{"operation"},
+		),
+		operationDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "maestro_grpc_operation_duration_seconds",
+				Help:    "Duration of Maestro GRPC operations in seconds",
+				Buckets: prometheus.DefBuckets,
+			},
+			[]string{"operation"},
+		),
+	}
+
+	r.MustRegister(
+		m.operationsTotal,
+		m.errorsTotal,
+		m.operationDuration,
+	)
+
+	// Pre-initialize all operation label values so metrics appear even with zero values
+	operations := []string{"create", "get", "delete", "patch", "list"}
+	for _, op := range operations {
+		m.operationsTotal.WithLabelValues(op)
+		m.errorsTotal.WithLabelValues(op)
+		m.operationDuration.WithLabelValues(op)
+	}
+
+	return m
+}
+
+type instrumentedMaestroClient struct {
+	client  Client
+	metrics *MaestroMetrics
+}
+
+func NewInstrumentedMaestroClient(client Client, metrics *MaestroMetrics) Client {
+	return &instrumentedMaestroClient{
+		client:  client,
+		metrics: metrics,
+	}
+}
+
+// isExpectedError returns true if the error is expected in normal operation
+// and should not be counted as a failure in error rate metrics.
+func isExpectedError(operation string, err error) bool {
+	// NotFound on Get is expected in GetOrCreateMaestroBundle pattern
+	// where Get is used to check existence before Create.
+	if operation == "get" && k8serrors.IsNotFound(err) {
+		return true
+	}
+
+	// AlreadyExists on Create is expected during concurrent creates
+	// in GetOrCreateMaestroBundle pattern (handled by retry with Get).
+	if operation == "create" && k8serrors.IsAlreadyExists(err) {
+		return true
+	}
+
+	return false
+}
+
+// observe records metrics for a completed operation.
+func (c *instrumentedMaestroClient) observe(operation string, start time.Time, err error) {
+	c.metrics.operationDuration.WithLabelValues(operation).Observe(time.Since(start).Seconds())
+
+	if err != nil && !isExpectedError(operation, err) {
+		c.metrics.errorsTotal.WithLabelValues(operation).Inc()
+	}
+}
+
+func (c *instrumentedMaestroClient) Create(ctx context.Context, manifestWork *workv1.ManifestWork, opts metav1.CreateOptions) (*workv1.ManifestWork, error) {
+	operation := "create"
+	start := time.Now()
+	c.metrics.operationsTotal.WithLabelValues(operation).Inc()
+
+	result, err := c.client.Create(ctx, manifestWork, opts)
+	c.observe(operation, start, err)
+
+	return result, err
+}
+
+func (c *instrumentedMaestroClient) Get(ctx context.Context, name string, opts metav1.GetOptions) (*workv1.ManifestWork, error) {
+	operation := "get"
+	start := time.Now()
+	c.metrics.operationsTotal.WithLabelValues(operation).Inc()
+
+	result, err := c.client.Get(ctx, name, opts)
+	c.observe(operation, start, err)
+
+	return result, err
+}
+
+func (c *instrumentedMaestroClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	operation := "delete"
+	start := time.Now()
+	c.metrics.operationsTotal.WithLabelValues(operation).Inc()
+
+	err := c.client.Delete(ctx, name, opts)
+	c.observe(operation, start, err)
+
+	return err
+}
+
+func (c *instrumentedMaestroClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*workv1.ManifestWork, error) {
+	operation := "patch"
+	start := time.Now()
+	c.metrics.operationsTotal.WithLabelValues(operation).Inc()
+
+	result, err := c.client.Patch(ctx, name, pt, data, opts, subresources...)
+	c.observe(operation, start, err)
+
+	return result, err
+}
+
+func (c *instrumentedMaestroClient) List(ctx context.Context, opts metav1.ListOptions) (*workv1.ManifestWorkList, error) {
+	operation := "list"
+	start := time.Now()
+	c.metrics.operationsTotal.WithLabelValues(operation).Inc()
+
+	result, err := c.client.List(ctx, opts)
+	c.observe(operation, start, err)
+
+	return result, err
+}

--- a/backend/pkg/maestro/maestro_client_metrics_test.go
+++ b/backend/pkg/maestro/maestro_client_metrics_test.go
@@ -1,0 +1,261 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maestro
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	workv1 "open-cluster-management.io/api/work/v1"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// mockMaestroClient implements Client for testing
+type mockMaestroClient struct {
+	createErr error
+	getErr    error
+	deleteErr error
+	patchErr  error
+	listErr   error
+}
+
+func (m *mockMaestroClient) Create(ctx context.Context, manifestWork *workv1.ManifestWork, opts metav1.CreateOptions) (*workv1.ManifestWork, error) {
+	return manifestWork, m.createErr
+}
+
+func (m *mockMaestroClient) Get(ctx context.Context, name string, opts metav1.GetOptions) (*workv1.ManifestWork, error) {
+	return &workv1.ManifestWork{}, m.getErr
+}
+
+func (m *mockMaestroClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return m.deleteErr
+}
+
+func (m *mockMaestroClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*workv1.ManifestWork, error) {
+	return &workv1.ManifestWork{}, m.patchErr
+}
+
+func (m *mockMaestroClient) List(ctx context.Context, opts metav1.ListOptions) (*workv1.ManifestWorkList, error) {
+	return &workv1.ManifestWorkList{}, m.listErr
+}
+
+func TestIsExpectedError(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation string
+		err       error
+		expected  bool
+	}{
+		{
+			name:      "NotFound on Get is expected",
+			operation: "get",
+			err:       k8serrors.NewNotFound(schema.GroupResource{Group: "work.open-cluster-management.io", Resource: "manifestworks"}, "test"),
+			expected:  true,
+		},
+		{
+			name:      "AlreadyExists on Create is expected",
+			operation: "create",
+			err:       k8serrors.NewAlreadyExists(schema.GroupResource{Group: "work.open-cluster-management.io", Resource: "manifestworks"}, "test"),
+			expected:  true,
+		},
+		{
+			name:      "NotFound on Create is unexpected",
+			operation: "create",
+			err:       k8serrors.NewNotFound(schema.GroupResource{Group: "work.open-cluster-management.io", Resource: "manifestworks"}, "test"),
+			expected:  false,
+		},
+		{
+			name:      "AlreadyExists on Get is unexpected",
+			operation: "get",
+			err:       k8serrors.NewAlreadyExists(schema.GroupResource{Group: "work.open-cluster-management.io", Resource: "manifestworks"}, "test"),
+			expected:  false,
+		},
+		{
+			name:      "Forbidden on Get is unexpected",
+			operation: "get",
+			err:       k8serrors.NewForbidden(schema.GroupResource{Group: "work.open-cluster-management.io", Resource: "manifestworks"}, "test", errors.New("forbidden")),
+			expected:  false,
+		},
+		{
+			name:      "Generic error on Create is unexpected",
+			operation: "create",
+			err:       errors.New("some generic error"),
+			expected:  false,
+		},
+		{
+			name:      "NotFound on Delete is unexpected",
+			operation: "delete",
+			err:       k8serrors.NewNotFound(schema.GroupResource{Group: "work.open-cluster-management.io", Resource: "manifestworks"}, "test"),
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isExpectedError(tt.operation, tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMaestroMetrics_ExpectedErrorsNotCounted(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := NewMaestroMetrics(registry)
+
+	notFoundErr := k8serrors.NewNotFound(schema.GroupResource{Group: "work.open-cluster-management.io", Resource: "manifestworks"}, "test")
+	alreadyExistsErr := k8serrors.NewAlreadyExists(schema.GroupResource{Group: "work.open-cluster-management.io", Resource: "manifestworks"}, "test")
+
+	mockClient := &mockMaestroClient{
+		getErr:    notFoundErr,
+		createErr: alreadyExistsErr,
+	}
+	client := NewInstrumentedMaestroClient(mockClient, metrics)
+
+	ctx := context.Background()
+
+	// Perform Get (NotFound error - expected)
+	_, _ = client.Get(ctx, "test", metav1.GetOptions{})
+
+	// Perform Create (AlreadyExists error - expected)
+	_, _ = client.Create(ctx, &workv1.ManifestWork{}, metav1.CreateOptions{})
+
+	// Verify that errors_total counter is still 0 for both operations
+	expectedMetrics := `
+# HELP maestro_grpc_errors_total Total number of unexpected Maestro GRPC operation failures (excludes expected errors like NotFound/AlreadyExists)
+# TYPE maestro_grpc_errors_total counter
+maestro_grpc_errors_total{operation="create"} 0
+maestro_grpc_errors_total{operation="delete"} 0
+maestro_grpc_errors_total{operation="get"} 0
+maestro_grpc_errors_total{operation="list"} 0
+maestro_grpc_errors_total{operation="patch"} 0
+`
+	if err := testutil.CollectAndCompare(metrics.errorsTotal, strings.NewReader(expectedMetrics)); err != nil {
+		t.Errorf("unexpected metric value:\n%s", err)
+	}
+}
+
+func TestMaestroMetrics_UnexpectedErrorsCounted(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := NewMaestroMetrics(registry)
+
+	forbiddenErr := k8serrors.NewForbidden(schema.GroupResource{Group: "work.open-cluster-management.io", Resource: "manifestworks"}, "test", errors.New("forbidden"))
+	genericErr := errors.New("connection refused")
+
+	mockClient := &mockMaestroClient{
+		getErr:    forbiddenErr,
+		createErr: genericErr,
+	}
+	client := NewInstrumentedMaestroClient(mockClient, metrics)
+
+	ctx := context.Background()
+
+	// Perform Get (Forbidden error - unexpected)
+	_, _ = client.Get(ctx, "test", metav1.GetOptions{})
+
+	// Perform Create (generic error - unexpected)
+	_, _ = client.Create(ctx, &workv1.ManifestWork{}, metav1.CreateOptions{})
+
+	// Verify that errors_total counter incremented for both operations
+	expectedMetrics := `
+# HELP maestro_grpc_errors_total Total number of unexpected Maestro GRPC operation failures (excludes expected errors like NotFound/AlreadyExists)
+# TYPE maestro_grpc_errors_total counter
+maestro_grpc_errors_total{operation="create"} 1
+maestro_grpc_errors_total{operation="delete"} 0
+maestro_grpc_errors_total{operation="get"} 1
+maestro_grpc_errors_total{operation="list"} 0
+maestro_grpc_errors_total{operation="patch"} 0
+`
+	if err := testutil.CollectAndCompare(metrics.errorsTotal, strings.NewReader(expectedMetrics)); err != nil {
+		t.Errorf("unexpected metric value:\n%s", err)
+	}
+}
+
+func TestMaestroMetrics_OperationsTotalIncremented(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := NewMaestroMetrics(registry)
+
+	mockClient := &mockMaestroClient{}
+	client := NewInstrumentedMaestroClient(mockClient, metrics)
+
+	ctx := context.Background()
+
+	// Perform operations
+	_, _ = client.Get(ctx, "test", metav1.GetOptions{})
+	_, _ = client.Create(ctx, &workv1.ManifestWork{}, metav1.CreateOptions{})
+	_, _ = client.List(ctx, metav1.ListOptions{})
+
+	// Verify operations_total counter
+	expectedMetrics := `
+# HELP maestro_grpc_operations_total Total number of Maestro GRPC operations by operation type
+# TYPE maestro_grpc_operations_total counter
+maestro_grpc_operations_total{operation="create"} 1
+maestro_grpc_operations_total{operation="delete"} 0
+maestro_grpc_operations_total{operation="get"} 1
+maestro_grpc_operations_total{operation="list"} 1
+maestro_grpc_operations_total{operation="patch"} 0
+`
+	if err := testutil.CollectAndCompare(metrics.operationsTotal, strings.NewReader(expectedMetrics)); err != nil {
+		t.Errorf("unexpected metric value:\n%s", err)
+	}
+}
+
+func TestMaestroMetrics_DurationRecorded(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := NewMaestroMetrics(registry)
+
+	mockClient := &mockMaestroClient{}
+	client := NewInstrumentedMaestroClient(mockClient, metrics)
+
+	ctx := context.Background()
+
+	// Perform an operation
+	_, _ = client.Get(ctx, "test", metav1.GetOptions{})
+
+	// Verify that duration histogram has recorded a sample
+	// We can't verify exact duration, but we can check that count > 0
+	metricFamilies, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+
+	var found bool
+	for _, mf := range metricFamilies {
+		if mf.GetName() == "maestro_grpc_operation_duration_seconds" {
+			found = true
+			for _, m := range mf.GetMetric() {
+				for _, label := range m.GetLabel() {
+					if label.GetName() == "operation" && label.GetValue() == "get" {
+						if m.GetHistogram().GetSampleCount() != 1 {
+							t.Errorf("expected 1 sample for get operation, got %d", m.GetHistogram().GetSampleCount())
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if !found {
+		t.Error("maestro_grpc_operation_duration_seconds metric not found")
+	}
+}

--- a/observability/grafana-dashboards/backend/backend.json
+++ b/observability/grafana-dashboards/backend/backend.json
@@ -57,6 +57,164 @@
       ],
       "title": "SLO Availability: Backend Health",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate of Maestro GRPC operations (create, get, list, patch, delete) from backend client",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "showPoints": "never"
+          }
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (operation) (\n  max without(prometheus_replica) (\n    rate(maestro_grpc_operations_total{cluster=\"$cluster\"}[5m])\n  )\n)",
+          "instant": false,
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Maestro GRPC Operations Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Error rate for Maestro GRPC operations. High values indicate communication issues with Maestro server.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "showPoints": "never"
+          },
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(\n  sum by (operation) (\n    max without(prometheus_replica) (\n      rate(maestro_grpc_errors_total{cluster=\"$cluster\"}[5m])\n    )\n  )\n  /\n  sum by (operation) (\n    max without(prometheus_replica) (\n      rate(maestro_grpc_operations_total{cluster=\"$cluster\"}[5m])\n    )\n  )\n)\nand\nsum by (operation) (\n  max without(prometheus_replica) (\n    rate(maestro_grpc_operations_total{cluster=\"$cluster\"}[5m])\n  )\n) > 0",
+          "instant": false,
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Maestro GRPC Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "95th percentile latency for Maestro GRPC operations. High latency may contribute to cluster provisioning delays.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "showPoints": "never"
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95,\n  sum by (operation, le) (\n    max without(prometheus_replica) (\n      rate(maestro_grpc_operation_duration_seconds_bucket{cluster=\"$cluster\"}[5m])\n    )\n  )\n)",
+          "instant": false,
+          "legendFormat": "{{operation}} p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Maestro GRPC P95 Latency",
+      "type": "timeseries"
     }
   ],
   "schemaVersion": 39,


### PR DESCRIPTION
# Add Maestro GRPC Metrics for Backend Operations

Implements Maestro GRPC client observability to track throughput, errors, and latency as requested in [ARO-26754](https://redhat.atlassian.net/browse/ARO-26754).

## Changes

### Metrics Implementation
- **3 new Prometheus metric families** tracking Maestro GRPC client operations:
  - `maestro_grpc_operations_total` - Total operations by type (create, get, delete, patch, list)
  - `maestro_grpc_errors_total` - Failed operations by type (excludes expected errors like NotFound/AlreadyExists)
  - `maestro_grpc_operation_duration_seconds` - Histogram of operation latency by type

- **Instrumentation wrapper** for Maestro client using decorator pattern (`backend/pkg/maestro/maestro_client_metrics.go`)
- **Expected error filtering** - NotFound on Get and AlreadyExists on Create are not counted as failures (part of normal GetOrCreateMaestroBundle pattern)
- **Metric pre-initialization** to ensure all operation labels appear in Prometheus from startup
- **Integration** into backend initialization (`backend/pkg/app/backend.go`)

### Grafana Dashboard
Added 3 new panels to `observability/grafana-dashboards/backend/backend.json`:
- **Maestro GRPC Operations Rate** - ops/sec by operation type
- **Maestro GRPC Error Rate** - error percentage with volume guard to prevent NaN/Inf
- **Maestro GRPC P95 Latency** - 95th percentile latency by operation

All panels follow existing dashboard patterns with `cluster` variable filtering.

<img width="1797" height="773" alt="image" src="https://github.com/user-attachments/assets/ab20baa7-0460-445e-bc17-050d2a2406f6" />

### Alerts
**Alerts will be added in a follow-up PR** after 1-2 weeks of baseline data collection to establish appropriate thresholds, as requested by @mmazur.

## Files Changed
```
backend/pkg/maestro/maestro_client_metrics.go      | +170 (new file)
backend/pkg/maestro/maestro_client.go              | +25, -4
backend/pkg/app/backend.go                         | +2, -1
observability/grafana-dashboards/backend/backend.json | +158
```

## Testing & Validation
- ✅ Metrics validated in personal dev environment
- ✅ Prometheus scraping backend successfully
- ✅ Grafana dashboard panels displaying data
- ✅ All 3 metrics collecting operations with expected error filtering

## Related Issues
- Addresses [ARO-26754](https://redhat.atlassian.net/browse/ARO-26754) - Cluster provisioning latency diagnostics
- Related to [ARO-26043](https://redhat.atlassian.net/browse/ARO-26043) - MQTT metrics instrumentation
