### PR TITLE
Fix "failed post-install: resource ClusterSizingConfiguration//cluster still exists" provision error

### DIFF
--- a/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
+++ b/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": "hook-failed"
 spec:
   concurrency:
     limit: 9999
@@ -55,6 +56,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": "hook-failed"
 spec:
   concurrency:
     limit: 5

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -739,6 +739,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": "hook-failed"
 spec:
   concurrency:
     limit: 9999


### PR DESCRIPTION
### What

Fixes the intermittent (~5%) `"resource ClusterSizingConfiguration//cluster still exists"` failure in e2e presubmit jobs ([example failure](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/5318/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2056760557834342400)).

### Why

The `ClusterSizingConfiguration` hook has no explicit `helm.sh/hook-delete-policy`, so Helm [defaults to `before-hook-creation`](https://github.com/helm/helm/blob/340b06d8/pkg/action/hooks.go#L85-L92). On a fresh cluster, this is the sequence:

1. Weight-1 hook installs the HyperShift operator
2. The operator starts and creates its own default `ClusterSizingConfiguration/cluster` CR
3. Helm reaches the weight-2 hook, [deletes the existing CR and calls `WaitForDelete`](https://github.com/helm/helm/blob/340b06d8/pkg/action/hooks.go#L82-L83)
4. The operator's reconciliation loop immediately recreates the CR
5. [`waitForDelete`](https://github.com/helm/helm/blob/340b06d8/pkg/kube/statuswait.go#L130-L153) never sees `NotFoundStatus` and times out

The race is intermittent because it depends on whether the operator is reconciling fast enough to recreate the CR before the delete-watch confirms it's gone.

### How the fix works

Setting `"helm.sh/hook-delete-policy": "hook-failed"`:

1. **Skips the `before-hook-creation` delete** — no fight with the operator's reconciler
2. **SSA Create still works** — Helm's hook Create uses [`patchResourceServerSide`](https://github.com/helm/helm/blob/340b06d8/pkg/kube/client.go#L310-L333) (SSA PATCH), which is an upsert regardless of whether the resource exists
3. **`WatchUntilReady` succeeds immediately** — for non-Job/non-Pod resources, the StatusWatcher uses [`alwaysReady`](https://github.com/helm/helm/blob/340b06d8/pkg/kube/statuswait.go#L69-L73)
4. **No resource disappears during rollouts** — the CR is never deleted, so there's no window where the config is missing

### Supersedes

#5328