### PR TITLE
feat: add ValidatingAdmissionPolicy for FSI image sourcing (AROSLSRE-834)

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -41,6 +41,8 @@ ignore:
 - 'backend/deploy/templates/backend.service-key-vault.secretproviderclass.yaml'
 - 'backend/deploy/templates/backend.deployment.yaml'
 - 'tooling/aro-hcp-exporter/deploy/templates/deployment.yaml'
+- 'image-registry-policy/deploy/templates/validatingadmissionpolicybinding.yaml'
+- 'image-registry-policy/values.yaml'
 rules:
   brackets: enable
   colons: enable

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -2488,6 +2488,29 @@
         "enabled"
       ]
     },
+    "imageRegistryPolicy": {
+      "type": "object",
+      "properties": {
+        "extraAllowedRegistries": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "validationActions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["Deny", "Audit", "Warn"]
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "extraAllowedRegistries",
+        "validationActions"
+      ]
+    },
     "acrPull": {
       "type": "object",
       "properties": {
@@ -3260,6 +3283,7 @@
     "global",
     "hypershift",
     "imageSync",
+    "imageRegistryPolicy",
     "acrPull",
     "secretSyncController",
     "maestro",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1234,10 +1234,10 @@ clouds:
       # Image Registry Policy — dev-only registries for local dev tooling
       imageRegistryPolicy:
         extraAllowedRegistries:
-        - docker.io
-        - jaegertracing
-        - grafana
-        - otel
+        - docker.io/jaegertracing
+        - docker.io/grafana
+        - docker.io/otel
+        - docker.io/library/postgres
         validationActions:
         - Deny
       # ACRs

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -96,6 +96,11 @@ defaults:
       untaggedImagesRetention:
         enabled: true
         days: 90
+  # Image Registry Policy
+  imageRegistryPolicy:
+    extraAllowedRegistries: []
+    validationActions:
+    - Audit
   # ACR Pull
   acrPull:
     image:
@@ -1226,6 +1231,15 @@ clouds:
         prometheus:
           prometheusSpec:
             shards: 1
+      # Image Registry Policy — dev-only registries for local dev tooling
+      imageRegistryPolicy:
+        extraAllowedRegistries:
+        - docker.io
+        - jaegertracing
+        - grafana
+        - otel
+        validationActions:
+        - Deny
       # ACRs
       acr:
         svc:

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -416,6 +416,14 @@ hypershift:
     digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageRegistryPolicy:
+  extraAllowedRegistries:
+  - docker.io
+  - jaegertracing
+  - grafana
+  - otel
+  validationActions:
+  - Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -418,10 +418,10 @@ hypershift:
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:
   extraAllowedRegistries:
-  - docker.io
-  - jaegertracing
-  - grafana
-  - otel
+  - docker.io/jaegertracing
+  - docker.io/grafana
+  - docker.io/otel
+  - docker.io/library/postgres
   validationActions:
   - Deny
 imageSync:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -416,6 +416,14 @@ hypershift:
     digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageRegistryPolicy:
+  extraAllowedRegistries:
+  - docker.io
+  - jaegertracing
+  - grafana
+  - otel
+  validationActions:
+  - Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -418,10 +418,10 @@ hypershift:
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:
   extraAllowedRegistries:
-  - docker.io
-  - jaegertracing
-  - grafana
-  - otel
+  - docker.io/jaegertracing
+  - docker.io/grafana
+  - docker.io/otel
+  - docker.io/library/postgres
   validationActions:
   - Deny
 imageSync:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -416,6 +416,14 @@ hypershift:
     digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageRegistryPolicy:
+  extraAllowedRegistries:
+  - docker.io
+  - jaegertracing
+  - grafana
+  - otel
+  validationActions:
+  - Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -418,10 +418,10 @@ hypershift:
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:
   extraAllowedRegistries:
-  - docker.io
-  - jaegertracing
-  - grafana
-  - otel
+  - docker.io/jaegertracing
+  - docker.io/grafana
+  - docker.io/otel
+  - docker.io/library/postgres
   validationActions:
   - Deny
 imageSync:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -416,6 +416,14 @@ hypershift:
     digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageRegistryPolicy:
+  extraAllowedRegistries:
+  - docker.io
+  - jaegertracing
+  - grafana
+  - otel
+  validationActions:
+  - Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -418,10 +418,10 @@ hypershift:
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:
   extraAllowedRegistries:
-  - docker.io
-  - jaegertracing
-  - grafana
-  - otel
+  - docker.io/jaegertracing
+  - docker.io/grafana
+  - docker.io/otel
+  - docker.io/library/postgres
   validationActions:
   - Deny
 imageSync:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -416,6 +416,14 @@ hypershift:
     digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageRegistryPolicy:
+  extraAllowedRegistries:
+  - docker.io
+  - jaegertracing
+  - grafana
+  - otel
+  validationActions:
+  - Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -418,10 +418,10 @@ hypershift:
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:
   extraAllowedRegistries:
-  - docker.io
-  - jaegertracing
-  - grafana
-  - otel
+  - docker.io/jaegertracing
+  - docker.io/grafana
+  - docker.io/otel
+  - docker.io/library/postgres
   validationActions:
   - Deny
 imageSync:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -416,6 +416,14 @@ hypershift:
     digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageRegistryPolicy:
+  extraAllowedRegistries:
+  - docker.io
+  - jaegertracing
+  - grafana
+  - otel
+  validationActions:
+  - Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -418,10 +418,10 @@ hypershift:
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:
   extraAllowedRegistries:
-  - docker.io
-  - jaegertracing
-  - grafana
-  - otel
+  - docker.io/jaegertracing
+  - docker.io/grafana
+  - docker.io/otel
+  - docker.io/library/postgres
   validationActions:
   - Deny
 imageSync:

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -412,6 +412,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: upgrade-aks-cluster
+    - resourceGroup: management
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output
@@ -461,6 +463,34 @@ resourceGroups:
       - "Internal error occurred"
       maximumRetryCount: 3
       durationBetweenRetries: 1m
+  - name: image-registry-policy
+    aksCluster: '{{ .mgmt.aks.name }}'
+    action: Helm
+    releaseName: image-registry-policy
+    releaseNamespace: image-registry-policy
+    chartDir: ./../image-registry-policy/deploy
+    valuesFile: ./../image-registry-policy/values.yaml
+    kustoEndpoint:
+      resourceGroup: kusto
+      step: output
+      name: kustoUri
+    kustoDatabase: '{{ .kusto.serviceLogsDatabase }}'
+    kustoTable: 'containerLogs'
+    dependsOn:
+    - resourceGroup: management
+      step: cluster
+    - resourceGroup: management
+      step: upgrade-aks-cluster
+    identityFrom:
+      resourceGroup: global
+      step: output
+      name: globalMSIId
+    automatedRetry:
+      errorContainsAny:
+      - "500 Internal Server Error"
+      - "Internal error occurred"
+      maximumRetryCount: 3
+      durationBetweenRetries: 1m
   - name: storageclass
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Helm
@@ -477,6 +507,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: upgrade-aks-cluster
+    - resourceGroup: management
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output
@@ -505,6 +537,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: upgrade-aks-cluster
+    - resourceGroup: management
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output
@@ -531,6 +565,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: upgrade-aks-cluster
+    - resourceGroup: management
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output
@@ -645,6 +681,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: upgrade-aks-cluster
+    - resourceGroup: management
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -327,6 +327,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: service
       step: upgrade-aks-cluster
+    - resourceGroup: service
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output
@@ -469,6 +471,34 @@ resourceGroups:
       - "Internal error occurred"
       maximumRetryCount: 3
       durationBetweenRetries: 1m
+  - name: image-registry-policy
+    aksCluster: '{{ .svc.aks.name }}'
+    action: Helm
+    releaseName: image-registry-policy
+    releaseNamespace: image-registry-policy
+    chartDir: ./../image-registry-policy/deploy
+    valuesFile: ./../image-registry-policy/values.yaml
+    kustoEndpoint:
+      resourceGroup: kusto
+      step: output
+      name: kustoUri
+    kustoDatabase: '{{ .kusto.serviceLogsDatabase }}'
+    kustoTable: 'containerLogs'
+    dependsOn:
+    - resourceGroup: service
+      step: cluster
+    - resourceGroup: service
+      step: upgrade-aks-cluster
+    identityFrom:
+      resourceGroup: global
+      step: output
+      name: globalMSIId
+    automatedRetry:
+      errorContainsAny:
+      - "500 Internal Server Error"
+      - "Internal error occurred"
+      maximumRetryCount: 3
+      durationBetweenRetries: 1m
   - name: arobit-output
     action: ARM
     template: templates/arobit-lookup.bicep
@@ -533,6 +563,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: service
       step: upgrade-aks-cluster
+    - resourceGroup: service
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output
@@ -612,6 +644,8 @@ resourceGroups:
       step: prometheus
     - resourceGroup: service
       step: mirror-exporter-image
+    - resourceGroup: service
+      step: image-registry-policy
     inputVariables:
       kustoRegion:
         resourceGroup: kusto

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_image_registry_policy.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_image_registry_policy.yaml
@@ -1,0 +1,83 @@
+---
+# Source: image-registry-policy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "image-registry-allowlist-config"
+  namespace: 'image-registry-policy'
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+data:
+  allowedRegistries: 'arohcpsvcdev.azurecr.io,arohcpocpdev.azurecr.io,mcr.microsoft.com,kubernetesshared.azurecr.io,docker.io,jaegertracing,grafana,otel'
+---
+# Source: image-registry-policy/templates/validatingadmissionpolicy.yaml
+# This policy enforces FSI image sourcing requirements by restricting all pod
+# container images to a set of allowed registries. Images not matching any
+# allowed registry prefix are denied at admission time.
+#
+# The allowed registry list is provided via a ConfigMap parameter so it can be
+# managed independently of the policy definition.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "image-registry-allowlist-policy"
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: v1
+    kind: ConfigMap
+  matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system
+        - kube-node-lease
+        - kube-public
+        - gatekeeper-system
+    objectSelector: {}
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["pods"]
+      scope: Namespaced
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["UPDATE"]
+      resources: ["pods/ephemeralcontainers"]
+      scope: Namespaced
+  variables:
+  - name: allImages
+    expression: >-
+      object.spec.containers.map(c, c.image) + object.spec.?initContainers.orValue([]).map(c, c.image) + object.spec.?ephemeralContainers.orValue([]).map(c, c.image)
+  - name: allowedPrefixes
+    expression: "params.data.allowedRegistries.split(',')"
+  validations:
+  - expression: "variables.allImages.all(img, variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || img.startsWith(prefix + '@') || img.startsWith(prefix + ':')))"
+    messageExpression: "'One or more container images are not from an allowed registry. Allowed registries: ' + params.data.allowedRegistries + '. Images: ' + variables.allImages.filter(img, !variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || img.startsWith(prefix + '@') || img.startsWith(prefix + ':'))).join(', ')"
+    reason: Forbidden
+---
+# Source: image-registry-policy/templates/validatingadmissionpolicybinding.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "image-registry-allowlist-policy-binding"
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+spec:
+  policyName: "image-registry-allowlist-policy"
+  validationActions:
+  - Deny
+  paramRef:
+    name: "image-registry-allowlist-config"
+    namespace: 'image-registry-policy'
+    parameterNotFoundAction: Deny
+

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_image_registry_policy.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_image_registry_policy.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: image-registry-policy
     app.kubernetes.io/managed-by: Helm
 data:
-  allowedRegistries: 'arohcpsvcdev.azurecr.io,arohcpocpdev.azurecr.io,mcr.microsoft.com,kubernetesshared.azurecr.io,docker.io,jaegertracing,grafana,otel'
+  allowedRegistries: 'arohcpsvcdev.azurecr.io,arohcpocpdev.azurecr.io,mcr.microsoft.com,kubernetesshared.azurecr.io,docker.io/jaegertracing,docker.io/grafana,docker.io/otel,docker.io/library/postgres'
 ---
 # Source: image-registry-policy/templates/validatingadmissionpolicy.yaml
 # This policy enforces FSI image sourcing requirements by restricting all pod

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_image_registry_policy.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_image_registry_policy.yaml
@@ -1,0 +1,83 @@
+---
+# Source: image-registry-policy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "image-registry-allowlist-config"
+  namespace: 'image-registry-policy'
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+data:
+  allowedRegistries: 'arohcpsvcdev.azurecr.io,arohcpocpdev.azurecr.io,mcr.microsoft.com,kubernetesshared.azurecr.io,docker.io,jaegertracing,grafana,otel'
+---
+# Source: image-registry-policy/templates/validatingadmissionpolicy.yaml
+# This policy enforces FSI image sourcing requirements by restricting all pod
+# container images to a set of allowed registries. Images not matching any
+# allowed registry prefix are denied at admission time.
+#
+# The allowed registry list is provided via a ConfigMap parameter so it can be
+# managed independently of the policy definition.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "image-registry-allowlist-policy"
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: v1
+    kind: ConfigMap
+  matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system
+        - kube-node-lease
+        - kube-public
+        - gatekeeper-system
+    objectSelector: {}
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["pods"]
+      scope: Namespaced
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["UPDATE"]
+      resources: ["pods/ephemeralcontainers"]
+      scope: Namespaced
+  variables:
+  - name: allImages
+    expression: >-
+      object.spec.containers.map(c, c.image) + object.spec.?initContainers.orValue([]).map(c, c.image) + object.spec.?ephemeralContainers.orValue([]).map(c, c.image)
+  - name: allowedPrefixes
+    expression: "params.data.allowedRegistries.split(',')"
+  validations:
+  - expression: "variables.allImages.all(img, variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || img.startsWith(prefix + '@') || img.startsWith(prefix + ':')))"
+    messageExpression: "'One or more container images are not from an allowed registry. Allowed registries: ' + params.data.allowedRegistries + '. Images: ' + variables.allImages.filter(img, !variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || img.startsWith(prefix + '@') || img.startsWith(prefix + ':'))).join(', ')"
+    reason: Forbidden
+---
+# Source: image-registry-policy/templates/validatingadmissionpolicybinding.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "image-registry-allowlist-policy-binding"
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+spec:
+  policyName: "image-registry-allowlist-policy"
+  validationActions:
+  - Deny
+  paramRef:
+    name: "image-registry-allowlist-config"
+    namespace: 'image-registry-policy'
+    parameterNotFoundAction: Deny
+

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_image_registry_policy.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_image_registry_policy.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: image-registry-policy
     app.kubernetes.io/managed-by: Helm
 data:
-  allowedRegistries: 'arohcpsvcdev.azurecr.io,arohcpocpdev.azurecr.io,mcr.microsoft.com,kubernetesshared.azurecr.io,docker.io,jaegertracing,grafana,otel'
+  allowedRegistries: 'arohcpsvcdev.azurecr.io,arohcpocpdev.azurecr.io,mcr.microsoft.com,kubernetesshared.azurecr.io,docker.io/jaegertracing,docker.io/grafana,docker.io/otel,docker.io/library/postgres'
 ---
 # Source: image-registry-policy/templates/validatingadmissionpolicy.yaml
 # This policy enforces FSI image sourcing requirements by restricting all pod

--- a/image-registry-policy/deploy/Chart.yaml
+++ b/image-registry-policy/deploy/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: image-registry-policy
+description: Enforces FSI image sourcing requirements by restricting pod image pulls to allowed registries.
+type: application
+version: 0.1.0

--- a/image-registry-policy/deploy/templates/configmap.yaml
+++ b/image-registry-policy/deploy/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "image-registry-allowlist-config"
+  namespace: '{{ .Release.Namespace }}'
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+data:
+  allowedRegistries: '{{ .Values.allowedRegistries | join "," }}'

--- a/image-registry-policy/deploy/templates/validatingadmissionpolicy.yaml
+++ b/image-registry-policy/deploy/templates/validatingadmissionpolicy.yaml
@@ -1,0 +1,51 @@
+# This policy enforces FSI image sourcing requirements by restricting all pod
+# container images to a set of allowed registries. Images not matching any
+# allowed registry prefix are denied at admission time.
+#
+# The allowed registry list is provided via a ConfigMap parameter so it can be
+# managed independently of the policy definition.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "image-registry-allowlist-policy"
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: v1
+    kind: ConfigMap
+  matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system
+        - kube-node-lease
+        - kube-public
+        - gatekeeper-system
+    objectSelector: {}
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["pods"]
+      scope: Namespaced
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["UPDATE"]
+      resources: ["pods/ephemeralcontainers"]
+      scope: Namespaced
+  variables:
+  - name: allImages
+    expression: >-
+      object.spec.containers.map(c, c.image) + object.spec.?initContainers.orValue([]).map(c, c.image) + object.spec.?ephemeralContainers.orValue([]).map(c, c.image)
+  - name: allowedPrefixes
+    expression: "params.data.allowedRegistries.split(',')"
+  validations:
+  - expression: "variables.allImages.all(img, variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || img.startsWith(prefix + '@') || img.startsWith(prefix + ':')))"
+    messageExpression: "'One or more container images are not from an allowed registry. Allowed registries: ' + params.data.allowedRegistries + '. Images: ' + variables.allImages.filter(img, !variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || img.startsWith(prefix + '@') || img.startsWith(prefix + ':'))).join(', ')"
+    reason: Forbidden

--- a/image-registry-policy/deploy/templates/validatingadmissionpolicybinding.yaml
+++ b/image-registry-policy/deploy/templates/validatingadmissionpolicybinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "image-registry-allowlist-policy-binding"
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+spec:
+  policyName: "image-registry-allowlist-policy"
+  validationActions:
+  {{- range .Values.validationActions }}
+  - {{ . }}
+  {{- end }}
+  paramRef:
+    name: "image-registry-allowlist-config"
+    namespace: '{{ .Release.Namespace }}'
+    parameterNotFoundAction: Deny

--- a/image-registry-policy/deploy/values.yaml
+++ b/image-registry-policy/deploy/values.yaml
@@ -1,0 +1,7 @@
+allowedRegistries:
+- '{{ .acr.svc.name }}.{{ .acrDNSSuffix }}'
+- '{{ .acr.ocp.name }}.{{ .acrDNSSuffix }}'
+- mcr.microsoft.com
+- kubernetesshared.azurecr.io
+validationActions:
+- Audit

--- a/image-registry-policy/values.yaml
+++ b/image-registry-policy/values.yaml
@@ -1,0 +1,12 @@
+allowedRegistries:
+- '{{ .acr.svc.name }}.{{ .acrDNSSuffix }}'
+- '{{ .acr.ocp.name }}.{{ .acrDNSSuffix }}'
+- mcr.microsoft.com
+- kubernetesshared.azurecr.io
+{{- range .imageRegistryPolicy.extraAllowedRegistries }}
+- '{{ . }}'
+{{- end }}
+validationActions:
+{{- range .imageRegistryPolicy.validationActions }}
+- '{{ . }}'
+{{- end }}

--- a/nonlocal-e2e-specs.txt
+++ b/nonlocal-e2e-specs.txt
@@ -11,5 +11,6 @@
   "should be able to create an HCP cluster then delete it by deleting the customer resource group",
   "should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings",
   "should confirm the HCP cluster is deleted (not found)",
-  "should create an HCP cluster and validate TLS certificates"
+  "should create an HCP cluster and validate TLS certificates",
+  "should deny pods with images from disallowed registries"
 ]

--- a/test/e2e/image_registry_policy.go
+++ b/test/e2e/image_registry_policy.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/Azure/ARO-HCP/test/util/labels"
+)
+
+const (
+	disallowedImage = "quay.io/library/nginx:latest"
+)
+
+var _ = Describe("Image Registry Policy", func() {
+	var kubeClient kubernetes.Interface
+
+	BeforeEach(func() {
+		restConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			clientcmd.NewDefaultClientConfigLoadingRules(),
+			&clientcmd.ConfigOverrides{},
+		).ClientConfig()
+		Expect(err).NotTo(HaveOccurred(), "Failed to load kubeconfig")
+
+		kubeClient, err = kubernetes.NewForConfig(restConfig)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create Kubernetes client")
+	})
+
+	It("should deny pods with images from disallowed registries",
+		labels.RequireNothing,
+		labels.High,
+		labels.Negative,
+		labels.CoreInfraService,
+		labels.DevelopmentOnly,
+		func(ctx context.Context) {
+			By("creating a test namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "image-policy-test-",
+				},
+			}
+			createdNS, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create test namespace")
+			testNS := createdNS.Name
+			DeferCleanup(func(ctx context.Context) {
+				_ = kubeClient.CoreV1().Namespaces().Delete(ctx, testNS, metav1.DeleteOptions{})
+			})
+
+			By(fmt.Sprintf("attempting to create a pod with disallowed image %q", disallowedImage))
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "policy-test-disallowed",
+					Namespace: testNS,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "test",
+							Image:   disallowedImage,
+							Command: []string{"/bin/sh", "-c", "sleep 1"},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			}
+			_, err = kubeClient.CoreV1().Pods(testNS).Create(ctx, pod, metav1.CreateOptions{})
+			Expect(err).To(HaveOccurred(), "Pod with disallowed image should be denied")
+			Expect(apierrors.IsForbidden(err)).To(BeTrue(),
+				"Expected Forbidden error for disallowed image, got: %v", err)
+		})
+})

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -58,6 +58,7 @@ Customer should be able to create a cluster with an external auth config and get
 Customer should be able to lifecycle and confirm external auth on a cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
+Image Registry Policy should deny pods with images from disallowed registries
 Engineering should be able to retrieve kusto logs for a cluster and services
 MISE Routing routes to the correct frontend based on version header MISE v2 when x-ms-mise-version header is set
 MISE Routing routes to the correct frontend based on version header default route returns no version header


### PR DESCRIPTION
## Summary

Add a ValidatingAdmissionPolicy that restricts container images to allowed registries, enforcing FSI image sourcing requirements.

## Changes

- **ValidatingAdmissionPolicy** helm chart with configmap-based allowlist, per-environment validation actions, and namespaceSelector for system namespace exclusions
- **Config**: schema, defaults (Audit globally), dev overlay (Deny mode, extra docker.io FQDN registries)
- **Pipeline**: svc and mgmt pipeline steps with automated retry
- **E2E**: deny test for disallowed images
- **CEL**: colon/tag separator handling, disallowedImages variable extraction, CPO image skip

## Allowed registries

Default: `arohcpsvc*.azurecr.io`, `arohcpocp*.azurecr.io`, `mcr.microsoft.com`, `kubernetesshared.azurecr.io`

Dev extra: `docker.io/jaegertracing`, `docker.io/grafana`, `docker.io/otel`, `docker.io/library/postgres`

## Test plan

- [x] E2E deny test (disallowed image gets Forbidden)
- [x] Helm test fixtures
- [x] Config materialized
- [ ] E2E parallel

Squashed from [#4690](https://github.com/Azure/ARO-HCP/pull/4690) with FQDN fix from [AROSLSRE-834](https://redhat.atlassian.net/browse/AROSLSRE-834).

Closes #4690