### PR TITLE
chore(config): validate additionalProperties on all schema objects (AROSLSRE-233)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,12 @@ verify-kql:
 update: deepcopy json-format
 .PHONY: update
 
-verify: verify-deepcopy verify-json-format verify-generate verify-yamlfmt verify-materialize verify-gomega-assertions
+verify: verify-deepcopy verify-json-format verify-generate verify-yamlfmt verify-materialize verify-gomega-assertions verify-schema
 .PHONY: verify
+
+verify-schema:
+	go run ./hack/verify-schema-additional-properties config/config.schema.json
+.PHONY: verify-schema
 
 verify-gomega-assertions:
 	go run ./hack/verify-gomega-assertions ./test/e2e/ ./test/util/

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -313,7 +313,8 @@
                 ]
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       }
     },
@@ -376,7 +377,8 @@
           "required": [
             "enabled",
             "days"
-          ]
+          ],
+          "additionalProperties": false
         }
       },
       "additionalProperties": false,
@@ -1074,7 +1076,8 @@
           },
           "required": [
             "bundle"
-          ]
+          ],
+          "additionalProperties": false
         },
         "mce": {
           "type": "object",
@@ -1591,7 +1594,8 @@
           "required": [
             "accountName",
             "cloudSuffix"
-          ]
+          ],
+          "additionalProperties": false
         },
         "pav2": {
           "type": "object",
@@ -1602,7 +1606,8 @@
           },
           "required": [
             "cloudName"
-          ]
+          ],
+          "additionalProperties": false
         },
         "kusto": {
           "type": "object",
@@ -1636,7 +1641,8 @@
             "clusterPrincipals",
             "dstsGroups",
             "vmUsageStaleThreshold"
-          ]
+          ],
+          "additionalProperties": false
         },
         "eventHub": {
           "type": "object",
@@ -1655,7 +1661,8 @@
             "namespace",
             "subscriptionId",
             "resourceGroupName"
-          ]
+          ],
+          "additionalProperties": false
         },
         "imageArtifact": {
           "$ref": "#/definitions/imageArtifact"
@@ -2095,7 +2102,8 @@
             "applicationId",
             "authorityFQDN",
             "audienceFQDN"
-          ]
+          ],
+          "additionalProperties": false
         },
         "genevaActions": {
           "type": "object",
@@ -2117,7 +2125,8 @@
             "policyLabel",
             "authorityFQDN",
             "audienceFQDN"
-          ]
+          ],
+          "additionalProperties": false
         },
         "sessiongate": {
           "type": "object",
@@ -2139,7 +2148,8 @@
             "policyLabel",
             "authorityFQDN",
             "audience"
-          ]
+          ],
+          "additionalProperties": false
         },
         "image": {
           "$ref": "#/definitions/containerImage"
@@ -2474,7 +2484,8 @@
             "image"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "customExporter": {
       "type": "object",
@@ -3298,7 +3309,8 @@
               "type": "string",
               "description": "The name of the KeyVault secret in the global AKV that stores the token used to authenticate with Prow."
             }
-          }
+          },
+          "additionalProperties": false
         },
         "regionTest": {
           "type": "object",
@@ -3313,7 +3325,8 @@
           "required": [
             "prowJobName",
             "gatePromotion"
-          ]
+          ],
+          "additionalProperties": false
         }
       },
       "additionalProperties": false,

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -48,6 +48,7 @@
           "type": "boolean"
         }
       },
+      "additionalProperties": false,
       "required": [
         "name"
       ]
@@ -86,7 +87,8 @@
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "k8sDeploymentStrategy": {
       "type": "object",
@@ -99,7 +101,8 @@
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "k8sDeployment": {
       "type": "object",
@@ -236,6 +239,7 @@
           "type": "string"
         }
       },
+      "additionalProperties": false,
       "required": [
         "keyVault",
         "name"
@@ -975,7 +979,8 @@
         "storageAccountContainerName": {
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     }
   },
   "properties": {

--- a/go.work
+++ b/go.work
@@ -8,6 +8,7 @@ use (
 	./dev-infrastructure/scripts/recreate-system-pool
 	./frontend
 	./hack/verify-gomega-assertions
+	./hack/verify-schema-additional-properties
 	./internal
 	./kube-applier
 	./mgmt-agent

--- a/hack/verify-schema-additional-properties/go.mod
+++ b/hack/verify-schema-additional-properties/go.mod
@@ -1,0 +1,3 @@
+module github.com/Azure/ARO-HCP/hack/verify-schema-additional-properties
+
+go 1.25.7

--- a/hack/verify-schema-additional-properties/main.go
+++ b/hack/verify-schema-additional-properties/main.go
@@ -40,7 +40,7 @@ type schemaNode struct {
 }
 
 func (n schemaNode) isObject() bool {
-	if len(n.Properties) > 0 || len(n.PatternProperties) > 0 || n.AdditionalProperties != nil {
+	if n.Properties != nil || n.PatternProperties != nil || n.AdditionalProperties != nil {
 		return true
 	}
 	if n.Type == nil {
@@ -75,20 +75,20 @@ func walkSchema(node schemaNode, path string, missing *[]string) {
 	for name, child := range node.Properties {
 		walkSchema(child, joinPath(path, name), missing)
 	}
-	for _, child := range node.PatternProperties {
-		walkSchema(child, joinPath(path, "(patternProperty)"), missing)
+	for pattern, child := range node.PatternProperties {
+		walkSchema(child, joinPath(path, fmt.Sprintf("(patternProperty:%s)", pattern)), missing)
 	}
 	if node.Items != nil {
 		walkSchema(*node.Items, joinPath(path, "(items)"), missing)
 	}
-	for _, child := range node.AllOf {
-		walkSchema(child, path, missing)
+	for i, child := range node.AllOf {
+		walkSchema(child, joinPath(path, fmt.Sprintf("(allOf[%d])", i)), missing)
 	}
-	for _, child := range node.OneOf {
-		walkSchema(child, path, missing)
+	for i, child := range node.OneOf {
+		walkSchema(child, joinPath(path, fmt.Sprintf("(oneOf[%d])", i)), missing)
 	}
-	for _, child := range node.AnyOf {
-		walkSchema(child, path, missing)
+	for i, child := range node.AnyOf {
+		walkSchema(child, joinPath(path, fmt.Sprintf("(anyOf[%d])", i)), missing)
 	}
 	if node.Not != nil {
 		walkSchema(*node.Not, joinPath(path, "(not)"), missing)

--- a/hack/verify-schema-additional-properties/main.go
+++ b/hack/verify-schema-additional-properties/main.go
@@ -26,10 +26,54 @@ import (
 	"sort"
 )
 
-type schemaDefinition struct {
-	Type                 string                      `json:"type"`
-	AdditionalProperties *json.RawMessage            `json:"additionalProperties"`
-	Definitions          map[string]schemaDefinition `json:"definitions"`
+type schemaNode struct {
+	Type                 string                `json:"type"`
+	AdditionalProperties *json.RawMessage      `json:"additionalProperties"`
+	Properties           map[string]schemaNode `json:"properties"`
+	Definitions          map[string]schemaNode `json:"definitions"`
+	PatternProperties    map[string]schemaNode `json:"patternProperties"`
+	Items                *schemaNode           `json:"items"`
+	AllOf                []schemaNode          `json:"allOf"`
+	OneOf                []schemaNode          `json:"oneOf"`
+	AnyOf                []schemaNode          `json:"anyOf"`
+}
+
+func walkSchema(node schemaNode, path string, missing *[]string) {
+	if node.Type == "object" && node.AdditionalProperties == nil {
+		if path == "" {
+			path = "(root)"
+		}
+		*missing = append(*missing, path)
+	}
+
+	for name, child := range node.Definitions {
+		walkSchema(child, joinPath(path, name), missing)
+	}
+	for name, child := range node.Properties {
+		walkSchema(child, joinPath(path, name), missing)
+	}
+	for _, child := range node.PatternProperties {
+		walkSchema(child, joinPath(path, "(patternProperty)"), missing)
+	}
+	if node.Items != nil {
+		walkSchema(*node.Items, joinPath(path, "(items)"), missing)
+	}
+	for _, child := range node.AllOf {
+		walkSchema(child, path, missing)
+	}
+	for _, child := range node.OneOf {
+		walkSchema(child, path, missing)
+	}
+	for _, child := range node.AnyOf {
+		walkSchema(child, path, missing)
+	}
+}
+
+func joinPath(base, name string) string {
+	if base == "" {
+		return name
+	}
+	return base + "." + name
 }
 
 func check(path string) ([]string, error) {
@@ -38,20 +82,13 @@ func check(path string) ([]string, error) {
 		return nil, err
 	}
 
-	var schema schemaDefinition
+	var schema schemaNode
 	if err := json.Unmarshal(data, &schema); err != nil {
 		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
 	}
 
 	var missing []string
-	if schema.Type == "object" && schema.AdditionalProperties == nil {
-		missing = append(missing, "(root)")
-	}
-	for name, def := range schema.Definitions {
-		if def.Type == "object" && def.AdditionalProperties == nil {
-			missing = append(missing, name)
-		}
-	}
+	walkSchema(schema, "", &missing)
 	sort.Strings(missing)
 	return missing, nil
 }

--- a/hack/verify-schema-additional-properties/main.go
+++ b/hack/verify-schema-additional-properties/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 type schemaNode struct {
-	Type                 string                `json:"type"`
+	Type                 json.RawMessage       `json:"type"`
 	AdditionalProperties *json.RawMessage      `json:"additionalProperties"`
 	Properties           map[string]schemaNode `json:"properties"`
 	Definitions          map[string]schemaNode `json:"definitions"`
@@ -36,10 +36,33 @@ type schemaNode struct {
 	AllOf                []schemaNode          `json:"allOf"`
 	OneOf                []schemaNode          `json:"oneOf"`
 	AnyOf                []schemaNode          `json:"anyOf"`
+	Not                  *schemaNode           `json:"not"`
+}
+
+func (n schemaNode) isObject() bool {
+	if len(n.Properties) > 0 || len(n.PatternProperties) > 0 || n.AdditionalProperties != nil {
+		return true
+	}
+	if n.Type == nil {
+		return false
+	}
+	var s string
+	if json.Unmarshal(n.Type, &s) == nil {
+		return s == "object"
+	}
+	var arr []string
+	if json.Unmarshal(n.Type, &arr) == nil {
+		for _, t := range arr {
+			if t == "object" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func walkSchema(node schemaNode, path string, missing *[]string) {
-	if node.Type == "object" && node.AdditionalProperties == nil {
+	if node.isObject() && node.AdditionalProperties == nil {
 		if path == "" {
 			path = "(root)"
 		}
@@ -66,6 +89,9 @@ func walkSchema(node schemaNode, path string, missing *[]string) {
 	}
 	for _, child := range node.AnyOf {
 		walkSchema(child, path, missing)
+	}
+	if node.Not != nil {
+		walkSchema(*node.Not, joinPath(path, "(not)"), missing)
 	}
 }
 

--- a/hack/verify-schema-additional-properties/main.go
+++ b/hack/verify-schema-additional-properties/main.go
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// verify-schema-additional-properties checks that all object definitions in a
+// verify-schema-additional-properties checks that all object schemas in a
 // JSON schema file have an "additionalProperties" field set. Without it, the
 // schema silently allows unexpected properties, defeating typo detection.
 //
-// Exit code is 1 if any object definitions are missing the field.
+// Exit code is 1 if any object schemas are missing the field.
 package main
 
 import (
@@ -134,11 +134,11 @@ func main() {
 			continue
 		}
 		if len(missing) > 0 {
-			fmt.Fprintf(os.Stderr, "ERROR: %d object definition(s) missing additionalProperties in %s:\n", len(missing), path)
+			fmt.Fprintf(os.Stderr, "ERROR: %d object schema(s) missing additionalProperties in %s:\n", len(missing), path)
 			for _, m := range missing {
 				fmt.Fprintf(os.Stderr, "  - %s\n", m)
 			}
-			fmt.Fprintf(os.Stderr, "\nAdd \"additionalProperties\": false (or true) to each definition.\n")
+			fmt.Fprintf(os.Stderr, "\nAdd \"additionalProperties\": false (or true) to each object schema.\n")
 			exitCode = 1
 		}
 	}

--- a/hack/verify-schema-additional-properties/main.go
+++ b/hack/verify-schema-additional-properties/main.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// verify-schema-additional-properties checks that all object definitions in a
+// JSON schema file have an "additionalProperties" field set. Without it, the
+// schema silently allows unexpected properties, defeating typo detection.
+//
+// Exit code is 1 if any object definitions are missing the field.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+)
+
+type schemaDefinition struct {
+	Type                 string                      `json:"type"`
+	AdditionalProperties *json.RawMessage            `json:"additionalProperties"`
+	Definitions          map[string]schemaDefinition `json:"definitions"`
+}
+
+func check(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var schema schemaDefinition
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+	}
+
+	var missing []string
+	if schema.Type == "object" && schema.AdditionalProperties == nil {
+		missing = append(missing, "(root)")
+	}
+	for name, def := range schema.Definitions {
+		if def.Type == "object" && def.AdditionalProperties == nil {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(missing)
+	return missing, nil
+}
+
+func main() {
+	paths := os.Args[1:]
+	if len(paths) == 0 {
+		paths = []string{"config/config.schema.json"}
+	}
+
+	exitCode := 0
+	for _, path := range paths {
+		missing, err := check(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+			exitCode = 1
+			continue
+		}
+		if len(missing) > 0 {
+			fmt.Fprintf(os.Stderr, "ERROR: %d object definition(s) missing additionalProperties in %s:\n", len(missing), path)
+			for _, m := range missing {
+				fmt.Fprintf(os.Stderr, "  - %s\n", m)
+			}
+			fmt.Fprintf(os.Stderr, "\nAdd \"additionalProperties\": false (or true) to each definition.\n")
+			exitCode = 1
+		}
+	}
+	os.Exit(exitCode)
+}


### PR DESCRIPTION
[AROSLSRE-233](https://redhat.atlassian.net/browse/AROSLSRE-233)

### What

Add `additionalProperties: false` to 18 object schemas that were missing it in `config/config.schema.json`, and a CI validation check to prevent regressions.

### Why

JSON Schema defaults to allowing additional properties. Without explicit `additionalProperties: false`, typos in config.yaml (e.g. `stoargeAccount` instead of `storageAccount`) are silently accepted. This change enforces strict property validation across all object schemas — both top-level definitions and nested objects under `properties`, `patternProperties`, and composition keywords.

### Testing

- `make verify` passes (includes new `verify-schema` target)
- `make lint` passes
- New Go verifier at `hack/verify-schema-additional-properties/` recursively walks the full schema tree and checks every object node

### Special notes for your reviewer

- The verifier detects objects by both explicit `type: "object"` and implicit indicators (`properties`/`patternProperties` present without a `type` field), and handles the array form of `type`
- `imageRegistryPolicy` definition was added by another PR while this was in flight — it is now properly referenced and has `additionalProperties: false`
- e2e failure on prior run was unrelated (HCP cluster creation timeouts) — `/retest` should clear it

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge