### PR TITLE
fix: changing sub name to fix e2e

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1649,7 +1649,7 @@ clouds:
           # MC
           mgmt:
             subscription:
-              key: ARO HCP E2E Infrastructure (EA Subscription)
+              key: ARO HCP E2E Service Clusters (EA Subscription)
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"
@@ -1674,7 +1674,7 @@ clouds:
           # SVC
           svc:
             subscription:
-              key: ARO HCP E2E Infrastructure (EA Subscription)
+              key: ARO HCP E2E Service Clusters (EA Subscription)
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -655,7 +655,7 @@ mgmt:
     - '*.hcp.osadev.cloud'
     - '*.hcpsvc.osadev.cloud'
     displayName: Azure Red Hat OpenShift HCP - West US 3 - MGMT - 1
-    key: ARO HCP E2E Infrastructure (EA Subscription)
+    key: ARO HCP E2E Service Clusters (EA Subscription)
     providers:
       Microsoft.Compute:
         features:
@@ -974,7 +974,7 @@ svc:
     certificateDomains:
     - '*.hcpsvc.osadev.cloud'
     displayName: Azure Red Hat OpenShift HCP - West US 3 - SVC
-    key: ARO HCP E2E Infrastructure (EA Subscription)
+    key: ARO HCP E2E Service Clusters (EA Subscription)
     providers:
       Microsoft.Compute:
         features:


### PR DESCRIPTION
[<!-- Link to Jira issue -->](https://redhat.atlassian.net/browse/AROSLSRE-884)

### What

changing sub name in config for e2e svc and mgmt clusters to match the new name in azure

### Why

someone changed the subscription name and because we use names instead of ID's for some reason, e2e is blocked.

### Testing

e2e

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
