### PR TITLE
feat: add oc adm inspect output to prow artifacts

### DIFF
--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -118,12 +118,21 @@ func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster(
 
 	switch m := any(operationResult).(type) {
 	case hcpsdk20240610preview.HcpOpenShiftClustersClientRequestAdminCredentialResponse:
-		return clientcmd.BuildConfigFromKubeconfigGetter("", func() (*clientcmdapi.Config, error) {
+		restConfig, err := clientcmd.BuildConfigFromKubeconfigGetter("", func() (*clientcmdapi.Config, error) {
 			if m.Kubeconfig == nil {
 				return nil, fmt.Errorf("kubeconfig content is nil")
 			}
 			return clientcmd.Load([]byte(*m.Kubeconfig))
 		})
+		if err != nil {
+			return nil, err
+		}
+
+		tc.contextLock.Lock()
+		tc.hcpAdminConfigs[resourceGroupName+"/"+hcpClusterName] = restConfig
+		tc.contextLock.Unlock()
+
+		return restConfig, nil
 	default:
 		return nil, fmt.Errorf("unknown type %T", m)
 	}

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -682,7 +682,7 @@ func (tc *perItOrDescribeTestContext) collectHCPInspectData(ctx context.Context)
 		currKey := clusterKey
 		currConfig := restConfig
 		inspectGroup.Go(func() error {
-			utilruntime.HandleCrashWithContext(inspectCtx)
+			defer utilruntime.HandleCrashWithContext(inspectCtx)
 			tc.runOCAdmInspect(inspectCtx, currKey, currConfig)
 			return nil
 		})
@@ -717,12 +717,16 @@ func (tc *perItOrDescribeTestContext) runOCAdmInspect(ctx context.Context, clust
 		return
 	}
 	defer os.Remove(kubeconfigFile.Name())
+	defer kubeconfigFile.Close()
 
 	if _, err := kubeconfigFile.WriteString(kubeconfigContent); err != nil {
 		logger.Error(err, "failed to write temp kubeconfig file, skipping")
 		return
 	}
-	kubeconfigFile.Close()
+	if err := kubeconfigFile.Close(); err != nil {
+		logger.Error(err, "failed to flush temp kubeconfig file, skipping")
+		return
+	}
 
 	inspectDir := filepath.Join(tc.LogDirPath, fmt.Sprintf("inspect-%s", clusterName))
 

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -38,6 +39,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/rand"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
 
 	"sigs.k8s.io/yaml"
 
@@ -75,6 +77,7 @@ type perItOrDescribeTestContext struct {
 	azureLogFile     *os.File
 	timingMetadata   timing.SpecTimingMetadata
 	knownDeployments []deploymentInfo
+	hcpAdminConfigs  map[string]*rest.Config
 }
 
 type deploymentInfo struct {
@@ -131,6 +134,7 @@ func NewTestContext() *perItOrDescribeTestContext {
 		perBinaryInvocationTestContext: invocationContext(),
 		LogDirPath:                     logDirPath,
 		azureLogFile:                   azureLogFile,
+		hcpAdminConfigs:                make(map[string]*rest.Config),
 		timingMetadata: timing.SpecTimingMetadata{
 			// Answering the question of "what's the currently-running test name?" in Ginkgo is difficult -
 			// all we know in general is the hierarchy of nodes under which we are currently running. We
@@ -374,6 +378,11 @@ func (tc *perItOrDescribeTestContext) collectDebugInfo(ctx context.Context) {
 			return tc.collectDebugInfoForResourceGroup(ctx, currResourceGroupName)
 		})
 	}
+	waitGroup.Go(func() error {
+		defer utilruntime.HandleCrashWithContext(ctx)
+		tc.collectHCPInspectData(ctx)
+		return nil
+	})
 	if err := waitGroup.Wait(); err != nil {
 		// remember that Wait only shows the first error, not all the errors.
 		if !isResourceGroupNotFoundError(err) {
@@ -645,6 +654,94 @@ func (tc *perItOrDescribeTestContext) collectDebugInfoForResourceGroup(ctx conte
 	}
 
 	return errors.Join(errs...)
+}
+
+func (tc *perItOrDescribeTestContext) collectHCPInspectData(ctx context.Context) {
+	if _, err := exec.LookPath("oc"); err != nil {
+		ginkgo.GinkgoLogr.Info("oc not found in PATH, skipping HCP inspect data collection")
+		return
+	}
+
+	tc.contextLock.RLock()
+	configs := make(map[string]*rest.Config, len(tc.hcpAdminConfigs))
+	for k, v := range tc.hcpAdminConfigs {
+		configs[k] = v
+	}
+	tc.contextLock.RUnlock()
+
+	if len(configs) == 0 {
+		return
+	}
+
+	inspectGroup, inspectCtx := errgroup.WithContext(ctx)
+	for clusterKey, restConfig := range configs {
+		currKey := clusterKey
+		currConfig := restConfig
+		inspectGroup.Go(func() error {
+			utilruntime.HandleCrashWithContext(inspectCtx)
+			tc.runOCAdmInspect(inspectCtx, currKey, currConfig)
+			return nil
+		})
+	}
+	_ = inspectGroup.Wait()
+}
+
+func (tc *perItOrDescribeTestContext) runOCAdmInspect(ctx context.Context, clusterKey string, restConfig *rest.Config) {
+	parts := strings.SplitN(clusterKey, "/", 2)
+	if len(parts) != 2 {
+		ginkgo.GinkgoLogr.Error(fmt.Errorf("invalid cluster key %q", clusterKey), "skipping oc adm inspect")
+		return
+	}
+	clusterName := parts[1]
+	logger := ginkgo.GinkgoLogr.WithValues("cluster", clusterKey)
+	logger.Info("starting oc adm inspect for HCP cluster")
+
+	startTime := time.Now()
+	defer func() {
+		tc.RecordTestStep(fmt.Sprintf("oc adm inspect %s", clusterKey), startTime, time.Now())
+	}()
+
+	kubeconfigContent, err := GenerateKubeconfig(restConfig)
+	if err != nil {
+		logger.Error(err, "failed to generate kubeconfig for HCP inspect, skipping")
+		return
+	}
+
+	kubeconfigFile, err := os.CreateTemp("", fmt.Sprintf("inspect-kubeconfig-%s-*.yaml", clusterName))
+	if err != nil {
+		logger.Error(err, "failed to create temp kubeconfig file, skipping")
+		return
+	}
+	defer os.Remove(kubeconfigFile.Name())
+
+	if _, err := kubeconfigFile.WriteString(kubeconfigContent); err != nil {
+		logger.Error(err, "failed to write temp kubeconfig file, skipping")
+		return
+	}
+	kubeconfigFile.Close()
+
+	inspectDir := filepath.Join(tc.perBinaryInvocationTestContext.artifactDir, fmt.Sprintf("inspect-%s", clusterName))
+
+	inspectCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(inspectCtx, "oc", "adm", "inspect",
+		"--kubeconfig", kubeconfigFile.Name(),
+		"--dest-dir", inspectDir,
+		"ns/openshift-ingress",
+		"ns/openshift-ingress-operator",
+		"clusteroperator/ingress",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.Error(err, "oc adm inspect failed", "output", string(output))
+		if mkdirErr := os.MkdirAll(inspectDir, 0755); mkdirErr == nil {
+			_ = os.WriteFile(filepath.Join(inspectDir, "inspect-error.log"), output, 0644)
+		}
+		return
+	}
+
+	logger.Info("oc adm inspect completed successfully", "outputDir", inspectDir)
 }
 
 func (tc *perItOrDescribeTestContext) NewAppRegistrationWithServicePrincipal(ctx context.Context) (*graphutil.Application, *graphutil.ServicePrincipal, error) {

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -657,6 +657,10 @@ func (tc *perItOrDescribeTestContext) collectDebugInfoForResourceGroup(ctx conte
 }
 
 func (tc *perItOrDescribeTestContext) collectHCPInspectData(ctx context.Context) {
+	if tc.LogDirPath == "" {
+		return
+	}
+
 	if _, err := exec.LookPath("oc"); err != nil {
 		ginkgo.GinkgoLogr.Info("oc not found in PATH, skipping HCP inspect data collection")
 		return
@@ -720,7 +724,7 @@ func (tc *perItOrDescribeTestContext) runOCAdmInspect(ctx context.Context, clust
 	}
 	kubeconfigFile.Close()
 
-	inspectDir := filepath.Join(tc.perBinaryInvocationTestContext.artifactDir, fmt.Sprintf("inspect-%s", clusterName))
+	inspectDir := filepath.Join(tc.LogDirPath, fmt.Sprintf("inspect-%s", clusterName))
 
 	inspectCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()


### PR DESCRIPTION
https://redhat.atlassian.net/issues?filter=-1&selectedIssue=[AROSLSRE-846](https://redhat.atlassian.net/browse/AROSLSRE-846)

### What
  
test/util/framework/hcp_helper.go — GetAdminRESTConfigForHCPCluster now caches the admin REST config in tc.hcpAdminConfigs (keyed by resourceGroup/clusterName) after a successful credential request.

  test/util/framework/per_test_framework.go:
  - Added hcpAdminConfigs map[string]*rest.Config field to the test context struct, initialized in NewTestContext
  - collectDebugInfo launches an additional goroutine for collectHCPInspectData alongside existing ARM collection
  - collectHCPInspectData — reads cached admin configs, checks for oc availability, runs inspect per-cluster in parallel
  - runOCAdmInspect — generates kubeconfig from cached REST config, writes to temp file, runs oc adm inspect targeting ns/openshift-ingress, ns/openshift-ingress-operator, and clusteroperator/ingress, outputs to ${ARTIFACT_DIR}/inspect-{clusterName}/

### Why

The ingress cert provisioning chain has async hops that happen on the customer's cluster (ACM policy delivers cert to HCP's openshift-ingress/cluster-ingress-cert, IngressController reloads). We cannot gate our backend's Succeeded state on these customer-side steps -- the backend cannot couple its readiness to the customer's kube-apiserver or nodes. But E2E tests can and should collect diagnostic data when these steps haven't completed.

### Testing

e2e

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
