### PR TITLE
Retry EventGrid internal errors

### DIFF
--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -130,6 +130,11 @@ resourceGroups:
     template: templates/region.bicep
     parameters: configurations/region.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    automatedRetry:
+      errorContainsAny:
+      - "Internal error"
+      maximumRetryCount: 4
+      durationBetweenRetries: 2m
     variables:
     - name: globalMSIId
       input:


### PR DESCRIPTION
The EventGrid resource provider fails with "Internal error" quite frequently (~4% last 7d). The error message itself indicates that the request should be retried.

```
"The operation failed due to an internal server error. The initial state of the impacted resources (if any) are restored. Please try again in few minutes. If error still persists, report <id> to our forums for assistance or raise a support ticket ."
```

This PR adds pipeline level retries to mitigate this issue.