### PR TITLE
test: skip minor upgrade test when no install version found

### DIFF
--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -106,6 +106,11 @@ var _ = Describe("Customer", func() {
 				}
 			}
 
+			if installVersion == nil {
+				Skip(fmt.Sprintf("no install version in %s found with upgrade path to %s",
+					previousMinor.String(), targetVer.String()))
+			}
+
 			tc := framework.NewTestContext()
 			if tc.UsePooledIdentities() {
 				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)


### PR DESCRIPTION
Narrowest possible nil pointer fix to easy to reason about merge.

The y-stream upgrade E2E test panics with nil pointer dereference at line 119 when no possibleInstallVersion has an upgrade path to the target minor. This happens when Cincinnati has no valid upgrade edges for the version combination being tested.

Add a nil check on installVersion before proceeding, skipping the test with a descriptive message instead of panicking.

