### PR TITLE
fix: skip 4.21 e2e tests until upstream ocp fixed

### DIFF
--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -49,6 +49,14 @@ var _ = Describe("ARO-HCP", func() {
 
 	DescribeTable("should be able to perform a control plane and node pool install with OCP "+framework.DefaultOpenshiftChannelGroup()+" channel",
 		func(ctx context.Context, version string) {
+			parsedVersion, _ := semver.ParseTolerant(version)
+			if parsedVersion.GTE(semver.MustParse("4.21.0")) {
+				timeBombDeadline := mustParseDate("2026-05-25")
+				if time.Now().Before(timeBombDeadline) {
+					Skip(fmt.Sprintf("Skipping OCP %s: community-operators-catalog v4.21 image has broken permissions in ACR cache (AROSLSRE-835)", version))
+				}
+				Fail(fmt.Sprintf("AROSLSRE-835 deadline %s passed: community-operators-catalog v4.21 image still broken, needs upstream fix", timeBombDeadline.Format("2006-01-02")))
+			}
 
 			customerNetworkSecurityGroupName := "customer-nsg-" + channelGroup + "-"
 			customerVnetName := "customer-vnet-" + channelGroup + "-"

--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -48,6 +48,15 @@ var _ = Describe("Service Provider", func() {
 				customerClusterNamePrefix        = "cluster-zstream-"
 			)
 
+			parsedMinor, _ := semver.ParseTolerant(minorVersion)
+			if parsedMinor.GTE(semver.MustParse("4.21.0")) {
+				timeBombDeadline := mustParseDate("2026-05-25")
+				if time.Now().Before(timeBombDeadline) {
+					Skip(fmt.Sprintf("Skipping z-stream upgrade for %s: community-operators-catalog v4.21 image has broken permissions in ACR cache (AROSLSRE-835)", minorVersion))
+				}
+				Fail(fmt.Sprintf("AROSLSRE-835 deadline %s passed: community-operators-catalog v4.21 image still broken, needs upstream fix", timeBombDeadline.Format("2006-01-02")))
+			}
+
 			tc := framework.NewTestContext()
 
 			if len(baseInstallVersion) == 0 {

--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -60,6 +60,14 @@ var _ = Describe("Customer", func() {
 				previousMinor = semver.Version{Major: targetVer.Major, Minor: targetVer.Minor - 1}
 			}
 
+			if previousMinor.GTE(semver.MustParse("4.21.0")) {
+				timeBombDeadline := mustParseDate("2026-05-25")
+				if time.Now().Before(timeBombDeadline) {
+					Skip(fmt.Sprintf("Skipping upgrade to %s: cluster install at %s uses community-operators-catalog v4.21 which has broken permissions in ACR cache (AROSLSRE-835)", targetMinor, previousMinor))
+				}
+				Fail(fmt.Sprintf("AROSLSRE-835 deadline %s passed: community-operators-catalog v4.21 image still broken, needs upstream fix", timeBombDeadline.Format("2006-01-02")))
+			}
+
 			var installVersion *semver.Version
 			cincinnatiClient := cvocincinnati.NewClient(uuid.NameSpaceDNS, &http.Transport{}, "ARO-HCP", cincinnati.NewAlwaysConditionRegistry())
 

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -50,6 +50,14 @@ var _ = Describe("Customer", func() {
 			targetMinorVersion := api.Must(semver.ParseTolerant(targetMinor))
 			nodePoolMinorVersion := api.Must(semver.ParseTolerant(nodePoolMinor))
 
+			if targetMinorVersion.GTE(semver.MustParse("4.21.0")) {
+				timeBombDeadline := mustParseDate("2026-05-25")
+				if time.Now().Before(timeBombDeadline) {
+					Skip(fmt.Sprintf("Skipping nodepool upgrade to %s: cluster created at %s uses community-operators-catalog v4.21 which has broken permissions in ACR cache (AROSLSRE-835)", targetMinor, targetMinor))
+				}
+				Fail(fmt.Sprintf("AROSLSRE-835 deadline %s passed: community-operators-catalog v4.21 image still broken, needs upstream fix", timeBombDeadline.Format("2006-01-02")))
+			}
+
 			var (
 				nodePoolInitialVersion string
 				hasUpgradePath         bool


### PR DESCRIPTION
[<!-- Link to Jira issue -->](https://redhat.atlassian.net/browse/AROSLSRE-835)

### What

Skip 4.21 upgrade tests for 1 week

### Why

Upstream ocp image has a permissions bug causing upgrade tests using ocp 4.21 to fail.

### Testing

e2e

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
