### PR TITLE
fix: defer HandleCrashWithContext to actually catch panics (AROSLSRE-888)

### DIFF
--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -460,7 +460,7 @@ func DeleteAllHCPClusters(
 	for _, hcpClusterName := range hcpClusterNames {
 		waitGroup.Go(func() error {
 			// prevent a stray panic from exiting the process. Don't do this generally because ginkgo/gomega rely on panics to function.
-			utilruntime.HandleCrashWithContext(ctx)
+			defer utilruntime.HandleCrashWithContext(ctx)
 
 			return DeleteHCPCluster(ctx, hcpClient, resourceGroupName, hcpClusterName, timeout)
 		})

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -322,7 +322,7 @@ func (tc *perItOrDescribeTestContext) CleanupResourceGroups(ctx context.Context,
 		go func(ctx context.Context) {
 			defer wg.Done()
 			// prevent a stray panic from exiting the process. Don't do this generally because ginkgo/gomega rely on panics to function.
-			utilruntime.HandleCrashWithContext(ctx)
+			defer utilruntime.HandleCrashWithContext(ctx)
 
 			switch opts.CleanupWorkflow {
 			case CleanupWorkflowStandard:
@@ -369,7 +369,7 @@ func (tc *perItOrDescribeTestContext) collectDebugInfo(ctx context.Context) {
 		currResourceGroupName := resourceGroupName
 		waitGroup.Go(func() error {
 			// prevent a stray panic from exiting the process. Don't do this generally because ginkgo/gomega rely on panics to function.
-			utilruntime.HandleCrashWithContext(ctx)
+			defer utilruntime.HandleCrashWithContext(ctx)
 
 			return tc.collectDebugInfoForResourceGroup(ctx, currResourceGroupName)
 		})


### PR DESCRIPTION
### What

Add missing `defer` keyword to 3 calls to `utilruntime.HandleCrashWithContext` in test framework goroutines.

### Why

`HandleCrashWithContext` is [documented](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/runtime#HandleCrashWithContext) as "Meant to be called via defer" but was called immediately at the start of goroutines in `DeleteAllHCPClusters` and `cleanupCreatedResources`. Without `defer`, the crash handler executes once and returns, providing no panic protection.

When `PollUntilDone` panics during cluster deletion (e.g. ARM API returns a malformed response causing deserialization failure), the panic propagates uncaught and crashes the entire test process instead of being logged and handled gracefully.

Evidence from Prow run [2056571922535157760](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/4690/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2056571922535157760): panic at `hcp_helper.go:196` in `PollUntilDone` with `Deserialization Error: no output from command`.

### Testing

3 identical fixes across 2 files. No functional change -- only adds the missing `defer` keyword.