### PR TITLE
feat: add prometheus alerting on frontend http request handling panics

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -462,6 +462,33 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
         for: 'PT5M'
         severity: 4
       }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'FrontendHttpRequestPanics'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'FrontendHttpRequestPanics/{{ $labels.cluster }}'
+          description: 'Frontend HTTP request handler has panicked {{ printf "%.0f" $value }} time(s) in the last 5 minutes.'
+          info: 'Frontend HTTP request handler has panicked {{ printf "%.0f" $value }} time(s) in the last 5 minutes.'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html'
+          summary: 'Frontend is panicking during HTTP request handling'
+          title: 'Frontend is panicking during HTTP request handling'
+        }
+        expression: 'sum by (cluster) ( increase(frontend_http_request_panics_total[5m]) ) > 0'
+        for: 'PT1M'
+        severity: 3
+      }
     ]
     scopes: [
       azureMonitoring

--- a/frontend/alerts/frontend-prometheusRule.yaml
+++ b/frontend/alerts/frontend-prometheusRule.yaml
@@ -59,3 +59,15 @@ spec:
         summary: "Frontend audit log connection is degraded."
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html'
         description: "The frontend failed to connect to the audit server and is running with a no-op audit client. No audit logs are being sent."
+    - alert: FrontendHttpRequestPanics
+      expr: |
+        sum by (cluster) (
+          increase(frontend_http_request_panics_total[5m])
+        ) > 0
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        description: 'Frontend HTTP request handler has panicked {{ printf "%.0f" $value }} time(s) in the last 5 minutes.'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html'
+        summary: 'Frontend is panicking during HTTP request handling'

--- a/frontend/alerts/frontend-prometheusRule_test.yaml
+++ b/frontend/alerts/frontend-prometheusRule_test.yaml
@@ -101,3 +101,27 @@ tests:
   - eval_time: 10m
     alertname: FrontendAuditLogConnectionDegraded
     exp_alerts: []
+# Test: FrontendHttpRequestPanics fires when panics occur
+- interval: 1m
+  input_series:
+  - series: 'frontend_http_request_panics_total{path_pattern="/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/{hcpOpenShiftClusterName}", method="GET"}'
+    values: "0 1 2 3 4 5 6 7 8 9 10"
+  alert_rule_test:
+  - eval_time: 6m
+    alertname: FrontendHttpRequestPanics
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+      exp_annotations:
+        description: 'Frontend HTTP request handler has panicked 5 time(s) in the last 5 minutes.'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html'
+        summary: 'Frontend is panicking during HTTP request handling'
+# Test: FrontendHttpRequestPanics does not fire when no panics
+- interval: 1m
+  input_series:
+  - series: 'frontend_http_request_panics_total{path_pattern="/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/{hcpOpenShiftClusterName}", method="GET"}'
+    values: "0+0x10"
+  alert_rule_test:
+  - eval_time: 6m
+    alertname: FrontendHttpRequestPanics
+    exp_alerts: []


### PR DESCRIPTION
We add a new prometheus rule FrontendHttpRequestPanics that triggers when there's been a panic caught by the frontend http request handling panic middleware in the last 5 minutes.
