### PR TITLE
chore: manual bump of CS to an image digest corresponding to commit sha 84b200b1d25eddb2d09ea820adcf5208e1de9779

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -945,7 +945,7 @@ defaults:
     image:
       registry: quay.io
       repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5 # dbb022a3dd3f0533ae1c8eebd4e6929ba1ca1ede (2026-05-19 06:44)
+      digest: sha256:449827838d1e8d19a442ca470c86acfc206628345b1a4dea47c57cbd4865b7c9 # 84b200b1d25eddb2d09ea820adcf5208e1de9779
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -163,7 +163,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5
+    digest: sha256:449827838d1e8d19a442ca470c86acfc206628345b1a4dea47c57cbd4865b7c9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -163,7 +163,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5
+    digest: sha256:449827838d1e8d19a442ca470c86acfc206628345b1a4dea47c57cbd4865b7c9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -163,7 +163,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5
+    digest: sha256:449827838d1e8d19a442ca470c86acfc206628345b1a4dea47c57cbd4865b7c9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -163,7 +163,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5
+    digest: sha256:449827838d1e8d19a442ca470c86acfc206628345b1a4dea47c57cbd4865b7c9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -163,7 +163,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5
+    digest: sha256:449827838d1e8d19a442ca470c86acfc206628345b1a4dea47c57cbd4865b7c9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -163,7 +163,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpprow
   image:
-    digest: sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5
+    digest: sha256:449827838d1e8d19a442ca470c86acfc206628345b1a4dea47c57cbd4865b7c9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -43,13 +43,19 @@ import (
 var TestArtifactsFS embed.FS
 
 var _ = Describe("ARO-HCP", func() {
-	// Use channel group from environment variable, or default to stable
-	var channelGroup = framework.DefaultOpenshiftChannelGroup()
-	var nodePoolChannelGroup = framework.DefaultOpenshiftNodePoolChannelGroup()
 
 	DescribeTable("should be able to perform a control plane and node pool install with OCP "+framework.DefaultOpenshiftChannelGroup()+" channel",
 		func(ctx context.Context, version string) {
+			// Use channel group from environment variable, or default to stable
+			var channelGroup = framework.DefaultOpenshiftChannelGroup()
+			var nodePoolChannelGroup = framework.DefaultOpenshiftNodePoolChannelGroup()
 
+			if version == "4.23" || version == "5.0" {
+				// Nightly channel picks up the Hypershift fix for Swift NIC scheduling overrides
+				// (https://github.com/openshift/hypershift/pull/8552) and test it against the CS bump.
+				channelGroup = "nightly"
+				nodePoolChannelGroup = "nightly"
+			}
 			customerNetworkSecurityGroupName := "customer-nsg-" + channelGroup + "-"
 			customerVnetName := "customer-vnet-" + channelGroup + "-"
 			customerVnetSubnetName := "customer-vnet-subnet-" + channelGroup + "-"
@@ -61,6 +67,7 @@ var _ = Describe("ARO-HCP", func() {
 			clusterParams := framework.NewDefaultClusterParams()
 			clusterParams.ClusterName = clusterName
 			clusterParams.OpenshiftVersionId = version
+			clusterParams.ChannelGroup = channelGroup
 			openShiftControlPlaneVersion, err := framework.GetLatestInstallVersion(ctx, clusterParams.ChannelGroup, version)
 			if err != nil {
 				if errors.Is(err, framework.ErrNightlyReleaseStreamNotFound) || errors.Is(err, framework.ErrNoAcceptedNightlyTags) || errors.Is(err, framework.ErrVersionNotFound) {
@@ -103,7 +110,7 @@ var _ = Describe("ARO-HCP", func() {
 			// (https://github.com/openshift/hypershift/pull/8552), and Cluster Service applies the matching
 			// NIC resource request (https://redhat.atlassian.net/browse/ARO-27209).
 			if version == "4.23" || version == "5.0" {
-				By(fmt.Sprintf("creating a Swift cluster on version '%s' and channel group '%s'", clusterParams.OpenshiftVersionId, channelGroup))
+				By(fmt.Sprintf("creating a Swift cluster on version '%s' and channel group '%s'", clusterParams.OpenshiftVersionId, clusterParams.ChannelGroup))
 				clusterResource, err := framework.BuildHCPCluster20251223FromParams(clusterParams, tc.Location(), nil)
 				Expect(err).NotTo(HaveOccurred(), "Swift cluster resource for %s should build from params", clusterName)
 				clientFactory, err := tc.Get20251223ClientFactory(ctx)
@@ -146,6 +153,7 @@ var _ = Describe("ARO-HCP", func() {
 			nodePoolParams := framework.NewDefaultNodePoolParams()
 			nodePoolParams.ClusterName = clusterName
 			nodePoolParams.NodePoolName = nodePoolName
+			nodePoolParams.ChannelGroup = nodePoolChannelGroup
 			// Calculate the node pool version
 			configClient, err := configv1client.NewForConfig(adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to create OpenShift config client for cluster %q", clusterName)


### PR DESCRIPTION
### What

chore: manual bump of CS to an image digest corresponding to commit sha 84b200b1d25eddb2d09ea820adcf5208e1de9779)

### Why

To bring in the changes that's related to https://redhat.atlassian.net/browse/ARO-27209

See https://github.com/Azure/ARO-HCP/pull/5346 for an attempt to add e2e that will gate against the hypershift change

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
