### PR TITLE
docs(ops): cover ManagedClusterAddon finalizers in stuck-cluster cleanup runbook

### DIFF
--- a/docs/ops/cleanup-stuck-cluster-deletion.md
+++ b/docs/ops/cleanup-stuck-cluster-deletion.md
@@ -85,6 +85,9 @@ Clusters Service (sets state to "uninstalling")
   → Maestro Server (deletes ResourceBundle)
     → Maestro Agent (deletes ManifestWork on MGMT)
       → ManifestWork cleanup (deletes HostedCluster, ManagedCluster, etc.)
+        → ManagedCluster destructor (hypershift-managed-cluster-destructor)
+          → ManagedClusterAddon pre-delete hooks (finalizer: hosting-addon-pre-delete)
+          → ManagedClusterAddon manifests cleanup (finalizer: hosting-manifests-cleanup)
         → HostedCluster deletion (finalizer: hypershift.openshift.io/finalizer)
           → NodePool deletion (finalizer: hypershift.openshift.io/finalizer)
           → Control Plane namespace cleanup
@@ -138,8 +141,12 @@ kubectl get namespaces -o json | \
   jq -r '.items[] | select(.status.phase == "Terminating") |
   "\(.metadata.name)\t\(.metadata.deletionTimestamp)"'
 
-# Check ManagedClusters
+# Check ManagedClusters (look for status JOINED vs Detaching)
 kubectl get managedcluster
+
+# Check ManagedClusterAddons in the cluster namespace
+# (klusterlet auth loss during Detaching can leave addons with held finalizers)
+kubectl get managedclusteraddon -n ${CLUSTER_ID}
 
 # Check all HostedClusters and their status
 kubectl get hostedcluster -A
@@ -183,6 +190,16 @@ kubectl get hostedclusters.hypershift.openshift.io,hostedcontrolplanes.hypershif
   -n <namespace> -o json | \
   jq '[.items[] | select(.metadata.finalizers != null) |
   {kind, name: .metadata.name, finalizers: .metadata.finalizers}]'
+
+# Check ManagedCluster conditions (look for Detaching state, klusterlet auth errors)
+kubectl get managedcluster ${CLUSTER_ID} \
+  -o jsonpath='{.status.conditions}' | jq .
+
+# Check ManagedClusterAddon finalizers (hosting-manifests-cleanup, hosting-addon-pre-delete
+# can be held when klusterlet user lost Azure AD authorization during Detaching)
+kubectl get managedclusteraddon -n ${CLUSTER_ID} -o json | \
+  jq '[.items[] | select(.metadata.finalizers != null) |
+  {name: .metadata.name, finalizers: .metadata.finalizers}]'
 ```
 
 ### Phase 2: Check the Service Cluster
@@ -268,9 +285,19 @@ kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
 
 #### Strategy 3: Manual Finalizer Removal on Management Cluster (Last Resort)
 
-Only after ensuring the source (CS/Maestro) won't recreate resources, remove finalizers **bottom-up** on the management cluster:
+Only after ensuring the source (CS/Maestro) won't recreate resources, remove finalizers **bottom-up** on the management cluster.
+
+> **Note**: If Phase 1 Step 4 shows the `ManagedCluster` in `Detaching` state or `ManagedClusterAddon` resources with held finalizers, clear those **first** (step 0 below). The destruct chain stops at the `hypershift-managed-cluster-destructor` step when addon pre-delete hooks fail (commonly due to klusterlet auth loss during Detaching), and the CP namespace teardown is never even attempted.
 
 ```bash
+# 0. (Conditional) Clear ManagedClusterAddon finalizers when the destruct chain is stuck
+#    at the ManagedCluster layer (Detaching + addon pre-delete hooks failing).
+#    Uses a merge patch (idempotent when .metadata.finalizers is absent).
+for name in $(kubectl get managedclusteraddon -n ${CLUSTER_ID} -o jsonpath='{.items[*].metadata.name}'); do
+  kubectl patch managedclusteraddon $name -n ${CLUSTER_ID} \
+    --type=merge -p='{"metadata":{"finalizers":null}}'
+done
+
 # 1. Check what's blocking the CP namespace (if Terminating):
 kubectl get namespace <cp-namespace> -o json | jq '.status.conditions[] | select(.type == "NamespaceContentRemaining")'
 
@@ -395,6 +422,14 @@ kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
 
 **Fix**: Patch the finalizers on all four kinds in the CP namespace (see Strategy 3, step 2).
 
+### Scenario 6: ManagedCluster Stuck Detaching - Addon Finalizers Held
+
+**Symptoms**: HCP deletion never advances past the ACM layer. `kubectl get managedcluster ${CLUSTER_ID}` shows the cluster in `Detaching` state for an extended period. `kubectl get managedclusteraddon -n ${CLUSTER_ID}` lists addons (typically `config-policy-controller`, `governance-policy-framework`) with `hosting-manifests-cleanup` and/or `hosting-addon-pre-delete` finalizers held. The CP namespace cleanup is never attempted because the destruct chain is blocked upstream at `hypershift-managed-cluster-destructor`.
+
+**Cause**: The hosting addon pre-delete hook executes against the hosted cluster using the klusterlet user, but that identity has already lost its Azure AD authorization as part of the Detaching flow. The pre-delete hook fails, the addon's finalizers are never removed, and the ManagedCluster destructor cannot complete.
+
+**Fix**: Clear the held `ManagedClusterAddon` finalizers manually (see Strategy 3, step 0). After this, the `ManagedCluster` destructor completes, the `ManifestWork` cleanup proceeds, and the rest of the deletion chain advances normally.
+
 ## Quick Reference: Key API Endpoints
 
 | Component | Endpoint | Notes |
@@ -417,6 +452,8 @@ kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
 | `azuremachine.infrastructure.cluster.x-k8s.io` | AzureMachine | CAPZ (Cluster API Provider Azure) |
 | `cluster.open-cluster-management.io/manifest-work-cleanup` | ManifestWork | ACM Work Agent |
 | `cluster.open-cluster-management.io/api-resource-cleanup` | ManagedCluster | ACM |
+| `hosting-manifests-cleanup` | ManagedClusterAddon | Hosting Addon Controller |
+| `hosting-addon-pre-delete` | ManagedClusterAddon | Hosting Addon Controller |
 
 ## Quick Reference: Key Controller Logs
 


### PR DESCRIPTION
Follow-up to #5306 incorporating PR review feedback from @weherdh on [PR comment 4484039763](https://github.com/Azure/ARO-HCP/pull/5306#issuecomment-4484039763).

[AROSLSRE-883](https://redhat.atlassian.net/browse/AROSLSRE-883) (3 stuck HCPs on STG uksouth) surfaced a distinct failure mode at the **ManagedCluster** layer that the existing runbook didn't cover. The destruct chain never advanced past `hypershift-managed-cluster-destructor` because `ManagedClusterAddon` resources (`config-policy-controller`, `governance-policy-framework`) had held finalizers (`hosting-manifests-cleanup`, `hosting-addon-pre-delete`) -- the addon pre-delete hooks failed when the klusterlet user lost Azure AD authorization during `Detaching`. The conventional bottom-up CP-namespace cleanup is moot in this scenario because the destruct chain stops upstream of the CP namespace.

## Changes

| Section | What was added |
|---|---|
| Deletion chain diagram | `ManagedCluster destructor` + addon pre-delete / manifests-cleanup hooks branch between ManifestWork cleanup and HostedCluster deletion |
| Phase 1 Step 2 (initial inventory) | `kubectl get managedclusteraddon -n ${CLUSTER_ID}` + `JOINED` vs `Detaching` hint |
| Phase 1 Step 4 (finalizer scan) | ManagedCluster `.status.conditions` extraction + ManagedClusterAddon finalizer scan |
| Strategy 3 | New **step 0** to clear addon finalizers when the chain is stuck at the MC layer, with a `> Note` explaining why this must come before the existing bottom-up flow |
| Scenarios | New **Scenario 6: ManagedCluster Stuck Detaching - Addon Finalizers Held** (Symptoms / Cause / Fix) |
| Finalizer reference table | `hosting-manifests-cleanup` and `hosting-addon-pre-delete` rows |

## Relationship to #5306

#5306 covered the **NodePool / CAPI AzureMachine / Maestro** failure modes from [AROSLSRE-881](https://redhat.atlassian.net/browse/AROSLSRE-881) (4 stuck HCPs on INT uksouth where the destruct chain reached the CP namespace and stalled on CAPI/NodePool finalizers). This PR is **complementary**, not duplicative -- it covers the case where the destruct chain stalls **before** ever reaching the CP namespace.

## Source

- [AROSLSRE-883](https://redhat.atlassian.net/browse/AROSLSRE-883) -- Stage uksouth stuck-cluster bug (3 HCPs)
- @weherdh's PR comment with the original analysis and recommended diagnostic + remediation commands

## Verification

- `git diff --stat`: `1 file changed, 39 insertions(+), 2 deletions(-)`
- Markdown renders cleanly; the new step 0 uses the same idempotent merge-patch pattern (`--type=merge -p='{"metadata":{"finalizers":null}}'`) as the NodePool / AzureMachine examples already in the runbook from #5306.