### PR TITLE
Fix: Race condition The provided principal ID was not found in the AAD tenant.

### DIFF
--- a/dev-infrastructure/scripts/validate-mi-aad-propagation.sh
+++ b/dev-infrastructure/scripts/validate-mi-aad-propagation.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+az login --identity
+
+PRINCIPALS=("$@")
+MAX_WAIT=120  # Maximum 2 minutes per principal
+POLL_INTERVAL=5  # Check every 5 seconds
+
+echo "Validating ${#PRINCIPALS[@]} managed identity principals are propagated to AAD..."
+
+for PRINCIPAL_ID in "${PRINCIPALS[@]}"; do
+  echo "Checking principal: $PRINCIPAL_ID"
+  elapsed=0
+
+  # List role assignments to force ARM to validate the principal exists in AAD
+  until az role assignment list --assignee "$PRINCIPAL_ID" --output none; do
+    if [ $elapsed -ge $MAX_WAIT ]; then
+      echo "✗ Principal $PRINCIPAL_ID still not available after ${MAX_WAIT}s"
+      exit 1
+    fi
+    sleep $POLL_INTERVAL
+    elapsed=$((elapsed + POLL_INTERVAL))
+  done
+  echo "✓ Principal $PRINCIPAL_ID available in AAD (${elapsed}s)"
+done
+
+echo "✓ All ${#PRINCIPALS[@]} principals validated in AAD"

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -761,7 +761,7 @@ resource validateMIPropagation 'Microsoft.Resources/deploymentScripts@2023-08-01
   }
   properties: {
     azCliVersion: '2.53.1'
-    timeout: 'PT5M'
+    timeout: 'PT10M'
     retentionInterval: 'PT1H'
     arguments: '${frontendMI.uamiPrincipalID} ${backendMI.uamiPrincipalID} ${adminApiMI.uamiPrincipalID}'
     scriptContent: loadTextContent('../scripts/validate-mi-aad-propagation.sh')

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -747,6 +747,31 @@ var frontendMI = mi.getManagedIdentityByName(managedIdentities.outputs.managedId
 var backendMI = mi.getManagedIdentityByName(managedIdentities.outputs.managedIdentities, backendMIName)
 var adminApiMI = mi.getManagedIdentityByName(managedIdentities.outputs.managedIdentities, adminApiMIName)
 
+// Validate that managed identity principals are available in AAD before attempting Cosmos DB role assignments
+// This prevents race conditions where principals haven't replicated to all AAD endpoints yet
+resource validateMIPropagation 'Microsoft.Resources/deploymentScripts@2023-08-01' = if (rpCosmosDbAccountId != '') {
+  name: 'validate-mi-aad-propagation-script'
+  location: location
+  kind: 'AzureCLI'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${globalMSIId}': {}
+    }
+  }
+  properties: {
+    azCliVersion: '2.53.1'
+    timeout: 'PT5M'
+    retentionInterval: 'PT1H'
+    arguments: '${frontendMI.uamiPrincipalID} ${backendMI.uamiPrincipalID} ${adminApiMI.uamiPrincipalID}'
+    scriptContent: loadTextContent('../scripts/validate-mi-aad-propagation.sh')
+    cleanupPreference: 'OnSuccess'
+  }
+  dependsOn: [
+    managedIdentities
+  ]
+}
+
 module rpCosmosDb '../modules/rp-cosmos.bicep' = if (rpCosmosDbAccountId != '') {
   name: 'rp_cosmos_db'
   scope: resourceGroup(regionalResourceGroup)
@@ -758,6 +783,9 @@ module rpCosmosDb '../modules/rp-cosmos.bicep' = if (rpCosmosDbAccountId != '') 
     locksContainerMaxScale: locksContainerMaxScale
     fleetContainerMaxScale: fleetContainerMaxScale
   }
+  dependsOn: [
+    validateMIPropagation
+  ]
 }
 
 module rpCosmosdbPrivateEndpoint '../modules/private-endpoint.bicep' = if (rpCosmosDbPrivate && rpCosmosDbAccountId != '') {


### PR DESCRIPTION
[ARO-27150](https://redhat.atlassian.net/browse/ARO-27150)

### What

Add AAD propagation validation before Cosmos DB role assignments to prevent "principal not found in AAD tenant" failures.

Changes:
- New deployment script in svc-cluster.bicep that polls az role assignment list --assignee <principalId> to verify managed identity principals are available in AAD 
- Script waits up to 120 seconds (polling every 5s) for all 3 MIs: frontend, backend, admin-api
- rpCosmosDb module now depends on validation completing

### Why

PR #5138 moved Cosmos account creation to region.bicep, removing an accidental 30-60s delay that was masking an AAD replication race condition.

Before: MI created → Cosmos account created (delay) → role assignments 
After: MI created → role assignments immediately → AAD not replicated yet → failure

Azure Active Directory uses eventual consistency - principals take 15-120 seconds to replicate across all endpoints. We now explicitly wait for propagation instead of relying on accidental timing.

Why az role assignment list:
- ARM validates principals via AAD graph when listing assignments
- Uses existing Global MSI Reader permissions (no new permissions needed)
- Tests the same ARM→AAD code path that Cosmos role assignments use

### Testing

Script was testes locally

### Special notes for your reviewer

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
