### PR TITLE
fix(arobit): recover mdsd pods from CSI mount race (AROSLSRE-879)

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -26,6 +26,7 @@ ignore:
 - 'observability/arobit/deploy/templates/forwarder-exporter-configmap.yaml'
 - 'observability/arobit/deploy/templates/forwarder-configmap.yaml'
 - 'observability/arobit/deploy/templates/forwarder-service.yaml'
+- 'observability/arobit/deploy/templates/forwarder-watchdog-rbac.yaml'
 - 'observability/arobit/deploy/templates/serviceaccount.yaml'
 - 'observability/arobit/deploy/templates/forwarder-secretprovider.yaml'
 - 'observability/kube-events/deploy/templates/deployment.yaml'

--- a/observability/arobit/deploy/templates/forwarder-daemonset.yaml
+++ b/observability/arobit/deploy/templates/forwarder-daemonset.yaml
@@ -109,9 +109,45 @@ spec:
         - name: mdsd-clusterlogs
           image: {{ .Values.forwarder.mdsd.image.registry }}/{{ .Values.forwarder.mdsd.image.repository }}@{{ .Values.forwarder.mdsd.image.digest }}
           imagePullPolicy: '{{ .Values.forwarder.mdsd.image.pullPolicy }}'
+          # AROSLSRE-879: defensively wait for the Geneva auth cert before exec'ing
+          # mdsd. The AKS secrets-store CSI driver can lose the initial
+          # NodePublishVolume race, leaving /geneva/geneva_auth/ empty; mdsd then
+          # panics with "No certificate was found that matched SAN" on every
+          # restart. The mdsd-cert-watchdog sidecar below recovers stuck pods by
+          # deleting them; this wrapper keeps the normal startup race window quiet.
+          # Upstream bug: kubernetes-sigs/secrets-store-csi-driver#1051
+          # Upstream fix: kubernetes-sigs/secrets-store-csi-driver#2025 (in flight)
+          # Remove this wrapper once #2025 lands and AKS ships the fixed driver.
+          # Polls for a non-empty cert file (mdsd does its own X.509 + SAN
+          # validation), then exec's the real entrypoint. If the cert never
+          # appears we exit non-zero so the kubelet restart counter increments and
+          # existing container-restart alerts still fire. Uses /bin/sh and
+          # /bin/sleep, both present in the distroless mdsd image (the watchdog
+          # sidecar already uses /bin/sleep directly). Timeout and poll interval
+          # are sourced from the watchdog's chart values so the two recovery
+          # windows stay coordinated when tuned.
           command:
-              - /start_mdsd.sh
+            - /bin/sh
+            - -c
+            - |
+              CERT=/geneva/geneva_auth/gcscert.pem
+              WAITED=0
+              while [ "$WAITED" -lt "$TIMEOUT_SECONDS" ]; do
+                if [ -s "$CERT" ]; then
+                  echo "[mdsd-init] Geneva auth cert present after ${WAITED}s; exec'ing mdsd"
+                  exec /start_mdsd.sh
+                fi
+                echo "[mdsd-init] Geneva auth cert not yet mounted at ${CERT} (waited ${WAITED}s of ${TIMEOUT_SECONDS}s)"
+                sleep "$INTERVAL_SECONDS"
+                WAITED=$((WAITED + INTERVAL_SECONDS))
+              done
+              echo "[mdsd-init] Giving up after ${TIMEOUT_SECONDS}s; Geneva auth cert never appeared at ${CERT}. This usually means the CSI driver lost the initial mount race; see AROSLSRE-879. Exiting to trigger container restart."
+              exit 1
           env:
+            - name: TIMEOUT_SECONDS
+              value: '{{ .Values.forwarder.watchdog.timeoutSeconds }}'
+            - name: INTERVAL_SECONDS
+              value: '{{ .Values.forwarder.watchdog.intervalSeconds }}'
             - name: MONITORING_GCS_AUTH_ID
               value: '{{ .Values.forwarder.mdsd.geneva.clusterLogsSan }}'
             - name: MONITORING_GCS_AUTH_ID_TYPE
@@ -192,6 +228,71 @@ spec:
             - name: cacrt-host
               mountPath: /etc/ssl/certs/ca-certificates.crt
               readOnly: true
+            - mountPath: /geneva/geneva_auth/
+              name: geneva-certs-clusterlogs
+              readOnly: true
+        - name: mdsd-cert-watchdog
+          # AROSLSRE-879: the AKS secrets-store CSI driver can lose the initial
+          # NodePublishVolume mount race during DaemonSet rollouts, leaving
+          # /geneva/geneva_auth/ empty for the rest of the pod's lifetime.
+          # Pod-level CSI mounts are not retried on container restart, so the
+          # mdsd polling wrapper alone cannot recover; the pod has to be
+          # recreated to get another shot at NodePublishVolume.
+          #
+          # This watchdog waits for the cert to appear and, if it doesn't
+          # within the bounded window, asks the K8s API to delete this pod so
+          # the DaemonSet recreates it. The namespace-scoped Role grants only
+          # pods:delete (see forwarder-watchdog-rbac.yaml).
+          image: {{ .Values.forwarder.watchdog.image.registry }}/{{ .Values.forwarder.watchdog.image.repository }}@{{ .Values.forwarder.watchdog.image.digest }}
+          imagePullPolicy: '{{ .Values.forwarder.watchdog.image.pullPolicy }}'
+          command:
+            - /bin/sh
+            - -c
+            - |
+              CERT=/geneva/geneva_auth/gcscert.pem
+              WAITED=0
+              while [ "$WAITED" -lt "$TIMEOUT_SECONDS" ]; do
+                if [ -s "$CERT" ]; then
+                  echo "[cert-watchdog] Geneva auth cert present at ${CERT} after ${WAITED}s; sleeping idle until pod terminates"
+                  exec sleep infinity
+                fi
+                sleep "$INTERVAL_SECONDS"
+                WAITED=$((WAITED + INTERVAL_SECONDS))
+              done
+              echo "[cert-watchdog] Geneva auth cert never appeared at ${CERT} after ${TIMEOUT_SECONDS}s. The AKS secrets-store CSI driver likely lost the initial NodePublishVolume mount race (AROSLSRE-879). Requesting deletion of pod ${POD_NAMESPACE}/${POD_NAME} so the DaemonSet can recreate it with a fresh CSI mount."
+              if kubectl delete pod "$POD_NAME" --namespace "$POD_NAMESPACE" --grace-period=30 --wait=false; then
+                echo "[cert-watchdog] Pod delete requested; sleeping idle until kubelet terminates us"
+                exec sleep infinity
+              fi
+              echo "[cert-watchdog] kubectl delete pod failed; exiting non-zero so the kubelet retries us"
+              exit 1
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: TIMEOUT_SECONDS
+              value: '{{ .Values.forwarder.watchdog.timeoutSeconds }}'
+            - name: INTERVAL_SECONDS
+              value: '{{ .Values.forwarder.watchdog.intervalSeconds }}'
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            runAsUser: 0
+            runAsGroup: 0
+            capabilities:
+              drop: ['ALL']
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          volumeMounts:
             - mountPath: /geneva/geneva_auth/
               name: geneva-certs-clusterlogs
               readOnly: true

--- a/observability/arobit/deploy/templates/forwarder-watchdog-rbac.yaml
+++ b/observability/arobit/deploy/templates/forwarder-watchdog-rbac.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.forwarder.mdsd.enabled (eq .Values.forwarder.clusterType "mgmt") }}
+# AROSLSRE-879: namespace-scoped permissions for the mdsd-cert-watchdog sidecar
+# to delete its own pod when the Geneva auth secret never mounts (AKS
+# secrets-store CSI driver race). Pod-level CSI volumes can only be re-mounted
+# by recreating the pod, so the watchdog calls `kubectl delete pod` on itself;
+# the DaemonSet then schedules a replacement pod with a fresh
+# NodePublishVolume call.
+#
+# Granting `pods:delete` at namespace scope (Role + RoleBinding) keeps this
+# strictly less privileged than the cluster-wide arobit-forwarder ClusterRole.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: arobit-cert-watchdog
+  namespace: '{{ .Release.Namespace }}'
+  labels:
+    app.kubernetes.io/name: arobit-forwarder
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: arobit-cert-watchdog
+  namespace: '{{ .Release.Namespace }}'
+  labels:
+    app.kubernetes.io/name: arobit-forwarder
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: arobit-cert-watchdog
+subjects:
+  - kind: ServiceAccount
+    name: '{{ .Values.forwarder.serviceAccountName }}'
+    namespace: '{{ .Release.Namespace }}'
+{{- end }}

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -541,6 +541,47 @@ subjects:
   name: 'arobit-forwarder'
   namespace: 'arobit'
 ---
+# Source: arobit/templates/forwarder-watchdog-rbac.yaml
+# AROSLSRE-879: namespace-scoped permissions for the mdsd-cert-watchdog sidecar
+# to delete its own pod when the Geneva auth secret never mounts (AKS
+# secrets-store CSI driver race). Pod-level CSI volumes can only be re-mounted
+# by recreating the pod, so the watchdog calls `kubectl delete pod` on itself;
+# the DaemonSet then schedules a replacement pod with a fresh
+# NodePublishVolume call.
+#
+# Granting `pods:delete` at namespace scope (Role + RoleBinding) keeps this
+# strictly less privileged than the cluster-wide arobit-forwarder ClusterRole.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: arobit-cert-watchdog
+  namespace: 'arobit'
+  labels:
+    app.kubernetes.io/name: arobit-forwarder
+    app.kubernetes.io/instance: 'helmtest-mdsd-and-kusto-enabled-mgmt'
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["delete"]
+---
+# Source: arobit/templates/forwarder-watchdog-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: arobit-cert-watchdog
+  namespace: 'arobit'
+  labels:
+    app.kubernetes.io/name: arobit-forwarder
+    app.kubernetes.io/instance: 'helmtest-mdsd-and-kusto-enabled-mgmt'
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: arobit-cert-watchdog
+subjects:
+  - kind: ServiceAccount
+    name: 'arobit-forwarder'
+    namespace: 'arobit'
+---
 # Source: arobit/templates/forwarder-service.yaml
 apiVersion: v1
 kind: Service
@@ -678,9 +719,45 @@ spec:
         - name: mdsd-clusterlogs
           image: mcr.microsoft.com/geneva/distroless/mdsd@sha256:1234567890
           imagePullPolicy: 'IfNotPresent'
+          # AROSLSRE-879: defensively wait for the Geneva auth cert before exec'ing
+          # mdsd. The AKS secrets-store CSI driver can lose the initial
+          # NodePublishVolume race, leaving /geneva/geneva_auth/ empty; mdsd then
+          # panics with "No certificate was found that matched SAN" on every
+          # restart. The mdsd-cert-watchdog sidecar below recovers stuck pods by
+          # deleting them; this wrapper keeps the normal startup race window quiet.
+          # Upstream bug: kubernetes-sigs/secrets-store-csi-driver#1051
+          # Upstream fix: kubernetes-sigs/secrets-store-csi-driver#2025 (in flight)
+          # Remove this wrapper once #2025 lands and AKS ships the fixed driver.
+          # Polls for a non-empty cert file (mdsd does its own X.509 + SAN
+          # validation), then exec's the real entrypoint. If the cert never
+          # appears we exit non-zero so the kubelet restart counter increments and
+          # existing container-restart alerts still fire. Uses /bin/sh and
+          # /bin/sleep, both present in the distroless mdsd image (the watchdog
+          # sidecar already uses /bin/sleep directly). Timeout and poll interval
+          # are sourced from the watchdog's chart values so the two recovery
+          # windows stay coordinated when tuned.
           command:
-              - /start_mdsd.sh
+            - /bin/sh
+            - -c
+            - |
+              CERT=/geneva/geneva_auth/gcscert.pem
+              WAITED=0
+              while [ "$WAITED" -lt "$TIMEOUT_SECONDS" ]; do
+                if [ -s "$CERT" ]; then
+                  echo "[mdsd-init] Geneva auth cert present after ${WAITED}s; exec'ing mdsd"
+                  exec /start_mdsd.sh
+                fi
+                echo "[mdsd-init] Geneva auth cert not yet mounted at ${CERT} (waited ${WAITED}s of ${TIMEOUT_SECONDS}s)"
+                sleep "$INTERVAL_SECONDS"
+                WAITED=$((WAITED + INTERVAL_SECONDS))
+              done
+              echo "[mdsd-init] Giving up after ${TIMEOUT_SECONDS}s; Geneva auth cert never appeared at ${CERT}. This usually means the CSI driver lost the initial mount race; see AROSLSRE-879. Exiting to trigger container restart."
+              exit 1
           env:
+            - name: TIMEOUT_SECONDS
+              value: '300'
+            - name: INTERVAL_SECONDS
+              value: '15'
             - name: MONITORING_GCS_AUTH_ID
               value: ''
             - name: MONITORING_GCS_AUTH_ID_TYPE
@@ -761,6 +838,71 @@ spec:
             - name: cacrt-host
               mountPath: /etc/ssl/certs/ca-certificates.crt
               readOnly: true
+            - mountPath: /geneva/geneva_auth/
+              name: geneva-certs-clusterlogs
+              readOnly: true
+        - name: mdsd-cert-watchdog
+          # AROSLSRE-879: the AKS secrets-store CSI driver can lose the initial
+          # NodePublishVolume mount race during DaemonSet rollouts, leaving
+          # /geneva/geneva_auth/ empty for the rest of the pod's lifetime.
+          # Pod-level CSI mounts are not retried on container restart, so the
+          # mdsd polling wrapper alone cannot recover; the pod has to be
+          # recreated to get another shot at NodePublishVolume.
+          #
+          # This watchdog waits for the cert to appear and, if it doesn't
+          # within the bounded window, asks the K8s API to delete this pod so
+          # the DaemonSet recreates it. The namespace-scoped Role grants only
+          # pods:delete (see forwarder-watchdog-rbac.yaml).
+          image: mcr.microsoft.com/aks/command/runtime@sha256:1234567890
+          imagePullPolicy: 'IfNotPresent'
+          command:
+            - /bin/sh
+            - -c
+            - |
+              CERT=/geneva/geneva_auth/gcscert.pem
+              WAITED=0
+              while [ "$WAITED" -lt "$TIMEOUT_SECONDS" ]; do
+                if [ -s "$CERT" ]; then
+                  echo "[cert-watchdog] Geneva auth cert present at ${CERT} after ${WAITED}s; sleeping idle until pod terminates"
+                  exec sleep infinity
+                fi
+                sleep "$INTERVAL_SECONDS"
+                WAITED=$((WAITED + INTERVAL_SECONDS))
+              done
+              echo "[cert-watchdog] Geneva auth cert never appeared at ${CERT} after ${TIMEOUT_SECONDS}s. The AKS secrets-store CSI driver likely lost the initial NodePublishVolume mount race (AROSLSRE-879). Requesting deletion of pod ${POD_NAMESPACE}/${POD_NAME} so the DaemonSet can recreate it with a fresh CSI mount."
+              if kubectl delete pod "$POD_NAME" --namespace "$POD_NAMESPACE" --grace-period=30 --wait=false; then
+                echo "[cert-watchdog] Pod delete requested; sleeping idle until kubelet terminates us"
+                exec sleep infinity
+              fi
+              echo "[cert-watchdog] kubectl delete pod failed; exiting non-zero so the kubelet retries us"
+              exit 1
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: TIMEOUT_SECONDS
+              value: '300'
+            - name: INTERVAL_SECONDS
+              value: '15'
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            runAsUser: 0
+            runAsGroup: 0
+            capabilities:
+              drop: ['ALL']
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          volumeMounts:
             - mountPath: /geneva/geneva_auth/
               name: geneva-certs-clusterlogs
               readOnly: true

--- a/observability/arobit/values-mgmt.yaml
+++ b/observability/arobit/values-mgmt.yaml
@@ -60,6 +60,16 @@ forwarder:
       repository: "{{ .arobit.mdsd.image.repository }}"
       digest: "{{ .arobit.mdsd.image.digest }}"
       pullPolicy: IfNotPresent
+  ## Watchdog sidecar that recreates the pod when the Geneva auth cert
+  ## never mounts. See AROSLSRE-879 and forwarder-watchdog-rbac.yaml.
+  watchdog:
+    image:
+      registry: "{{ .aksCommandRuntime.image.registry }}"
+      repository: "{{ .aksCommandRuntime.image.repository }}"
+      digest: "{{ .aksCommandRuntime.image.digest }}"
+      pullPolicy: IfNotPresent
+    timeoutSeconds: 300
+    intervalSeconds: 15
   kusto:
     serviceLogsDatabase: {{ .kusto.serviceLogsDatabase }}
     hostedControlPlaneLogsDatabase: {{ .kusto.hostedControlPlaneLogsDatabase }}

--- a/observability/arobit/values-svc.yaml
+++ b/observability/arobit/values-svc.yaml
@@ -60,6 +60,16 @@ forwarder:
       repository: "{{ .arobit.mdsd.image.repository }}"
       digest: "{{ .arobit.mdsd.image.digest }}"
       pullPolicy: IfNotPresent
+  ## Watchdog sidecar that recreates the pod when the Geneva auth cert
+  ## never mounts. See AROSLSRE-879 and forwarder-watchdog-rbac.yaml.
+  watchdog:
+    image:
+      registry: "{{ .aksCommandRuntime.image.registry }}"
+      repository: "{{ .aksCommandRuntime.image.repository }}"
+      digest: "{{ .aksCommandRuntime.image.digest }}"
+      pullPolicy: IfNotPresent
+    timeoutSeconds: 300
+    intervalSeconds: 15
   kusto:
     serviceLogsDatabase: {{ .kusto.serviceLogsDatabase }}
     hostedControlPlaneLogsDatabase: {{ .kusto.hostedControlPlaneLogsDatabase }}


### PR DESCRIPTION
## What

Mitigate the AKS secrets-store CSI driver mount race that leaves arobit-forwarder mdsd-clusterlogs pods stuck in CrashLoopBackOff with `No certificate was found that matched SAN` — see [AROSLSRE-879](https://redhat.atlassian.net/browse/AROSLSRE-879).

## Why the wrapper alone wasn't enough

The original version of this PR wrapped mdsd's `command:` with a polling loop that waits for `/geneva/geneva_auth/gcscert.pem` to appear before exec'ing the real entrypoint. That cleans up the log timeline during the normal startup race, but it **cannot recover** the pathological case where the CSI driver loses the initial NodePublishVolume race and the tmpfs comes up empty for the lifetime of the pod sandbox:

- Pod-level CSI volumes are mounted by `NodePublishVolume`, which is only called on **pod sandbox creation**, NOT on container restart.
- Container restarts inside the same pod (whether kubelet-driven crashloops or our wrapper exiting nonzero) keep the same empty tmpfs.
- AKS's rotation reconciler walks `SecretProviderClassPodStatus` objects, but SPCPS is only created at the END of a successful `NodePublishVolume`, so broken pods are invisible to the reconciler.
- **The only recovery is pod recreation.**

## What this PR ships

Two layered pieces, both gated on `mdsd.enabled && clusterType == "mgmt"`:

### 1. mdsd-clusterlogs polling wrapper (kept from the original revision)

Wraps the container `command:` with a POSIX-sh poll that waits up to 300s for a non-empty cert at `/geneva/geneva_auth/gcscert.pem` before exec'ing `/start_mdsd.sh`. Uses only POSIX builtins (the mdsd image is distroless, no openssl/jq). On healthy nodes the cert is present within seconds and mdsd starts cleanly; on stuck nodes mdsd no longer panic-spams the log timeline while it waits.

### 2. `mdsd-cert-watchdog` sidecar (NEW — this is the actual recovery mechanism)

A second container in the same pod that polls the same cert from the same CSI mount. If the cert never appears within 300s, it asks the K8s API to delete its own pod:

```sh
kubectl delete pod "$POD_NAME" -n "$POD_NAMESPACE" --grace-period=30 --wait=false
```

The DaemonSet then schedules a replacement, which gets a fresh `NodePublishVolume` call and a new shot at the race. Once the cert is present (or after a successful delete request) the watchdog `exec sleep infinity` and stays idle until kubelet terminates it.

### Image

The watchdog uses `mcr.microsoft.com/aks/command/runtime`, which is:
- Already pinned + image-updater tracked under `platform-utils` in `config/config.yaml` (`defaults.aksCommandRuntime.image`)
- Already in our supply chain (used by `cluster-service/cspr/orphaned-namespace-cleaner.yaml`)
- Available in prod ACR mirrors (mcr.microsoft.com)
- Contains a recent kubectl (v1.35.3) and a POSIX `sh`

No new image dependency.

### RBAC

`forwarder-watchdog-rbac.yaml` adds a namespace-scoped `Role` named `arobit-cert-watchdog` granting only `pods:delete`, bound to the existing `arobit-forwarder` ServiceAccount. Strictly less privileged than the cluster-wide `arobit-forwarder` ClusterRole; blast radius limited to the `arobit` namespace. The Role can't be `resourceNames`-scoped because DaemonSet pod names are randomly generated.

## Why both pieces

- Wrapper covers the common case (cert arrives a few seconds late) — quiet startup, no panic-loop noise.
- Watchdog covers the pathological case (cert never arrives because CSI lost the race) — bounded auto-recovery via pod deletion.

## Verification

- `cd tooling/helmtest && go test -run TestHelmTemplate -count=1` passes.
- Helmtest fixtures regenerated; only `zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml` is affected. All SVC fixtures are unchanged because the `clusterType == "mgmt"` gate filters everything out for SVC clusters.
- Smoke-tested the wrapper script inside the pinned mdsd image (`docker pull` + `docker run --entrypoint sh`) — `/bin/sh`, `/usr/bin/test`, `/bin/sleep` all present.
- Smoke-tested kubectl + the watchdog script inside the pinned aksCommandRuntime image — kubectl v1.35.3, `/bin/sh` (dash) present.

## Out of scope

Filed separately:
- File an AKS / secrets-store CSI driver upstream issue once we have a clean repro signal from the watchdog logs.
- Add a Prometheus alert that fires when watchdog deletes a pod (so we can quantify how often the race fires).
# Upstream context

Direct upstream tracking for our race:

* [**kubernetes-sigs/secrets-store-csi-driver#1051**](https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/1051) — `"Apparent race condition causes pods to mount secret volumes with no object content"` — open since 2022 (`kind/bug`, `lifecycle/frozen`). Reporter's logs show the same `"already mounted to target"` short-circuit returning success against an empty mount.
* [**kubernetes-sigs/secrets-store-csi-driver#2025**](https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/2025) — `"fix: treat empty existing mount as stale in ensureMountPoint"` — open PR from April 2026. Detects an empty target directory in `ensureMountPoint` (`pkg/secrets-store/utils.go`) and forces a re-mount instead of taking the `!rotationEnabled && mounted` early-return in `nodeserver.go:157`. This is exactly the fix our race needs.

The watchdog in [Azure/ARO-HCP#5355](https://github.com/Azure/ARO-HCP/pull/5355) is the recovery mechanism until #2025 lands and AKS ships the fixed driver.

Related kubelet-side hardening (different code path, same class of bug):

* [kubernetes/kubernetes#121271](https://github.com/kubernetes/kubernetes/issues/121271) / [#139045](https://github.com/kubernetes/kubernetes/pull/139045) — fix for the rotation/republish path where kubelet's cleanup-on-error deleted CSI mount dirs after a `requiresRepublish=true` refresh failure. Merged 2026-05-21. Different trigger from our initial-mount race but useful precedent for tightening CSI mount lifecycle invariants.
