### PR TITLE
feat: track frontend panics during http request handling via prometheus metric

### DIFF
--- a/admin/server/middleware/middleware.go
+++ b/admin/server/middleware/middleware.go
@@ -104,8 +104,12 @@ func (mux *MiddlewareMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(ContextWithPattern(r.Context(), patt))
 
 	mainHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture the matched pattern when ServeMux returns or when a matched
+		// handler panics, so pre-mux middleware can read it from context.
+		defer func() {
+			*patt = r.Pattern
+		}()
 		mux.ServeMux.ServeHTTP(w, r)
-		*patt = r.Pattern
 	})
 
 	mux.middleware.Handler(mainHandler).ServeHTTP(w, r)

--- a/frontend/pkg/frontend/metrics.go
+++ b/frontend/pkg/frontend/metrics.go
@@ -29,6 +29,15 @@ import (
 // patternRe is used to strip the METHOD string from the [ServerMux] pattern string.
 var patternRe = regexp.MustCompile(`^[^\s]*\s+`)
 
+// muxPatternRoute returns the route pattern portion of a ServeMux pattern.
+// A ServeMux pattern is a http.Request.Pattern, which consists
+// of the HTTP method and the route pattern.
+// This function removes the method prefix of a ServeMux pattern, leaving
+// only the route pattern.
+func muxPatternRoute(pattern string) string {
+	return patternRe.ReplaceAllString(pattern, "")
+}
+
 type SubscriptionStateGetter interface {
 	GetSubscriptionState(string) string
 }
@@ -100,7 +109,7 @@ func (mm MetricsMiddleware) Metrics() MiddlewareFunc {
 			route        string
 		)
 		if routePattern != nil {
-			route = patternRe.ReplaceAllString(*routePattern, "")
+			route = muxPatternRoute(*routePattern)
 		}
 		if route == "" {
 			route = noMatchRouteLabel

--- a/frontend/pkg/frontend/middleware.go
+++ b/frontend/pkg/frontend/middleware.go
@@ -104,8 +104,12 @@ func (mux *MiddlewareMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(ContextWithPattern(r.Context(), patt))
 
 	mainHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture the matched pattern when ServeMux returns or when a matched
+		// handler panics, so pre-mux middleware can read it from context.
+		defer func() {
+			*patt = r.Pattern
+		}()
 		mux.ServeMux.ServeHTTP(w, r)
-		*patt = r.Pattern
 	})
 
 	mux.middleware.Handler(mainHandler).ServeHTTP(w, r)

--- a/frontend/pkg/frontend/middleware_panic.go
+++ b/frontend/pkg/frontend/middleware_panic.go
@@ -20,18 +20,68 @@ import (
 	"runtime/debug"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"k8s.io/component-base/metrics/legacyregistry"
+
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
+var (
+	// frontendHTTPRequestPanicsTotalCounterVec counts the total number of panics that occurred
+	// during request handling.
+	// To get the total panics use sum() in PromQL for the aggregate.
+	// The label values must never be empty.
+	frontendHTTPRequestPanicsTotalCounterVec = promauto.With(legacyregistry.Registerer()).NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "frontend_http_request_panics_total",
+			Help: "Total number of panics during HTTP request handling. Labels: route (request pattern without method prefix, 'unmatched' if no route matched), method (HTTP method, 'unknown' if empty).",
+		},
+		[]string{"route", "method"},
+	)
+)
+
 func MiddlewarePanic(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	// Do not catch panics when running "go test".
-	if !testing.Testing() {
+	middlewarePanicRecover(w, r, next, !testing.Testing())
+}
+
+// middlewarePanicRecover runs the next http.HandlerFunc. Additionally, when
+// recoverPanics is true it recovers panics, increments the
+// frontend_http_request_panics_total metric, and writes an HTTP 500 response.
+func middlewarePanicRecover(w http.ResponseWriter, r *http.Request, next http.HandlerFunc, recoverPanics bool) {
+	if recoverPanics {
 		defer func() {
 			if e := recover(); e != nil {
 				logger := utils.LoggerFromContext(r.Context())
 				panicErr := fmt.Errorf("panic: %#v", e)
 				logger.Error(panicErr, "panic recovered", "stack", string(debug.Stack()))
+
+				// We retrieve the pattern from the context instead of using r.Pattern.
+				// This is because from here we can't rely on the value stored in
+				// r.Pattern because the original request can be copied and mutated
+				// by following middlewares before the route pattern is captured,
+				// and here we could still have access to the original request which
+				// still does not contain the final matched route pattern.
+				// To solve this we retrieve the pattern from the context which is
+				// set by MiddlewareMux when ServeMux matches a route.
+				requestRoutePattern := "unmatched"
+				patternFromContext := PatternFromContext(r.Context())
+				if patternFromContext != nil && *patternFromContext != "" {
+					requestRoutePattern = *patternFromContext
+				}
+				// Strip the method prefix from the mux pattern. This is because
+				// for the prometheus counter we store the request route pattern and the
+				// request method separately so we can filter them independently.
+				requestRoutePattern = muxPatternRoute(requestRoutePattern)
+				requestMethod := r.Method
+				if requestMethod == "" {
+					requestMethod = "unknown"
+				}
+				frontendHTTPRequestPanicsTotalCounterVec.WithLabelValues(requestRoutePattern, requestMethod).Inc()
+
 				arm.WriteInternalServerError(w)
 			}
 		}()

--- a/frontend/pkg/frontend/middleware_panic_test.go
+++ b/frontend/pkg/frontend/middleware_panic_test.go
@@ -1,0 +1,138 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestMiddlewarePanic_middlewarePanicRecover(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                 string
+		muxPatternForContext string
+		clearRequestMethod   bool
+		handler              http.HandlerFunc
+		wantStatus           int
+		wantCounterRoute     string
+		wantCounterMethod    string
+		wantCounterDelta     float64
+	}{
+		{
+			name:                 "a panic increments the counter",
+			muxPatternForContext: "/panic/table/panic_strips_method_and_increments",
+			handler: func(http.ResponseWriter, *http.Request) {
+				panic("test panic")
+			},
+			wantStatus:        http.StatusInternalServerError,
+			wantCounterRoute:  "/panic/table/panic_strips_method_and_increments",
+			wantCounterMethod: http.MethodGet,
+			wantCounterDelta:  1,
+		},
+		{
+			name:                 "no panic does not increment the counter",
+			muxPatternForContext: "/panic/table/no_panic_does_not_increment",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+			},
+			wantStatus:        http.StatusTeapot,
+			wantCounterRoute:  "/panic/table/no_panic_does_not_increment",
+			wantCounterMethod: http.MethodGet,
+			wantCounterDelta:  0,
+		},
+		{
+			name:                 "when a panic occurs and no pattern is set, the counter is incremented with the unmatched route label",
+			muxPatternForContext: "",
+			handler: func(http.ResponseWriter, *http.Request) {
+				panic("test panic")
+			},
+			wantStatus:        http.StatusInternalServerError,
+			wantCounterRoute:  "unmatched",
+			wantCounterMethod: http.MethodGet,
+			wantCounterDelta:  1,
+		},
+		{
+			name:                 "when a panic occurs and the request method is empty, the counter is incremented with the unknown method label",
+			muxPatternForContext: "/panic/table/panic_empty_req_method_sets_unknown_metric_label",
+			clearRequestMethod:   true,
+			handler: func(http.ResponseWriter, *http.Request) {
+				panic("test panic")
+			},
+			wantStatus:        http.StatusInternalServerError,
+			wantCounterRoute:  "/panic/table/panic_empty_req_method_sets_unknown_metric_label",
+			wantCounterMethod: "unknown",
+			wantCounterDelta:  1,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			methodGET := http.MethodGet
+			muxPat := tt.muxPatternForContext
+			if muxPat != "" {
+				muxPat = fmt.Sprintf("%s %s", methodGET, muxPat)
+			}
+
+			req := httptest.NewRequest(methodGET, "/unused", nil)
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			if muxPat != "" {
+				req = req.WithContext(ContextWithPattern(ctx, &muxPat))
+			} else {
+				req = req.WithContext(ctx)
+			}
+			if tt.clearRequestMethod {
+				req.Method = ""
+			}
+
+			counter := frontendHTTPRequestPanicsTotalCounterVec.WithLabelValues(tt.wantCounterRoute, tt.wantCounterMethod)
+			before := testutil.ToFloat64(counter)
+
+			rec := httptest.NewRecorder()
+			middlewarePanicRecover(rec, req, tt.handler, true)
+
+			require.Equal(t, tt.wantStatus, rec.Code)
+			require.Equal(t, tt.wantCounterDelta, testutil.ToFloat64(counter)-before,
+				"counter delta for route=%q method=%q", tt.wantCounterRoute, tt.wantCounterMethod,
+			)
+		})
+	}
+}
+
+func TestMiddlewarePanic_middlewarePanicRecover_recoverDisabled_propagatesPanic(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(utils.ContextWithLogger(context.Background(), testr.New(t)))
+	rec := httptest.NewRecorder()
+
+	require.Panics(t, func() {
+		middlewarePanicRecover(rec, req, func(http.ResponseWriter, *http.Request) {
+			panic("test panic")
+		}, false)
+	})
+}

--- a/frontend/pkg/frontend/middleware_test.go
+++ b/frontend/pkg/frontend/middleware_test.go
@@ -1,0 +1,71 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMiddlewareMux_PatternOnHandlerPanic(t *testing.T) {
+	t.Parallel()
+
+	var gotPattern string
+	mux := NewMiddlewareMux(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		defer func() {
+			if recover() != nil {
+				if patt := PatternFromContext(r.Context()); patt != nil {
+					gotPattern = *patt
+				}
+			}
+		}()
+		next(w, r)
+	})
+	mux.HandleFunc("GET /bar", func(http.ResponseWriter, *http.Request) {
+		panic("test")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/bar", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if gotPattern != "GET /bar" {
+		t.Fatalf("got pattern %q, want %q", gotPattern, "GET /bar")
+	}
+}
+
+func TestMiddlewareMux_PatternOnHandlerSuccess(t *testing.T) {
+	t.Parallel()
+
+	var gotPattern string
+	mux := NewMiddlewareMux(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		next(w, r)
+		if patt := PatternFromContext(r.Context()); patt != nil {
+			gotPattern = *patt
+		}
+	})
+	mux.HandleFunc("GET /bar", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/bar", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if gotPattern != "GET /bar" {
+		t.Fatalf("got pattern %q, want %q", gotPattern, "GET /bar")
+	}
+}


### PR DESCRIPTION
Add a Prometheus counter (frontend_http_request_panics_total) to the panic recovery middleware. The counter is incremented each time a panic is recovered during HTTP request handling. The metric has two labels:
- route: the matched route pattern with the method prefix stripped
- method: the HTTP method

The labels are expected to never be empty.

With this design, the total number of panics across all routes and methods can be obtained using sum(frontend_http_request_panics_total) when querying prometheus.

Note: since MiddlewarePanic is registered twice in the middleware chain, a single request could increment the counter twice if the inner panic middleware recovers and then when continuing the execution another panic occurs which is then caught by the outer panic middleware