### PR TITLE
fix: add wait-for-db init container to maestro server (AROSLSRE-887)

### DIFF
--- a/maestro/server/deploy/templates/maestro.deployment.yaml
+++ b/maestro/server/deploy/templates/maestro.deployment.yaml
@@ -61,18 +61,18 @@ spec:
         - /bin/sh
         - -c
         - |
-          set -euo pipefail
+          set -eu
           DB_HOST=$(cat /secrets/db/db.host)
           DB_PORT=$(cat /secrets/db/db.port)
           DB_USER=$(cat /secrets/db/db.user)
-          TIMEOUT=300
+          TIMEOUT=180
           ELAPSED=0
           until /usr/bin/pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -q; do
             if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
               echo "PostgreSQL not ready after ${TIMEOUT}s, giving up"
               exit 1
             fi
-            echo "Waiting for postgres at $DB_HOST:$DB_PORT (${ELAPSED}s/${TIMEOUT}s)..."
+            echo "waiting for postgres at $DB_HOST:$DB_PORT (${ELAPSED}s/${TIMEOUT}s)..."
             sleep 5
             ELAPSED=$((ELAPSED + 5))
           done

--- a/maestro/server/deploy/templates/maestro.deployment.yaml
+++ b/maestro/server/deploy/templates/maestro.deployment.yaml
@@ -53,6 +53,33 @@ spec:
           volumeAttributes:
             secretProviderClass: "maestro"
       initContainers:
+      {{- if not .Values.database.azureDb }}
+      - name: wait-for-db
+        image: '{{ .Values.database.containerizedDbImage }}'
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          DB_HOST=$(cat /secrets/db/db.host)
+          DB_PORT=$(cat /secrets/db/db.port)
+          DB_USER=$(cat /secrets/db/db.user)
+          TIMEOUT=300
+          ELAPSED=0
+          until /usr/bin/pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -q; do
+            if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+              echo "PostgreSQL not ready after ${TIMEOUT}s, giving up"
+              exit 1
+            fi
+            echo "Waiting for postgres at $DB_HOST:$DB_PORT (${ELAPSED}s/${TIMEOUT}s)..."
+            sleep 5
+            ELAPSED=$((ELAPSED + 5))
+          done
+        volumeMounts:
+        - name: db
+          mountPath: /secrets/db
+      {{- end }}
       - name: maestro-server-migration
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
         imagePullPolicy: IfNotPresent

--- a/maestro/server/pipeline.yaml
+++ b/maestro/server/pipeline.yaml
@@ -71,6 +71,7 @@ resourceGroups:
   - name: deploy
     aksCluster: '{{ .svc.aks.name }}'
     action: Helm
+    timeout: 10m
     releaseName: 'maestro-server'
     releaseNamespace: '{{ .maestro.server.k8s.namespace }}'
     chartDir: ./deploy


### PR DESCRIPTION
[AROSLSRE-887](https://redhat.atlassian.net/browse/AROSLSRE-887)

### What

Add a `wait-for-db` init container to the maestro server deployment that polls postgres with `pg_isready` before the migration init container runs. Only added when using containerized postgres (`database.azureDb` is false).

### Why

The `maestro-server-migration` init container panics on startup because the containerized PostgreSQL isn't ready yet. Both are deployed simultaneously by Helm, but postgres needs ~43s for Azure disk provisioning, volume attach, image pull, and initialization. The migration tries to connect immediately and crash-loops for ~45 minutes.

Kusto evidence from `ci01-j5157760-svc` (2026-05-19):
```
03:52:04 | maestro-db PVC created, Azure disk provisioning starts
03:52:15 | maestro-server-migration panics: connection reset by peer
03:52:47 | postgres container finally started
03:52-04:37 | 80x BackOff events
```

### Testing

Helm template change only. Verified via `make -C config materialize`. E2E will validate maestro starts without crash-loop BackOff events.