### PR TITLE
fix: use acrDNSSuffix in HyperShift registryOverrides (AROSLSRE-815)

### DIFF
--- a/hypershiftoperator/values.yaml
+++ b/hypershiftoperator/values.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 version: 0.1.0
 description: A Helm chart to manage Hypershift Operator and dependencies for ARO HCP
 name: aro-hcp-hypershift-operator
-image: "{{ .acr.svc.name }}.azurecr.io/{{ .hypershift.image.repository }}"
+image: "{{ .acr.svc.name }}.{{ .acrDNSSuffix }}/{{ .hypershift.image.repository }}"
 imageDigest: "{{ .hypershift.image.digest }}"
-registryOverrides: "quay.io/openshift-release-dev/ocp-v4.0-art-dev={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly={{ .acr.ocp.name }}.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat={{ .acr.ocp.name }}.azurecr.io/redhat"
+registryOverrides: "quay.io/openshift-release-dev/ocp-v4.0-art-dev={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/redhat"
 azureKeyVaultClientId: "__csiSecretStoreClientId__"
 additionalArgs: "{{ .hypershift.additionalInstallArg }}"
 operatorEnvVars:


### PR DESCRIPTION
[AROSLSRE-815](https://redhat.atlassian.net/browse/AROSLSRE-815)

### What

Replace hardcoded `.azurecr.io` with `{{ .acrDNSSuffix }}` in `hypershiftoperator/values.yaml` for the `image` and `registryOverrides` fields.

### Why

The `registryOverrides` string hardcodes `.azurecr.io` for all ACR domain references instead of using the `{{ .acrDNSSuffix }}` template variable. This breaks correctness for sovereign clouds with different ACR DNS suffixes. The same file already uses `{{ .acrDNSSuffix }}` for `sharedIngressImage` (line 12) but not for the other 6 references.

### Testing

`make -C config materialize` passes. No rendered config changes since `acrDNSSuffix` resolves to `azurecr.io` in dev environments. The change is a no-op for dev but required for sovereign cloud correctness.