### PR TITLE
fix: add mgmt-agent and kube-applier to image-updater (AROSLSRE-878)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -169,7 +169,7 @@ defaults:
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: mgmt-agent
-      digest: ""
+      digest: sha256:c767d194d71665ddf1b86f22d64b02eb1cfe353871558e0a6122ca92396ea474 # 6d1cdc8 (2026-05-15 20:18)
     k8s:
       namespace: mgmt-agent
       serviceAccountName: mgmt-agent
@@ -179,7 +179,7 @@ defaults:
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: kube-applier
-      digest: ""
+      digest: sha256:0535faa7e94c83856cc6f578d64bc01c1201c36eebd92139b4ae9283d9c8e2d5 # 6d1cdc8 (2026-05-15 20:18)
     cosmosContainerName: "Manifests-MC-{{ .ctx.stamp }}"
     cosmosContainerMaxScale: 4000
     managedIdentityName: kube-applier

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -434,7 +434,7 @@ kubeApplier:
   cosmosContainerMaxScale: 4000
   cosmosContainerName: Manifests-MC-1
   image:
-    digest: ""
+    digest: sha256:0535faa7e94c83856cc6f578d64bc01c1201c36eebd92139b4ae9283d9c8e2d5
     registry: arohcpsvcdev.azurecr.io
     repository: kube-applier
   k8s:
@@ -680,7 +680,7 @@ mgmt:
     usePlannedQuota: true
 mgmtAgent:
   image:
-    digest: ""
+    digest: sha256:c767d194d71665ddf1b86f22d64b02eb1cfe353871558e0a6122ca92396ea474
     registry: arohcpsvcdev.azurecr.io
     repository: mgmt-agent
   k8s:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -434,7 +434,7 @@ kubeApplier:
   cosmosContainerMaxScale: 4000
   cosmosContainerName: Manifests-MC-1
   image:
-    digest: ""
+    digest: sha256:0535faa7e94c83856cc6f578d64bc01c1201c36eebd92139b4ae9283d9c8e2d5
     registry: arohcpsvcdev.azurecr.io
     repository: kube-applier
   k8s:
@@ -678,7 +678,7 @@ mgmt:
     usePlannedQuota: true
 mgmtAgent:
   image:
-    digest: ""
+    digest: sha256:c767d194d71665ddf1b86f22d64b02eb1cfe353871558e0a6122ca92396ea474
     registry: arohcpsvcdev.azurecr.io
     repository: mgmt-agent
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -434,7 +434,7 @@ kubeApplier:
   cosmosContainerMaxScale: 4000
   cosmosContainerName: Manifests-MC-1
   image:
-    digest: ""
+    digest: sha256:0535faa7e94c83856cc6f578d64bc01c1201c36eebd92139b4ae9283d9c8e2d5
     registry: arohcpsvcdev.azurecr.io
     repository: kube-applier
   k8s:
@@ -678,7 +678,7 @@ mgmt:
     usePlannedQuota: true
 mgmtAgent:
   image:
-    digest: ""
+    digest: sha256:c767d194d71665ddf1b86f22d64b02eb1cfe353871558e0a6122ca92396ea474
     registry: arohcpsvcdev.azurecr.io
     repository: mgmt-agent
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -434,7 +434,7 @@ kubeApplier:
   cosmosContainerMaxScale: 4000
   cosmosContainerName: Manifests-MC-1
   image:
-    digest: ""
+    digest: sha256:0535faa7e94c83856cc6f578d64bc01c1201c36eebd92139b4ae9283d9c8e2d5
     registry: arohcpsvcdev.azurecr.io
     repository: kube-applier
   k8s:
@@ -678,7 +678,7 @@ mgmt:
     usePlannedQuota: true
 mgmtAgent:
   image:
-    digest: ""
+    digest: sha256:c767d194d71665ddf1b86f22d64b02eb1cfe353871558e0a6122ca92396ea474
     registry: arohcpsvcdev.azurecr.io
     repository: mgmt-agent
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -434,7 +434,7 @@ kubeApplier:
   cosmosContainerMaxScale: 4000
   cosmosContainerName: Manifests-MC-1
   image:
-    digest: ""
+    digest: sha256:0535faa7e94c83856cc6f578d64bc01c1201c36eebd92139b4ae9283d9c8e2d5
     registry: arohcpsvcdev.azurecr.io
     repository: kube-applier
   k8s:
@@ -680,7 +680,7 @@ mgmt:
     usePlannedQuota: true
 mgmtAgent:
   image:
-    digest: ""
+    digest: sha256:c767d194d71665ddf1b86f22d64b02eb1cfe353871558e0a6122ca92396ea474
     registry: arohcpsvcdev.azurecr.io
     repository: mgmt-agent
   k8s:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -434,7 +434,7 @@ kubeApplier:
   cosmosContainerMaxScale: 4000
   cosmosContainerName: Manifests-MC-1
   image:
-    digest: ""
+    digest: sha256:0535faa7e94c83856cc6f578d64bc01c1201c36eebd92139b4ae9283d9c8e2d5
     registry: arohcpsvcdev.azurecr.io
     repository: kube-applier
   k8s:
@@ -680,7 +680,7 @@ mgmt:
     usePlannedQuota: true
 mgmtAgent:
   image:
-    digest: ""
+    digest: sha256:c767d194d71665ddf1b86f22d64b02eb1cfe353871558e0a6122ca92396ea474
     registry: arohcpsvcdev.azurecr.io
     repository: mgmt-agent
   k8s:

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -170,6 +170,26 @@ images:
     targets:
     - jsonPath: defaults.secretSyncController.providerImage.digest
       filePath: ../../config/config.yaml
+  # Mgmt Agent image
+  mgmt-agent:
+    group: mgmt-agent
+    source:
+      image: arohcpsvcdev.azurecr.io/mgmt-agent
+      tagPattern: "^[a-f0-9]{7}$"
+      useAuth: true
+    targets:
+    - jsonPath: defaults.mgmtAgent.image.digest
+      filePath: ../../config/config.yaml
+  # Kube Applier image
+  kube-applier:
+    group: kube-applier
+    source:
+      image: arohcpsvcdev.azurecr.io/kube-applier
+      tagPattern: "^[a-f0-9]{7}$"
+      useAuth: true
+    targets:
+    - jsonPath: defaults.kubeApplier.image.digest
+      filePath: ../../config/config.yaml
   # Image Sync
   imageSync:
     group: aro-deps


### PR DESCRIPTION
## Summary

[AROSLSRE-878](https://redhat.atlassian.net/browse/AROSLSRE-878)

Add `mgmt-agent` and `kube-applier` to the image-updater config so their digests are auto-populated in `config/config.yaml`. The empty digests were blocking EV2 GlobalBuildout rollouts for MgmtAgent `mirror-image` steps.

## Changes

- `tooling/image-updater/config.yaml`: Added `mgmt-agent` and `kube-applier` entries with `arohcpsvcdev.azurecr.io` source, `^[a-f0-9]{7}$` tag pattern, and `useAuth: true`
- `config/config.yaml`: Digests populated by running the image-updater locally
- `config/rendered/`: Regenerated

## Verification

Ran the image-updater locally with `--groups mgmt-agent,kube-applier`:

```
┌──────────────┬────────────┬───────────────┬─────────┬──────────────────┬─────────┐
│ NAME         │ OLD DIGEST │ NEW DIGEST    │ TAG     │ DATE             │ STATUS  │
├──────────────┼────────────┼───────────────┼─────────┼──────────────────┼─────────┤
│ mgmt-agent   │            │ c767d194d716… │ 6d1cdc8 │ 2026-05-15 20:18 │ updated │
│ kube-applier │            │ 0535faa7e94c… │ 6d1cdc8 │ 2026-05-15 20:18 │ updated │
└──────────────┴────────────┴───────────────┴─────────┴──────────────────┴─────────┘
```