### PR TITLE
Set explicit 150-minute per-spec timeout for dev/rp-api-compat e2e suites

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -171,6 +171,7 @@ func setupCli() *cobra.Command {
 		rpApiCompatBaseQualifier = fmt.Sprintf(`%s && !labels.exists(l, l=="%s")`, rpApiCompatBaseQualifier, labels.DevelopmentOnly[0])
 	}
 
+	rpApiCompatTestTimeout := 150 * time.Minute
 	ext.AddSuite(e.Suite{
 		Name:       "rp-api-compat-all/parallel",
 		Qualifiers: []string{fastTestsOnly(rpApiCompatBaseQualifier)},
@@ -178,6 +179,7 @@ func setupCli() *cobra.Command {
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=20
 		Parallelism: 24,
+		TestTimeout: &rpApiCompatTestTimeout,
 	})
 	ext.AddSuite(e.Suite{
 		Name:       "rp-api-compat-all/parallel/slow",
@@ -186,6 +188,7 @@ func setupCli() *cobra.Command {
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=20
 		Parallelism: 24,
+		TestTimeout: &rpApiCompatTestTimeout,
 	})
 
 	// If using Ginkgo, build test specs automatically


### PR DESCRIPTION
Set explicit `TestTimeout` of 150 minutes on `rp-api-compat-all/parallel` and `rp-api-compat-all/parallel/slow`suites, matching the value already used by `integration/parallel`, `stage/parallel`, and `prod/parallel`.

The `e2e-parallel` presubmit (e.g. [failing run on PR #5326](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/5326/pull-ci-Azure-ARO-HCP-main-e2e-parallel/)) is hitting the **default 90-minute per-spec timeout** from `openshift-tests-extension`.

The `rp-api-compat-all/parallel` suite (used in dev e2e-parallel presubmit) did not set a `TestTimeout`, falling back to the framework's built-in 90-minute default. However, due to identity container lease contention, some tests routinely spend 40-55 minutes waiting for a free identity container before even beginning actual work. For upgrade tests that need ~35 minutes of real execution + cleanup, the total exceeds 90 minutes:

```
~55min  identity container acquisition (lease wait)
~10min  cluster creation
~12min  upgrade verification
~11min  cleanup (cluster deletion)
────────
~88min  total — fails if anything is slightly slow
```

The 3 failed tests all ran for exactly 5400 seconds (90 minutes) before being interrupted:
- "Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20"
- "Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21"
- "Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor"

The `integration/parallel` suite already uses 150 minutes for the same tests.