### PR TITLE
Fix: Race condition resource ClusterSizingConfiguration//cluster still exists

### DIFF
--- a/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
+++ b/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
@@ -6,7 +6,8 @@ metadata:
   name: cluster
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-weight": "10"
+    "argocd.argoproj.io/sync-options": "ServerSideApply=true"
 spec:
   concurrency:
     limit: 9999
@@ -54,7 +55,8 @@ metadata:
   name: cluster
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-weight": "10"
+    "argocd.argoproj.io/sync-options": "ServerSideApply=true"
 spec:
   concurrency:
     limit: 5

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -738,7 +738,8 @@ metadata:
   name: cluster
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-weight": "10"
+    "argocd.argoproj.io/sync-options": "ServerSideApply=true"
 spec:
   concurrency:
     limit: 9999


### PR DESCRIPTION
[ARO-27214](https://redhat.atlassian.net/browse/ARO-27214)

### What

This PR fixes ownership conflicts in the clustersizingconfiguration custom resource for HyperShift by making two changes:
1. Increases the Helm hook weight from 2 to 10 for the clustersizingconfiguration resource
2. Enables server-side apply by adding the ArgoCD annotation "argocd.argoproj.io/sync-options": 
  "ServerSideApply=true"

### Why

Problem: There were ownership conflicts when multiple controllers or processes tried to manage the clustersizingconfiguration resource simultaneously during Helm deployments.

Solution:
- Higher hook weight (10) - Delays the Helm hook execution, ensuring it runs after other resources are created/updated, reducing race conditions
- Server-side apply - Kubernetes server-side apply allows multiple controllers to manage different fields of the same resource without ownership conflicts, as opposed to client-side apply which requires a single owner
  
This ensures the clustersizingconfiguration resource can be properly managed by both Helm and other controllers (like ArgoCD or the HyperShift operator) without conflicts.

### Testing

In progress

### Special notes for your reviewer

Base PR #3795 

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
