### PR TITLE
Test framework API versioning changes

### DIFF
--- a/test/e2e/admin_credential_lifecycle.go
+++ b/test/e2e/admin_credential_lifecycle.go
@@ -42,7 +42,7 @@ import (
 
 	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -50,7 +50,7 @@ import (
 
 var _ = Describe("Customer", func() {
 
-	terminalProvisioningStates := sets.New(hcpsdk20240610preview.ProvisioningStateSucceeded, hcpsdk20240610preview.ProvisioningStateFailed, hcpsdk20240610preview.ProvisioningStateCanceled)
+	terminalProvisioningStates := sets.New(armredhatopenshifthcp.ProvisioningStateSucceeded, armredhatopenshifthcp.ProvisioningStateFailed, armredhatopenshifthcp.ProvisioningStateCanceled)
 
 	It("should be able to test admin credentials before cluster ready, then full admin credential lifecycle",
 		labels.RequireNothing,
@@ -87,7 +87,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("starting HCP cluster creation asynchronously")
-			clusterClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			clusterClient := tc.GetHCPClustersClientOrDie(ctx)
 			timeout := 45 * time.Minute
 			deploymentCtx, deploymentCancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during admin credential lifecycle test", timeout.Minutes()))
 			defer deploymentCancel()
@@ -106,7 +106,7 @@ var _ = Describe("Customer", func() {
 			By("waiting for cluster to appear and testing admin credentials while in deploying state")
 			// Poll the cluster state and test admin credentials when we find it deploying
 			var testedWhileDeploying bool
-			var previousState hcpsdk20240610preview.ProvisioningState
+			var previousState armredhatopenshifthcp.ProvisioningState
 			GinkgoLogr.Info("creating cluster, waiting for it to reach a terminal state")
 			Eventually(func() bool {
 				cluster, err := framework.GetHCPCluster(ctx, clusterClient, *resourceGroup.Name, clusterName)
@@ -145,7 +145,7 @@ var _ = Describe("Customer", func() {
 				}
 
 				// If cluster is ready, we're done
-				if *cluster.Properties.ProvisioningState == hcpsdk20240610preview.ProvisioningStateSucceeded {
+				if *cluster.Properties.ProvisioningState == armredhatopenshifthcp.ProvisioningStateSucceeded {
 					if !testedWhileDeploying {
 						Fail("Cluster provisioned too quickly to test 409 behavior - unable to validate admin credentials fail during deployment")
 					}
@@ -153,7 +153,7 @@ var _ = Describe("Customer", func() {
 				}
 
 				// If cluster failed, that's an error
-				if *cluster.Properties.ProvisioningState == hcpsdk20240610preview.ProvisioningStateFailed {
+				if *cluster.Properties.ProvisioningState == armredhatopenshifthcp.ProvisioningStateFailed {
 					Fail("Cluster provisioning failed")
 				}
 
@@ -245,7 +245,7 @@ var _ = Describe("Customer", func() {
 			skipSuite := os.Getenv("ARO_HCP_SUITE_NAME") == "integration/parallel" && time.Now().Before(time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC))
 
 			By("revoking all cluster admin credentials via ARO HCP RP API")
-			err = tc.RevokeCredentialsAndWait(ctx, clusterClient, *resourceGroup.Name, clusterName, 15*time.Minute)
+			err = tc.RevokeCredentialsAndWait(ctx, *resourceGroup.Name, clusterName, 15*time.Minute)
 			if err != nil && skipSuite {
 				Skip("skipping revocation and remaining steps in integration/parallel suite")
 			}
@@ -289,7 +289,6 @@ var _ = Describe("Customer", func() {
 			// This validates the revocation endpoint doesn't break the cluster
 			newAdminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				clusterClient,
 				*resourceGroup.Name,
 				clusterName,
 				10*time.Minute,

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -35,7 +35,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 )
@@ -135,7 +135,7 @@ var _ = Describe("Authorized CIDRs", func() {
 				By("getting cluster details")
 				clusterResponse, err := framework.GetHCPCluster(
 					ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+					tc.GetHCPClustersClientOrDie(ctx),
 					*resourceGroup.Name,
 					clusterName,
 				)
@@ -176,7 +176,6 @@ var _ = Describe("Authorized CIDRs", func() {
 				By("verifying VM can access cluster API with credentials")
 				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 					ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
 					clusterName,
 					10*time.Minute,
@@ -253,51 +252,51 @@ var _ = Describe("Authorized CIDRs", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				By("creating an external auth config with a prefix")
-				extAuth := hcpsdk20240610preview.ExternalAuth{
-					Properties: &hcpsdk20240610preview.ExternalAuthProperties{
-						Issuer: &hcpsdk20240610preview.TokenIssuerProfile{
+				extAuth := armredhatopenshifthcp.ExternalAuth{
+					Properties: &armredhatopenshifthcp.ExternalAuthProperties{
+						Issuer: &armredhatopenshifthcp.TokenIssuerProfile{
 							URL:       to.Ptr(fmt.Sprintf("https://login.microsoftonline.com/%s/v2.0", tc.TenantID())),
 							Audiences: []*string{to.Ptr(app.AppID)},
 						},
-						Claim: &hcpsdk20240610preview.ExternalAuthClaimProfile{
-							Mappings: &hcpsdk20240610preview.TokenClaimMappingsProfile{
-								Username: &hcpsdk20240610preview.UsernameClaimProfile{
+						Claim: &armredhatopenshifthcp.ExternalAuthClaimProfile{
+							Mappings: &armredhatopenshifthcp.TokenClaimMappingsProfile{
+								Username: &armredhatopenshifthcp.UsernameClaimProfile{
 									Claim:        to.Ptr("sub"), // objectID of SP
-									PrefixPolicy: to.Ptr(hcpsdk20240610preview.UsernameClaimPrefixPolicyPrefix),
+									PrefixPolicy: to.Ptr(armredhatopenshifthcp.UsernameClaimPrefixPolicyPrefix),
 									Prefix:       to.Ptr(externalAuthSubjectPrefix),
 								},
-								Groups: &hcpsdk20240610preview.GroupClaimProfile{
+								Groups: &armredhatopenshifthcp.GroupClaimProfile{
 									Claim: to.Ptr("groups"),
 								},
 							},
 						},
-						Clients: []*hcpsdk20240610preview.ExternalAuthClientProfile{
+						Clients: []*armredhatopenshifthcp.ExternalAuthClientProfile{
 							{
 								ClientID: to.Ptr(app.AppID),
-								Component: &hcpsdk20240610preview.ExternalAuthClientComponentProfile{
+								Component: &armredhatopenshifthcp.ExternalAuthClientComponentProfile{
 									Name:                to.Ptr("console"),
 									AuthClientNamespace: to.Ptr("openshift-console"),
 								},
-								Type: to.Ptr(hcpsdk20240610preview.ExternalAuthClientTypeConfidential),
+								Type: to.Ptr(armredhatopenshifthcp.ExternalAuthClientTypeConfidential),
 							},
 							{
 								ClientID: to.Ptr(app.AppID),
-								Component: &hcpsdk20240610preview.ExternalAuthClientComponentProfile{
+								Component: &armredhatopenshifthcp.ExternalAuthClientComponentProfile{
 									Name:                to.Ptr("cli"),
 									AuthClientNamespace: to.Ptr("openshift-console"),
 								},
-								Type: to.Ptr(hcpsdk20240610preview.ExternalAuthClientTypePublic),
+								Type: to.Ptr(armredhatopenshifthcp.ExternalAuthClientTypePublic),
 							},
 						},
 					},
 				}
-				_, err = framework.CreateOrUpdateExternalAuthAndWait(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, clusterName, customerExternalAuthName, extAuth, 15*time.Minute)
+				_, err = framework.CreateOrUpdateExternalAuthAndWait(ctx, tc.GetExternalAuthsClientOrDie(ctx), *resourceGroup.Name, clusterName, customerExternalAuthName, extAuth, 15*time.Minute)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("verifying ExternalAuth is in a Succeeded state")
-				eaResult, err := framework.GetExternalAuth(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, clusterName, customerExternalAuthName)
+				eaResult, err := framework.GetExternalAuth(ctx, tc.GetExternalAuthsClientOrDie(ctx), *resourceGroup.Name, clusterName, customerExternalAuthName)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(*eaResult.Properties.ProvisioningState).To(Equal(hcpsdk20240610preview.ExternalAuthProvisioningStateSucceeded))
+				Expect(*eaResult.Properties.ProvisioningState).To(Equal(armredhatopenshifthcp.ExternalAuthProvisioningStateSucceeded))
 
 				By("creating a cluster role binding for the entra application via VM")
 				clusterRoleBindingName := "external-auth-cluster-admin"
@@ -394,7 +393,7 @@ var _ = Describe("Authorized CIDRs", func() {
 				// Get the current cluster state
 				currentCluster, err := framework.GetHCPCluster(
 					ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+					tc.GetHCPClustersClientOrDie(ctx),
 					*resourceGroup.Name,
 					clusterName,
 				)
@@ -406,7 +405,7 @@ var _ = Describe("Authorized CIDRs", func() {
 				}
 
 				// Use CreateOrUpdate (PUT) to apply the change
-				poller, err := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().BeginCreateOrUpdate(
+				poller, err := tc.GetHCPClustersClientOrDie(ctx).BeginCreateOrUpdate(
 					ctx,
 					*resourceGroup.Name,
 					clusterName,

--- a/test/e2e/cluster_autoscaling.go
+++ b/test/e2e/cluster_autoscaling.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 )
@@ -68,7 +68,7 @@ var _ = Describe("Customer", func() {
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
-			clusterParams.Autoscaling = &hcpsdk20240610preview.ClusterAutoscalingProfile{
+			clusterParams.Autoscaling = &armredhatopenshifthcp.ClusterAutoscalingProfile{
 				MaxNodeProvisionTimeSeconds: to.Ptr(autoscalingMaxNodeProvisionTimeSeconds),
 				MaxPodGracePeriodSeconds:    to.Ptr(autoscalingMaxPodGracePeriodSeconds),
 				PodPriorityThreshold:        to.Ptr(autoscalingPodPriorityThreshold),
@@ -100,7 +100,7 @@ var _ = Describe("Customer", func() {
 			By("ensuring the custom autoscaling was honored")
 			got, err := framework.GetHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				tc.GetHCPClustersClientOrDie(ctx),
 				*resourceGroup.Name,
 				customerClusterName,
 			)
@@ -129,12 +129,12 @@ var _ = Describe("Customer", func() {
 			By("patching the cluster to set maxNodesTotal")
 			_, err = framework.UpdateHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				tc.GetHCPClustersClientOrDie(ctx),
 				*resourceGroup.Name,
 				customerClusterName,
-				hcpsdk20240610preview.HcpOpenShiftClusterUpdate{
-					Properties: &hcpsdk20240610preview.HcpOpenShiftClusterPropertiesUpdate{
-						Autoscaling: &hcpsdk20240610preview.ClusterAutoscalingProfile{
+				armredhatopenshifthcp.HcpOpenShiftClusterUpdate{
+					Properties: &armredhatopenshifthcp.HcpOpenShiftClusterPropertiesUpdate{
+						Autoscaling: &armredhatopenshifthcp.ClusterAutoscalingProfile{
 							MaxNodesTotal: to.Ptr(autoscalingMaxNodesTotal),
 						},
 					},

--- a/test/e2e/cluster_create_cni_cilium.go
+++ b/test/e2e/cluster_create_cni_cilium.go
@@ -86,7 +86,6 @@ var _ = Describe("Customer", func() {
 			By("getting credentials and verifying cluster is available")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,

--- a/test/e2e/cluster_create_complex_cilium_kv.go
+++ b/test/e2e/cluster_create_complex_cilium_kv.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -25,12 +24,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-
 	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 
-	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -50,6 +45,7 @@ var _ = Describe("Customer", func() {
 			)
 
 			tc := framework.NewTestContext()
+			tc.SetHCPAPIVersionForTest(framework.HCPAPIVersion20251223)
 
 			if tc.UsePooledIdentities() {
 				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
@@ -81,25 +77,12 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("creating the HCP cluster with no CNI and private etcd via v20251223preview")
-			clusterResource, err := framework.BuildHCPCluster20251223FromParams(clusterParams, tc.Location(), nil)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Set KeyVault visibility to Private
-			if clusterResource.Properties != nil && clusterResource.Properties.Etcd != nil &&
-				clusterResource.Properties.Etcd.DataEncryption != nil &&
-				clusterResource.Properties.Etcd.DataEncryption.CustomerManaged != nil &&
-				clusterResource.Properties.Etcd.DataEncryption.CustomerManaged.Kms != nil {
-				clusterResource.Properties.Etcd.DataEncryption.CustomerManaged.Kms.Visibility = to.Ptr(hcpsdk20251223preview.KeyVaultVisibilityPrivate)
-			}
-
-			_, err = framework.CreateHCPCluster20251223AndWait(
+			By("creating the HCP cluster with no CNI and private etcd")
+			err = tc.CreateHCPClusterFromParam(
 				ctx,
 				GinkgoLogr,
-				tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
-				customerClusterName,
-				clusterResource,
+				clusterParams,
 				45*time.Minute,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -107,7 +90,6 @@ var _ = Describe("Customer", func() {
 			By("getting admin credentials for the cluster")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,
@@ -156,55 +138,24 @@ var _ = Describe("Customer", func() {
 			err = framework.InstallCiliumChart(ctx, "1.19.2", ciliumValues, kubeconfigContent, "kube-system")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("creating the node pool via v20251223preview")
+			By("creating the node pool")
 			nodePoolParams := framework.NewDefaultNodePoolParams()
-			nodePool := hcpsdk20251223preview.NodePool{
-				Location: to.Ptr(tc.Location()),
-				Properties: &hcpsdk20251223preview.NodePoolProperties{
-					Version: &hcpsdk20251223preview.NodePoolVersionProfile{
-						ID:           to.Ptr(nodePoolParams.OpenshiftVersionId),
-						ChannelGroup: to.Ptr(nodePoolParams.ChannelGroup),
-					},
-					Replicas: to.Ptr(int32(2)),
-					Platform: &hcpsdk20251223preview.NodePoolPlatformProfile{
-						VMSize: to.Ptr(nodePoolParams.VMSize),
-						OSDisk: &hcpsdk20251223preview.OsDiskProfile{
-							SizeGiB:                to.Ptr(nodePoolParams.OSDiskSizeGiB),
-							DiskStorageAccountType: to.Ptr(hcpsdk20251223preview.DiskStorageAccountType(nodePoolParams.DiskStorageAccountType)),
-						},
-					},
-					AutoRepair: to.Ptr(true),
-				},
-			}
-
-			_, nodePoolErr := framework.CreateNodePoolAndWait20251223(
+			nodePoolParams.ClusterName = customerClusterName
+			nodePoolParams.NodePoolName = customerNodePoolName
+			nodePoolErr := tc.CreateNodePoolFromParam(
 				ctx,
-				tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+				GinkgoLogr,
 				*resourceGroup.Name,
+				clusterParams.ManagedResourceGroupName,
 				customerClusterName,
-				customerNodePoolName,
-				nodePool,
+				nodePoolParams,
 				45*time.Minute,
 			)
-			// We delay checking the error on purpose to get more details
-			// about the issue by running the verifiers.
-
-			var consoleLogErr error = nil
-			if nodePoolErr != nil {
-				var computeFactory *armcompute.ClientFactory
-				computeFactory, consoleLogErr = tc.GetARMComputeClientFactory(ctx)
-				if consoleLogErr == nil {
-					consoleLogErr = framework.DownloadAllVirtualMachineConsoleLogs(
-						ctx,
-						computeFactory,
-						clusterParams.ManagedResourceGroupName,
-						tc.LogDirPath)
-				}
-			}
+			Expect(nodePoolErr).NotTo(HaveOccurred())
 
 			By("verifying nodes become Ready with Cilium CNI")
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodesReady(), verifiers.VerifyCiliumOperational("kube-system", "k8s-app=cilium"))
-			Expect(errors.Join(err, nodePoolErr, consoleLogErr)).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying a simple web app can run with cilium")
 			err = verifiers.VerifySimpleWebApp().Verify(ctx, adminRESTConfig)

--- a/test/e2e/cluster_create_nodepool_osdisk.go
+++ b/test/e2e/cluster_create_nodepool_osdisk.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -98,7 +98,6 @@ var _ = Describe("Customer", func() {
 			By("getting credentials")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,
@@ -111,7 +110,7 @@ var _ = Describe("Customer", func() {
 
 			By("verifying the node pool is created and has the correct osDisk size")
 			created, err := framework.GetNodePool(ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+				tc.GetNodePoolsClientOrDie(ctx),
 				*resourceGroup.Name,
 				customerClusterName,
 				customerNodePoolName,
@@ -119,7 +118,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(created.Properties).ToNot(BeNil(), "nodepool Properties was nil")
 			Expect(created.Properties.ProvisioningState).ToNot(BeNil(), "nodepool Properties.ProvisioningState was nil")
-			Expect(*created.Properties.ProvisioningState).To(Equal(hcpsdk20240610preview.ProvisioningStateSucceeded))
+			Expect(*created.Properties.ProvisioningState).To(Equal(armredhatopenshifthcp.ProvisioningStateSucceeded))
 			Expect(created.Properties.Platform).ToNot(BeNil(), "nodepool Properties.Platform was nil")
 			Expect(created.Properties.Platform.OSDisk).ToNot(BeNil(), "nodepool Properties.Platform.OSDisk was nil")
 			Expect(*created.Properties.Platform.OSDisk.SizeGiB).To(Equal(customerNodeOsDiskSizeGiB))

--- a/test/e2e/cluster_create_private_kv.go
+++ b/test/e2e/cluster_create_private_kv.go
@@ -22,9 +22,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-
-	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -49,6 +46,7 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			const customerClusterName = "private-kv-cluster"
 
 			tc := framework.NewTestContext()
+			tc.SetHCPAPIVersionForTest(framework.HCPAPIVersion20251223)
 
 			if tc.UsePooledIdentities() {
 				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
@@ -79,24 +77,11 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating the HCP cluster")
-			clusterResource, err := framework.BuildHCPCluster20251223FromParams(clusterParams, tc.Location(), nil)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Set KeyVault visibility
-			if clusterResource.Properties != nil && clusterResource.Properties.Etcd != nil &&
-				clusterResource.Properties.Etcd.DataEncryption != nil &&
-				clusterResource.Properties.Etcd.DataEncryption.CustomerManaged != nil &&
-				clusterResource.Properties.Etcd.DataEncryption.CustomerManaged.Kms != nil {
-				clusterResource.Properties.Etcd.DataEncryption.CustomerManaged.Kms.Visibility = to.Ptr(hcpsdk20251223preview.KeyVaultVisibilityPrivate)
-			}
-
-			_, err = framework.CreateHCPCluster20251223AndWait(
+			err = tc.CreateHCPClusterFromParam(
 				ctx,
 				GinkgoLogr,
-				tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
-				customerClusterName,
-				clusterResource,
+				clusterParams,
 				45*time.Minute,
 			)
 			if isAPINotDeployedError(err) {
@@ -108,33 +93,22 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying cluster was created with private keyvault visibility")
-			clientFactory := tc.Get20251223ClientFactoryOrDie(ctx)
-			cluster, err := clientFactory.NewHcpOpenShiftClustersClient().Get(
-				ctx,
-				*resourceGroup.Name,
-				customerClusterName,
-				nil,
-			)
+			visibility, err := tc.GetClusterKeyVaultVisibility(ctx, *resourceGroup.Name, customerClusterName)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(cluster.Properties).ToNot(BeNil())
-			Expect(cluster.Properties.Etcd).ToNot(BeNil())
-			Expect(cluster.Properties.Etcd.DataEncryption).ToNot(BeNil())
-			Expect(cluster.Properties.Etcd.DataEncryption.CustomerManaged).ToNot(BeNil())
-			Expect(cluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms).ToNot(BeNil())
 
-			visibilityNotPresent := cluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.Visibility == nil
+			visibilityNotPresent := visibility == nil
 			if visibilityNotPresent {
 				if time.Now().Before(timeBombDeadline) {
 					Skip("v20251223preview deployed but Visibility field not present in cluster response; skipping until rollout completes")
 				}
 				Fail(fmt.Sprintf("Visibility field still not present in v20251223preview cluster response as of %s deadline", timeBombDeadline.Format(time.RFC3339)))
 			}
-			Expect(*cluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.Visibility).To(Equal(hcpsdk20251223preview.KeyVaultVisibilityPrivate))
+			Expect(*visibility).To(Equal("Private"))
 
 			GinkgoLogr.Info("Cluster created successfully with private keyvault",
 				"clusterName", customerClusterName,
 				"keyVaultName", clusterParams.KeyVaultName,
-				"keyVaultVisibility", *cluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.Visibility)
+				"keyVaultVisibility", *visibility)
 
 			By("creating the node pool")
 			nodePoolParams := framework.NewDefaultNodePoolParams()
@@ -159,7 +133,6 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			By("getting admin credentials for the cluster")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,

--- a/test/e2e/cluster_create_test.go
+++ b/test/e2e/cluster_create_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 )
@@ -33,12 +33,12 @@ var _ = Describe("Put HCPOpenShiftCluster", func() {
 		clusterName := "non-existing-cluster"
 		customerRGName := "non-existing-group"
 		var (
-			clusterResource hcpsdk20240610preview.HcpOpenShiftCluster
-			clusterOptions  *hcpsdk20240610preview.HcpOpenShiftClustersClientBeginCreateOrUpdateOptions
+			clusterResource armredhatopenshifthcp.HcpOpenShiftCluster
+			clusterOptions  *armredhatopenshifthcp.HcpOpenShiftClustersClientBeginCreateOrUpdateOptions
 		)
 
 		By("Sending put request to create HCPOpenshiftCluster")
-		_, err := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().BeginCreateOrUpdate(ctx, customerRGName, clusterName, clusterResource, clusterOptions)
+		_, err := tc.GetHCPClustersClientOrDie(ctx).BeginCreateOrUpdate(ctx, customerRGName, clusterName, clusterResource, clusterOptions)
 		Expect(err).ToNot(BeNil())
 		errMessage := "The location property is required"
 		Expect(strings.ToLower(err.Error())).To(ContainSubstring(strings.ToLower(errMessage)))

--- a/test/e2e/cluster_delete_cx_rg.go
+++ b/test/e2e/cluster_delete_cx_rg.go
@@ -91,7 +91,6 @@ var _ = Describe("Customer", func() {
 			By("getting credentials")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,

--- a/test/e2e/cluster_delete_test.go
+++ b/test/e2e/cluster_delete_test.go
@@ -36,7 +36,7 @@ var _ = Describe("ARO-HCP Cluster Deletion", func() {
 
 	It("should confirm the HCP cluster is deleted (not found)", labels.TeardownValidation, labels.Critical, func(ctx context.Context) {
 		tc := framework.NewTestContext()
-		hcpClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+		hcpClient := tc.GetHCPClustersClientOrDie(ctx)
 		By("checking that the HCP cluster is not present")
 		_, err := hcpClient.Get(ctx, resourceGroup, clusterName, nil)
 		Expect(err).ToNot(BeNil())

--- a/test/e2e/cluster_get_test.go
+++ b/test/e2e/cluster_get_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Get HCPOpenShiftCluster", func() {
 			tc := framework.NewTestContext()
 
 			By("Checking Provisioning state with RP")
-			out, err := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().Get(ctx, customerEnv.CustomerRGName, clusterInfo.Name, nil)
+			out, err := tc.GetHCPClustersClientOrDie(ctx).Get(ctx, customerEnv.CustomerRGName, clusterInfo.Name, nil)
 			Expect(err).To(BeNil())
 			Expect(string(*out.Properties.ProvisioningState)).To(Equal(("Succeeded")))
 		})
@@ -56,7 +56,7 @@ var _ = Describe("Get HCPOpenShiftCluster", func() {
 
 			clusterName := "non-existing-cluster"
 			By("Sending a GET request for the nonexistent cluster")
-			_, err := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().Get(ctx, customerEnv.CustomerRGName, clusterName, nil)
+			_, err := tc.GetHCPClustersClientOrDie(ctx).Get(ctx, customerEnv.CustomerRGName, clusterName, nil)
 			Expect(err).ToNot(BeNil())
 			errMessage := fmt.Sprintf("hcpOpenShiftClusters/%s' under resource group '%s' was not found.", clusterName, customerEnv.CustomerRGName)
 			Expect(strings.ToLower(err.Error())).To(ContainSubstring(strings.ToLower(errMessage)))

--- a/test/e2e/cluster_list_test.go
+++ b/test/e2e/cluster_list_test.go
@@ -44,7 +44,7 @@ var _ = Describe("List HCPOpenShiftCluster", func() {
 			tc := framework.NewTestContext()
 
 			By("Preparing pager to list clusters")
-			pager := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().NewListByResourceGroupPager(customerEnv.CustomerRGName, nil)
+			pager := tc.GetHCPClustersClientOrDie(ctx).NewListByResourceGroupPager(customerEnv.CustomerRGName, nil)
 			By("Accessing IDs of all fetched clusters")
 			foundPreCreated := false
 			clusterCount := 0

--- a/test/e2e/cluster_pullsecret.go
+++ b/test/e2e/cluster_pullsecret.go
@@ -128,7 +128,6 @@ var _ = Describe("Customer", func() {
 			By("getting credentials")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,

--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -94,7 +94,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("ensuring the API TLS certificate is signed by a trusted Azure CA")
-			clusterClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			clusterClient := tc.GetHCPClustersClientOrDie(ctx)
 			Eventually(func(ctx context.Context) error {
 				clusterResp, err := clusterClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
 				if err != nil {
@@ -137,7 +137,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("ensuring the ingress TLS certificate is signed by a trusted Azure CA")
-			hcpOpenShiftClustersClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			hcpOpenShiftClustersClient := tc.GetHCPClustersClientOrDie(ctx)
 
 			By("waiting for the console URL to become available")
 			var consoleURL string

--- a/test/e2e/cluster_update.go
+++ b/test/e2e/cluster_update.go
@@ -22,18 +22,18 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
 )
 
 // Helper to convert ManagedServiceIdentity to AzureResourceManagerCommonTypesManagedServiceIdentityUpdate
-func toIdentityUpdate(identity *hcpsdk20240610preview.ManagedServiceIdentity) *hcpsdk20240610preview.AzureResourceManagerCommonTypesManagedServiceIdentityUpdate {
+func toIdentityUpdate(identity *armredhatopenshifthcp.ManagedServiceIdentity) *armredhatopenshifthcp.AzureResourceManagerCommonTypesManagedServiceIdentityUpdate {
 	if identity == nil {
 		return nil
 	}
-	return &hcpsdk20240610preview.AzureResourceManagerCommonTypesManagedServiceIdentityUpdate{
+	return &armredhatopenshifthcp.AzureResourceManagerCommonTypesManagedServiceIdentityUpdate{
 		Type:                   identity.Type,
 		UserAssignedIdentities: identity.UserAssignedIdentities,
 	}
@@ -86,7 +86,6 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				By("getting credentials")
 				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 					ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
 					clusterName,
 					10*time.Minute,
@@ -99,12 +98,12 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 
 				By("sending a PATCH request attempting to change the resource name")
 				newName := clusterName + "-renamed"
-				update := hcpsdk20240610preview.HcpOpenShiftClusterUpdate{
+				update := armredhatopenshifthcp.HcpOpenShiftClusterUpdate{
 					Name: &newName,
 				}
 				_, err = framework.UpdateHCPCluster(
 					ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+					tc.GetHCPClustersClientOrDie(ctx),
 					*resourceGroup.Name,
 					clusterName,
 					update,
@@ -162,7 +161,6 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				By("getting credentials")
 				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 					ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
 					clusterName,
 					10*time.Minute,
@@ -175,7 +173,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 
 				By("sending a PATCH request to set a tag")
 				val := "should succeed"
-				update := hcpsdk20240610preview.HcpOpenShiftClusterUpdate{
+				update := armredhatopenshifthcp.HcpOpenShiftClusterUpdate{
 					Identity: toIdentityUpdate(clusterParams.Identity),
 					Tags: map[string]*string{
 						"test": &val,
@@ -183,7 +181,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				}
 				resp, err := framework.UpdateHCPCluster(
 					ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+					tc.GetHCPClustersClientOrDie(ctx),
 					*resourceGroup.Name,
 					clusterName,
 					update,
@@ -199,7 +197,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				By("verifying the tag is present on the cluster")
 				respGet, err := framework.GetHCPCluster(
 					ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+					tc.GetHCPClustersClientOrDie(ctx),
 					*resourceGroup.Name,
 					clusterName,
 				)

--- a/test/e2e/cluster_version_backlevel.go
+++ b/test/e2e/cluster_version_backlevel.go
@@ -29,7 +29,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 
 	"github.com/Azure/ARO-HCP/internal/api"
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -135,7 +135,7 @@ var _ = Describe("Customer", func() {
 					identityProfile,
 				)
 				Expect(err).NotTo(HaveOccurred())
-				hcpClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+				hcpClient := tc.GetHCPClustersClientOrDie(ctx)
 				_, err = framework.CreateHCPClusterAndWait(
 					ctx,
 					GinkgoLogr,
@@ -149,7 +149,6 @@ var _ = Describe("Customer", func() {
 
 				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 					ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
 					clusterName,
 					10*time.Minute,
@@ -179,7 +178,7 @@ var _ = Describe("Customer", func() {
 						defaultNodePoolDefaults,
 					)
 					Expect(err).NotTo(HaveOccurred())
-					nodePoolClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
+					nodePoolClient := tc.GetNodePoolsClientOrDie(ctx)
 					_, err = framework.CreateNodePoolAndWait(ctx,
 						nodePoolClient,
 						*resourceGroup.Name,
@@ -239,15 +238,15 @@ func buildHCPClusterRequest(
 	controlPlaneVersion string,
 	channelGroup string,
 	customerInfra customerInfraOutputs,
-	userAssignedIdentitiesProfile *hcpsdk20240610preview.UserAssignedIdentitiesProfile,
-	identityProfile *hcpsdk20240610preview.ManagedServiceIdentity,
-) (hcpsdk20240610preview.HcpOpenShiftCluster, error) {
+	userAssignedIdentitiesProfile *armredhatopenshifthcp.UserAssignedIdentitiesProfile,
+	identityProfile *armredhatopenshifthcp.ManagedServiceIdentity,
+) (armredhatopenshifthcp.HcpOpenShiftCluster, error) {
 
 	switch controlPlaneVersion {
 	case "4.19":
 		return buildHCPClusterRequest_4_19(location, managedResourceGroupName, controlPlaneVersion, channelGroup, customerInfra, userAssignedIdentitiesProfile, identityProfile), nil
 	default:
-		return hcpsdk20240610preview.HcpOpenShiftCluster{}, fmt.Errorf("unsupported control plane version: %s", controlPlaneVersion)
+		return armredhatopenshifthcp.HcpOpenShiftCluster{}, fmt.Errorf("unsupported control plane version: %s", controlPlaneVersion)
 	}
 }
 
@@ -257,48 +256,48 @@ func buildHCPClusterRequest_4_19(
 	controlPlaneVersion string,
 	channelGroup string,
 	customerInfra customerInfraOutputs,
-	userAssignedIdentitiesProfile *hcpsdk20240610preview.UserAssignedIdentitiesProfile,
-	identityProfile *hcpsdk20240610preview.ManagedServiceIdentity,
-) hcpsdk20240610preview.HcpOpenShiftCluster {
-	return hcpsdk20240610preview.HcpOpenShiftCluster{
+	userAssignedIdentitiesProfile *armredhatopenshifthcp.UserAssignedIdentitiesProfile,
+	identityProfile *armredhatopenshifthcp.ManagedServiceIdentity,
+) armredhatopenshifthcp.HcpOpenShiftCluster {
+	return armredhatopenshifthcp.HcpOpenShiftCluster{
 		Location: to.Ptr(location),
 		Identity: identityProfile,
 		Tags: map[string]*string{
 			api.TagClusterSizeOverride: to.Ptr(string(api.MinimalControlPlanePodSizing)),
 		},
-		Properties: &hcpsdk20240610preview.HcpOpenShiftClusterProperties{
-			Version: &hcpsdk20240610preview.VersionProfile{
+		Properties: &armredhatopenshifthcp.HcpOpenShiftClusterProperties{
+			Version: &armredhatopenshifthcp.VersionProfile{
 				ID:           to.Ptr(controlPlaneVersion),
 				ChannelGroup: to.Ptr(channelGroup),
 			},
-			Platform: &hcpsdk20240610preview.PlatformProfile{
+			Platform: &armredhatopenshifthcp.PlatformProfile{
 				ManagedResourceGroup:   to.Ptr(managedResourceGroupName),
 				NetworkSecurityGroupID: to.Ptr(customerInfra.nsgID),
 				SubnetID:               to.Ptr(customerInfra.subnetID),
-				OperatorsAuthentication: &hcpsdk20240610preview.OperatorsAuthenticationProfile{
+				OperatorsAuthentication: &armredhatopenshifthcp.OperatorsAuthenticationProfile{
 					UserAssignedIdentities: userAssignedIdentitiesProfile,
 				},
 			},
-			Network: &hcpsdk20240610preview.NetworkProfile{
-				NetworkType: to.Ptr(hcpsdk20240610preview.NetworkType("OVNKubernetes")),
+			Network: &armredhatopenshifthcp.NetworkProfile{
+				NetworkType: to.Ptr(armredhatopenshifthcp.NetworkType("OVNKubernetes")),
 				PodCIDR:     to.Ptr("10.128.0.0/14"),
 				ServiceCIDR: to.Ptr("172.30.0.0/16"),
 				MachineCIDR: to.Ptr("10.0.0.0/16"),
 				HostPrefix:  to.Ptr(int32(23)),
 			},
-			API: &hcpsdk20240610preview.APIProfile{
-				Visibility: to.Ptr(hcpsdk20240610preview.Visibility("Public")),
+			API: &armredhatopenshifthcp.APIProfile{
+				Visibility: to.Ptr(armredhatopenshifthcp.Visibility("Public")),
 			},
-			ClusterImageRegistry: &hcpsdk20240610preview.ClusterImageRegistryProfile{
-				State: to.Ptr(hcpsdk20240610preview.ClusterImageRegistryState("Enabled")),
+			ClusterImageRegistry: &armredhatopenshifthcp.ClusterImageRegistryProfile{
+				State: to.Ptr(armredhatopenshifthcp.ClusterImageRegistryState("Enabled")),
 			},
-			Etcd: &hcpsdk20240610preview.EtcdProfile{
-				DataEncryption: &hcpsdk20240610preview.EtcdDataEncryptionProfile{
-					KeyManagementMode: to.Ptr(hcpsdk20240610preview.EtcdDataEncryptionKeyManagementModeType("CustomerManaged")),
-					CustomerManaged: &hcpsdk20240610preview.CustomerManagedEncryptionProfile{
-						EncryptionType: to.Ptr(hcpsdk20240610preview.CustomerManagedEncryptionType("KMS")),
-						Kms: &hcpsdk20240610preview.KmsEncryptionProfile{
-							ActiveKey: &hcpsdk20240610preview.KmsKey{
+			Etcd: &armredhatopenshifthcp.EtcdProfile{
+				DataEncryption: &armredhatopenshifthcp.EtcdDataEncryptionProfile{
+					KeyManagementMode: to.Ptr(armredhatopenshifthcp.EtcdDataEncryptionKeyManagementModeType("CustomerManaged")),
+					CustomerManaged: &armredhatopenshifthcp.CustomerManagedEncryptionProfile{
+						EncryptionType: to.Ptr(armredhatopenshifthcp.CustomerManagedEncryptionType("KMS")),
+						Kms: &armredhatopenshifthcp.KmsEncryptionProfile{
+							ActiveKey: &armredhatopenshifthcp.KmsKey{
 								VaultName: to.Ptr(customerInfra.keyVaultName),
 								Name:      to.Ptr(customerInfra.etcdEncryptionKeyName),
 								Version:   to.Ptr(customerInfra.etcdEncryptionKeyVersion),
@@ -315,12 +314,12 @@ func buildNodePoolRequest(
 	location string,
 	nodePoolVersion string,
 	defaults nodePoolDefaults,
-) (hcpsdk20240610preview.NodePool, error) {
+) (armredhatopenshifthcp.NodePool, error) {
 	switch nodePoolVersion {
 	case "4.19.7":
 		return buildNodePoolRequest_4_19(location, nodePoolVersion, defaults), nil
 	default:
-		return hcpsdk20240610preview.NodePool{}, fmt.Errorf("unsupported node pool version: %s", nodePoolVersion)
+		return armredhatopenshifthcp.NodePool{}, fmt.Errorf("unsupported node pool version: %s", nodePoolVersion)
 	}
 }
 
@@ -328,20 +327,20 @@ func buildNodePoolRequest_4_19(
 	location string,
 	nodePoolVersion string,
 	defaults nodePoolDefaults,
-) hcpsdk20240610preview.NodePool {
-	return hcpsdk20240610preview.NodePool{
+) armredhatopenshifthcp.NodePool {
+	return armredhatopenshifthcp.NodePool{
 		Location: to.Ptr(location),
-		Properties: &hcpsdk20240610preview.NodePoolProperties{
-			Version: &hcpsdk20240610preview.NodePoolVersionProfile{
+		Properties: &armredhatopenshifthcp.NodePoolProperties{
+			Version: &armredhatopenshifthcp.NodePoolVersionProfile{
 				ID:           to.Ptr(nodePoolVersion),
 				ChannelGroup: to.Ptr(defaults.channelGroup),
 			},
 			Replicas: to.Ptr(defaults.replicas),
-			Platform: &hcpsdk20240610preview.NodePoolPlatformProfile{
+			Platform: &armredhatopenshifthcp.NodePoolPlatformProfile{
 				VMSize: to.Ptr(defaults.vmSize),
-				OSDisk: &hcpsdk20240610preview.OsDiskProfile{
+				OSDisk: &armredhatopenshifthcp.OsDiskProfile{
 					SizeGiB:                to.Ptr(defaults.osDiskSizeGiB),
-					DiskStorageAccountType: to.Ptr(hcpsdk20240610preview.DiskStorageAccountType(defaults.diskStorageAccountType)),
+					DiskStorageAccountType: to.Ptr(armredhatopenshifthcp.DiskStorageAccountType(defaults.diskStorageAccountType)),
 				},
 			},
 		},

--- a/test/e2e/cluster_versions.go
+++ b/test/e2e/cluster_versions.go
@@ -35,7 +35,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			By("listing HCP OpenShift versions")
-			versionsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftVersionsClient()
+			versionsClient := tc.GetHCPVersionsClientOrDie(ctx)
 			versionsPager := versionsClient.NewListPager(tc.Location(), nil)
 
 			versions, err := versionsPager.NextPage(ctx)

--- a/test/e2e/clusters_sharing_resgroup.go
+++ b/test/e2e/clusters_sharing_resgroup.go
@@ -97,7 +97,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("starting creation of both clusters in parallel")
-			clusterClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			clusterClient := tc.GetHCPClustersClientOrDie(ctx)
 
 			// Start first cluster creation
 			poller1, err := framework.BeginCreateHCPCluster(

--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -111,7 +111,6 @@ var _ = Describe("ARO-HCP", func() {
 			By("verifying the cluster is viable")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				clusterName,
 				10*time.Minute,
@@ -162,8 +161,8 @@ var _ = Describe("ARO-HCP", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying nodepool DiskStorageAccountType matches framework default")
-			err = framework.ValidateNodePoolDiskStorageAccountType(ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+			err = tc.ValidateNodePoolDiskStorageAccountType(
+				ctx,
 				*resourceGroup.Name,
 				clusterName,
 				nodePoolName,

--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -143,7 +143,6 @@ var _ = Describe("Service Provider", func() {
 			By("verifying the cluster is viable")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				clusterName,
 				10*time.Minute,

--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -37,7 +37,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/upgradecontrollers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/cincinnati"
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -146,10 +146,9 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("getting admin credentials")
-			hcpClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			hcpClient := tc.GetHCPClustersClientOrDie(ctx)
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				hcpClient,
 				*resourceGroup.Name,
 				clusterName,
 				10*time.Minute,
@@ -168,9 +167,9 @@ var _ = Describe("Customer", func() {
 
 			By(fmt.Sprintf("triggering control plane y-stream upgrade to %s (target minor %s)", targetMinor,
 				targetVer.String()))
-			update := hcpsdk20240610preview.HcpOpenShiftClusterUpdate{
-				Properties: &hcpsdk20240610preview.HcpOpenShiftClusterPropertiesUpdate{
-					Version: &hcpsdk20240610preview.VersionProfile{
+			update := armredhatopenshifthcp.HcpOpenShiftClusterUpdate{
+				Properties: &armredhatopenshifthcp.HcpOpenShiftClusterPropertiesUpdate{
+					Version: &armredhatopenshifthcp.VersionProfile{
 						ID:           to.Ptr(targetMinor),
 						ChannelGroup: to.Ptr(channelGroup),
 					},

--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -33,7 +33,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -95,7 +95,6 @@ var _ = Describe("Customer", func() {
 			By("getting credentials")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,
@@ -132,51 +131,51 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating an external auth config with a prefix")
-			extAuth := hcpsdk20240610preview.ExternalAuth{
-				Properties: &hcpsdk20240610preview.ExternalAuthProperties{
-					Issuer: &hcpsdk20240610preview.TokenIssuerProfile{
+			extAuth := armredhatopenshifthcp.ExternalAuth{
+				Properties: &armredhatopenshifthcp.ExternalAuthProperties{
+					Issuer: &armredhatopenshifthcp.TokenIssuerProfile{
 						URL:       to.Ptr(fmt.Sprintf("https://login.microsoftonline.com/%s/v2.0", tc.TenantID())),
 						Audiences: []*string{to.Ptr(app.AppID)},
 					},
-					Claim: &hcpsdk20240610preview.ExternalAuthClaimProfile{
-						Mappings: &hcpsdk20240610preview.TokenClaimMappingsProfile{
-							Username: &hcpsdk20240610preview.UsernameClaimProfile{
+					Claim: &armredhatopenshifthcp.ExternalAuthClaimProfile{
+						Mappings: &armredhatopenshifthcp.TokenClaimMappingsProfile{
+							Username: &armredhatopenshifthcp.UsernameClaimProfile{
 								Claim:        to.Ptr("sub"),                                                 // objectID of SP
-								PrefixPolicy: to.Ptr(hcpsdk20240610preview.UsernameClaimPrefixPolicyPrefix), // TODO: ARO-21008 preventing us setting NoPrefix
+								PrefixPolicy: to.Ptr(armredhatopenshifthcp.UsernameClaimPrefixPolicyPrefix), // TODO: ARO-21008 preventing us setting NoPrefix
 								Prefix:       to.Ptr(externalAuthSubjectPrefix),
 							},
-							Groups: &hcpsdk20240610preview.GroupClaimProfile{
+							Groups: &armredhatopenshifthcp.GroupClaimProfile{
 								Claim: to.Ptr("groups"),
 							},
 						},
 					},
-					Clients: []*hcpsdk20240610preview.ExternalAuthClientProfile{
+					Clients: []*armredhatopenshifthcp.ExternalAuthClientProfile{
 						{
 							ClientID: to.Ptr(app.AppID),
-							Component: &hcpsdk20240610preview.ExternalAuthClientComponentProfile{
+							Component: &armredhatopenshifthcp.ExternalAuthClientComponentProfile{
 								Name:                to.Ptr("console"),
 								AuthClientNamespace: to.Ptr("openshift-console"),
 							},
-							Type: to.Ptr(hcpsdk20240610preview.ExternalAuthClientTypeConfidential),
+							Type: to.Ptr(armredhatopenshifthcp.ExternalAuthClientTypeConfidential),
 						},
 						{
 							ClientID: to.Ptr(app.AppID),
-							Component: &hcpsdk20240610preview.ExternalAuthClientComponentProfile{
+							Component: &armredhatopenshifthcp.ExternalAuthClientComponentProfile{
 								Name:                to.Ptr("cli"),
 								AuthClientNamespace: to.Ptr("openshift-console"),
 							},
-							Type: to.Ptr(hcpsdk20240610preview.ExternalAuthClientTypePublic),
+							Type: to.Ptr(armredhatopenshifthcp.ExternalAuthClientTypePublic),
 						},
 					},
 				},
 			}
-			_, err = framework.CreateOrUpdateExternalAuthAndWait(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, customerClusterName, customerExternalAuthName, extAuth, 15*time.Minute)
+			_, err = framework.CreateOrUpdateExternalAuthAndWait(ctx, tc.GetExternalAuthsClientOrDie(ctx), *resourceGroup.Name, customerClusterName, customerExternalAuthName, extAuth, 15*time.Minute)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying ExternalAuth is in a Succeeded state")
-			eaResult, err := framework.GetExternalAuth(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, customerClusterName, customerExternalAuthName)
+			eaResult, err := framework.GetExternalAuth(ctx, tc.GetExternalAuthsClientOrDie(ctx), *resourceGroup.Name, customerClusterName, customerExternalAuthName)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(*eaResult.Properties.ProvisioningState).To(Equal(hcpsdk20240610preview.ExternalAuthProvisioningStateSucceeded))
+			Expect(*eaResult.Properties.ProvisioningState).To(Equal(armredhatopenshifthcp.ExternalAuthProvisioningStateSucceeded))
 
 			By("creating a cluster role binding for the entra application")
 			err = framework.CreateClusterRoleBinding(ctx, externalAuthSubjectPrefix+sp.ID, adminRESTConfig)

--- a/test/e2e/external_auth_list_and_verify.go
+++ b/test/e2e/external_auth_list_and_verify.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
-	hcpsdk "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 )
@@ -83,21 +83,21 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			expectedExternalAuth := hcpsdk.ExternalAuth{
+			expectedExternalAuth := armredhatopenshifthcp.ExternalAuth{
 				Name: to.Ptr(testingPrefix),
-				Properties: &hcpsdk.ExternalAuthProperties{
-					Issuer: &hcpsdk.TokenIssuerProfile{
+				Properties: &armredhatopenshifthcp.ExternalAuthProperties{
+					Issuer: &armredhatopenshifthcp.TokenIssuerProfile{
 						URL:       to.Ptr(fmt.Sprintf("https://login.microsoftonline.com/%s/v2.0", tc.TenantID())),
 						Audiences: []*string{to.Ptr(dummyUID)},
 					},
-					Claim: &hcpsdk.ExternalAuthClaimProfile{
-						Mappings: &hcpsdk.TokenClaimMappingsProfile{
-							Username: &hcpsdk.UsernameClaimProfile{
+					Claim: &armredhatopenshifthcp.ExternalAuthClaimProfile{
+						Mappings: &armredhatopenshifthcp.TokenClaimMappingsProfile{
+							Username: &armredhatopenshifthcp.UsernameClaimProfile{
 								Claim:        to.Ptr("sub"), // objectID of SP
-								PrefixPolicy: to.Ptr(hcpsdk.UsernameClaimPrefixPolicyPrefix),
+								PrefixPolicy: to.Ptr(armredhatopenshifthcp.UsernameClaimPrefixPolicyPrefix),
 								Prefix:       to.Ptr(testingPrefix),
 							},
-							Groups: &hcpsdk.GroupClaimProfile{
+							Groups: &armredhatopenshifthcp.GroupClaimProfile{
 								Claim: to.Ptr("groups"),
 							},
 						},
@@ -108,7 +108,7 @@ var _ = Describe("Customer", func() {
 			By("create an external auth and confirm it's in a succeeded state")
 			_, err = framework.CreateOrUpdateExternalAuthAndWait(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(),
+				tc.GetExternalAuthsClientOrDie(ctx),
 				*resourceGroup.Name,
 				clusterName,
 				*expectedExternalAuth.Name,
@@ -119,20 +119,20 @@ var _ = Describe("Customer", func() {
 
 			result, err := framework.GetExternalAuth(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(),
+				tc.GetExternalAuthsClientOrDie(ctx),
 				*resourceGroup.Name,
 				clusterName,
 				*expectedExternalAuth.Name,
 			)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(*result.Properties.ProvisioningState).To(Equal(hcpsdk.ExternalAuthProvisioningStateSucceeded))
+			Expect(*result.Properties.ProvisioningState).To(Equal(armredhatopenshifthcp.ExternalAuthProvisioningStateSucceeded))
 
 			By("confirming we're only allowed to create a single external auth")
 			anotherExternalAuth := expectedExternalAuth
 			anotherExternalAuth.Name = to.Ptr(testingPrefix + "2")
 			_, err = framework.CreateOrUpdateExternalAuthAndWait(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(),
+				tc.GetExternalAuthsClientOrDie(ctx),
 				*resourceGroup.Name,
 				clusterName,
 				*anotherExternalAuth.Name,
@@ -142,9 +142,9 @@ var _ = Describe("Customer", func() {
 			Expect(err).To(HaveOccurred())
 
 			By("listing all external auth configs to verify a list call works")
-			externalAuthClient := tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient()
+			externalAuthClient := tc.GetExternalAuthsClientOrDie(ctx)
 			pager := externalAuthClient.NewListByParentPager(*resourceGroup.Name, clusterName, nil)
-			var extAuthResult []hcpsdk.ExternalAuth
+			var extAuthResult []armredhatopenshifthcp.ExternalAuth
 			for pager.More() {
 				page, err := pager.NextPage(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -180,7 +180,7 @@ var _ = Describe("Customer", func() {
 			expectedExternalAuth.Properties.Claim.Mappings.Username.Prefix = to.Ptr(testingPrefix + "updated")
 			_, err = framework.CreateOrUpdateExternalAuthAndWait(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(),
+				tc.GetExternalAuthsClientOrDie(ctx),
 				*resourceGroup.Name,
 				clusterName,
 				*expectedExternalAuth.Name,
@@ -191,13 +191,13 @@ var _ = Describe("Customer", func() {
 
 			updatedResult, err := framework.GetExternalAuth(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(),
+				tc.GetExternalAuthsClientOrDie(ctx),
 				*resourceGroup.Name,
 				clusterName,
 				*expectedExternalAuth.Name,
 			)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(*updatedResult.Properties.ProvisioningState).To(Equal(hcpsdk.ExternalAuthProvisioningStateSucceeded))
+			Expect(*updatedResult.Properties.ProvisioningState).To(Equal(armredhatopenshifthcp.ExternalAuthProvisioningStateSucceeded))
 			Expect(*updatedResult.Properties.Claim.Mappings.Username.Prefix).To(Equal(*expectedExternalAuth.Properties.Claim.Mappings.Username.Prefix))
 
 		})

--- a/test/e2e/gpu_nodepools_create_delete.go
+++ b/test/e2e/gpu_nodepools_create_delete.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -101,7 +101,6 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				By("getting credentials and verifying cluster is viable")
 				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 					ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
 					customerClusterName,
 					10*time.Minute,
@@ -150,7 +149,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 
 				By("verifying GPU nodepool provisioning succeeded with correct VM size")
 				created, err := framework.GetNodePool(ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+					tc.GetNodePoolsClientOrDie(ctx),
 					*resourceGroup.Name,
 					customerClusterName,
 					gpuNodePoolName,
@@ -158,7 +157,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(created.Properties).ToNot(BeNil(), "GPU nodepool Properties was nil")
 				Expect(created.Properties.ProvisioningState).ToNot(BeNil(), "GPU nodepool Properties.ProvisioningState was nil")
-				Expect(*created.Properties.ProvisioningState).To(Equal(hcpsdk20240610preview.ProvisioningStateSucceeded))
+				Expect(*created.Properties.ProvisioningState).To(Equal(armredhatopenshifthcp.ProvisioningStateSucceeded))
 				Expect(created.Properties.Platform).ToNot(BeNil(), "GPU nodepool Properties.Platform was nil")
 				Expect(created.Properties.Platform.VMSize).ToNot(BeNil(), "GPU nodepool Properties.Platform.VMSize was nil")
 				Expect(*created.Properties.Platform.VMSize).To(Equal(sku.vmSize))
@@ -166,7 +165,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				By("deleting GPU nodepool")
 				Expect(framework.DeleteNodePool(
 					ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+					tc.GetNodePoolsClientOrDie(ctx),
 					*resourceGroup.Name,
 					customerClusterName,
 					gpuNodePoolName,
@@ -175,7 +174,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 
 				By("confirming GPU nodepool has been deleted")
 				_, getErr := framework.GetNodePool(ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+					tc.GetNodePoolsClientOrDie(ctx),
 					*resourceGroup.Name,
 					customerClusterName,
 					gpuNodePoolName,

--- a/test/e2e/idms_lifecycle.go
+++ b/test/e2e/idms_lifecycle.go
@@ -30,7 +30,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 
-	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -58,6 +58,7 @@ var _ = Describe("Customer", func() {
 			)
 
 			tc := framework.NewTestContext()
+			tc.SetHCPAPIVersionForTest(framework.HCPAPIVersion20251223)
 
 			if tc.UsePooledIdentities() {
 				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
@@ -89,20 +90,23 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating the HCP cluster with ImageDigestMirrors via v20251223preview")
-			imageDigestMirrors := []*hcpsdk20251223preview.ImageDigestMirror{
+			imageDigestMirrors := []*armredhatopenshifthcp.ImageDigestMirror{
 				{
 					Source:  to.Ptr(idmsSource),
 					Mirrors: []*string{to.Ptr(idmsMirror)},
 				},
 			}
 
-			createErr := tc.CreateHCPCluster20251223FromParam(
+			createErr := tc.CreateHCPClusterFromParamWithOptions(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				imageDigestMirrors,
 				45*time.Minute,
+				framework.CreateHCPClusterOptions{
+					APIVersion:         tc.EffectiveHCPAPIVersion(),
+					ImageDigestMirrors: imageDigestMirrors,
+				},
 			)
 
 			var respErr *azcore.ResponseError
@@ -124,7 +128,6 @@ var _ = Describe("Customer", func() {
 			By("getting admin credentials")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,
@@ -153,9 +156,9 @@ var _ = Describe("Customer", func() {
 			}, 1*time.Minute, 15*time.Second).Should(Succeed(), "ImageDigestMirrorSet CRDs should exist on the hosted cluster")
 
 			By("updating the cluster to add a second ImageDigestMirror set")
-			updateAdd := hcpsdk20251223preview.HcpOpenShiftClusterUpdate{
-				Properties: &hcpsdk20251223preview.HcpOpenShiftClusterPropertiesUpdate{
-					ImageDigestMirrors: []*hcpsdk20251223preview.ImageDigestMirror{
+			updateAdd := armredhatopenshifthcp.HcpOpenShiftClusterUpdate{
+				Properties: &armredhatopenshifthcp.HcpOpenShiftClusterPropertiesUpdate{
+					ImageDigestMirrors: []*armredhatopenshifthcp.ImageDigestMirror{
 						{
 							Source:  to.Ptr(idmsSource),
 							Mirrors: []*string{to.Ptr(idmsMirror)},
@@ -206,9 +209,9 @@ var _ = Describe("Customer", func() {
 			}, 10*time.Minute, 15*time.Second).Should(Succeed(), "both ImageDigestMirrorSet entries should exist on the hosted cluster")
 
 			By("updating the cluster to remove the second ImageDigestMirror set")
-			updateRemove := hcpsdk20251223preview.HcpOpenShiftClusterUpdate{
-				Properties: &hcpsdk20251223preview.HcpOpenShiftClusterPropertiesUpdate{
-					ImageDigestMirrors: []*hcpsdk20251223preview.ImageDigestMirror{
+			updateRemove := armredhatopenshifthcp.HcpOpenShiftClusterUpdate{
+				Properties: &armredhatopenshifthcp.HcpOpenShiftClusterPropertiesUpdate{
+					ImageDigestMirrors: []*armredhatopenshifthcp.ImageDigestMirror{
 						{
 							Source:  to.Ptr(idmsSource),
 							Mirrors: []*string{to.Ptr(idmsMirror)},

--- a/test/e2e/image_registry_cluster_create.go
+++ b/test/e2e/image_registry_cluster_create.go
@@ -23,7 +23,7 @@ import (
 
 	"k8s.io/utils/ptr"
 
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -62,7 +62,7 @@ var _ = Describe("Customer", func() {
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
-			clusterParams.ImageRegistryState = string(hcpsdk20240610preview.ClusterImageRegistryStateDisabled)
+			clusterParams.ImageRegistryState = string(armredhatopenshifthcp.ClusterImageRegistryStateDisabled)
 
 			By("creating customer resources")
 			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
@@ -88,16 +88,15 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			actualHCPCluster, err := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+			actualHCPCluster, err := tc.GetHCPClustersClientOrDie(ctx).Get(ctx, *resourceGroup.Name, customerClusterName, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(actualHCPCluster.Properties.ClusterImageRegistry).NotTo(BeNil(), "cluster Properties.ClusterImageRegistry was nil")
 			Expect(actualHCPCluster.Properties.ClusterImageRegistry.State).NotTo(BeNil(), "cluster Properties.ClusterImageRegistry.State was nil")
-			Expect(ptr.Deref(actualHCPCluster.Properties.ClusterImageRegistry.State, "")).To(Equal(hcpsdk20240610preview.ClusterImageRegistryStateDisabled))
+			Expect(ptr.Deref(actualHCPCluster.Properties.ClusterImageRegistry.State, "")).To(Equal(armredhatopenshifthcp.ClusterImageRegistryStateDisabled))
 
 			By("getting credentials")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,

--- a/test/e2e/nodepool_autoscaling.go
+++ b/test/e2e/nodepool_autoscaling.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 )
@@ -96,7 +96,7 @@ var _ = Describe("Customer", func() {
 
 			By("verifying the cluster has default autoscaling parameters")
 			clusterResp, err := framework.GetHCPCluster(ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				tc.GetHCPClustersClientOrDie(ctx),
 				*resourceGroup.Name,
 				customerClusterName)
 			Expect(err).NotTo(HaveOccurred())
@@ -111,14 +111,13 @@ var _ = Describe("Customer", func() {
 			By("getting admin credentials for the cluster")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			nodePoolsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
+			nodePoolsClient := tc.GetNodePoolsClientOrDie(ctx)
 			kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -168,9 +167,9 @@ var _ = Describe("Customer", func() {
 					*resourceGroup.Name,
 					customerClusterName,
 					azNodePoolName,
-					hcpsdk20240610preview.NodePoolUpdate{
-						Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
-							AutoScaling: &hcpsdk20240610preview.NodePoolAutoScaling{
+					armredhatopenshifthcp.NodePoolUpdate{
+						Properties: &armredhatopenshifthcp.NodePoolPropertiesUpdate{
+							AutoScaling: &armredhatopenshifthcp.NodePoolAutoScaling{
 								Min: to.Ptr(azAutoscalingMin),
 								Max: to.Ptr(int32(4)),
 							},
@@ -260,7 +259,7 @@ var _ = Describe("Customer", func() {
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
-			clusterParams.Autoscaling = &hcpsdk20240610preview.ClusterAutoscalingProfile{
+			clusterParams.Autoscaling = &armredhatopenshifthcp.ClusterAutoscalingProfile{
 				MaxNodesTotal: to.Ptr(int32(3)), // Set low limit
 			}
 

--- a/test/e2e/nodepool_ephemeral_osdisk.go
+++ b/test/e2e/nodepool_ephemeral_osdisk.go
@@ -29,7 +29,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 
-	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -76,6 +76,7 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 			)
 
 			tc := framework.NewTestContext()
+			tc.SetHCPAPIVersionForTest(framework.HCPAPIVersion20251223)
 
 			if tc.UsePooledIdentities() {
 				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
@@ -116,7 +117,7 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 			nodePool := buildNodePoolWithDiskType(
 				nodePoolParams,
 				tc.Location(),
-				hcpsdk20251223preview.OsDiskTypeEphemeral,
+				armredhatopenshifthcp.OsDiskTypeEphemeral,
 				true,
 			)
 
@@ -150,7 +151,7 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 				}
 				Fail(fmt.Sprintf("DiskType field still not present in v20251223preview nodepool response as of %s deadline", timeBombDeadline.Format(time.RFC3339)))
 			}
-			Expect(*created.Properties.Platform.OSDisk.DiskType).To(Equal(hcpsdk20251223preview.OsDiskTypeEphemeral))
+			Expect(*created.Properties.Platform.OSDisk.DiskType).To(Equal(armredhatopenshifthcp.OsDiskTypeEphemeral))
 			Expect(created.Properties.AutoRepair).ToNot(BeNil())
 			Expect(*created.Properties.AutoRepair).To(BeTrue())
 
@@ -166,14 +167,13 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 			Expect(fetched.Properties.Platform).ToNot(BeNil())
 			Expect(fetched.Properties.Platform.OSDisk).ToNot(BeNil())
 			Expect(fetched.Properties.Platform.OSDisk.DiskType).ToNot(BeNil())
-			Expect(*fetched.Properties.Platform.OSDisk.DiskType).To(Equal(hcpsdk20251223preview.OsDiskTypeEphemeral))
+			Expect(*fetched.Properties.Platform.OSDisk.DiskType).To(Equal(armredhatopenshifthcp.OsDiskTypeEphemeral))
 			Expect(fetched.Properties.AutoRepair).ToNot(BeNil())
 			Expect(*fetched.Properties.AutoRepair).To(BeTrue())
 
 			By("getting credentials to verify cluster health")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,
@@ -208,23 +208,23 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 func buildNodePoolWithDiskType(
 	params framework.NodePoolParams,
 	location string,
-	diskType hcpsdk20251223preview.OsDiskType,
+	diskType armredhatopenshifthcp.OsDiskType,
 	autoRepair bool,
-) hcpsdk20251223preview.NodePool {
-	return hcpsdk20251223preview.NodePool{
+) armredhatopenshifthcp.NodePool {
+	return armredhatopenshifthcp.NodePool{
 		Location: to.Ptr(location),
-		Properties: &hcpsdk20251223preview.NodePoolProperties{
-			Version: &hcpsdk20251223preview.NodePoolVersionProfile{
+		Properties: &armredhatopenshifthcp.NodePoolProperties{
+			Version: &armredhatopenshifthcp.NodePoolVersionProfile{
 				ID:           to.Ptr(params.OpenshiftVersionId),
 				ChannelGroup: to.Ptr(params.ChannelGroup),
 			},
 			NodeDrainTimeoutMinutes: params.NodeDrainTimeoutMinutes,
 			Replicas:                to.Ptr(params.Replicas),
-			Platform: &hcpsdk20251223preview.NodePoolPlatformProfile{
+			Platform: &armredhatopenshifthcp.NodePoolPlatformProfile{
 				VMSize: to.Ptr(params.VMSize),
-				OSDisk: &hcpsdk20251223preview.OsDiskProfile{
+				OSDisk: &armredhatopenshifthcp.OsDiskProfile{
 					SizeGiB:                to.Ptr(params.OSDiskSizeGiB),
-					DiskStorageAccountType: to.Ptr(hcpsdk20251223preview.DiskStorageAccountType(params.DiskStorageAccountType)),
+					DiskStorageAccountType: to.Ptr(armredhatopenshifthcp.DiskStorageAccountType(params.DiskStorageAccountType)),
 					DiskType:               to.Ptr(diskType),
 				},
 			},

--- a/test/e2e/nodepool_get_test.go
+++ b/test/e2e/nodepool_get_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/integration"
 	"github.com/Azure/ARO-HCP/test/util/labels"
@@ -29,7 +29,7 @@ import (
 var _ = Describe("Get HCPOpenShiftCluster nodepool", func() {
 	var (
 		clusterEnv      *integration.Cluster
-		nodePoolOptions *hcpsdk20240610preview.NodePoolsClientGetOptions
+		nodePoolOptions *armredhatopenshifthcp.NodePoolsClientGetOptions
 		customerEnv     *integration.CustomerEnv
 		nodePools       *[]integration.Nodepool
 	)
@@ -49,7 +49,7 @@ var _ = Describe("Get HCPOpenShiftCluster nodepool", func() {
 				nps := *nodePools
 				for np := range nps {
 					By("Send get request for nodepool")
-					clusterNodePool, err := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient().Get(ctx, customerEnv.CustomerRGName, clusterEnv.Name, nps[np].Name, nodePoolOptions)
+					clusterNodePool, err := tc.GetNodePoolsClientOrDie(ctx).Get(ctx, customerEnv.CustomerRGName, clusterEnv.Name, nps[np].Name, nodePoolOptions)
 					Expect(err).To(BeNil())
 					Expect(clusterNodePool).ToNot(BeNil(), "nodepool GET response was nil for nodepool %s", nps[np].Name)
 					By("Check to see nodepool exists and is successfully provisioned")

--- a/test/e2e/nodepool_labels_taints.go
+++ b/test/e2e/nodepool_labels_taints.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -93,7 +93,6 @@ var _ = Describe("Customer", func() {
 			By("getting credentials")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,
@@ -112,23 +111,23 @@ var _ = Describe("Customer", func() {
 
 			nodePool := framework.BuildNodePoolFromParams(nodePoolParams, tc.Location())
 
-			nodePool.Properties.Labels = []*hcpsdk20240610preview.Label{
+			nodePool.Properties.Labels = []*armredhatopenshifthcp.Label{
 				{
 					Key:   to.Ptr("key1"),
 					Value: to.Ptr("value1"),
 				},
 			}
-			nodePool.Properties.Taints = []*hcpsdk20240610preview.Taint{
+			nodePool.Properties.Taints = []*armredhatopenshifthcp.Taint{
 				{
 					Key:    to.Ptr("key1"),
 					Value:  to.Ptr("value1"),
-					Effect: to.Ptr(hcpsdk20240610preview.EffectNoSchedule),
+					Effect: to.Ptr(armredhatopenshifthcp.EffectNoSchedule),
 				},
 			}
 
 			_, err = framework.CreateNodePoolAndWait(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+				tc.GetNodePoolsClientOrDie(ctx),
 				*resourceGroup.Name,
 				customerClusterName,
 				customerNodePoolName,
@@ -159,21 +158,21 @@ var _ = Describe("Customer", func() {
 
 			By("updating nodepool with new taints and scaling up")
 			taintReplicas := int32(3)
-			updateTaints := hcpsdk20240610preview.NodePoolUpdate{
-				Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
+			updateTaints := armredhatopenshifthcp.NodePoolUpdate{
+				Properties: &armredhatopenshifthcp.NodePoolPropertiesUpdate{
 					Replicas: to.Ptr(taintReplicas),
-					Taints: []*hcpsdk20240610preview.Taint{
+					Taints: []*armredhatopenshifthcp.Taint{
 						{
 							Key:    to.Ptr("key2"),
 							Value:  to.Ptr("value2"),
-							Effect: to.Ptr(hcpsdk20240610preview.EffectPreferNoSchedule),
+							Effect: to.Ptr(armredhatopenshifthcp.EffectPreferNoSchedule),
 						},
 					},
 				},
 			}
 
 			_, err = framework.UpdateNodePoolAndWait(ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+				tc.GetNodePoolsClientOrDie(ctx),
 				*resourceGroup.Name,
 				customerClusterName,
 				customerNodePoolName,
@@ -202,10 +201,10 @@ var _ = Describe("Customer", func() {
 
 			By("updating nodepool with a new label and scaling up")
 			finalReplicas := int32(4)
-			update := hcpsdk20240610preview.NodePoolUpdate{
-				Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
+			update := armredhatopenshifthcp.NodePoolUpdate{
+				Properties: &armredhatopenshifthcp.NodePoolPropertiesUpdate{
 					Replicas: to.Ptr(finalReplicas),
-					Labels: []*hcpsdk20240610preview.Label{
+					Labels: []*armredhatopenshifthcp.Label{
 						{
 							Key:   to.Ptr("key2"),
 							Value: to.Ptr("value2"),
@@ -215,7 +214,7 @@ var _ = Describe("Customer", func() {
 			}
 
 			_, err = framework.UpdateNodePoolAndWait(ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+				tc.GetNodePoolsClientOrDie(ctx),
 				*resourceGroup.Name,
 				customerClusterName,
 				customerNodePoolName,

--- a/test/e2e/nodepool_update_nodes.go
+++ b/test/e2e/nodepool_update_nodes.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -84,7 +84,6 @@ var _ = Describe("Customer", func() {
 			By("getting admin credentials for the cluster")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,
@@ -137,13 +136,13 @@ var _ = Describe("Customer", func() {
 
 			By("scaling up the nodepool replicas from 2 to 3 replicas")
 			mainNodeCount = 3
-			update := hcpsdk20240610preview.NodePoolUpdate{
-				Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
+			update := armredhatopenshifthcp.NodePoolUpdate{
+				Properties: &armredhatopenshifthcp.NodePoolPropertiesUpdate{
 					Replicas: to.Ptr(int32(mainNodeCount)),
 				},
 			}
 			scaleUpResp, err := framework.UpdateNodePoolAndWait(ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+				tc.GetNodePoolsClientOrDie(ctx),
 				*resourceGroup.Name,
 				customerClusterName,
 				customerNodePoolName,
@@ -160,12 +159,12 @@ var _ = Describe("Customer", func() {
 			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
 			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
 
-			nodePoolsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
+			nodePoolsClient := tc.GetNodePoolsClientOrDie(ctx)
 
 			By("scaling down the nodepool replicas from 3 to 2 replicas")
 			mainNodeCount = 2
-			update = hcpsdk20240610preview.NodePoolUpdate{
-				Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
+			update = armredhatopenshifthcp.NodePoolUpdate{
+				Properties: &armredhatopenshifthcp.NodePoolPropertiesUpdate{
 					Replicas: to.Ptr(int32(mainNodeCount)),
 				},
 			}
@@ -188,10 +187,10 @@ var _ = Describe("Customer", func() {
 			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
 
 			By("updating the one-replica nodepool replicas to 0 and enabling autoscaling with a PATCH")
-			update = hcpsdk20240610preview.NodePoolUpdate{
-				Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
+			update = armredhatopenshifthcp.NodePoolUpdate{
+				Properties: &armredhatopenshifthcp.NodePoolPropertiesUpdate{
 					Replicas: to.Ptr(int32(0)),
-					AutoScaling: &hcpsdk20240610preview.NodePoolAutoScaling{
+					AutoScaling: &armredhatopenshifthcp.NodePoolAutoScaling{
 						Min: to.Ptr(int32(2)),
 						Max: to.Ptr(int32(3)),
 					},

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/cincinnati"
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -152,7 +152,6 @@ var _ = Describe("Customer", func() {
 			By("getting admin credentials and lowest control plane version from OpenShift version history")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				clusterName,
 				10*time.Minute,
@@ -195,11 +194,11 @@ var _ = Describe("Customer", func() {
 
 			By(fmt.Sprintf("triggering nodepool upgrade to version %s and update replicas to 3", nodePoolDesiredVersion))
 			updateReplicas := 3
-			nodePoolsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
-			update := hcpsdk20240610preview.NodePoolUpdate{
-				Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
+			nodePoolsClient := tc.GetNodePoolsClientOrDie(ctx)
+			update := armredhatopenshifthcp.NodePoolUpdate{
+				Properties: &armredhatopenshifthcp.NodePoolPropertiesUpdate{
 					Replicas: ptr.To(int32(updateReplicas)),
-					Version: &hcpsdk20240610preview.NodePoolVersionProfile{
+					Version: &armredhatopenshifthcp.NodePoolVersionProfile{
 						ID:           to.Ptr(nodePoolDesiredVersion),
 						ChannelGroup: to.Ptr(channelGroup),
 					},

--- a/test/e2e/oidc_issuer_workload_identity.go
+++ b/test/e2e/oidc_issuer_workload_identity.go
@@ -216,7 +216,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("getting the cluster's OIDC issuer URL")
-			hcpClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			hcpClient := tc.GetHCPClustersClientOrDie(ctx)
 			clusterResp, err := hcpClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(clusterResp.Properties).NotTo(BeNil())
@@ -231,7 +231,6 @@ var _ = Describe("Customer", func() {
 			By("getting admin credentials")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				hcpClient,
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,

--- a/test/e2e/simple_negative_cases.go
+++ b/test/e2e/simple_negative_cases.go
@@ -30,7 +30,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
 	"github.com/Azure/ARO-HCP/internal/api"
-	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -82,12 +82,12 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			nodePoolClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
+			nodePoolClient := tc.GetNodePoolsClientOrDie(ctx)
 			var errs []error
 
 			// TEST CASE: ARO-22570
 			By("attempting to list clusters in a non-existent resource group")
-			clusterClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			clusterClient := tc.GetHCPClustersClientOrDie(ctx)
 			nonExistentRgName := "non-existent-rg"
 			clusterPager := clusterClient.NewListByResourceGroupPager(nonExistentRgName, nil)
 			_, err = clusterPager.NextPage(ctx)
@@ -112,7 +112,6 @@ var _ = Describe("Customer", func() {
 			By("getting credentials")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName,
 				10*time.Minute,
@@ -193,7 +192,7 @@ var _ = Describe("Customer", func() {
 				nodePool.Properties.Platform.AvailabilityZone = to.Ptr("2")
 				if nodePool.Properties.Platform.OSDisk != nil {
 					nodePool.Properties.Platform.OSDisk.SizeGiB = to.Ptr[int32](256)
-					nodePool.Properties.Platform.OSDisk.DiskStorageAccountType = to.Ptr(hcpsdk20240610preview.DiskStorageAccountTypePremiumLRS)
+					nodePool.Properties.Platform.OSDisk.DiskStorageAccountType = to.Ptr(armredhatopenshifthcp.DiskStorageAccountTypePremiumLRS)
 				}
 
 				_, err = nodePoolClient.BeginCreateOrUpdate(ctx, *resourceGroup.Name, clusterParams.ClusterName, nodePoolParams.NodePoolName, nodePool.NodePool, nil)
@@ -220,7 +219,7 @@ var _ = Describe("Customer", func() {
 								errs = append(errs, fmt.Errorf("osDisk.sizeGiB was modified despite immutable error"))
 							}
 
-							if platform.OSDisk.DiskStorageAccountType != nil && *platform.OSDisk.DiskStorageAccountType != hcpsdk20240610preview.DiskStorageAccountTypeStandardSSDLRS {
+							if platform.OSDisk.DiskStorageAccountType != nil && *platform.OSDisk.DiskStorageAccountType != armredhatopenshifthcp.DiskStorageAccountTypeStandardSSDLRS {
 								errs = append(errs, fmt.Errorf("osDisk.diskStorageAccountType was modified despite immutable error"))
 							}
 						}

--- a/test/util/framework/api_version.go
+++ b/test/util/framework/api_version.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const hcpAPIVersionEnvVar = "ARO_HCP_E2E_API_VERSION"
+
+type HCPAPIVersion string
+
+const (
+	HCPAPIVersion20240610 HCPAPIVersion = "v20240610preview"
+	HCPAPIVersion20251223 HCPAPIVersion = "v20251223preview"
+
+	DefaultHCPAPIVersion = HCPAPIVersion20240610
+)
+
+func ParseHCPAPIVersion(raw string) (HCPAPIVersion, error) {
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	switch normalized {
+	case "":
+		return DefaultHCPAPIVersion, nil
+	case "20240610", "v20240610", "20240610preview", string(HCPAPIVersion20240610):
+		return HCPAPIVersion20240610, nil
+	case "20251223", "v20251223", "20251223preview", string(HCPAPIVersion20251223):
+		return HCPAPIVersion20251223, nil
+	default:
+		return "", fmt.Errorf("invalid HCP API version %q, supported values: %s, %s", raw, HCPAPIVersion20240610, HCPAPIVersion20251223)
+	}
+}
+
+func configuredHCPAPIVersion() (HCPAPIVersion, error) {
+	return ParseHCPAPIVersion(os.Getenv(hcpAPIVersionEnvVar))
+}

--- a/test/util/framework/deployment_helper.go
+++ b/test/util/framework/deployment_helper.go
@@ -33,6 +33,27 @@ import (
 	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 )
 
+type CreateHCPClusterOptions struct {
+	APIVersion         HCPAPIVersion
+	ImageDigestMirrors []*hcpsdk20251223preview.ImageDigestMirror
+}
+
+func defaultCreateHCPClusterOptions(tc *perItOrDescribeTestContext) CreateHCPClusterOptions {
+	return CreateHCPClusterOptions{
+		APIVersion: tc.EffectiveHCPAPIVersion(),
+	}
+}
+
+type CreateNodePoolOptions struct {
+	APIVersion HCPAPIVersion
+}
+
+func defaultCreateNodePoolOptions(tc *perItOrDescribeTestContext) CreateNodePoolOptions {
+	return CreateNodePoolOptions{
+		APIVersion: tc.EffectiveHCPAPIVersion(),
+	}
+}
+
 func GetOutputValueString(deploymentInfo *armresources.DeploymentExtended, outputName string) (string, error) {
 	outputMap, ok := deploymentInfo.Properties.Outputs.(map[string]interface{})
 	if !ok {
@@ -328,9 +349,27 @@ func (tc *perItOrDescribeTestContext) CreateHCPClusterFromParam(
 	parameters ClusterParams,
 	timeout time.Duration,
 ) error {
+	return tc.CreateHCPClusterFromParamWithOptions(
+		ctx,
+		logger,
+		resourceGroupName,
+		parameters,
+		timeout,
+		defaultCreateHCPClusterOptions(tc),
+	)
+}
+
+func (tc *perItOrDescribeTestContext) CreateHCPClusterFromParamWithOptions(
+	ctx context.Context,
+	logger logr.Logger,
+	resourceGroupName string,
+	parameters ClusterParams,
+	timeout time.Duration,
+	options CreateHCPClusterOptions,
+) error {
 	if timeout > 0*time.Second {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during CreateHCPClusterFromParam for cluster %s in resource group %s", timeout.Minutes(), parameters.ClusterName, resourceGroupName))
+		ctx, cancel = context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during CreateHCPClusterFromParamWithOptions for cluster %s in resource group %s", timeout.Minutes(), parameters.ClusterName, resourceGroupName))
 		defer cancel()
 	}
 	clusterName := parameters.ClusterName
@@ -341,23 +380,58 @@ func (tc *perItOrDescribeTestContext) CreateHCPClusterFromParam(
 		tc.RecordTestStep(fmt.Sprintf("Deploy HCP cluster %s/%s", resourceGroupName, clusterName), startTime, finishTime)
 	}()
 
-	cluster := BuildHCPClusterFromParams(parameters, tc.Location())
-
-	if _, err := CreateHCPClusterAndWait(
-		ctx,
-		logger,
-		tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
-		resourceGroupName,
-		clusterName,
-		cluster,
-		timeout,
-	); err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return fmt.Errorf("failed to create HCP cluster %s, caused by: %w, error: %w", clusterName, context.Cause(ctx), err)
-		}
-		return fmt.Errorf("failed to create HCP cluster %s: %w", clusterName, err)
+	selectedVersion := options.APIVersion
+	if selectedVersion == "" {
+		selectedVersion = tc.EffectiveHCPAPIVersion()
 	}
-	return nil
+
+	switch selectedVersion {
+	case HCPAPIVersion20240610:
+		if len(options.ImageDigestMirrors) > 0 {
+			return fmt.Errorf("imageDigestMirrors is only supported with API version %s", HCPAPIVersion20251223)
+		}
+
+		cluster := BuildHCPClusterFromParams(parameters, tc.Location())
+		if _, err := CreateHCPClusterAndWait(
+			ctx,
+			logger,
+			newHCPClustersClient20240610Facade(tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()),
+			resourceGroupName,
+			clusterName,
+			cluster,
+			timeout,
+		); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				return fmt.Errorf("failed to create HCP cluster %s, caused by: %w, error: %w", clusterName, context.Cause(ctx), err)
+			}
+			return fmt.Errorf("failed to create HCP cluster %s: %w", clusterName, err)
+		}
+		return nil
+
+	case HCPAPIVersion20251223:
+		cluster, err := BuildHCPCluster20251223FromParams(parameters, tc.Location(), options.ImageDigestMirrors)
+		if err != nil {
+			return fmt.Errorf("failed to build HCP cluster %s: %w", clusterName, err)
+		}
+
+		if _, err := CreateHCPCluster20251223AndWait(
+			ctx,
+			logger,
+			tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+			resourceGroupName,
+			clusterName,
+			cluster,
+			timeout,
+		); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				return fmt.Errorf("failed to create HCP cluster %s, caused by: %w, error: %w", clusterName, context.Cause(ctx), err)
+			}
+			return fmt.Errorf("failed to create HCP cluster %s: %w", clusterName, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported HCP API version %q", selectedVersion)
+	}
 }
 
 func (tc *perItOrDescribeTestContext) CreateHCPCluster20251223FromParam(
@@ -368,39 +442,17 @@ func (tc *perItOrDescribeTestContext) CreateHCPCluster20251223FromParam(
 	imageDigestMirrors []*hcpsdk20251223preview.ImageDigestMirror,
 	timeout time.Duration,
 ) error {
-	if timeout > 0*time.Second {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during CreateHCPCluster20251223FromParam for cluster %s in resource group %s", timeout.Minutes(), parameters.ClusterName, resourceGroupName))
-		defer cancel()
-	}
-	clusterName := parameters.ClusterName
-
-	startTime := time.Now()
-	defer func() {
-		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Deploy HCP cluster %s/%s (v20251223preview)", resourceGroupName, clusterName), startTime, finishTime)
-	}()
-
-	cluster, err := BuildHCPCluster20251223FromParams(parameters, tc.Location(), imageDigestMirrors)
-	if err != nil {
-		return fmt.Errorf("failed to build HCP cluster %s: %w", clusterName, err)
-	}
-
-	if _, err := CreateHCPCluster20251223AndWait(
+	return tc.CreateHCPClusterFromParamWithOptions(
 		ctx,
 		logger,
-		tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 		resourceGroupName,
-		clusterName,
-		cluster,
+		parameters,
 		timeout,
-	); err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return fmt.Errorf("failed to create HCP cluster %s, caused by: %w, error: %w", clusterName, context.Cause(ctx), err)
-		}
-		return fmt.Errorf("failed to create HCP cluster %s: %w", clusterName, err)
-	}
-	return nil
+		CreateHCPClusterOptions{
+			APIVersion:         HCPAPIVersion20251223,
+			ImageDigestMirrors: imageDigestMirrors,
+		},
+	)
 }
 
 func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam(
@@ -411,6 +463,28 @@ func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam(
 	hcpClusterName string,
 	parameters NodePoolParams,
 	timeout time.Duration,
+) error {
+	return tc.CreateNodePoolFromParamWithOptions(
+		ctx,
+		logger,
+		resourceGroupName,
+		managedResourceGroupName,
+		hcpClusterName,
+		parameters,
+		timeout,
+		defaultCreateNodePoolOptions(tc),
+	)
+}
+
+func (tc *perItOrDescribeTestContext) CreateNodePoolFromParamWithOptions(
+	ctx context.Context,
+	logger logr.Logger,
+	resourceGroupName string,
+	managedResourceGroupName string,
+	hcpClusterName string,
+	parameters NodePoolParams,
+	timeout time.Duration,
+	options CreateNodePoolOptions,
 ) error {
 	nodePoolCtx, cancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during CreateNodePoolFromParam for node pool %s in resource group %s", timeout.Minutes(), parameters.NodePoolName, resourceGroupName))
 	defer cancel()
@@ -426,17 +500,43 @@ func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam(
 		return fmt.Errorf("nodePoolName parameter not found or empty")
 	}
 
-	nodePool := BuildNodePoolFromParams(parameters, tc.Location())
+	selectedVersion := options.APIVersion
+	if selectedVersion == "" {
+		selectedVersion = tc.EffectiveHCPAPIVersion()
+	}
 
-	if _, err := CreateNodePoolAndWait(
-		nodePoolCtx,
-		tc.Get20240610ClientFactoryOrDie(nodePoolCtx).NewNodePoolsClient(),
-		resourceGroupName,
-		hcpClusterName,
-		nodePoolName,
-		nodePool,
-		timeout,
-	); err != nil {
+	var err error
+	switch selectedVersion {
+	case HCPAPIVersion20240610:
+		nodePool := BuildNodePoolFromParams(parameters, tc.Location())
+		_, err = CreateNodePoolAndWait(
+			nodePoolCtx,
+			newNodePoolsClient20240610Facade(tc.Get20240610ClientFactoryOrDie(nodePoolCtx).NewNodePoolsClient()),
+			resourceGroupName,
+			hcpClusterName,
+			nodePoolName,
+			nodePool,
+			timeout,
+		)
+	case HCPAPIVersion20251223:
+		nodePool, buildErr := BuildNodePool20251223FromParams(parameters, tc.Location())
+		if buildErr != nil {
+			return fmt.Errorf("failed to build NodePool %s: %w", nodePoolName, buildErr)
+		}
+		_, err = CreateNodePoolAndWait20251223(
+			nodePoolCtx,
+			tc.Get20251223ClientFactoryOrDie(nodePoolCtx).NewNodePoolsClient(),
+			resourceGroupName,
+			hcpClusterName,
+			nodePoolName,
+			nodePool,
+			timeout,
+		)
+	default:
+		return fmt.Errorf("unsupported HCP API version %q", selectedVersion)
+	}
+
+	if err != nil {
 		// a separate context for console log download with its own timeout,
 		// to make sure logs are fetched even when the node pool deployment
 		// context is cancelled due to timeout

--- a/test/util/framework/hcp_client_facade.go
+++ b/test/util/framework/hcp_client_facade.go
@@ -1,0 +1,467 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+
+	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+)
+
+type HCPClustersListByResourceGroupPager interface {
+	More() bool
+	NextPage(ctx context.Context) (hcpsdk20240610preview.HcpOpenShiftClustersClientListByResourceGroupResponse, error)
+}
+
+type HCPClustersCreateOrUpdatePoller interface {
+	PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.HcpOpenShiftClustersClientCreateOrUpdateResponse, error)
+	Poll(ctx context.Context) (*http.Response, error)
+}
+
+type HCPClustersUpdatePoller interface {
+	PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.HcpOpenShiftClustersClientUpdateResponse, error)
+}
+
+type HCPClustersDeletePoller interface {
+	PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.HcpOpenShiftClustersClientDeleteResponse, error)
+}
+
+type HCPClustersRequestAdminCredentialPoller interface {
+	PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.HcpOpenShiftClustersClientRequestAdminCredentialResponse, error)
+}
+
+type HCPClustersClientFacade interface {
+	Get(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *hcpsdk20240610preview.HcpOpenShiftClustersClientGetOptions) (hcpsdk20240610preview.HcpOpenShiftClustersClientGetResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, resource hcpsdk20240610preview.HcpOpenShiftCluster, options *hcpsdk20240610preview.HcpOpenShiftClustersClientBeginCreateOrUpdateOptions) (HCPClustersCreateOrUpdatePoller, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, properties hcpsdk20240610preview.HcpOpenShiftClusterUpdate, options *hcpsdk20240610preview.HcpOpenShiftClustersClientBeginUpdateOptions) (HCPClustersUpdatePoller, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *hcpsdk20240610preview.HcpOpenShiftClustersClientBeginDeleteOptions) (HCPClustersDeletePoller, error)
+	BeginRequestAdminCredential(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *hcpsdk20240610preview.HcpOpenShiftClustersClientBeginRequestAdminCredentialOptions) (HCPClustersRequestAdminCredentialPoller, error)
+	NewListByResourceGroupPager(resourceGroupName string, options *hcpsdk20240610preview.HcpOpenShiftClustersClientListByResourceGroupOptions) HCPClustersListByResourceGroupPager
+}
+
+type NodePoolsCreateOrUpdatePoller interface {
+	PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.NodePoolsClientCreateOrUpdateResponse, error)
+}
+
+type NodePoolsUpdatePoller interface {
+	PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.NodePoolsClientUpdateResponse, error)
+}
+
+type NodePoolsDeletePoller interface {
+	PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.NodePoolsClientDeleteResponse, error)
+}
+
+type NodePoolsListByParentPager interface {
+	More() bool
+	NextPage(ctx context.Context) (hcpsdk20240610preview.NodePoolsClientListByParentResponse, error)
+}
+
+type NodePoolsClientFacade interface {
+	Get(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, nodePoolName string, options *hcpsdk20240610preview.NodePoolsClientGetOptions) (hcpsdk20240610preview.NodePoolsClientGetResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, nodePoolName string, resource hcpsdk20240610preview.NodePool, options *hcpsdk20240610preview.NodePoolsClientBeginCreateOrUpdateOptions) (NodePoolsCreateOrUpdatePoller, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, nodePoolName string, properties hcpsdk20240610preview.NodePoolUpdate, options *hcpsdk20240610preview.NodePoolsClientBeginUpdateOptions) (NodePoolsUpdatePoller, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, nodePoolName string, options *hcpsdk20240610preview.NodePoolsClientBeginDeleteOptions) (NodePoolsDeletePoller, error)
+	NewListByParentPager(resourceGroupName string, hcpOpenShiftClusterName string, options *hcpsdk20240610preview.NodePoolsClientListByParentOptions) NodePoolsListByParentPager
+}
+
+type hcpClustersClient20240610Adapter struct {
+	client *hcpsdk20240610preview.HcpOpenShiftClustersClient
+}
+
+func newHCPClustersClient20240610Facade(client *hcpsdk20240610preview.HcpOpenShiftClustersClient) HCPClustersClientFacade {
+	return &hcpClustersClient20240610Adapter{client: client}
+}
+
+func (a *hcpClustersClient20240610Adapter) Get(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *hcpsdk20240610preview.HcpOpenShiftClustersClientGetOptions) (hcpsdk20240610preview.HcpOpenShiftClustersClientGetResponse, error) {
+	return a.client.Get(ctx, resourceGroupName, hcpOpenShiftClusterName, options)
+}
+
+func (a *hcpClustersClient20240610Adapter) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, resource hcpsdk20240610preview.HcpOpenShiftCluster, options *hcpsdk20240610preview.HcpOpenShiftClustersClientBeginCreateOrUpdateOptions) (HCPClustersCreateOrUpdatePoller, error) {
+	return a.client.BeginCreateOrUpdate(ctx, resourceGroupName, hcpOpenShiftClusterName, resource, options)
+}
+
+func (a *hcpClustersClient20240610Adapter) BeginUpdate(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, properties hcpsdk20240610preview.HcpOpenShiftClusterUpdate, options *hcpsdk20240610preview.HcpOpenShiftClustersClientBeginUpdateOptions) (HCPClustersUpdatePoller, error) {
+	return a.client.BeginUpdate(ctx, resourceGroupName, hcpOpenShiftClusterName, properties, options)
+}
+
+func (a *hcpClustersClient20240610Adapter) BeginDelete(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *hcpsdk20240610preview.HcpOpenShiftClustersClientBeginDeleteOptions) (HCPClustersDeletePoller, error) {
+	return a.client.BeginDelete(ctx, resourceGroupName, hcpOpenShiftClusterName, options)
+}
+
+func (a *hcpClustersClient20240610Adapter) BeginRequestAdminCredential(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *hcpsdk20240610preview.HcpOpenShiftClustersClientBeginRequestAdminCredentialOptions) (HCPClustersRequestAdminCredentialPoller, error) {
+	return a.client.BeginRequestAdminCredential(ctx, resourceGroupName, hcpOpenShiftClusterName, options)
+}
+
+func (a *hcpClustersClient20240610Adapter) NewListByResourceGroupPager(resourceGroupName string, options *hcpsdk20240610preview.HcpOpenShiftClustersClientListByResourceGroupOptions) HCPClustersListByResourceGroupPager {
+	return &hcpClustersPager20240610Adapter{pager: a.client.NewListByResourceGroupPager(resourceGroupName, options)}
+}
+
+type hcpClustersPager20240610Adapter struct {
+	pager *runtime.Pager[hcpsdk20240610preview.HcpOpenShiftClustersClientListByResourceGroupResponse]
+}
+
+func (a *hcpClustersPager20240610Adapter) More() bool { return a.pager.More() }
+func (a *hcpClustersPager20240610Adapter) NextPage(ctx context.Context) (hcpsdk20240610preview.HcpOpenShiftClustersClientListByResourceGroupResponse, error) {
+	return a.pager.NextPage(ctx)
+}
+
+type hcpClustersClient20251223Adapter struct {
+	client *hcpsdk20251223preview.HcpOpenShiftClustersClient
+}
+
+func (a *hcpClustersClient20251223Adapter) Get(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, _ *hcpsdk20240610preview.HcpOpenShiftClustersClientGetOptions) (hcpsdk20240610preview.HcpOpenShiftClustersClientGetResponse, error) {
+	resp, err := a.client.Get(ctx, resourceGroupName, hcpOpenShiftClusterName, nil)
+	if err != nil {
+		return hcpsdk20240610preview.HcpOpenShiftClustersClientGetResponse{}, err
+	}
+	converted, err := convertPermissive[hcpsdk20240610preview.HcpOpenShiftClustersClientGetResponse](resp)
+	if err != nil {
+		return hcpsdk20240610preview.HcpOpenShiftClustersClientGetResponse{}, err
+	}
+	return *converted, nil
+}
+
+func (a *hcpClustersClient20251223Adapter) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, resource hcpsdk20240610preview.HcpOpenShiftCluster, options *hcpsdk20240610preview.HcpOpenShiftClustersClientBeginCreateOrUpdateOptions) (HCPClustersCreateOrUpdatePoller, error) {
+	resource51223, err := convertPermissive[hcpsdk20251223preview.HcpOpenShiftCluster](resource)
+	if err != nil {
+		return nil, err
+	}
+	var options51223 *hcpsdk20251223preview.HcpOpenShiftClustersClientBeginCreateOrUpdateOptions
+	if options != nil {
+		options51223 = &hcpsdk20251223preview.HcpOpenShiftClustersClientBeginCreateOrUpdateOptions{ResumeToken: options.ResumeToken}
+	}
+	poller, err := a.client.BeginCreateOrUpdate(ctx, resourceGroupName, hcpOpenShiftClusterName, *resource51223, options51223)
+	if err != nil {
+		return nil, err
+	}
+	return &hcpClustersCreateOrUpdatePoller20251223Adapter{poller: poller}, nil
+}
+
+func (a *hcpClustersClient20251223Adapter) BeginUpdate(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, properties hcpsdk20240610preview.HcpOpenShiftClusterUpdate, options *hcpsdk20240610preview.HcpOpenShiftClustersClientBeginUpdateOptions) (HCPClustersUpdatePoller, error) {
+	update51223, err := convertPermissive[hcpsdk20251223preview.HcpOpenShiftClusterUpdate](properties)
+	if err != nil {
+		return nil, err
+	}
+	var options51223 *hcpsdk20251223preview.HcpOpenShiftClustersClientBeginUpdateOptions
+	if options != nil {
+		options51223 = &hcpsdk20251223preview.HcpOpenShiftClustersClientBeginUpdateOptions{ResumeToken: options.ResumeToken}
+	}
+	poller, err := a.client.BeginUpdate(ctx, resourceGroupName, hcpOpenShiftClusterName, *update51223, options51223)
+	if err != nil {
+		return nil, err
+	}
+	return &hcpClustersUpdatePoller20251223Adapter{poller: poller}, nil
+}
+
+func (a *hcpClustersClient20251223Adapter) BeginDelete(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *hcpsdk20240610preview.HcpOpenShiftClustersClientBeginDeleteOptions) (HCPClustersDeletePoller, error) {
+	var options51223 *hcpsdk20251223preview.HcpOpenShiftClustersClientBeginDeleteOptions
+	if options != nil {
+		options51223 = &hcpsdk20251223preview.HcpOpenShiftClustersClientBeginDeleteOptions{ResumeToken: options.ResumeToken}
+	}
+	poller, err := a.client.BeginDelete(ctx, resourceGroupName, hcpOpenShiftClusterName, options51223)
+	if err != nil {
+		return nil, err
+	}
+	return &hcpClustersDeletePoller20251223Adapter{poller: poller}, nil
+}
+
+func (a *hcpClustersClient20251223Adapter) BeginRequestAdminCredential(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, options *hcpsdk20240610preview.HcpOpenShiftClustersClientBeginRequestAdminCredentialOptions) (HCPClustersRequestAdminCredentialPoller, error) {
+	var options51223 *hcpsdk20251223preview.HcpOpenShiftClustersClientBeginRequestAdminCredentialOptions
+	if options != nil {
+		options51223 = &hcpsdk20251223preview.HcpOpenShiftClustersClientBeginRequestAdminCredentialOptions{
+			ResumeToken: options.ResumeToken,
+		}
+	}
+	poller, err := a.client.BeginRequestAdminCredential(ctx, resourceGroupName, hcpOpenShiftClusterName, options51223)
+	if err != nil {
+		return nil, err
+	}
+	return &hcpClustersRequestAdminCredentialPoller20251223Adapter{poller: poller}, nil
+}
+
+func (a *hcpClustersClient20251223Adapter) NewListByResourceGroupPager(resourceGroupName string, _ *hcpsdk20240610preview.HcpOpenShiftClustersClientListByResourceGroupOptions) HCPClustersListByResourceGroupPager {
+	return &hcpClustersPager20251223Adapter{pager: a.client.NewListByResourceGroupPager(resourceGroupName, nil)}
+}
+
+type hcpClustersPager20251223Adapter struct {
+	pager *runtime.Pager[hcpsdk20251223preview.HcpOpenShiftClustersClientListByResourceGroupResponse]
+}
+
+func (a *hcpClustersPager20251223Adapter) More() bool { return a.pager.More() }
+func (a *hcpClustersPager20251223Adapter) NextPage(ctx context.Context) (hcpsdk20240610preview.HcpOpenShiftClustersClientListByResourceGroupResponse, error) {
+	resp, err := a.pager.NextPage(ctx)
+	if err != nil {
+		return hcpsdk20240610preview.HcpOpenShiftClustersClientListByResourceGroupResponse{}, err
+	}
+	converted, err := convertPermissive[hcpsdk20240610preview.HcpOpenShiftClustersClientListByResourceGroupResponse](resp)
+	if err != nil {
+		return hcpsdk20240610preview.HcpOpenShiftClustersClientListByResourceGroupResponse{}, err
+	}
+	return *converted, nil
+}
+
+type hcpClustersCreateOrUpdatePoller20251223Adapter struct {
+	poller *runtime.Poller[hcpsdk20251223preview.HcpOpenShiftClustersClientCreateOrUpdateResponse]
+}
+
+func (a *hcpClustersCreateOrUpdatePoller20251223Adapter) PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.HcpOpenShiftClustersClientCreateOrUpdateResponse, error) {
+	resp, err := a.poller.PollUntilDone(ctx, options)
+	if err != nil {
+		return hcpsdk20240610preview.HcpOpenShiftClustersClientCreateOrUpdateResponse{}, err
+	}
+	converted, err := convertPermissive[hcpsdk20240610preview.HcpOpenShiftClustersClientCreateOrUpdateResponse](resp)
+	if err != nil {
+		return hcpsdk20240610preview.HcpOpenShiftClustersClientCreateOrUpdateResponse{}, err
+	}
+	return *converted, nil
+}
+
+func (a *hcpClustersCreateOrUpdatePoller20251223Adapter) Poll(ctx context.Context) (*http.Response, error) {
+	return a.poller.Poll(ctx)
+}
+
+type hcpClustersUpdatePoller20251223Adapter struct {
+	poller *runtime.Poller[hcpsdk20251223preview.HcpOpenShiftClustersClientUpdateResponse]
+}
+
+func (a *hcpClustersUpdatePoller20251223Adapter) PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.HcpOpenShiftClustersClientUpdateResponse, error) {
+	resp, err := a.poller.PollUntilDone(ctx, options)
+	if err != nil {
+		return hcpsdk20240610preview.HcpOpenShiftClustersClientUpdateResponse{}, err
+	}
+	converted, err := convertPermissive[hcpsdk20240610preview.HcpOpenShiftClustersClientUpdateResponse](resp)
+	if err != nil {
+		return hcpsdk20240610preview.HcpOpenShiftClustersClientUpdateResponse{}, err
+	}
+	return *converted, nil
+}
+
+type hcpClustersDeletePoller20251223Adapter struct {
+	poller *runtime.Poller[hcpsdk20251223preview.HcpOpenShiftClustersClientDeleteResponse]
+}
+
+func (a *hcpClustersDeletePoller20251223Adapter) PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.HcpOpenShiftClustersClientDeleteResponse, error) {
+	resp, err := a.poller.PollUntilDone(ctx, options)
+	if err != nil {
+		return hcpsdk20240610preview.HcpOpenShiftClustersClientDeleteResponse{}, err
+	}
+	converted, err := convertPermissive[hcpsdk20240610preview.HcpOpenShiftClustersClientDeleteResponse](resp)
+	if err != nil {
+		return hcpsdk20240610preview.HcpOpenShiftClustersClientDeleteResponse{}, err
+	}
+	return *converted, nil
+}
+
+type hcpClustersRequestAdminCredentialPoller20251223Adapter struct {
+	poller *runtime.Poller[hcpsdk20251223preview.HcpOpenShiftClustersClientRequestAdminCredentialResponse]
+}
+
+func (a *hcpClustersRequestAdminCredentialPoller20251223Adapter) PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.HcpOpenShiftClustersClientRequestAdminCredentialResponse, error) {
+	resp, err := a.poller.PollUntilDone(ctx, options)
+	if err != nil {
+		return hcpsdk20240610preview.HcpOpenShiftClustersClientRequestAdminCredentialResponse{}, err
+	}
+	converted, err := convertPermissive[hcpsdk20240610preview.HcpOpenShiftClustersClientRequestAdminCredentialResponse](resp)
+	if err != nil {
+		return hcpsdk20240610preview.HcpOpenShiftClustersClientRequestAdminCredentialResponse{}, err
+	}
+	return *converted, nil
+}
+
+type nodePoolsClient20240610Adapter struct {
+	client *hcpsdk20240610preview.NodePoolsClient
+}
+
+func newNodePoolsClient20240610Facade(client *hcpsdk20240610preview.NodePoolsClient) NodePoolsClientFacade {
+	return &nodePoolsClient20240610Adapter{client: client}
+}
+
+func (a *nodePoolsClient20240610Adapter) Get(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, nodePoolName string, options *hcpsdk20240610preview.NodePoolsClientGetOptions) (hcpsdk20240610preview.NodePoolsClientGetResponse, error) {
+	return a.client.Get(ctx, resourceGroupName, hcpOpenShiftClusterName, nodePoolName, options)
+}
+
+func (a *nodePoolsClient20240610Adapter) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, nodePoolName string, resource hcpsdk20240610preview.NodePool, options *hcpsdk20240610preview.NodePoolsClientBeginCreateOrUpdateOptions) (NodePoolsCreateOrUpdatePoller, error) {
+	return a.client.BeginCreateOrUpdate(ctx, resourceGroupName, hcpOpenShiftClusterName, nodePoolName, resource, options)
+}
+
+func (a *nodePoolsClient20240610Adapter) BeginUpdate(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, nodePoolName string, properties hcpsdk20240610preview.NodePoolUpdate, options *hcpsdk20240610preview.NodePoolsClientBeginUpdateOptions) (NodePoolsUpdatePoller, error) {
+	return a.client.BeginUpdate(ctx, resourceGroupName, hcpOpenShiftClusterName, nodePoolName, properties, options)
+}
+
+func (a *nodePoolsClient20240610Adapter) BeginDelete(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, nodePoolName string, options *hcpsdk20240610preview.NodePoolsClientBeginDeleteOptions) (NodePoolsDeletePoller, error) {
+	return a.client.BeginDelete(ctx, resourceGroupName, hcpOpenShiftClusterName, nodePoolName, options)
+}
+
+func (a *nodePoolsClient20240610Adapter) NewListByParentPager(resourceGroupName string, hcpOpenShiftClusterName string, options *hcpsdk20240610preview.NodePoolsClientListByParentOptions) NodePoolsListByParentPager {
+	return &nodePoolsListByParentPager20240610Adapter{pager: a.client.NewListByParentPager(resourceGroupName, hcpOpenShiftClusterName, options)}
+}
+
+type nodePoolsListByParentPager20240610Adapter struct {
+	pager *runtime.Pager[hcpsdk20240610preview.NodePoolsClientListByParentResponse]
+}
+
+func (a *nodePoolsListByParentPager20240610Adapter) More() bool { return a.pager.More() }
+func (a *nodePoolsListByParentPager20240610Adapter) NextPage(ctx context.Context) (hcpsdk20240610preview.NodePoolsClientListByParentResponse, error) {
+	return a.pager.NextPage(ctx)
+}
+
+type nodePoolsClient20251223Adapter struct {
+	client *hcpsdk20251223preview.NodePoolsClient
+}
+
+func (a *nodePoolsClient20251223Adapter) Get(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, nodePoolName string, _ *hcpsdk20240610preview.NodePoolsClientGetOptions) (hcpsdk20240610preview.NodePoolsClientGetResponse, error) {
+	resp, err := a.client.Get(ctx, resourceGroupName, hcpOpenShiftClusterName, nodePoolName, nil)
+	if err != nil {
+		return hcpsdk20240610preview.NodePoolsClientGetResponse{}, err
+	}
+	converted, err := convertPermissive[hcpsdk20240610preview.NodePoolsClientGetResponse](resp)
+	if err != nil {
+		return hcpsdk20240610preview.NodePoolsClientGetResponse{}, err
+	}
+	return *converted, nil
+}
+
+func (a *nodePoolsClient20251223Adapter) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, nodePoolName string, resource hcpsdk20240610preview.NodePool, options *hcpsdk20240610preview.NodePoolsClientBeginCreateOrUpdateOptions) (NodePoolsCreateOrUpdatePoller, error) {
+	resource51223, err := convertPermissive[hcpsdk20251223preview.NodePool](resource)
+	if err != nil {
+		return nil, err
+	}
+	var options51223 *hcpsdk20251223preview.NodePoolsClientBeginCreateOrUpdateOptions
+	if options != nil {
+		options51223 = &hcpsdk20251223preview.NodePoolsClientBeginCreateOrUpdateOptions{ResumeToken: options.ResumeToken}
+	}
+	poller, err := a.client.BeginCreateOrUpdate(ctx, resourceGroupName, hcpOpenShiftClusterName, nodePoolName, *resource51223, options51223)
+	if err != nil {
+		return nil, err
+	}
+	return &nodePoolsCreateOrUpdatePoller20251223Adapter{poller: poller}, nil
+}
+
+func (a *nodePoolsClient20251223Adapter) BeginUpdate(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, nodePoolName string, properties hcpsdk20240610preview.NodePoolUpdate, options *hcpsdk20240610preview.NodePoolsClientBeginUpdateOptions) (NodePoolsUpdatePoller, error) {
+	update51223, err := convertPermissive[hcpsdk20251223preview.NodePoolUpdate](properties)
+	if err != nil {
+		return nil, err
+	}
+	var options51223 *hcpsdk20251223preview.NodePoolsClientBeginUpdateOptions
+	if options != nil {
+		options51223 = &hcpsdk20251223preview.NodePoolsClientBeginUpdateOptions{ResumeToken: options.ResumeToken}
+	}
+	poller, err := a.client.BeginUpdate(ctx, resourceGroupName, hcpOpenShiftClusterName, nodePoolName, *update51223, options51223)
+	if err != nil {
+		return nil, err
+	}
+	return &nodePoolsUpdatePoller20251223Adapter{poller: poller}, nil
+}
+
+func (a *nodePoolsClient20251223Adapter) BeginDelete(ctx context.Context, resourceGroupName string, hcpOpenShiftClusterName string, nodePoolName string, options *hcpsdk20240610preview.NodePoolsClientBeginDeleteOptions) (NodePoolsDeletePoller, error) {
+	var options51223 *hcpsdk20251223preview.NodePoolsClientBeginDeleteOptions
+	if options != nil {
+		options51223 = &hcpsdk20251223preview.NodePoolsClientBeginDeleteOptions{ResumeToken: options.ResumeToken}
+	}
+	poller, err := a.client.BeginDelete(ctx, resourceGroupName, hcpOpenShiftClusterName, nodePoolName, options51223)
+	if err != nil {
+		return nil, err
+	}
+	return &nodePoolsDeletePoller20251223Adapter{poller: poller}, nil
+}
+
+func (a *nodePoolsClient20251223Adapter) NewListByParentPager(resourceGroupName string, hcpOpenShiftClusterName string, _ *hcpsdk20240610preview.NodePoolsClientListByParentOptions) NodePoolsListByParentPager {
+	return &nodePoolsListByParentPager20251223Adapter{pager: a.client.NewListByParentPager(resourceGroupName, hcpOpenShiftClusterName, nil)}
+}
+
+type nodePoolsListByParentPager20251223Adapter struct {
+	pager *runtime.Pager[hcpsdk20251223preview.NodePoolsClientListByParentResponse]
+}
+
+func (a *nodePoolsListByParentPager20251223Adapter) More() bool { return a.pager.More() }
+func (a *nodePoolsListByParentPager20251223Adapter) NextPage(ctx context.Context) (hcpsdk20240610preview.NodePoolsClientListByParentResponse, error) {
+	resp, err := a.pager.NextPage(ctx)
+	if err != nil {
+		return hcpsdk20240610preview.NodePoolsClientListByParentResponse{}, err
+	}
+	converted, err := convertPermissive[hcpsdk20240610preview.NodePoolsClientListByParentResponse](resp)
+	if err != nil {
+		return hcpsdk20240610preview.NodePoolsClientListByParentResponse{}, err
+	}
+	return *converted, nil
+}
+
+type nodePoolsCreateOrUpdatePoller20251223Adapter struct {
+	poller *runtime.Poller[hcpsdk20251223preview.NodePoolsClientCreateOrUpdateResponse]
+}
+
+func (a *nodePoolsCreateOrUpdatePoller20251223Adapter) PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.NodePoolsClientCreateOrUpdateResponse, error) {
+	resp, err := a.poller.PollUntilDone(ctx, options)
+	if err != nil {
+		return hcpsdk20240610preview.NodePoolsClientCreateOrUpdateResponse{}, err
+	}
+	converted, err := convertPermissive[hcpsdk20240610preview.NodePoolsClientCreateOrUpdateResponse](resp)
+	if err != nil {
+		return hcpsdk20240610preview.NodePoolsClientCreateOrUpdateResponse{}, err
+	}
+	return *converted, nil
+}
+
+type nodePoolsUpdatePoller20251223Adapter struct {
+	poller *runtime.Poller[hcpsdk20251223preview.NodePoolsClientUpdateResponse]
+}
+
+func (a *nodePoolsUpdatePoller20251223Adapter) PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.NodePoolsClientUpdateResponse, error) {
+	resp, err := a.poller.PollUntilDone(ctx, options)
+	if err != nil {
+		return hcpsdk20240610preview.NodePoolsClientUpdateResponse{}, err
+	}
+	converted, err := convertPermissive[hcpsdk20240610preview.NodePoolsClientUpdateResponse](resp)
+	if err != nil {
+		return hcpsdk20240610preview.NodePoolsClientUpdateResponse{}, err
+	}
+	return *converted, nil
+}
+
+type nodePoolsDeletePoller20251223Adapter struct {
+	poller *runtime.Poller[hcpsdk20251223preview.NodePoolsClientDeleteResponse]
+}
+
+func (a *nodePoolsDeletePoller20251223Adapter) PollUntilDone(ctx context.Context, options *runtime.PollUntilDoneOptions) (hcpsdk20240610preview.NodePoolsClientDeleteResponse, error) {
+	resp, err := a.poller.PollUntilDone(ctx, options)
+	if err != nil {
+		return hcpsdk20240610preview.NodePoolsClientDeleteResponse{}, err
+	}
+	converted, err := convertPermissive[hcpsdk20240610preview.NodePoolsClientDeleteResponse](resp)
+	if err != nil {
+		return hcpsdk20240610preview.NodePoolsClientDeleteResponse{}, err
+	}
+	return *converted, nil
+}
+
+func convertPermissive[T any](src any) (*T, error) {
+	b, err := json.Marshal(src)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal for type conversion: %w", err)
+	}
+	var dst T
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	if err = decoder.Decode(&dst); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal for type conversion: %w", err)
+	}
+	return &dst, nil
+}

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -80,7 +80,7 @@ func checkOperationResult(expectModel, resultModel any) error {
 	return nil
 }
 
-func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster(
+func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster20240610(
 	ctx context.Context,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
 	resourceGroupName string,
@@ -129,7 +129,84 @@ func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster(
 	}
 }
 
-func (tc *perItOrDescribeTestContext) RevokeCredentialsAndWait(
+func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster20251223(
+	ctx context.Context,
+	hcpClient *hcpsdk20251223preview.HcpOpenShiftClustersClient,
+	resourceGroupName string,
+	hcpClusterName string,
+	timeout time.Duration,
+) (*rest.Config, error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during GetAdminRESTConfigForHCPCluster20251223 for cluster %s in resource group %s", timeout.Minutes(), hcpClusterName, resourceGroupName))
+	defer cancel()
+
+	startTime := time.Now()
+	defer func() {
+		finishTime := time.Now()
+		tc.RecordTestStep("Collect admin credentials for cluster", startTime, finishTime)
+	}()
+
+	adminCredentialRequestPoller, err := hcpClient.BeginRequestAdminCredential(
+		ctx,
+		resourceGroupName,
+		hcpClusterName,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start credential request: %w", err)
+	}
+
+	operationResult, err := adminCredentialRequestPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
+		Frequency: StandardPollInterval,
+	})
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("failed waiting for hcpCluster=%q in resourcegroup=%q to finish getting creds, caused by: %w, error: %w", hcpClusterName, resourceGroupName, context.Cause(ctx), err)
+		}
+		return nil, fmt.Errorf("failed waiting for hcpCluster=%q in resourcegroup=%q to finish getting creds: %w", hcpClusterName, resourceGroupName, err)
+	}
+
+	switch m := any(operationResult).(type) {
+	case hcpsdk20251223preview.HcpOpenShiftClustersClientRequestAdminCredentialResponse:
+		return clientcmd.BuildConfigFromKubeconfigGetter("", func() (*clientcmdapi.Config, error) {
+			if m.Kubeconfig == nil {
+				return nil, fmt.Errorf("kubeconfig content is nil")
+			}
+			return clientcmd.Load([]byte(*m.Kubeconfig))
+		})
+	default:
+		return nil, fmt.Errorf("unknown type %T", m)
+	}
+}
+
+func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster(
+	ctx context.Context,
+	resourceGroupName string,
+	hcpClusterName string,
+	timeout time.Duration,
+) (*rest.Config, error) {
+	switch tc.EffectiveHCPAPIVersion() {
+	case HCPAPIVersion20240610:
+		return tc.GetAdminRESTConfigForHCPCluster20240610(
+			ctx,
+			tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+			resourceGroupName,
+			hcpClusterName,
+			timeout,
+		)
+	case HCPAPIVersion20251223:
+		return tc.GetAdminRESTConfigForHCPCluster20251223(
+			ctx,
+			tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+			resourceGroupName,
+			hcpClusterName,
+			timeout,
+		)
+	default:
+		return nil, fmt.Errorf("unsupported HCP API version %q", tc.EffectiveHCPAPIVersion())
+	}
+}
+
+func (tc *perItOrDescribeTestContext) RevokeCredentialsAndWait20240610(
 	ctx context.Context,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
 	resourceGroupName string,
@@ -168,10 +245,77 @@ func (tc *perItOrDescribeTestContext) RevokeCredentialsAndWait(
 	}
 }
 
+func (tc *perItOrDescribeTestContext) RevokeCredentialsAndWait20251223(
+	ctx context.Context,
+	hcpClient *hcpsdk20251223preview.HcpOpenShiftClustersClient,
+	resourceGroupName string,
+	hcpClusterName string,
+	timeout time.Duration,
+) error {
+	ctx, cancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during RevokeCredentialsAndWait20251223 for cluster %s in resource group %s", timeout.Minutes(), hcpClusterName, resourceGroupName))
+	defer cancel()
+
+	startTime := time.Now()
+	defer func() {
+		finishTime := time.Now()
+		tc.RecordTestStep("Collect revoke admin credentials for cluster", startTime, finishTime)
+	}()
+
+	poller, err := hcpClient.BeginRevokeCredentials(ctx, resourceGroupName, hcpClusterName, nil)
+	if err != nil {
+		return fmt.Errorf("failed to start credential revocation for hcpCluster=%q in resourcegroup=%q: %w", hcpClusterName, resourceGroupName, err)
+	}
+
+	operationResult, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
+		Frequency: StandardPollInterval,
+	})
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("failed waiting for hcpCluster=%q in resourcegroup=%q to finish revoking creds, caused by: %w, error: %w", hcpClusterName, resourceGroupName, context.Cause(ctx), err)
+		}
+		return fmt.Errorf("failed waiting for hcpCluster=%q in resourcegroup=%q to finish revoking creds: %w", hcpClusterName, resourceGroupName, err)
+	}
+
+	switch m := any(operationResult).(type) {
+	case hcpsdk20251223preview.HcpOpenShiftClustersClientRevokeCredentialsResponse:
+		return nil
+	default:
+		return fmt.Errorf("unknown type %T", m)
+	}
+}
+
+func (tc *perItOrDescribeTestContext) RevokeCredentialsAndWait(
+	ctx context.Context,
+	resourceGroupName string,
+	hcpClusterName string,
+	timeout time.Duration,
+) error {
+	switch tc.EffectiveHCPAPIVersion() {
+	case HCPAPIVersion20240610:
+		return tc.RevokeCredentialsAndWait20240610(
+			ctx,
+			tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+			resourceGroupName,
+			hcpClusterName,
+			timeout,
+		)
+	case HCPAPIVersion20251223:
+		return tc.RevokeCredentialsAndWait20251223(
+			ctx,
+			tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+			resourceGroupName,
+			hcpClusterName,
+			timeout,
+		)
+	default:
+		return fmt.Errorf("unsupported HCP API version %q", tc.EffectiveHCPAPIVersion())
+	}
+}
+
 // DeleteHCPCluster deletes an hcp cluster and waits for the operation to complete
 func DeleteHCPCluster(
 	ctx context.Context,
-	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
+	hcpClient HCPClustersClientFacade,
 	resourceGroupName string,
 	hcpClusterName string,
 	timeout time.Duration,
@@ -216,7 +360,7 @@ func DeleteHCPCluster(
 // waitForHCPClusterDeletion polls GET on the cluster until it returns 404 (deleted).
 func waitForHCPClusterDeletion(
 	ctx context.Context,
-	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
+	hcpClient HCPClustersClientFacade,
 	resourceGroupName string,
 	hcpClusterName string,
 ) error {
@@ -247,7 +391,7 @@ func waitForHCPClusterDeletion(
 // Transient 500, 409, and CS state conflict 400 errors are retried automatically with exponential backoff.
 func UpdateHCPCluster(
 	ctx context.Context,
-	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
+	hcpClient HCPClustersClientFacade,
 	resourceGroupName string,
 	hcpClusterName string,
 	update hcpsdk20240610preview.HcpOpenShiftClusterUpdate,
@@ -419,17 +563,59 @@ func UpdateHCPCluster20251223(
 // GetHCPCluster fetches an HCP cluster
 func GetHCPCluster(
 	ctx context.Context,
-	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
+	hcpClient HCPClustersClientFacade,
 	resourceGroupName string,
 	hcpClusterName string,
 ) (hcpsdk20240610preview.HcpOpenShiftClustersClientGetResponse, error) {
 	return hcpClient.Get(ctx, resourceGroupName, hcpClusterName, nil)
 }
 
+func (tc *perItOrDescribeTestContext) GetClusterKeyVaultVisibility(
+	ctx context.Context,
+	resourceGroupName string,
+	hcpClusterName string,
+) (*string, error) {
+	switch tc.EffectiveHCPAPIVersion() {
+	case HCPAPIVersion20240610:
+		_, err := GetHCPCluster(
+			ctx,
+			tc.GetHCPClustersClientOrDie(ctx),
+			resourceGroupName,
+			hcpClusterName,
+		)
+		if err != nil {
+			return nil, err
+		}
+		// Visibility is not modeled in v20240610preview.
+		return nil, nil
+	case HCPAPIVersion20251223:
+		cluster, err := tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().Get(
+			ctx,
+			resourceGroupName,
+			hcpClusterName,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if cluster.Properties == nil ||
+			cluster.Properties.Etcd == nil ||
+			cluster.Properties.Etcd.DataEncryption == nil ||
+			cluster.Properties.Etcd.DataEncryption.CustomerManaged == nil ||
+			cluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms == nil ||
+			cluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.Visibility == nil {
+			return nil, nil
+		}
+		return to.Ptr(string(*cluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.Visibility)), nil
+	default:
+		return nil, fmt.Errorf("unsupported HCP API version %q", tc.EffectiveHCPAPIVersion())
+	}
+}
+
 // DeleteAllHCPClusters deletes all Clusters within a resource group and waits
 func DeleteAllHCPClusters(
 	ctx context.Context,
-	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
+	hcpClient HCPClustersClientFacade,
 	resourceGroupName string,
 	timeout time.Duration,
 ) error {
@@ -491,7 +677,7 @@ func (e *NonConformingClustersError) Error() string {
 // DeleteNodePool deletes a nodepool and waits for the operation to complete
 func DeleteNodePool(
 	ctx context.Context,
-	nodePoolsClient *hcpsdk20240610preview.NodePoolsClient,
+	nodePoolsClient NodePoolsClientFacade,
 	resourceGroupName string,
 	hcpClusterName string,
 	nodePoolName string,
@@ -540,7 +726,7 @@ func DeleteNodePool(
 // waitForNodePoolDeletion polls GET on the nodepool until it returns 404 (deleted).
 func waitForNodePoolDeletion(
 	ctx context.Context,
-	nodePoolsClient *hcpsdk20240610preview.NodePoolsClient,
+	nodePoolsClient NodePoolsClientFacade,
 	resourceGroupName string,
 	hcpClusterName string,
 	nodePoolName string,
@@ -571,7 +757,7 @@ func waitForNodePoolDeletion(
 // GetNodePool fetches a nodepool resource
 func GetNodePool(
 	ctx context.Context,
-	nodePoolsClient *hcpsdk20240610preview.NodePoolsClient,
+	nodePoolsClient NodePoolsClientFacade,
 	resourceGroupName string,
 	hcpClusterName string,
 	nodePoolName string,
@@ -583,7 +769,7 @@ func GetNodePool(
 // within the provided timeout. It returns the final update response or an error.
 func UpdateNodePoolAndWait(
 	ctx context.Context,
-	nodePoolsClient *hcpsdk20240610preview.NodePoolsClient,
+	nodePoolsClient NodePoolsClientFacade,
 	resourceGroupName string,
 	hcpClusterName string,
 	nodePoolName string,
@@ -808,12 +994,12 @@ func CreateTestDockerConfigSecret(host, username, password, email, secretName, n
 func BeginCreateHCPCluster(
 	ctx context.Context,
 	logger logr.Logger,
-	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
+	hcpClient HCPClustersClientFacade,
 	resourceGroupName string,
 	hcpClusterName string,
 	clusterParams ClusterParams,
 	location string,
-) (*runtime.Poller[hcpsdk20240610preview.HcpOpenShiftClustersClientCreateOrUpdateResponse], error) {
+) (HCPClustersCreateOrUpdatePoller, error) {
 	cluster := BuildHCPClusterFromParams(clusterParams, location)
 	logger.Info("Starting HCP cluster creation", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName)
 	poller, err := hcpClient.BeginCreateOrUpdate(ctx, resourceGroupName, hcpClusterName, cluster, nil)
@@ -828,7 +1014,7 @@ func BeginCreateHCPCluster(
 func CreateHCPClusterAndWait(
 	ctx context.Context,
 	logger logr.Logger,
-	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
+	hcpClient HCPClustersClientFacade,
 	resourceGroupName string,
 	hcpClusterName string,
 	cluster hcpsdk20240610preview.HcpOpenShiftCluster,
@@ -949,7 +1135,7 @@ func BuildHCPClusterFromParams(
 
 func CreateNodePoolAndWait(
 	ctx context.Context,
-	nodePoolsClient *hcpsdk20240610preview.NodePoolsClient,
+	nodePoolsClient NodePoolsClientFacade,
 	resourceGroupName string,
 	hcpClusterName string,
 	nodePoolName string,
@@ -1028,6 +1214,18 @@ func BuildNodePoolFromParams(
 	}
 
 	return nodePool
+}
+
+func BuildNodePool20251223FromParams(
+	parameters NodePoolParams,
+	location string,
+) (hcpsdk20251223preview.NodePool, error) {
+	oldNodePool := BuildNodePoolFromParams(parameters, location)
+	converted, err := convertViaJSON[hcpsdk20251223preview.NodePool](oldNodePool)
+	if err != nil {
+		return hcpsdk20251223preview.NodePool{}, err
+	}
+	return *converted, nil
 }
 
 // Helper to generate SSH key pair
@@ -1258,7 +1456,7 @@ func ValidateNodePoolDiskStorageAccountType(
 	hcpClusterName string,
 	nodePoolName string,
 ) error {
-	nodePoolResp, err := GetNodePool(ctx, nodePoolsClient, resourceGroupName, hcpClusterName, nodePoolName)
+	nodePoolResp, err := GetNodePool(ctx, newNodePoolsClient20240610Facade(nodePoolsClient), resourceGroupName, hcpClusterName, nodePoolName)
 	if err != nil {
 		return fmt.Errorf("failed to get nodepool %s: %w", nodePoolName, err)
 	}
@@ -1292,6 +1490,58 @@ func ValidateNodePoolDiskStorageAccountType(
 	}
 
 	return nil
+}
+
+func (tc *perItOrDescribeTestContext) ValidateNodePoolDiskStorageAccountType(
+	ctx context.Context,
+	resourceGroupName string,
+	hcpClusterName string,
+	nodePoolName string,
+) error {
+	switch tc.EffectiveHCPAPIVersion() {
+	case HCPAPIVersion20240610:
+		return ValidateNodePoolDiskStorageAccountType(
+			ctx,
+			tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+			resourceGroupName,
+			hcpClusterName,
+			nodePoolName,
+		)
+	case HCPAPIVersion20251223:
+		nodePool, err := GetNodePool20251223(
+			ctx,
+			tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+			resourceGroupName,
+			hcpClusterName,
+			nodePoolName,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to get nodepool %s: %w", nodePoolName, err)
+		}
+
+		if nodePool.Properties == nil {
+			return fmt.Errorf("nodepool %s has no properties", nodePoolName)
+		}
+		if nodePool.Properties.Platform == nil {
+			return fmt.Errorf("nodepool %s has no platform configuration", nodePoolName)
+		}
+		if nodePool.Properties.Platform.OSDisk == nil {
+			return fmt.Errorf("nodepool %s has no OS disk configuration", nodePoolName)
+		}
+		if nodePool.Properties.Platform.OSDisk.DiskStorageAccountType == nil {
+			return fmt.Errorf("nodepool %s has no DiskStorageAccountType set", nodePoolName)
+		}
+
+		expectedDiskType := "StandardSSD_LRS"
+		actualDiskType := string(*nodePool.Properties.Platform.OSDisk.DiskStorageAccountType)
+		if actualDiskType != expectedDiskType {
+			return fmt.Errorf("nodepool %s has incorrect DiskStorageAccountType: expected %s (framework default), got %s",
+				nodePoolName, expectedDiskType, actualDiskType)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported HCP API version %q", tc.EffectiveHCPAPIVersion())
+	}
 }
 
 func HasNodeLabel(nodes []corev1.Node, key, value string, expectedCount ...int) bool {

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -57,6 +57,7 @@ type perBinaryInvocationTestContext struct {
 	skipCleanup              bool
 	pooledIdentities         bool
 	compressTimingMetadata   bool
+	hcpAPIVersion            HCPAPIVersion
 
 	contextLock       sync.RWMutex
 	subscriptionID    string
@@ -92,6 +93,11 @@ var azureRetryOptions = policy.RetryOptions{
 // AZURE_CLIENT_SECRET
 func invocationContext() *perBinaryInvocationTestContext {
 	initializeOnce.Do(func() {
+		hcpAPIVersion, err := configuredHCPAPIVersion()
+		if err != nil {
+			panic(err)
+		}
+
 		invocationContextInstance = &perBinaryInvocationTestContext{
 			artifactDir:              artifactDir(),
 			sharedDir:                SharedDir(),
@@ -107,6 +113,7 @@ func invocationContext() *perBinaryInvocationTestContext {
 			skipCleanup:              skipCleanup(),
 			pooledIdentities:         pooledIdentities(),
 			compressTimingMetadata:   compressTimingMetadata(),
+			hcpAPIVersion:            hcpAPIVersion,
 			defaultTransport:         defaultHTTPTransport(),
 		}
 	})
@@ -277,6 +284,10 @@ func (tc *perBinaryInvocationTestContext) Location() string {
 
 func (tc *perBinaryInvocationTestContext) UsePooledIdentities() bool {
 	return tc.pooledIdentities
+}
+
+func (tc *perBinaryInvocationTestContext) HCPAPIVersion() HCPAPIVersion {
+	return tc.hcpAPIVersion
 }
 
 func (tc *perBinaryInvocationTestContext) getLeasedIdentityPoolState() (*leasedIdentityPoolState, error) {

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -70,6 +70,7 @@ type perItOrDescribeTestContext struct {
 	armSubscriptionsClientFactory *armsubscriptions.ClientFactory
 	armNetworkClientFactory       *armnetwork.ClientFactory
 	graphClient                   *graphutil.Client
+	hcpAPIVersionOverride         *HCPAPIVersion
 
 	LogDirPath       string
 	azureLogFile     *os.File
@@ -498,7 +499,7 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 
 	var nonConformantErr error
 	ginkgo.GinkgoLogr.Info("deleting all hcp clusters in resource group", "resourceGroup", resourceGroupName)
-	if err := DeleteAllHCPClusters(ctx, hcpClientFactory.NewHcpOpenShiftClustersClient(), resourceGroupName, timeout); err != nil {
+	if err := DeleteAllHCPClusters(ctx, newHCPClustersClient20240610Facade(hcpClientFactory.NewHcpOpenShiftClustersClient()), resourceGroupName, timeout); err != nil {
 		if errors.Is(err, &NonConformingClustersError{}) {
 			nonConformantErr = err
 		} else if isResourceGroupNotFoundError(err) {
@@ -696,6 +697,40 @@ func (tc *perItOrDescribeTestContext) GetARMComputeClientFactoryOrDie(ctx contex
 
 func (tc *perItOrDescribeTestContext) Get20240610ClientFactoryOrDie(ctx context.Context) *hcpsdk20240610preview.ClientFactory {
 	return Must(tc.Get20240610ClientFactory(ctx))
+}
+
+// GetHCPClustersClientOrDie returns a version-routed facade for HCP cluster operations.
+func (tc *perItOrDescribeTestContext) GetHCPClustersClientOrDie(ctx context.Context) HCPClustersClientFacade {
+	switch tc.EffectiveHCPAPIVersion() {
+	case HCPAPIVersion20240610:
+		return &hcpClustersClient20240610Adapter{client: tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()}
+	case HCPAPIVersion20251223:
+		return &hcpClustersClient20251223Adapter{client: tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()}
+	default:
+		panic(fmt.Errorf("unsupported HCP API version %q", tc.EffectiveHCPAPIVersion()))
+	}
+}
+
+// GetNodePoolsClientOrDie returns a version-routed facade for node pool operations.
+func (tc *perItOrDescribeTestContext) GetNodePoolsClientOrDie(ctx context.Context) NodePoolsClientFacade {
+	switch tc.EffectiveHCPAPIVersion() {
+	case HCPAPIVersion20240610:
+		return &nodePoolsClient20240610Adapter{client: tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()}
+	case HCPAPIVersion20251223:
+		return &nodePoolsClient20251223Adapter{client: tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient()}
+	default:
+		panic(fmt.Errorf("unsupported HCP API version %q", tc.EffectiveHCPAPIVersion()))
+	}
+}
+
+// GetExternalAuthsClientOrDie returns an external auths client for framework helpers.
+func (tc *perItOrDescribeTestContext) GetExternalAuthsClientOrDie(ctx context.Context) *hcpsdk20240610preview.ExternalAuthsClient {
+	return tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient()
+}
+
+// GetHCPVersionsClientOrDie returns an HCP versions client for framework helpers.
+func (tc *perItOrDescribeTestContext) GetHCPVersionsClientOrDie(ctx context.Context) *hcpsdk20240610preview.HcpOpenShiftVersionsClient {
+	return tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftVersionsClient()
 }
 
 func (tc *perItOrDescribeTestContext) GetARMSubscriptionsClientFactory() (*armsubscriptions.ClientFactory, error) {
@@ -1088,6 +1123,27 @@ func (tc *perItOrDescribeTestContext) AzureCredential() (azcore.TokenCredential,
 
 func (tc *perItOrDescribeTestContext) TenantID() string {
 	return tc.perBinaryInvocationTestContext.tenantID
+}
+
+func (tc *perItOrDescribeTestContext) SetHCPAPIVersionForTest(version HCPAPIVersion) {
+	tc.contextLock.Lock()
+	defer tc.contextLock.Unlock()
+	tc.hcpAPIVersionOverride = &version
+}
+
+func (tc *perItOrDescribeTestContext) ResetHCPAPIVersionOverride() {
+	tc.contextLock.Lock()
+	defer tc.contextLock.Unlock()
+	tc.hcpAPIVersionOverride = nil
+}
+
+func (tc *perItOrDescribeTestContext) EffectiveHCPAPIVersion() HCPAPIVersion {
+	tc.contextLock.RLock()
+	defer tc.contextLock.RUnlock()
+	if tc.hcpAPIVersionOverride != nil {
+		return *tc.hcpAPIVersionOverride
+	}
+	return tc.perBinaryInvocationTestContext.HCPAPIVersion()
 }
 
 func (tc *perItOrDescribeTestContext) recordDeploymentOperationsUnlocked(resourceGroup, deployment string, operations []timing.Operation) {


### PR DESCRIPTION

https://redhat.atlassian.net/browse/ARO-27211

### What

- Added API version abstraction in framework
- The default API version is the oldest one (20240610). It can be configured using `ARO_HCP_E2E_API_VERSION` environment variable, or specifically for one test with `tc.SetHCPAPIVersionForTest(framework.HCPAPIVersion*)`
- Refactored cluster and node pool creation routing
- Added facade for cluster and node pool clients
- Added version-agnostic helpers for admin credential/revoke  helpers, nodepool disk-type validations and KeyVault visibility checks


### Why

- Decouple tests from SDK version churn: tests no longer need to hardcode which API client/helper to use for common operations.
- Centralize version selection: one place (env or test context) controls API version behavior.
- Safer migration path: wrappers preserve compatibility while enabling gradual cleanup.
- Cleaner test code: fewer low-level SDK calls in tests; framework owns version routing.
- Future-ready: adding a new API version mostly becomes framework wiring, not mass test rewrites.

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
