### PR TITLE
fix(image-registry-policy): reapply allowlist with scalar config

### DIFF
--- a/.yamlfmt.yaml
+++ b/.yamlfmt.yaml
@@ -4,6 +4,8 @@ exclude:
 - '**/zz_fixture_*.yaml'
 - 'frontend/deploy/templates/frontend.deployment.yaml'
 - 'frontend/deploy/templates/frontend-v2.deployment.yaml'
+- 'image-registry-policy/values.yaml'
+- 'image-registry-policy/deploy/templates/validatingadmissionpolicybinding.yaml'
 formatter:
   type: basic
   indentless_arrays: true

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -45,6 +45,8 @@ ignore:
 - 'dev-infrastructure/opstool/opstool-gateway/deploy/templates/gateway.yaml'
 - 'tooling/aro-hcp-exporter/deploy/templates/deployment.yaml'
 - 'kube-applier/deploy/templates/deployment.yaml'
+- 'image-registry-policy/deploy/templates/validatingadmissionpolicybinding.yaml'
+- 'image-registry-policy/values.yaml'
 rules:
   brackets: enable
   colons: enable

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -2519,8 +2519,9 @@
       "type": "object",
       "properties": {
         "extraAllowedRegistries": {
-          "description": "Comma-separated additional image registry prefixes to allow. Leave empty when no extra registries are needed.",
-          "type": "string"
+          "description": "Comma-separated additional image registry prefixes to allow. Entries must not contain whitespace. Leave empty when no extra registries are needed.",
+          "type": "string",
+          "pattern": "^$|^[^,\\s]+(,[^,\\s]+)*$"
         },
         "validationActions": {
           "description": "Comma-separated ValidatingAdmissionPolicyBinding validation actions. Allowed values are Deny, Audit, and Warn.",

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -2519,17 +2519,13 @@
       "type": "object",
       "properties": {
         "extraAllowedRegistries": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "Comma-separated additional image registry prefixes to allow. Leave empty when no extra registries are needed.",
+          "type": "string"
         },
         "validationActions": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": ["Deny", "Audit", "Warn"]
-          }
+          "description": "Comma-separated ValidatingAdmissionPolicyBinding validation actions. Allowed values are Deny, Audit, and Warn.",
+          "type": "string",
+          "pattern": "^(Deny|Audit|Warn)(,(Deny|Audit|Warn))*$"
         }
       },
       "additionalProperties": false,

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -2515,6 +2515,29 @@
         "enabled"
       ]
     },
+    "imageRegistryPolicy": {
+      "type": "object",
+      "properties": {
+        "extraAllowedRegistries": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "validationActions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["Deny", "Audit", "Warn"]
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "extraAllowedRegistries",
+        "validationActions"
+      ]
+    },
     "acrPull": {
       "type": "object",
       "properties": {
@@ -3320,6 +3343,7 @@
     "global",
     "hypershift",
     "imageSync",
+    "imageRegistryPolicy",
     "acrPull",
     "secretSyncController",
     "maestro",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -96,6 +96,11 @@ defaults:
       untaggedImagesRetention:
         enabled: true
         days: 90
+  # Image Registry Policy
+  imageRegistryPolicy:
+    extraAllowedRegistries: []
+    validationActions:
+    - Audit
   # ACR Pull
   acrPull:
     image:
@@ -1250,6 +1255,15 @@ clouds:
         prometheus:
           prometheusSpec:
             shards: 1
+      # Image Registry Policy — dev-only image prefixes for local dev tooling
+      imageRegistryPolicy:
+        extraAllowedRegistries:
+        - docker.io/jaegertracing
+        - docker.io/grafana
+        - docker.io/otel
+        - docker.io/library/postgres
+        validationActions:
+        - Deny
       # ACRs
       acr:
         svc:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -98,9 +98,8 @@ defaults:
         days: 90
   # Image Registry Policy
   imageRegistryPolicy:
-    extraAllowedRegistries: []
-    validationActions:
-    - Audit
+    extraAllowedRegistries: ""
+    validationActions: Audit
   # ACR Pull
   acrPull:
     image:
@@ -1257,13 +1256,8 @@ clouds:
             shards: 1
       # Image Registry Policy — dev-only image prefixes for local dev tooling
       imageRegistryPolicy:
-        extraAllowedRegistries:
-        - docker.io/jaegertracing
-        - docker.io/grafana
-        - docker.io/otel
-        - docker.io/library/postgres
-        validationActions:
-        - Deny
+        extraAllowedRegistries: docker.io/jaegertracing,docker.io/grafana,docker.io/otel,docker.io/library/postgres
+        validationActions: Deny
       # ACRs
       acr:
         svc:

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -422,13 +422,8 @@ hypershift:
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:
-  extraAllowedRegistries:
-  - docker.io/jaegertracing
-  - docker.io/grafana
-  - docker.io/otel
-  - docker.io/library/postgres
-  validationActions:
-  - Deny
+  extraAllowedRegistries: docker.io/jaegertracing,docker.io/grafana,docker.io/otel,docker.io/library/postgres
+  validationActions: Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -421,6 +421,14 @@ hypershift:
     digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageRegistryPolicy:
+  extraAllowedRegistries:
+  - docker.io/jaegertracing
+  - docker.io/grafana
+  - docker.io/otel
+  - docker.io/library/postgres
+  validationActions:
+  - Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -422,13 +422,8 @@ hypershift:
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:
-  extraAllowedRegistries:
-  - docker.io/jaegertracing
-  - docker.io/grafana
-  - docker.io/otel
-  - docker.io/library/postgres
-  validationActions:
-  - Deny
+  extraAllowedRegistries: docker.io/jaegertracing,docker.io/grafana,docker.io/otel,docker.io/library/postgres
+  validationActions: Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -421,6 +421,14 @@ hypershift:
     digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageRegistryPolicy:
+  extraAllowedRegistries:
+  - docker.io/jaegertracing
+  - docker.io/grafana
+  - docker.io/otel
+  - docker.io/library/postgres
+  validationActions:
+  - Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -422,13 +422,8 @@ hypershift:
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:
-  extraAllowedRegistries:
-  - docker.io/jaegertracing
-  - docker.io/grafana
-  - docker.io/otel
-  - docker.io/library/postgres
-  validationActions:
-  - Deny
+  extraAllowedRegistries: docker.io/jaegertracing,docker.io/grafana,docker.io/otel,docker.io/library/postgres
+  validationActions: Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -421,6 +421,14 @@ hypershift:
     digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageRegistryPolicy:
+  extraAllowedRegistries:
+  - docker.io/jaegertracing
+  - docker.io/grafana
+  - docker.io/otel
+  - docker.io/library/postgres
+  validationActions:
+  - Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -422,13 +422,8 @@ hypershift:
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:
-  extraAllowedRegistries:
-  - docker.io/jaegertracing
-  - docker.io/grafana
-  - docker.io/otel
-  - docker.io/library/postgres
-  validationActions:
-  - Deny
+  extraAllowedRegistries: docker.io/jaegertracing,docker.io/grafana,docker.io/otel,docker.io/library/postgres
+  validationActions: Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -421,6 +421,14 @@ hypershift:
     digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageRegistryPolicy:
+  extraAllowedRegistries:
+  - docker.io/jaegertracing
+  - docker.io/grafana
+  - docker.io/otel
+  - docker.io/library/postgres
+  validationActions:
+  - Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -422,13 +422,8 @@ hypershift:
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:
-  extraAllowedRegistries:
-  - docker.io/jaegertracing
-  - docker.io/grafana
-  - docker.io/otel
-  - docker.io/library/postgres
-  validationActions:
-  - Deny
+  extraAllowedRegistries: docker.io/jaegertracing,docker.io/grafana,docker.io/otel,docker.io/library/postgres
+  validationActions: Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -421,6 +421,14 @@ hypershift:
     digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageRegistryPolicy:
+  extraAllowedRegistries:
+  - docker.io/jaegertracing
+  - docker.io/grafana
+  - docker.io/otel
+  - docker.io/library/postgres
+  validationActions:
+  - Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -422,13 +422,8 @@ hypershift:
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:
-  extraAllowedRegistries:
-  - docker.io/jaegertracing
-  - docker.io/grafana
-  - docker.io/otel
-  - docker.io/library/postgres
-  validationActions:
-  - Deny
+  extraAllowedRegistries: docker.io/jaegertracing,docker.io/grafana,docker.io/otel,docker.io/library/postgres
+  validationActions: Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -421,6 +421,14 @@ hypershift:
     digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageRegistryPolicy:
+  extraAllowedRegistries:
+  - docker.io/jaegertracing
+  - docker.io/grafana
+  - docker.io/otel
+  - docker.io/library/postgres
+  validationActions:
+  - Deny
 imageSync:
   environmentName: aro-hcp-image-sync
   ocMirror:

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -412,6 +412,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: upgrade-aks-cluster
+    - resourceGroup: management
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output
@@ -461,6 +463,34 @@ resourceGroups:
       - "Internal error occurred"
       maximumRetryCount: 3
       durationBetweenRetries: 1m
+  - name: image-registry-policy
+    aksCluster: '{{ .mgmt.aks.name }}'
+    action: Helm
+    releaseName: image-registry-policy
+    releaseNamespace: image-registry-policy
+    chartDir: ./../image-registry-policy/deploy
+    valuesFile: ./../image-registry-policy/values.yaml
+    kustoEndpoint:
+      resourceGroup: kusto
+      step: output
+      name: kustoUri
+    kustoDatabase: '{{ .kusto.serviceLogsDatabase }}'
+    kustoTable: 'containerLogs'
+    dependsOn:
+    - resourceGroup: management
+      step: cluster
+    - resourceGroup: management
+      step: upgrade-aks-cluster
+    identityFrom:
+      resourceGroup: global
+      step: output
+      name: globalMSIId
+    automatedRetry:
+      errorContainsAny:
+      - "500 Internal Server Error"
+      - "Internal error occurred"
+      maximumRetryCount: 3
+      durationBetweenRetries: 1m
   - name: storageclass
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Helm
@@ -477,6 +507,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: upgrade-aks-cluster
+    - resourceGroup: management
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output
@@ -505,6 +537,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: upgrade-aks-cluster
+    - resourceGroup: management
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output
@@ -531,6 +565,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: upgrade-aks-cluster
+    - resourceGroup: management
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output
@@ -647,6 +683,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: upgrade-aks-cluster
+    - resourceGroup: management
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -328,6 +328,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: service
       step: upgrade-aks-cluster
+    - resourceGroup: service
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output
@@ -470,6 +472,34 @@ resourceGroups:
       - "Internal error occurred"
       maximumRetryCount: 3
       durationBetweenRetries: 1m
+  - name: image-registry-policy
+    aksCluster: '{{ .svc.aks.name }}'
+    action: Helm
+    releaseName: image-registry-policy
+    releaseNamespace: image-registry-policy
+    chartDir: ./../image-registry-policy/deploy
+    valuesFile: ./../image-registry-policy/values.yaml
+    kustoEndpoint:
+      resourceGroup: kusto
+      step: output
+      name: kustoUri
+    kustoDatabase: '{{ .kusto.serviceLogsDatabase }}'
+    kustoTable: 'containerLogs'
+    dependsOn:
+    - resourceGroup: service
+      step: cluster
+    - resourceGroup: service
+      step: upgrade-aks-cluster
+    identityFrom:
+      resourceGroup: global
+      step: output
+      name: globalMSIId
+    automatedRetry:
+      errorContainsAny:
+      - "500 Internal Server Error"
+      - "Internal error occurred"
+      maximumRetryCount: 3
+      durationBetweenRetries: 1m
   - name: arobit-output
     action: ARM
     template: templates/arobit-lookup.bicep
@@ -536,6 +566,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: service
       step: upgrade-aks-cluster
+    - resourceGroup: service
+      step: image-registry-policy
     identityFrom:
       resourceGroup: global
       step: output
@@ -615,6 +647,8 @@ resourceGroups:
       step: prometheus
     - resourceGroup: service
       step: mirror-exporter-image
+    - resourceGroup: service
+      step: image-registry-policy
     inputVariables:
       kustoRegion:
         resourceGroup: kusto

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_image_registry_policy.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_image_registry_policy.yaml
@@ -64,7 +64,7 @@ spec:
   - name: allowedPrefixes
     expression: "params.data.allowedRegistries.split(',')"
   - name: disallowedImages
-    expression: "variables.allImages.filter(img, !img.startsWith('quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-') && !variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || img.startsWith(prefix + '@') || (prefix.split('/').size() >= 3 && img.startsWith(prefix + ':'))))"
+    expression: "variables.allImages.filter(img, !img.startsWith('quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-') && !variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || (prefix.split('/').size() >= 2 && (img.startsWith(prefix + '@') || img.startsWith(prefix + ':')))))"
   validations:
   - expression: "variables.disallowedImages.size() == 0"
     messageExpression: "'One or more container images are not from an allowed registry. Allowed registries: ' + params.data.allowedRegistries + '. Images: ' + variables.disallowedImages.join(', ')"

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_image_registry_policy.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_image_registry_policy.yaml
@@ -1,0 +1,89 @@
+---
+# Source: image-registry-policy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "image-registry-allowlist-config"
+  namespace: 'image-registry-policy'
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+data:
+  allowedRegistries: 'arohcpsvcdev.azurecr.io,arohcpocpdev.azurecr.io,mcr.microsoft.com,kubernetesshared.azurecr.io,docker.io/jaegertracing,docker.io/grafana,docker.io/otel,docker.io/library/postgres'
+---
+# Source: image-registry-policy/templates/validatingadmissionpolicy.yaml
+# This policy enforces FSI image sourcing requirements by restricting all pod
+# container images to a set of allowed registries. The enforcement action
+# (Deny or Audit) is configured per-environment via the policy binding.
+#
+# The allowed registry list is provided via a ConfigMap parameter so it can be
+# managed independently of the policy definition.
+#
+# CPO images (quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-*)
+# are temporarily excluded per-image until registryOverride + ACR pull-through
+# cache are deployed (AROSLSRE-777).
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "image-registry-allowlist-policy"
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: v1
+    kind: ConfigMap
+  matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system
+        - kube-node-lease
+        - kube-public
+        - gatekeeper-system
+    objectSelector: {}
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["pods"]
+      scope: Namespaced
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["UPDATE"]
+      resources: ["pods/ephemeralcontainers"]
+      scope: Namespaced
+  variables:
+  - name: allImages
+    expression: >-
+      object.spec.containers.map(c, c.image) + object.spec.?initContainers.orValue([]).map(c, c.image) + object.spec.?ephemeralContainers.orValue([]).map(c, c.image)
+  - name: allowedPrefixes
+    expression: "params.data.allowedRegistries.split(',')"
+  - name: disallowedImages
+    expression: "variables.allImages.filter(img, !img.startsWith('quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-') && !variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || img.startsWith(prefix + '@') || (prefix.split('/').size() >= 3 && img.startsWith(prefix + ':'))))"
+  validations:
+  - expression: "variables.disallowedImages.size() == 0"
+    messageExpression: "'One or more container images are not from an allowed registry. Allowed registries: ' + params.data.allowedRegistries + '. Images: ' + variables.disallowedImages.join(', ')"
+    reason: Forbidden
+---
+# Source: image-registry-policy/templates/validatingadmissionpolicybinding.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "image-registry-allowlist-policy-binding"
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+spec:
+  policyName: "image-registry-allowlist-policy"
+  validationActions:
+  - Deny
+  paramRef:
+    name: "image-registry-allowlist-config"
+    namespace: 'image-registry-policy'
+    parameterNotFoundAction: Deny
+

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_image_registry_policy.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_image_registry_policy.yaml
@@ -64,7 +64,7 @@ spec:
   - name: allowedPrefixes
     expression: "params.data.allowedRegistries.split(',')"
   - name: disallowedImages
-    expression: "variables.allImages.filter(img, !img.startsWith('quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-') && !variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || img.startsWith(prefix + '@') || (prefix.split('/').size() >= 3 && img.startsWith(prefix + ':'))))"
+    expression: "variables.allImages.filter(img, !img.startsWith('quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-') && !variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || (prefix.split('/').size() >= 2 && (img.startsWith(prefix + '@') || img.startsWith(prefix + ':')))))"
   validations:
   - expression: "variables.disallowedImages.size() == 0"
     messageExpression: "'One or more container images are not from an allowed registry. Allowed registries: ' + params.data.allowedRegistries + '. Images: ' + variables.disallowedImages.join(', ')"

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_image_registry_policy.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_image_registry_policy.yaml
@@ -1,0 +1,89 @@
+---
+# Source: image-registry-policy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "image-registry-allowlist-config"
+  namespace: 'image-registry-policy'
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+data:
+  allowedRegistries: 'arohcpsvcdev.azurecr.io,arohcpocpdev.azurecr.io,mcr.microsoft.com,kubernetesshared.azurecr.io,docker.io/jaegertracing,docker.io/grafana,docker.io/otel,docker.io/library/postgres'
+---
+# Source: image-registry-policy/templates/validatingadmissionpolicy.yaml
+# This policy enforces FSI image sourcing requirements by restricting all pod
+# container images to a set of allowed registries. The enforcement action
+# (Deny or Audit) is configured per-environment via the policy binding.
+#
+# The allowed registry list is provided via a ConfigMap parameter so it can be
+# managed independently of the policy definition.
+#
+# CPO images (quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-*)
+# are temporarily excluded per-image until registryOverride + ACR pull-through
+# cache are deployed (AROSLSRE-777).
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "image-registry-allowlist-policy"
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: v1
+    kind: ConfigMap
+  matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system
+        - kube-node-lease
+        - kube-public
+        - gatekeeper-system
+    objectSelector: {}
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["pods"]
+      scope: Namespaced
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["UPDATE"]
+      resources: ["pods/ephemeralcontainers"]
+      scope: Namespaced
+  variables:
+  - name: allImages
+    expression: >-
+      object.spec.containers.map(c, c.image) + object.spec.?initContainers.orValue([]).map(c, c.image) + object.spec.?ephemeralContainers.orValue([]).map(c, c.image)
+  - name: allowedPrefixes
+    expression: "params.data.allowedRegistries.split(',')"
+  - name: disallowedImages
+    expression: "variables.allImages.filter(img, !img.startsWith('quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-') && !variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || img.startsWith(prefix + '@') || (prefix.split('/').size() >= 3 && img.startsWith(prefix + ':'))))"
+  validations:
+  - expression: "variables.disallowedImages.size() == 0"
+    messageExpression: "'One or more container images are not from an allowed registry. Allowed registries: ' + params.data.allowedRegistries + '. Images: ' + variables.disallowedImages.join(', ')"
+    reason: Forbidden
+---
+# Source: image-registry-policy/templates/validatingadmissionpolicybinding.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "image-registry-allowlist-policy-binding"
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+spec:
+  policyName: "image-registry-allowlist-policy"
+  validationActions:
+  - Deny
+  paramRef:
+    name: "image-registry-allowlist-config"
+    namespace: 'image-registry-policy'
+    parameterNotFoundAction: Deny
+

--- a/image-registry-policy/deploy/Chart.yaml
+++ b/image-registry-policy/deploy/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: image-registry-policy
+description: Enforces FSI image sourcing requirements by restricting pod image pulls to allowed registries.
+type: application
+version: 0.1.0

--- a/image-registry-policy/deploy/templates/configmap.yaml
+++ b/image-registry-policy/deploy/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "image-registry-allowlist-config"
+  namespace: '{{ .Release.Namespace }}'
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+data:
+  allowedRegistries: '{{ .Values.allowedRegistries | join "," }}'

--- a/image-registry-policy/deploy/templates/configmap.yaml
+++ b/image-registry-policy/deploy/templates/configmap.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/name: image-registry-policy
     app.kubernetes.io/managed-by: Helm
 data:
-  allowedRegistries: '{{ .Values.allowedRegistries | join "," }}'
+  allowedRegistries: '{{ .Values.allowedRegistries | trimSuffix "," }}'

--- a/image-registry-policy/deploy/templates/validatingadmissionpolicy.yaml
+++ b/image-registry-policy/deploy/templates/validatingadmissionpolicy.yaml
@@ -1,0 +1,57 @@
+# This policy enforces FSI image sourcing requirements by restricting all pod
+# container images to a set of allowed registries. The enforcement action
+# (Deny or Audit) is configured per-environment via the policy binding.
+#
+# The allowed registry list is provided via a ConfigMap parameter so it can be
+# managed independently of the policy definition.
+#
+# CPO images (quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-*)
+# are temporarily excluded per-image until registryOverride + ACR pull-through
+# cache are deployed (AROSLSRE-777).
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "image-registry-allowlist-policy"
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: v1
+    kind: ConfigMap
+  matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system
+        - kube-node-lease
+        - kube-public
+        - gatekeeper-system
+    objectSelector: {}
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["pods"]
+      scope: Namespaced
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["UPDATE"]
+      resources: ["pods/ephemeralcontainers"]
+      scope: Namespaced
+  variables:
+  - name: allImages
+    expression: >-
+      object.spec.containers.map(c, c.image) + object.spec.?initContainers.orValue([]).map(c, c.image) + object.spec.?ephemeralContainers.orValue([]).map(c, c.image)
+  - name: allowedPrefixes
+    expression: "params.data.allowedRegistries.split(',')"
+  - name: disallowedImages
+    expression: "variables.allImages.filter(img, !img.startsWith('quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-') && !variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || img.startsWith(prefix + '@') || (prefix.split('/').size() >= 3 && img.startsWith(prefix + ':'))))"
+  validations:
+  - expression: "variables.disallowedImages.size() == 0"
+    messageExpression: "'One or more container images are not from an allowed registry. Allowed registries: ' + params.data.allowedRegistries + '. Images: ' + variables.disallowedImages.join(', ')"
+    reason: Forbidden

--- a/image-registry-policy/deploy/templates/validatingadmissionpolicy.yaml
+++ b/image-registry-policy/deploy/templates/validatingadmissionpolicy.yaml
@@ -50,7 +50,7 @@ spec:
   - name: allowedPrefixes
     expression: "params.data.allowedRegistries.split(',')"
   - name: disallowedImages
-    expression: "variables.allImages.filter(img, !img.startsWith('quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-') && !variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || img.startsWith(prefix + '@') || (prefix.split('/').size() >= 3 && img.startsWith(prefix + ':'))))"
+    expression: "variables.allImages.filter(img, !img.startsWith('quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-') && !variables.allowedPrefixes.exists(prefix, img.startsWith(prefix + '/') || (prefix.split('/').size() >= 2 && (img.startsWith(prefix + '@') || img.startsWith(prefix + ':')))))"
   validations:
   - expression: "variables.disallowedImages.size() == 0"
     messageExpression: "'One or more container images are not from an allowed registry. Allowed registries: ' + params.data.allowedRegistries + '. Images: ' + variables.disallowedImages.join(', ')"

--- a/image-registry-policy/deploy/templates/validatingadmissionpolicybinding.yaml
+++ b/image-registry-policy/deploy/templates/validatingadmissionpolicybinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "image-registry-allowlist-policy-binding"
+  labels:
+    app.kubernetes.io/name: image-registry-policy
+    app.kubernetes.io/managed-by: Helm
+spec:
+  policyName: "image-registry-allowlist-policy"
+  validationActions:
+  {{- range .Values.validationActions }}
+  - {{ . }}
+  {{- end }}
+  paramRef:
+    name: "image-registry-allowlist-config"
+    namespace: '{{ .Release.Namespace }}'
+    parameterNotFoundAction: Deny

--- a/image-registry-policy/deploy/templates/validatingadmissionpolicybinding.yaml
+++ b/image-registry-policy/deploy/templates/validatingadmissionpolicybinding.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   policyName: "image-registry-allowlist-policy"
   validationActions:
-  {{- range .Values.validationActions }}
-  - {{ . }}
+  {{- range splitList "," .Values.validationActions }}
+  - {{ . | trim }}
   {{- end }}
   paramRef:
     name: "image-registry-allowlist-config"

--- a/image-registry-policy/deploy/values.yaml
+++ b/image-registry-policy/deploy/values.yaml
@@ -1,0 +1,7 @@
+allowedRegistries:
+- '{{ .acr.svc.name }}.{{ .acrDNSSuffix }}'
+- '{{ .acr.ocp.name }}.{{ .acrDNSSuffix }}'
+- mcr.microsoft.com
+- kubernetesshared.azurecr.io
+validationActions:
+- Audit

--- a/image-registry-policy/deploy/values.yaml
+++ b/image-registry-policy/deploy/values.yaml
@@ -1,7 +1,2 @@
-allowedRegistries:
-- '{{ .acr.svc.name }}.{{ .acrDNSSuffix }}'
-- '{{ .acr.ocp.name }}.{{ .acrDNSSuffix }}'
-- mcr.microsoft.com
-- kubernetesshared.azurecr.io
-validationActions:
-- Audit
+allowedRegistries: '{{ .acr.svc.name }}.{{ .acrDNSSuffix }},{{ .acr.ocp.name }}.{{ .acrDNSSuffix }},mcr.microsoft.com,kubernetesshared.azurecr.io'
+validationActions: Audit

--- a/image-registry-policy/values.yaml
+++ b/image-registry-policy/values.yaml
@@ -1,0 +1,12 @@
+allowedRegistries:
+- '{{ .acr.svc.name }}.{{ .acrDNSSuffix }}'
+- '{{ .acr.ocp.name }}.{{ .acrDNSSuffix }}'
+- mcr.microsoft.com
+- kubernetesshared.azurecr.io
+{{- range .imageRegistryPolicy.extraAllowedRegistries }}
+- '{{ . }}'
+{{- end }}
+validationActions:
+{{- range .imageRegistryPolicy.validationActions }}
+- '{{ . }}'
+{{- end }}

--- a/image-registry-policy/values.yaml
+++ b/image-registry-policy/values.yaml
@@ -1,12 +1,2 @@
-allowedRegistries:
-- '{{ .acr.svc.name }}.{{ .acrDNSSuffix }}'
-- '{{ .acr.ocp.name }}.{{ .acrDNSSuffix }}'
-- mcr.microsoft.com
-- kubernetesshared.azurecr.io
-{{- range .imageRegistryPolicy.extraAllowedRegistries }}
-- '{{ . }}'
-{{- end }}
-validationActions:
-{{- range .imageRegistryPolicy.validationActions }}
-- '{{ . }}'
-{{- end }}
+allowedRegistries: '{{ .acr.svc.name }}.{{ .acrDNSSuffix }},{{ .acr.ocp.name }}.{{ .acrDNSSuffix }},mcr.microsoft.com,kubernetesshared.azurecr.io,{{ .imageRegistryPolicy.extraAllowedRegistries }}'
+validationActions: '{{ .imageRegistryPolicy.validationActions }}'

--- a/nonlocal-e2e-specs.txt
+++ b/nonlocal-e2e-specs.txt
@@ -8,8 +8,10 @@
   "Successfully lists clusters filtered by resource group name",
   "creates a cluster and fails to update its name with a PATCH request",
   "creates and deletes vm type NC4asT4v3 in a single cluster",
+  "should allow pods with images from allowed registries and have a valid allowlist",
   "should be able to create an HCP cluster then delete it by deleting the customer resource group",
   "should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings",
   "should confirm the HCP cluster is deleted (not found)",
-  "should create an HCP cluster and validate TLS certificates"
+  "should create an HCP cluster and validate TLS certificates",
+  "should deny pods with images from disallowed registries"
 ]

--- a/observability/tracing/deploy/collector.yaml
+++ b/observability/tracing/deploy/collector.yaml
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
       - name: otel-collector
-        image: otel/opentelemetry-collector-contrib:0.128.0
+        image: docker.io/otel/opentelemetry-collector-contrib:0.128.0
         args: ["--config=/etc/otel/config/otel-collector-config.yaml"]
         volumeMounts:
         - name: otel-config

--- a/observability/tracing/deploy/jaeger.yaml
+++ b/observability/tracing/deploy/jaeger.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: jaeger
-        image: jaegertracing/all-in-one:1.63.0
+        image: docker.io/jaegertracing/all-in-one:1.63.0
         env:
         - name: SPAN_STORAGE_TYPE
           value: memory

--- a/observability/tracing/deploy/lgtm.yaml
+++ b/observability/tracing/deploy/lgtm.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: lgtm
-        image: grafana/otel-lgtm:latest
+        image: docker.io/grafana/otel-lgtm:latest
         ports:
         - containerPort: 3000
         - containerPort: 4317

--- a/test/e2e/image_registry_policy.go
+++ b/test/e2e/image_registry_policy.go
@@ -78,10 +78,10 @@ var _ = Describe("Image Registry Policy", func() {
 				ctx, "image-registry-allowlist-policy-binding", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), "Failed to get VAP binding")
 
-			isAuditMode := false
+			hasDenyAction := false
 			for _, action := range binding.Spec.ValidationActions {
-				if action == admissionregistrationv1.Audit {
-					isAuditMode = true
+				if action == admissionregistrationv1.Deny {
+					hasDenyAction = true
 					break
 				}
 			}
@@ -105,21 +105,21 @@ var _ = Describe("Image Registry Policy", func() {
 			}
 			_, err = kubeClient.CoreV1().Pods(testNS).Create(ctx, pod, metav1.CreateOptions{})
 
-			if isAuditMode {
-				if err != nil && apierrors.IsForbidden(err) {
-					GinkgoLogr.Info("Pod was denied even in Audit mode — policy may have been switched to Deny")
-				} else {
-					GinkgoLogr.Info("Pod with disallowed image was allowed (policy in Audit mode) — violation logged but not blocked")
-				}
-				if err == nil {
-					_ = kubeClient.CoreV1().Pods(testNS).Delete(ctx, pod.Name, metav1.DeleteOptions{})
-				}
-			} else {
+			if hasDenyAction {
 				Expect(err).To(HaveOccurred(), "Pod with disallowed image should be denied")
 				Expect(apierrors.IsForbidden(err)).To(BeTrue(),
 					"Expected Forbidden error for disallowed image, got: %v", err)
 				Expect(err.Error()).To(ContainSubstring("not from an allowed registry"),
 					"Denial should come from the image registry policy, got: %v", err)
+			} else {
+				if err != nil && apierrors.IsForbidden(err) {
+					GinkgoLogr.Info("Pod was denied even without Deny validation action; another admission policy may be enforcing")
+				} else {
+					GinkgoLogr.Info("Pod with disallowed image was allowed because policy does not include Deny")
+				}
+				if err == nil {
+					_ = kubeClient.CoreV1().Pods(testNS).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+				}
 			}
 		})
 

--- a/test/e2e/image_registry_policy.go
+++ b/test/e2e/image_registry_policy.go
@@ -112,14 +112,9 @@ var _ = Describe("Image Registry Policy", func() {
 				Expect(err.Error()).To(ContainSubstring("not from an allowed registry"),
 					"Denial should come from the image registry policy, got: %v", err)
 			} else {
-				if err != nil && apierrors.IsForbidden(err) {
-					GinkgoLogr.Info("Pod was denied even without Deny validation action; another admission policy may be enforcing")
-				} else {
-					GinkgoLogr.Info("Pod with disallowed image was allowed because policy does not include Deny")
-				}
-				if err == nil {
-					_ = kubeClient.CoreV1().Pods(testNS).Delete(ctx, pod.Name, metav1.DeleteOptions{})
-				}
+				Expect(err).NotTo(HaveOccurred(), "Pod with disallowed image should be allowed when validationActions does not include Deny")
+				GinkgoLogr.Info("Pod with disallowed image was allowed because policy does not include Deny")
+				_ = kubeClient.CoreV1().Pods(testNS).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 			}
 		})
 

--- a/test/e2e/image_registry_policy.go
+++ b/test/e2e/image_registry_policy.go
@@ -1,0 +1,189 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/Azure/ARO-HCP/test/util/labels"
+)
+
+const (
+	disallowedImage           = "quay.io/library/nginx:latest"
+	allowedImage              = "mcr.microsoft.com/mirror/pause:3.9"
+	allowedRegistryMCR        = "mcr.microsoft.com"
+	allowedRegistryKubeShared = "kubernetesshared.azurecr.io"
+)
+
+var _ = Describe("Image Registry Policy", func() {
+	var kubeClient kubernetes.Interface
+
+	BeforeEach(func() {
+		restConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			clientcmd.NewDefaultClientConfigLoadingRules(),
+			&clientcmd.ConfigOverrides{},
+		).ClientConfig()
+		Expect(err).NotTo(HaveOccurred(), "Failed to load kubeconfig")
+
+		kubeClient, err = kubernetes.NewForConfig(restConfig)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create Kubernetes client")
+	})
+
+	It("should deny pods with images from disallowed registries",
+		labels.RequireNothing,
+		labels.High,
+		labels.Negative,
+		labels.CoreInfraService,
+		labels.DevelopmentOnly,
+		func(ctx context.Context) {
+			By("creating a test namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "image-policy-test-",
+				},
+			}
+			createdNS, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create test namespace")
+			testNS := createdNS.Name
+			DeferCleanup(func(ctx context.Context) {
+				_ = kubeClient.CoreV1().Namespaces().Delete(ctx, testNS, metav1.DeleteOptions{})
+			})
+
+			By("checking the policy validation action")
+			binding, err := kubeClient.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(
+				ctx, "image-registry-allowlist-policy-binding", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to get VAP binding")
+
+			isAuditMode := false
+			for _, action := range binding.Spec.ValidationActions {
+				if action == admissionregistrationv1.Audit {
+					isAuditMode = true
+					break
+				}
+			}
+
+			By(fmt.Sprintf("attempting to create a pod with disallowed image %q", disallowedImage))
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "policy-test-disallowed",
+					Namespace: testNS,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "test",
+							Image:   disallowedImage,
+							Command: []string{"/bin/sh", "-c", "sleep 1"},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			}
+			_, err = kubeClient.CoreV1().Pods(testNS).Create(ctx, pod, metav1.CreateOptions{})
+
+			if isAuditMode {
+				if err != nil && apierrors.IsForbidden(err) {
+					GinkgoLogr.Info("Pod was denied even in Audit mode — policy may have been switched to Deny")
+				} else {
+					GinkgoLogr.Info("Pod with disallowed image was allowed (policy in Audit mode) — violation logged but not blocked")
+				}
+				if err == nil {
+					_ = kubeClient.CoreV1().Pods(testNS).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+				}
+			} else {
+				Expect(err).To(HaveOccurred(), "Pod with disallowed image should be denied")
+				Expect(apierrors.IsForbidden(err)).To(BeTrue(),
+					"Expected Forbidden error for disallowed image, got: %v", err)
+				Expect(err.Error()).To(ContainSubstring("not from an allowed registry"),
+					"Denial should come from the image registry policy, got: %v", err)
+			}
+		})
+
+	It("should allow pods with images from allowed registries and have a valid allowlist",
+		labels.RequireNothing,
+		labels.High,
+		labels.Positive,
+		labels.CoreInfraService,
+		func(ctx context.Context) {
+			By("verifying the ValidatingAdmissionPolicy exists")
+			_, err := kubeClient.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(
+				ctx, "image-registry-allowlist-policy", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "ValidatingAdmissionPolicy should exist")
+
+			By("verifying the ValidatingAdmissionPolicyBinding exists")
+			_, err = kubeClient.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(
+				ctx, "image-registry-allowlist-policy-binding", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "ValidatingAdmissionPolicyBinding should exist")
+
+			By("verifying the ConfigMap allowlist is non-empty and contains required registries")
+			cm, err := kubeClient.CoreV1().ConfigMaps("image-registry-policy").Get(
+				ctx, "image-registry-allowlist-config", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "ConfigMap image-registry-allowlist-config should exist")
+			Expect(cm.Data["allowedRegistries"]).NotTo(BeEmpty(), "allowedRegistries should not be empty")
+			prefixes := strings.Split(cm.Data["allowedRegistries"], ",")
+			Expect(prefixes).To(ContainElement(allowedRegistryMCR),
+				"%s should be an exact entry in the allowlist", allowedRegistryMCR)
+			Expect(prefixes).To(ContainElement(allowedRegistryKubeShared),
+				"%s should be an exact entry in the allowlist", allowedRegistryKubeShared)
+
+			By("creating a test namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "image-policy-test-",
+				},
+			}
+			createdNS, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create test namespace")
+			testNS := createdNS.Name
+			DeferCleanup(func(ctx context.Context) {
+				_ = kubeClient.CoreV1().Namespaces().Delete(ctx, testNS, metav1.DeleteOptions{})
+			})
+
+			By(fmt.Sprintf("creating a pod with an image from an allowed registry %q", allowedImage))
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "policy-test-allowed",
+					Namespace: testNS,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test",
+							Image: allowedImage,
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			}
+			_, err = kubeClient.CoreV1().Pods(testNS).Create(ctx, pod, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(),
+				"Pod with allowed image %q should be admitted by the policy", allowedImage)
+			DeferCleanup(func(ctx context.Context) {
+				_ = kubeClient.CoreV1().Pods(testNS).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+			})
+		})
+})

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -58,6 +58,7 @@ Customer should be able to lifecycle and confirm external auth on a cluster
 HCP Nodepools GPU instances creates and deletes vm type NC4asT4v3 in a single cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
+Image Registry Policy should allow pods with images from allowed registries and have a valid allowlist
 MISE Routing routes to the correct frontend based on version header MISE v2 when x-ms-mise-version header is set
 MISE Routing routes to the correct frontend based on version header default route returns no version header
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -57,6 +57,7 @@ Customer should be able to create a cluster with an external auth config and get
 Customer should be able to lifecycle and confirm external auth on a cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
+Image Registry Policy should allow pods with images from allowed registries and have a valid allowlist
 MISE Routing routes to the correct frontend based on version header MISE v2 when x-ms-mise-version header is set
 MISE Routing routes to the correct frontend based on version header default route returns no version header
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -58,6 +58,7 @@ Customer should be able to create a cluster with an external auth config and get
 Customer should be able to lifecycle and confirm external auth on a cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
+Image Registry Policy should deny pods with images from disallowed registries
 Engineering should be able to retrieve kusto logs for a cluster and services
 MISE Routing routes to the correct frontend based on version header MISE v2 when x-ms-mise-version header is set
 MISE Routing routes to the correct frontend based on version header default route returns no version header

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -57,6 +57,7 @@ Customer should be able to create a cluster with an external auth config and get
 Customer should be able to lifecycle and confirm external auth on a cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
+Image Registry Policy should allow pods with images from allowed registries and have a valid allowlist
 MISE Routing routes to the correct frontend based on version header MISE v2 when x-ms-mise-version header is set
 MISE Routing routes to the correct frontend based on version header default route returns no version header
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits


### PR DESCRIPTION
## Re-revert #5357 / re-land image registry policy

This reverts the temporary revert from #5357 and restores the image-registry-policy ValidatingAdmissionPolicy from #4690.

### Important change from the original #4690

The original implementation modeled these values as arrays in ARO-HCP configuration:

- `imageRegistryPolicy.extraAllowedRegistries`
- `imageRegistryPolicy.validationActions`

That conflicts with the documented configuration limitation in `docs/configuration.md#limitations`: configuration should only reference basic fields from pipeline/Bicep flows, and arrays should be avoided because they do not translate well to EV2 configuration settings.

This PR changes the restored config shape to scalar CSV strings instead:

- `extraAllowedRegistries: ""` by default, with dev using comma-separated prefixes
- `validationActions: Audit` / `Deny`

The Helm chart now splits `validationActions` at render time and passes `allowedRegistries` as the CSV string consumed by the CEL policy ConfigMap.

### Validation

- `make -C config materialize`
- `make -C config validate`
- `make test-helm-fixtures`
- `make validate-config-pipelines`

Jira: [AROSLSRE-918](https://redhat.atlassian.net/browse/AROSLSRE-918) (sub-task of [AROSLSRE-913](https://redhat.atlassian.net/browse/AROSLSRE-913))

Refs: #5357, #4690, [AROSLSRE-913](https://redhat.atlassian.net/browse/AROSLSRE-913)

