### PR TITLE
dev-infrastructure: allow assigning Kusto view to MSI

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -3,6 +3,11 @@
   "title": "Generated schema for Root",
   "type": "object",
   "definitions": {
+    "csvPrincipalList": {
+      "type": "string",
+      "description": "CSV separated list of principals, each in the format '(tenantId/)principalId' where tenantId is optional. Both tenantId and principalId must be UUIDs.",
+      "pattern": "^$|^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(,([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})*$"
+    },
     "namespaceName": {
       "type": "string",
       "minLength": 1,
@@ -1922,10 +1927,16 @@
           "type": "string"
         },
         "adminGroups": {
-          "type": "string"
+          "$ref": "#/definitions/csvPrincipalList",
+          "description": "CSV separated list of AAD groups to grant AllDatabasesAdmin on the Kusto cluster."
         },
         "viewerGroups": {
-          "type": "string"
+          "$ref": "#/definitions/csvPrincipalList",
+          "description": "CSV separated list of AAD groups to grant AllDatabasesViewer on the Kusto cluster."
+        },
+        "viewerIdentities": {
+          "$ref": "#/definitions/csvPrincipalList",
+          "description": "CSV separated list of app/managed identity principals to grant AllDatabasesViewer on the Kusto cluster."
         },
         "crossClusterServiceLogsScript": {
           "type": "string"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -295,6 +295,7 @@ defaults:
     hostedControlPlaneLogsDatabase: "HostedControlPlaneLogs"
     adminGroups: ""
     viewerGroups: ""
+    viewerIdentities: ""
     crossClusterServiceLogsScript: ""
     crossClusterHostedControlPlaneLogsScript: ""
     sku: ""

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -481,6 +481,7 @@ kusto:
   sku: Standard_E8ads_v5
   tier: Standard
   viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
+  viewerIdentities: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
 kvCertAccessRoleId: ""
 kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -481,6 +481,7 @@ kusto:
   sku: Standard_E8ads_v5
   tier: Standard
   viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
+  viewerIdentities: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
 kvCertAccessRoleId: ""
 kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -481,6 +481,7 @@ kusto:
   sku: Standard_E8ads_v5
   tier: Standard
   viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
+  viewerIdentities: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
 kvCertAccessRoleId: ""
 kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -481,6 +481,7 @@ kusto:
   sku: Standard_E8ads_v5
   tier: Standard
   viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
+  viewerIdentities: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
 kvCertAccessRoleId: ""
 kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -481,6 +481,7 @@ kusto:
   sku: Standard_E8ads_v5
   tier: Standard
   viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
+  viewerIdentities: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
 kvCertAccessRoleId: ""
 kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -481,6 +481,7 @@ kusto:
   sku: Standard_E8ads_v5
   tier: Standard
   viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
+  viewerIdentities: ""
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
 kvCertAccessRoleId: ""
 kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/dev-infrastructure/configurations/kusto.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/kusto.tmpl.bicepparam
@@ -17,6 +17,8 @@ param adminGroups = '{{ .kusto.adminGroups }}'
 
 param viewerGroups = '{{ .kusto.viewerGroups }}'
 
+param viewerIdentities = '{{ .kusto.viewerIdentities }}'
+
 param autoScaleMin = {{ .kusto.autoScaleMin }}
 
 param autoScaleMax = {{ .kusto.autoScaleMax }}

--- a/dev-infrastructure/modules/logs/kusto/cluster.bicep
+++ b/dev-infrastructure/modules/logs/kusto/cluster.bicep
@@ -20,6 +20,9 @@ param adminGroups string
 @description('CSV separated list of groups to assign viewer in the Kusto cluster, format: "(tenantId/)groupId", if tenantId is not provided, the current tenant will be used')
 param viewerGroups string
 
+@description('CSV separated list of identities (apps/managed identities) to assign viewer in the Kusto cluster, format: "(tenantId/)principalId", if tenantId is not provided, the current tenant will be used')
+param viewerIdentities string = ''
+
 @description('Minimum number of nodes for autoscale')
 param autoScaleMin int
 
@@ -45,6 +48,13 @@ var viewerPermissions = [
   for group in csvToArray(viewerGroups): {
     tenantId: contains(group, '/') ? split(group, '/')[0] : tenant().tenantId
     groupId: contains(group, '/') ? split(group, '/')[1] : group
+  }
+]
+
+var viewerIdentityPermissions = [
+  for identity in csvToArray(viewerIdentities): {
+    tenantId: contains(identity, '/') ? split(identity, '/')[0] : tenant().tenantId
+    principalId: contains(identity, '/') ? split(identity, '/')[1] : identity
   }
 ]
 
@@ -89,6 +99,18 @@ resource kusto 'Microsoft.Kusto/clusters@2024-04-13' = {
       properties: {
         principalId: permission.groupId
         principalType: 'Group'
+        role: 'AllDatabasesViewer'
+        tenantId: permission.tenantId
+      }
+    }
+  ]
+
+  resource clusterViewPermissionsForIdentities 'principalAssignments' = [
+    for permission in viewerIdentityPermissions: {
+      name: 'viewer-app-${permission.principalId}'
+      properties: {
+        principalId: permission.principalId
+        principalType: 'App'
         role: 'AllDatabasesViewer'
         tenantId: permission.tenantId
       }

--- a/dev-infrastructure/modules/logs/kusto/main.bicep
+++ b/dev-infrastructure/modules/logs/kusto/main.bicep
@@ -22,6 +22,9 @@ param adminGroups string
 @description('CSV separated list of groups to assign viewer in the Kusto cluster')
 param viewerGroups string
 
+@description('CSV separated list of identities (apps/managed identities) to assign viewer in the Kusto cluster')
+param viewerIdentities string = ''
+
 @description('Name of the Kusto cluster to create')
 param kustoName string
 
@@ -78,6 +81,7 @@ module cluster 'cluster.bicep' = {
     tier: tier
     adminGroups: adminGroups
     viewerGroups: viewerGroups
+    viewerIdentities: viewerIdentities
     autoScaleMin: autoScaleMin
     autoScaleMax: autoScaleMax
     enableAutoScale: enableAutoScale

--- a/dev-infrastructure/templates/kusto.bicep
+++ b/dev-infrastructure/templates/kusto.bicep
@@ -22,6 +22,9 @@ param adminGroups string
 @description('CSV separated list of groups to assign viewer in the Kusto cluster')
 param viewerGroups string
 
+@description('CSV separated list of identities (apps/managed identities) to assign viewer in the Kusto cluster')
+param viewerIdentities string = ''
+
 @description('Name of the Kusto cluster to create')
 param kustoName string
 
@@ -53,6 +56,7 @@ module kusto '../modules/logs/kusto/main.bicep' = if (manageInstance) {
     hostedControlPlaneLogsDatabase: hostedControlPlaneLogsDatabase
     adminGroups: adminGroups
     viewerGroups: viewerGroups
+    viewerIdentities: viewerIdentities
     autoScaleMin: autoScaleMin
     autoScaleMax: autoScaleMax
     enableAutoScale: enableAutoScale


### PR DESCRIPTION
We need to give some MSI access to all of our Kusto, but the current approaches are hard-coded to only allow groups.
