### PR TITLE
Specify API version suffixes in test framework helper functions

### DIFF
--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -2,17 +2,18 @@
 
 ## Provision HCP cluster
 
-* **Cluster creation:** Cluster creation, which leverages methods from the framework module, offers three main approaches for creating and deploying an HCP cluster: `CreateHCPClusterFromParam`, which handles creation and automatically waits for successful deployment; `BeginCreateHCPCluster`, which initiates the process but requires explicit test logic to wait for provisioning completion; and an alternative using `CreateHCPClusterFromParam` with a 0-second timeout, which executes the creation but immediately bypasses the waiting phase for provisioning to finish.
-* **Cluster Params:** The `NewDefaultClusterParams` method from the framework module should be used to configure the default cluster parameters. Before creating cluster customer resources, the `ClusterName` parameter must be set. Different cluster configurations can be achieved by assigning custom values to the parameters.
+* **Cluster creation:** Cluster creation, which leverages methods from the framework module, offers three main approaches for creating and deploying an HCP cluster: `CreateHCPClusterFromParam20240610`, which handles creation and automatically waits for successful deployment; `BeginCreateHCPCluster20240610`, which initiates the process but requires explicit test logic to wait for provisioning completion; and an alternative using `CreateHCPClusterFromParam20240610` with a 0-second timeout, which executes the creation but immediately bypasses the waiting phase for provisioning to finish.
+* **Cluster Params:** The `NewDefaultClusterParams20240610` method from the framework module should be used to configure the default cluster parameters. Before creating cluster customer resources, the `ClusterName` parameter must be set. Different cluster configurations can be achieved by assigning custom values to the parameters.
 * **Prepare cluster customer resources:** Creating a cluster requires several
   resources (like an NSG, VNet, subnet, and managed identities). To create
   these resources and set the cluster's parameters, use the
-  `CreateClusterCustomerResources` method from the framework module.
+  `CreateClusterCustomerResources20240610` method from the framework module.
   Use `RBACScopeResourceGroup` as RBACScope argument of
-  `CreateClusterCustomerResources` function, but make sure that
+  `CreateClusterCustomerResources20240610` function, but make sure that
   `framework.RBACScopeResource` is used in at least one test case in E2E
   test suite.
-* **Nodepool creation:** To create a nodepool, utilize the `CreateNodePoolFromParam` method. Beforehand, the default nodepool parameters should be prepared using the `NewDefaultNodePoolParams` method. Both of these methods are located within the `framework` module. Like cluster parameters, custom configurations can be assigned to the nodepool parameter values.
+* **Nodepool creation:** To create a nodepool, utilize the `CreateNodePoolFromParam20240610` method. Beforehand, the default nodepool parameters should be prepared using the `NewDefaultNodePoolParams20240610` method. Both of these methods are located within the `framework` module. Like cluster parameters, custom configurations can be assigned to the nodepool parameter values.
+* **API version suffix convention:** Framework helpers that call the ARM SDK must use explicit API version suffixes in their names. Prefer `...20240610` helpers for the stable test path (for example `GetHCPCluster20240610`, `UpdateHCPCluster20240610`, `CreateNodePoolAndWait20240610`) and `...20251223` or any future versions helpers only when testing preview-specific behavior (for example `BuildHCPClusterFromParams20251223`, `CreateHCPClusterAndWait20251223`).
 * **Timeout of deployment:** Timeouts should be defined as named constants in `test/util/framework/constants.go` to ensure reusability and consistency across the test suite. Use the appropriate constant (e.g. `framework.ClusterCreationTimeout`, `framework.NodePoolCreationTimeout`, `framework.ExternalAuthCreationTimeout`) rather than hardcoding duration values. When a new timeout category is needed, add a constant to that file first.
 
 ## Resource naming \- Independence and Isolation
@@ -28,13 +29,13 @@
 
 ## Kubernetes verifiers
 
-* **K8S client-go:** Use this client to communicate with created HCP clusters. Client requires rest Config which is provided by method `GetAdminRESTConfigForHCPCluster` with 10 minutes timeout.
+* **K8S client-go:** Use this client to communicate with created HCP clusters. Client requires rest Config which is provided by method `GetAdminRESTConfigForHCPCluster20240610` with 10 minutes timeout.
 * **HostedClusterVerifier:** This interface is designed for all verifiers and provides the essential `Name` and `Verify` methods for extension.
 * **Code location:** Verifiers are located in the util module `verifiers`. ([https://github.com/Azure/ARO-HCP/tree/main/test/util/verifiers](https://github.com/Azure/ARO-HCP/tree/main/test/util/verifiers))
 
 ## Cleanup of Resources
 
-* **TestContext:** Using [TestContext](https://github.com/Azure/ARO-HCP/blob/main/test/util/framework/per_test_framework.go#L51), to create a resource group, will automatically register it for a cleanup after the test. The cleanup process involves deleting all HCP clusters within the designated resource groups. The resource groups themselves are removed, along with any remaining Azure resources.
+* **TestContext:** Using [TestContext](https://github.com/Azure/ARO-HCP/blob/main/test/util/framework/per_test_framework.go#L51), to create a resource group, will automatically register it for a cleanup after the test. The cleanup process involves deleting all HCP clusters within the designated resource groups (via `DeleteAllHCPClusters20240610`). The resource groups themselves are removed, along with any remaining Azure resources.
 * **Test resources:** Within the test, remove any created resources that are not part of the TestContext resource group or its associated HCP clusters. Ensure all tests start from a known, clean state to avoid flakiness and false positives.
 
 # Best Practices for Writing E2E Test Cases

--- a/test/e2e/admin_api.go
+++ b/test/e2e/admin_api.go
@@ -61,13 +61,13 @@ var _ = Describe("SRE", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for admin-api-breakglass")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = engineeringClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -81,7 +81,7 @@ var _ = Describe("SRE", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for breakglass cluster")
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -276,13 +276,13 @@ var _ = Describe("SRE", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for serial console test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = engineeringClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -296,7 +296,7 @@ var _ = Describe("SRE", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for serial console cluster")
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -306,12 +306,12 @@ var _ = Describe("SRE", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q for serial console test", engineeringClusterName)
 
 			By("creating a nodepool to provision worker VMs")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = engineeringClusterName
 			nodePoolParams.NodePoolName = "worker"
 			nodePoolParams.Replicas = int32(1)
 
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,
@@ -385,13 +385,13 @@ var _ = Describe("SRE", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for boot diagnostics test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = engineeringClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -405,7 +405,7 @@ var _ = Describe("SRE", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for boot diagnostics cluster")
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -415,12 +415,12 @@ var _ = Describe("SRE", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q for boot diagnostics test", engineeringClusterName)
 
 			By("creating a nodepool to provision worker VMs")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = engineeringClusterName
 			nodePoolParams.NodePoolName = "worker"
 			nodePoolParams.Replicas = int32(1)
 
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,

--- a/test/e2e/admin_credential_lifecycle.go
+++ b/test/e2e/admin_credential_lifecycle.go
@@ -71,13 +71,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for admin credential lifecycle test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = clusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]any{},
@@ -92,7 +92,7 @@ var _ = Describe("Customer", func() {
 			deploymentCtx, deploymentCancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during admin credential lifecycle test", timeout.Minutes()))
 			defer deploymentCancel()
 
-			_, err = framework.BeginCreateHCPCluster(
+			_, err = framework.BeginCreateHCPCluster20240610(
 				deploymentCtx,
 				GinkgoLogr,
 				clusterClient,
@@ -109,7 +109,7 @@ var _ = Describe("Customer", func() {
 			var previousState hcpsdk20240610preview.ProvisioningState
 			GinkgoLogr.Info("creating cluster, waiting for it to reach a terminal state")
 			Eventually(func() bool {
-				cluster, err := framework.GetHCPCluster(ctx, clusterClient, *resourceGroup.Name, clusterName)
+				cluster, err := framework.GetHCPCluster20240610(ctx, clusterClient, *resourceGroup.Name, clusterName)
 				if err != nil {
 					var respErr *azcore.ResponseError
 					if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
@@ -245,7 +245,7 @@ var _ = Describe("Customer", func() {
 			skipSuite := os.Getenv("ARO_HCP_SUITE_NAME") == "integration/parallel" && time.Now().Before(time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC))
 
 			By("revoking all cluster admin credentials via ARO HCP RP API")
-			err = tc.RevokeCredentialsAndWait(ctx, clusterClient, *resourceGroup.Name, clusterName, 15*time.Minute)
+			err = tc.RevokeCredentialsAndWait20240610(ctx, clusterClient, *resourceGroup.Name, clusterName, 15*time.Minute)
 			if err != nil && skipSuite {
 				Skip("skipping revocation and remaining steps in integration/parallel suite")
 			}
@@ -287,7 +287,7 @@ var _ = Describe("Customer", func() {
 			By("verifying new admin credentials can still be requested after revocation")
 			// After revocation, new admin credential requests should still work
 			// This validates the revocation endpoint doesn't break the cluster
-			newAdminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			newAdminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				clusterClient,
 				*resourceGroup.Name,

--- a/test/e2e/arm64_nodepool.go
+++ b/test/e2e/arm64_nodepool.go
@@ -60,13 +60,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for ARM64 nodepool test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -80,7 +80,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for ARM64 nodepool cluster")
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -94,13 +94,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to find an ARM64-capable VM size")
 
 			By(fmt.Sprintf("creating the ARM64-based node pool %q with VM size %q", customerNodePoolName, nodePoolVMSize))
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.NodePoolName = customerNodePoolName
 			nodePoolParams.Replicas = int32(2)
 			nodePoolParams.VMSize = nodePoolVMSize
 
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -70,13 +70,13 @@ var _ = Describe("Authorized CIDRs", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create resource group for authorized CIDRs connectivity test")
 
 				By("creating cluster parameters")
-				clusterParams := framework.NewDefaultClusterParams()
+				clusterParams := framework.NewDefaultClusterParams20240610()
 				clusterParams.ClusterName = clusterName
 				managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 				clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 				By("creating customer resources")
-				clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+				clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 					resourceGroup,
 					clusterParams,
 					map[string]interface{}{
@@ -124,7 +124,7 @@ var _ = Describe("Authorized CIDRs", func() {
 					to.Ptr(fmt.Sprintf("%s/32", vmPublicIP)),
 				}
 
-				err = tc.CreateHCPClusterFromParam(
+				err = tc.CreateHCPClusterFromParam20240610(
 					ctx,
 					GinkgoLogr,
 					*resourceGroup.Name,
@@ -134,7 +134,7 @@ var _ = Describe("Authorized CIDRs", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with authorized CIDRs", clusterName)
 
 				By("getting cluster details")
-				clusterResponse, err := framework.GetHCPCluster(
+				clusterResponse, err := framework.GetHCPCluster20240610(
 					ctx,
 					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
@@ -175,7 +175,7 @@ var _ = Describe("Authorized CIDRs", func() {
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Get \"%s/healthz\": EOF", apiURL)), "Should fail with EOF error indicating blocked connection")
 
 				By("verifying VM can access cluster API with credentials")
-				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 					ctx,
 					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
@@ -228,12 +228,12 @@ var _ = Describe("Authorized CIDRs", func() {
 				}, 5*time.Minute, 10*time.Second).Should(Succeed())
 
 				By("creating the node pool")
-				nodePoolParams := framework.NewDefaultNodePoolParams()
+				nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 				nodePoolParams.ClusterName = clusterName
 				nodePoolParams.NodePoolName = "np-1"
 				nodePoolParams.Replicas = int32(2)
 
-				err = tc.CreateNodePoolFromParam(ctx,
+				err = tc.CreateNodePoolFromParam20240610(ctx,
 					GinkgoLogr,
 					*resourceGroup.Name,
 					managedResourceGroupName,
@@ -292,12 +292,11 @@ var _ = Describe("Authorized CIDRs", func() {
 						},
 					},
 				}
-
-				_, err = framework.CreateOrUpdateExternalAuthAndWait(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, clusterName, customerExternalAuthName, extAuth, framework.ExternalAuthCreationTimeout)
+				_, err = framework.CreateOrUpdateExternalAuthAndWait20240610(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, clusterName, customerExternalAuthName, extAuth, framework.ExternalAuthCreationTimeout)
 				Expect(err).NotTo(HaveOccurred(), "failed to create external auth config %q", customerExternalAuthName)
 
 				By("verifying ExternalAuth is in a Succeeded state")
-				eaResult, err := framework.GetExternalAuth(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, clusterName, customerExternalAuthName)
+				eaResult, err := framework.GetExternalAuth20240610(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, clusterName, customerExternalAuthName)
 				Expect(err).NotTo(HaveOccurred(), "failed to get external auth config %q", customerExternalAuthName)
 				Expect(*eaResult.Properties.ProvisioningState).To(Equal(hcpsdk20240610preview.ExternalAuthProvisioningStateSucceeded), "external auth %q provisioning state should be Succeeded", customerExternalAuthName)
 
@@ -394,7 +393,7 @@ var _ = Describe("Authorized CIDRs", func() {
 
 				By("updating cluster to remove VM from authorized CIDRs")
 				// Get the current cluster state
-				currentCluster, err := framework.GetHCPCluster(
+				currentCluster, err := framework.GetHCPCluster20240610(
 					ctx,
 					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,

--- a/test/e2e/cluster_autoscaling.go
+++ b/test/e2e/cluster_autoscaling.go
@@ -64,7 +64,7 @@ var _ = Describe("Customer", func() {
 			resourceGroup, err := tc.NewResourceGroup(ctx, "autoscaling-cluster", tc.Location())
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for autoscaling cluster test")
 
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
@@ -75,7 +75,7 @@ var _ = Describe("Customer", func() {
 			}
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -89,7 +89,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for autoscaling cluster")
 
 			By("creating the cluster")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
@@ -98,7 +98,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with custom autoscaling", customerClusterName)
 
 			By("ensuring the custom autoscaling was honored")
-			got, err := framework.GetHCPCluster(
+			got, err := framework.GetHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -111,12 +111,12 @@ var _ = Describe("Customer", func() {
 			Expect(got.Properties.Autoscaling.PodPriorityThreshold).To(Equal(to.Ptr(autoscalingPodPriorityThreshold)), "cluster autoscaling PodPriorityThreshold should be %d", autoscalingPodPriorityThreshold)
 
 			By("creating the node pool")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.NodePoolName = customerNodePoolName
 			nodePoolParams.Replicas = int32(2)
 
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,
@@ -127,7 +127,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create nodepool %q for autoscaling cluster", customerNodePoolName)
 
 			By("patching the cluster to set maxNodesTotal")
-			_, err = framework.UpdateHCPCluster(
+			_, err = framework.UpdateHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,

--- a/test/e2e/cluster_create_cni_cilium.go
+++ b/test/e2e/cluster_create_cni_cilium.go
@@ -51,7 +51,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for cilium CNI test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
@@ -64,7 +64,7 @@ var _ = Describe("Customer", func() {
 			clusterParams.Network.HostPrefix = 23
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]any{},
@@ -74,7 +74,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for cilium CNI cluster")
 
 			By("creating HCP cluster without CNI")
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -84,7 +84,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q without CNI", customerClusterName)
 
 			By("getting credentials and verifying cluster is available")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -148,9 +148,9 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to install Cilium chart via Helm")
 
 			By("creating the node pool")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.NodePoolName = customerNodePoolName
-			nodePoolErr := tc.CreateNodePoolFromParam(
+			nodePoolErr := tc.CreateNodePoolFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,

--- a/test/e2e/cluster_create_complex_cilium_kv.go
+++ b/test/e2e/cluster_create_complex_cilium_kv.go
@@ -61,7 +61,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for complex cilium keyvault test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20251223()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
@@ -70,7 +70,7 @@ var _ = Describe("Customer", func() {
 			clusterParams.Network.NetworkType = "Other"
 
 			By("creating customer resources (infrastructure and managed identities)")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]any{
@@ -82,7 +82,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources with private key vault")
 
 			By("creating the HCP cluster with no CNI and private etcd via v20251223preview")
-			clusterResource, err := framework.BuildHCPCluster20251223FromParams(clusterParams, tc.Location(), nil)
+			clusterResource, err := framework.BuildHCPClusterFromParams20251223(clusterParams, tc.Location(), nil)
 			Expect(err).NotTo(HaveOccurred(), "failed to build HCP cluster resource from params")
 
 			// Set KeyVault visibility to Private
@@ -93,7 +93,7 @@ var _ = Describe("Customer", func() {
 				clusterResource.Properties.Etcd.DataEncryption.CustomerManaged.Kms.Visibility = to.Ptr(hcpsdk20251223preview.KeyVaultVisibilityPrivate)
 			}
 
-			_, err = framework.CreateHCPCluster20251223AndWait(
+			_, err = framework.CreateHCPClusterAndWait20251223(
 				ctx,
 				GinkgoLogr,
 				tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
@@ -105,7 +105,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with no CNI and private etcd", customerClusterName)
 
 			By("getting admin credentials for the cluster")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -157,33 +157,17 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to install Cilium chart via Helm")
 
 			By("creating the node pool via v20251223preview")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
-			nodePool := hcpsdk20251223preview.NodePool{
-				Location: to.Ptr(tc.Location()),
-				Properties: &hcpsdk20251223preview.NodePoolProperties{
-					Version: &hcpsdk20251223preview.NodePoolVersionProfile{
-						ID:           to.Ptr(nodePoolParams.OpenshiftVersionId),
-						ChannelGroup: to.Ptr(nodePoolParams.ChannelGroup),
-					},
-					Replicas: to.Ptr(int32(2)),
-					Platform: &hcpsdk20251223preview.NodePoolPlatformProfile{
-						VMSize: to.Ptr(nodePoolParams.VMSize),
-						OSDisk: &hcpsdk20251223preview.OsDiskProfile{
-							SizeGiB:                to.Ptr(nodePoolParams.OSDiskSizeGiB),
-							DiskStorageAccountType: to.Ptr(hcpsdk20251223preview.DiskStorageAccountType(nodePoolParams.DiskStorageAccountType)),
-						},
-					},
-					AutoRepair: to.Ptr(true),
-				},
-			}
-
-			_, nodePoolErr := framework.CreateNodePoolAndWait20251223(
+			nodePoolParams := framework.NewDefaultNodePoolParams20251223()
+			nodePoolParams.ClusterName = customerClusterName
+			nodePoolParams.NodePoolName = customerNodePoolName
+			nodePoolParams.AutoRepair = true
+			nodePoolErr := tc.CreateNodePoolFromParam20251223(
 				ctx,
-				tc.Get20251223ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+				GinkgoLogr,
 				*resourceGroup.Name,
+				clusterParams.ManagedResourceGroupName,
 				customerClusterName,
-				customerNodePoolName,
-				nodePool,
+				nodePoolParams,
 				framework.NodePoolCreationTimeout,
 			)
 			// We delay checking the error on purpose to get more details

--- a/test/e2e/cluster_create_nodepool_osdisk.go
+++ b/test/e2e/cluster_create_nodepool_osdisk.go
@@ -55,13 +55,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for nodepool osDisk test")
 
 			// creating cluster parameters
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources (infrastructure and managed identities) for cluster")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{},
@@ -71,7 +71,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for cluster %q", customerClusterName)
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
@@ -80,12 +80,12 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q", customerClusterName)
 
 			By("creating the node pool with custom osDisk size")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.NodePoolName = customerNodePoolName
 			nodePoolParams.OSDiskSizeGiB = customerNodeOsDiskSizeGiB
 
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,
@@ -96,7 +96,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create node pool %q with 128GiB osDisk", customerNodePoolName)
 
 			By("getting credentials")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -110,7 +110,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster %q is viable", customerClusterName)
 
 			By("verifying the node pool is created and has the correct osDisk size")
-			created, err := framework.GetNodePool(ctx,
+			created, err := framework.GetNodePool20240610(ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
 				*resourceGroup.Name,
 				customerClusterName,

--- a/test/e2e/cluster_create_private_kv.go
+++ b/test/e2e/cluster_create_private_kv.go
@@ -60,14 +60,14 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for private keyvault test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20251223()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 			clusterParams.KeyVaultVisibility = "Private"
 
 			By("creating customer resources (infrastructure and managed identities)")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -79,7 +79,7 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources with private key vault")
 
 			By("creating the HCP cluster")
-			clusterResource, err := framework.BuildHCPCluster20251223FromParams(clusterParams, tc.Location(), nil)
+			clusterResource, err := framework.BuildHCPClusterFromParams20251223(clusterParams, tc.Location(), nil)
 			Expect(err).NotTo(HaveOccurred(), "failed to build HCP cluster resource from params")
 
 			// Set KeyVault visibility
@@ -90,7 +90,7 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 				clusterResource.Properties.Etcd.DataEncryption.CustomerManaged.Kms.Visibility = to.Ptr(hcpsdk20251223preview.KeyVaultVisibilityPrivate)
 			}
 
-			_, err = framework.CreateHCPCluster20251223AndWait(
+			_, err = framework.CreateHCPClusterAndWait20251223(
 				ctx,
 				GinkgoLogr,
 				tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
@@ -137,12 +137,12 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 				"keyVaultVisibility", *cluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.Visibility)
 
 			By("creating the node pool")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.NodePoolName = "np-1"
 			nodePoolParams.Replicas = int32(2)
 
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,
@@ -157,7 +157,7 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 				"nodePoolName", nodePoolParams.NodePoolName)
 
 			By("getting admin credentials for the cluster")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,

--- a/test/e2e/cluster_delete_cx_rg.go
+++ b/test/e2e/cluster_delete_cx_rg.go
@@ -59,13 +59,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resource group")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -79,7 +79,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for cluster %q", customerClusterName)
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -89,7 +89,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q", customerClusterName)
 
 			By("getting credentials")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -103,19 +103,19 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster %q is viable", customerClusterName)
 
 			By("creating both nodepools in parallel")
-			nodePoolParams1 := framework.NewDefaultNodePoolParams()
+			nodePoolParams1 := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams1.NodePoolName = customerNodePool1Name
 			nodePoolParams1.Replicas = int32(2)
 
-			nodePoolParams2 := framework.NewDefaultNodePoolParams()
+			nodePoolParams2 := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams2.NodePoolName = customerNodePool2Name
 			nodePoolParams2.Replicas = int32(1)
 
 			errCh := make(chan error, 2)
 			group, groupCtx := errgroup.WithContext(ctx)
-			for _, nodePoolParams := range []framework.NodePoolParams{nodePoolParams1, nodePoolParams2} {
+			for _, nodePoolParams := range []framework.NodePoolParams20240610{nodePoolParams1, nodePoolParams2} {
 				group.Go(func() error {
-					createErr := tc.CreateNodePoolFromParam(
+					createErr := tc.CreateNodePoolFromParam20240610(
 						groupCtx,
 						GinkgoLogr,
 						*resourceGroup.Name,

--- a/test/e2e/cluster_nsg_subnet_reuse.go
+++ b/test/e2e/cluster_nsg_subnet_reuse.go
@@ -51,11 +51,11 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for NSG/subnet reuse test")
 
 			By("creating customer resources")
-			clusterParams1 := framework.NewDefaultClusterParams()
+			clusterParams1 := framework.NewDefaultClusterParams20240610()
 			clusterParams1.ClusterName = "basic-cluster"
 			clusterParams1.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed-1", 64)
 
-			clusterParams2 := framework.NewDefaultClusterParams()
+			clusterParams2 := framework.NewDefaultClusterParams20240610()
 			clusterParams2.ClusterName = "cluster-subnet-reuse"
 			clusterParams2.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed-2", 64)
 
@@ -66,7 +66,7 @@ var _ = Describe("Customer", func() {
 
 			go func() {
 				defer close(customerRes1DoneCh)
-				clusterParams1, err1 = tc.CreateClusterCustomerResources(ctx,
+				clusterParams1, err1 = tc.CreateClusterCustomerResources20240610(ctx,
 					resourceGroup,
 					clusterParams1,
 					map[string]any{
@@ -80,7 +80,7 @@ var _ = Describe("Customer", func() {
 			}()
 			go func() {
 				defer close(customerRes2DoneCh)
-				clusterParams2, err2 = tc.CreateClusterCustomerResources(ctx,
+				clusterParams2, err2 = tc.CreateClusterCustomerResources20240610(ctx,
 					resourceGroup,
 					clusterParams2,
 					map[string]any{
@@ -97,7 +97,7 @@ var _ = Describe("Customer", func() {
 			Expect(err1).NotTo(HaveOccurred(), "failed to create customer resources for basic-cluster")
 
 			By("seeding HCP cluster")
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -113,7 +113,7 @@ var _ = Describe("Customer", func() {
 			originalSubnetResourceID := clusterParams2.SubnetResourceID
 			clusterParams2.SubnetResourceID = clusterParams1.SubnetResourceID
 
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -129,7 +129,7 @@ var _ = Describe("Customer", func() {
 
 			clusterParams2.NsgResourceID = clusterParams1.NsgResourceID
 			clusterParams2.ClusterName = "cluster-nsg-reuse"
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,

--- a/test/e2e/cluster_pullsecret.go
+++ b/test/e2e/cluster_pullsecret.go
@@ -87,13 +87,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for pull secret test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{},
@@ -103,7 +103,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for pull secret cluster")
 
 			By("Creating the cluster")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
@@ -111,11 +111,11 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster for pull secret test")
 			By("Creating the node pool")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.NodePoolName = "np-1"
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.Replicas = int32(2)
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,
@@ -126,7 +126,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create node pool np-1 for pull secret cluster")
 
 			By("getting credentials")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,

--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -69,13 +69,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for TLS endpoint test")
 
 			// creating cluster parameters
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources (infrastructure and managed identities) for cluster")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{},
@@ -85,7 +85,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for TLS endpoint cluster")
 
 			By("creating a standard hcp cluster")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
@@ -122,11 +122,11 @@ var _ = Describe("Customer", func() {
 				"expect API certificate to be signed by a trusted Azure CA")
 
 			By("creating the node pool")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.NodePoolName = customerNodePoolName
 
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,

--- a/test/e2e/cluster_update.go
+++ b/test/e2e/cluster_update.go
@@ -58,13 +58,13 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create resource group for patch-name test")
 
 				By("creating cluster parameters")
-				clusterParams := framework.NewDefaultClusterParams()
+				clusterParams := framework.NewDefaultClusterParams20240610()
 				clusterParams.ClusterName = clusterName
 				managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 				clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 				By("creating customer resources")
-				clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+				clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 					resourceGroup,
 					clusterParams,
 					map[string]interface{}{},
@@ -74,7 +74,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for patch-name cluster")
 
 				By("creating the HCP cluster")
-				err = tc.CreateHCPClusterFromParam(
+				err = tc.CreateHCPClusterFromParam20240610(
 					ctx,
 					GinkgoLogr,
 					*resourceGroup.Name,
@@ -84,7 +84,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster for patch-name test")
 
 				By("getting credentials")
-				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 					ctx,
 					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
@@ -102,7 +102,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				update := hcpsdk20240610preview.HcpOpenShiftClusterUpdate{
 					Name: &newName,
 				}
-				_, err = framework.UpdateHCPCluster(
+				_, err = framework.UpdateHCPCluster20240610(
 					ctx,
 					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
@@ -134,13 +134,13 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create resource group for patch-tags test")
 
 				By("creating cluster parameters")
-				clusterParams := framework.NewDefaultClusterParams()
+				clusterParams := framework.NewDefaultClusterParams20240610()
 				clusterParams.ClusterName = clusterName
 				managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 				clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 				By("creating customer resources")
-				clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+				clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 					resourceGroup,
 					clusterParams,
 					map[string]interface{}{},
@@ -150,7 +150,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for patch-tags cluster")
 
 				By("creating the HCP cluster")
-				err = tc.CreateHCPClusterFromParam(
+				err = tc.CreateHCPClusterFromParam20240610(
 					ctx,
 					GinkgoLogr,
 					*resourceGroup.Name,
@@ -160,7 +160,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster for patch-tags test")
 
 				By("getting credentials")
-				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 					ctx,
 					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
@@ -181,7 +181,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 						"test": &val,
 					},
 				}
-				resp, err := framework.UpdateHCPCluster(
+				resp, err := framework.UpdateHCPCluster20240610(
 					ctx,
 					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
@@ -197,7 +197,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				Expect(*resp.Tags["test"]).To(Equal(val), "update response Tags[\"test\"] should equal %q", val)
 
 				By("verifying the tag is present on the cluster")
-				respGet, err := framework.GetHCPCluster(
+				respGet, err := framework.GetHCPCluster20240610(
 					ctx,
 					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,

--- a/test/e2e/cluster_version_backlevel.go
+++ b/test/e2e/cluster_version_backlevel.go
@@ -119,9 +119,9 @@ var _ = Describe("Customer", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to get userAssignedIdentitiesValue output from managed identities deployment")
 				identityValue, err := framework.GetOutputValue(managedIdentitiesDeployment, "identityValue")
 				Expect(err).NotTo(HaveOccurred(), "failed to get identityValue output from managed identities deployment")
-				userAssignedIdentitiesProfile, err := framework.ConvertToUserAssignedIdentitiesProfile(userAssignedIdentitiesValue)
+				userAssignedIdentitiesProfile, err := framework.ConvertToUserAssignedIdentitiesProfile20240610(userAssignedIdentitiesValue)
 				Expect(err).NotTo(HaveOccurred(), "failed to convert userAssignedIdentitiesValue to profile")
-				identityProfile, err := framework.ConvertToManagedServiceIdentity(identityValue)
+				identityProfile, err := framework.ConvertToManagedServiceIdentity20240610(identityValue)
 				Expect(err).NotTo(HaveOccurred(), "failed to convert identityValue to ManagedServiceIdentity")
 
 				By("creating HCP cluster version " + version.controlPlaneVersion)
@@ -136,7 +136,7 @@ var _ = Describe("Customer", func() {
 				)
 				Expect(err).NotTo(HaveOccurred(), "failed to build HCP cluster request for version %s", version.controlPlaneVersion)
 				hcpClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
-				_, err = framework.CreateHCPClusterAndWait(
+				_, err = framework.CreateHCPClusterAndWait20240610(
 					ctx,
 					GinkgoLogr,
 					hcpClient,
@@ -147,7 +147,7 @@ var _ = Describe("Customer", func() {
 				)
 				Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster version %s", version.controlPlaneVersion)
 
-				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 					ctx,
 					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
@@ -180,7 +180,7 @@ var _ = Describe("Customer", func() {
 					)
 					Expect(err).NotTo(HaveOccurred(), "failed to build node pool request for version %s", matchingNodePoolVersion)
 					nodePoolClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
-					_, err = framework.CreateNodePoolAndWait(ctx,
+					_, err = framework.CreateNodePoolAndWait20240610(ctx,
 						nodePoolClient,
 						*resourceGroup.Name,
 						clusterName,

--- a/test/e2e/clusters_sharing_resgroup.go
+++ b/test/e2e/clusters_sharing_resgroup.go
@@ -67,10 +67,10 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create shared customer resource group")
 
 			By("creating customer infrastructure and managed identities for first cluster")
-			clusterParams1 := framework.NewDefaultClusterParams()
+			clusterParams1 := framework.NewDefaultClusterParams20240610()
 			clusterParams1.ClusterName = customerClusterName
 			clusterParams1.ManagedResourceGroupName = framework.SuffixName(*customerResourceGroup.Name, "-managed", 64)
-			clusterParams1, err = tc.CreateClusterCustomerResources(ctx, customerResourceGroup, clusterParams1,
+			clusterParams1, err = tc.CreateClusterCustomerResources20240610(ctx, customerResourceGroup, clusterParams1,
 				map[string]interface{}{
 					"customerNsgName":        customerNetworkSecurityGroupName,
 					"customerVnetName":       customerVnetName,
@@ -82,10 +82,10 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for first cluster %q", customerClusterName)
 
 			By("creating customer infrastructure and managed identities for second cluster")
-			clusterParams2 := framework.NewDefaultClusterParams()
+			clusterParams2 := framework.NewDefaultClusterParams20240610()
 			clusterParams2.ClusterName = customerClusterName2
 			clusterParams2.ManagedResourceGroupName = framework.SuffixName(*customerResourceGroup.Name, "-managed-2", 64)
-			clusterParams2, err = tc.CreateClusterCustomerResources(ctx, customerResourceGroup, clusterParams2,
+			clusterParams2, err = tc.CreateClusterCustomerResources20240610(ctx, customerResourceGroup, clusterParams2,
 				map[string]interface{}{
 					"customerNsgName":        customerNetworkSecurityGroupName2,
 					"customerVnetName":       customerVnetName2,
@@ -100,7 +100,7 @@ var _ = Describe("Customer", func() {
 			clusterClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
 
 			// Start first cluster creation
-			poller1, err := framework.BeginCreateHCPCluster(
+			poller1, err := framework.BeginCreateHCPCluster20240610(
 				ctx,
 				GinkgoLogr,
 				clusterClient,
@@ -112,7 +112,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to begin creation of first cluster %q", customerClusterName)
 
 			// Start second cluster creation
-			poller2, err := framework.BeginCreateHCPCluster(
+			poller2, err := framework.BeginCreateHCPCluster20240610(
 				ctx,
 				GinkgoLogr,
 				clusterClient,
@@ -140,10 +140,10 @@ var _ = Describe("Customer", func() {
 
 			// Third cluster (should fail)
 			By("creating customer infrastructure and managed identities for third cluster")
-			clusterParams3 := framework.NewDefaultClusterParams()
+			clusterParams3 := framework.NewDefaultClusterParams20240610()
 			clusterParams3.ClusterName = customerClusterName3
 			clusterParams3.ManagedResourceGroupName = clusterParams2.ManagedResourceGroupName // Reuse cluster2's managed RG
-			clusterParams3, err = tc.CreateClusterCustomerResources(ctx, customerResourceGroup, clusterParams3,
+			clusterParams3, err = tc.CreateClusterCustomerResources20240610(ctx, customerResourceGroup, clusterParams3,
 				map[string]interface{}{
 					"customerNsgName":        customerNetworkSecurityGroupName3,
 					"customerVnetName":       customerVnetName3,
@@ -155,8 +155,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for third cluster %q", customerClusterName3)
 
 			By("attempting to create a third cluster using the same managed resource group as the second cluster")
-
-			err = tc.CreateHCPClusterFromParam(ctx, GinkgoLogr, *customerResourceGroup.Name, clusterParams3, framework.ClusterCreationTimeout)
+			err = tc.CreateHCPClusterFromParam20240610(ctx, GinkgoLogr, *customerResourceGroup.Name, clusterParams3, framework.ClusterCreationTimeout)
 			Expect(err).To(HaveOccurred(), "expected error when creating third cluster %q with duplicate managed resource group", customerClusterName3)
 			Expect(err).To(MatchError(MatchRegexp("please provide a unique managed resource group name")), "error should indicate duplicate managed resource group name")
 

--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -58,7 +58,7 @@ var _ = Describe("ARO-HCP", func() {
 			versionLabel := strings.ReplaceAll(version, ".", "-") // e.g. "4.20" -> "4-20"
 			suffix := rand.String(6)
 			clusterName := customerClusterNamePrefix + versionLabel + "-" + suffix
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20251223()
 			clusterParams.ClusterName = clusterName
 			clusterParams.OpenshiftVersionId = version
 			openShiftControlPlaneVersion, err := framework.GetLatestInstallVersion(ctx, clusterParams.ChannelGroup, version)
@@ -85,7 +85,7 @@ var _ = Describe("ARO-HCP", func() {
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -104,11 +104,11 @@ var _ = Describe("ARO-HCP", func() {
 			// NIC resource request (https://redhat.atlassian.net/browse/ARO-27209).
 			if version == "4.23" || version == "5.0" {
 				By(fmt.Sprintf("creating a Swift cluster on version '%s' and channel group '%s'", clusterParams.OpenshiftVersionId, channelGroup))
-				clusterResource, err := framework.BuildHCPCluster20251223FromParams(clusterParams, tc.Location(), nil)
+				clusterResource, err := framework.BuildHCPClusterFromParams20251223(clusterParams, tc.Location(), nil)
 				Expect(err).NotTo(HaveOccurred(), "Swift cluster resource for %s should build from params", clusterName)
 				clientFactory, err := tc.Get20251223ClientFactory(ctx)
 				Expect(err).NotTo(HaveOccurred(), "Get20251223ClientFactory: client factory should be obtained for Swift cluster %s", clusterName)
-				_, err = framework.CreateHCPCluster20251223AndWait(
+				_, err = framework.CreateHCPClusterAndWait20251223(
 					ctx,
 					GinkgoLogr,
 					clientFactory.NewHcpOpenShiftClustersClient(),
@@ -120,18 +120,19 @@ var _ = Describe("ARO-HCP", func() {
 				Expect(err).NotTo(HaveOccurred(), "Swift cluster %s/%s should provision", *resourceGroup.Name, clusterName)
 			} else {
 				By(fmt.Sprintf("creating the HCP cluster with version '%s' on %s channel", clusterParams.OpenshiftVersionId, channelGroup))
-				err = tc.CreateHCPClusterFromParam(
+				err = tc.CreateHCPClusterFromParam20251223(
 					ctx,
 					GinkgoLogr,
 					*resourceGroup.Name,
 					clusterParams,
+					nil,
 					framework.ClusterCreationTimeout,
 				)
 				Expect(err).NotTo(HaveOccurred(), "HCP cluster %s/%s should provision", *resourceGroup.Name, clusterName)
 			}
 
 			By("verifying the cluster is viable")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -143,7 +144,7 @@ var _ = Describe("ARO-HCP", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster %q is viable", clusterName)
 
 			nodePoolName := "np-" + suffix
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = clusterName
 			nodePoolParams.NodePoolName = nodePoolName
 			// Calculate the node pool version
@@ -172,7 +173,7 @@ var _ = Describe("ARO-HCP", func() {
 			nodePoolParams.OpenshiftVersionId = parseableVersions[0]
 
 			By(fmt.Sprintf("creating node pool %q with version '%s' on %s channel", nodePoolName, nodePoolParams.OpenshiftVersionId, nodePoolChannelGroup))
-			err = tc.CreateNodePoolFromParam(
+			err = tc.CreateNodePoolFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -184,7 +185,7 @@ var _ = Describe("ARO-HCP", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create node pool %q for cluster %q", nodePoolName, clusterName)
 
 			By("verifying nodepool DiskStorageAccountType matches framework default")
-			err = framework.ValidateNodePoolDiskStorageAccountType(ctx,
+			err = framework.ValidateNodePoolDiskStorageAccountType20240610(ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
 				*resourceGroup.Name,
 				clusterName,

--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -65,7 +65,7 @@ var _ = Describe("Service Provider", func() {
 			versionLabel := strings.ReplaceAll(minorVersion, ".", "-") // e.g. "4.20" -> "4-20"
 			suffix := rand.String(6)
 			clusterName := customerClusterNamePrefix + versionLabel + "-" + suffix
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = clusterName
 			clusterParams.OpenshiftVersionId = installVersion
 
@@ -82,7 +82,7 @@ var _ = Describe("Service Provider", func() {
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -108,7 +108,7 @@ var _ = Describe("Service Provider", func() {
 				Steps:    25,
 				Cap:      45 * time.Second,
 			}, func(_ context.Context) (done bool, err error) {
-				createErr := tc.CreateHCPClusterFromParam(
+				createErr := tc.CreateHCPClusterFromParam20240610(
 					ctx,
 					GinkgoLogr,
 					*resourceGroup.Name,
@@ -137,7 +137,7 @@ var _ = Describe("Service Provider", func() {
 			Expect(backoffErr).NotTo(HaveOccurred(), "failed to create HCP cluster %q with version %s on candidate channel", clusterName, installVersion)
 
 			By("verifying the cluster is viable")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,

--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -126,14 +126,14 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for y-stream upgrade to %s", targetMinor)
 
 			By("creating cluster parameters at install (previous minor) version")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = clusterName
 			clusterParams.OpenshiftVersionId = fmt.Sprintf("%d.%d", installVersion.Major, installVersion.Minor)
 			clusterParams.ChannelGroup = channelGroup
 			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name+"-cp-ystream-"+suffix, "-managed", 64)
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -148,7 +148,7 @@ var _ = Describe("Customer", func() {
 
 			By(fmt.Sprintf("creating the HCP cluster with install version %s (previous minor %s)", installVersion,
 				previousMinorLine))
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -159,7 +159,7 @@ var _ = Describe("Customer", func() {
 
 			By("getting admin credentials")
 			hcpClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				hcpClient,
 				*resourceGroup.Name,
@@ -188,7 +188,7 @@ var _ = Describe("Customer", func() {
 					},
 				},
 			}
-			_, err = framework.UpdateHCPCluster(ctx, hcpClient, *resourceGroup.Name, clusterName, update, 45*time.Minute)
+			_, err = framework.UpdateHCPCluster20240610(ctx, hcpClient, *resourceGroup.Name, clusterName, update, 45*time.Minute)
 			Expect(err).NotTo(HaveOccurred(), "failed to trigger y-stream upgrade of cluster %q to %s", clusterName, targetMinor)
 
 			By("verifying control plane reached desired version and cluster remains viable")

--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -68,13 +68,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for external auth cluster")
 
 			// creating cluster parameters
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources (infrastructure and managed identities) for cluster")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{},
@@ -84,7 +84,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for external auth cluster")
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
@@ -93,7 +93,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster for external auth test")
 
 			By("getting credentials")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -107,11 +107,11 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster viability")
 
 			By("creating the node pool")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.NodePoolName = customerNodePoolName
 
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,
@@ -170,12 +170,11 @@ var _ = Describe("Customer", func() {
 					},
 				},
 			}
-
-			_, err = framework.CreateOrUpdateExternalAuthAndWait(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, customerClusterName, customerExternalAuthName, extAuth, framework.ExternalAuthCreationTimeout)
+			_, err = framework.CreateOrUpdateExternalAuthAndWait20240610(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, customerClusterName, customerExternalAuthName, extAuth, framework.ExternalAuthCreationTimeout)
 			Expect(err).NotTo(HaveOccurred(), "failed to create external auth config %s", customerExternalAuthName)
 
 			By("verifying ExternalAuth is in a Succeeded state")
-			eaResult, err := framework.GetExternalAuth(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, customerClusterName, customerExternalAuthName)
+			eaResult, err := framework.GetExternalAuth20240610(ctx, tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(), *resourceGroup.Name, customerClusterName, customerExternalAuthName)
 			Expect(err).NotTo(HaveOccurred(), "failed to get external auth config %s", customerExternalAuthName)
 			Expect(*eaResult.Properties.ProvisioningState).To(Equal(hcpsdk20240610preview.ExternalAuthProvisioningStateSucceeded), "external auth %s provisioning state should be Succeeded", customerExternalAuthName)
 

--- a/test/e2e/external_auth_list_and_verify.go
+++ b/test/e2e/external_auth_list_and_verify.go
@@ -59,13 +59,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for external auth list test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = clusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{},
@@ -75,7 +75,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for external auth list test")
 
 			By("creating HCP cluster")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
@@ -106,7 +106,7 @@ var _ = Describe("Customer", func() {
 			}
 
 			By("create an external auth and confirm it's in a succeeded state")
-			_, err = framework.CreateOrUpdateExternalAuthAndWait(
+			_, err = framework.CreateOrUpdateExternalAuthAndWait20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(),
 				*resourceGroup.Name,
@@ -117,7 +117,7 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create external auth config on cluster %s", clusterName)
 
-			result, err := framework.GetExternalAuth(
+			result, err := framework.GetExternalAuth20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(),
 				*resourceGroup.Name,
@@ -130,7 +130,7 @@ var _ = Describe("Customer", func() {
 			By("confirming we're only allowed to create a single external auth")
 			anotherExternalAuth := expectedExternalAuth
 			anotherExternalAuth.Name = to.Ptr(testingPrefix + "2")
-			_, err = framework.CreateOrUpdateExternalAuthAndWait(
+			_, err = framework.CreateOrUpdateExternalAuthAndWait20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(),
 				*resourceGroup.Name,
@@ -178,7 +178,7 @@ var _ = Describe("Customer", func() {
 
 			By("updating the external auth to a different prefix and confirming the update works")
 			expectedExternalAuth.Properties.Claim.Mappings.Username.Prefix = to.Ptr(testingPrefix + "updated")
-			_, err = framework.CreateOrUpdateExternalAuthAndWait(
+			_, err = framework.CreateOrUpdateExternalAuthAndWait20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(),
 				*resourceGroup.Name,
@@ -189,7 +189,7 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to update external auth config prefix on cluster %s", clusterName)
 
-			updatedResult, err := framework.GetExternalAuth(
+			updatedResult, err := framework.GetExternalAuth20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient(),
 				*resourceGroup.Name,

--- a/test/e2e/gpu_nodepools_create_delete.go
+++ b/test/e2e/gpu_nodepools_create_delete.go
@@ -74,13 +74,13 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				resourceGroup, err := tc.NewResourceGroup(ctx, "rg-gpu-nodepool-"+sku.display, tc.Location())
 				Expect(err).NotTo(HaveOccurred(), "failed to create resource group for GPU nodepool test")
 
-				clusterParams := framework.NewDefaultClusterParams()
+				clusterParams := framework.NewDefaultClusterParams20240610()
 				clusterParams.ClusterName = customerClusterName
 				managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 				clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 				By("creating customer resources (infrastructure and managed identities) for cluster")
-				clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+				clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 					resourceGroup,
 					clusterParams,
 					map[string]interface{}{},
@@ -90,7 +90,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for GPU nodepool cluster")
 
 				By("creating the HCP cluster")
-				err = tc.CreateHCPClusterFromParam(ctx,
+				err = tc.CreateHCPClusterFromParam20240610(ctx,
 					GinkgoLogr,
 					*resourceGroup.Name,
 					clusterParams,
@@ -99,7 +99,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster for GPU nodepool test")
 
 				By("getting credentials and verifying cluster is viable")
-				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 					ctx,
 					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 					*resourceGroup.Name,
@@ -116,12 +116,12 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				// we create a default node pool with two replicas instead of one,
 				// because in the latter case we will get this error: "A hosted cluster requires at least 2 replicas"
 				By("creating default nodepool")
-				defaultNodePoolParams := framework.NewDefaultNodePoolParams()
+				defaultNodePoolParams := framework.NewDefaultNodePoolParams20240610()
 				defaultNodePoolParams.ClusterName = customerClusterName
 				defaultNodePoolParams.NodePoolName = defaultNodePoolName
 				defaultNodePoolParams.Replicas = int32(2)
 
-				err = tc.CreateNodePoolFromParam(ctx,
+				err = tc.CreateNodePoolFromParam20240610(ctx,
 					GinkgoLogr,
 					*resourceGroup.Name,
 					managedResourceGroupName,
@@ -132,13 +132,13 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create default nodepool %s", defaultNodePoolName)
 
 				By(fmt.Sprintf("creating GPU nodepool with VM size %q", sku.vmSize))
-				gpuNodePoolParams := framework.NewDefaultNodePoolParams()
+				gpuNodePoolParams := framework.NewDefaultNodePoolParams20240610()
 				gpuNodePoolParams.ClusterName = customerClusterName
 				gpuNodePoolParams.NodePoolName = gpuNodePoolName
 				gpuNodePoolParams.Replicas = int32(1)
 				gpuNodePoolParams.VMSize = sku.vmSize
 
-				err = tc.CreateNodePoolFromParam(ctx,
+				err = tc.CreateNodePoolFromParam20240610(ctx,
 					GinkgoLogr,
 					*resourceGroup.Name,
 					managedResourceGroupName,
@@ -149,7 +149,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create GPU nodepool %s with VM size %s", gpuNodePoolName, sku.vmSize)
 
 				By("verifying GPU nodepool provisioning succeeded with correct VM size")
-				created, err := framework.GetNodePool(ctx,
+				created, err := framework.GetNodePool20240610(ctx,
 					tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
 					*resourceGroup.Name,
 					customerClusterName,
@@ -164,7 +164,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				Expect(*created.Properties.Platform.VMSize).To(Equal(sku.vmSize), "GPU nodepool %s VM size should be %s", gpuNodePoolName, sku.vmSize)
 
 				By("deleting GPU nodepool")
-				Expect(framework.DeleteNodePool(
+				Expect(framework.DeleteNodePool20240610(
 					ctx,
 					tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
 					*resourceGroup.Name,
@@ -174,7 +174,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				)).To(Succeed(), "failed to delete GPU nodepool %s", gpuNodePoolName)
 
 				By("confirming GPU nodepool has been deleted")
-				_, getErr := framework.GetNodePool(ctx,
+				_, getErr := framework.GetNodePool20240610(ctx,
 					tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
 					*resourceGroup.Name,
 					customerClusterName,

--- a/test/e2e/idms_lifecycle.go
+++ b/test/e2e/idms_lifecycle.go
@@ -69,13 +69,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for IDMS test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20251223()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -96,7 +96,7 @@ var _ = Describe("Customer", func() {
 				},
 			}
 
-			createErr := tc.CreateHCPCluster20251223FromParam(
+			createErr := tc.CreateHCPClusterFromParam20251223(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -122,7 +122,7 @@ var _ = Describe("Customer", func() {
 			Expect(ptr.Deref(actualCluster.Properties.ImageDigestMirrors[0].Mirrors[0], "")).To(Equal(idmsMirror), "first ImageDigestMirror mirror should be %s", idmsMirror)
 
 			By("getting admin credentials")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,

--- a/test/e2e/image_registry_cluster_create.go
+++ b/test/e2e/image_registry_cluster_create.go
@@ -58,14 +58,14 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for disabled-image-registry test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 			clusterParams.ImageRegistryState = string(hcpsdk20240610preview.ClusterImageRegistryStateDisabled)
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -79,7 +79,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
 
 			By("creating the hcp cluster with the image registry disabled")
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -95,7 +95,7 @@ var _ = Describe("Customer", func() {
 			Expect(ptr.Deref(actualHCPCluster.Properties.ClusterImageRegistry.State, "")).To(Equal(hcpsdk20240610preview.ClusterImageRegistryStateDisabled), "cluster image registry state should be Disabled")
 
 			By("getting credentials")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,

--- a/test/e2e/kusto_logs_present.go
+++ b/test/e2e/kusto_logs_present.go
@@ -57,13 +57,13 @@ var _ = Describe("Engineering", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for kusto-logs test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = engineeringClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -77,7 +77,7 @@ var _ = Describe("Engineering", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,

--- a/test/e2e/mise_routing.go
+++ b/test/e2e/mise_routing.go
@@ -92,12 +92,12 @@ var _ = Describe("MISE Routing", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for MISE routing test")
 
 			By("Creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20251223()
 			clusterParams.ClusterName = "mise-routing"
 			clusterParams.ManagedResourceGroupName = framework.SuffixName(*rg.Name, "-managed", 64)
 
 			By("Creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,
 				rg,
 				clusterParams,
 				map[string]any{
@@ -120,12 +120,12 @@ var _ = Describe("MISE Routing", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to build client factory with MISE policies")
 
 			By("Building HCP cluster from parameters")
-			cluster, err := framework.BuildHCPCluster20251223FromParams(clusterParams, tc.Location(), nil)
+			cluster, err := framework.BuildHCPClusterFromParams20251223(clusterParams, tc.Location(), nil)
 			Expect(err).NotTo(HaveOccurred(), "failed to build HCP cluster from params")
 
 			By("Creating HCP cluster")
 			hcpClient := clientFactory.NewHcpOpenShiftClustersClient()
-			_, err = framework.CreateHCPCluster20251223AndWait(
+			_, err = framework.CreateHCPClusterAndWait20251223(
 				ctx, GinkgoLogr, hcpClient,
 				*rg.Name, clusterParams.ClusterName, cluster,
 				45*time.Minute,

--- a/test/e2e/nodepool_autoscaling.go
+++ b/test/e2e/nodepool_autoscaling.go
@@ -70,13 +70,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for nodepool autoscaling test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]any{},
@@ -86,7 +86,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
@@ -95,7 +95,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %s", customerClusterName)
 
 			By("verifying the cluster has default autoscaling parameters")
-			clusterResp, err := framework.GetHCPCluster(ctx,
+			clusterResp, err := framework.GetHCPCluster20240610(ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
 				customerClusterName)
@@ -109,7 +109,7 @@ var _ = Describe("Customer", func() {
 			Expect(clusterResp.Properties.Autoscaling.MaxNodesTotal).To(BeNil(), "Expected MaxNodesTotal to be nil when not explicitly set")
 
 			By("getting admin credentials for the cluster")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -126,7 +126,7 @@ var _ = Describe("Customer", func() {
 				By("skipping AZ nodepool creation: region does not support availability zones")
 			} else {
 				By("creating the AZ nodepool with 500 max replicas")
-				azNodePoolParams := framework.NewDefaultNodePoolParams()
+				azNodePoolParams := framework.NewDefaultNodePoolParams20240610()
 				azNodePoolParams.ClusterName = customerClusterName
 				azNodePoolParams.NodePoolName = azNodePoolName
 				azNodePoolParams.AutoScaling = &framework.NodePoolAutoScalingParams{
@@ -135,7 +135,7 @@ var _ = Describe("Customer", func() {
 				}
 				azNodePoolParams.AvailabilityZone = availabilityZone
 
-				err = tc.CreateNodePoolFromParam(ctx,
+				err = tc.CreateNodePoolFromParam20240610(ctx,
 					GinkgoLogr,
 					*resourceGroup.Name,
 					managedResourceGroupName,
@@ -146,7 +146,7 @@ var _ = Describe("Customer", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create AZ nodepool %s with autoscaling", azNodePoolName)
 
 				By("verifying the AZ nodepool has the correct autoscaling configuration")
-				azNodePoolResp, err := framework.GetNodePool(ctx,
+				azNodePoolResp, err := framework.GetNodePool20240610(ctx,
 					nodePoolsClient,
 					*resourceGroup.Name,
 					customerClusterName,
@@ -163,7 +163,7 @@ var _ = Describe("Customer", func() {
 				Expect(len(nodes.Items)).To(BeNumerically(">=", int(azAutoscalingMin)), "expected at least %d nodes after AZ nodepool creation", azAutoscalingMin)
 
 				By("updating the AZ nodepool max replicas from 500 to 4 before creating the next nodepool")
-				_, err = framework.UpdateNodePoolAndWait(ctx,
+				_, err = framework.UpdateNodePoolAndWait20240610(ctx,
 					nodePoolsClient,
 					*resourceGroup.Name,
 					customerClusterName,
@@ -181,7 +181,7 @@ var _ = Describe("Customer", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to update AZ nodepool %s max replicas to 4", azNodePoolName)
 
 				By("verifying the AZ nodepool max replicas was updated to 4")
-				azNodePoolUpdatedResp, err := framework.GetNodePool(ctx,
+				azNodePoolUpdatedResp, err := framework.GetNodePool20240610(ctx,
 					nodePoolsClient,
 					*resourceGroup.Name,
 					customerClusterName,
@@ -193,7 +193,7 @@ var _ = Describe("Customer", func() {
 			}
 
 			By("creating the no-AZ nodepool with 200 max replicas")
-			noAZNodePoolParams := framework.NewDefaultNodePoolParams()
+			noAZNodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			noAZNodePoolParams.ClusterName = customerClusterName
 			noAZNodePoolParams.NodePoolName = noAZNodePoolName
 			noAZNodePoolParams.AutoScaling = &framework.NodePoolAutoScalingParams{
@@ -201,7 +201,7 @@ var _ = Describe("Customer", func() {
 				Max: noAZAutoscalingMax,
 			}
 
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,
@@ -212,7 +212,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create no-AZ nodepool %s with autoscaling", noAZNodePoolName)
 
 			By("verifying the no-AZ nodepool has the correct autoscaling configuration")
-			noAZNodePoolResp, err := framework.GetNodePool(ctx,
+			noAZNodePoolResp, err := framework.GetNodePool20240610(ctx,
 				nodePoolsClient,
 				*resourceGroup.Name,
 				customerClusterName,
@@ -256,7 +256,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for node-limit test")
 
 			By("creating cluster with MaxNodesTotal limit")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
@@ -264,7 +264,7 @@ var _ = Describe("Customer", func() {
 				MaxNodesTotal: to.Ptr(int32(3)), // Set low limit
 			}
 
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]any{},
@@ -273,7 +273,7 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources for node-limit test")
 
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
@@ -282,7 +282,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %s with MaxNodesTotal limit", customerClusterName)
 
 			By("attempting to create nodepool with Min > MaxNodesTotal")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.NodePoolName = customerNodePoolName
 			nodePoolParams.AutoScaling = &framework.NodePoolAutoScalingParams{
@@ -291,7 +291,7 @@ var _ = Describe("Customer", func() {
 			}
 
 			// Should fail quickly during validation
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,

--- a/test/e2e/nodepool_drain_timeout_update.go
+++ b/test/e2e/nodepool_drain_timeout_update.go
@@ -45,7 +45,7 @@ var _ = Describe("Customer", func() {
 		func(ctx context.Context) {
 			suffix := rand.String(6)
 
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterName := "np-drain-timeout-and-upgrade-" + suffix
 			clusterParams.ClusterName = clusterName
 
@@ -78,7 +78,7 @@ var _ = Describe("Customer", func() {
 			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -92,7 +92,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources")
 
 			By(fmt.Sprintf("creating the HCP cluster with version %s", clusterParams.OpenshiftVersionId))
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -103,12 +103,12 @@ var _ = Describe("Customer", func() {
 
 			By(fmt.Sprintf("creating nodepool with version %s and NodeDrainTimeoutMinutes=1", nodePoolInitialVersion))
 			customerNodePoolName := "np-" + suffix
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.NodePoolName = customerNodePoolName
 			nodePoolParams.OpenshiftVersionId = nodePoolInitialVersion
 			nodePoolParams.ChannelGroup = channelGroup
 			nodePoolParams.NodeDrainTimeoutMinutes = to.Ptr(int32(1))
-			err = tc.CreateNodePoolFromParam(
+			err = tc.CreateNodePoolFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -122,7 +122,7 @@ var _ = Describe("Customer", func() {
 			nodePoolsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
 
 			By("verifying NodeDrainTimeoutMinutes is 1 via GET")
-			npResp, err := framework.GetNodePool(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
+			npResp, err := framework.GetNodePool20240610(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
 			Expect(err).NotTo(HaveOccurred(), "failed to get nodepool %q", customerNodePoolName)
 			Expect(npResp.Properties).NotTo(BeNil(), "node pool GET response Properties was nil")
 			Expect(npResp.Properties.NodeDrainTimeoutMinutes).NotTo(BeNil(), "node pool GET response Properties.NodeDrainTimeoutMinutes was nil after creation")
@@ -134,18 +134,18 @@ var _ = Describe("Customer", func() {
 					NodeDrainTimeoutMinutes: to.Ptr(int32(0)),
 				},
 			}
-			_, err = framework.UpdateNodePoolAndWait(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName, drainUpdate, 45*time.Minute)
+			_, err = framework.UpdateNodePoolAndWait20240610(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName, drainUpdate, 45*time.Minute)
 			Expect(err).NotTo(HaveOccurred(), "failed to update nodepool %q Properties.NodeDrainTimeoutMinutes to 0", customerNodePoolName)
 
 			By("verifying NodeDrainTimeoutMinutes is 0 via GET")
-			npResp, err = framework.GetNodePool(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
+			npResp, err = framework.GetNodePool20240610(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
 			Expect(err).NotTo(HaveOccurred(), "failed to get nodepool %q", customerNodePoolName)
 			Expect(npResp.Properties).NotTo(BeNil(), "node pool GET response Properties was nil")
 			Expect(npResp.Properties.NodeDrainTimeoutMinutes).NotTo(BeNil(), "node pool GET response Properties.NodeDrainTimeoutMinutes was nil after update")
 			Expect(*npResp.Properties.NodeDrainTimeoutMinutes).To(Equal(int32(0)), "expected NodeDrainTimeoutMinutes to be 0 after update")
 
 			By("getting admin credentials")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -180,7 +180,7 @@ var _ = Describe("Customer", func() {
 					},
 				},
 			}
-			_, err = framework.UpdateNodePoolAndWait(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName, versionUpdate, 45*time.Minute)
+			_, err = framework.UpdateNodePoolAndWait20240610(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName, versionUpdate, 45*time.Minute)
 			Expect(err).NotTo(HaveOccurred(), "failed to upgrade nodepool %s to version %s", customerNodePoolName, nodePoolDesiredVersion)
 
 			By("verifying nodes are ready, updated to expected version, and release images differ from pre-upgrade")
@@ -189,7 +189,7 @@ var _ = Describe("Customer", func() {
 			}, 45*time.Minute, 2*time.Minute).Should(Succeed())
 
 			By("verifying node pool GET still reflects the new version")
-			npGetResponse, err := framework.GetNodePool(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
+			npGetResponse, err := framework.GetNodePool20240610(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
 			Expect(err).NotTo(HaveOccurred(), "failed to get nodepool %q", customerNodePoolName)
 			Expect(npGetResponse.Properties).NotTo(BeNil(), "node pool GET response Properties was nil")
 			Expect(npGetResponse.Properties.Version).NotTo(BeNil(), "node pool GET response Properties.Version was nil")

--- a/test/e2e/nodepool_ephemeral_osdisk.go
+++ b/test/e2e/nodepool_ephemeral_osdisk.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 
 	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
@@ -87,13 +86,13 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for ephemeral OS disk test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources (infrastructure and managed identities)")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{},
@@ -103,7 +102,7 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
@@ -112,24 +111,21 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %s", customerClusterName)
 
 			By("creating nodepool with ephemeral OS disk and autoRepair enabled")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
-			nodePool := buildNodePoolWithDiskType(
+			nodePoolParams := framework.NewDefaultNodePoolParams20251223()
+			nodePoolParams.ClusterName = customerClusterName
+			nodePoolParams.NodePoolName = customerNodePoolName
+			nodePoolParams.DiskType = hcpsdk20251223preview.OsDiskTypeEphemeral
+			nodePoolParams.AutoRepair = true
+			err = tc.CreateNodePoolFromParam20251223(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams.ManagedResourceGroupName,
+				customerClusterName,
 				nodePoolParams,
-				tc.Location(),
-				hcpsdk20251223preview.OsDiskTypeEphemeral,
-				true,
-			)
+				framework.NodePoolCreationTimeout)
 
 			client20251223 := tc.Get20251223ClientFactoryOrDie(ctx)
-			created, err := framework.CreateNodePoolAndWait20251223(
-				ctx,
-				client20251223.NewNodePoolsClient(),
-				*resourceGroup.Name,
-				customerClusterName,
-				customerNodePoolName,
-				nodePool,
-				framework.NodePoolCreationTimeout,
-			)
 			if isAPINotDeployedError(err) {
 				if time.Now().Before(timeBombDeadline) {
 					Skip(fmt.Sprintf("v20251223preview API not yet deployed; skipping until %s", timeBombDeadline.Format(time.RFC3339)))
@@ -139,21 +135,15 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create nodepool %s with ephemeral OS disk", customerNodePoolName)
 
 			By("verifying nodepool ARM resource has diskType=Ephemeral from LRO result")
+			created, err := framework.GetNodePool20251223(ctx, client20251223.NewNodePoolsClient(), *resourceGroup.Name, customerClusterName, customerNodePoolName)
+			Expect(err).NotTo(HaveOccurred(), "failed to get nodepool %s", customerNodePoolName)
 			Expect(created.Properties).ToNot(BeNil(), "created nodepool response Properties was nil")
 			Expect(created.Properties.Platform).ToNot(BeNil(), "created nodepool response Properties.Platform was nil")
 			Expect(created.Properties.Platform.OSDisk).ToNot(BeNil(), "created nodepool response Properties.Platform.OSDisk was nil")
-
-			diskTypeNotPresent := created.Properties.Platform.OSDisk.DiskType == nil
-			if diskTypeNotPresent {
-				if time.Now().Before(timeBombDeadline) {
-					Skip("v20251223preview deployed but DiskType field not present in nodepool response; skipping until rollout completes")
-				}
-				Fail(fmt.Sprintf("DiskType field still not present in v20251223preview nodepool response as of %s deadline", timeBombDeadline.Format(time.RFC3339)))
-			}
+			Expect(created.Properties.Platform.OSDisk.DiskType).ToNot(BeNil(), "created nodepool response Properties.Platform.OSDisk.DiskType was nil")
 			Expect(*created.Properties.Platform.OSDisk.DiskType).To(Equal(hcpsdk20251223preview.OsDiskTypeEphemeral), "expected created nodepool OSDisk.DiskType to be Ephemeral")
 			Expect(created.Properties.AutoRepair).ToNot(BeNil(), "created nodepool response Properties.AutoRepair was nil")
 			Expect(*created.Properties.AutoRepair).To(BeTrue(), "expected created nodepool AutoRepair to be true")
-
 			By("confirming diskType and autoRepair persist via separate GET (round-trip verification)")
 			fetched, err := framework.GetNodePool20251223(ctx,
 				client20251223.NewNodePoolsClient(),
@@ -171,7 +161,7 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 			Expect(*fetched.Properties.AutoRepair).To(BeTrue(), "expected fetched nodepool AutoRepair to be true")
 
 			By("getting credentials to verify cluster health")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -203,35 +193,6 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 		})
 
 })
-
-// buildNodePoolWithDiskType builds a v20251223preview NodePool with specific diskType and autoRepair settings.
-func buildNodePoolWithDiskType(
-	params framework.NodePoolParams,
-	location string,
-	diskType hcpsdk20251223preview.OsDiskType,
-	autoRepair bool,
-) hcpsdk20251223preview.NodePool {
-	return hcpsdk20251223preview.NodePool{
-		Location: to.Ptr(location),
-		Properties: &hcpsdk20251223preview.NodePoolProperties{
-			Version: &hcpsdk20251223preview.NodePoolVersionProfile{
-				ID:           to.Ptr(params.OpenshiftVersionId),
-				ChannelGroup: to.Ptr(params.ChannelGroup),
-			},
-			NodeDrainTimeoutMinutes: params.NodeDrainTimeoutMinutes,
-			Replicas:                to.Ptr(params.Replicas),
-			Platform: &hcpsdk20251223preview.NodePoolPlatformProfile{
-				VMSize: to.Ptr(params.VMSize),
-				OSDisk: &hcpsdk20251223preview.OsDiskProfile{
-					SizeGiB:                to.Ptr(params.OSDiskSizeGiB),
-					DiskStorageAccountType: to.Ptr(hcpsdk20251223preview.DiskStorageAccountType(params.DiskStorageAccountType)),
-					DiskType:               to.Ptr(diskType),
-				},
-			},
-			AutoRepair: to.Ptr(autoRepair),
-		},
-	}
-}
 
 // filterNodePoolVMs filters VMs whose name contains the nodepool name.
 // CAPZ derives VM names from the NodePool name via the MachineDeployment.

--- a/test/e2e/nodepool_labels_taints.go
+++ b/test/e2e/nodepool_labels_taints.go
@@ -61,13 +61,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group rg-np-labels-taints")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]any{
@@ -81,7 +81,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -91,7 +91,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %s", customerClusterName)
 
 			By("getting credentials")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -101,7 +101,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %s", customerClusterName)
 
 			By("creating the node pool with initial labels and taints")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.NodePoolName = customerNodePoolName
 			nodePoolParams.Replicas = int32(2)
@@ -110,7 +110,7 @@ var _ = Describe("Customer", func() {
 			// using a smaller VM size for faster provisioning
 			nodePoolParams.VMSize = "Standard_D4s_v3"
 
-			nodePool := framework.BuildNodePoolFromParams(nodePoolParams, tc.Location())
+			nodePool := framework.BuildNodePoolFromParams20240610(nodePoolParams, tc.Location())
 
 			nodePool.Properties.Labels = []*hcpsdk20240610preview.Label{
 				{
@@ -126,7 +126,7 @@ var _ = Describe("Customer", func() {
 				},
 			}
 
-			_, err = framework.CreateNodePoolAndWait(
+			_, err = framework.CreateNodePoolAndWait20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
 				*resourceGroup.Name,
@@ -172,7 +172,7 @@ var _ = Describe("Customer", func() {
 				},
 			}
 
-			_, err = framework.UpdateNodePoolAndWait(ctx,
+			_, err = framework.UpdateNodePoolAndWait20240610(ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
 				*resourceGroup.Name,
 				customerClusterName,
@@ -214,7 +214,7 @@ var _ = Describe("Customer", func() {
 				},
 			}
 
-			_, err = framework.UpdateNodePoolAndWait(ctx,
+			_, err = framework.UpdateNodePoolAndWait20240610(ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
 				*resourceGroup.Name,
 				customerClusterName,

--- a/test/e2e/nodepool_update_nodes.go
+++ b/test/e2e/nodepool_update_nodes.go
@@ -57,13 +57,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group nodepool-update-nodes")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{},
@@ -73,7 +73,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
@@ -82,7 +82,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %s", customerClusterName)
 
 			By("getting admin credentials for the cluster")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -95,19 +95,19 @@ var _ = Describe("Customer", func() {
 			mainNodeCount := 2
 			oneNodeCount := 1
 
-			mainNodePoolParams := framework.NewDefaultNodePoolParams()
+			mainNodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			mainNodePoolParams.NodePoolName = customerNodePoolName
 			mainNodePoolParams.Replicas = int32(mainNodeCount)
 
-			oneNodePoolParams := framework.NewDefaultNodePoolParams()
+			oneNodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			oneNodePoolParams.NodePoolName = oneNodePoolName
 			oneNodePoolParams.Replicas = int32(oneNodeCount)
 
 			errCh := make(chan error, 2)
 			group, groupCtx := errgroup.WithContext(ctx)
-			for _, nodePoolParams := range []framework.NodePoolParams{mainNodePoolParams, oneNodePoolParams} {
+			for _, nodePoolParams := range []framework.NodePoolParams20240610{mainNodePoolParams, oneNodePoolParams} {
 				group.Go(func() error {
-					createErr := tc.CreateNodePoolFromParam(
+					createErr := tc.CreateNodePoolFromParam20240610(
 						groupCtx,
 						GinkgoLogr,
 						*resourceGroup.Name,
@@ -142,7 +142,7 @@ var _ = Describe("Customer", func() {
 					Replicas: to.Ptr(int32(mainNodeCount)),
 				},
 			}
-			scaleUpResp, err := framework.UpdateNodePoolAndWait(ctx,
+			scaleUpResp, err := framework.UpdateNodePoolAndWait20240610(ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
 				*resourceGroup.Name,
 				customerClusterName,
@@ -169,7 +169,7 @@ var _ = Describe("Customer", func() {
 					Replicas: to.Ptr(int32(mainNodeCount)),
 				},
 			}
-			scaleDownResp, err := framework.UpdateNodePoolAndWait(ctx,
+			scaleDownResp, err := framework.UpdateNodePoolAndWait20240610(ctx,
 				nodePoolsClient,
 				*resourceGroup.Name,
 				customerClusterName,
@@ -197,7 +197,7 @@ var _ = Describe("Customer", func() {
 					},
 				},
 			}
-			autoscaleResp, err := framework.UpdateNodePoolAndWait(ctx,
+			autoscaleResp, err := framework.UpdateNodePoolAndWait20240610(ctx,
 				nodePoolsClient,
 				*resourceGroup.Name,
 				customerClusterName,

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -95,7 +95,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for nodepool version upgrade")
 
 			By("creating cluster parameters at control plane version")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = clusterName
 			clusterInstallVersion, err := framework.GetLatestVersionInMinor(ctx, channelGroup, targetMinor)
 			if cincinnati.IsCincinnatiVersionNotFoundError(err) {
@@ -108,7 +108,7 @@ var _ = Describe("Customer", func() {
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -122,7 +122,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
 
 			By(fmt.Sprintf("creating the HCP cluster with version %s", clusterInstallVersion))
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -134,12 +134,12 @@ var _ = Describe("Customer", func() {
 			By(fmt.Sprintf("creating nodepool with version %s (behind control plane; upgrade path validated via Cincinnati)", nodePoolInitialVersion))
 			// Node pool name must be a DNS label (no '.'); encode minor as e.g. 4.20 -> npupgrade-4-20.
 			customerNodePoolName := fmt.Sprintf("npupgrade-%s", strings.ReplaceAll(nodePoolMinor, ".", "-"))
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.NodePoolName = customerNodePoolName
 			nodePoolParams.OpenshiftVersionId = nodePoolInitialVersion
 			nodePoolParams.ChannelGroup = channelGroup
 			nodePoolParams.NodeDrainTimeoutMinutes = to.Ptr(int32(10))
-			err = tc.CreateNodePoolFromParam(
+			err = tc.CreateNodePoolFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -151,7 +151,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create node pool %s with version %s", customerNodePoolName, nodePoolInitialVersion)
 
 			By("getting admin credentials and lowest control plane version from OpenShift version history")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -206,7 +206,7 @@ var _ = Describe("Customer", func() {
 					},
 				},
 			}
-			_, err = framework.UpdateNodePoolAndWait(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName, update, 45*time.Minute)
+			_, err = framework.UpdateNodePoolAndWait20240610(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName, update, 45*time.Minute)
 			Expect(err).NotTo(HaveOccurred(), "failed to upgrade node pool %s to version %s", customerNodePoolName, nodePoolDesiredVersion)
 
 			By("verifying nodes are ready, updated to expected version, and release images differ from pre-upgrade")
@@ -220,7 +220,7 @@ var _ = Describe("Customer", func() {
 			}, 45*time.Minute, 2*time.Minute).Should(Succeed())
 
 			By("verifying node pool GET still reflects the new version")
-			npGetResponse, err := framework.GetNodePool(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
+			npGetResponse, err := framework.GetNodePool20240610(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
 			Expect(err).NotTo(HaveOccurred(), "failed to GET node pool %s after upgrade", customerNodePoolName)
 			Expect(npGetResponse.Properties).NotTo(BeNil(), "node pool GET response Properties was nil")
 			Expect(npGetResponse.Properties.Version).NotTo(BeNil(), "node pool GET response Properties.Version was nil")
@@ -281,14 +281,14 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group")
 
 			By("creating cluster parameters at control plane version")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = clusterName
 			clusterParams.OpenshiftVersionId = clusterInstallVersion
 			clusterParams.ChannelGroup = channelGroup
 			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name+"-np-ne-"+suffix, "-managed", 64)
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -302,7 +302,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
 
 			By(fmt.Sprintf("creating the HCP cluster with version %s", clusterInstallVersion))
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -313,12 +313,12 @@ var _ = Describe("Customer", func() {
 
 			By(fmt.Sprintf("creating nodepool at version %s (no Cincinnati edge to %s)", fromVersion, toVersion))
 			customerNodePoolName := fmt.Sprintf("npnoedge-%s", strings.ReplaceAll(minor, ".", "-"))
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.NodePoolName = customerNodePoolName
 			nodePoolParams.OpenshiftVersionId = fromVersion.String()
 			nodePoolParams.ChannelGroup = channelGroup
 			nodePoolParams.NodeDrainTimeoutMinutes = to.Ptr(int32(10))
-			err = tc.CreateNodePoolFromParam(
+			err = tc.CreateNodePoolFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -330,7 +330,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create nodepool %s at version %s", customerNodePoolName, fromVersion)
 
 			By("getting admin credentials")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -354,7 +354,7 @@ var _ = Describe("Customer", func() {
 					},
 				},
 			}
-			_, err = framework.UpdateNodePoolAndWait(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName, update, 45*time.Minute)
+			_, err = framework.UpdateNodePoolAndWait20240610(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName, update, 45*time.Minute)
 			Expect(err).NotTo(HaveOccurred(), "failed to upgrade nodepool %s from %s to %s", customerNodePoolName, fromVersion, toVersion)
 
 			By("verifying nodes are recreated at the target version")
@@ -363,7 +363,7 @@ var _ = Describe("Customer", func() {
 			}, 45*time.Minute, 2*time.Minute).Should(Succeed())
 
 			By("verifying node pool GET reflects the target version")
-			npGetResponse, err := framework.GetNodePool(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
+			npGetResponse, err := framework.GetNodePool20240610(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
 			Expect(err).NotTo(HaveOccurred(), "failed to GET nodepool %s", customerNodePoolName)
 			Expect(npGetResponse.Properties).NotTo(BeNil(), "nodepool %s response Properties was nil", customerNodePoolName)
 			Expect(npGetResponse.Properties.Version).NotTo(BeNil(), "nodepool %s Properties.Version was nil", customerNodePoolName)
@@ -411,7 +411,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group")
 
 			By("creating cluster parameters at control plane version")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = clusterName
 			clusterParams.OpenshiftVersionId = clusterInstallVersion
 			clusterParams.ChannelGroup = channelGroup
@@ -419,7 +419,7 @@ var _ = Describe("Customer", func() {
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]any{
@@ -433,7 +433,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
 
 			By(fmt.Sprintf("creating the HCP cluster with version %s", clusterInstallVersion))
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -444,12 +444,12 @@ var _ = Describe("Customer", func() {
 
 			By(fmt.Sprintf("creating nodepool at version %s (2 minors behind CP %s)", nodePoolInstallVersion, clusterInstallVersion))
 			customerNodePoolName := fmt.Sprintf("nps-%s-%s", strings.ReplaceAll(nodePoolMinor, ".", ""), strings.ReplaceAll(targetMinor, ".", ""))
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.NodePoolName = customerNodePoolName
 			nodePoolParams.OpenshiftVersionId = nodePoolInstallVersion
 			nodePoolParams.ChannelGroup = channelGroup
 			nodePoolParams.NodeDrainTimeoutMinutes = to.Ptr(int32(10))
-			err = tc.CreateNodePoolFromParam(
+			err = tc.CreateNodePoolFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -461,7 +461,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create nodepool %s at version %s", customerNodePoolName, nodePoolInstallVersion)
 
 			By("getting admin credentials")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -485,7 +485,7 @@ var _ = Describe("Customer", func() {
 					},
 				},
 			}
-			_, err = framework.UpdateNodePoolAndWait(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName, update, 45*time.Minute)
+			_, err = framework.UpdateNodePoolAndWait20240610(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName, update, 45*time.Minute)
 			Expect(err).NotTo(HaveOccurred(), "failed to upgrade nodepool %s from %s to %s", customerNodePoolName, nodePoolInstallVersion, nodePoolDesiredVersion)
 
 			By("verifying nodes are recreated at the target version")
@@ -494,7 +494,7 @@ var _ = Describe("Customer", func() {
 			}, 45*time.Minute, 2*time.Minute).Should(Succeed())
 
 			By("verifying node pool GET reflects the target version")
-			npGetResponse, err := framework.GetNodePool(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
+			npGetResponse, err := framework.GetNodePool20240610(ctx, nodePoolsClient, *resourceGroup.Name, clusterName, customerNodePoolName)
 			Expect(err).NotTo(HaveOccurred(), "failed to GET nodepool %s", customerNodePoolName)
 			Expect(npGetResponse.Properties).NotTo(BeNil(), "nodepool %s response Properties was nil", customerNodePoolName)
 			Expect(npGetResponse.Properties.Version).NotTo(BeNil(), "nodepool %s Properties.Version was nil", customerNodePoolName)

--- a/test/e2e/oidc_issuer_workload_identity.go
+++ b/test/e2e/oidc_issuer_workload_identity.go
@@ -191,13 +191,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for OIDC workload identity test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources (infrastructure and managed identities) for cluster")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]any{},
@@ -207,7 +207,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(ctx,
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
@@ -229,7 +229,7 @@ var _ = Describe("Customer", func() {
 			GinkgoWriter.Printf("Cluster OIDC issuer URL: %s\n", oidcIssuerURL)
 
 			By("getting admin credentials")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				hcpClient,
 				*resourceGroup.Name,
@@ -243,12 +243,12 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "cluster %s is not viable", customerClusterName)
 
 			By("creating the node pool")
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.NodePoolName = customerNodePoolName
 			nodePoolParams.Replicas = int32(2)
 
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,

--- a/test/e2e/shoebox_logs.go
+++ b/test/e2e/shoebox_logs.go
@@ -243,12 +243,12 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for shoebox test")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]any{
@@ -262,8 +262,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
 
 			By("creating the HCP cluster")
-
-			err = tc.CreateHCPClusterFromParam(ctx, GinkgoLogr, *resourceGroup.Name, clusterParams, framework.ClusterCreationTimeout)
+			err = tc.CreateHCPClusterFromParam20240610(ctx, GinkgoLogr, *resourceGroup.Name, clusterParams, framework.ClusterCreationTimeout)
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %s", customerClusterName)
 
 			subscriptionID, err := tc.SubscriptionID(ctx)

--- a/test/e2e/simple_negative_cases.go
+++ b/test/e2e/simple_negative_cases.go
@@ -63,13 +63,13 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group rg-negative-tests")
 
 			By("creating cluster parameters")
-			clusterParams := framework.NewDefaultClusterParams()
+			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]any{
@@ -100,7 +100,7 @@ var _ = Describe("Customer", func() {
 			checkExpectedError(&errs, "node pool listing in non-existent resource group", err, "resource group not found")
 
 			By("creating the HCP cluster")
-			err = tc.CreateHCPClusterFromParam(
+			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -110,7 +110,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %s", customerClusterName)
 
 			By("getting credentials")
-			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster(
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
 				*resourceGroup.Name,
@@ -123,7 +123,7 @@ var _ = Describe("Customer", func() {
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred(), "cluster %s is not viable", customerClusterName)
 
-			nodePoolParams := framework.NewDefaultNodePoolParams()
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = clusterParams.ClusterName
 			nodePoolParams.NodePoolName = customerNodePoolName
 
@@ -135,7 +135,7 @@ var _ = Describe("Customer", func() {
 			nodePoolParamsInvalidQuota.Replicas = int32(201)
 
 			By("attempting to create a node pool with invalid instance type")
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,
@@ -146,7 +146,7 @@ var _ = Describe("Customer", func() {
 			checkExpectedError(&errs, "node pool creation with invalid instance type", err, "machine type not supported")
 
 			By("attempting to create a node pool with invalid quota")
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,
@@ -157,7 +157,7 @@ var _ = Describe("Customer", func() {
 			checkExpectedError(&errs, "node pool creation with invalid quota", err, "invalid value must be less than or equal to")
 
 			By("creating a nodepool")
-			err = tc.CreateNodePoolFromParam(ctx,
+			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				managedResourceGroupName,

--- a/test/util/framework/deployment_helper.go
+++ b/test/util/framework/deployment_helper.go
@@ -321,11 +321,11 @@ func ListAllOperations(
 	return allOperations, nil
 }
 
-func (tc *perItOrDescribeTestContext) CreateHCPClusterFromParam(
+func (tc *perItOrDescribeTestContext) CreateHCPClusterFromParam20240610(
 	ctx context.Context,
 	logger logr.Logger,
 	resourceGroupName string,
-	parameters ClusterParams,
+	parameters ClusterParams20240610,
 	timeout time.Duration,
 ) error {
 	if timeout > 0*time.Second {
@@ -341,9 +341,9 @@ func (tc *perItOrDescribeTestContext) CreateHCPClusterFromParam(
 		tc.RecordTestStep(fmt.Sprintf("Deploy HCP cluster %s/%s", resourceGroupName, clusterName), startTime, finishTime)
 	}()
 
-	cluster := BuildHCPClusterFromParams(parameters, tc.Location())
+	cluster := BuildHCPClusterFromParams20240610(parameters, tc.Location())
 
-	if _, err := CreateHCPClusterAndWait(
+	if _, err := CreateHCPClusterAndWait20240610(
 		ctx,
 		logger,
 		tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
@@ -360,11 +360,11 @@ func (tc *perItOrDescribeTestContext) CreateHCPClusterFromParam(
 	return nil
 }
 
-func (tc *perItOrDescribeTestContext) CreateHCPCluster20251223FromParam(
+func (tc *perItOrDescribeTestContext) CreateHCPClusterFromParam20251223(
 	ctx context.Context,
 	logger logr.Logger,
 	resourceGroupName string,
-	parameters ClusterParams,
+	parameters ClusterParams20251223,
 	imageDigestMirrors []*hcpsdk20251223preview.ImageDigestMirror,
 	timeout time.Duration,
 ) error {
@@ -381,12 +381,12 @@ func (tc *perItOrDescribeTestContext) CreateHCPCluster20251223FromParam(
 		tc.RecordTestStep(fmt.Sprintf("Deploy HCP cluster %s/%s (v20251223preview)", resourceGroupName, clusterName), startTime, finishTime)
 	}()
 
-	cluster, err := BuildHCPCluster20251223FromParams(parameters, tc.Location(), imageDigestMirrors)
+	cluster, err := BuildHCPClusterFromParams20251223(parameters, tc.Location(), imageDigestMirrors)
 	if err != nil {
 		return fmt.Errorf("failed to build HCP cluster %s: %w", clusterName, err)
 	}
 
-	if _, err := CreateHCPCluster20251223AndWait(
+	if _, err := CreateHCPClusterAndWait20251223(
 		ctx,
 		logger,
 		tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
@@ -403,13 +403,13 @@ func (tc *perItOrDescribeTestContext) CreateHCPCluster20251223FromParam(
 	return nil
 }
 
-func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam(
+func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam20240610(
 	ctx context.Context,
 	logger logr.Logger,
 	resourceGroupName string,
 	managedResourceGroupName string,
 	hcpClusterName string,
-	parameters NodePoolParams,
+	parameters NodePoolParams20240610,
 	timeout time.Duration,
 ) error {
 	nodePoolCtx, cancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during CreateNodePoolFromParam for node pool %s in resource group %s", timeout.Minutes(), parameters.NodePoolName, resourceGroupName))
@@ -426,9 +426,9 @@ func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam(
 		return fmt.Errorf("nodePoolName parameter not found or empty")
 	}
 
-	nodePool := BuildNodePoolFromParams(parameters, tc.Location())
+	nodePool := BuildNodePoolFromParams20240610(parameters, tc.Location())
 
-	if _, err := CreateNodePoolAndWait(
+	if _, err := CreateNodePoolAndWait20240610(
 		nodePoolCtx,
 		tc.Get20240610ClientFactoryOrDie(nodePoolCtx).NewNodePoolsClient(),
 		resourceGroupName,
@@ -469,4 +469,70 @@ func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam(
 	return nil
 }
 
-// CreateHCPClusterFromParamV20251223 creates a v20251223preview HCP cluster from ClusterParamsV20251223
+func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam20251223(
+	ctx context.Context,
+	logger logr.Logger,
+	resourceGroupName string,
+	managedResourceGroupName string,
+	hcpClusterName string,
+	parameters NodePoolParams20251223,
+	timeout time.Duration,
+) error {
+	nodePoolCtx, cancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during CreateNodePoolFromParam for node pool %s in resource group %s", timeout.Minutes(), parameters.NodePoolName, resourceGroupName))
+	defer cancel()
+
+	startTime := time.Now()
+	defer func() {
+		finishTime := time.Now()
+		tc.RecordTestStep(fmt.Sprintf("Deploy node pool %s", parameters.NodePoolName), startTime, finishTime)
+	}()
+
+	nodePoolName := parameters.NodePoolName
+	if nodePoolName == "" {
+		return fmt.Errorf("nodePoolName parameter not found or empty")
+	}
+
+	nodePool := BuildNodePoolFromParams20251223(parameters, tc.Location())
+
+	if _, err := CreateNodePoolAndWait20251223(
+		nodePoolCtx,
+		tc.Get20251223ClientFactoryOrDie(nodePoolCtx).NewNodePoolsClient(),
+		resourceGroupName,
+		hcpClusterName,
+		nodePoolName,
+		nodePool,
+		timeout,
+	); err != nil {
+		// a separate context for console log download with its own timeout,
+		// to make sure logs are fetched even when the node pool deployment
+		// context is cancelled due to timeout
+		downloadTimeout := 5 * time.Minute
+		downloadCtx, downloadCancel := context.WithTimeoutCause(
+			ctx,
+			downloadTimeout,
+			fmt.Errorf("timeout '%f' minutes exceeded during DownloadAllVirtualMachineConsoleLogs for VMs in managed resource group %s", downloadTimeout.Minutes(), managedResourceGroupName))
+		defer downloadCancel()
+		computeFactory, clientErr := tc.GetARMComputeClientFactory(downloadCtx)
+		if clientErr == nil {
+			consoleLogErr := DownloadAllVirtualMachineConsoleLogs(
+				downloadCtx,
+				computeFactory,
+				managedResourceGroupName,
+				tc.LogDirPath)
+			if consoleLogErr != nil {
+				logger.Error(consoleLogErr, "failed to download VM console logs")
+			}
+		} else {
+			logger.Error(clientErr, "failed to get ARM compute client to download VM console logs")
+		}
+
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("failed to create NodePool %s, caused by: %w, error: %w", nodePoolName, context.Cause(nodePoolCtx), err)
+		}
+		return fmt.Errorf("failed to create NodePool %s: %w", nodePoolName, err)
+	}
+
+	return nil
+}
+
+// CreateHCPClusterFromParam20251223 creates a v20251223preview HCP cluster from ClusterParams20251223

--- a/test/util/framework/deployment_params.go
+++ b/test/util/framework/deployment_params.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 )
 
 type RBACScope string
@@ -51,7 +52,7 @@ const (
 	DefaultK8sServiceIP = "172.30.0.1"
 )
 
-type ClusterParams struct {
+type ClusterParams20240610 struct {
 	OpenshiftVersionId            string
 	ClusterName                   string
 	ManagedResourceGroupName      string
@@ -75,6 +76,33 @@ type ClusterParams struct {
 	ChannelGroup                  string
 	AuthorizedCIDRs               []*string
 	Autoscaling                   *hcpsdk20240610preview.ClusterAutoscalingProfile
+	Tags                          map[string]*string
+}
+
+type ClusterParams20251223 struct {
+	OpenshiftVersionId            string
+	ClusterName                   string
+	ManagedResourceGroupName      string
+	NsgResourceID                 string
+	NsgName                       string
+	SubnetResourceID              string
+	SubnetName                    string
+	VnetName                      string
+	UserAssignedIdentitiesProfile *hcpsdk20251223preview.UserAssignedIdentitiesProfile
+	Identity                      *hcpsdk20251223preview.ManagedServiceIdentity
+	KeyVaultName                  string
+	EtcdEncryptionKeyName         string
+	EtcdEncryptionKeyVersion      string
+	EncryptionKeyManagementMode   string
+	EncryptionType                string
+	VnetIntegrationSubnetID       string
+	KeyVaultVisibility            string
+	Network                       NetworkConfig
+	APIVisibility                 string
+	ImageRegistryState            string
+	ChannelGroup                  string
+	AuthorizedCIDRs               []*string
+	Autoscaling                   *hcpsdk20251223preview.ClusterAutoscalingProfile
 	Tags                          map[string]*string
 }
 
@@ -162,8 +190,8 @@ func DefaultOpenshiftNodePoolChannelGroup() string {
 	return channelGroup
 }
 
-func NewDefaultClusterParams() ClusterParams {
-	return ClusterParams{
+func NewDefaultClusterParams20240610() ClusterParams20240610 {
+	return ClusterParams20240610{
 		OpenshiftVersionId: DefaultOpenshiftControlPlaneVersionId(),
 		Network: NetworkConfig{
 			NetworkType: "OVNKubernetes",
@@ -186,7 +214,31 @@ func NewDefaultClusterParams() ClusterParams {
 	}
 }
 
-type NodePoolParams struct {
+func NewDefaultClusterParams20251223() ClusterParams20251223 {
+	return ClusterParams20251223{
+		OpenshiftVersionId: DefaultOpenshiftControlPlaneVersionId(),
+		Network: NetworkConfig{
+			NetworkType: "OVNKubernetes",
+			PodCIDR:     DefaultPodCIDR,
+			ServiceCIDR: DefaultServiceCIDR,
+			MachineCIDR: "10.0.0.0/16",
+			HostPrefix:  23,
+		},
+		EncryptionKeyManagementMode: "CustomerManaged",
+		EncryptionType:              "KMS",
+		KeyVaultVisibility:          "Public",
+		APIVisibility:               "Public",
+		ImageRegistryState:          "Enabled",
+		ChannelGroup:                DefaultOpenshiftChannelGroup(),
+		// NOTE: The E2E subscription must have the ExperimentalReleaseFeatures AFEC
+		// registered for this tag to be honored.
+		Tags: map[string]*string{
+			api.TagClusterSizeOverride: to.Ptr(string(api.MinimalControlPlanePodSizing)),
+		},
+	}
+}
+
+type NodePoolParams20240610 struct {
 	OpenshiftVersionId     string
 	ClusterName            string
 	NodePoolName           string
@@ -204,14 +256,34 @@ type NodePoolParams struct {
 	AvailabilityZone string
 }
 
+type NodePoolParams20251223 struct {
+	OpenshiftVersionId     string
+	ClusterName            string
+	NodePoolName           string
+	Replicas               int32
+	VMSize                 string
+	OSDiskSizeGiB          int32
+	DiskType               hcpsdk20251223preview.OsDiskType
+	DiskStorageAccountType string
+	ChannelGroup           string
+	// NodeDrainTimeoutMinutes: how long (in minutes) to respect Pod Disruption Budgets when draining
+	// nodes in this pool (e.g. upgrades, scale-in). Valid: 0 to 10080. 0 = no time limit for that phase.
+	// When omitted from the create payload or nil here, the cluster-configured global nodeDrainTimeoutMinutes kicks in.
+	NodeDrainTimeoutMinutes *int32
+	// AutoScaling enables nodepool autoscaling. When set, Replicas is ignored.
+	AutoScaling      *NodePoolAutoScalingParams
+	AvailabilityZone string
+	AutoRepair       bool
+}
+
 // NodePoolAutoScalingParams contains min/max node counts for nodepool autoscaling
 type NodePoolAutoScalingParams struct {
 	Min int32
 	Max int32
 }
 
-func NewDefaultNodePoolParams() NodePoolParams {
-	return NodePoolParams{
+func NewDefaultNodePoolParams20240610() NodePoolParams20240610 {
+	return NodePoolParams20240610{
 		OpenshiftVersionId:     DefaultOpenshiftNodePoolVersionId(),
 		Replicas:               int32(2),
 		VMSize:                 "Standard_D8s_v3",
@@ -221,7 +293,18 @@ func NewDefaultNodePoolParams() NodePoolParams {
 	}
 }
 
-func ConvertToUserAssignedIdentitiesProfile(value interface{}) (*hcpsdk20240610preview.UserAssignedIdentitiesProfile, error) {
+func NewDefaultNodePoolParams20251223() NodePoolParams20251223 {
+	return NodePoolParams20251223{
+		OpenshiftVersionId:     DefaultOpenshiftNodePoolVersionId(),
+		Replicas:               int32(2),
+		VMSize:                 "Standard_D8s_v3",
+		OSDiskSizeGiB:          int32(64),
+		DiskStorageAccountType: "StandardSSD_LRS",
+		ChannelGroup:           DefaultOpenshiftNodePoolChannelGroup(),
+	}
+}
+
+func ConvertToUserAssignedIdentitiesProfile20240610(value interface{}) (*hcpsdk20240610preview.UserAssignedIdentitiesProfile, error) {
 	if value == nil {
 		return nil, nil
 	}
@@ -236,7 +319,22 @@ func ConvertToUserAssignedIdentitiesProfile(value interface{}) (*hcpsdk20240610p
 	return &uamis, nil
 }
 
-func ConvertToManagedServiceIdentity(value interface{}) (*hcpsdk20240610preview.ManagedServiceIdentity, error) {
+func ConvertToUserAssignedIdentitiesProfile20251223(value interface{}) (*hcpsdk20251223preview.UserAssignedIdentitiesProfile, error) {
+	if value == nil {
+		return nil, nil
+	}
+	b, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal UserAssignedIdentitiesValue: %w", err)
+	}
+	var uamis hcpsdk20251223preview.UserAssignedIdentitiesProfile
+	if err := json.Unmarshal(b, &uamis); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal UserAssignedIdentitiesValue: %w", err)
+	}
+	return &uamis, nil
+}
+
+func ConvertToManagedServiceIdentity20240610(value interface{}) (*hcpsdk20240610preview.ManagedServiceIdentity, error) {
 	if value == nil {
 		return nil, nil
 	}
@@ -251,10 +349,25 @@ func ConvertToManagedServiceIdentity(value interface{}) (*hcpsdk20240610preview.
 	return &msi, nil
 }
 
-func PopulateClusterParamsFromCustomerInfraDeployment(
-	params ClusterParams,
+func ConvertToManagedServiceIdentity20251223(value interface{}) (*hcpsdk20251223preview.ManagedServiceIdentity, error) {
+	if value == nil {
+		return nil, nil
+	}
+	b, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal IdentityValue: %w", err)
+	}
+	var msi hcpsdk20251223preview.ManagedServiceIdentity
+	if err := json.Unmarshal(b, &msi); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal IdentityValue: %w", err)
+	}
+	return &msi, nil
+}
+
+func PopulateClusterParamsFromCustomerInfraDeployment20240610(
+	params ClusterParams20240610,
 	customerInfraDeploymentResult *armresources.DeploymentExtended,
-) (ClusterParams, error) {
+) (ClusterParams20240610, error) {
 	if customerInfraDeploymentResult == nil {
 		return params, fmt.Errorf("customerInfraDeploymentResult cannot be nil")
 	}
@@ -307,10 +420,66 @@ func PopulateClusterParamsFromCustomerInfraDeployment(
 	return params, nil
 }
 
-func PopulateClusterParamsFromManagedIdentitiesDeployment(
-	params ClusterParams,
+func PopulateClusterParamsFromCustomerInfraDeployment20251223(
+	params ClusterParams20251223,
+	customerInfraDeploymentResult *armresources.DeploymentExtended,
+) (ClusterParams20251223, error) {
+	if customerInfraDeploymentResult == nil {
+		return params, fmt.Errorf("customerInfraDeploymentResult cannot be nil")
+	}
+
+	keyVaultName, err := GetOutputValueString(customerInfraDeploymentResult, "keyVaultName")
+	if err != nil {
+		return params, fmt.Errorf("failed to get keyVaultName from customer infra deployment: %w", err)
+	}
+	etcdEncryptionKeyVersion, err := GetOutputValueString(customerInfraDeploymentResult, "etcdEncryptionKeyVersion")
+	if err != nil {
+		return params, fmt.Errorf("failed to get etcdEncryptionKeyVersion from customer infra deployment: %w", err)
+	}
+	etcdEncryptionKeyName, err := GetOutputValueString(customerInfraDeploymentResult, "etcdEncryptionKeyName")
+	if err != nil {
+		return params, fmt.Errorf("failed to get etcdEncryptionKeyName from customer infra deployment: %w", err)
+	}
+	nsgResourceID, err := GetOutputValueString(customerInfraDeploymentResult, "nsgID")
+	if err != nil {
+		return params, fmt.Errorf("failed to get nsgID from customer infra deployment: %w", err)
+	}
+	subnetResourceID, err := GetOutputValueString(customerInfraDeploymentResult, "vnetSubnetID")
+	if err != nil {
+		return params, fmt.Errorf("failed to get vnetSubnetID from customer infra deployment: %w", err)
+	}
+	vnetIntegrationSubnetID, err := GetOutputValueString(customerInfraDeploymentResult, "vnetIntegrationSubnetID")
+	if err != nil {
+		return params, fmt.Errorf("failed to get vnetIntegrationSubnetID from customer infra deployment: %w", err)
+	}
+	vnetName, err := GetOutputValueString(customerInfraDeploymentResult, "vnetName")
+	if err != nil {
+		return params, fmt.Errorf("failed to get vnetName from customer infra deployment: %w", err)
+	}
+	nsgName, err := GetOutputValueString(customerInfraDeploymentResult, "nsgName")
+	if err != nil {
+		return params, fmt.Errorf("failed to get nsgName from customer infra deployment: %w", err)
+	}
+	subnetName, err := GetOutputValueString(customerInfraDeploymentResult, "vnetSubnetName")
+	if err != nil {
+		return params, fmt.Errorf("failed to get vnetSubnetName from customer infra deployment: %w", err)
+	}
+	params.KeyVaultName = keyVaultName
+	params.EtcdEncryptionKeyVersion = etcdEncryptionKeyVersion
+	params.EtcdEncryptionKeyName = etcdEncryptionKeyName
+	params.NsgResourceID = nsgResourceID
+	params.SubnetResourceID = subnetResourceID
+	params.VnetIntegrationSubnetID = vnetIntegrationSubnetID
+	params.VnetName = vnetName
+	params.NsgName = nsgName
+	params.SubnetName = subnetName
+	return params, nil
+}
+
+func PopulateClusterParamsFromManagedIdentitiesDeployment20240610(
+	params ClusterParams20240610,
 	managedIdentitiesDeploymentResult *armresources.DeploymentExtended,
-) (ClusterParams, error) {
+) (ClusterParams20240610, error) {
 	if managedIdentitiesDeploymentResult == nil {
 		return params, fmt.Errorf("managedIdentitiesDeploymentResult cannot be nil")
 	}
@@ -319,7 +488,7 @@ func PopulateClusterParamsFromManagedIdentitiesDeployment(
 	if err != nil {
 		return params, fmt.Errorf("failed to get userAssignedIdentitiesValue from managed identity deployment: %w", err)
 	}
-	userAssignedIdentitiesProfile, err := ConvertToUserAssignedIdentitiesProfile(userAssignedIdentities)
+	userAssignedIdentitiesProfile, err := ConvertToUserAssignedIdentitiesProfile20240610(userAssignedIdentities)
 	if err != nil {
 		return params, fmt.Errorf("failed to convert userAssignedIdentitiesValue: %w", err)
 	}
@@ -328,7 +497,7 @@ func PopulateClusterParamsFromManagedIdentitiesDeployment(
 	if err != nil {
 		return params, fmt.Errorf("failed to get identityValue from managed identity deployment: %w", err)
 	}
-	identityProfile, err := ConvertToManagedServiceIdentity(identityValue)
+	identityProfile, err := ConvertToManagedServiceIdentity20240610(identityValue)
 	if err != nil {
 		return params, fmt.Errorf("failed to convert identityValue: %w", err)
 	}
@@ -339,13 +508,45 @@ func PopulateClusterParamsFromManagedIdentitiesDeployment(
 	return params, nil
 }
 
-func (tc *perItOrDescribeTestContext) CreateClusterCustomerResources(ctx context.Context,
+func PopulateClusterParamsFromManagedIdentitiesDeployment20251223(
+	params ClusterParams20251223,
+	managedIdentitiesDeploymentResult *armresources.DeploymentExtended,
+) (ClusterParams20251223, error) {
+	if managedIdentitiesDeploymentResult == nil {
+		return params, fmt.Errorf("managedIdentitiesDeploymentResult cannot be nil")
+	}
+
+	userAssignedIdentities, err := GetOutputValue(managedIdentitiesDeploymentResult, "userAssignedIdentitiesValue")
+	if err != nil {
+		return params, fmt.Errorf("failed to get userAssignedIdentitiesValue from managed identity deployment: %w", err)
+	}
+	userAssignedIdentitiesProfile, err := ConvertToUserAssignedIdentitiesProfile20251223(userAssignedIdentities)
+	if err != nil {
+		return params, fmt.Errorf("failed to convert userAssignedIdentitiesValue: %w", err)
+	}
+
+	identityValue, err := GetOutputValue(managedIdentitiesDeploymentResult, "identityValue")
+	if err != nil {
+		return params, fmt.Errorf("failed to get identityValue from managed identity deployment: %w", err)
+	}
+	identityProfile, err := ConvertToManagedServiceIdentity20251223(identityValue)
+	if err != nil {
+		return params, fmt.Errorf("failed to convert identityValue: %w", err)
+	}
+
+	params.UserAssignedIdentitiesProfile = userAssignedIdentitiesProfile
+	params.Identity = identityProfile
+
+	return params, nil
+}
+
+func (tc *perItOrDescribeTestContext) CreateClusterCustomerResources20240610(ctx context.Context,
 	resourceGroup *armresources.ResourceGroup,
-	clusterParams ClusterParams,
+	clusterParams ClusterParams20240610,
 	infraParameters map[string]interface{},
 	artifactsFS embed.FS,
 	rbacScope RBACScope,
-) (ClusterParams, error) {
+) (ClusterParams20240610, error) {
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
@@ -371,7 +572,7 @@ func (tc *perItOrDescribeTestContext) CreateClusterCustomerResources(ctx context
 	if err != nil {
 		return clusterParams, fmt.Errorf("failed to create customer-infra: %w", err)
 	}
-	clusterParams, err = PopulateClusterParamsFromCustomerInfraDeployment(clusterParams, customerInfraDeploymentResult)
+	clusterParams, err = PopulateClusterParamsFromCustomerInfraDeployment20240610(clusterParams, customerInfraDeploymentResult)
 	if err != nil {
 		return clusterParams, fmt.Errorf("failed to populate cluster params from customer-infra: %w", err)
 	}
@@ -393,7 +594,68 @@ func (tc *perItOrDescribeTestContext) CreateClusterCustomerResources(ctx context
 	if err != nil {
 		return clusterParams, fmt.Errorf("failed to create managed identities: %w", err)
 	}
-	clusterParams, err = PopulateClusterParamsFromManagedIdentitiesDeployment(clusterParams, managedIdentityDeploymentResult)
+	clusterParams, err = PopulateClusterParamsFromManagedIdentitiesDeployment20240610(clusterParams, managedIdentityDeploymentResult)
+	if err != nil {
+		return clusterParams, fmt.Errorf("failed to populate cluster params from managed identities: %w", err)
+	}
+	return clusterParams, nil
+}
+
+func (tc *perItOrDescribeTestContext) CreateClusterCustomerResources20251223(ctx context.Context,
+	resourceGroup *armresources.ResourceGroup,
+	clusterParams ClusterParams20251223,
+	infraParameters map[string]interface{},
+	artifactsFS embed.FS,
+	rbacScope RBACScope,
+) (ClusterParams20251223, error) {
+	startTime := time.Now()
+	defer func() {
+		finishTime := time.Now()
+		tc.RecordTestStep(fmt.Sprintf("Deploy customer resources in resource group %s", *resourceGroup.Name), startTime, finishTime)
+	}()
+
+	// Generate unique deployment names by combining cluster name with random suffix
+	randomSuffix := rand.String(6)
+	customerInfraDeploymentName := fmt.Sprintf("customer-infra-%s-%s", clusterParams.ClusterName, randomSuffix)
+	managedIdentitiesDeploymentName := fmt.Sprintf("mi-%s-%s", clusterParams.ClusterName, randomSuffix)
+
+	// ensure customer-infra resource names are unique per cluster
+	infraParameters["clusterName"] = clusterParams.ClusterName
+
+	customerInfraDeploymentResult, err := tc.CreateBicepTemplateAndWait(ctx,
+		WithTemplateFromFS(artifactsFS, "test-artifacts/generated-test-artifacts/modules/customer-infra.json"),
+		WithDeploymentName(customerInfraDeploymentName),
+		WithScope(BicepDeploymentScopeResourceGroup),
+		WithClusterResourceGroup(*resourceGroup.Name),
+		WithParameters(infraParameters),
+		WithTimeout(45*time.Minute),
+	)
+	if err != nil {
+		return clusterParams, fmt.Errorf("failed to create customer-infra: %w", err)
+	}
+	clusterParams, err = PopulateClusterParamsFromCustomerInfraDeployment20251223(clusterParams, customerInfraDeploymentResult)
+	if err != nil {
+		return clusterParams, fmt.Errorf("failed to populate cluster params from customer-infra: %w", err)
+	}
+
+	managedIdentityDeploymentResult, err := tc.DeployManagedIdentities(ctx,
+		clusterParams.ClusterName,
+		rbacScope,
+		WithTemplateFromFS(artifactsFS, "test-artifacts/generated-test-artifacts/modules/managed-identities.json"),
+		WithDeploymentName(managedIdentitiesDeploymentName),
+		WithClusterResourceGroup(*resourceGroup.Name),
+		WithParameters(map[string]interface{}{
+			"nsgName":      clusterParams.NsgName,
+			"vnetName":     clusterParams.VnetName,
+			"subnetName":   clusterParams.SubnetName,
+			"keyVaultName": clusterParams.KeyVaultName,
+		}),
+	)
+
+	if err != nil {
+		return clusterParams, fmt.Errorf("failed to create managed identities: %w", err)
+	}
+	clusterParams, err = PopulateClusterParamsFromManagedIdentitiesDeployment20251223(clusterParams, managedIdentityDeploymentResult)
 	if err != nil {
 		return clusterParams, fmt.Errorf("failed to populate cluster params from managed identities: %w", err)
 	}

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -80,7 +80,7 @@ func checkOperationResult(expectModel, resultModel any) error {
 	return nil
 }
 
-func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster(
+func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster20240610(
 	ctx context.Context,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
 	resourceGroupName string,
@@ -129,7 +129,7 @@ func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster(
 	}
 }
 
-func (tc *perItOrDescribeTestContext) RevokeCredentialsAndWait(
+func (tc *perItOrDescribeTestContext) RevokeCredentialsAndWait20240610(
 	ctx context.Context,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
 	resourceGroupName string,
@@ -168,10 +168,10 @@ func (tc *perItOrDescribeTestContext) RevokeCredentialsAndWait(
 	}
 }
 
-// DeleteHCPCluster deletes an hcp cluster and waits for the operation to complete.
+// DeleteHCPCluster20240610 deletes an hcp cluster and waits for the operation to complete
 // Transient ConflictingConcurrentWriteNotAllowed (409) errors are retried automatically
 // with exponential backoff.
-func DeleteHCPCluster(
+func DeleteHCPCluster20240610(
 	ctx context.Context,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
 	resourceGroupName string,
@@ -221,7 +221,7 @@ func deleteHCPClusterAttempt(
 			if getErr == nil && resp.Properties != nil && resp.Properties.ProvisioningState != nil && *resp.Properties.ProvisioningState == hcpsdk20240610preview.ProvisioningStateDeleting {
 				ginkgo.GinkgoLogr.Info("cluster already deleting, waiting for completion",
 					"cluster", hcpClusterName, "resourceGroup", resourceGroupName)
-				return waitForHCPClusterDeletion(ctx, hcpClient, resourceGroupName, hcpClusterName)
+				return waitForHCPClusterDeletion20240610(ctx, hcpClient, resourceGroupName, hcpClusterName)
 			}
 		}
 		return err
@@ -247,8 +247,8 @@ func deleteHCPClusterAttempt(
 	return nil
 }
 
-// waitForHCPClusterDeletion polls GET on the cluster until it returns 404 (deleted).
-func waitForHCPClusterDeletion(
+// waitForHCPClusterDeletion20240610 polls GET on the cluster until it returns 404 (deleted).
+func waitForHCPClusterDeletion20240610(
 	ctx context.Context,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
 	resourceGroupName string,
@@ -277,9 +277,9 @@ func waitForHCPClusterDeletion(
 	}
 }
 
-// UpdateHCPCluster updates an HCP cluster using the v20240610preview SDK and waits for the operation to complete.
+// UpdateHCPCluster20240610 updates an HCP cluster using the v20240610preview SDK and waits for the operation to complete.
 // Transient 500, 409, and CS state conflict 400 errors are retried automatically with exponential backoff.
-func UpdateHCPCluster(
+func UpdateHCPCluster20240610(
 	ctx context.Context,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
 	resourceGroupName string,
@@ -324,7 +324,7 @@ func UpdateHCPCluster(
 
 		switch m := any(operationResult).(type) {
 		case hcpsdk20240610preview.HcpOpenShiftClustersClientUpdateResponse:
-			expect, err := GetHCPCluster(ctx, hcpClient, resourceGroupName, hcpClusterName)
+			expect, err := GetHCPCluster20240610(ctx, hcpClient, resourceGroupName, hcpClusterName)
 			if err != nil {
 				if errors.Is(err, context.DeadlineExceeded) {
 					return false, fmt.Errorf("failed getting hcpCluster=%q in resourcegroup=%q, caused by: %w, error: %w", hcpClusterName, resourceGroupName, context.Cause(ctx), err)
@@ -465,8 +465,8 @@ func UpdateHCPCluster20251223(
 	return hcpOpenShiftCluster, err
 }
 
-// GetHCPCluster fetches an HCP cluster
-func GetHCPCluster(
+// GetHCPCluster20240610 fetches an HCP cluster
+func GetHCPCluster20240610(
 	ctx context.Context,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
 	resourceGroupName string,
@@ -475,8 +475,8 @@ func GetHCPCluster(
 	return hcpClient.Get(ctx, resourceGroupName, hcpClusterName, nil)
 }
 
-// DeleteAllHCPClusters deletes all Clusters within a resource group and waits
-func DeleteAllHCPClusters(
+// DeleteAllHCPClusters20240610 deletes all Clusters within a resource group and waits
+func DeleteAllHCPClusters20240610(
 	ctx context.Context,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
 	resourceGroupName string,
@@ -511,7 +511,7 @@ func DeleteAllHCPClusters(
 			// prevent a stray panic from exiting the process. Don't do this generally because ginkgo/gomega rely on panics to function.
 			defer utilruntime.HandleCrashWithContext(ctx)
 
-			return DeleteHCPCluster(ctx, hcpClient, resourceGroupName, hcpClusterName, timeout)
+			return DeleteHCPCluster20240610(ctx, hcpClient, resourceGroupName, hcpClusterName, timeout)
 		})
 	}
 	if err := waitGroup.Wait(); err != nil {
@@ -537,8 +537,8 @@ func (e *NonConformingClustersError) Error() string {
 	return fmt.Sprintf("the following clusters did not have tags[%s]=%s: %v; we require end-to-end tests to opt into this tag to ensure that the control planes we provision during automated test runs have minimal footprints on our production infrastructure", api.TagClusterSizeOverride, api.MinimalControlPlanePodSizing, e.clusters)
 }
 
-// DeleteNodePool deletes a nodepool and waits for the operation to complete
-func DeleteNodePool(
+// DeleteNodePool20240610 deletes a nodepool and waits for the operation to complete
+func DeleteNodePool20240610(
 	ctx context.Context,
 	nodePoolsClient *hcpsdk20240610preview.NodePoolsClient,
 	resourceGroupName string,
@@ -557,7 +557,7 @@ func DeleteNodePool(
 			if getErr == nil && resp.Properties != nil && resp.Properties.ProvisioningState != nil && *resp.Properties.ProvisioningState == hcpsdk20240610preview.ProvisioningStateDeleting {
 				ginkgo.GinkgoLogr.Info("nodepool already deleting, waiting for completion",
 					"nodePool", nodePoolName, "cluster", hcpClusterName, "resourceGroup", resourceGroupName)
-				return waitForNodePoolDeletion(ctx, nodePoolsClient, resourceGroupName, hcpClusterName, nodePoolName)
+				return waitForNodePoolDeletion20240610(ctx, nodePoolsClient, resourceGroupName, hcpClusterName, nodePoolName)
 			}
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -586,8 +586,8 @@ func DeleteNodePool(
 	return nil
 }
 
-// waitForNodePoolDeletion polls GET on the nodepool until it returns 404 (deleted).
-func waitForNodePoolDeletion(
+// waitForNodePoolDeletion20240610 polls GET on the nodepool until it returns 404 (deleted).
+func waitForNodePoolDeletion20240610(
 	ctx context.Context,
 	nodePoolsClient *hcpsdk20240610preview.NodePoolsClient,
 	resourceGroupName string,
@@ -617,8 +617,8 @@ func waitForNodePoolDeletion(
 	}
 }
 
-// GetNodePool fetches a nodepool resource
-func GetNodePool(
+// GetNodePool20240610 fetches a nodepool resource
+func GetNodePool20240610(
 	ctx context.Context,
 	nodePoolsClient *hcpsdk20240610preview.NodePoolsClient,
 	resourceGroupName string,
@@ -628,9 +628,9 @@ func GetNodePool(
 	return nodePoolsClient.Get(ctx, resourceGroupName, hcpClusterName, nodePoolName, nil)
 }
 
-// UpdateNodePoolAndWait sends a PATCH (BeginUpdate) request for a nodepool and waits for completion
+// UpdateNodePoolAndWait20240610 sends a PATCH (BeginUpdate) request for a nodepool and waits for completion
 // within the provided timeout. It returns the final update response or an error.
-func UpdateNodePoolAndWait(
+func UpdateNodePoolAndWait20240610(
 	ctx context.Context,
 	nodePoolsClient *hcpsdk20240610preview.NodePoolsClient,
 	resourceGroupName string,
@@ -659,7 +659,7 @@ func UpdateNodePoolAndWait(
 
 	switch m := any(operationResult).(type) {
 	case hcpsdk20240610preview.NodePoolsClientUpdateResponse:
-		expect, err := GetNodePool(ctx, nodePoolsClient, resourceGroupName, hcpClusterName, nodePoolName)
+		expect, err := GetNodePool20240610(ctx, nodePoolsClient, resourceGroupName, hcpClusterName, nodePoolName)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
 				return nil, fmt.Errorf("failed getting nodepool=%q in cluster=%q resourcegroup=%q, caused by: %w, error: %w", nodePoolName, hcpClusterName, resourceGroupName, context.Cause(ctx), err)
@@ -676,8 +676,8 @@ func UpdateNodePoolAndWait(
 	}
 }
 
-// CreateOrUpdateExternalAuthAndWait creates or updates an external auth on an HCP cluster and waits
-func CreateOrUpdateExternalAuthAndWait(
+// CreateOrUpdateExternalAuthAndWait20240610 creates or updates an external auth on an HCP cluster and waits
+func CreateOrUpdateExternalAuthAndWait20240610(
 	ctx context.Context,
 	externalAuthClient *hcpsdk20240610preview.ExternalAuthsClient,
 	resourceGroupName string,
@@ -717,7 +717,7 @@ func CreateOrUpdateExternalAuthAndWait(
 		// endpoint for the operation is supposed to respond as though the operation
 		// were completed synchronously. In production, ARM would call this endpoint
 		// automatically. In this context, the poller calls it automatically.
-		expect, err := GetExternalAuth(ctx, externalAuthClient, resourceGroupName, hcpClusterName, externalAuthName)
+		expect, err := GetExternalAuth20240610(ctx, externalAuthClient, resourceGroupName, hcpClusterName, externalAuthName)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
 				return nil, fmt.Errorf("failed getting external auth %q in resourcegroup=%q for cluster=%q, caused by: %w, error: %w", externalAuthName, resourceGroupName, hcpClusterName, context.Cause(ctx), err)
@@ -736,7 +736,7 @@ func CreateOrUpdateExternalAuthAndWait(
 }
 
 // CreateExternalAuthAndWait creates a an external auth on an HCP cluster and waits
-func GetExternalAuth(
+func GetExternalAuth20240610(
 	ctx context.Context,
 	externalAuthClient *hcpsdk20240610preview.ExternalAuthsClient,
 	resourceGroupName string,
@@ -752,8 +752,8 @@ func GetExternalAuth(
 	)
 }
 
-// DeleteExternalAuthAndWait deletes a an external auth on an HCP cluster and waits
-func DeleteExternalAuthAndWait(
+// DeleteExternalAuthAndWait20240610 deletes a an external auth on an HCP cluster and waits
+func DeleteExternalAuthAndWait20240610(
 	ctx context.Context,
 	externalAuthClient *hcpsdk20240610preview.ExternalAuthsClient,
 	resourceGroupName string,
@@ -854,16 +854,16 @@ func CreateTestDockerConfigSecret(host, username, password, email, secretName, n
 	}, nil
 }
 
-func BeginCreateHCPCluster(
+func BeginCreateHCPCluster20240610(
 	ctx context.Context,
 	logger logr.Logger,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
 	resourceGroupName string,
 	hcpClusterName string,
-	clusterParams ClusterParams,
+	clusterParams ClusterParams20240610,
 	location string,
 ) (*runtime.Poller[hcpsdk20240610preview.HcpOpenShiftClustersClientCreateOrUpdateResponse], error) {
-	cluster := BuildHCPClusterFromParams(clusterParams, location)
+	cluster := BuildHCPClusterFromParams20240610(clusterParams, location)
 	logger.Info("Starting HCP cluster creation", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName)
 	poller, err := hcpClient.BeginCreateOrUpdate(ctx, resourceGroupName, hcpClusterName, cluster, nil)
 	if err != nil {
@@ -872,9 +872,9 @@ func BeginCreateHCPCluster(
 	return poller, nil
 }
 
-// CreateHCPClusterAndWait Note that the timeout parameter will only take effect if its value is greater than 0. Otherwise,
+// CreateHCPClusterAndWait20240610 Note that the timeout parameter will only take effect if its value is greater than 0. Otherwise,
 // the function won't wait for the deployment to be ready.
-func CreateHCPClusterAndWait(
+func CreateHCPClusterAndWait20240610(
 	ctx context.Context,
 	logger logr.Logger,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
@@ -912,7 +912,7 @@ func CreateHCPClusterAndWait(
 			// endpoint for the operation is supposed to respond as though the operation
 			// were completed synchronously. In production, ARM would call this endpoint
 			// automatically. In this context, the poller calls it automatically.
-			expect, err := GetHCPCluster(ctx, hcpClient, resourceGroupName, hcpClusterName)
+			expect, err := GetHCPCluster20240610(ctx, hcpClient, resourceGroupName, hcpClusterName)
 			if err != nil {
 				if errors.Is(err, context.DeadlineExceeded) {
 					return nil, fmt.Errorf("failed getting cluster=%q in resourcegroup=%q, caused by: %w, error: %w", hcpClusterName, resourceGroupName, context.Cause(ctx), err)
@@ -941,8 +941,8 @@ func CreateHCPClusterAndWait(
 
 }
 
-func BuildHCPClusterFromParams(
-	parameters ClusterParams,
+func BuildHCPClusterFromParams20240610(
+	parameters ClusterParams20240610,
 	location string,
 ) hcpsdk20240610preview.HcpOpenShiftCluster {
 
@@ -996,7 +996,7 @@ func BuildHCPClusterFromParams(
 	}
 }
 
-func CreateNodePoolAndWait(
+func CreateNodePoolAndWait20240610(
 	ctx context.Context,
 	nodePoolsClient *hcpsdk20240610preview.NodePoolsClient,
 	resourceGroupName string,
@@ -1025,7 +1025,7 @@ func CreateNodePoolAndWait(
 		// endpoint for the operation is supposed to respond as though the operation
 		// were completed synchronously. In production, ARM would call this endpoint
 		// automatically. In this context, the poller calls it automatically.
-		expect, err := GetNodePool(ctx, nodePoolsClient, resourceGroupName, hcpClusterName, nodePoolName)
+		expect, err := GetNodePool20240610(ctx, nodePoolsClient, resourceGroupName, hcpClusterName, nodePoolName)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
 				return nil, fmt.Errorf("failed to get nodepool, caused by: %w, error: %w", context.Cause(ctx), err)
@@ -1043,8 +1043,8 @@ func CreateNodePoolAndWait(
 	}
 }
 
-func BuildNodePoolFromParams(
-	parameters NodePoolParams,
+func BuildNodePoolFromParams20240610(
+	parameters NodePoolParams20240610,
 	location string,
 ) hcpsdk20240610preview.NodePool {
 
@@ -1069,6 +1069,44 @@ func BuildNodePoolFromParams(
 
 	if parameters.AutoScaling != nil {
 		nodePool.Properties.AutoScaling = &hcpsdk20240610preview.NodePoolAutoScaling{
+			Min: to.Ptr(parameters.AutoScaling.Min),
+			Max: to.Ptr(parameters.AutoScaling.Max),
+		}
+	} else {
+		nodePool.Properties.Replicas = to.Ptr(parameters.Replicas)
+	}
+
+	return nodePool
+}
+
+func BuildNodePoolFromParams20251223(
+	parameters NodePoolParams20251223,
+	location string,
+) hcpsdk20251223preview.NodePool {
+
+	nodePool := hcpsdk20251223preview.NodePool{
+		Location: to.Ptr(location),
+		Properties: &hcpsdk20251223preview.NodePoolProperties{
+			Version: &hcpsdk20251223preview.NodePoolVersionProfile{
+				ID:           to.Ptr(parameters.OpenshiftVersionId),
+				ChannelGroup: to.Ptr(parameters.ChannelGroup),
+			},
+			NodeDrainTimeoutMinutes: parameters.NodeDrainTimeoutMinutes,
+			Platform: &hcpsdk20251223preview.NodePoolPlatformProfile{
+				VMSize: to.Ptr(parameters.VMSize),
+				OSDisk: &hcpsdk20251223preview.OsDiskProfile{
+					SizeGiB:                to.Ptr(parameters.OSDiskSizeGiB),
+					DiskStorageAccountType: to.Ptr(hcpsdk20251223preview.DiskStorageAccountType(parameters.DiskStorageAccountType)),
+					DiskType:               to.Ptr(parameters.DiskType),
+				},
+				AvailabilityZone: to.Ptr(parameters.AvailabilityZone),
+			},
+			AutoRepair: to.Ptr(parameters.AutoRepair),
+		},
+	}
+
+	if parameters.AutoScaling != nil {
+		nodePool.Properties.AutoScaling = &hcpsdk20251223preview.NodePoolAutoScaling{
 			Min: to.Ptr(parameters.AutoScaling.Min),
 			Max: to.Ptr(parameters.AutoScaling.Max),
 		}
@@ -1171,8 +1209,8 @@ func convertViaJSON[T any](src any) (*T, error) {
 	return &dst, nil
 }
 
-func BuildHCPCluster20251223FromParams(
-	parameters ClusterParams,
+func BuildHCPClusterFromParams20251223(
+	parameters ClusterParams20251223,
 	location string,
 	imageDigestMirrors []*hcpsdk20251223preview.ImageDigestMirror,
 ) (hcpsdk20251223preview.HcpOpenShiftCluster, error) {
@@ -1248,8 +1286,8 @@ func BuildHCPCluster20251223FromParams(
 	}, nil
 }
 
-// CreateHCPCluster20251223AndWait creates an HCP cluster using the v20251223preview API and waits for completion.
-func CreateHCPCluster20251223AndWait(
+// CreateHCPClusterAndWait20251223 creates an HCP cluster using the v20251223preview API and waits for completion.
+func CreateHCPClusterAndWait20251223(
 	ctx context.Context,
 	logger logr.Logger,
 	hcpClient *hcpsdk20251223preview.HcpOpenShiftClustersClient,
@@ -1300,14 +1338,14 @@ func CreateHCPCluster20251223AndWait(
 }
 
 // Verifies that a nodepool created using framework has DiskStorageAccountType set to the framework default "StandardSSD_LRS"
-func ValidateNodePoolDiskStorageAccountType(
+func ValidateNodePoolDiskStorageAccountType20240610(
 	ctx context.Context,
 	nodePoolsClient *hcpsdk20240610preview.NodePoolsClient,
 	resourceGroupName string,
 	hcpClusterName string,
 	nodePoolName string,
 ) error {
-	nodePoolResp, err := GetNodePool(ctx, nodePoolsClient, resourceGroupName, hcpClusterName, nodePoolName)
+	nodePoolResp, err := GetNodePool20240610(ctx, nodePoolsClient, resourceGroupName, hcpClusterName, nodePoolName)
 	if err != nil {
 		return fmt.Errorf("failed to get nodepool %s: %w", nodePoolName, err)
 	}
@@ -1430,4 +1468,4 @@ func GetNodePool20251223(
 	return &resp.NodePool, nil
 }
 
-// BuildHCPClusterFromParamsV20251223 builds a v20251223preview HCP cluster from ClusterParamsV20251223
+// BuildHCPClusterFromParams20251223 builds a v20251223preview HCP cluster from ClusterParams20251223

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -514,7 +514,7 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 
 	var nonConformantErr error
 	ginkgo.GinkgoLogr.Info("deleting all hcp clusters in resource group", "resourceGroup", resourceGroupName)
-	if err := DeleteAllHCPClusters(ctx, hcpClientFactory.NewHcpOpenShiftClustersClient(), resourceGroupName, timeout); err != nil {
+	if err := DeleteAllHCPClusters20240610(ctx, hcpClientFactory.NewHcpOpenShiftClustersClient(), resourceGroupName, timeout); err != nil {
 		if errors.Is(err, &NonConformingClustersError{}) {
 			nonConformantErr = err
 		} else if isResourceGroupNotFoundError(err) {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-27211

### What
This change is a versioned helper refactor across E2E tests and framework utilities.
It renames generic HCP helper methods to explicit API-versioned names and updates all test callsites accordingly.

- Standardized 20240610 helper names in framework utilities (cluster, nodepool, external auth, admin-credential helpers).
- Standardized 20251223 helper names for preview-specific cluster build/create flows.
- Updated E2E tests to call explicit versioned helpers instead of ambiguous generic helpers.
- Kept behavior intact: this is a naming/clarity refactor with no intended functional changes.

### Why

- Removes ambiguity now that multiple API versions are used in the same codebase.
- Prevents accidental use of the wrong SDK/API version in tests.
- Makes test intent and reviewability much clearer at each callsite.
- Creates a scalable naming pattern for future API-version additions without hidden coupling.

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
