### PR TITLE
feat(mgmt-pipeline): cluster-exists sentinel to decouple service rollouts from AKS MC ARM LRO state

### DIFF
--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -49,9 +49,11 @@ resourceGroups:
     deploymentLevel: ResourceGroup
     outputOnly: true
     externalDependsOn:
+    # `cluster-exists` (instead of `cluster`) decouples the CS rollout
+    # from the AKS MC ARM LRO state. See AROSLSRE-904.
     - serviceGroup: Microsoft.Azure.ARO.HCP.Management.Infra
       resourceGroup: management
-      step: cluster
+      step: cluster-exists
     - serviceGroup: Microsoft.Azure.ARO.HCP.Management.Infra
       resourceGroup: management
       step: svc-mgmt-permissions

--- a/dev-infrastructure/configurations/mgmt-cluster-exists.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster-exists.tmpl.bicepparam
@@ -1,0 +1,3 @@
+using '../templates/mgmt-cluster-exists.bicep'
+
+param aksClusterName = '{{ .mgmt.aks.name }}'

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -239,6 +239,34 @@ resourceGroups:
       - "DeploymentScriptExceededMaxAllowedTime"
       maximumRetryCount: 3
       durationBetweenRetries: 2m
+  # AKS MC existence sentinel.
+  # Provides a stable topology barrier downstream of the `cluster` step that
+  # is decoupled from its LRO state, so RBAC steps and downstream service
+  # rollouts can ride out transient PUTs failures against a healthy cluster
+  # (e.g. stuck nodepool updates). See AROSLSRE-904.
+  - name: cluster-exists
+    action: ARM
+    template: templates/mgmt-cluster-exists.bicep
+    parameters: configurations/mgmt-cluster-exists.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
+    dependsOn:
+    - resourceGroup: management
+      step: infra
+    # Retries cover the steady-state case where the cluster sentinel races
+    # the periodic `cluster` step on a healthy cluster, plus brownfield runs
+    # where the resource genuinely exists but ARM is temporarily slow to
+    # resolve it. Greenfield first-run regions where the AKS cluster has not
+    # been provisioned yet are expected to require an operator-driven re-run
+    # after `cluster` finishes the initial PUT.
+    automatedRetry:
+      errorContainsAny:
+      - "ResourceNotFound"
+      - "could not be found"
+      - "Could not be found"
+      - "NotFound"
+      maximumRetryCount: 10
+      durationBetweenRetries: 3m
   - name: svc-mgmt-aks-permissions
     action: ARM
     omitFromServiceGroupCompletion: true
@@ -253,7 +281,7 @@ resourceGroups:
         name: sessiongate
     dependsOn:
     - resourceGroup: management
-      step: cluster
+      step: cluster-exists
   - name: delete-non-swift-user-nodepools
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell

--- a/dev-infrastructure/templates/mgmt-cluster-exists.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster-exists.bicep
@@ -1,0 +1,38 @@
+// mgmt-cluster-exists.bicep
+//
+// Sentinel ARM step that establishes a stable topology barrier downstream of
+// the management cluster step without inheriting its LRO state.
+//
+// The full management-cluster step (templates/mgmt-cluster.bicep) is a
+// PUT against the AKS Managed Cluster and can fail when the underlying
+// resource is in a degraded state (e.g. stuck nodepool update,
+// OperationNotAllowed). When that PUT fails every downstream consumer that
+// depends on the step is skipped even when the cluster itself is fully
+// functional and only requires read-only access.
+//
+// This sentinel performs a read-only existing lookup of the AKS Managed
+// Cluster and emits its name and resource id. The deployment is treated as
+// successful whenever ARM can GET the cluster, regardless of whether the
+// last LRO terminated in Succeeded or Failed. Downstream RBAC steps and
+// external service rollouts (Cluster Service, HyperShift Operator) can
+// depend on this step instead of the management-cluster step to ride out
+// transient PUT failures without losing safety: if the cluster has never
+// been provisioned the GET will 404 and the sentinel will fail, gating the
+// rest of the pipeline correctly.
+//
+// See: AROSLSRE-904 (decouple service rollouts from AKS MC ARM LRO state).
+
+@description('The name of the AKS management cluster.')
+param aksClusterName string
+
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-10-01' existing = {
+  name: aksClusterName
+}
+
+output aksClusterName string = aksCluster.name
+output aksClusterId string = aksCluster.id
+// Emitting properties.provisioningState forces ARM to perform a GET on the
+// cluster, which fails if the cluster does not exist. Crucially, the GET
+// succeeds for any provisioningState (Succeeded, Failed, Updating, Canceled),
+// so the sentinel rides out degraded LRO states.
+output aksClusterProvisioningState string = aksCluster.properties.provisioningState

--- a/hypershiftoperator/pipeline.yaml
+++ b/hypershiftoperator/pipeline.yaml
@@ -84,6 +84,13 @@ resourceGroups:
     parameters: ./../dev-infrastructure/configurations/hypershift-lookup.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
+    # Wait for the management cluster sentinel before performing the
+    # lookup so the HO rollout is gated on the AKS resource existing,
+    # not on the latest ARM PUT against it. See AROSLSRE-904.
+    externalDependsOn:
+    - serviceGroup: Microsoft.Azure.ARO.HCP.Management.Infra
+      resourceGroup: management
+      step: cluster-exists
   - name: deploy
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Helm


### PR DESCRIPTION
## What

Introduce a `cluster-exists` sentinel step in `dev-infrastructure/mgmt-pipeline.yaml` and re-point dependency edges that only need _"the AKS resource exists"_ to depend on the sentinel instead of the full `cluster` step.

Affected pipelines:

| Pipeline | Change |
| --- | --- |
| `dev-infrastructure/mgmt-pipeline.yaml` | Add new `cluster-exists` step; re-point `svc-mgmt-aks-permissions` from `cluster` → `cluster-exists` |
| `cluster-service/pipeline.yaml` | Drop `cluster` from `management.output.externalDependsOn`; keep `svc-mgmt-permissions` |
| `hypershiftoperator/pipeline.yaml` | Add explicit `externalDependsOn` on `cluster-exists` to `management.output` |

Plus the supporting bicep template / param:

- `dev-infrastructure/templates/mgmt-cluster-exists.bicep`
- `dev-infrastructure/configurations/mgmt-cluster-exists.tmpl.bicepparam`

## Why

The current `cluster` step is a full ARM PUT on the AKS Managed Cluster. When AKS is in a degraded state (e.g. stuck nodepool update returning `OperationNotAllowed`, `Resource is in Updating state`) the PUT fails and every downstream consumer that gates on this step is skipped — Cluster Service, HyperShift Operator, ACM, Maestro Agent, KubeApplier and the in-cluster RBAC/helm steps. The management cluster itself is fully functional throughout, and every consumer only needs `existing = { name: ... }` lookups + RBAC that is already in place.

This was the exact failure mode of the May 2026 INT outage:

- JIRA: [AROSLSRE-880](https://redhat.atlassian.net/browse/AROSLSRE-880)
- IcM: 799593502
- Implementation tracking: [AROSLSRE-904](https://redhat.atlassian.net/browse/AROSLSRE-904)

The daily EV2 rollout was blocked for days even though the management cluster was healthy and could happily serve the lookups + helm operations that downstream services need.

## Design

`cluster-exists` is a read-only ARM step that performs an `existing` lookup of the AKS MC and emits its identity (`name`, `id`, `provisioningState`). The deployment:

- **Succeeds** for any provisioned cluster regardless of the latest LRO state (the bicep `existing` GET succeeds for any provisioningState — `Succeeded`, `Failed`, `Updating`, `Canceled`).
- **Fails** cleanly with `ResourceNotFound` when the cluster has never been provisioned, so it does not mask a genuinely missing greenfield cluster.

Edges that genuinely mutate the cluster spec (`delete-non-swift-user-nodepools`, `upgrade-aks-cluster`, `nsp`, `cluster-output`, prometheus/acrpull/etc.) **continue to depend on `cluster`** since they need the latest PUT to have succeeded.

A 10 × 3m `automatedRetry` budget covers the race where the sentinel runs in parallel with a long-running `cluster` step on brownfield re-runs. Truly greenfield first-runs (cluster never provisioned) are expected to require an operator-driven re-run after `cluster` completes the initial PUT — documented in the step comment.

## Effect on the dependency graph

**Before** — failure of `cluster` step skips all downstream consumers:

```
infra → … → cluster ↯ → svc-mgmt-aks-permissions → ✗
                     → svc-mgmt-permissions [unchanged via infra]
                     → CS.management.output (externalDependsOn) → ✗
                     → HO.management.output (implicit) → ✗
                     → delete-non-swift / upgrade / nsp / cluster-output → ✗ (intended)
                     → prometheus / acrpull / arobit / … → ✗ (intended)
```

**After** — failure of `cluster` only skips the steps that truly mutate the cluster spec:

```
infra → cluster-exists (always-success when cluster resource exists)
                     → svc-mgmt-aks-permissions → ✓
                     → CS.management.output → ✓
                     → HO.management.output (now explicit) → ✓
infra → … → cluster ↯ → delete-non-swift / upgrade / nsp / cluster-output → ✗ (intended)
                     → prometheus / acrpull / arobit / … → ✗ (intended)
```

## Validation

- `make validate-config-pipelines` — passes
- `make validate-changed-config-pipelines` — passes
- `make test-helm-fixtures` — all `TestACRValues` + `TestRecursiveLoadPipelineReturnHelmSteps` cases pass

End-to-end behaviour under a deliberately-failing `cluster` step has **not** been validated against a live region (requires platform-team coordination — tracked as a follow-up on [AROSLSRE-904](https://redhat.atlassian.net/browse/AROSLSRE-904)).

## Out of scope / follow-ups

- Split `cluster` step into provision vs. upgrade sub-steps (would let upgrade failures fail independently of the underlying cluster — separate larger refactor).
- Audit other Mgmt-Infra sub-services (Velero, ACM, Maestro Agent, KubeApplier) for the same coupling and decide which can be re-pointed.
- Consolidate the duplicate `csiSecretStoreClientId` lookup between `output-mgmt.bicep` and `hypershift-lookup.bicep`.
- Address `omitFromServiceGroupCompletion: true` on `svc-mgmt-permissions` (a service group can be reported "complete" while the RBAC grant is still pending — a hidden gotcha for any future consumer).