### PR TITLE
fix: run cleanup-pko as built Go binary

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -9,6 +9,20 @@
 $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Management.Infra
 rolloutName: Management Cluster Rollout
+buildStep:
+  command: bash
+  args:
+  - -c
+  - |
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+    tmp="$(mktemp ./scripts/cleanup-pko-resources/cleanup-pko-resources.XXXXXX)"
+    trap 'rm -f "${tmp}"' EXIT
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "${tmp}" ./scripts/cleanup-pko-resources
+    chmod 0755 "${tmp}"
+    mv "${tmp}" ./scripts/cleanup-pko-resources/cleanup-pko-resources
+    trap - EXIT
 resourceGroups:
 - name: global
   resourceGroup: '{{ .global.rg }}'
@@ -581,7 +595,7 @@ resourceGroups:
   - name: cleanup-pko
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell
-    command: go run ./scripts/cleanup-pko-resources || echo "[WARNING] cleanup-pko exited non-zero, continuing (best-effort)"
+    command: ./scripts/cleanup-pko-resources/cleanup-pko-resources
     workingDir: .
     shellIdentity:
       input:

--- a/dev-infrastructure/scripts/cleanup-pko-resources/main.go
+++ b/dev-infrastructure/scripts/cleanup-pko-resources/main.go
@@ -59,8 +59,7 @@ func main() {
 
 	if err := run(timeout); err != nil {
 		fmt.Fprintf(os.Stderr, "[ERROR] %v\n", err)
-		fmt.Printf("\n=== PKO cleanup completed with 1 error(s) (best-effort, not blocking rollout) ===\n")
-		return
+		os.Exit(1)
 	}
 }
 
@@ -91,7 +90,7 @@ func run(timeout time.Duration) error {
 	defer cancel()
 	var errors int
 
-	fmt.Println("=== Package Operator cleanup (best-effort) ===")
+	fmt.Println("=== Package Operator cleanup ===")
 
 	crds, err := discoverPKOCRDs(ctx, crdClient)
 	if err != nil {
@@ -104,10 +103,10 @@ func run(timeout time.Duration) error {
 		}
 		errors += cleanupPKOOperator(ctx, kubeClient)
 		if errors > 0 {
-			fmt.Printf("\n=== PKO cleanup completed with %d error(s) (best-effort, not blocking rollout) ===\n", errors)
-		} else {
-			fmt.Println("\n=== PKO cleanup complete ===")
+			fmt.Printf("\n=== PKO cleanup completed with %d error(s) ===\n", errors)
+			return fmt.Errorf("PKO cleanup completed with %d error(s)", errors)
 		}
+		fmt.Println("\n=== PKO cleanup complete ===")
 		return nil
 	}
 
@@ -148,10 +147,10 @@ func run(timeout time.Duration) error {
 	errors += cleanupPKOOperator(ctx, kubeClient)
 
 	if errors > 0 {
-		fmt.Printf("\n=== PKO cleanup completed with %d error(s) (best-effort, not blocking rollout) ===\n", errors)
-	} else {
-		fmt.Println("\n=== PKO cleanup complete ===")
+		fmt.Printf("\n=== PKO cleanup completed with %d error(s) ===\n", errors)
+		return fmt.Errorf("PKO cleanup completed with %d error(s)", errors)
 	}
+	fmt.Println("\n=== PKO cleanup complete ===")
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Fixes [AROSLSRE-916](https://redhat.atlassian.net/browse/AROSLSRE-916).

The cleanup-pko EV2 Shell step currently runs `go run ./scripts/cleanup-pko-resources || echo ...`. Prod action logs show the EV2 shell image does not have Go installed, so the step prints `go: command not found`, then the `|| echo` path returns success. EV2 reports cleanup-pko as succeeded even though the cleanup code never ran.

This PR keeps the cleanup implementation in Go and changes delivery/runtime behavior:

- Builds `dev-infrastructure/scripts/cleanup-pko-resources` as a Linux amd64 binary during SDP manifest generation.
- Uses an atomic temp-file + `mv` build output so parallel cloud/environment generation never archives a partial binary.
- Executes the built binary from the EV2 Shell step instead of using `go run` at rollout time.
- Removes the failure-masking `|| echo` path.
- Makes startup/cleanup errors return non-zero so EV2 fails visibly instead of reporting a false success.

Related: [AROSLSRE-789](https://redhat.atlassian.net/browse/AROSLSRE-789), [AROSLSRE-866](https://redhat.atlassian.net/browse/AROSLSRE-866).

## EV2/SDP packaging check

Verified in `sdp-pipelines` tooling:

- `tooling/pkg/ev2/manifests/generate/generate.go` executes `pipeline.BuildStep` while loading a pipeline, using the pipeline file directory as `workingDir`.
- `tooling/pkg/ev2/manifests/generate/options.go` creates `archive.tar.gz` only after `Generate(...)` returns.
- `tooling/pkg/ev2/manifests/generate/utils/archive.go` archives the source root with `tarWriter.AddFS(os.DirFS(srcDir))`, so the built binary is included in the EV2 content archive.

Because `mgmt-pipeline.yaml` lives under `dev-infrastructure/`, the build step runs from `dev-infrastructure/` and writes `scripts/cleanup-pko-resources/cleanup-pko-resources`. The Shell step also runs with `workingDir: .` relative to `dev-infrastructure/`, so `./scripts/cleanup-pko-resources/cleanup-pko-resources` resolves to the same file.

## Validation

- Atomic build command creates an executable Linux amd64 binary locally.
- Smoke-tested the built binary without kubeconfig and confirmed it exits non-zero.
- `go test ./dev-infrastructure/scripts/cleanup-pko-resources/...`
- `make validate-changed-config-pipelines`
- `git diff --check`
