### PR TITLE
fix: add deployment script to wait for Entra principal propagation before CosmosDB role assignments (AROSLSRE-890)

### DIFF
--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -1,4 +1,5 @@
 param cosmosDBAccountName string
+param location string
 param userAssignedMIs array
 param readOnlyUserAssignedMIs array = []
 
@@ -91,6 +92,48 @@ resource cosmosDbContainers 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/
   }
 ]
 
+// Wait for all UAMI principals to be visible in Entra before creating role assignments.
+// Freshly created managed identities may not be immediately resolvable by CosmosDB,
+// causing "principal ID was not found in the AAD tenant" errors.
+var allPrincipalIds = [for uami in concat(userAssignedMIs, readOnlyUserAssignedMIs): uami.uamiPrincipalID]
+
+resource waitForPrincipals 'Microsoft.Resources/deploymentScripts@2023-08-01' = if (length(allPrincipalIds) > 0) {
+  name: 'wait-for-entra-principals'
+  location: location
+  kind: 'AzureCLI'
+  properties: {
+    azCliVersion: '2.63.0'
+    retentionInterval: 'PT1H'
+    timeout: 'PT10M'
+    forceUpdateTag: guid(join(allPrincipalIds, ','))
+    environmentVariables: [
+      {
+        name: 'PRINCIPAL_IDS'
+        value: join(allPrincipalIds, ',')
+      }
+    ]
+    scriptContent: '''
+      #!/bin/bash
+      set -e
+      IFS=',' read -ra PRINCIPALS <<< "$PRINCIPAL_IDS"
+      for pid in "${PRINCIPALS[@]}"; do
+        echo "Waiting for principal $pid to be visible in Entra..."
+        for i in $(seq 1 18); do
+          if az ad sp show --id "$pid" &>/dev/null; then
+            echo "  Principal $pid found (attempt $i)"
+            break
+          fi
+          if [ $i -eq 18 ]; then
+            echo "  WARNING: Principal $pid not found after 18 attempts (3 min), proceeding anyway"
+          fi
+          sleep 10
+        done
+      done
+      echo "All principals checked."
+    '''
+  }
+}
+
 resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2021-04-15' = [
   for uami in userAssignedMIs: {
     name: guid(roleDefinitionId, uami.uamiPrincipalID, cosmosDbAccount.id)
@@ -100,6 +143,7 @@ resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignm
       principalId: uami.uamiPrincipalID
       scope: cosmosDbAccount.id
     }
+    dependsOn: [waitForPrincipals]
   }
 ]
 
@@ -112,5 +156,6 @@ resource sqlRoleAssignmentReadOnly 'Microsoft.DocumentDB/databaseAccounts/sqlRol
       principalId: uami.uamiPrincipalID
       scope: cosmosDbAccount.id
     }
+    dependsOn: [waitForPrincipals]
   }
 ]

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -752,6 +752,7 @@ module rpCosmosDb '../modules/rp-cosmos.bicep' = if (rpCosmosDbAccountId != '') 
   scope: resourceGroup(regionalResourceGroup)
   params: {
     cosmosDBAccountName: rpCosmosDbName
+    location: location
     userAssignedMIs: [frontendMI, backendMI, adminApiMI]
     resourceContainerMaxScale: resourceContainerMaxScale
     billingContainerMaxScale: billingContainerMaxScale


### PR DESCRIPTION
[AROSLSRE-890](https://redhat.atlassian.net/browse/AROSLSRE-890)
Related: [ARO-27150](https://redhat.atlassian.net/browse/ARO-27150)

### What

Add a deployment script in `rp-cosmos.bicep` that polls Entra for each UAMI principal before creating CosmosDB SQL role assignments.

### Why

Freshly created RP managed identities (frontend, backend, adminApi) may not be immediately visible to CosmosDB when creating SQL role assignments, causing `The provided principal ID was not found in the AAD tenant` errors. This hits ~27% of dev E2E runs in ephemeral Prow environments.

See also [PR #5323](https://github.com/Azure/ARO-HCP/pull/5323) for the pipeline retry counterpart.

### Changes

- `dev-infrastructure/modules/rp-cosmos.bicep`:
  - Added `location` parameter (needed for deployment script, can't use `cosmosDbAccount.location` on existing resources)
  - Added `waitForPrincipals` deployment script that polls `az ad sp show --id <principalId>` for each UAMI (18 retries x 10s = 3 min per principal, 10 min total timeout)
  - `forceUpdateTag` ensures script re-runs on retries
  - Both `sqlRoleAssignment` and `sqlRoleAssignmentReadOnly` depend on the script
- `dev-infrastructure/templates/svc-cluster.bicep`: Pass `location` to `rp-cosmos` module

### Testing

- Bicep compiles clean locally (`az bicep build`)
- E2E: the deployment script should prevent the principal-not-found error by waiting for Entra propagation