### PR TITLE
backend: expose node pool ID in CS State Dump

### DIFF
--- a/backend/pkg/controllers/datadumpcontrollers/cs_state_dump.go
+++ b/backend/pkg/controllers/datadumpcontrollers/cs_state_dump.go
@@ -147,6 +147,7 @@ func (c *csStateDump) SyncOnce(ctx context.Context, key controllerutils.HCPClust
 		logger.Info("cluster-service node pool state dump",
 			"clusterServiceID", csID.String(),
 			"nodePoolClusterServiceID", npCSID.String(),
+			"hcp_nodepool_name", nodePool.ID,
 			"csNodePool", nodePoolData,
 		)
 	}


### PR DESCRIPTION
Previously, it was not possible to query for *only* the CS dumps for one node pool.
