### PR TITLE
Refactor/verify errors match exact field

### DIFF
--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -220,9 +220,30 @@ func decodeDesiredNodePoolCreate(ctx context.Context, azureLocation string) (*ap
 	return newInternalNodePool, nil
 }
 
-func (f *Frontend) newNodePoolAdmissionContext(ctx context.Context, cluster *api.HCPOpenShiftCluster) (*admission.NodePoolAdmissionContext, error) {
+// newNodePoolAdmissionContext creates an admission context for node pool operations.
+// The cluster parameter is always required.
+// The spCluster and spNodePool parameters provide service provider state needed for
+// admission checks that depend on runtime state (e.g., version upgrade validation).
+// For UPDATE operations, these parameters are required and the function will fail if they're nil.
+// For CREATE operations, these can be nil since no prior state exists.
+func (f *Frontend) newNodePoolAdmissionContext(ctx context.Context, op operation.Operation, cluster *api.HCPOpenShiftCluster, spCluster *api.ServiceProviderCluster, spNodePool *api.ServiceProviderNodePool) (*admission.NodePoolAdmissionContext, error) {
+	if cluster == nil {
+		return nil, fmt.Errorf("cluster is required for admission context")
+	}
+
+	if op.Type == operation.Update {
+		if spCluster == nil {
+			return nil, fmt.Errorf("serviceProviderCluster is required for UPDATE operations")
+		}
+		if spNodePool == nil {
+			return nil, fmt.Errorf("serviceProviderNodePool is required for UPDATE operations")
+		}
+	}
+
 	return &admission.NodePoolAdmissionContext{
-		Cluster: cluster,
+		Cluster:                 cluster,
+		ServiceProviderCluster:  spCluster,
+		ServiceProviderNodePool: spNodePool,
 	}, nil
 }
 
@@ -263,13 +284,13 @@ func (f *Frontend) createNodePool(writer http.ResponseWriter, request *http.Requ
 		return utils.TrackError(fmt.Errorf("cluster %s has no ClusterServiceID", cluster.ID))
 	}
 
-	admissionContext, err := f.newNodePoolAdmissionContext(ctx, cluster)
-	if err != nil {
-		return utils.TrackError(err)
-	}
 	restOperation := operation.Operation{
 		Type:    operation.Create,
 		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
+	}
+	admissionContext, err := f.newNodePoolAdmissionContext(ctx, restOperation, cluster, nil, nil)
+	if err != nil {
+		return utils.TrackError(err)
 	}
 	if mutationErrs := admission.MutateNodePool(ctx, admissionContext, restOperation, newInternalNodePool, nil); len(mutationErrs) > 0 {
 		return utils.TrackError(arm.CloudErrorFromFieldErrors(mutationErrs))
@@ -277,7 +298,7 @@ func (f *Frontend) createNodePool(writer http.ResponseWriter, request *http.Requ
 
 	validationErrs := validation.ValidateNodePool(ctx, restOperation, newInternalNodePool, nil)
 	// in addition to static validation, we have validation based on the state of the hcp cluster
-	validationErrs = append(validationErrs, admission.AdmitNodePool(newInternalNodePool, nil, cluster)...)
+	validationErrs = append(validationErrs, admission.AdmitNodePool(ctx, admissionContext, restOperation, newInternalNodePool, nil)...)
 	if err := arm.CloudErrorFromFieldErrors(validationErrs); err != nil {
 		return utils.TrackError(err)
 	}
@@ -551,22 +572,20 @@ func (f *Frontend) updateNodePoolInCosmos(ctx context.Context, writer http.Respo
 		return utils.TrackError(err)
 	}
 
-	admissionContext, err := f.newNodePoolAdmissionContext(ctx, cluster)
-	if err != nil {
-		return utils.TrackError(err)
-	}
 	restOperation := operation.Operation{
 		Type:    operation.Update,
 		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
+	}
+	admissionContext, err := f.newNodePoolAdmissionContext(ctx, restOperation, cluster, spCluster, spNodePool)
+	if err != nil {
+		return utils.TrackError(err)
 	}
 	if mutationErrs := admission.MutateNodePool(ctx, admissionContext, restOperation, newInternalNodePool, oldInternalNodePool); len(mutationErrs) > 0 {
 		return utils.TrackError(arm.CloudErrorFromFieldErrors(mutationErrs))
 	}
 
 	validationErrs := validation.ValidateNodePool(ctx, restOperation, newInternalNodePool, oldInternalNodePool)
-	// in addition to static validation, we have validation based on the state of the hcp cluster
-	// AdmitNodePoolUpdate includes AdmitNodePool checks plus version upgrade validation
-	validationErrs = append(validationErrs, admission.AdmitNodePoolUpdate(newInternalNodePool, oldInternalNodePool, cluster, spNodePool, spCluster, restOperation)...)
+	validationErrs = append(validationErrs, admission.AdmitNodePool(ctx, admissionContext, restOperation, newInternalNodePool, oldInternalNodePool)...)
 	if err := arm.CloudErrorFromFieldErrors(validationErrs); err != nil {
 		return utils.TrackError(err)
 	}

--- a/internal/admission/admit_cluster_test.go
+++ b/internal/admission/admit_cluster_test.go
@@ -126,7 +126,7 @@ func TestMutateCluster(t *testing.T) {
 			subscription: afecRegistered,
 			tags:         map[string]string{api.TagClusterSingleReplica: "yes"},
 			expectErrors: []utils.ExpectedError{
-				{FieldPath: "tags", Message: "Invalid value"},
+				{FieldPath: "tags[aro-hcp.experimental.cluster.single-replica]", Message: "Invalid value"},
 			},
 		},
 		{
@@ -134,7 +134,7 @@ func TestMutateCluster(t *testing.T) {
 			subscription: afecRegistered,
 			tags:         map[string]string{api.TagClusterSingleReplica: "true"},
 			expectErrors: []utils.ExpectedError{
-				{FieldPath: "tags", Message: "Invalid value"},
+				{FieldPath: "tags[aro-hcp.experimental.cluster.single-replica]", Message: "Invalid value"},
 			},
 		},
 		{
@@ -142,7 +142,7 @@ func TestMutateCluster(t *testing.T) {
 			subscription: afecRegistered,
 			tags:         map[string]string{api.TagClusterSizeOverride: "1"},
 			expectErrors: []utils.ExpectedError{
-				{FieldPath: "tags", Message: "Invalid value"},
+				{FieldPath: "tags[aro-hcp.experimental.cluster.size-override]", Message: "Invalid value"},
 			},
 		},
 		{
@@ -150,7 +150,7 @@ func TestMutateCluster(t *testing.T) {
 			subscription: afecRegistered,
 			tags:         map[string]string{"aro-hcp.experimental.cluster.unknown-feature": string(api.SingleReplicaControlPlane)},
 			expectErrors: []utils.ExpectedError{
-				{FieldPath: "tags", Message: "unrecognized experimental tag"},
+				{FieldPath: "tags[aro-hcp.experimental.cluster.unknown-feature]", Message: "unrecognized experimental tag"},
 			},
 		},
 		{
@@ -165,7 +165,7 @@ func TestMutateCluster(t *testing.T) {
 			subscription: afecRegistered,
 			tags:         map[string]string{"ARO-HCP.Experimental.Cluster.Unknown-Feature": string(api.SingleReplicaControlPlane)},
 			expectErrors: []utils.ExpectedError{
-				{FieldPath: "tags", Message: "unrecognized experimental tag"},
+				{FieldPath: "tags[ARO-HCP.Experimental.Cluster.Unknown-Feature]", Message: "unrecognized experimental tag"},
 			},
 		},
 		{
@@ -180,7 +180,7 @@ func TestMutateCluster(t *testing.T) {
 			subscription: afecRegistered,
 			tags:         map[string]string{api.TagClusterSingleReplica: string(api.SingleReplicaControlPlane), "aro-hcp.experimental.cluster.unknown": "value"},
 			expectErrors: []utils.ExpectedError{
-				{FieldPath: "tags", Message: "unrecognized experimental tag"},
+				{FieldPath: "tags[aro-hcp.experimental.cluster.unknown]", Message: "unrecognized experimental tag"},
 			},
 		},
 		{

--- a/internal/admission/admit_nodepool.go
+++ b/internal/admission/admit_nodepool.go
@@ -30,10 +30,13 @@ import (
 	"github.com/Azure/ARO-HCP/internal/validation"
 )
 
-// NodePoolAdmissionContext carries dependencies that node pool mutation needs
-// beyond the node pool object itself, currently the parent cluster.
+// NodePoolAdmissionContext carries dependencies that node pool mutation/admission needs
+// beyond the node pool object itself. It includes the parent cluster and optionally
+// the service provider cluster and nodepool (for update-specific validations like version upgrades).
 type NodePoolAdmissionContext struct {
-	Cluster *api.HCPOpenShiftCluster
+	Cluster                 *api.HCPOpenShiftCluster
+	ServiceProviderNodePool *api.ServiceProviderNodePool
+	ServiceProviderCluster  *api.ServiceProviderCluster
 }
 
 // MutateNodePool applies admission-time mutations to a node pool (e.g. defaulting
@@ -68,37 +71,70 @@ func mutateNodePoolPlatform(ctx context.Context, admissionContext *NodePoolAdmis
 	return errs
 }
 
-// AdmitNodePool performs non-static checks of nodepool.  Checks that require more information than is contained inside of
-// of the nodepool instance itself.
-func AdmitNodePool(newNodePool, oldNodePool *api.HCPOpenShiftClusterNodePool, cluster *api.HCPOpenShiftCluster) field.ErrorList {
+// AdmitNodePool performs non-static checks of nodepool. Checks that require more information than is contained inside of
+// the nodepool instance itself. For update operations with version changes, include ServiceProviderNodePool and
+// ServiceProviderCluster in the admissionContext to enable version upgrade validation.
+func AdmitNodePool(ctx context.Context, admissionContext *NodePoolAdmissionContext, op operation.Operation, newNodePool, oldNodePool *api.HCPOpenShiftClusterNodePool) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, admitNodePoolProperties(ctx, admissionContext, op, field.NewPath("properties"), &newNodePool.Properties, safe.Field(oldNodePool, validation.ToNodePoolProperties))...)
+
+	return errs
+}
+
+func admitNodePoolProperties(ctx context.Context, admissionContext *NodePoolAdmissionContext, op operation.Operation, fldPath *field.Path, newObj, oldObj *api.HCPOpenShiftClusterNodePoolProperties) field.ErrorList {
+	errs := field.ErrorList{}
+
+	errs = append(errs, admitNodePoolVersion(ctx, admissionContext, op, fldPath.Child("version"), &newObj.Version, safe.Field(oldObj, validation.ToNodePoolPropertiesVersion))...)
+	errs = append(errs, admitNodePoolPlatform(ctx, admissionContext, op, fldPath.Child("platform"), &newObj.Platform, safe.Field(oldObj, validation.ToNodePoolPropertiesPlatform))...)
+
+	return errs
+}
+
+func admitNodePoolVersion(ctx context.Context, admissionContext *NodePoolAdmissionContext, op operation.Operation, fldPath *field.Path, newObj, oldObj *api.NodePoolVersionProfile) field.ErrorList {
+	errs := field.ErrorList{}
+
+	clusterVersion := &admissionContext.Cluster.CustomerProperties.Version
+
 	// Check only if it is a creating nodepool or a change in the channelGroup
-	if (oldNodePool == nil || newNodePool.Properties.Version.ChannelGroup != oldNodePool.Properties.Version.ChannelGroup) &&
-		newNodePool.Properties.Version.ChannelGroup != cluster.CustomerProperties.Version.ChannelGroup {
+	if (op.Type == operation.Create || newObj.ChannelGroup != oldObj.ChannelGroup) &&
+		newObj.ChannelGroup != clusterVersion.ChannelGroup {
 		errs = append(errs, field.Invalid(
-			field.NewPath("properties", "version", "channelGroup"),
-			newNodePool.Properties.Version.ChannelGroup,
-			fmt.Sprintf("must be the same as control plane channel group '%s'", cluster.CustomerProperties.Version.ChannelGroup),
+			fldPath.Child("channelGroup"),
+			newObj.ChannelGroup,
+			fmt.Sprintf("must be the same as control plane channel group '%s'", clusterVersion.ChannelGroup),
 		))
 	}
+
+	// Perform update-specific version upgrade validation
+	if op.Type == operation.Update {
+		errs = append(errs, validateNodePoolVersionChange(ctx, admissionContext, op, fldPath.Child("id"), newObj, oldObj)...)
+	}
+
+	return errs
+}
+
+func admitNodePoolPlatform(ctx context.Context, admissionContext *NodePoolAdmissionContext, op operation.Operation, fldPath *field.Path, newObj, oldObj *api.NodePoolPlatformProfile) field.ErrorList {
+	errs := field.ErrorList{}
+
+	clusterPlatform := &admissionContext.Cluster.CustomerProperties.Platform
 
 	// Check only if it is a creating nodepool or a change in the Subnet.
 	// Compare by string value (not pointer identity) so equal-but-distinct
 	// *azcorearm.ResourceID values aren't treated as a change.
-	if newNodePool.Properties.Platform.SubnetID != nil && cluster.CustomerProperties.Platform.SubnetID != nil {
+	if newObj.SubnetID != nil && clusterPlatform.SubnetID != nil {
 		var oldSubnetID string
-		if oldNodePool != nil && oldNodePool.Properties.Platform.SubnetID != nil {
-			oldSubnetID = oldNodePool.Properties.Platform.SubnetID.String()
+		if op.Type == operation.Update && oldObj.SubnetID != nil {
+			oldSubnetID = oldObj.SubnetID.String()
 		}
-		newSubnetID := newNodePool.Properties.Platform.SubnetID.String()
-		if oldNodePool == nil || !strings.EqualFold(newSubnetID, oldSubnetID) {
-			clusterVNet := cluster.CustomerProperties.Platform.SubnetID.Parent.String()
-			nodePoolVNet := newNodePool.Properties.Platform.SubnetID.Parent.String()
+		newSubnetID := newObj.SubnetID.String()
+		if op.Type == operation.Create || !strings.EqualFold(newSubnetID, oldSubnetID) {
+			clusterVNet := clusterPlatform.SubnetID.Parent.String()
+			nodePoolVNet := newObj.SubnetID.Parent.String()
 			if !strings.EqualFold(nodePoolVNet, clusterVNet) {
 				errs = append(errs, field.Invalid(
-					field.NewPath("properties", "platform", "subnetId"),
-					newNodePool.Properties.Platform.SubnetID,
+					fldPath.Child("subnetId"),
+					newObj.SubnetID,
 					fmt.Sprintf("must belong to the same VNet as the parent cluster VNet '%s'", clusterVNet),
 				))
 			}
@@ -108,41 +144,24 @@ func AdmitNodePool(newNodePool, oldNodePool *api.HCPOpenShiftClusterNodePool, cl
 	return errs
 }
 
-// AdmitNodePoolUpdate performs update-specific validation that requires both the old and new node pool states.
-// It includes all validations from AdmitNodePool plus version upgrade constraints.
-// The spNodePool and spCluster parameters provide the service provider state for version validation.
-func AdmitNodePoolUpdate(newNodePool, oldNodePool *api.HCPOpenShiftClusterNodePool, cluster *api.HCPOpenShiftCluster,
-	spNodePool *api.ServiceProviderNodePool, spCluster *api.ServiceProviderCluster, op operation.Operation) field.ErrorList {
-	errs := field.ErrorList{}
-
-	// Include all standard node pool admission checks
-	errs = append(errs, AdmitNodePool(newNodePool, oldNodePool, cluster)...)
-
-	// Add update-specific version upgrade validation
-	errs = append(errs, validateNodePoolVersionUpgrade(newNodePool, oldNodePool, spNodePool, spCluster, op)...)
-
-	return errs
-}
-
-// validateNodePoolVersionUpgrade validates that a node pool version change is a valid upgrade.
+// validateNodePoolVersionChange validates that a node pool version change is a valid upgrade.
 // It checks:
 //   - No downgrade: new version >= old version
 //   - No major version change: new major == old major (unless FeatureExperimentalReleaseFeatures is registered)
 //   - No skipping minor versions: new minor <= old minor + 1
 //   - Cannot exceed cluster version: new version <= cluster version
-func validateNodePoolVersionUpgrade(newNodePool, oldNodePool *api.HCPOpenShiftClusterNodePool, spNodePool *api.ServiceProviderNodePool, spCluster *api.ServiceProviderCluster, op operation.Operation) field.ErrorList {
-
+func validateNodePoolVersionChange(ctx context.Context, admissionContext *NodePoolAdmissionContext, op operation.Operation, fldPath *field.Path, newObj, oldObj *api.NodePoolVersionProfile) field.ErrorList {
+	spNodePool, spCluster := admissionContext.ServiceProviderNodePool, admissionContext.ServiceProviderCluster
 	// Skip validation if no version is specified or version didn't change
-	if len(newNodePool.Properties.Version.ID) == 0 || newNodePool.Properties.Version.ID == oldNodePool.Properties.Version.ID {
+	if len(newObj.ID) == 0 || newObj.ID == oldObj.ID {
 		return nil
 	}
 
 	errs := field.ErrorList{}
-	fldPath := field.NewPath("properties", "version", "id")
 
-	newVersion, err := semver.Parse(newNodePool.Properties.Version.ID)
+	newVersion, err := semver.Parse(newObj.ID)
 	if err != nil {
-		errs = append(errs, field.Invalid(fldPath, newNodePool.Properties.Version.ID, fmt.Sprintf("invalid node pool version format: %s", err.Error())))
+		errs = append(errs, field.Invalid(fldPath, newObj.ID, fmt.Sprintf("invalid node pool version format: %s", err.Error())))
 		// Return early, it cannot validate an unparseable version
 		return errs
 	}
@@ -154,11 +173,11 @@ func validateNodePoolVersionUpgrade(newNodePool, oldNodePool *api.HCPOpenShiftCl
 
 	lowestCPVersion, _ := apihelpers.FindLowestAndHighestClusterVersion(spCluster.Status.ControlPlaneVersion.ActiveVersions)
 	if err := validation.ValidateNodePoolUpgrade(newVersion, spNodePool.Status.NodePoolVersion.ActiveVersions, lowestCPVersion, op.HasOption(api.FeatureExperimentalReleaseFeatures)); err != nil {
-		errs = append(errs, field.Invalid(fldPath, newNodePool.Properties.Version.ID, err.Error()))
+		errs = append(errs, field.Invalid(fldPath, newObj.ID, err.Error()))
 	}
 
 	if spNodePool.Spec.NodePoolVersion.DesiredVersion != nil && newVersion.LE(*spNodePool.Spec.NodePoolVersion.DesiredVersion) {
-		errs = append(errs, field.Invalid(fldPath, newNodePool.Properties.Version.ID, fmt.Sprintf("cannot downgrade from version %s to %s", spNodePool.Spec.NodePoolVersion.DesiredVersion.String(), newVersion.String())))
+		errs = append(errs, field.Invalid(fldPath, newObj.ID, fmt.Sprintf("cannot downgrade from version %s to %s", spNodePool.Spec.NodePoolVersion.DesiredVersion.String(), newVersion.String())))
 	}
 	return errs
 }

--- a/internal/admission/admit_nodepool_test.go
+++ b/internal/admission/admit_nodepool_test.go
@@ -147,39 +147,84 @@ func TestAdmitNodePool_SubnetVNet(t *testing.T) {
 		return np
 	}
 
+	newAdmissionContext := func(withServiceProvider bool) *NodePoolAdmissionContext {
+		admissionContext := &NodePoolAdmissionContext{
+			Cluster: cluster,
+		}
+		if withServiceProvider {
+			version := semver.MustParse("4.14.0")
+			admissionContext.ServiceProviderNodePool = &api.ServiceProviderNodePool{
+				Spec: api.ServiceProviderNodePoolSpec{
+					NodePoolVersion: api.ServiceProviderNodePoolSpecVersion{
+						DesiredVersion: &version,
+					},
+				},
+				Status: api.ServiceProviderNodePoolStatus{
+					NodePoolVersion: api.ServiceProviderNodePoolStatusVersion{
+						ActiveVersions: []api.HCPNodePoolActiveVersion{
+							{Version: &version},
+						},
+					},
+				},
+			}
+			admissionContext.ServiceProviderCluster = &api.ServiceProviderCluster{
+				Status: api.ServiceProviderClusterStatus{
+					ControlPlaneVersion: api.ServiceProviderClusterStatusVersion{
+						ActiveVersions: []api.HCPClusterActiveVersion{
+							{Version: &version},
+						},
+					},
+				},
+			}
+		}
+		return admissionContext
+	}
+
 	tests := []struct {
-		name         string
-		newObj       *api.HCPOpenShiftClusterNodePool
-		oldObj       *api.HCPOpenShiftClusterNodePool
-		expectErrors []utils.ExpectedError
+		name             string
+		op               operation.Type
+		newObj           *api.HCPOpenShiftClusterNodePool
+		oldObj           *api.HCPOpenShiftClusterNodePool
+		admissionContext *NodePoolAdmissionContext
+		expectErrors     []utils.ExpectedError
 	}{
 		{
-			name:         "create: subnet matches cluster subnet (same cluster reuse allowed)",
-			newObj:       nodePoolWithSubnet(clusterSubnet),
-			expectErrors: []utils.ExpectedError{},
+			name:             "create: subnet matches cluster subnet (same cluster reuse allowed)",
+			op:               operation.Create,
+			newObj:           nodePoolWithSubnet(clusterSubnet),
+			admissionContext: newAdmissionContext(false),
+			expectErrors:     []utils.ExpectedError{},
 		},
 		{
-			name:         "create: subnet in same VNet allowed",
-			newObj:       nodePoolWithSubnet(sameVNetSubnet),
-			expectErrors: []utils.ExpectedError{},
+			name:             "create: subnet in same VNet allowed",
+			op:               operation.Create,
+			newObj:           nodePoolWithSubnet(sameVNetSubnet),
+			admissionContext: newAdmissionContext(false),
+			expectErrors:     []utils.ExpectedError{},
 		},
 		{
-			name:   "create: subnet in different VNet rejected",
-			newObj: nodePoolWithSubnet(differentVNetSubnet),
+			name:             "create: subnet in different VNet rejected",
+			op:               operation.Create,
+			newObj:           nodePoolWithSubnet(differentVNetSubnet),
+			admissionContext: newAdmissionContext(false),
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.platform.subnetId", Message: "must belong to the same VNet as the parent cluster VNet"},
 			},
 		},
 		{
-			name:         "update: unchanged subnet in different VNet not re-validated",
-			oldObj:       nodePoolWithSubnet(differentVNetSubnet),
-			newObj:       nodePoolWithSubnet(differentVNetSubnet),
-			expectErrors: []utils.ExpectedError{},
+			name:             "update: unchanged subnet in different VNet not re-validated",
+			op:               operation.Update,
+			oldObj:           nodePoolWithSubnet(differentVNetSubnet),
+			newObj:           nodePoolWithSubnet(differentVNetSubnet),
+			admissionContext: newAdmissionContext(true),
+			expectErrors:     []utils.ExpectedError{},
 		},
 		{
-			name:   "update: subnet changed to different VNet rejected",
-			oldObj: nodePoolWithSubnet(sameVNetSubnet),
-			newObj: nodePoolWithSubnet(differentVNetSubnet),
+			name:             "update: subnet changed to different VNet rejected",
+			op:               operation.Update,
+			oldObj:           nodePoolWithSubnet(sameVNetSubnet),
+			newObj:           nodePoolWithSubnet(differentVNetSubnet),
+			admissionContext: newAdmissionContext(true),
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.platform.subnetId", Message: "must belong to the same VNet as the parent cluster VNet"},
 			},
@@ -188,7 +233,7 @@ func TestAdmitNodePool_SubnetVNet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := AdmitNodePool(tt.newObj, tt.oldObj, cluster)
+			errs := AdmitNodePool(context.Background(), tt.admissionContext, operation.Operation{Type: tt.op}, tt.newObj, tt.oldObj)
 			utils.VerifyErrorsMatch(t, tt.expectErrors, errs)
 		})
 	}
@@ -206,7 +251,7 @@ func assertNodePoolEqual(t *testing.T, expected, actual *api.HCPOpenShiftCluster
 	assert.Equal(t, string(expectedJSON), string(actualJSON))
 }
 
-func TestAdmitNodePoolUpdate_VersionValidation(t *testing.T) {
+func TestAdmitNodePool_VersionValidation(t *testing.T) {
 	tests := []struct {
 		name               string
 		newVersion         string
@@ -489,14 +534,18 @@ func TestAdmitNodePoolUpdate_VersionValidation(t *testing.T) {
 				},
 			}
 
-			errs := AdmitNodePoolUpdate(newNodePool, oldNodePool, cluster, spNodePool, spCluster, op)
+			errs := AdmitNodePool(context.Background(), &NodePoolAdmissionContext{
+				Cluster:                 cluster,
+				ServiceProviderNodePool: spNodePool,
+				ServiceProviderCluster:  spCluster,
+			}, op, newNodePool, oldNodePool)
 			utils.VerifyErrorsMatch(t, tt.expectErrors, errs)
 		})
 	}
 }
 
-func TestAdmitNodePoolUpdate_IncludesAdmitNodePoolChecks(t *testing.T) {
-	// Test that AdmitNodePoolUpdate also performs AdmitNodePool checks
+func TestAdmitNodePool_IncludesChannelGroupCheck(t *testing.T) {
+	// Test that AdmitNodePool performs channel group validation from service provider state
 	newNodePool := &api.HCPOpenShiftClusterNodePool{
 		Properties: api.HCPOpenShiftClusterNodePoolProperties{
 			Version: api.NodePoolVersionProfile{
@@ -549,7 +598,11 @@ func TestAdmitNodePoolUpdate_IncludesAdmitNodePoolChecks(t *testing.T) {
 	// Empty update operation (no experimental features)
 	op := operation.Operation{Type: operation.Update}
 
-	errs := AdmitNodePoolUpdate(newNodePool, oldNodePool, cluster, spNodePool, spCluster, op)
+	errs := AdmitNodePool(context.Background(), &NodePoolAdmissionContext{
+		Cluster:                 cluster,
+		ServiceProviderNodePool: spNodePool,
+		ServiceProviderCluster:  spCluster,
+	}, op, newNodePool, oldNodePool)
 
 	expectedErrors := []utils.ExpectedError{
 		{FieldPath: "properties.version.channelGroup", Message: "must be the same as control plane channel group"},

--- a/internal/utils/testhelpers.go
+++ b/internal/utils/testhelpers.go
@@ -43,7 +43,7 @@ func VerifyErrorsMatch(t *testing.T, expectedErrors []ExpectedError, errs field.
 		found := false
 		for _, err := range errs {
 			messageMatch := strings.Contains(err.Detail, expectedErr.Message) || strings.Contains(err.Error(), expectedErr.Message)
-			fieldMatch := strings.Contains(err.Field, expectedErr.FieldPath)
+			fieldMatch := err.Field == expectedErr.FieldPath
 			if messageMatch && fieldMatch {
 				found = true
 				break
@@ -58,7 +58,7 @@ func VerifyErrorsMatch(t *testing.T, expectedErrors []ExpectedError, errs field.
 		found := false
 		for _, expectedErr := range expectedErrors {
 			messageMatch := strings.Contains(err.Detail, expectedErr.Message) || strings.Contains(err.Error(), expectedErr.Message)
-			fieldMatch := strings.Contains(err.Field, expectedErr.FieldPath)
+			fieldMatch := err.Field == expectedErr.FieldPath
 			if messageMatch && fieldMatch {
 				found = true
 				break

--- a/internal/validation/hcpopenshiftcluster_test.go
+++ b/internal/validation/hcpopenshiftcluster_test.go
@@ -593,7 +593,7 @@ func TestClusterValidate(t *testing.T) {
 			expectErrors: []utils.ExpectedError{
 				{
 					Message:   "Required value",
-					FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators",
+					FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[]",
 				},
 				{
 					Message:   "identity is not assigned to this resource",
@@ -620,7 +620,7 @@ func TestClusterValidate(t *testing.T) {
 			expectErrors: []utils.ExpectedError{
 				{
 					Message:   "Required value",
-					FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.dataPlaneOperators",
+					FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.dataPlaneOperators[]",
 				},
 			},
 		},
@@ -887,7 +887,7 @@ func TestClusterValidate(t *testing.T) {
 				},
 				{
 					Message:   "identity is assigned to this resource but not used",
-					FieldPath: "identity.userAssignedIdentities",
+					FieldPath: "identity.userAssignedIdentities[/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/testResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myManagedIdentity3]",
 				},
 				{
 					Message:   "identity is not assigned to this resource",
@@ -921,7 +921,7 @@ func TestClusterValidate(t *testing.T) {
 			expectErrors: []utils.ExpectedError{
 				{
 					Message:   "identity is used multiple times",
-					FieldPath: "identity.userAssignedIdentities",
+					FieldPath: "identity.userAssignedIdentities[/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/testResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myManagedIdentity1]",
 				},
 			},
 		},
@@ -949,7 +949,7 @@ func TestClusterValidate(t *testing.T) {
 			expectErrors: []utils.ExpectedError{
 				{
 					Message:   "identity is assigned to this resource but not used",
-					FieldPath: "identity.userAssignedIdentities",
+					FieldPath: "identity.userAssignedIdentities[/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/testResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myManagedIdentity1]",
 				},
 				{
 					Message:   "cannot use identity assigned to this resource by .identities.userAssignedIdentities",

--- a/internal/validation/hcpopenshiftclusterexternalauth_test.go
+++ b/internal/validation/hcpopenshiftclusterexternalauth_test.go
@@ -348,7 +348,7 @@ func TestExternalAuthValidate(t *testing.T) {
 			expectErrors: []utils.ExpectedError{
 				{
 					Message:   "must match an audience in issuer audiences",
-					FieldPath: "properties.clients",
+					FieldPath: "properties.clients[0].clientId",
 				},
 			},
 		},
@@ -388,7 +388,7 @@ func TestExternalAuthValidate(t *testing.T) {
 			expectErrors: []utils.ExpectedError{
 				{
 					Message:   "Duplicate value",
-					FieldPath: "properties.clients",
+					FieldPath: "properties.clients[1]",
 				},
 			},
 		},

--- a/internal/validation/validate_cluster_comprehensive_test.go
+++ b/internal/validation/validate_cluster_comprehensive_test.go
@@ -520,10 +520,10 @@ func TestValidateClusterCreate(t *testing.T) {
 				return c
 			}(),
 			expectErrors: []utils.ExpectedError{
-				{Message: "Required value", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators"},
+				{Message: "Required value", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[]"},
 				{Message: "must be in the same Azure subscription", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[]"},
 				{Message: "identity is not assigned to this resource", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[]"},
-				{Message: "identity is assigned to this resource but not used", FieldPath: "identity.userAssignedIdentities"},
+				{Message: "identity is assigned to this resource but not used", FieldPath: "identity.userAssignedIdentities[/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity]"},
 			},
 		},
 		{
@@ -539,7 +539,7 @@ func TestValidateClusterCreate(t *testing.T) {
 				{Message: "resource ID must reference an instance of type", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[test-operator]"},
 				{Message: "must be in the same Azure subscription", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[test-operator]"},
 				{Message: "identity is not assigned to this resource", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[test-operator]"},
-				{Message: "identity is assigned to this resource but not used", FieldPath: "identity.userAssignedIdentities"},
+				{Message: "identity is assigned to this resource but not used", FieldPath: "identity.userAssignedIdentities[/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity]"},
 			},
 		},
 		{
@@ -557,7 +557,7 @@ func TestValidateClusterCreate(t *testing.T) {
 				{Message: "Required value", FieldPath: "identity.type"},
 				{Message: "Unsupported value", FieldPath: "identity.state"},
 				{Message: "identity is not assigned to this resource", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[test-operator]"},
-				{Message: "identity is assigned to this resource but not used", FieldPath: "identity.userAssignedIdentities"},
+				{Message: "identity is assigned to this resource but not used", FieldPath: "identity.userAssignedIdentities[/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity]"},
 			},
 		},
 		{
@@ -575,7 +575,7 @@ func TestValidateClusterCreate(t *testing.T) {
 			expectErrors: []utils.ExpectedError{
 				{Message: "Unsupported value", FieldPath: "identity.state"},
 				{Message: "identity is not assigned to this resource", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[test-operator]"},
-				{Message: "identity is assigned to this resource but not used", FieldPath: "identity.userAssignedIdentities"},
+				{Message: "identity is assigned to this resource but not used", FieldPath: "identity.userAssignedIdentities[/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity]"},
 			},
 		},
 		{
@@ -591,8 +591,8 @@ func TestValidateClusterCreate(t *testing.T) {
 				return c
 			}(),
 			expectErrors: []utils.ExpectedError{
-				{Message: "resource ID must reference an instance of type", FieldPath: "identity.userAssignedIdentities"},
-				{Message: "identity is assigned to this resource but not used", FieldPath: "identity.userAssignedIdentities"},
+				{Message: "resource ID must reference an instance of type", FieldPath: "identity.userAssignedIdentities[/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet]"},
+				{Message: "identity is assigned to this resource but not used", FieldPath: "identity.userAssignedIdentities[/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet]"},
 				{Message: "identity is not assigned to this resource", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[test-operator]"},
 			},
 		},
@@ -816,7 +816,7 @@ func TestValidateClusterCreate(t *testing.T) {
 			expectErrors: []utils.ExpectedError{
 				{Message: "must be in the same Azure subscription", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[test-operator]"},
 				{Message: "identity is not assigned to this resource", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators[test-operator]"},
-				{Message: "identity is assigned to this resource but not used", FieldPath: "identity.userAssignedIdentities"},
+				{Message: "identity is assigned to this resource but not used", FieldPath: "identity.userAssignedIdentities[/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity]"},
 			},
 		},
 		{

--- a/internal/validation/validate_externalauth_comprehensive_test.go
+++ b/internal/validation/validate_externalauth_comprehensive_test.go
@@ -630,7 +630,7 @@ func TestValidateExternalAuthCustomValidation(t *testing.T) {
 				return obj
 			}(),
 			expectErrors: []utils.ExpectedError{
-				{FieldPath: "properties.clients[0]", Message: "must match an audience in issuer audiences"},
+				{FieldPath: "properties.clients[0].clientId", Message: "must match an audience in issuer audiences"},
 			},
 		},
 		{

--- a/internal/validation/validate_nodepools.go
+++ b/internal/validation/validate_nodepools.go
@@ -76,7 +76,11 @@ func toNodePoolPropertiesProvisioningState(oldObj *api.HCPOpenShiftClusterNodePo
 	return &oldObj.ProvisioningState
 }
 
-func toNodePoolPropertiesVersion(oldObj *api.HCPOpenShiftClusterNodePoolProperties) *api.NodePoolVersionProfile {
+// ToNodePoolPropertiesVersion returns a pointer to the Version field of node
+// pool properties. It is exported for use as a field accessor with safe.Field
+// by external callers (e.g. admission code) that need to navigate into the
+// Version subtree.
+func ToNodePoolPropertiesVersion(oldObj *api.HCPOpenShiftClusterNodePoolProperties) *api.NodePoolVersionProfile {
 	return &oldObj.Version
 }
 
@@ -115,7 +119,7 @@ func validateNodePoolProperties(ctx context.Context, op operation.Operation, fld
 	errs = append(errs, immutableByCompare(ctx, op, fldPath.Child("provisioningState"), &newObj.ProvisioningState, safe.Field(oldObj, toNodePoolPropertiesProvisioningState))...)
 
 	//Version                 NodePoolVersionProfile  `json:"version,omitempty"`
-	errs = append(errs, validateNodePoolVersionProfile(ctx, op, fldPath.Child("version"), &newObj.Version, safe.Field(oldObj, toNodePoolPropertiesVersion))...)
+	errs = append(errs, validateNodePoolVersionProfile(ctx, op, fldPath.Child("version"), &newObj.Version, safe.Field(oldObj, ToNodePoolPropertiesVersion))...)
 
 	//Platform                NodePoolPlatformProfile `json:"platform,omitempty"`
 	errs = append(errs, immutableByReflect(ctx, op, fldPath.Child("platform"), &newObj.Platform, safe.Field(oldObj, ToNodePoolPropertiesPlatform))...)

--- a/internal/validation/validate_nodepools_comprehensive_test.go
+++ b/internal/validation/validate_nodepools_comprehensive_test.go
@@ -16,7 +16,6 @@ package validation
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -27,26 +26,22 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 // Comprehensive tests for ValidateNodePoolCreate
 func TestValidateNodePoolCreate(t *testing.T) {
 	ctx := context.Background()
 
-	type expectedError struct {
-		message   string // Expected error message (partial match)
-		fieldPath string // Expected field path for the error
-	}
-
 	tests := []struct {
 		name         string
 		nodePool     *api.HCPOpenShiftClusterNodePool
-		expectErrors []expectedError
+		expectErrors []utils.ExpectedError
 	}{
 		{
 			name:         "valid nodepool - create",
 			nodePool:     createValidNodePool(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool with autoscaling - create",
@@ -59,7 +54,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Replicas = 0 // Should be 0 when autoscaling is enabled
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool with autoscaling min=0 - create",
@@ -72,7 +67,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Replicas = 0
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool with labels - create",
@@ -85,7 +80,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool with taints - create",
@@ -105,7 +100,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool with encryption set ID - create",
@@ -114,7 +109,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Platform.OSDisk.EncryptionSetID = api.Must(azcorearm.ParseResourceID("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.Compute/diskEncryptionSets/test-des"))
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool with custom OS disk size - create",
@@ -123,7 +118,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Platform.OSDisk.SizeGiB = ptr.To[int32](64)
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool with different storage account type - create",
@@ -132,7 +127,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Platform.OSDisk.DiskStorageAccountType = api.DiskStorageAccountTypeStandardSSD_LRS
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool with availability zone - create",
@@ -141,7 +136,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Platform.AvailabilityZone = "1"
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool with node drain timeout - create",
@@ -150,7 +145,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.NodeDrainTimeoutMinutes = ptr.To[int32](60)
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool with version ID - create",
@@ -160,7 +155,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Version.ChannelGroup = "fast"
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "invalid version ID - create",
@@ -169,8 +164,9 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Version.ID = "invalid-version"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "No Major.Minor.Patch elements found", fieldPath: "properties.version.id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "No Major.Minor.Patch elements found", FieldPath: "properties.version.id"},
+				{Message: "Short version cannot contain PreRelease/Build meta data", FieldPath: "properties.version.id"},
 			},
 		},
 		{
@@ -180,8 +176,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Version.ID = "4.20.0"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be at least 4.20.8", fieldPath: "properties.version.id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be at least 4.20.8", FieldPath: "properties.version.id"},
 			},
 		},
 		{
@@ -191,8 +187,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Version.ChannelGroup = ""
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "Required value", fieldPath: "properties.version.channelGroup"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "Required value", FieldPath: "properties.version.channelGroup"},
 			},
 		},
 		{
@@ -203,8 +199,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Version.ChannelGroup = "fast"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "Required value", fieldPath: "properties.version.id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "Required value", FieldPath: "properties.version.id"},
 			},
 		},
 		{
@@ -215,8 +211,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Version.ChannelGroup = "stable"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "Required value", fieldPath: "properties.version.id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "Required value", FieldPath: "properties.version.id"},
 			},
 		},
 		{
@@ -227,7 +223,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Platform.SubnetID = nil
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "wrong subnet resource type - create",
@@ -236,8 +232,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Platform.SubnetID = api.Must(azcorearm.ParseResourceID("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"))
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "resource ID must reference an instance of type", fieldPath: "properties.platform.subnetId"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "resource ID must reference an instance of type", FieldPath: "properties.platform.subnetId"},
 			},
 		},
 		{
@@ -247,8 +243,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Platform.VMSize = ""
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "Required value", fieldPath: "properties.platform.vmSize"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "Required value", FieldPath: "properties.platform.vmSize"},
 			},
 		},
 		{
@@ -258,8 +254,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Platform.OSDisk.SizeGiB = ptr.To[int32](63)
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be greater than or equal to 64", fieldPath: "properties.platform.osDisk.sizeGiB"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be greater than or equal to 64", FieldPath: "properties.platform.osDisk.sizeGiB"},
 			},
 		},
 		{
@@ -269,8 +265,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Platform.OSDisk.DiskStorageAccountType = "InvalidType"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "Unsupported value", fieldPath: "properties.platform.osDisk.diskStorageAccountType"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "Unsupported value", FieldPath: "properties.platform.osDisk.diskStorageAccountType"},
 			},
 		},
 		{
@@ -280,8 +276,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Platform.OSDisk.DiskType = "InvalidType"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "Unsupported value", fieldPath: "properties.platform.osDisk.diskType"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "Unsupported value", FieldPath: "properties.platform.osDisk.diskType"},
 			},
 		},
 		{
@@ -292,8 +288,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.AutoRepair = false
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be true when platform.osDisk.diskType is Ephemeral", fieldPath: "properties.autoRepair"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be true when platform.osDisk.diskType is Ephemeral", FieldPath: "properties.autoRepair"},
 			},
 		},
 		{
@@ -304,7 +300,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.AutoRepair = true
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "wrong encryption set resource type - create",
@@ -313,8 +309,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Platform.OSDisk.EncryptionSetID = api.Must(azcorearm.ParseResourceID("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"))
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "resource ID must reference an instance of type", fieldPath: "properties.platform.osDisk.encryptionSetId"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "resource ID must reference an instance of type", FieldPath: "properties.platform.osDisk.encryptionSetId"},
 			},
 		},
 		{
@@ -324,7 +320,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Replicas = MaxNodePoolNodes
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "negative replicas - create",
@@ -333,8 +329,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Replicas = -1
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be greater than or equal to 0", fieldPath: "properties.replicas"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be greater than or equal to 0", FieldPath: "properties.replicas"},
 			},
 		},
 		{
@@ -344,8 +340,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Replicas = MaxNodePoolNodes + 1
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be less than or equal to 200", fieldPath: "properties.replicas"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be less than or equal to 200", FieldPath: "properties.replicas"},
 			},
 		},
 		{
@@ -359,8 +355,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "cannot specify replicas when autoScaling is enabled", fieldPath: "properties.replicas"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "cannot specify replicas when autoScaling is enabled", FieldPath: "properties.replicas"},
 			},
 		},
 		{
@@ -374,7 +370,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "autoscaling min too small - create",
@@ -387,8 +383,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be greater than or equal to 0", fieldPath: "properties.autoScaling.min"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be greater than or equal to 0", FieldPath: "properties.autoScaling.min"},
 			},
 		},
 		{
@@ -403,8 +399,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be less than or equal to 200", fieldPath: "properties.autoScaling.min"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be less than or equal to 200", FieldPath: "properties.autoScaling.min"},
 			},
 		},
 		{
@@ -419,8 +415,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be greater than or equal to 0", fieldPath: "properties.autoScaling.min"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be greater than or equal to 0", FieldPath: "properties.autoScaling.min"},
 			},
 		},
 		{
@@ -434,8 +430,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be greater than or equal to 5", fieldPath: "properties.autoScaling.max"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be greater than or equal to 5", FieldPath: "properties.autoScaling.max"},
 			},
 		},
 		{
@@ -451,9 +447,9 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be less than or equal to 200", fieldPath: "properties.autoScaling.min"},
-				{message: "must be less than or equal to 200", fieldPath: "properties.autoScaling.max"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be less than or equal to 200", FieldPath: "properties.autoScaling.min"},
+				{Message: "must be less than or equal to 200", FieldPath: "properties.autoScaling.max"},
 			},
 		},
 		{
@@ -465,8 +461,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "name part must consist of alphanumeric characters", fieldPath: "properties.labels"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "name part must consist of alphanumeric characters", FieldPath: "properties.labels"},
 			},
 		},
 		{
@@ -478,8 +474,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "a valid label must be an empty string or consist of alphanumeric characters", fieldPath: "properties.labels[valid-key]"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "a valid label must be an empty string or consist of alphanumeric characters", FieldPath: "properties.labels[valid-key]"},
 			},
 		},
 		{
@@ -491,8 +487,9 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "name part must be non-empty", fieldPath: "properties.labels"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "name part must be non-empty", FieldPath: "properties.labels"},
+				{Message: "name part must consist of alphanumeric characters", FieldPath: "properties.labels"},
 			},
 		},
 		{
@@ -507,8 +504,10 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "Required value", fieldPath: "properties.taints[0].key"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "Required value", FieldPath: "properties.taints[0].key"},
+				{Message: "name part must be non-empty", FieldPath: "properties.taints[0].key"},
+				{Message: "name part must consist of alphanumeric characters", FieldPath: "properties.taints[0].key"},
 			},
 		},
 		{
@@ -524,8 +523,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "name part must consist of alphanumeric characters", fieldPath: "properties.taints[0].key"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "name part must consist of alphanumeric characters", FieldPath: "properties.taints[0].key"},
 			},
 		},
 		{
@@ -541,8 +540,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "a valid label must be an empty string or consist of alphanumeric characters", fieldPath: "properties.taints[0].value"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "a valid label must be an empty string or consist of alphanumeric characters", FieldPath: "properties.taints[0].value"},
 			},
 		},
 		{
@@ -558,8 +557,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "Unsupported value", fieldPath: "properties.taints[0].effect"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "Unsupported value", FieldPath: "properties.taints[0].effect"},
 			},
 		},
 		{
@@ -572,11 +571,12 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Replicas = -1
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "No Major.Minor.Patch elements found", fieldPath: "properties.version.id"},
-				{message: "Required value", fieldPath: "properties.platform.vmSize"},
-				{message: "must be greater than or equal to 64", fieldPath: "properties.platform.osDisk.sizeGiB"},
-				{message: "must be greater than or equal to 0", fieldPath: "properties.replicas"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "No Major.Minor.Patch elements found", FieldPath: "properties.version.id"},
+				{Message: "Short version cannot contain PreRelease/Build meta data", FieldPath: "properties.version.id"},
+				{Message: "Required value", FieldPath: "properties.platform.vmSize"},
+				{Message: "must be greater than or equal to 64", FieldPath: "properties.platform.osDisk.sizeGiB"},
+				{Message: "must be greater than or equal to 0", FieldPath: "properties.replicas"},
 			},
 		},
 		{
@@ -596,11 +596,13 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "Required value", fieldPath: "properties.taints[0].key"},
-				{message: "name part must consist of alphanumeric characters", fieldPath: "properties.taints[1].key"},
-				{message: "a valid label must be an empty string or consist of alphanumeric characters", fieldPath: "properties.taints[1].value"},
-				{message: "Unsupported value", fieldPath: "properties.taints[1].effect"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "Required value", FieldPath: "properties.taints[0].key"},
+				{Message: "name part must be non-empty", FieldPath: "properties.taints[0].key"},
+				{Message: "name part must consist of alphanumeric characters", FieldPath: "properties.taints[0].key"},
+				{Message: "name part must consist of alphanumeric characters", FieldPath: "properties.taints[1].key"},
+				{Message: "a valid label must be an empty string or consist of alphanumeric characters", FieldPath: "properties.taints[1].value"},
+				{Message: "Unsupported value", FieldPath: "properties.taints[1].effect"},
 			},
 		},
 		{
@@ -614,10 +616,11 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "name part must be non-empty", fieldPath: "properties.labels"},
-				{message: "name part must consist of alphanumeric characters", fieldPath: "properties.labels"},
-				{message: "a valid label must be an empty string or consist of alphanumeric characters", fieldPath: "properties.labels[valid-key]"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "name part must be non-empty", FieldPath: "properties.labels"},
+				{Message: "name part must consist of alphanumeric characters", FieldPath: "properties.labels"},
+				{Message: "name part must consist of alphanumeric characters", FieldPath: "properties.labels"},
+				{Message: "a valid label must be an empty string or consist of alphanumeric characters", FieldPath: "properties.labels[valid-key]"},
 			},
 		},
 		{
@@ -632,7 +635,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.NodeDrainTimeoutMinutes = nil
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "missing location - create",
@@ -641,8 +644,8 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Location = ""
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "Required value", fieldPath: "trackedResource.location"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "Required value", FieldPath: "trackedResource.location"},
 			},
 		},
 		{
@@ -653,7 +656,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Properties.Replicas = 250
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "autoscaling both min and max exceed 200 with availability zone set - valid - create",
@@ -667,7 +670,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		// Node pool resource naming validation tests (covering middleware_validatestatic_test.go patterns)
 		{
@@ -677,8 +680,9 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.ID.Name = "$"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be a valid DNS RFC 1035 label", fieldPath: "id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be equal to", FieldPath: "trackedResource.resource.name"},
+				{Message: "must be a valid DNS RFC 1035 label", FieldPath: "id"},
 			},
 		},
 		{
@@ -688,8 +692,9 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.ID.Name = "-abcde"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be a valid DNS RFC 1035 label", fieldPath: "id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be equal to", FieldPath: "trackedResource.resource.name"},
+				{Message: "must be a valid DNS RFC 1035 label", FieldPath: "id"},
 			},
 		},
 		{
@@ -699,8 +704,9 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.ID.Name = "1nodepool"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be a valid DNS RFC 1035 label", fieldPath: "id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be equal to", FieldPath: "trackedResource.resource.name"},
+				{Message: "must be a valid DNS RFC 1035 label", FieldPath: "id"},
 			},
 		},
 		{
@@ -710,8 +716,9 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.ID.Name = "my-pool-"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be a valid DNS RFC 1035 label", fieldPath: "id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be equal to", FieldPath: "trackedResource.resource.name"},
+				{Message: "must be a valid DNS RFC 1035 label", FieldPath: "id"},
 			},
 		},
 		{
@@ -721,8 +728,10 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.ID.Name = "07B4gc00vjA2C8KL3Ns4No9fi" // Too long for node pool name
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be a valid DNS RFC 1035 label", fieldPath: "id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be equal to", FieldPath: "trackedResource.resource.name"},
+				{Message: "Too long", FieldPath: "id"},
+				{Message: "must be a valid DNS RFC 1035 label", FieldPath: "id"},
 			},
 		},
 		{
@@ -732,8 +741,9 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.ID.Name = "a"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "must be a valid DNS RFC 1035 label", fieldPath: "id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be equal to", FieldPath: "trackedResource.resource.name"},
+				{Message: "must be a valid DNS RFC 1035 label", FieldPath: "id"},
 			},
 		},
 		{
@@ -744,7 +754,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Name = "abc"
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool resource name - with hyphens",
@@ -754,7 +764,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Name = "my-pool-1"
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool resource name - maximum length",
@@ -764,7 +774,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 				np.Name = "myNodePool12345"
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 	}
 
@@ -773,28 +783,7 @@ func TestValidateNodePoolCreate(t *testing.T) {
 			op := operation.Operation{Type: operation.Create}
 			errs := ValidateNodePool(ctx, op, tt.nodePool, nil)
 
-			if len(tt.expectErrors) == 0 {
-				if len(errs) != 0 {
-					t.Errorf("expected no errors, got %d: %v", len(errs), errs)
-				}
-				return
-			}
-
-			// Check that each expected error message and field path is found
-			for _, expectedErr := range tt.expectErrors {
-				found := false
-				for _, err := range errs {
-					messageMatch := strings.Contains(err.Detail, expectedErr.message) || strings.Contains(err.Error(), expectedErr.message)
-					fieldMatch := strings.Contains(err.Field, expectedErr.fieldPath)
-					if messageMatch && fieldMatch {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("expected error containing message '%s' at field '%s' but not found in: %v", expectedErr.message, expectedErr.fieldPath, errs)
-				}
-			}
+			utils.VerifyErrorsMatch(t, tt.expectErrors, errs)
 		})
 	}
 }
@@ -803,22 +792,17 @@ func TestValidateNodePoolCreate(t *testing.T) {
 func TestValidateNodePoolUpdate(t *testing.T) {
 	ctx := context.Background()
 
-	type expectedError struct {
-		message   string // Expected error message (partial match)
-		fieldPath string // Expected field path for the error
-	}
-
 	tests := []struct {
 		name         string
 		newNodePool  *api.HCPOpenShiftClusterNodePool
 		oldNodePool  *api.HCPOpenShiftClusterNodePool
-		expectErrors []expectedError
+		expectErrors []utils.ExpectedError
 	}{
 		{
 			name:         "valid nodepool update - no changes",
 			newNodePool:  createValidNodePool(),
 			oldNodePool:  createValidNodePool(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool update - replicas change",
@@ -832,7 +816,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Properties.Replicas = 3
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool update - autoscaling change",
@@ -854,7 +838,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool update - labels change",
@@ -873,7 +857,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool update - taints change",
@@ -904,7 +888,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool update - node drain timeout change",
@@ -918,7 +902,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Properties.NodeDrainTimeoutMinutes = ptr.To[int32](60)
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "valid nodepool update - version change",
@@ -932,7 +916,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Properties.Version.ID = "4.20.8"
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "immutable provisioning state - update",
@@ -946,8 +930,8 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Properties.ProvisioningState = arm.ProvisioningStateSucceeded
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "field is immutable", fieldPath: "properties.provisioningState"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "field is immutable", FieldPath: "properties.provisioningState"},
 			},
 		},
 		{
@@ -962,8 +946,9 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Properties.Platform.VMSize = "Standard_D2s_v3"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "field is immutable", fieldPath: "properties.platform"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "field is immutable", FieldPath: "properties.platform"},
+				{Message: "field is immutable", FieldPath: "properties.platform.vmSize"},
 			},
 		},
 		{
@@ -978,8 +963,9 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Properties.Platform.OSDisk.SizeGiB = ptr.To[int32](128)
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "field is immutable", fieldPath: "properties.platform"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "field is immutable", FieldPath: "properties.platform"},
+				{Message: "field is immutable", FieldPath: "properties.platform.osDisk"},
 			},
 		},
 		{
@@ -994,8 +980,8 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Properties.AutoRepair = true
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "field is immutable", fieldPath: "properties.autoRepair"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "field is immutable", FieldPath: "properties.autoRepair"},
 			},
 		},
 		{
@@ -1010,8 +996,8 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Location = "eastus"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "field is immutable", fieldPath: "trackedResource.location"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "field is immutable", FieldPath: "trackedResource.location"},
 			},
 		},
 		{
@@ -1022,8 +1008,8 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				return np
 			}(),
 			oldNodePool: createValidNodePool(),
-			expectErrors: []expectedError{
-				{message: "must be greater than or equal to 0", fieldPath: "properties.replicas"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be greater than or equal to 0", FieldPath: "properties.replicas"},
 			},
 		},
 		{
@@ -1037,7 +1023,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np := createValidNodePool()
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "replicas exceeds maximum limit - update",
@@ -1047,8 +1033,8 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				return np
 			}(),
 			oldNodePool: createValidNodePool(),
-			expectErrors: []expectedError{
-				{message: "must be less than or equal to 200", fieldPath: "properties.replicas"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be less than or equal to 200", FieldPath: "properties.replicas"},
 			},
 		},
 		{
@@ -1066,7 +1052,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np := createValidNodePool()
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "non-zero replicas with autoscaling - update",
@@ -1080,8 +1066,8 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				return np
 			}(),
 			oldNodePool: createValidNodePool(),
-			expectErrors: []expectedError{
-				{message: "cannot specify replicas when autoScaling is enabled", fieldPath: "properties.replicas"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "cannot specify replicas when autoScaling is enabled", FieldPath: "properties.replicas"},
 			},
 		},
 		{
@@ -1096,8 +1082,8 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				return np
 			}(),
 			oldNodePool: createValidNodePool(),
-			expectErrors: []expectedError{
-				{message: "must be greater than or equal to 5", fieldPath: "properties.autoScaling.max"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be greater than or equal to 5", FieldPath: "properties.autoScaling.max"},
 			},
 		},
 		{
@@ -1112,9 +1098,9 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				return np
 			}(),
 			oldNodePool: createValidNodePool(),
-			expectErrors: []expectedError{
-				{message: "must be less than or equal to 200", fieldPath: "properties.autoScaling.min"},
-				{message: "must be less than or equal to 200", fieldPath: "properties.autoScaling.max"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be less than or equal to 200", FieldPath: "properties.autoScaling.min"},
+				{Message: "must be less than or equal to 200", FieldPath: "properties.autoScaling.max"},
 			},
 		},
 		{
@@ -1127,8 +1113,8 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				return np
 			}(),
 			oldNodePool: createValidNodePool(),
-			expectErrors: []expectedError{
-				{message: "name part must consist of alphanumeric characters", fieldPath: "properties.labels"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "name part must consist of alphanumeric characters", FieldPath: "properties.labels"},
 			},
 		},
 		{
@@ -1145,8 +1131,8 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				return np
 			}(),
 			oldNodePool: createValidNodePool(),
-			expectErrors: []expectedError{
-				{message: "name part must consist of alphanumeric characters", fieldPath: "properties.taints[0].key"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "name part must consist of alphanumeric characters", FieldPath: "properties.taints[0].key"},
 			},
 		},
 		{
@@ -1157,8 +1143,9 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				return np
 			}(),
 			oldNodePool: createValidNodePool(),
-			expectErrors: []expectedError{
-				{message: "No Major.Minor.Patch elements found", fieldPath: "properties.version.id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "No Major.Minor.Patch elements found", FieldPath: "properties.version.id"},
+				{Message: "Short version cannot contain PreRelease/Build meta data", FieldPath: "properties.version.id"},
 			},
 		},
 		{
@@ -1169,8 +1156,8 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				return np
 			}(),
 			oldNodePool: createValidNodePool(),
-			expectErrors: []expectedError{
-				{message: "must be at least 4.20.8", fieldPath: "properties.version.id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be at least 4.20.8", FieldPath: "properties.version.id"},
 			},
 		},
 		{
@@ -1187,7 +1174,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Properties.Replicas = 3
 				return np
 			}(),
-			expectErrors: []expectedError{}, // No error because version validation is skipped
+			expectErrors: []utils.ExpectedError{}, // No error because version validation is skipped
 		},
 		// Version.id is required since 20251223preview, but legacy nodepools may not have it.
 		// On update with oldObj.ID empty: version.id is NOT required (legacy migration support).
@@ -1204,7 +1191,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Properties.Version.ID = ""
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "update: version.id cannot be cleared when old nodepool had version.id",
@@ -1214,8 +1201,8 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				return np
 			}(),
 			oldNodePool: createValidNodePool(),
-			expectErrors: []expectedError{
-				{message: "Required value", fieldPath: "properties.version.id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "Required value", FieldPath: "properties.version.id"},
 			},
 		},
 		{
@@ -1236,11 +1223,12 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Location = "eastus"
 				return np
 			}(),
-			expectErrors: []expectedError{
-				{message: "field is immutable", fieldPath: "properties.provisioningState"},
-				{message: "field is immutable", fieldPath: "properties.platform"},
-				{message: "field is immutable", fieldPath: "properties.autoRepair"},
-				{message: "field is immutable", fieldPath: "trackedResource.location"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "field is immutable", FieldPath: "trackedResource.location"},
+				{Message: "field is immutable", FieldPath: "properties.provisioningState"},
+				{Message: "field is immutable", FieldPath: "properties.platform"},
+				{Message: "field is immutable", FieldPath: "properties.platform.vmSize"},
+				{Message: "field is immutable", FieldPath: "properties.autoRepair"},
 			},
 		},
 		{
@@ -1260,7 +1248,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Properties.AutoScaling = nil
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "disable autoscaling - update",
@@ -1279,7 +1267,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "clear labels - update",
@@ -1296,7 +1284,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "clear taints - update",
@@ -1316,7 +1304,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				}
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "replicas exceeds 200 with availability zone set - valid - update",
@@ -1332,7 +1320,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Properties.Replicas = 3
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "autoscaling min exceeds 200 with availability zone set - valid - update",
@@ -1351,7 +1339,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Properties.Platform.AvailabilityZone = "2"
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "autoscaling both min and max exceed 200 with availability zone set - valid - update",
@@ -1370,7 +1358,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 				np.Properties.Platform.AvailabilityZone = "1"
 				return np
 			}(),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 	}
 
@@ -1379,28 +1367,7 @@ func TestValidateNodePoolUpdate(t *testing.T) {
 			op := operation.Operation{Type: operation.Update}
 			errs := ValidateNodePool(ctx, op, tt.newNodePool, tt.oldNodePool)
 
-			if len(tt.expectErrors) == 0 {
-				if len(errs) != 0 {
-					t.Errorf("expected no errors, got %d: %v", len(errs), errs)
-				}
-				return
-			}
-
-			// Check that each expected error message and field path is found
-			for _, expectedErr := range tt.expectErrors {
-				found := false
-				for _, err := range errs {
-					messageMatch := strings.Contains(err.Detail, expectedErr.message) || strings.Contains(err.Error(), expectedErr.message)
-					fieldMatch := strings.Contains(err.Field, expectedErr.fieldPath)
-					if messageMatch && fieldMatch {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("expected error containing message '%s' at field '%s' but not found in: %v", expectedErr.message, expectedErr.fieldPath, errs)
-				}
-			}
+			utils.VerifyErrorsMatch(t, tt.expectErrors, errs)
 		})
 	}
 }
@@ -1448,22 +1415,17 @@ func createValidNodePool() *api.HCPOpenShiftClusterNodePool {
 func TestValidateNodePoolVersionWithFeatureFlags(t *testing.T) {
 	ctx := context.Background()
 
-	type expectedError struct {
-		message   string
-		fieldPath string
-	}
-
 	tests := []struct {
 		name         string
 		nodePool     *api.HCPOpenShiftClusterNodePool
 		opOptions    []string
-		expectErrors []expectedError
+		expectErrors []utils.ExpectedError
 	}{
 		{
 			name:         "valid node pool with X.Y.Z version - no feature flag",
 			nodePool:     createValidNodePool(),
 			opOptions:    nil,
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "X.Y format rejected for stable channel ",
@@ -1474,8 +1436,8 @@ func TestValidateNodePoolVersionWithFeatureFlags(t *testing.T) {
 				return np
 			}(),
 			opOptions: testNodePoolFeatureOptions(api.FeatureExperimentalReleaseFeatures),
-			expectErrors: []expectedError{
-				{message: "No Major.Minor.Patch elements found", fieldPath: "properties.version.id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "No Major.Minor.Patch elements found", FieldPath: "properties.version.id"},
 			},
 		},
 		{
@@ -1487,8 +1449,8 @@ func TestValidateNodePoolVersionWithFeatureFlags(t *testing.T) {
 				return np
 			}(),
 			opOptions: testNodePoolFeatureOptions(api.FeatureExperimentalReleaseFeatures),
-			expectErrors: []expectedError{
-				{message: "Invalid character(s) found in patch number", fieldPath: "properties.version.id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "Invalid character(s) found in patch number", FieldPath: "properties.version.id"},
 			},
 		},
 		{
@@ -1500,7 +1462,7 @@ func TestValidateNodePoolVersionWithFeatureFlags(t *testing.T) {
 				return np
 			}(),
 			opOptions:    testNodePoolFeatureOptions(api.FeatureExperimentalReleaseFeatures),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "nightly version allowed with experimental flag",
@@ -1511,7 +1473,7 @@ func TestValidateNodePoolVersionWithFeatureFlags(t *testing.T) {
 				return np
 			}(),
 			opOptions:    testNodePoolFeatureOptions(api.FeatureExperimentalReleaseFeatures),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "malformed version rejected",
@@ -1521,8 +1483,9 @@ func TestValidateNodePoolVersionWithFeatureFlags(t *testing.T) {
 				return np
 			}(),
 			opOptions: nil,
-			expectErrors: []expectedError{
-				{message: "No Major.Minor.Patch elements found", fieldPath: "properties.version.id"},
+			expectErrors: []utils.ExpectedError{
+				{Message: "No Major.Minor.Patch elements found", FieldPath: "properties.version.id"},
+				{Message: "Short version cannot contain PreRelease/Build meta data", FieldPath: "properties.version.id"},
 			},
 		},
 		{
@@ -1533,7 +1496,7 @@ func TestValidateNodePoolVersionWithFeatureFlags(t *testing.T) {
 				return np
 			}(),
 			opOptions:    testNodePoolFeatureOptions(api.FeatureExperimentalReleaseFeatures),
-			expectErrors: []expectedError{},
+			expectErrors: []utils.ExpectedError{},
 		},
 	}
 
@@ -1542,27 +1505,7 @@ func TestValidateNodePoolVersionWithFeatureFlags(t *testing.T) {
 			op := operation.Operation{Type: operation.Create, Options: tt.opOptions}
 			errs := ValidateNodePool(ctx, op, tt.nodePool, nil)
 
-			if len(tt.expectErrors) == 0 {
-				if len(errs) != 0 {
-					t.Errorf("expected no errors, got %d: %v", len(errs), errs)
-				}
-				return
-			}
-
-			for _, expectedErr := range tt.expectErrors {
-				found := false
-				for _, err := range errs {
-					messageMatch := strings.Contains(err.Detail, expectedErr.message) || strings.Contains(err.Error(), expectedErr.message)
-					fieldMatch := strings.Contains(err.Field, expectedErr.fieldPath)
-					if messageMatch && fieldMatch {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("expected error containing message '%s' at field '%s' but not found in: %v", expectedErr.message, expectedErr.fieldPath, errs)
-				}
-			}
+			utils.VerifyErrorsMatch(t, tt.expectErrors, errs)
 		})
 	}
 }


### PR DESCRIPTION
### What

Fix test helper `VerifyErrorsMatch` to use exact field path matching and update all affected test cases.

### Why

The `VerifyErrorsMatch` helper was using substring matching (`strings.Contains`) for field paths, causing false positives when parent-child paths overlap:
- Parent path: `properties.platform`
- Child path: `properties.platform.vmSize`

Substring matching allowed child paths to incorrectly satisfy parent path expectations, masking missing validation errors.

### Testing

**Core Fix:**
- `internal/utils/testhelpers.go`: Changed `strings.Contains(err.Field, expectedErr.FieldPath)` to exact match `err.Field == expectedErr.FieldPath`

**Test Updates (55 test cases across 5 files):**
- `internal/admission/admit_cluster_test.go`: Fixed 6 tag validation tests to use exact paths like `tags[aro-hcp.experimental.cluster.single-replica]`
- `internal/validation/hcpopenshiftcluster_test.go`: Fixed 5 identity validation tests with full resource IDs
- `internal/validation/hcpopenshiftclusterexternalauth_test.go`: Fixed 2 client validation tests with array indices
- `internal/validation/validate_cluster_comprehensive_test.go`: Fixed 6 identity/resource tests
- `internal/validation/validate_externalauth_comprehensive_test.go`: Fixed 1 audience validation test
