### PR TITLE
feat: allow per-alert correlationId overrides; use for hostedcluster KAS alerts

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -1887,7 +1887,7 @@ resource hcpHostedclusterMonitorRules 'Microsoft.AlertsManagement/prometheusRule
           short_window: '30m'
         }
         annotations: {
-          correlationId: 'hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}'
+          correlationId: 'hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}/{{ $labels._id }}'
           description: 'HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})'
           info: 'HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})'
           summary: 'High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}'
@@ -1915,7 +1915,7 @@ resource hcpHostedclusterMonitorRules 'Microsoft.AlertsManagement/prometheusRule
           short_window: '30m'
         }
         annotations: {
-          correlationId: 'hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}'
+          correlationId: 'hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}/{{ $labels._id }}'
           description: 'HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})'
           info: 'HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})'
           summary: 'High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}'
@@ -1943,7 +1943,7 @@ resource hcpHostedclusterMonitorRules 'Microsoft.AlertsManagement/prometheusRule
           short_window: '2h'
         }
         annotations: {
-          correlationId: 'hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}'
+          correlationId: 'hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}/{{ $labels._id }}'
           description: 'HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})'
           info: 'HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})'
           summary: 'High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}'
@@ -1971,7 +1971,7 @@ resource hcpHostedclusterMonitorRules 'Microsoft.AlertsManagement/prometheusRule
           short_window: '6h'
         }
         annotations: {
-          correlationId: 'hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}'
+          correlationId: 'hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}/{{ $labels._id }}'
           description: 'HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})'
           info: 'HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})'
           summary: 'High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}'

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -105,7 +105,7 @@ This default is intentional: fine-grained correlation IDs (per-pod, per-queue, e
 
 #### Overriding the correlationId
 
-If the default per-management-cluster grouping is too coarse, you can set a custom `correlationId` annotation directly in the source `PrometheusRule` YAML. The generator will preserve it instead of applying the default.
+If the default per-infra-cluster grouping is too coarse, you can set a custom `correlationId` annotation directly in the source `PrometheusRule` YAML. The generator will preserve it instead of applying the default.
 
 For example, to create a separate IcM incident per hosted cluster:
 

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -91,7 +91,7 @@ Use `description` for dynamic detail with template variables. The `description` 
 
 ### CorrelationID behavior
 
-The generator automatically sets a `correlationId` annotation on every alert:
+The generator automatically sets a `correlationId` annotation on every alert unless the source rule already defines one:
 
 ```
 <AlertName>/{{ $labels.cluster }}
@@ -101,7 +101,22 @@ IcM uses the correlation ID to group alerts into incidents. Alerts with the same
 
 This means that all firings of the same alert on the same cluster are grouped together. For example, if `BackendControllerRetryHotLoop` fires for two different workqueues on the same cluster, they become one incident. The specific workqueue name is still visible in the alert `description`.
 
-This is intentional: fine-grained correlation IDs (per-pod, per-queue, etc.) were found to cause excessive incident fragmentation. If you need to distinguish between instances in the incident, include the relevant labels in the `description` annotation where they are visible to the responder.
+This default is intentional: fine-grained correlation IDs (per-pod, per-queue, etc.) were found to cause excessive incident fragmentation. If you need to distinguish between instances in the incident, include the relevant labels in the `description` annotation where they are visible to the responder.
+
+#### Overriding the correlationId
+
+If the default per-management-cluster grouping is too coarse, you can set a custom `correlationId` annotation directly in the source `PrometheusRule` YAML. The generator will preserve it instead of applying the default.
+
+For example, to create a separate IcM incident per hosted cluster:
+
+```yaml
+annotations:
+  summary: "High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}"
+  description: "..."
+  correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}/{{ $labels._id }}"
+```
+
+Use this sparingly — only when distinct instances genuinely need independent incident tracking (e.g. different hosted clusters on the same management cluster).
 
 ## 2. Write tests
 

--- a/observability/alerts/HCPkasMonitor-prometheusRule-KSM.yaml
+++ b/observability/alerts/HCPkasMonitor-prometheusRule-KSM.yaml
@@ -18,6 +18,7 @@ spec:
       annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}"
         description: "HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})"
+        correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}/{{ $labels._id }}"
     - alert: hostedcluster-KubeAPIServer-ErrorBudgetBurn
       expr: 1 - (hostedClusterAPI_kubeapiserver_available:sum_over_time_30m / hostedClusterAPI_kubeapiserver_available:count_over_time_30m) > (6 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_30m > 30 and 1 - (hostedClusterAPI_kubeapiserver_available:sum_over_time_6h / hostedClusterAPI_kubeapiserver_available:count_over_time_6h) > (6 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_6h > 360
       for: 15m
@@ -28,6 +29,7 @@ spec:
       annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}"
         description: "HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})"
+        correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}/{{ $labels._id }}"
     - alert: hostedcluster-KubeAPIServer-ErrorBudgetBurn
       expr: 1 - (hostedClusterAPI_kubeapiserver_available:sum_over_time_2h / hostedClusterAPI_kubeapiserver_available:count_over_time_2h) > (3 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_2h > 120 and 1 - sum by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available:ratio_avg_1d) > (3 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_1d > 1440
       for: 1h
@@ -38,6 +40,7 @@ spec:
       annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}"
         description: "HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})"
+        correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}/{{ $labels._id }}"
     - alert: hostedcluster-KubeAPIServer-ErrorBudgetBurn
       expr: 1 - (hostedClusterAPI_kubeapiserver_available:sum_over_time_6h / hostedClusterAPI_kubeapiserver_available:count_over_time_6h) > (1 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_6h > 360 and 1 - sum by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available:ratio_avg_3d) > (1 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_3d > 4320
       for: 3h
@@ -48,3 +51,4 @@ spec:
       annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}"
         description: "HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})"
+        correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}/{{ $labels._id }}"

--- a/observability/alerts/HCPkasMonitor-prometheusRule-KSM_test.yaml
+++ b/observability/alerts/HCPkasMonitor-prometheusRule-KSM_test.yaml
@@ -41,6 +41,7 @@ tests:
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
+        correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/mgmt-cluster/abc-123"
 # Test 3: Medium burn - KubeAPIServer failure triggers 30m/6h alert (for: 15m)
 - interval: 30s
   name: "Test 3: KubeAPIServer medium burn - triggers 30m/6h alert"
@@ -64,6 +65,7 @@ tests:
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
+        correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/mgmt-cluster/abc-123"
         # Note: 1d/2h alert does NOT fire - insufficient samples (need 1440, have ~360)
   - eval_time: 210m # 6h alert fires: condition true at ~181m (>360 samples) + for:15m = 196m, check at 210m for safety
     alertname: hostedcluster-KubeAPIServer-ErrorBudgetBurn
@@ -79,6 +81,7 @@ tests:
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
+        correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/mgmt-cluster/abc-123"
     - exp_labels:
         severity: info
         long_window: 6h
@@ -90,6 +93,7 @@ tests:
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
+        correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/mgmt-cluster/abc-123"
         # Note: 1d/2h alert does NOT fire - insufficient samples (need >1440, have ~420)
 # Test 4: All four KubeAPIServer alerts fire simultaneously after prolonged failure
 - interval: 30s
@@ -113,6 +117,7 @@ tests:
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
+        correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/mgmt-cluster/abc-123"
     - exp_labels:
         severity: info
         long_window: 6h
@@ -124,6 +129,7 @@ tests:
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
+        correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/mgmt-cluster/abc-123"
     - exp_labels:
         severity: info
         long_window: 1d
@@ -135,6 +141,7 @@ tests:
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
+        correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/mgmt-cluster/abc-123"
     - exp_labels:
         severity: info
         long_window: 3d
@@ -146,6 +153,7 @@ tests:
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
+        correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/mgmt-cluster/abc-123"
 # Test 5: Partial failure - below error budget threshold, no alert
 - interval: 30s
   name: "Test 5: Partial failure below threshold - no alert fires"

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -391,7 +391,13 @@ param location string = resourceGroup().location
 					annotations["title"] = ptr.To(rule.Alert)
 				}
 
-				annotations["correlationId"] = ptr.To(rule.Alert + "/{{ $labels.cluster }}")
+				// Default correlationId groups all firings of an alert on the same cluster into one
+				// IcM incident. Individual alerts can override this by setting a `correlationId`
+				// annotation in their source rule — useful when finer-grained grouping is wanted
+				// (e.g. one incident per hosted cluster, not per management cluster).
+				if _, hasOverride := annotations["correlationId"]; !hasOverride {
+					annotations["correlationId"] = ptr.To(rule.Alert + "/{{ $labels.cluster }}")
+				}
 
 				// Filter rules based on the output file type
 				if rule.Alert != "" && isAlertingRulesFile {


### PR DESCRIPTION
## Summary
- The prometheus rules generator now respects `correlationId` annotations from source YAML instead of always overwriting them with the default `<AlertName>/{{ $labels.cluster }}`
- Adds `correlationId` override to `hostedcluster-KubeAPIServer-ErrorBudgetBurn` so each hosted cluster (`_id`) gets its own IcM incident, instead of collapsing all hosted clusters on a management cluster into one
- Updates KSM test expectations to match

Supersedes #5303