### PR TITLE
Arobit: Bump timeout and add retries

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -597,6 +597,7 @@ resourceGroups:
     releaseNamespace: 'arobit'
     chartDir: ../observability/arobit/deploy
     valuesFile: ../observability/arobit/values-mgmt.yaml
+    timeout: 10m
     kustoEndpoint:
       resourceGroup: kusto
       step: output
@@ -627,6 +628,7 @@ resourceGroups:
       errorContainsAny:
       - "500 Internal Server Error"
       - "Internal error occurred"
+      - "arobit-forwarder not ready. status: InProgress"
       maximumRetryCount: 3
       durationBetweenRetries: 1m
   - name: kube-events

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -486,6 +486,7 @@ resourceGroups:
     releaseNamespace: 'arobit'
     chartDir: ../observability/arobit/deploy
     valuesFile: ../observability/arobit/values-svc.yaml
+    timeout: 10m
     kustoEndpoint:
       resourceGroup: kusto
       step: output
@@ -516,6 +517,7 @@ resourceGroups:
       errorContainsAny:
       - "500 Internal Server Error"
       - "Internal error occurred"
+      - "arobit-forwarder not ready. status: InProgress"
       maximumRetryCount: 3
       durationBetweenRetries: 1m
   - name: kube-events


### PR DESCRIPTION


<!-- Link to Jira issue -->

### What/Why

Increase the timeout of the helm deployment, cause we saw issues during node upgrades and other deployment issues resolving after some time. Also add a retry if deployment is still in progress, so it wil wait at max 33 minutes before failing in these cases now.
