### PR TITLE
chore: bump clusters-service image (ARO-26792)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -916,7 +916,7 @@ defaults:
     image:
       registry: quay.io
       repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:8ab0246038cbe1dfdca7bdf82f1ff27795402268caad9cdc6e040ab46a8e06e7 # e2d2136cbc1d8bd348ba989d1419576949717565 (2026-05-06 13:30)
+      digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5 # dbb022a3dd3f0533ae1c8eebd4e6929ba1ca1ede (2026-05-19 06:44)
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -163,7 +163,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:8ab0246038cbe1dfdca7bdf82f1ff27795402268caad9cdc6e040ab46a8e06e7
+    digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -163,7 +163,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:8ab0246038cbe1dfdca7bdf82f1ff27795402268caad9cdc6e040ab46a8e06e7
+    digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -163,7 +163,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:8ab0246038cbe1dfdca7bdf82f1ff27795402268caad9cdc6e040ab46a8e06e7
+    digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -163,7 +163,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:8ab0246038cbe1dfdca7bdf82f1ff27795402268caad9cdc6e040ab46a8e06e7
+    digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -163,7 +163,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:8ab0246038cbe1dfdca7bdf82f1ff27795402268caad9cdc6e040ab46a8e06e7
+    digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -163,7 +163,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpprow
   image:
-    digest: sha256:8ab0246038cbe1dfdca7bdf82f1ff27795402268caad9cdc6e040ab46a8e06e7
+    digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:


### PR DESCRIPTION
## Summary

[ARO-26792](https://redhat.atlassian.net/browse/ARO-26792)

Bump Clusters Service image digest to pick up the fix for [ARO-26792](https://redhat.atlassian.net/browse/ARO-26792) (Adobe nodepool upgrade issue). Unblocks #5153.

```
┌──────────────────┬───────────────┬───────────────┬────────┬──────────────────┬─────────┐
│ NAME             │ OLD DIGEST    │ NEW DIGEST    │ TAG    │ DATE             │ STATUS  │
├──────────────────┼───────────────┼───────────────┼────────┼──────────────────┼─────────┤
│ clusters-service │ 9b81fcc0a6dd… │ c7c3d1b499fb… │ latest │ 2026-05-19 06:44 │ updated │
└──────────────────┴───────────────┴───────────────┴────────┴──────────────────┴─────────┘
```

## Related

- [ARO-26792](https://redhat.atlassian.net/browse/ARO-26792) -- Adobe nodepool upgrade fix
- #5153 -- Remove Cincinnati upgrade-graph validation (blocked on this CS bump)
- #5271 -- Full image digest bump (keeps failing on infra)