### PR TITLE
docs(ops): expand stuck-cluster cleanup runbook with NodePool/CAPI/Maestro findings

### DIFF
--- a/docs/ops/cleanup-stuck-cluster-deletion.md
+++ b/docs/ops/cleanup-stuck-cluster-deletion.md
@@ -50,7 +50,6 @@ Management Cluster (MGMT)
 ├── Namespace: ocm-${CLUSTER_PREFIX}-${CLUSTER_ID} (HostedCluster namespace)
 │   ├── HostedCluster (Primary HCP resource)
 │   │   └── Finalizer: hypershift.openshift.io/finalizer
-│   ├── HostedControlPlane (Control plane configuration)
 │   ├── NodePool(s) (one per worker pool)
 │   │   └── Finalizer: hypershift.openshift.io/finalizer
 │   ├── Secrets (credentials, certificates, pull secrets)
@@ -74,6 +73,8 @@ Management Cluster (MGMT)
     ├── Services, Pods, Secrets, ConfigMaps
     └── PersistentVolumeClaims (etcd storage)
 ```
+
+> **Note**: `HostedControlPlane` lives in the **Control Plane namespace** (the `ocm-${CLUSTER_PREFIX}-${CLUSTER_ID}-${CLUSTER_NAME}` namespace), not in the `HostedCluster` namespace.
 
 ### Deletion Chain Dependencies
 
@@ -279,16 +280,18 @@ kubectl patch deployment <name> -n <cp-namespace> \
   --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
 
 # AzureMachines (infrastructure.cluster.x-k8s.io)
+# Uses a merge patch so the command is idempotent even if .metadata.finalizers is absent
+# on some items (JSONPatch `replace` would fail on those).
 for name in $(kubectl get azuremachines.infrastructure.cluster.x-k8s.io -n <cp-namespace> -o jsonpath='{.items[*].metadata.name}'); do
   kubectl patch azuremachines.infrastructure.cluster.x-k8s.io $name -n <cp-namespace> \
-    --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
+    --type=merge -p='{"metadata":{"finalizers":null}}'
 done
 
 # Machines / MachineSets / MachineDeployments (cluster.x-k8s.io)
 for kind in machines.cluster.x-k8s.io machinesets.cluster.x-k8s.io machinedeployments.cluster.x-k8s.io; do
   for name in $(kubectl get $kind -n <cp-namespace> -o jsonpath='{.items[*].metadata.name}'); do
     kubectl patch $kind $name -n <cp-namespace> \
-      --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
+      --type=merge -p='{"metadata":{"finalizers":null}}'
   done
 done
 
@@ -301,9 +304,10 @@ kubectl patch hostedcontrolplanes.hypershift.openshift.io <name> -n <cp-namespac
   --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
 
 # 3. Remove NodePool finalizers in the HostedCluster namespace
+# Uses a merge patch (idempotent when .metadata.finalizers is absent).
 for name in $(kubectl get nodepool -n ocm-${CLUSTER_PREFIX}-${CLUSTER_ID} -o jsonpath='{.items[*].metadata.name}'); do
   kubectl patch nodepool $name -n ocm-${CLUSTER_PREFIX}-${CLUSTER_ID} \
-    --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
+    --type=merge -p='{"metadata":{"finalizers":null}}'
 done
 
 # 4. Remove HostedCluster finalizer (only after CP namespace resources and NodePools are cleared)

--- a/docs/ops/cleanup-stuck-cluster-deletion.md
+++ b/docs/ops/cleanup-stuck-cluster-deletion.md
@@ -51,6 +51,8 @@ Management Cluster (MGMT)
 │   ├── HostedCluster (Primary HCP resource)
 │   │   └── Finalizer: hypershift.openshift.io/finalizer
 │   ├── HostedControlPlane (Control plane configuration)
+│   ├── NodePool(s) (one per worker pool)
+│   │   └── Finalizer: hypershift.openshift.io/finalizer
 │   ├── Secrets (credentials, certificates, pull secrets)
 │   ├── ConfigMaps (configuration data)
 │   └── Other Hypershift-managed resources
@@ -62,6 +64,12 @@ Management Cluster (MGMT)
     │   └── Finalizer: cluster.cluster.x-k8s.io
     ├── HostedControlPlane
     │   └── Finalizer: hypershift.openshift.io/finalizer
+    ├── MachineDeployment / MachineSet / Machine (cluster.x-k8s.io)
+    │   └── Finalizers: cluster.x-k8s.io/machinedeployment,
+    │                   cluster.x-k8s.io/machineset,
+    │                   machine.cluster.x-k8s.io
+    ├── AzureMachine (infrastructure.cluster.x-k8s.io)
+    │   └── Finalizer: azuremachine.infrastructure.cluster.x-k8s.io
     ├── StatefulSets (etcd, control plane components)
     ├── Services, Pods, Secrets, ConfigMaps
     └── PersistentVolumeClaims (etcd storage)
@@ -77,10 +85,13 @@ Clusters Service (sets state to "uninstalling")
     → Maestro Agent (deletes ManifestWork on MGMT)
       → ManifestWork cleanup (deletes HostedCluster, ManagedCluster, etc.)
         → HostedCluster deletion (finalizer: hypershift.openshift.io/finalizer)
+          → NodePool deletion (finalizer: hypershift.openshift.io/finalizer)
           → Control Plane namespace cleanup
             → Deployments (finalizer: hypershift.openshift.io/component-finalizer)
             → Cluster CRD (finalizer: cluster.cluster.x-k8s.io)
             → HostedControlPlane (finalizer: hypershift.openshift.io/finalizer)
+            → MachineDeployment / MachineSet / Machine (CAPI finalizers)
+            → AzureMachine (finalizer: azuremachine.infrastructure.cluster.x-k8s.io)
 ```
 
 **Key insight**: Deleting resources on the management cluster without first removing the source (ResourceBundle in Maestro / cluster record in CS) will result in the resources being **recreated** by the Maestro Agent.
@@ -248,6 +259,12 @@ kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
 # Expected: {"code":"maestro-7","reason":"Resource with id='...' not found"}
 ```
 
+> **Note**: Maestro bundles behave differently on `DELETE`:
+> - **Readonly bundles** (the `*-readonly` HostedCluster / NodePool reflections) are hard-deleted immediately.
+> - **Bundles backing a `ManifestWork`** are only soft-deleted — the `DELETE` returns `204`, but the bundle remains listed with `metadata.deleted_at` set. The record is only removed from the Maestro store after the corresponding `ManifestWork` on the management cluster is also removed.
+>
+> If you see bundles still listed with a non-null `deleted_at` after `DELETE`, that is expected — proceed to Strategy 3 to clear the `ManifestWork` finalizers so Maestro can finish its own cleanup.
+
 #### Strategy 3: Manual Finalizer Removal on Management Cluster (Last Resort)
 
 Only after ensuring the source (CS/Maestro) won't recreate resources, remove finalizers **bottom-up** on the management cluster:
@@ -261,6 +278,20 @@ kubectl get namespace <cp-namespace> -o json | jq '.status.conditions[] | select
 kubectl patch deployment <name> -n <cp-namespace> \
   --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
 
+# AzureMachines (infrastructure.cluster.x-k8s.io)
+for name in $(kubectl get azuremachines.infrastructure.cluster.x-k8s.io -n <cp-namespace> -o jsonpath='{.items[*].metadata.name}'); do
+  kubectl patch azuremachines.infrastructure.cluster.x-k8s.io $name -n <cp-namespace> \
+    --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
+done
+
+# Machines / MachineSets / MachineDeployments (cluster.x-k8s.io)
+for kind in machines.cluster.x-k8s.io machinesets.cluster.x-k8s.io machinedeployments.cluster.x-k8s.io; do
+  for name in $(kubectl get $kind -n <cp-namespace> -o jsonpath='{.items[*].metadata.name}'); do
+    kubectl patch $kind $name -n <cp-namespace> \
+      --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
+  done
+done
+
 # Cluster CRD with cluster.cluster.x-k8s.io finalizer
 kubectl patch clusters.cluster.x-k8s.io <name> -n <cp-namespace> \
   --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
@@ -269,15 +300,21 @@ kubectl patch clusters.cluster.x-k8s.io <name> -n <cp-namespace> \
 kubectl patch hostedcontrolplanes.hypershift.openshift.io <name> -n <cp-namespace> \
   --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
 
-# 3. Remove HostedCluster finalizer (only after CP namespace resources are cleared)
+# 3. Remove NodePool finalizers in the HostedCluster namespace
+for name in $(kubectl get nodepool -n ocm-${CLUSTER_PREFIX}-${CLUSTER_ID} -o jsonpath='{.items[*].metadata.name}'); do
+  kubectl patch nodepool $name -n ocm-${CLUSTER_PREFIX}-${CLUSTER_ID} \
+    --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
+done
+
+# 4. Remove HostedCluster finalizer (only after CP namespace resources and NodePools are cleared)
 kubectl patch hostedcluster <name> -n ocm-${CLUSTER_PREFIX}-${CLUSTER_ID} \
   --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
 
-# 4. Remove ManifestWork finalizers
+# 5. Remove ManifestWork finalizers
 kubectl patch manifestwork <name> -n local-cluster \
   --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
 
-# 5. Delete orphaned namespaces (only after all resources are cleared)
+# 6. Delete orphaned namespaces (only after all resources are cleared)
 kubectl delete namespace <namespace>
 ```
 
@@ -301,6 +338,8 @@ kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
   "curl -s 'http://localhost:8000/api/maestro/v1/resource-bundles?size=2900'" | \
   jq --arg cid "${CLUSTER_ID}" '[.items[] | select(.manifests | tostring | test($cid)) | {id, name}]'
 ```
+
+> **Note**: If CS still has the cluster record in `uninstalling` state after management cluster cleanup, re-issue the ARO-HCP `DELETE` (Strategy 1). With Maestro and the management cluster cleared, the CS controller can now complete the deletion and subsequent `GET`s will return `404`.
 
 ## Common Stuck Scenarios
 
@@ -339,6 +378,19 @@ kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
 
 **Fix**: Check `kubectl get namespace <ns> -o json | jq '.status.conditions'` to identify blocking resources, then remove their finalizers (Strategy 3).
 
+### Scenario 5: CP Namespace Stuck After Cluster and HostedControlPlane Are Cleared
+
+**Symptoms**: After force-removing finalizers on the CAPI `Cluster`, the `HostedControlPlane`, and the Hypershift Deployments, the CP namespace is still `Terminating`. `kubectl get namespace <cp-ns> -o json | jq '.status.conditions'` references infrastructure or machine kinds.
+
+**Cause**: CAPI machine resources hold their own finalizers and are not removed when the parent `Cluster` is force-deleted (finalizer cleared). Common blockers in the CP namespace:
+
+- `azuremachines.infrastructure.cluster.x-k8s.io` (`azuremachine.infrastructure.cluster.x-k8s.io`)
+- `machines.cluster.x-k8s.io` (`machine.cluster.x-k8s.io`)
+- `machinesets.cluster.x-k8s.io` (`cluster.x-k8s.io/machineset`)
+- `machinedeployments.cluster.x-k8s.io` (`cluster.x-k8s.io/machinedeployment`)
+
+**Fix**: Patch the finalizers on all four kinds in the CP namespace (see Strategy 3, step 2).
+
 ## Quick Reference: Key API Endpoints
 
 | Component | Endpoint | Notes |
@@ -355,6 +407,10 @@ kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
 | `hypershift.openshift.io/finalizer` | HostedCluster, HostedControlPlane | Hypershift Operator |
 | `hypershift.openshift.io/component-finalizer` | Deployments in CP namespace | Hypershift Operator |
 | `cluster.cluster.x-k8s.io` | Cluster (CAPI) | Cluster API |
+| `machine.cluster.x-k8s.io` | Machine (CAPI) | Cluster API |
+| `cluster.x-k8s.io/machineset` | MachineSet (CAPI) | Cluster API |
+| `cluster.x-k8s.io/machinedeployment` | MachineDeployment (CAPI) | Cluster API |
+| `azuremachine.infrastructure.cluster.x-k8s.io` | AzureMachine | CAPZ (Cluster API Provider Azure) |
 | `cluster.open-cluster-management.io/manifest-work-cleanup` | ManifestWork | ACM Work Agent |
 | `cluster.open-cluster-management.io/api-resource-cleanup` | ManagedCluster | ACM |
 


### PR DESCRIPTION
## Summary

Expands `docs/ops/cleanup-stuck-cluster-deletion.md` with gaps observed while cleaning up an INT cluster that was stuck on deletion (source: internal Red Hat Jira **[AROSLSRE-881](https://redhat.atlassian.net/browse/AROSLSRE-881)**; cluster id `2q9boc73v3qsrfp02080efahjacs3ncp`).

The existing runbook covers the high-level flow, but a real recovery had to deal with several blockers that weren't in the doc — particularly **NodePool finalizers**, **CAPI machine resources in the CP namespace**, and **Maestro soft-delete semantics for bundles backing a ManifestWork**. After the management cluster was cleaned up, **a second ARO-HCP `DELETE` was required** for CS to finalise (state had been left in `uninstalling`).

## Changes (all in `docs/ops/cleanup-stuck-cluster-deletion.md`)

- **Resource hierarchy diagram**:
  - HostedCluster namespace: add `NodePool` (with `hypershift.openshift.io/finalizer`).
  - CP namespace: add `MachineDeployment / MachineSet / Machine` (CAPI) and `AzureMachine` (CAPZ) with their finalizers.
- **Deletion chain dependencies**: insert `NodePool` and the CAPI machine kinds in the chain.
- **Strategy 2 (Maestro bundles)**: add a note explaining bundle deletion semantics — readonly bundles hard-delete immediately, but bundles backing a `ManifestWork` only soft-delete (`metadata.deleted_at` set) until the corresponding MW is removed on the management cluster. This is the failure mode that makes Strategy 2 appear to do nothing.
- **Strategy 3 (bottom-up finalizer removal)**:
  - Add a step to patch CAPI machine kinds (`azuremachines`, `machines`, `machinesets`, `machinedeployments`) in the CP namespace. These are not cleared when the parent `Cluster` is force-deleted, and they block the CP namespace from leaving `Terminating`.
  - Add a step to patch `NodePool` finalizers in the HostedCluster namespace before patching the `HostedCluster` itself.
  - Renumber subsequent steps.
- **Phase 4 (verification)**: add a note that CS may need a second `DELETE` via the ARO-HCP endpoint once Maestro and the management cluster are clean.
- **Common Stuck Scenarios**: add **Scenario 5 — CP Namespace Stuck After Cluster and HostedControlPlane Are Cleared**, describing the CAPI/CAPZ machine-resource blocker and pointing at Strategy 3, step 2.
- **Quick Reference: Common Finalizers**: add four rows for `machine.cluster.x-k8s.io`, `cluster.x-k8s.io/machineset`, `cluster.x-k8s.io/machinedeployment`, and `azuremachine.infrastructure.cluster.x-k8s.io`.

## Why these specific additions

Recovery sequence that produced these findings:

1. CS still had the cluster record (`state="error"`, `description="Manifest work deletion is stuck"`).
2. `DELETE /api/aro_hcp/v1alpha1/clusters/<id>` flipped state to `uninstalling`, but ~90 s later it bounced back to `error`.
3. The 8 Maestro bundles for the cluster all returned `204` on `DELETE`. Three `*-readonly` bundles hard-deleted. The five MW-backed bundles only got `metadata.deleted_at` set and stayed listed — this is the new Strategy 2 note.
4. On the management cluster, after patching finalizers off Deployments / CAPI `Cluster` / `HostedControlPlane` / `HostedCluster` / `NodePool` / `ManifestWork`, the CP namespace was still `Terminating`. `kubectl get namespace ... -o json | jq .status.conditions` pointed at infrastructure/machine kinds — these turned out to be CAPI `Machine`/`MachineSet`/`MachineDeployment` and CAPZ `AzureMachine`. Patching those four kinds finally let the namespace go.
5. CS was still in `uninstalling` and the cluster record still existed. A second `DELETE` against `/api/aro_hcp/v1alpha1/clusters/<id>` finalised it; subsequent `GET`s returned `404` — this is the new Phase 4 note.

After the changes: Maestro bundles for the cluster → 0; ManifestWorks → 0; AppliedManifestWorks → 0; HostedClusters → 0; HC and CP namespaces → gone; CS → 404 on the cluster id.

## Notes

- The source ticket ([AROSLSRE-881](https://redhat.atlassian.net/browse/AROSLSRE-881)) is in Red Hat's private Jira and not world-readable. All substantive details are inline in this PR description and in the diff itself.
- Edits are surgical (`+59 / -3`); no existing wording was changed.
