### PR TITLE
fix(e2e): retry subscription lookup with exponential backoff (AROSLSRE-884)

### DIFF
--- a/test/util/framework/resourcegroup_helper.go
+++ b/test/util/framework/resourcegroup_helper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/onsi/ginkgo/v2"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -34,20 +35,52 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 )
 
+var subscriptionLookupBackoff = wait.Backoff{
+	Steps:    4,
+	Duration: 15 * time.Second,
+	Factor:   2.0,
+	Jitter:   0.1,
+}
+
 func GetSubscriptionID(ctx context.Context, subscriptionClient *armsubscriptions.Client, subscriptionName string) (string, error) {
-	pager := subscriptionClient.NewListPager(nil)
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return "", err
+	var subscriptionID string
+	attempt := 0
+
+	err := wait.ExponentialBackoffWithContext(ctx, subscriptionLookupBackoff, func(ctx context.Context) (bool, error) {
+		attempt++
+		if attempt > 1 {
+			ginkgo.GinkgoLogr.Info("Retrying subscription lookup",
+				"subscription", subscriptionName,
+				"attempt", attempt)
 		}
-		for _, sub := range page.Value {
-			if *sub.DisplayName == subscriptionName {
-				return *sub.SubscriptionID, nil
+
+		pager := subscriptionClient.NewListPager(nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				ginkgo.GinkgoLogr.Info("Subscription list API error, will retry",
+					"error", err,
+					"attempt", attempt)
+				return false, nil
+			}
+			for _, sub := range page.Value {
+				if *sub.DisplayName == subscriptionName {
+					subscriptionID = *sub.SubscriptionID
+					return true, nil
+				}
 			}
 		}
+
+		ginkgo.GinkgoLogr.Info("Subscription not found in list, will retry",
+			"subscription", subscriptionName,
+			"attempt", attempt)
+		return false, nil
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("subscription with name '%s' not found after %d attempts: %w", subscriptionName, attempt, err)
 	}
-	return "", fmt.Errorf("subscription with name '%s' not found", subscriptionName)
+	return subscriptionID, nil
 }
 
 // CreateResourceGroup creates a resource group

--- a/test/util/framework/resourcegroup_helper.go
+++ b/test/util/framework/resourcegroup_helper.go
@@ -36,7 +36,7 @@ import (
 )
 
 var subscriptionLookupBackoff = wait.Backoff{
-	Steps:    4,
+	Steps:    5,
 	Duration: 15 * time.Second,
 	Factor:   2.0,
 	Jitter:   0.1,
@@ -81,7 +81,7 @@ func GetSubscriptionID(ctx context.Context, subscriptionClient *armsubscriptions
 
 	if err != nil {
 		if lastErr != nil {
-			return "", fmt.Errorf("subscription lookup for '%s' failed after %d attempts (last API error: %v): %w", subscriptionName, attempt, lastErr, err)
+			return "", fmt.Errorf("subscription lookup for '%s' failed after %d attempts (last API error: %w): %w", subscriptionName, attempt, lastErr, err)
 		}
 		return "", fmt.Errorf("subscription with name '%s' not found after %d attempts: %w", subscriptionName, attempt, err)
 	}

--- a/test/util/framework/resourcegroup_helper.go
+++ b/test/util/framework/resourcegroup_helper.go
@@ -44,6 +44,7 @@ var subscriptionLookupBackoff = wait.Backoff{
 
 func GetSubscriptionID(ctx context.Context, subscriptionClient *armsubscriptions.Client, subscriptionName string) (string, error) {
 	var subscriptionID string
+	var lastErr error
 	attempt := 0
 
 	err := wait.ExponentialBackoffWithContext(ctx, subscriptionLookupBackoff, func(ctx context.Context) (bool, error) {
@@ -58,6 +59,7 @@ func GetSubscriptionID(ctx context.Context, subscriptionClient *armsubscriptions
 		for pager.More() {
 			page, err := pager.NextPage(ctx)
 			if err != nil {
+				lastErr = err
 				ginkgo.GinkgoLogr.Info("Subscription list API error, will retry",
 					"error", err,
 					"attempt", attempt)
@@ -78,6 +80,9 @@ func GetSubscriptionID(ctx context.Context, subscriptionClient *armsubscriptions
 	})
 
 	if err != nil {
+		if lastErr != nil {
+			return "", fmt.Errorf("subscription lookup for '%s' failed after %d attempts (last API error: %v): %w", subscriptionName, attempt, lastErr, err)
+		}
 		return "", fmt.Errorf("subscription with name '%s' not found after %d attempts: %w", subscriptionName, attempt, err)
 	}
 	return subscriptionID, nil


### PR DESCRIPTION
[AROSLSRE-884](https://redhat.atlassian.net/browse/AROSLSRE-884)

### What

Add exponential backoff retry to `GetSubscriptionID` in the E2E test framework. Retries up to 4 times (15s, 30s, 60s, 120s) on both API errors and subscription-not-found, with structured logging on each attempt.

### Why

Starting ~15:00 UTC on 2026-05-18, all Prow E2E tests that create resource groups are panicking with `subscription with name '...' not found`. This affects both dev (PR e2e-parallel) and INT (branch e2e-integration). The root cause is external (Azure credential/RBAC change), but `GetSubscriptionID` fails immediately on a single attempt, making the framework fragile to transient subscription visibility issues.

### Testing

No new tests. The retry uses the same `wait.ExponentialBackoffWithContext` pattern established in [`hcp_helper.go:262`](https://github.com/Azure/ARO-HCP/blob/main/test/util/framework/hcp_helper.go#L262) for `UpdateHCPCluster`. Verified with `go build` and `make lint`.

### Special notes for your reviewer

This is a mitigation, not a fix for the underlying credential/RBAC issue. The Prow service principal needs to be checked separately.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge