### PR TITLE
feature: updating quota management fields in config

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -2816,6 +2816,39 @@
         "alertRuleOwningTeamTag"
       ]
     },
+    "quotaizer": {
+      "type": "object",
+      "properties": {
+        "quotaGroup": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "displayName": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "displayName"
+          ]
+        },
+        "managedIdentityName": {
+          "type": "string"
+        },
+        "image": {
+          "$ref": "#/definitions/containerImage"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "quotaGroup",
+        "managedIdentityName",
+        "image"
+      ]
+    },
     "routeMonitorOperator": {
       "type": "object",
       "properties": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -378,6 +378,15 @@ defaults:
         actionGroupShortName: ""
         routingId: ""
         automitigationEnabled: ""
+  quotaizer:
+    quotaGroup:
+      id: "aro-{{ .ctx.environment }}-{{ .ctx.region }}"
+      displayName: "HCP - {{ .ctx.environment }} {{ .ctx.region }}"
+    managedIdentityName: aro-quotaizer
+    image:
+      registry: "empty-sentinel"
+      repository: "empty-sentinel"
+      digest: ""
   # Route Monitor Operator
   routeMonitorOperator:
     operatorImage:

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -819,6 +819,15 @@ oidc:
     privateLinkLocation: westus3
     public: true
     zoneRedundantMode: Auto
+quotaizer:
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  managedIdentityName: aro-quotaizer
+  quotaGroup:
+    displayName: HCP - ci01 westus3
+    id: aro-ci01-westus3
 region: westus3
 regionRG: hcp-underlay-ci01-j7654321
 routeMonitorOperator:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -817,6 +817,15 @@ oidc:
     privateLinkLocation: westus3
     public: true
     zoneRedundantMode: Auto
+quotaizer:
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  managedIdentityName: aro-quotaizer
+  quotaGroup:
+    displayName: HCP - cspr westus3
+    id: aro-cspr-westus3
 region: westus3
 regionRG: hcp-underlay-cspr-westus3
 routeMonitorOperator:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -817,6 +817,15 @@ oidc:
     privateLinkLocation: westus3
     public: true
     zoneRedundantMode: Auto
+quotaizer:
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  managedIdentityName: aro-quotaizer
+  quotaGroup:
+    displayName: HCP - dev westus3
+    id: aro-dev-westus3
 region: westus3
 regionRG: hcp-underlay-dev-westus3
 routeMonitorOperator:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -817,6 +817,15 @@ oidc:
     privateLinkLocation: westus3
     public: true
     zoneRedundantMode: Auto
+quotaizer:
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  managedIdentityName: aro-quotaizer
+  quotaGroup:
+    displayName: HCP - perf westus3
+    id: aro-perf-westus3
 region: westus3
 regionRG: hcp-underlay-perf-usw3ptest
 routeMonitorOperator:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -819,6 +819,15 @@ oidc:
     privateLinkLocation: westus3
     public: true
     zoneRedundantMode: Auto
+quotaizer:
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  managedIdentityName: aro-quotaizer
+  quotaGroup:
+    displayName: HCP - pers westus3
+    id: aro-pers-westus3
 region: westus3
 regionRG: hcp-underlay-pers-usw3test
 routeMonitorOperator:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -819,6 +819,15 @@ oidc:
     privateLinkLocation: westus3
     public: true
     zoneRedundantMode: Auto
+quotaizer:
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  managedIdentityName: aro-quotaizer
+  quotaGroup:
+    displayName: HCP - prow westus3
+    id: aro-prow-westus3
 region: westus3
 regionRG: hcp-underlay-prow-j7654321
 routeMonitorOperator:


### PR DESCRIPTION
[ARO-26770](https://redhat.atlassian.net/browse/ARO-26770)
### What

Add region-specific fields for group quota + add image configuration for quota management app (quotaizer)

### Why

Previously added global management group, but I prefer region-specific quota groups to make it easier for the regional quotaizer app to discover which subscriptions it will manage. I will remove the global one after this change gets picked up in sdp-pipelines, and I can update the config over there so that the group is in the new location in config.

### Testing

Just adding additional fields to config. Tested by e2e parallel test.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [X] PR is scoped to a single task (no mixed concerns)
- [X] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] Summary explains the "Why" behind the change
- [X] Linked to relevant ticket/issue
- [X] Screenshots included (if graph/UI/metrics changes)
- [X] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [X] Draft PR used for WIP (if applicable)
- [X] Commit history is clean (rebased/squashed)
- [X] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
