### PR TITLE
fix: add retry for Entra propagation race in service/cluster step (AROSLSRE-890)

### DIFF
--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -207,6 +207,7 @@ resourceGroups:
       - "Resource is in Updating state"
       - "There was a problem communicating with the identity service"
       - "DeploymentScriptExceededMaxAllowedTime"
+      - "was not found in the AAD tenant"
       maximumRetryCount: 3
       durationBetweenRetries: 2m
   - name: delete-old-user-nodepools


### PR DESCRIPTION
[AROSLSRE-890](https://redhat.atlassian.net/browse/AROSLSRE-890)
Related: [ARO-27150](https://redhat.atlassian.net/browse/ARO-27150)

### What

Add `"was not found in the AAD tenant"` to the `service/cluster` step's `automatedRetry.errorContainsAny` list.

### Why

Freshly created RP managed identities may not be visible to CosmosDB when creating SQL role assignments, causing `The provided principal ID was not found in the AAD tenant` errors. This hits ~27% of dev E2E runs. The step already has retry logic for other transient errors; this adds the Entra propagation error to the same list.

### Changes

- `dev-infrastructure/svc-pipeline.yaml`: 1 line added to `errorContainsAny`

### Testing

- E2E: the service/cluster step will retry on this error instead of failing permanently