### PR TITLE
fix: match credential refresher alert + dashboard with metric

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -1409,13 +1409,40 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
         }
         annotations: {
           correlationId: 'ClusterCredentialExpired/{{ $labels.cluster }}'
-          description: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} have expired.'
-          info: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} have expired.'
+          description: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} expired.'
+          info: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} expired.'
           runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
-          summary: 'Customer cluster credential has expired'
-          title: 'Customer cluster credential has expired'
+          summary: 'Customer cluster credential expired'
+          title: 'Customer cluster credential expired'
         }
-        expression: 'increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="0"}[30m]) > 0'
+        expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="0"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="-90"}[30m])) > 0'
+        for: 'PT5M'
+        severity: 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'ClusterCredentialNotRenewable'
+        enabled: true
+        labels: {
+          severity: 'critical'
+        }
+        annotations: {
+          correlationId: 'ClusterCredentialNotRenewable/{{ $labels.cluster }}'
+          description: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} are no longer renewable.'
+          info: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} are no longer renewable.'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
+          summary: 'Customer cluster credential is no longer renewable'
+          title: 'Customer cluster credential is no longer renewable'
+        }
+        expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="-90"}[30m])) > 0'
         for: 'PT5M'
         severity: 3
       }

--- a/observability/alerts/msi-credential-refresher-prometheusRule.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule.yaml
@@ -19,12 +19,22 @@ spec:
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
         correlationId: 'ClusterCredentialExpiringSoon/{{ $labels.cluster }}'
     - alert: ClusterCredentialExpired
-      expr: increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="0"}[30m]) > 0
+      expr: sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="0"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="-90"}[30m])) > 0
       for: 5m
       labels:
         severity: critical
       annotations:
-        description: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} have expired.'
-        summary: 'Customer cluster credential has expired'
+        description: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} expired.'
+        summary: 'Customer cluster credential expired'
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
         correlationId: 'ClusterCredentialExpired/{{ $labels.cluster }}'
+    - alert: ClusterCredentialNotRenewable
+      expr: sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="-90"}[30m])) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} are no longer renewable.'
+        summary: 'Customer cluster credential is no longer renewable'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
+        correlationId: 'ClusterCredentialNotRenewable/{{ $labels.cluster }}'

--- a/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
@@ -37,9 +37,38 @@ tests:
     exp_alerts: []
 - interval: 1m
   input_series:
-  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="0"}'
-    # Credential has expired - observations in the 0 bucket are increasing
+  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="-90"}'
+    # Credential is non-renewable - observations in the -90 bucket are increasing
     values: '0+1x35'
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: ClusterCredentialNotRenewable
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        cluster: test-cluster
+      exp_annotations:
+        description: 'Credential(s) for customer cluster monitored by test-cluster are no longer renewable.'
+        summary: 'Customer cluster credential is no longer renewable'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
+        correlationId: 'ClusterCredentialNotRenewable/test-cluster'
+- interval: 1m
+  input_series:
+  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="-90"}'
+    # No increase - no non-renewable credentials
+    values: '0x35'
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: ClusterCredentialNotRenewable
+    exp_alerts: []
+- interval: 1m
+  input_series:
+  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="0"}'
+    # Credentials have expired (in le="0" bucket) but are not yet non-renewable (le="-90" unchanged)
+    values: '0+1x35'
+  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="-90"}'
+    # No increase - not yet non-renewable, so subtraction yields > 0
+    values: '0x35'
   alert_rule_test:
   - eval_time: 35m
     alertname: ClusterCredentialExpired
@@ -47,12 +76,23 @@ tests:
     - exp_labels:
         severity: critical
         cluster: test-cluster
-        le: "0"
       exp_annotations:
-        description: 'Credential(s) for customer cluster monitored by test-cluster have expired.'
-        summary: 'Customer cluster credential has expired'
+        description: 'Credential(s) for customer cluster monitored by test-cluster expired.'
+        summary: 'Customer cluster credential expired'
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
         correlationId: 'ClusterCredentialExpired/test-cluster'
+- interval: 1m
+  input_series:
+  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="0"}'
+    # le="0" increases at the same rate as le="-90" - all expired credentials are also non-renewable
+    values: '0+1x35'
+  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="-90"}'
+    # Same increase as le="0" - subtraction yields 0, no alert
+    values: '0+1x35'
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: ClusterCredentialExpired
+    exp_alerts: []
 - interval: 1m
   input_series:
   - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="0"}'

--- a/observability/grafana-dashboards/msi-credential-refresher/msi-credential-refresher.json
+++ b/observability/grafana-dashboards/msi-credential-refresher/msi-credential-refresher.json
@@ -11,21 +11,7 @@
         "defaults": {
           "custom": {
             "axisLabel": "Number of Credentials"
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": { "text": "<0" },
-                "3": { "text": "0-3" },
-                "7": { "text": "4-7" },
-                "14": { "text": "8-14" },
-                "30": { "text": "15-30" },
-                "60": { "text": "31-60" },
-                "Infinity": { "text": ">60" }
-              },
-              "type": "value"
-            }
-          ]
+          }
         },
         "overrides": [
           {
@@ -37,6 +23,48 @@
               {
                 "id": "custom.axisLabel",
                 "value": "Days until Expiration"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "-90": {
+                        "text": "<-90",
+                        "index": 0
+                      },
+                      "0": {
+                        "text": "-90-0",
+                        "index": 1
+                      },
+                      "3": {
+                        "text": "1-3",
+                        "index": 2
+                      },
+                      "7": {
+                        "text": "4-7",
+                        "index": 3
+                      },
+                      "14": {
+                        "text": "8-14",
+                        "index": 4
+                      },
+                      "30": {
+                        "text": "15-30",
+                        "index": 5
+                      },
+                      "60": {
+                        "text": "31-60",
+                        "index": 6
+                      },
+                      "Infinity": {
+                        "text": ">60",
+                        "index": 7
+                      }
+                    }
+                  }
+                ]
               }
             ]
           }
@@ -65,7 +93,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(credential_refresher_days_until_msi_credential_expiration_bucket[60m]) * 600",
+          "expr": "sum by (le) (rate(credential_refresher_days_until_msi_credential_expiration_bucket[60m])) * 600",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -88,6 +116,17 @@
           }
         },
         {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "fieldName": "le",
+                "destinationType": "number"
+              }
+            ]
+          }
+        },
+        {
           "id": "sortBy",
           "options": {
             "sort": [
@@ -96,6 +135,21 @@
                 "desc": false
               }
             ]
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Count",
+            "mode": "window",
+            "replaceFields": true,
+            "window": {
+              "field": "Count",
+              "size": 1,
+              "sizeMode": "window",
+              "windowAlignment": "trailing",
+              "function": "delta"
+            }
           }
         }
       ],

--- a/observability/observability-msft.yaml
+++ b/observability/observability-msft.yaml
@@ -75,6 +75,7 @@ prometheusRules:
     alerts:
     - ClusterCredentialExpiringSoon
     - ClusterCredentialExpired
+    - ClusterCredentialNotRenewable
   outputReplacements:
   - from: 'job="kube-scheduler"'
     to: 'job="controlplane-kube-scheduler"'


### PR DESCRIPTION
[ARO-27144](https://redhat.atlassian.net/browse/ARO-27144?atlOrigin=eyJpIjoiM2E3OTVhMWE4MTQyNDYwZDg2OWQ2MzBhMjI0MDNmMjEiLCJwIjoiaiJ9)

### What

Adjust alert and graph thresholds to match credential_refresher_days_until_msi_credential_expiration_bucket metric with new <-90 bucket

### Why

The credential expires from the customer perspective 90 days before it can't be renewed. The metric was recently updated to reflect that. Also updating the dashboard so it calculates the difference between the buckets rather that the cumulative number in each bucket.

### Testing

Alert unit tests updated and passed. Manually uploaded the new grafana dashboard in int to confirm it looks good.

### Special notes for your reviewer

<img width="952" height="308" alt="image" src="https://github.com/user-attachments/assets/c74505c5-bab6-4a4a-9773-e5e531a03be3" />


### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
