### PR TITLE
test: refactor armResourceGroupValidationPolicy and add unit test cases

### DIFF
--- a/test/util/framework/azure_client_policies.go
+++ b/test/util/framework/azure_client_policies.go
@@ -15,6 +15,7 @@
 package framework
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -54,13 +55,30 @@ func (p *armSystemDataPolicy) Do(req *policy.Request) (*http.Response, error) {
 	return req.Next()
 }
 
+type resourceGroupClient interface {
+	Get(ctx context.Context, subscriptionID, resourceGroupName string) error
+}
+
+type defaultResourceGroupClient struct {
+	cred azcore.TokenCredential
+}
+
+func (c *defaultResourceGroupClient) Get(ctx context.Context, subscriptionID, resourceGroupName string) error {
+	client, err := armresources.NewResourceGroupsClient(subscriptionID, c.cred, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create resource group client: %w", err)
+	}
+	_, err = client.Get(ctx, resourceGroupName, nil)
+	return err
+}
+
 // armResourceGroupValidationPolicy simulates ARM's resource group validation
 // for development environments where requests go directly to the RP frontend.
 // In production, ARM validates that the target resource group exists before
 // routing requests to the RP. This policy replicates that behavior so that
 // AroRpApiCompatible tests produce consistent results across environments.
 type armResourceGroupValidationPolicy struct {
-	cred azcore.TokenCredential
+	rgClient resourceGroupClient
 }
 
 func (p *armResourceGroupValidationPolicy) Do(req *policy.Request) (*http.Response, error) {
@@ -78,12 +96,7 @@ func (p *armResourceGroupValidationPolicy) Do(req *policy.Request) (*http.Respon
 		return req.Next()
 	}
 
-	client, err := armresources.NewResourceGroupsClient(subID, p.cred, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create resource group client: %w", err)
-	}
-
-	_, err = client.Get(req.Raw().Context(), rgName, nil)
+	err = p.rgClient.Get(req.Raw().Context(), subID, rgName)
 	if err != nil {
 		var respErr *azcore.ResponseError
 		if errors.As(err, &respErr) && respErr.ErrorCode == arm.CloudErrorCodeResourceGroupNotFound {

--- a/test/util/framework/azure_client_policies_test.go
+++ b/test/util/framework/azure_client_policies_test.go
@@ -280,6 +280,7 @@ func TestArmResourceGroupValidationPolicy(t *testing.T) {
 
 		resp, err := pipeline.Do(req)
 		require.NoError(t, err)
+		defer resp.Body.Close()
 		assert.False(t, called, "transport should not have been called")
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))

--- a/test/util/framework/azure_client_policies_test.go
+++ b/test/util/framework/azure_client_policies_test.go
@@ -16,6 +16,7 @@ package framework
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -207,6 +208,14 @@ func TestArmSystemDataPolicy(t *testing.T) {
 	})
 }
 
+type fakeResourceGroupClient struct {
+	err error
+}
+
+func (f *fakeResourceGroupClient) Get(_ context.Context, _, _ string) error {
+	return f.err
+}
+
 func TestArmResourceGroupValidationPolicy(t *testing.T) {
 	t.Setenv("FRONTEND_ADDRESS", "https://"+frontendHost)
 
@@ -230,7 +239,7 @@ func TestArmResourceGroupValidationPolicy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pol := &armResourceGroupValidationPolicy{cred: nil}
+			pol := &armResourceGroupValidationPolicy{rgClient: &fakeResourceGroupClient{}}
 			called := false
 			transport := &fakeTransport{
 				do: func(r *http.Request) (*http.Response, error) {
@@ -248,6 +257,68 @@ func TestArmResourceGroupValidationPolicy(t *testing.T) {
 			assert.True(t, called, "transport should have been called")
 		})
 	}
+
+	t.Run("returns 404 CloudError when resource group does not exist", func(t *testing.T) {
+		pol := &armResourceGroupValidationPolicy{
+			rgClient: &fakeResourceGroupClient{
+				err: &azcore.ResponseError{
+					StatusCode: http.StatusNotFound,
+					ErrorCode:  arm.CloudErrorCodeResourceGroupNotFound,
+				},
+			},
+		}
+		called := false
+		transport := &fakeTransport{
+			do: func(r *http.Request) (*http.Response, error) {
+				called = true
+				return okResponse()
+			},
+		}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://"+frontendHost+"/subscriptions/sub-id/resourceGroups/nonexistent-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster")
+		require.NoError(t, err)
+
+		resp, err := pipeline.Do(req)
+		require.NoError(t, err)
+		assert.False(t, called, "transport should not have been called")
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+		var cloudErr arm.CloudError
+		err = json.NewDecoder(resp.Body).Decode(&cloudErr)
+		require.NoError(t, err)
+		assert.Equal(t, arm.CloudErrorCodeResourceGroupNotFound, cloudErr.Code)
+		assert.Contains(t, cloudErr.Message, "nonexistent-rg")
+	})
+
+	t.Run("propagates non-ResourceGroupNotFound errors from resource group client", func(t *testing.T) {
+		pol := &armResourceGroupValidationPolicy{
+			rgClient: &fakeResourceGroupClient{
+				err: &azcore.ResponseError{
+					StatusCode: http.StatusForbidden,
+					ErrorCode:  "AuthorizationFailed",
+				},
+			},
+		}
+		called := false
+		transport := &fakeTransport{
+			do: func(r *http.Request) (*http.Response, error) {
+				called = true
+				return okResponse()
+			},
+		}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://"+frontendHost+"/subscriptions/sub-id/resourceGroups/some-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster")
+		require.NoError(t, err)
+
+		_, err = pipeline.Do(req)
+		assert.Error(t, err)
+		assert.False(t, called, "transport should not have been called")
+
+		var respErr *azcore.ResponseError
+		require.ErrorAs(t, err, &respErr)
+		assert.Equal(t, http.StatusForbidden, respErr.StatusCode)
+	})
 }
 
 func TestRequestIDPolicy(t *testing.T) {

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -192,7 +192,7 @@ func (tc *perBinaryInvocationTestContext) getHCPClientFactoryOptions() *azcorear
 		clientOpts.PerCallPolicies = []policy.Policy{
 			&requestIDPolicy{},
 			&armSystemDataPolicy{},
-			&armResourceGroupValidationPolicy{cred: tc.azureCredentials},
+			&armResourceGroupValidationPolicy{rgClient: &defaultResourceGroupClient{cred: tc.azureCredentials}},
 			&sanitizeAuthHeaderPolicy{},
 		}
 		return &azcorearm.ClientOptions{


### PR DESCRIPTION
[ARO-26910](https://redhat.atlassian.net/browse/ARO-26910)

### What

Refactor armResourceGroupValidationPolicy to accept an external ARM resource group client. 

Add test scenarios:

- RG doesn't exist → policy returns a synthetic 404 CloudError response with ResourceGroupNotFound

- Other than 404 error occurs → error is propagated as-is

### Why

Be able to mock RG client and test negative scenarios. 

### Testing

The PR adds 2 unit tests

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
