### PR TITLE
test: explicitly mark test begin & end

### DIFF
--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -200,6 +200,22 @@ func (tc *perItOrDescribeTestContext) BeforeEach(ctx context.Context) {
 	ginkgo.DeferCleanup(tc.commitTimingMetadata, AnnotatedLocation("dump timing info"), ginkgo.NodeTimeout(45*time.Minute))
 
 	ginkgo.DeferCleanup(tc.closeAzureLogFile, AnnotatedLocation("close azure log file"))
+
+	// Registered last so it runs first in the FILO cleanup order, marking the
+	// boundary between the test body and cleanup.
+	ginkgo.DeferCleanup(tc.logTestEndAndCleanupStart, AnnotatedLocation("log test end and cleanup start"))
+
+	ginkgo.GinkgoLogr.Info("===== TEST CASE BEGAN =====")
+}
+
+func (tc *perItOrDescribeTestContext) logTestEndAndCleanupStart() {
+	report := ginkgo.CurrentSpecReport()
+	result := "SUCCESS"
+	if report.Failed() {
+		result = "FAILURE"
+	}
+	ginkgo.GinkgoLogr.Info(fmt.Sprintf("===== TEST CASE ENDED: %s =====", result))
+	ginkgo.GinkgoLogr.Info("===== CLEANUP BEGAN =====")
 }
 
 func (tc *perItOrDescribeTestContext) closeAzureLogFile() {


### PR DESCRIPTION
Ginkgo test logs are hard to read as-is, but even worse so, it's not even obvious where the test begins and ends, and when cleanup starts. Help humans and agents read the log by saying so.
