### PR TITLE
fix: change priority on upgrade tests

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -178,7 +178,7 @@ func setupCli() *cobra.Command {
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=20
-		Parallelism: 24,
+		Parallelism: 20,
 		TestTimeout: &rpApiCompatTestTimeout,
 	})
 	ext.AddSuite(e.Suite{

--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -257,10 +257,9 @@ func setupCli() *cobra.Command {
 	//	}
 	// })
 
-	// Sort specs so tests with higher managed identity container demand are
-	// dispatched first. This prevents starvation: multi-container tests get
-	// dispatched while the pool is full, before single-container tests can
-	// consume all available capacity.
+	// Sort specs so high-priority tests are dispatched first. This covers
+	// both multi-container tests (which need pool capacity) and long-running
+	// tests like upgrades (which need to start early to finish in time).
 	sort.SliceStable(specs, func(i, j int) bool {
 		return miDemandPriority(specs[i]) > miDemandPriority(specs[j])
 	})

--- a/test/e2e/admin_credential_lifecycle.go
+++ b/test/e2e/admin_credential_lifecycle.go
@@ -54,6 +54,7 @@ var _ = Describe("Customer", func() {
 
 	It("should be able to test admin credentials before cluster ready, then full admin credential lifecycle",
 		labels.RequireNothing,
+		labels.MIDemandHigh,
 		labels.High,
 		labels.Positive,
 		labels.AroRpApiCompatible,

--- a/test/e2e/arm64_nodepool.go
+++ b/test/e2e/arm64_nodepool.go
@@ -34,6 +34,7 @@ var _ = Describe("Customer", func() {
 
 	It("should be able to create node pools with ARM64-based VMs",
 		labels.RequireNothing,
+		labels.MIDemandHigh,
 		labels.Critical,
 		labels.Positive,
 		labels.AroRpApiCompatible,

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -45,6 +45,7 @@ var _ = Describe("Authorized CIDRs", func() {
 	Context("Connectivity", func() {
 		It("should allow API access only from authorized VM IP",
 			labels.RequireNothing,
+			labels.MIDemandHigh,
 			labels.Critical,
 			labels.Positive,
 			labels.AroRpApiCompatible,

--- a/test/e2e/cluster_autoscaling.go
+++ b/test/e2e/cluster_autoscaling.go
@@ -35,6 +35,7 @@ var _ = Describe("Customer", func() {
 
 	It("should be able to create an HCP cluster with custom autoscaling",
 		labels.RequireNothing,
+		labels.MIDemandHigh,
 		labels.Medium,
 		labels.Positive,
 		labels.AroRpApiCompatible,

--- a/test/e2e/cluster_create_test.go
+++ b/test/e2e/cluster_create_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var _ = Describe("Put HCPOpenShiftCluster", func() {
-	It("Attempts to put HCPOpenshiftCluster with non-existent Resource Group and cluster resource as nil", labels.CreateCluster, labels.RequireNothing, labels.Medium, labels.Negative, func(ctx context.Context) {
+	It("Attempts to put HCPOpenshiftCluster with non-existent Resource Group and cluster resource as nil", labels.CreateCluster, labels.RequireNothing, labels.Medium, labels.Negative, labels.MIDemandHigh, func(ctx context.Context) {
 		tc := framework.NewTestContext()
 
 		clusterName := "non-existing-cluster"

--- a/test/e2e/cluster_nsg_subnet_reuse.go
+++ b/test/e2e/cluster_nsg_subnet_reuse.go
@@ -32,7 +32,6 @@ var _ = Describe("Customer", func() {
 		labels.Medium,
 		labels.Negative,
 		labels.AroRpApiCompatible,
-		labels.MIDemandMedium,
 		func(ctx context.Context) {
 			const (
 				customerNetworkSecurityGroupName = "customer-nsg-name"

--- a/test/e2e/cluster_pullsecret.go
+++ b/test/e2e/cluster_pullsecret.go
@@ -46,6 +46,7 @@ var _ = Describe("Customer", func() {
 
 	It("should be able to create an HCP cluster and manage pull secrets",
 		labels.RequireNothing,
+		labels.MIDemandHigh,
 		labels.Critical,
 		labels.Positive,
 		labels.AroRpApiCompatible,

--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -44,6 +44,7 @@ var _ = Describe("Customer", func() {
 
 	It("should create an HCP cluster and validate TLS certificates",
 		labels.RequireNothing,
+		labels.MIDemandHigh,
 		labels.Critical,
 		labels.Positive,
 		func(ctx context.Context) {

--- a/test/e2e/cluster_version_backlevel.go
+++ b/test/e2e/cluster_version_backlevel.go
@@ -48,6 +48,7 @@ var _ = Describe("Customer", func() {
 	for _, version := range backlevelVersions {
 		It("should be able to create an HCP cluster with back-level version "+version.controlPlaneVersion,
 			labels.RequireNothing,
+			labels.MIDemandHigh,
 			labels.Critical,
 			labels.Positive,
 			labels.AroRpApiCompatible,

--- a/test/e2e/cluster_versions.go
+++ b/test/e2e/cluster_versions.go
@@ -28,6 +28,7 @@ var _ = Describe("Customer", func() {
 
 	It("should be able to list available HCP OpenShift versions and validate response content",
 		labels.RequireNothing,
+		labels.MIDemandHigh,
 		labels.Medium,
 		labels.Positive,
 		labels.AroRpApiCompatible,

--- a/test/e2e/clusters_sharing_resgroup.go
+++ b/test/e2e/clusters_sharing_resgroup.go
@@ -37,7 +37,6 @@ var _ = Describe("Customer", func() {
 		labels.AroRpApiCompatible,
 		labels.Critical,
 		labels.Positive,
-		labels.MIDemandHigh,
 		func(ctx context.Context) {
 			const (
 				customerNetworkSecurityGroupName = "customer-nsg-name"

--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -163,10 +163,10 @@ var _ = Describe("Service Provider", func() {
 		// for 4.19, if we start with 4.19.0, the version that has an upgrade path to 4.19.latest is
 		// 4.19.3 but cluster install on this version fails with KMS authentication problem.
 		// For all the other minor versions, we can start with 4.y.0 and install the latest version in the candidate channel.
-		Entry("for 4.19", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium, "4.19", "4.19.25"),
-		Entry("for 4.20", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium, "4.20", ""),
-		Entry("for 4.21", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium, "4.21", ""),
-		Entry("for 4.22", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium, "4.22", ""),
-		Entry("for 4.23", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium, "4.23", ""),
+		Entry("for 4.19", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandHigh, "4.19", "4.19.25"),
+		Entry("for 4.20", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandHigh, "4.20", ""),
+		Entry("for 4.21", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandHigh, "4.21", ""),
+		Entry("for 4.22", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandHigh, "4.22", ""),
+		Entry("for 4.23", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandHigh, "4.23", ""),
 	)
 })

--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -163,10 +163,10 @@ var _ = Describe("Service Provider", func() {
 		// for 4.19, if we start with 4.19.0, the version that has an upgrade path to 4.19.latest is
 		// 4.19.3 but cluster install on this version fails with KMS authentication problem.
 		// For all the other minor versions, we can start with 4.y.0 and install the latest version in the candidate channel.
-		Entry("for 4.19", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.19", "4.19.25"),
-		Entry("for 4.20", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.20", ""),
-		Entry("for 4.21", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.21", ""),
-		Entry("for 4.22", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.22", ""),
-		Entry("for 4.23", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.23", ""),
+		Entry("for 4.19", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium, "4.19", "4.19.25"),
+		Entry("for 4.20", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium, "4.20", ""),
+		Entry("for 4.21", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium, "4.21", ""),
+		Entry("for 4.22", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium, "4.22", ""),
+		Entry("for 4.23", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium, "4.23", ""),
 	)
 })

--- a/test/e2e/kusto_logs_present.go
+++ b/test/e2e/kusto_logs_present.go
@@ -33,6 +33,7 @@ var _ = Describe("Engineering", func() {
 
 	It("should be able to retrieve kusto logs for a cluster and services",
 		labels.RequireNothing,
+		labels.MIDemandHigh,
 		labels.High,
 		labels.Positive,
 		labels.CoreInfraService,

--- a/test/e2e/nodepool_ephemeral_osdisk.go
+++ b/test/e2e/nodepool_ephemeral_osdisk.go
@@ -66,6 +66,7 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 
 	It("should create a nodepool with ephemeral OS disk when autoRepair is enabled",
 		labels.RequireNothing,
+		labels.MIDemandHigh,
 		labels.Critical,
 		labels.Positive,
 		labels.AroRpApiCompatible,

--- a/test/e2e/nodepool_labels_taints.go
+++ b/test/e2e/nodepool_labels_taints.go
@@ -38,6 +38,7 @@ var _ = Describe("Customer", func() {
 
 	It("should be able to update node pool labels and taints",
 		labels.RequireNothing,
+		labels.MIDemandHigh,
 		labels.Medium,
 		labels.Positive,
 		labels.AroRpApiCompatible,

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -232,13 +232,13 @@ var _ = Describe("Customer", func() {
 
 		},
 		Entry("from 4.20.z to 4.21.zLatest",
-			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium,
+			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandHigh,
 			"4.20", "4.21"),
 		Entry("from 4.21.z to 4.21.zLatest",
-			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium,
+			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandHigh,
 			"4.21", "4.21"),
 		Entry("from 4.20.z to 4.20.zLatest",
-			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium,
+			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandHigh,
 			"4.20", "4.20"),
 	)
 

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -232,13 +232,13 @@ var _ = Describe("Customer", func() {
 
 		},
 		Entry("from 4.20.z to 4.21.zLatest",
-			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible,
+			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium,
 			"4.20", "4.21"),
 		Entry("from 4.21.z to 4.21.zLatest",
-			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible,
+			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium,
 			"4.21", "4.21"),
 		Entry("from 4.20.z to 4.20.zLatest",
-			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible,
+			labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.MIDemandMedium,
 			"4.20", "4.20"),
 	)
 

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -1,18 +1,29 @@
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 Customer should be able to list available HCP OpenShift versions and validate response content
-SRE should be able to log into a cluster via a breakglass session
-SRE should be able to retrieve serial console logs for a VM
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling
+Customer should be able to create an HCP cluster and manage pull secrets
+Customer should be able to create an HCP cluster with back-level version 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
+Engineering should be able to retrieve kusto logs for a cluster and services
+Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
+Customer should be able to update node pool labels and taints
+Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
+Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
+Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
+SRE should be able to log into a cluster via a breakglass session
+SRE should be able to retrieve serial console logs for a VM
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
-Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
-Customer should be able to create an HCP cluster with back-level version 4.19
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -30,11 +41,6 @@ ARO-HCP should be able to perform a control plane and node pool install with OCP
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.10
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.11
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.12
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
 Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
 Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
 Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
@@ -56,15 +62,9 @@ Customer should be able to create a cluster with an external auth config and get
 Customer should be able to lifecycle and confirm external auth on a cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
-Engineering should be able to retrieve kusto logs for a cluster and services
 MISE Routing routes to the correct frontend based on version header MISE v2 when x-ms-mise-version header is set
 MISE Routing routes to the correct frontend based on version header default route returns no version header
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
-Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
-Customer should be able to update node pool labels and taints
 Customer should be able to update nodepool replicas and autoscaling
-Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
-Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
-Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should be able to use workload identity via the cluster OIDC issuer URL

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -1,20 +1,30 @@
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
-Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to list available HCP OpenShift versions and validate response content
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling
+Customer should be able to create an HCP cluster and manage pull secrets
+Customer should create an HCP cluster and validate TLS certificates
+Customer should be able to create an HCP cluster with back-level version 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
+Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
+Customer should be able to update node pool labels and taints
+Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
+Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
+Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
-Customer should be able to create an HCP cluster and manage pull secrets
-Customer should create an HCP cluster and validate TLS certificates
+Customer should not be able to reuse subnets and NSGs between clusters
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
-Customer should be able to create an HCP cluster with back-level version 4.19
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -32,11 +42,6 @@ ARO-HCP should be able to perform a control plane and node pool install with OCP
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.10
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.11
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.12
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
 Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
 Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
 Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
@@ -63,11 +68,6 @@ MISE Routing routes to the correct frontend based on version header MISE v2 when
 MISE Routing routes to the correct frontend based on version header default route returns no version header
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Customer should respect cluster-wide node limits with nodepool autoscaling
-Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
-Customer should be able to update node pool labels and taints
-Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
-Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
-Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -1,20 +1,30 @@
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
-Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to list available HCP OpenShift versions and validate response content
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling
+Customer should be able to create an HCP cluster and manage pull secrets
+Customer should create an HCP cluster and validate TLS certificates
+Customer should be able to create an HCP cluster with back-level version 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
+Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
+Customer should be able to update node pool labels and taints
+Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
+Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
+Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
-Customer should be able to create an HCP cluster and manage pull secrets
-Customer should create an HCP cluster and validate TLS certificates
+Customer should not be able to reuse subnets and NSGs between clusters
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
-Customer should be able to create an HCP cluster with back-level version 4.19
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -32,11 +42,6 @@ ARO-HCP should be able to perform a control plane and node pool install with OCP
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.10
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.11
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.12
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
 Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
 Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
 Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
@@ -62,11 +67,6 @@ MISE Routing routes to the correct frontend based on version header MISE v2 when
 MISE Routing routes to the correct frontend based on version header default route returns no version header
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Customer should respect cluster-wide node limits with nodepool autoscaling
-Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
-Customer should be able to update node pool labels and taints
-Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
-Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
-Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -1,20 +1,31 @@
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
-Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to list available HCP OpenShift versions and validate response content
-SRE should be able to log into a cluster via a breakglass session
-SRE should be able to retrieve serial console logs for a VM
-SRE should return 409 when boot diagnostics is disabled on a VM
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling
+Customer should be able to create an HCP cluster and manage pull secrets
+Customer should be able to create an HCP cluster with back-level version 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
+Engineering should be able to retrieve kusto logs for a cluster and services
+Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
+Customer should be able to update node pool labels and taints
+Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
+Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
+Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
+SRE should be able to log into a cluster via a breakglass session
+SRE should be able to retrieve serial console logs for a VM
+SRE should return 409 when boot diagnostics is disabled on a VM
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
-Customer should be able to create an HCP cluster and manage pull secrets
+Customer should not be able to reuse subnets and NSGs between clusters
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
-Customer should be able to create an HCP cluster with back-level version 4.19
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -32,11 +43,6 @@ ARO-HCP should be able to perform a control plane and node pool install with OCP
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.10
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.11
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.12
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
 Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
 Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
 Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
@@ -59,17 +65,11 @@ Customer should be able to lifecycle and confirm external auth on a cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
 Image Registry Policy should deny pods with images from disallowed registries
-Engineering should be able to retrieve kusto logs for a cluster and services
 MISE Routing routes to the correct frontend based on version header MISE v2 when x-ms-mise-version header is set
 MISE Routing routes to the correct frontend based on version header default route returns no version header
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Customer should respect cluster-wide node limits with nodepool autoscaling
-Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
-Customer should be able to update node pool labels and taints
 Customer should be able to update nodepool replicas and autoscaling
-Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
-Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
-Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -1,17 +1,27 @@
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
-Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to list available HCP OpenShift versions and validate response content
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling
+Customer should be able to create an HCP cluster and manage pull secrets
+Customer should be able to create an HCP cluster with back-level version 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
+Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
+Customer should be able to update node pool labels and taints
+Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
+Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
+Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
-Customer should be able to create an HCP cluster and manage pull secrets
+Customer should not be able to reuse subnets and NSGs between clusters
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
-Customer should be able to create an HCP cluster with back-level version 4.19
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -29,11 +39,6 @@ ARO-HCP should be able to perform a control plane and node pool install with OCP
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.10
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.11
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.12
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
 Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
 Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
 Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
@@ -58,11 +63,6 @@ MISE Routing routes to the correct frontend based on version header MISE v2 when
 MISE Routing routes to the correct frontend based on version header default route returns no version header
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Customer should respect cluster-wide node limits with nodepool autoscaling
-Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
-Customer should be able to update node pool labels and taints
-Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
-Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
-Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -1,20 +1,30 @@
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
-Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to list available HCP OpenShift versions and validate response content
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling
+Customer should be able to create an HCP cluster and manage pull secrets
+Customer should create an HCP cluster and validate TLS certificates
+Customer should be able to create an HCP cluster with back-level version 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
+Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
+Customer should be able to update node pool labels and taints
+Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
+Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
+Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
-Customer should be able to create an HCP cluster and manage pull secrets
-Customer should create an HCP cluster and validate TLS certificates
+Customer should not be able to reuse subnets and NSGs between clusters
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
-Customer should be able to create an HCP cluster with back-level version 4.19
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -32,11 +42,6 @@ ARO-HCP should be able to perform a control plane and node pool install with OCP
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.10
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.11
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.12
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
 Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
 Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
 Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
@@ -62,11 +67,6 @@ MISE Routing routes to the correct frontend based on version header MISE v2 when
 MISE Routing routes to the correct frontend based on version header default route returns no version header
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Customer should respect cluster-wide node limits with nodepool autoscaling
-Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
-Customer should be able to update node pool labels and taints
-Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
-Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
-Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings

--- a/test/util/labels/labels.go
+++ b/test/util/labels/labels.go
@@ -54,8 +54,10 @@ var (
 	AroRpApiCompatible = ginkgo.Label("ARO-HCP-RP-API-Compatible")
 )
 
-// Managed identity container demand for resource-aware scheduling.
-// Tests without these labels default to needing 1 container.
+// Scheduling priority based on managed identity demand or expected duration.
+// Higher priority tests run earlier to avoid tail latency from slow tests
+// waiting for containers. Also use for long-running tests (e.g. upgrades)
+// that should start early to finish within the suite timeout.
 var (
 	MIDemandHigh   = ginkgo.Label("MIDemand:High")
 	MIDemandMedium = ginkgo.Label("MIDemand:Medium")


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

  1. test/e2e/control_plane_automated_z_stream_upgrade.go — Added labels.MIDemandMedium to all 5 z-stream upgrade test entries (4.19-4.23)
  2. test/e2e/nodepool_version_upgrade.go — Added labels.MIDemandMedium to all 3 nodepool version upgrade test entries
  3. test/util/labels/labels.go — Updated comment to reflect that MIDemand labels are used for scheduling priority generally, not just container demand
  4. test/cmd/aro-hcp-tests/main.go — Updated sort comment to match
### Why

With this change, all 8 upgrade tests will be sorted to priority 1 (alongside cluster_nsg_subnet_reuse) and dispatched before the ~65 default-priority tests. They'll get MSI containers immediately at suite start instead of waiting 30-65 minutes. Since they take ~25 min total (create + upgrade + cleanup), they'll finish well before the 90-minute suite timeout even without the 150-minute bump.

### Testing

e2e

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
