### PR TITLE
feat: support FIPS mode via feature flags & cluster tags

### DIFF
--- a/internal/admission/admit_cluster.go
+++ b/internal/admission/admit_cluster.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/blang/semver/v4"
@@ -124,7 +125,7 @@ func mutateClusterExperimentalFeatures(_ context.Context, admissionContext *Clus
 	var errs field.ErrorList
 
 	// Reject unrecognized experimental tags.
-	knownTags := sets.New(api.TagClusterSingleReplica, api.TagClusterSizeOverride, api.TagClusterCPOImageOverride)
+	knownTags := sets.New(api.TagClusterSingleReplica, api.TagClusterSizeOverride, api.TagClusterCPOImageOverride, api.TagClusterFIPSEnabled)
 	for k := range tags {
 		if strings.HasPrefix(strings.ToLower(k), api.ExperimentalClusterTagPrefix) && !knownTags.Has(strings.ToLower(k)) {
 			errs = append(errs, field.Invalid(tagsPath.Key(k), k, "unrecognized experimental tag"))
@@ -170,6 +171,16 @@ func mutateClusterExperimentalFeatures(_ context.Context, admissionContext *Clus
 			))
 		} else {
 			experimentalFeatures.ControlPlaneOperatorImage = trimmed
+		}
+	}
+
+	fipsEnabled := lookupTag(tags, api.TagClusterFIPSEnabled)
+	if fipsEnabled != "" {
+		boolValue, err := strconv.ParseBool(fipsEnabled)
+		if err != nil {
+			errs = append(errs, field.Invalid(tagsPath.Key(api.TagClusterFIPSEnabled), fipsEnabled, "must be true or false"))
+		} else {
+			experimentalFeatures.FIPSEnabled = boolValue
 		}
 	}
 

--- a/internal/admission/admit_cluster_test.go
+++ b/internal/admission/admit_cluster_test.go
@@ -56,6 +56,7 @@ func TestMutateCluster(t *testing.T) {
 		expectedControlPlaneAvailability  api.ControlPlaneAvailability
 		expectedControlPlanePodSizing     api.ControlPlanePodSizing
 		expectedControlPlaneOperatorImage string
+		expectedFIPSEnabled               bool
 	}{
 		{
 			name:               "nil subscription ignores all tags",
@@ -233,6 +234,49 @@ func TestMutateCluster(t *testing.T) {
 			expectErrors:                      []utils.ExpectedError{},
 			expectedControlPlaneOperatorImage: "quay.io/openshift/cpo:v1.0",
 		},
+		{
+			name:                "AFEC registered with FIPS enabled",
+			subscription:        afecRegistered,
+			tags:                map[string]string{api.TagClusterFIPSEnabled: "true"},
+			expectErrors:        []utils.ExpectedError{},
+			expectedFIPSEnabled: true,
+		},
+		{
+			name:                "AFEC registered with FIPS disabled",
+			subscription:        afecRegistered,
+			tags:                map[string]string{api.TagClusterFIPSEnabled: "false"},
+			expectErrors:        []utils.ExpectedError{},
+			expectedFIPSEnabled: false,
+		},
+		{
+			name:               "AFEC registered with FIPS empty string defaults to disabled",
+			subscription:       afecRegistered,
+			tags:               map[string]string{api.TagClusterFIPSEnabled: ""},
+			expectErrors:       []utils.ExpectedError{},
+			expectZeroFeatures: true,
+		},
+		{
+			name:         "AFEC registered with invalid FIPS value",
+			subscription: afecRegistered,
+			tags:         map[string]string{api.TagClusterFIPSEnabled: "yes"},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "tags", Message: "must be true or false"},
+			},
+		},
+		{
+			name:               "no AFEC registered ignores FIPS tag",
+			subscription:       noAFEC,
+			tags:               map[string]string{api.TagClusterFIPSEnabled: "true"},
+			expectErrors:       []utils.ExpectedError{},
+			expectZeroFeatures: true,
+		},
+		{
+			name:                "AFEC registered with case insensitive FIPS tag key",
+			subscription:        afecRegistered,
+			tags:                map[string]string{"ARO-HCP.Experimental.Cluster.FIPS-Enabled": "true"},
+			expectErrors:        []utils.ExpectedError{},
+			expectedFIPSEnabled: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -267,6 +311,10 @@ func TestMutateCluster(t *testing.T) {
 			if cluster.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneOperatorImage != tt.expectedControlPlaneOperatorImage {
 				t.Errorf("expected ControlPlaneOperatorImage %q, got %q",
 					tt.expectedControlPlaneOperatorImage, cluster.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneOperatorImage)
+			}
+			if cluster.ServiceProviderProperties.ExperimentalFeatures.FIPSEnabled != tt.expectedFIPSEnabled {
+				t.Errorf("expected FIPSEnabled %t, got %t",
+					tt.expectedFIPSEnabled, cluster.ServiceProviderProperties.ExperimentalFeatures.FIPSEnabled)
 			}
 		})
 	}

--- a/internal/api/featureflags.go
+++ b/internal/api/featureflags.go
@@ -54,4 +54,9 @@ const (
 	// the control plane operator image for a HostedCluster when the
 	// ExperimentalReleaseFeatures AFEC is registered on the subscription.
 	TagClusterCPOImageOverride = ExperimentalClusterTagPrefix + "control-plane-operator-image-override"
+
+	// TagClusterFIPSEnabled is the ARM resource tag that enables FIPS mode
+	// for the ARO-HCP cluster during installation when the ExperimentalReleaseFeatures
+	// AFEC is registered on the subscription.
+	TagClusterFIPSEnabled = ExperimentalClusterTagPrefix + "fips-enabled"
 )

--- a/internal/api/types_experimental.go
+++ b/internal/api/types_experimental.go
@@ -33,6 +33,9 @@ type ExperimentalFeatures struct {
 	// the control_plane_operator_image CS cluster property, which CS
 	// translates into the HostedCluster annotation.
 	ControlPlaneOperatorImage string `json:"controlPlaneOperatorImage,omitempty"`
+
+	// FIPSEnabled controls the fips mode for a new ARO-HCP cluster installation.
+	FIPSEnabled bool `json:"fipsEnabled,omitempty"`
 }
 
 // ControlPlaneAvailability controls the AvailabilityPolicy for control plane components.

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -507,7 +507,8 @@ func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpC
 			MachineCIDR(hcpCluster.CustomerProperties.Network.MachineCIDR).
 			HostPrefix(int(hcpCluster.CustomerProperties.Network.HostPrefix))).
 		ImageRegistry(arohcpv1alpha1.NewClusterImageRegistry().
-			State(clusterImageRegistryState))
+			State(clusterImageRegistryState)).
+		FIPS(hcpCluster.ServiceProviderProperties.ExperimentalFeatures.FIPSEnabled)
 	azureBuilder := arohcpv1alpha1.NewAzure().
 		TenantID(tenantID).
 		SubscriptionID(strings.ToLower(subscriptionID)).

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -137,6 +137,28 @@ func TestWithImmutableAttributes(t *testing.T) {
 			want: ocmCluster(t, ocmClusterDefaults(api.TestLocation).Version(
 				arohcpv1alpha1.NewVersion().ID("openshift-v4.21.20").ChannelGroup("stable"))),
 		},
+		{
+			name: "with FIPS enabled",
+			hcpCluster: &api.HCPOpenShiftCluster{
+				ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+					ExperimentalFeatures: api.ExperimentalFeatures{
+						FIPSEnabled: true,
+					},
+				},
+			},
+			want: ocmCluster(t, ocmClusterDefaults(api.TestLocation).FIPS(true)),
+		},
+		{
+			name: "with FIPS disabled",
+			hcpCluster: &api.HCPOpenShiftCluster{
+				ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+					ExperimentalFeatures: api.ExperimentalFeatures{
+						FIPSEnabled: false,
+					},
+				},
+			},
+			want: ocmCluster(t, ocmClusterDefaults(api.TestLocation).FIPS(false)),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -244,7 +266,8 @@ func ocmClusterDefaults(azureLocation string) *arohcpv1alpha1.ClusterBuilder {
 		ImageRegistry(arohcpv1alpha1.NewClusterImageRegistry().
 			State(csImageRegistryStateEnabled)).
 		RegistryConfig(arohcpv1alpha1.NewClusterRegistryConfig().
-			ImageDigestMirrors())
+			ImageDigestMirrors()).
+		FIPS(false)
 }
 
 func getHCPNodePoolResource(opts ...func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {

--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -295,6 +295,9 @@ var (
 	toServiceProviderManagedIdentitiesDataPlaneIdentityURL = func(oldObj *api.HCPOpenShiftClusterServiceProviderProperties) *string {
 		return &oldObj.ManagedIdentitiesDataPlaneIdentityURL
 	}
+	toExperimentalFeaturesFIPSEnabled = func(oldObj *api.HCPOpenShiftClusterServiceProviderProperties) *bool {
+		return &oldObj.ExperimentalFeatures.FIPSEnabled
+	}
 )
 
 // ToClusterServiceProviderPropertiesClusterUID returns a pointer to the
@@ -346,6 +349,9 @@ func validateClusterServiceProviderProperties(ctx context.Context, op operation.
 		errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("clusterUID"), &newObj.ClusterUID, nil)...)
 	}
 	errs = append(errs, immutableByCompare(ctx, op, fldPath.Child("clusterUID"), &newObj.ClusterUID, safe.Field(oldObj, ToClusterServiceProviderPropertiesClusterUID))...)
+
+	// ExperimentalFeatures.FIPSEnabled is immutable
+	errs = append(errs, immutableByCompare(ctx, op, fldPath.Child("tags").Key(api.TagClusterFIPSEnabled), &newObj.ExperimentalFeatures.FIPSEnabled, safe.Field(oldObj, toExperimentalFeaturesFIPSEnabled))...)
 
 	return errs
 }

--- a/internal/validation/validate_cluster_comprehensive_test.go
+++ b/internal/validation/validate_cluster_comprehensive_test.go
@@ -2036,6 +2036,83 @@ func TestValidateClusterUpdate(t *testing.T) {
 				{Message: "field is immutable", FieldPath: "serviceProviderProperties.managedIdentitiesDataPlaneIdentityURL"},
 			},
 		},
+		// Test cases for FIPS tag immutability
+		{
+			name: "update FIPS from true to false - rejected",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.ServiceProviderProperties.ExperimentalFeatures.FIPSEnabled = false
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.ServiceProviderProperties.ExperimentalFeatures.FIPSEnabled = true
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "field is immutable", FieldPath: "serviceProviderProperties.tags[aro-hcp.experimental.cluster.fips-enabled]"},
+			},
+		},
+		{
+			name: "update FIPS from false to true - rejected",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.ServiceProviderProperties.ExperimentalFeatures.FIPSEnabled = true
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.ServiceProviderProperties.ExperimentalFeatures.FIPSEnabled = false
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "field is immutable", FieldPath: "serviceProviderProperties.tags[aro-hcp.experimental.cluster.fips-enabled]"},
+			},
+		},
+		{
+			name: "update with FIPS unchanged at true - allowed",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.ServiceProviderProperties.ExperimentalFeatures.FIPSEnabled = true
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.ServiceProviderProperties.ExperimentalFeatures.FIPSEnabled = true
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name: "update with FIPS unchanged at false - allowed",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.ServiceProviderProperties.ExperimentalFeatures.FIPSEnabled = false
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.ServiceProviderProperties.ExperimentalFeatures.FIPSEnabled = false
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name: "update with other fields changed but FIPS unchanged - allowed",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.ServiceProviderProperties.ExperimentalFeatures.FIPSEnabled = true
+				c.CustomerProperties.NodeDrainTimeoutMinutes = 60
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.ServiceProviderProperties.ExperimentalFeatures.FIPSEnabled = true
+				c.CustomerProperties.NodeDrainTimeoutMinutes = 30
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{},
+		},
 		// Test cases for version.id requirement validation on update
 		// The new validation rules for version.id are:
 		// - On create (oldObj == nil): version.id is always required

--- a/test/e2e/cluster_fips_mode.go
+++ b/test/e2e/cluster_fips_mode.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+var _ = Describe("FIPS Mode Support", func() {
+	Context("with ExperimentalReleaseFeatures AFEC registered", func() {
+		It("should create an HCP cluster with FIPS mode enabled via experimental tag",
+			labels.RequireNothing,
+			labels.Medium,
+			labels.Positive,
+			labels.AroRpApiCompatible,
+			labels.CreateCluster,
+			func(ctx context.Context) {
+				const customerClusterName = "fips-enabled-cluster"
+
+				tc := framework.NewTestContext()
+
+				if tc.UsePooledIdentities() {
+					err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+					Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+				}
+
+				By("creating a resource group")
+				resourceGroup, err := tc.NewResourceGroup(ctx, "fips-enabled", tc.Location())
+				Expect(err).NotTo(HaveOccurred(), "failed to create resource group for fips-enabled test")
+
+				By("creating cluster parameters with FIPS enabled tag")
+				clusterParams := framework.NewDefaultClusterParams20251223()
+				clusterParams.ClusterName = customerClusterName
+				managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+				clusterParams.ManagedResourceGroupName = managedResourceGroupName
+				clusterParams.Tags[api.TagClusterFIPSEnabled] = to.Ptr("true")
+
+				By("creating customer resources (infrastructure and managed identities)")
+				clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,
+					resourceGroup,
+					clusterParams,
+					map[string]interface{}{},
+					TestArtifactsFS,
+					framework.RBACScopeResourceGroup,
+				)
+				Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
+
+				By("creating the ARO-HCP cluster with FIPS enabled")
+				clusterResource, err := framework.BuildHCPClusterFromParams20251223(clusterParams, tc.Location(), nil)
+				Expect(err).NotTo(HaveOccurred(), "failed to build HCP cluster resource from params")
+
+				_, err = framework.CreateHCPClusterAndWait20251223(
+					ctx,
+					GinkgoLogr,
+					tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+					*resourceGroup.Name,
+					customerClusterName,
+					clusterResource,
+					framework.ClusterCreationTimeout,
+				)
+				Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with FIPS enabled", customerClusterName)
+
+				By("creating the node pool with FIPS enabled machines")
+				nodePoolParams := framework.NewDefaultNodePoolParams20251223()
+				nodePoolParams.ClusterName = customerClusterName
+				nodePoolParams.NodePoolName = "np-1"
+				nodePoolParams.Replicas = int32(2)
+
+				err = tc.CreateNodePoolFromParam20251223(ctx,
+					GinkgoLogr,
+					*resourceGroup.Name,
+					managedResourceGroupName,
+					customerClusterName,
+					nodePoolParams,
+					framework.NodePoolCreationTimeout,
+				)
+				Expect(err).NotTo(HaveOccurred(), "failed to create node pool %q for fips-enabled cluster %q", nodePoolParams.NodePoolName, customerClusterName)
+
+				By("verifying the cluster was created with the FIPS tag")
+				actualHCPCluster, err := tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+				Expect(err).NotTo(HaveOccurred(), "failed to get HCP cluster %s", customerClusterName)
+				Expect(actualHCPCluster.Tags).NotTo(BeNil(), "cluster tags should not be nil")
+				fipsTag, exists := actualHCPCluster.Tags[api.TagClusterFIPSEnabled]
+				Expect(exists).To(BeTrue(), "FIPS tag should exist")
+				Expect(fipsTag).NotTo(BeNil(), "FIPS tag value should not be nil")
+				Expect(*fipsTag).To(Equal("true"), "FIPS tag should be set to 'true'")
+
+				By("getting credentials")
+				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+					ctx,
+					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+					*resourceGroup.Name,
+					customerClusterName,
+					framework.GetAdminRESTConfigTimeout,
+				)
+				Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for HCP cluster %s", customerClusterName)
+
+				By("verifying FIPS mode is enabled on the cluster")
+				err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyFIPSEnabled())
+				Expect(err).NotTo(HaveOccurred(), "failed to verify FIPS is enabled on cluster %s", customerClusterName)
+			})
+
+		It("should reject an HCP cluster creation with invalid FIPS tag value",
+			labels.RequireNothing,
+			labels.Medium,
+			labels.Negative,
+			labels.AroRpApiCompatible,
+			labels.CreateCluster,
+			func(ctx context.Context) {
+				const (
+					customerClusterName = "fips-invalid-cluster"
+				)
+				tc := framework.NewTestContext()
+
+				if tc.UsePooledIdentities() {
+					err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+					Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+				}
+
+				By("creating a resource group")
+				resourceGroup, err := tc.NewResourceGroup(ctx, "fips-invalid", tc.Location())
+				Expect(err).NotTo(HaveOccurred(), "failed to create resource group for fips-invalid test")
+
+				By("creating cluster parameters with invalid FIPS tag value")
+				clusterParams := framework.NewDefaultClusterParams20251223()
+				clusterParams.ClusterName = customerClusterName
+				managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+				clusterParams.ManagedResourceGroupName = managedResourceGroupName
+				clusterParams.Tags[api.TagClusterFIPSEnabled] = to.Ptr("yes")
+
+				By("creating customer resources (infrastructure and managed identities)")
+				clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,
+					resourceGroup,
+					clusterParams,
+					map[string]interface{}{},
+					TestArtifactsFS,
+					framework.RBACScopeResourceGroup,
+				)
+				Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
+
+				By("attempting to create the hcp cluster with invalid FIPS value")
+				clusterResource, err := framework.BuildHCPClusterFromParams20251223(clusterParams, tc.Location(), nil)
+				Expect(err).NotTo(HaveOccurred(), "failed to build HCP cluster resource from params")
+				_, err = framework.CreateHCPClusterAndWait20251223(
+					ctx,
+					GinkgoLogr,
+					tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+					*resourceGroup.Name,
+					customerClusterName,
+					clusterResource,
+					framework.ClusterCreationTimeout,
+				)
+
+				Expect(err).To(HaveOccurred(), "expected cluster creation to fail with invalid FIPS tag value")
+				errMessage := "must be true or false"
+				Expect(strings.ToLower(err.Error())).To(ContainSubstring(strings.ToLower(errMessage)), "error should indicate FIPS value must be true or false")
+			})
+	})
+})

--- a/test/e2e/cluster_fips_mode.go
+++ b/test/e2e/cluster_fips_mode.go
@@ -121,6 +121,30 @@ var _ = Describe("FIPS Mode Support", func() {
 				By("verifying FIPS mode is enabled on the cluster")
 				err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyFIPSEnabled())
 				Expect(err).NotTo(HaveOccurred(), "failed to verify FIPS is enabled on cluster %s", customerClusterName)
+
+				By("attempting to change FIPS tag from true to false - should be rejected")
+				actualHCPCluster.Tags[api.TagClusterFIPSEnabled] = to.Ptr("false")
+				poller, err := tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().BeginCreateOrUpdate(
+					ctx,
+					*resourceGroup.Name,
+					customerClusterName,
+					actualHCPCluster.HcpOpenShiftCluster,
+					nil,
+				)
+				if err == nil {
+					_, err = poller.PollUntilDone(ctx, nil)
+				}
+				Expect(err).To(HaveOccurred(), "expected FIPS tag modification to be rejected")
+				Expect(strings.ToLower(err.Error())).To(ContainSubstring("immutable"), "error should indicate FIPS tag is immutable")
+
+				By("verifying FIPS tag remains unchanged at true")
+				verifyCluster, err := tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+				Expect(err).NotTo(HaveOccurred(), "failed to get HCP cluster after PATCH attempt")
+				Expect(verifyCluster.Tags).NotTo(BeNil(), "cluster tags should not be nil")
+				fipsTagAfterPatch, exists := verifyCluster.Tags[api.TagClusterFIPSEnabled]
+				Expect(exists).To(BeTrue(), "FIPS tag should still exist")
+				Expect(fipsTagAfterPatch).NotTo(BeNil(), "FIPS tag value should not be nil")
+				Expect(*fipsTagAfterPatch).To(Equal("true"), "FIPS tag should remain 'true' after rejected PATCH")
 			})
 
 		It("should reject an HCP cluster creation with invalid FIPS tag value",

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -12,6 +12,7 @@ Customer should be able to create an HCP cluster and custom node pool osDisk siz
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using the 2026-06-30-preview API version
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
+FIPS Mode Support with ExperimentalReleaseFeatures AFEC registered should create an HCP cluster with FIPS mode enabled via experimental tag
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -12,6 +12,8 @@ Create HCPOpenShiftCluster with Private KeyVault should create a cluster with pr
 Customer should create a cluster using the 2026-06-30-preview API version
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
+FIPS Mode Support with ExperimentalReleaseFeatures AFEC registered should create an HCP cluster with FIPS mode enabled via experimental tag
+FIPS Mode Support with ExperimentalReleaseFeatures AFEC registered should reject an HCP cluster creation with invalid FIPS tag value
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -12,6 +12,8 @@ Create HCPOpenShiftCluster with Private KeyVault should create a cluster with pr
 Customer should create a cluster using the 2026-06-30-preview API version
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
+FIPS Mode Support with ExperimentalReleaseFeatures AFEC registered should create an HCP cluster with FIPS mode enabled via experimental tag
+FIPS Mode Support with ExperimentalReleaseFeatures AFEC registered should reject an HCP cluster creation with invalid FIPS tag value
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -14,6 +14,8 @@ Customer should be able to create an HCP cluster and custom node pool osDisk siz
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using the 2026-06-30-preview API version
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
+FIPS Mode Support with ExperimentalReleaseFeatures AFEC registered should create an HCP cluster with FIPS mode enabled via experimental tag
+FIPS Mode Support with ExperimentalReleaseFeatures AFEC registered should reject an HCP cluster creation with invalid FIPS tag value
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -11,6 +11,8 @@ Customer should be able to create an HCP cluster and custom node pool osDisk siz
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using the 2026-06-30-preview API version
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
+FIPS Mode Support with ExperimentalReleaseFeatures AFEC registered should create an HCP cluster with FIPS mode enabled via experimental tag
+FIPS Mode Support with ExperimentalReleaseFeatures AFEC registered should reject an HCP cluster creation with invalid FIPS tag value
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -12,6 +12,8 @@ Create HCPOpenShiftCluster with Private KeyVault should create a cluster with pr
 Customer should create a cluster using the 2026-06-30-preview API version
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
+FIPS Mode Support with ExperimentalReleaseFeatures AFEC registered should create an HCP cluster with FIPS mode enabled via experimental tag
+FIPS Mode Support with ExperimentalReleaseFeatures AFEC registered should reject an HCP cluster creation with invalid FIPS tag value
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request

--- a/test/util/verifiers/fips.go
+++ b/test/util/verifiers/fips.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verifiers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type verifyFIPSEnabledImpl struct{}
+
+func (v verifyFIPSEnabledImpl) Name() string {
+	return "VerifyFIPSEnabled"
+}
+
+func (v verifyFIPSEnabledImpl) Verify(ctx context.Context, adminRESTConfig *rest.Config) error {
+	kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	nodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	if len(nodes.Items) == 0 {
+		return fmt.Errorf("no nodes found in the cluster")
+	}
+
+	for _, node := range nodes.Items {
+		fipsEnabled, err := checkNodeFIPSMode(ctx, kubeClient, &node)
+		if err != nil {
+			return fmt.Errorf("failed to check FIPS mode on node %s: %w", node.Name, err)
+		}
+		if !fipsEnabled {
+			return fmt.Errorf("FIPS mode is not enabled on node %s", node.Name)
+		}
+	}
+
+	return nil
+}
+
+func checkNodeFIPSMode(ctx context.Context, kubeClient *kubernetes.Clientset, node *corev1.Node) (bool, error) {
+	namespace, err := kubeClient.CoreV1().Namespaces().Create(
+		ctx,
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "e2e-fips-test-",
+			},
+		},
+		metav1.CreateOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to create namespace: %w", err)
+	}
+
+	defer func() {
+		_ = kubeClient.CoreV1().Namespaces().Delete(ctx, namespace.Name, metav1.DeleteOptions{})
+	}()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "fips-check-",
+			Namespace:    namespace.Name,
+		},
+		Spec: corev1.PodSpec{
+			NodeName:      node.Name,
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:    "fips-check",
+					Image:   "mcr.microsoft.com/azurelinux/distroless/debug:3.0",
+					Command: []string{"busybox", "cat", "/proc/sys/crypto/fips_enabled"},
+				},
+			},
+		},
+	}
+
+	createdPod, err := kubeClient.CoreV1().Pods(namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to create FIPS check pod: %w", err)
+	}
+
+	defer func() {
+		_ = kubeClient.CoreV1().Pods(namespace.Name).Delete(ctx, createdPod.Name, metav1.DeleteOptions{})
+	}()
+
+	var prevPodPhase corev1.PodPhase
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+		p, err := kubeClient.CoreV1().Pods(namespace.Name).Get(ctx, createdPod.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if prevPodPhase == "" {
+			prevPodPhase = p.Status.Phase
+		}
+
+		// track pod state transitions for better visibility in test output
+		if prevPodPhase != p.Status.Phase {
+			ginkgo.GinkgoWriter.Printf("Pod state transitioned from '%s' to '%s'\n", prevPodPhase, p.Status.Phase)
+			prevPodPhase = p.Status.Phase
+		}
+
+		if p.Status.Phase == corev1.PodFailed {
+			// Log container status for debugging
+			var errMsg strings.Builder
+			errMsg.WriteString(fmt.Sprintf("pod %s failed", createdPod.Name))
+			for _, cs := range p.Status.ContainerStatuses {
+				if cs.State.Terminated != nil {
+					errMsg.WriteString(fmt.Sprintf("; container %s terminated with exit code %d, reason: %s, message: %s",
+						cs.Name, cs.State.Terminated.ExitCode, cs.State.Terminated.Reason, cs.State.Terminated.Message))
+				}
+			}
+			// Attempt to fetch pod logs for diagnostics
+			logs, logErr := kubeClient.CoreV1().Pods(namespace.Name).GetLogs(createdPod.Name, &corev1.PodLogOptions{}).Do(ctx).Raw()
+			if logErr == nil && len(logs) > 0 {
+				errMsg.WriteString(fmt.Sprintf("; pod logs: %s", string(logs)))
+			}
+			return false, fmt.Errorf("%s", errMsg.String())
+		}
+
+		return p.Status.Phase == corev1.PodSucceeded, nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed waiting for pod to complete: %w", err)
+	}
+
+	// Read pod logs
+	logs, err := kubeClient.CoreV1().Pods(namespace.Name).GetLogs(createdPod.Name, &corev1.PodLogOptions{}).Do(ctx).Raw()
+	if err != nil {
+		return false, fmt.Errorf("failed to get pod logs: %w", err)
+	}
+
+	output := strings.TrimSpace(string(logs))
+	return output == "1", nil
+}
+
+func VerifyFIPSEnabled() HostedClusterVerifier {
+	return verifyFIPSEnabledImpl{}
+}


### PR DESCRIPTION
<!-- Link to Jira issue -->

https://redhat.atlassian.net/browse/ARO-27735

### What

<!-- Briefly describe what this PR does -->

This pull request adds the ability to provision a new ARO-HCP cluster in FIPS mode using Azure feature flags & new optional cluster tag `aro-hcp.experimental.cluster.fips-enabled: true / false`. This implementation is to validate that the provisioning of a fips-enabled ARO-HCP cluster works end to end. Eventually, this implementation will be removed in favor of specifying the FIPS flag via standard ARO-HCP API.

### Why

This change allows for creating an ARO-HCP cluster with fips-enabled node pools (the ARO-HCP control plane pods are always deployed on fips-enabled clusters). 

<!-- Briefly explain why this change is needed -->

### Testing

The PR includes end2end test for the feature. To manually test the feature, enable the `microsoft.redhatopenshift/experimentalreleasefeatures` AFEC for your subscription and add the `aro-hcp.experimental.cluster.fips-enabled: true` tag to the newly created cluster. The tag needs to be set during cluster installation and changing it later won't have any effect (this is a day-1 operation).

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
