### PR TITLE
hcpctl: snapshot: add a local analysis CLI

### DIFF
--- a/docs/snapshot-analysis.md
+++ b/docs/snapshot-analysis.md
@@ -1,0 +1,101 @@
+# Snapshot Gathering and Analysis
+
+The `hcpctl snapshot` commands gather structured diagnostic data for failed
+E2E tests and run LLM-driven root cause analysis on the results.
+
+The workflow has two steps:
+
+1. **Gather** — fetch Prow job artifacts, test logs, and Kusto query results
+   into a local directory.
+2. **Analyze** — send the gathered data to a Copilot agent that produces a
+   structured causal chain explaining why the test failed.
+
+## Prerequisites
+
+- Azure CLI logged in (`az login`) — needed for Kusto queries.
+- GitHub Copilot CLI [installed])(https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli)
+  and authenticated (`gh auth login`) — needed for the analysis agent.
+- Local git checkouts of the four repositories at the commits that were deployed
+  when the test ran: ARO-HCP, HyperShift, Maestro, and Clusters Service.
+
+## Step 1: Gather
+
+```bash
+hcpctl snapshot from-prow-job \
+  --url https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-aro-hcp-e2e-parallel/1234567890 \
+  --test TestNodePoolCreation
+```
+
+The `--test` flag is a substring match against test names in the Prow job. The
+command fetches the job's JUnit results, identifies the matching failed test,
+and gathers:
+
+- `manifest.json` — test metadata, Kusto cluster/database info, time windows.
+- `test_logs/error.log` and `test_logs/output.log` — the test's stderr and stdout.
+- `sibling_tests.json` — metadata about other tests in the same job (useful for
+  identifying systemic failures).
+- Per-resource Kusto query results organized by phase (`test_phase/`, `cleanup_phase/`).
+
+The output directory defaults to `snapshot-<timestamp>/` and can be overridden
+with `--output-dir`.
+
+## Step 2: Analyze
+
+```bash
+hcpctl snapshot analyze ./snapshot-20250101-120000/periodic-ci-.../1234567890/TestNodePoolCreation \
+  --aro-hcp ~/code/ARO-HCP \
+  --hypershift ~/code/hypershift \
+  --maestro ~/code/maestro \
+  --clusters-service ~/code/clusters-service
+```
+
+The argument is the data directory produced by `gather` (the directory
+containing `manifest.json`).
+
+The agent runs through several phases:
+
+1. **Initial prompt** — the agent receives the manifest, test logs, and data
+   directory contents, and produces a draft causal chain as structured JSON.
+2. **Validation loop** — the draft is parsed and validated (correct JSON
+   structure, valid repository references, syntactically correct Kusto queries,
+   non-empty code excerpts). If validation fails, the agent receives feedback
+   and re-emits corrected output. This repeats for up to `--max-rounds`
+   iterations.
+3. **Hydration** — Kusto queries from the draft are executed against the real
+   cluster, and code excerpt references are resolved from the local git
+   checkouts. The results are embedded into the chain.
+4. **Review rounds** — the agent sees its own output rendered as a complete
+   markdown document and reviews it for coherence, evidence quality, depth,
+   and accuracy. It re-emits corrected JSON, which goes through validation
+   and hydration again. This repeats for `--review-rounds` iterations.
+
+### Analyze output
+
+The command writes three files to the output directory (defaults to the data
+directory, overridable with `--output`):
+
+- `analysis.json` — the fully hydrated causal chain as structured JSON.
+- `analysis.md` — the chain rendered as a readable markdown document.
+- `conversation.json` — the full conversation history with the agent,
+  including all prompts, responses, and tool calls.
+
+## Debugging with conversation.json
+
+When the analysis produces unexpected results or the agent gets stuck in
+validation loops, `conversation.json` is the primary debugging tool. It
+contains the complete message history between the CLI and the agent, in the
+same format the Copilot SDK uses internally.
+
+The conversation is snapshotted after every successful agent turn. If you
+interrupt the process with ctrl-C, the file will contain everything up to and
+including the last completed turn.
+
+## Analyzing Pull Request Jobs
+
+When analyzing `pull-ci` jobs for a pull request, set `$AZURE_CONFIG_DIR` to
+an `az` login for the Red Hat tenant, and provide `$AZURE_TOKEN_CREDENTIALS`
+as `AzureCLICredentials`. The GitHub Copilot authentication mode will retain
+whichever credentials are available for the `copilot` CLI, _not_ the Azure
+credentials provided via environment variables for authentication to Kusto,
+etc. This allows authentication to the Red Hat tenant for Kusto queries and
+to the Microsoft tenant for the Copilot subscription.

--- a/docs/snapshot-analysis.md
+++ b/docs/snapshot-analysis.md
@@ -13,7 +13,7 @@ The workflow has two steps:
 ## Prerequisites
 
 - Azure CLI logged in (`az login`) — needed for Kusto queries.
-- GitHub Copilot CLI [installed])(https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli)
+- GitHub Copilot CLI [installed](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli)
   and authenticated (`gh auth login`) — needed for the analysis agent.
 - Local git checkouts of the four repositories at the commits that were deployed
   when the test ran: ARO-HCP, HyperShift, Maestro, and Clusters Service.

--- a/test/cmd/aro-hcp-tests/gather-snapshot/options.go
+++ b/test/cmd/aro-hcp-tests/gather-snapshot/options.go
@@ -211,6 +211,9 @@ func (o Options) Run(ctx context.Context) error {
 	var allManifests []*snapshot.Manifest
 
 	for testName, ti := range o.TestTimingInfo {
+		if ctx.Err() != nil {
+			break
+		}
 		if len(ti.ResourceGroupNames) == 0 {
 			logger.V(1).Info("Skipping test without resource groups", "test", testName)
 			continue
@@ -232,16 +235,28 @@ func (o Options) Run(ctx context.Context) error {
 				HCPDatabase:     o.HCPDB,
 				ResourceGroup:   rg,
 				TimeWindow: snapshot.TimeWindow{
-					Start: ti.StartTime,
-					End:   ti.EndTime,
+					Start:           ti.StartTime,
+					End:             ti.EndTime,
+					SetupFinishTime: ti.SetupFinishTime,
 				},
 				QueryTimeout:     5 * time.Minute,
+				TestStartTime:    ti.TestStartTime,
 				CleanupStartTime: ti.CleanupStartTime,
+			}
+
+			if input.TestStartTime.IsZero() {
+				return fmt.Errorf("test %q: TestStartTime is zero; timing metadata is incomplete", testName)
+			}
+			if input.CleanupStartTime.IsZero() {
+				return fmt.Errorf("test %q: CleanupStartTime is zero; timing metadata is incomplete", testName)
 			}
 
 			manifest, report, err := gatherer.Gather(ctx, input, testOutputDir)
 			if err != nil {
 				logger.Error(err, "Failed to gather snapshot", "test", testName, "resourceGroup", rg)
+				if ctx.Err() != nil {
+					break
+				}
 				continue
 			}
 
@@ -256,7 +271,7 @@ func (o Options) Run(ctx context.Context) error {
 			logger.Info("Snapshot complete",
 				"test", testName,
 				"resourceGroup", rg,
-				"resources", len(manifest.Resources),
+				"phases", len(manifest.Phases),
 				"verificationCases", len(report.Cases),
 			)
 		}

--- a/test/util/timing/timewindow.go
+++ b/test/util/timing/timewindow.go
@@ -51,6 +51,8 @@ type TimeWindow struct {
 type TimingInfo struct {
 	StartTime          time.Time
 	EndTime            time.Time
+	SetupFinishTime    time.Time
+	TestStartTime      time.Time
 	CleanupStartTime   time.Time
 	ResourceGroupNames []string
 	Steps              []StepTimingMetadata
@@ -171,10 +173,14 @@ func LoadTestTimingInfo(ctx context.Context, dir string) (map[string]TimingInfo,
 			}
 		}
 
+		setupFinishTime, testStartTime := deriveSetupTestBoundary(tm.Steps)
+
 		key := strings.Join(tm.Identifier, " ")
 		result[key] = TimingInfo{
 			StartTime:          startedAt,
 			EndTime:            finishedAt.Add(endGracePeriodDuration),
+			SetupFinishTime:    setupFinishTime,
+			TestStartTime:      testStartTime,
 			CleanupStartTime:   finishedAt,
 			ResourceGroupNames: rgNames,
 			Steps:              tm.Steps,
@@ -185,6 +191,42 @@ func LoadTestTimingInfo(ctx context.Context, dir string) (map[string]TimingInfo,
 		return nil, fmt.Errorf("failed to walk timing input dir %s: %w", dir, err)
 	}
 	return result, nil
+}
+
+// identityContainerStep reports whether a step name refers to identity container setup.
+func identityContainerStep(name string) bool {
+	return strings.Contains(strings.ToLower(name), "identity container")
+}
+
+// deriveSetupTestBoundary inspects the steps in the timing metadata and returns:
+//   - setupFinishTime: the latest FinishedAt among steps whose name contains
+//     "identity container" (setup steps).
+//   - testStartTime: the earliest StartedAt among steps whose name does NOT
+//     contain "identity container" (test steps).
+//
+// Either or both may be zero when the relevant steps are not present or their
+// timestamps cannot be parsed.
+func deriveSetupTestBoundary(steps []StepTimingMetadata) (setupFinishTime, testStartTime time.Time) {
+	for _, step := range steps {
+		if identityContainerStep(step.Name) {
+			if step.FinishedAt != "" {
+				if t, err := time.Parse(time.RFC3339, step.FinishedAt); err == nil {
+					if setupFinishTime.IsZero() || t.After(setupFinishTime) {
+						setupFinishTime = t
+					}
+				}
+			}
+		} else {
+			if step.StartedAt != "" {
+				if t, err := time.Parse(time.RFC3339, step.StartedAt); err == nil {
+					if testStartTime.IsZero() || t.Before(testStartTime) {
+						testStartTime = t
+					}
+				}
+			}
+		}
+	}
+	return setupFinishTime, testStartTime
 }
 
 // ComputeTimeWindow derives a start/end time range from steps, test timing

--- a/test/util/timing/timewindow_test.go
+++ b/test/util/timing/timewindow_test.go
@@ -538,3 +538,110 @@ func TestComputeTimeWindow_TestTimingNotUsedWhenStepsProvide(t *testing.T) {
 		t.Errorf("end: got %v, want %v (test timing should not override steps)", got.End, wantEnd)
 	}
 }
+
+func TestDeriveSetupTestBoundary(t *testing.T) {
+	tests := []struct {
+		name            string
+		steps           []StepTimingMetadata
+		wantSetupFinish string // RFC3339 or "" for zero
+		wantTestStart   string
+	}{
+		{
+			name:            "no steps",
+			steps:           nil,
+			wantSetupFinish: "",
+			wantTestStart:   "",
+		},
+		{
+			name: "only identity container steps",
+			steps: []StepTimingMetadata{
+				{Name: "Assign 2 identity containers", StartedAt: "2025-06-01T10:00:00Z", FinishedAt: "2025-06-01T10:01:00Z"},
+				{Name: "Lease identity container", StartedAt: "2025-06-01T10:01:00Z", FinishedAt: "2025-06-01T10:02:00Z"},
+			},
+			wantSetupFinish: "2025-06-01T10:02:00Z",
+			wantTestStart:   "",
+		},
+		{
+			name: "only test steps",
+			steps: []StepTimingMetadata{
+				{Name: "Create cluster", StartedAt: "2025-06-01T10:05:00Z", FinishedAt: "2025-06-01T10:30:00Z"},
+			},
+			wantSetupFinish: "",
+			wantTestStart:   "2025-06-01T10:05:00Z",
+		},
+		{
+			name: "mixed setup and test steps",
+			steps: []StepTimingMetadata{
+				{Name: "Assign 2 identity containers", StartedAt: "2025-06-01T10:00:00Z", FinishedAt: "2025-06-01T10:01:00Z"},
+				{Name: "Lease identity container", StartedAt: "2025-06-01T10:01:00Z", FinishedAt: "2025-06-01T10:03:00Z"},
+				{Name: "Create cluster", StartedAt: "2025-06-01T10:03:00Z", FinishedAt: "2025-06-01T10:30:00Z"},
+				{Name: "Verify cluster health", StartedAt: "2025-06-01T10:30:00Z", FinishedAt: "2025-06-01T10:35:00Z"},
+			},
+			wantSetupFinish: "2025-06-01T10:03:00Z",
+			wantTestStart:   "2025-06-01T10:03:00Z",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSetup, gotTest := deriveSetupTestBoundary(tt.steps)
+
+			if tt.wantSetupFinish == "" {
+				if !gotSetup.IsZero() {
+					t.Errorf("setupFinishTime: got %v, want zero", gotSetup)
+				}
+			} else {
+				want := mustParseTime(t, tt.wantSetupFinish)
+				if !gotSetup.Equal(want) {
+					t.Errorf("setupFinishTime: got %v, want %v", gotSetup, want)
+				}
+			}
+
+			if tt.wantTestStart == "" {
+				if !gotTest.IsZero() {
+					t.Errorf("testStartTime: got %v, want zero", gotTest)
+				}
+			} else {
+				want := mustParseTime(t, tt.wantTestStart)
+				if !gotTest.Equal(want) {
+					t.Errorf("testStartTime: got %v, want %v", gotTest, want)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadTestTimingInfo_SetupTestBoundary(t *testing.T) {
+	dir := t.TempDir()
+	tm := SpecTimingMetadata{
+		Identifier: []string{"boundary-test"},
+		StartedAt:  "2025-06-01T10:00:00Z",
+		FinishedAt: "2025-06-01T11:00:00Z",
+		Steps: []StepTimingMetadata{
+			{Name: "Assign 2 identity containers", StartedAt: "2025-06-01T10:00:00Z", FinishedAt: "2025-06-01T10:02:00Z"},
+			{Name: "Create cluster", StartedAt: "2025-06-01T10:02:00Z", FinishedAt: "2025-06-01T10:50:00Z"},
+		},
+	}
+	writeYAML(t, filepath.Join(dir, "timing-metadata-boundary.yaml"), tm)
+
+	ctx := ctxWithLogger(t)
+	got, err := LoadTestTimingInfo(ctx, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	info := got["boundary-test"]
+
+	wantSetupFinish := mustParseTime(t, "2025-06-01T10:02:00Z")
+	if !info.SetupFinishTime.Equal(wantSetupFinish) {
+		t.Errorf("SetupFinishTime: got %v, want %v", info.SetupFinishTime, wantSetupFinish)
+	}
+
+	wantTestStart := mustParseTime(t, "2025-06-01T10:02:00Z")
+	if !info.TestStartTime.Equal(wantTestStart) {
+		t.Errorf("TestStartTime: got %v, want %v", info.TestStartTime, wantTestStart)
+	}
+
+	wantCleanup := mustParseTime(t, "2025-06-01T11:00:00Z")
+	if !info.CleanupStartTime.Equal(wantCleanup) {
+		t.Errorf("CleanupStartTime: got %v, want %v", info.CleanupStartTime, wantCleanup)
+	}
+}

--- a/tooling/hcpctl/cmd/must-gather/cmd.go
+++ b/tooling/hcpctl/cmd/must-gather/cmd.go
@@ -16,8 +16,6 @@ package mustgather
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/Azure/ARO-HCP/tooling/hcpctl/cmd/must-gather/snapshot"
 )
 
 var ServicesLogDirectory = "service"
@@ -62,12 +60,6 @@ and collecting diagnostic data for troubleshooting and analysis.`,
 		return nil, err
 	}
 	cmd.AddCommand(cleanCommand)
-
-	snapshotCommand, err := snapshot.NewCommand()
-	if err != nil {
-		return nil, err
-	}
-	cmd.AddCommand(snapshotCommand)
 
 	return cmd, nil
 }

--- a/tooling/hcpctl/cmd/must-gather/snapshot/from_prow_job_cmd.go
+++ b/tooling/hcpctl/cmd/must-gather/snapshot/from_prow_job_cmd.go
@@ -185,11 +185,13 @@ func (o *validatedFromProwJobOptions) run(ctx context.Context) error {
 			HCPDatabase:     jobConfig.HCPDatabase,
 			ResourceGroup:   test.ResourceGroup,
 			TimeWindow: snapshotpkg.TimeWindow{
-				Start: startTime,
-				End:   endTime,
+				Start:           startTime,
+				End:             endTime,
+				SetupFinishTime: test.SetupFinishTime,
 			},
 			QueryTimeout:     o.queryTimeout,
 			Concurrency:      o.concurrency,
+			TestStartTime:    test.TestStartTime,
 			CleanupStartTime: test.CleanupStartTime,
 		}
 
@@ -197,6 +199,9 @@ func (o *validatedFromProwJobOptions) run(ctx context.Context) error {
 		if err != nil {
 			logger.Error(err, "Failed to gather snapshot for test", "test", test.Name)
 			gatherErrors = append(gatherErrors, fmt.Errorf("test %q: %w", test.Name, err))
+			if ctx.Err() != nil {
+				break
+			}
 			continue
 		}
 
@@ -213,7 +218,7 @@ func (o *validatedFromProwJobOptions) run(ctx context.Context) error {
 
 		logger.Info("Snapshot complete for test",
 			"test", test.Name,
-			"resources", len(manifest.Resources),
+			"phases", len(manifest.Phases),
 		)
 	}
 

--- a/tooling/hcpctl/cmd/must-gather/snapshot/from_resource_cmd.go
+++ b/tooling/hcpctl/cmd/must-gather/snapshot/from_resource_cmd.go
@@ -162,7 +162,7 @@ func (o *completedFromResourceOptions) run(ctx context.Context) error {
 
 	logger.Info("Snapshot complete",
 		"outputDir", o.outputDir,
-		"resources", len(manifest.Resources),
+		"phases", len(manifest.Phases),
 	)
 
 	return nil

--- a/tooling/hcpctl/cmd/snapshot/analyze_cmd.go
+++ b/tooling/hcpctl/cmd/snapshot/analyze_cmd.go
@@ -1,0 +1,417 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/agent"
+	snapshotpkg "github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/snapshot"
+)
+
+// RawAnalyzeOptions holds the unvalidated CLI options for the analyze subcommand.
+type RawAnalyzeOptions struct {
+	DataDir             string
+	AROHCPPath          string
+	HypershiftPath      string
+	MaestroPath         string
+	ClustersServicePath string
+	ReviewRounds        int
+	MaxRounds           int
+	Output              string
+	Model               string
+
+	AuthMode        string
+	GitHubTokenFile string
+	ModelEndpoint   string
+	ModelDeployment string
+
+	Verbosity int
+}
+
+func defaultAnalyzeOptions() *RawAnalyzeOptions {
+	return &RawAnalyzeOptions{
+		ReviewRounds: 3,
+		MaxRounds:    50,
+		AuthMode:     agent.CopilotAuthModeLoggedIn,
+	}
+}
+
+func bindAnalyzeOptions(opts *RawAnalyzeOptions, cmd *cobra.Command) error {
+	cmd.Flags().StringVar(&opts.AROHCPPath, "aro-hcp", opts.AROHCPPath, "Path to ARO-HCP git checkout (required)")
+	cmd.Flags().StringVar(&opts.HypershiftPath, "hypershift", opts.HypershiftPath, "Path to HyperShift git checkout (required)")
+	cmd.Flags().StringVar(&opts.MaestroPath, "maestro", opts.MaestroPath, "Path to Maestro git checkout (required)")
+	cmd.Flags().StringVar(&opts.ClustersServicePath, "clusters-service", opts.ClustersServicePath, "Path to Clusters Service git checkout (required)")
+	cmd.Flags().IntVar(&opts.ReviewRounds, "review-rounds", opts.ReviewRounds, "Number of review rounds")
+	cmd.Flags().IntVar(&opts.MaxRounds, "max-rounds", opts.MaxRounds, "Maximum validation rounds per cycle")
+	cmd.Flags().StringVar(&opts.Output, "output", opts.Output, "Output directory for analysis results (defaults to data-dir)")
+	cmd.Flags().StringVar(&opts.Model, "model", opts.Model, "Override the Copilot model")
+	cmd.Flags().StringVar(&opts.AuthMode, "auth-mode", opts.AuthMode, "Copilot auth mode: logged-in, token, or byok")
+	cmd.Flags().StringVar(&opts.GitHubTokenFile, "github-token-file", opts.GitHubTokenFile, "Path to file containing GitHub token (required for token auth mode)")
+	cmd.Flags().StringVar(&opts.ModelEndpoint, "model-endpoint", opts.ModelEndpoint, "Azure AI Foundry endpoint URL (required for byok auth mode)")
+	cmd.Flags().StringVar(&opts.ModelDeployment, "model-deployment", opts.ModelDeployment, "Model deployment name (required for byok auth mode)")
+
+	for _, flag := range []string{"aro-hcp", "hypershift", "maestro", "clusters-service"} {
+		if err := cmd.MarkFlagRequired(flag); err != nil {
+			return fmt.Errorf("failed to mark %s as required: %w", flag, err)
+		}
+	}
+	return nil
+}
+
+type validatedAnalyzeOptions struct {
+	dataDir       string
+	worktreePaths map[string]string
+	reviewRounds  int
+	maxRounds     int
+	outputDir     string
+	agentConfig   *agent.AgentConfig
+}
+
+func (o *RawAnalyzeOptions) validate() (*validatedAnalyzeOptions, error) {
+	if o.DataDir == "" {
+		return nil, fmt.Errorf("data-dir argument is required")
+	}
+
+	// Verify data directory exists and contains a manifest.
+	manifestPath := filepath.Join(o.DataDir, "manifest.json")
+	if _, err := os.Stat(manifestPath); err != nil {
+		return nil, fmt.Errorf("data directory %q does not contain manifest.json: %w", o.DataDir, err)
+	}
+
+	// Verify all worktree paths exist.
+	worktreePaths := map[string]string{
+		"ARO-HCP":          o.AROHCPPath,
+		"hypershift":       o.HypershiftPath,
+		"maestro":          o.MaestroPath,
+		"clusters-service": o.ClustersServicePath,
+	}
+	for name, path := range worktreePaths {
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("--%s path %q: %w", name, path, err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("--%s path %q is not a directory", name, path)
+		}
+	}
+
+	outputDir := o.Output
+	if outputDir == "" {
+		outputDir = o.DataDir
+	}
+
+	// Validate auth mode.
+	agentCfg := &agent.AgentConfig{
+		AuthMode:        o.AuthMode,
+		GitHubTokenFile: o.GitHubTokenFile,
+		ModelEndpoint:   o.ModelEndpoint,
+		ModelDeployment: o.ModelDeployment,
+		Model:           o.Model,
+		MaxRounds:       o.MaxRounds,
+		Verbosity:       o.Verbosity,
+	}
+	switch o.AuthMode {
+	case agent.CopilotAuthModeLoggedIn, "":
+		agentCfg.AuthMode = agent.CopilotAuthModeLoggedIn
+	case agent.CopilotAuthModeToken:
+		if o.GitHubTokenFile == "" {
+			return nil, fmt.Errorf("--github-token-file is required when --auth-mode is %q", o.AuthMode)
+		}
+		if _, err := os.Stat(o.GitHubTokenFile); err != nil {
+			return nil, fmt.Errorf("--github-token-file %q: %w", o.GitHubTokenFile, err)
+		}
+	case agent.CopilotAuthModeBYOK:
+		if o.ModelEndpoint == "" {
+			return nil, fmt.Errorf("--model-endpoint is required when --auth-mode is %q", o.AuthMode)
+		}
+		if o.ModelDeployment == "" {
+			return nil, fmt.Errorf("--model-deployment is required when --auth-mode is %q", o.AuthMode)
+		}
+		// BYOK requires an Azure credential for Entra token acquisition.
+		cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
+			AdditionallyAllowedTenants:   []string{"*"},
+			RequireAzureTokenCredentials: true,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Azure credential for BYOK auth: %w", err)
+		}
+		agentCfg.AzureCredential = cred
+	default:
+		return nil, fmt.Errorf("unknown --auth-mode %q, must be one of: logged-in, token, byok", o.AuthMode)
+	}
+
+	return &validatedAnalyzeOptions{
+		dataDir:       o.DataDir,
+		worktreePaths: worktreePaths,
+		reviewRounds:  o.ReviewRounds,
+		maxRounds:     o.MaxRounds,
+		outputDir:     outputDir,
+		agentConfig:   agentCfg,
+	}, nil
+}
+
+func (o *validatedAnalyzeOptions) run(ctx context.Context) error {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	// Read manifest.
+	manifestData, err := os.ReadFile(filepath.Join(o.dataDir, "manifest.json"))
+	if err != nil {
+		return fmt.Errorf("failed to read manifest: %w", err)
+	}
+	var manifest snapshotpkg.Manifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return fmt.Errorf("failed to parse manifest: %w", err)
+	}
+
+	testError := readFileOrEmpty(filepath.Join(o.dataDir, "test_logs", "error.log"))
+	testOutput := readFileOrEmpty(filepath.Join(o.dataDir, "test_logs", "output.log"))
+	siblingTests := readFileOrEmpty(filepath.Join(o.dataDir, "sibling_tests.json"))
+
+	// Create Azure credential for Kusto access.
+	cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
+		AdditionallyAllowedTenants:   []string{"*"},
+		RequireAzureTokenCredentials: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create Azure credential: %w", err)
+	}
+
+	// Create Kusto client from manifest info.
+	kustoClient, err := agent.NewADXKustoClient(cred, manifest.KustoCluster, manifest.KustoDatabase)
+	if err != nil {
+		return fmt.Errorf("failed to create Kusto client: %w", err)
+	}
+	defer func() {
+		if err := kustoClient.Close(); err != nil {
+			logger.Error(err, "Failed to close Kusto client.")
+		}
+	}()
+	cachedKustoClient := agent.NewCachingKustoClient(kustoClient)
+
+	// Build Copilot session.
+	kustoTool := agent.NewKustoTool(cachedKustoClient)
+	systemMessage, err := agent.BuildSystemMessageConfig()
+	if err != nil {
+		return fmt.Errorf("failed to build system message config: %w", err)
+	}
+
+	// Set up workspace with symlinks in a temp directory.
+	workspaceDir, cleanup, err := setupAnalysisWorkspace(o.dataDir, o.worktreePaths)
+	if err != nil {
+		return fmt.Errorf("failed to set up analysis workspace: %w", err)
+	}
+	defer cleanup()
+
+	copilotClient, err := agent.NewCopilotClient(o.agentConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create Copilot client: %w", err)
+	}
+	defer func() {
+		if err := copilotClient.Stop(); err != nil {
+			logger.Error(err, "Failed to stop Copilot client.")
+		}
+	}()
+
+	session, err := copilotClient.CreateSession(ctx, logger, agent.SessionConfig{
+		WorkingDirectory: workspaceDir,
+		SystemMessage:    systemMessage,
+		Tools:            []copilot.Tool{kustoTool},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create Copilot session: %w", err)
+	}
+	var analysisErr error
+	defer func() {
+		session.SaveConversation(filepath.Join(o.outputDir, "conversation.json"))
+		if analysisErr == nil {
+			if err := session.Delete(ctx); err != nil {
+				logger.Error(err, "Failed to delete Copilot session.")
+			}
+		} else {
+			if err := session.Disconnect(); err != nil {
+				logger.Error(err, "Failed to disconnect Copilot session.")
+			}
+		}
+	}()
+
+	result, err := agent.Analyze(ctx, logger, session, cachedKustoClient, agent.AnalyzeOptions{
+		Manifest:            manifestData,
+		TestName:            manifest.TestName,
+		TestError:           testError,
+		TestOutput:          testOutput,
+		SiblingTests:        siblingTests,
+		DataDir:             o.dataDir,
+		WorktreePaths:       o.worktreePaths,
+		KustoCluster:        manifest.KustoCluster,
+		KustoDatabase:       manifest.KustoDatabase,
+		MaxValidationRounds: o.maxRounds,
+		ReviewRounds:        o.reviewRounds,
+	})
+	if err != nil {
+		analysisErr = err
+		return analysisErr
+	}
+	hydratedChain := result.HydratedChain
+
+	// Phase 5: Write output.
+	logger.Info("Phase 5: Writing output.")
+	if err := os.MkdirAll(o.outputDir, 0o755); err != nil {
+		analysisErr = fmt.Errorf("failed to create output directory: %w", err)
+		return analysisErr
+	}
+
+	analysisJSON, err := json.MarshalIndent(hydratedChain, "", "  ")
+	if err != nil {
+		analysisErr = fmt.Errorf("failed to marshal analysis: %w", err)
+		return analysisErr
+	}
+	if err := os.WriteFile(filepath.Join(o.outputDir, "analysis.json"), analysisJSON, 0o644); err != nil {
+		analysisErr = fmt.Errorf("failed to write analysis.json: %w", err)
+		return analysisErr
+	}
+
+	rendered := agent.RenderMarkdown(hydratedChain, manifest.TestName)
+	if err := os.WriteFile(filepath.Join(o.outputDir, "analysis.md"), []byte(rendered), 0o644); err != nil {
+		analysisErr = fmt.Errorf("failed to write analysis.md: %w", err)
+		return analysisErr
+	}
+
+	logger.Info("Analysis complete.",
+		"outputDir", o.outputDir,
+		"analysisJSON", filepath.Join(o.outputDir, "analysis.json"),
+		"analysisMarkdown", filepath.Join(o.outputDir, "analysis.md"),
+	)
+
+	return nil
+}
+
+// setupAnalysisWorkspace creates a temporary directory with symlinks to the
+// data directory and source code worktrees. Returns the workspace path and
+// a cleanup function that removes it.
+func setupAnalysisWorkspace(dataDir string, worktreePaths map[string]string) (string, func(), error) {
+	workspaceDir, err := os.MkdirTemp("", "hcpctl-analyze-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temp workspace: %w", err)
+	}
+
+	cleanup := func() {
+		os.RemoveAll(workspaceDir)
+	}
+
+	// Symlink data directory.
+	absDataDir, err := filepath.Abs(dataDir)
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("failed to resolve data directory: %w", err)
+	}
+	if err := os.Symlink(absDataDir, filepath.Join(workspaceDir, "data")); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("failed to symlink data directory: %w", err)
+	}
+
+	// Symlink source code worktrees.
+	if len(worktreePaths) > 0 {
+		srcDir := filepath.Join(workspaceDir, "src")
+		if err := os.MkdirAll(srcDir, 0o755); err != nil {
+			cleanup()
+			return "", nil, fmt.Errorf("failed to create src directory: %w", err)
+		}
+		for repo, repoPath := range worktreePaths {
+			absPath, err := filepath.Abs(repoPath)
+			if err != nil {
+				cleanup()
+				return "", nil, fmt.Errorf("failed to resolve path for %s: %w", repo, err)
+			}
+			if err := os.Symlink(absPath, filepath.Join(srcDir, repo)); err != nil {
+				cleanup()
+				return "", nil, fmt.Errorf("failed to symlink worktree for %s: %w", repo, err)
+			}
+		}
+	}
+
+	return workspaceDir, cleanup, nil
+}
+
+// readFileOrEmpty reads a file and returns its contents as a string,
+// or an empty string if the file does not exist or cannot be read.
+func readFileOrEmpty(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func newAnalyzeCommand() (*cobra.Command, error) {
+	opts := defaultAnalyzeOptions()
+	cmd := &cobra.Command{
+		Use:   "analyze <data-dir>",
+		Short: "Run LLM-driven root cause analysis on gathered diagnostic data",
+		Long: `Analyze a previously gathered diagnostic snapshot using an LLM agent
+(GitHub Copilot) to produce a structured root cause analysis.
+
+The agent examines the manifest, test logs, and Kusto query results,
+then iteratively refines its analysis through validation and review rounds.
+
+Requires a logged-in GitHub Copilot CLI session (gh auth login).
+
+The four repository flags point to local git checkouts at the commits
+that were deployed when the test ran. The agent uses these to read
+source code for evidence in its causal chain.`,
+		Example: `  # Analyze a gathered snapshot
+  hcpctl snapshot analyze ./snapshot-20250101-120000/periodic-ci-.../12345/TestFoo \
+    --aro-hcp ~/code/ARO-HCP \
+    --hypershift ~/code/hypershift \
+    --maestro ~/code/maestro \
+    --clusters-service ~/code/clusters-service
+
+  # With custom model and output directory
+  hcpctl snapshot analyze ./data \
+    --aro-hcp ~/code/ARO-HCP \
+    --hypershift ~/code/hypershift \
+    --maestro ~/code/maestro \
+    --clusters-service ~/code/clusters-service \
+    --model claude-opus-4.7 \
+    --output ./results`,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.DataDir = args[0]
+			verbosity, _ := cmd.Flags().GetInt("verbosity")
+			opts.Verbosity = verbosity
+			validated, err := opts.validate()
+			if err != nil {
+				return err
+			}
+			return validated.run(cmd.Context())
+		},
+	}
+	if err := bindAnalyzeOptions(opts, cmd); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}

--- a/tooling/hcpctl/cmd/snapshot/cmd.go
+++ b/tooling/hcpctl/cmd/snapshot/cmd.go
@@ -18,11 +18,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCommand creates the "snapshot" parent command with its subcommands.
-func NewCommand() (*cobra.Command, error) {
+// NewCommand creates the "snapshot" top-level command with its subcommands.
+func NewCommand(group string) (*cobra.Command, error) {
 	cmd := &cobra.Command{
-		Use:   "snapshot",
-		Short: "Gather a structured diagnostic snapshot for specific resources",
+		Use:     "snapshot",
+		Short:   "Gather and analyze structured diagnostic snapshots",
+		GroupID: group,
 		Long: `Gather a minimal, structured diagnostic snapshot by tracing ARM requests
 through frontend, backend, Clusters Service, Maestro, and HyperShift.
 
@@ -31,7 +32,8 @@ manifest.json index, suitable for automated analysis or manual review.
 
 Use one of the subcommands to specify the entrypoint:
   from-resource    Start from a resource group and time window
-  from-prow-job    Start from a Prow job URL (use --test to select a specific test)`,
+  from-prow-job    Start from a Prow job URL (use --test to select a specific test)
+  analyze          Run LLM-driven root cause analysis on gathered data`,
 		CompletionOptions: cobra.CompletionOptions{
 			HiddenDefaultCmd: true,
 		},
@@ -48,6 +50,12 @@ Use one of the subcommands to specify the entrypoint:
 		return nil, err
 	}
 	cmd.AddCommand(fromProwJobCmd)
+
+	analyzeCmd, err := newAnalyzeCommand()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(analyzeCmd)
 
 	return cmd, nil
 }

--- a/tooling/hcpctl/cmd/snapshot/from_prow_job_cmd.go
+++ b/tooling/hcpctl/cmd/snapshot/from_prow_job_cmd.go
@@ -88,7 +88,7 @@ func (o *validatedFromProwJobOptions) run(ctx context.Context) error {
 	logger.Info("Fetching Prow job data",
 		"job", o.prowInfo.JobName,
 		"prowID", o.prowInfo.ProwID,
-		"isPR", o.prowInfo.IsPR,
+		"isPR", o.prowInfo.IsPullRequest(),
 	)
 
 	// Phase 1 (per-job): Download Prow artifacts and parse config + test results.

--- a/tooling/hcpctl/cmd/snapshot/from_prow_job_cmd.go
+++ b/tooling/hcpctl/cmd/snapshot/from_prow_job_cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Azure/azure-kusto-go/azkustodata"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 
 	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/kusto"
 	snapshotpkg "github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/snapshot"
@@ -90,7 +91,7 @@ func (o *validatedFromProwJobOptions) run(ctx context.Context) error {
 		"isPR", o.prowInfo.IsPR,
 	)
 
-	// Phase 1: Download Prow artifacts and parse config + test results.
+	// Phase 1 (per-job): Download Prow artifacts and parse config + test results.
 	jobConfig, allTests, err := snapshotpkg.FetchProwJobData(ctx, o.prowInfo)
 	if err != nil {
 		return fmt.Errorf("failed to fetch Prow job data: %w", err)
@@ -123,14 +124,25 @@ func (o *validatedFromProwJobOptions) run(ctx context.Context) error {
 
 	logger.Info("Processing tests", "count", len(tests))
 
-	// Phase 2: Create Kusto client from the job's config.
+	// Compute sibling test summaries once for all tests.
+	siblingTests := snapshotpkg.ConvertTestResults(allTests)
+
+	// Phase 1 (per-job): Create Kusto client from the job's config.
 	kustoEndpoint, err := kusto.KustoEndpoint(jobConfig.KustoName, jobConfig.Region)
 	if err != nil {
 		return fmt.Errorf("failed to create Kusto endpoint: %w", err)
 	}
 
+	cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
+		AdditionallyAllowedTenants:   []string{"*"},
+		RequireAzureTokenCredentials: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create Azure credential: %w", err)
+	}
+
 	kcsb := azkustodata.NewConnectionStringBuilder(kustoEndpoint.String())
-	kcsb = kcsb.WithDefaultAzureCredential()
+	kcsb = kcsb.WithTokenCredential(cred)
 	kustoClient, err := azkustodata.New(kcsb)
 	if err != nil {
 		return fmt.Errorf("failed to create Kusto client: %w", err)
@@ -143,59 +155,33 @@ func (o *validatedFromProwJobOptions) run(ctx context.Context) error {
 
 	gatherer := snapshotpkg.NewGatherer(kustoClient)
 
-	// Phase 3: For each test, gather a snapshot.
+	// Phase 2 (per-test): Gather an enriched snapshot for each test.
 	var gatherErrors []error
-	for _, test := range tests {
+	for i := range tests {
+		test := &tests[i]
 		testName := snapshotpkg.SanitizeTestName(test.Name)
 		testOutputDir := filepath.Join(o.outputDir, o.prowInfo.JobName, o.prowInfo.ProwID, testName)
-
-		if test.ResourceGroup == "" {
-			logger.Info("Skipping test: could not extract resource group from test output",
-				"test", test.Name,
-			)
-			gatherErrors = append(gatherErrors, fmt.Errorf("test %q: no resource group found in test output", test.Name))
-			continue
-		}
-
-		// Determine time window: use test start/end times, with padding.
-		startTime := test.StartTime
-		endTime := test.EndTime
-		if startTime.IsZero() || endTime.IsZero() {
-			logger.Info("Skipping test: no start/end time available",
-				"test", test.Name,
-			)
-			gatherErrors = append(gatherErrors, fmt.Errorf("test %q: no start/end time available", test.Name))
-			continue
-		}
-		// Add 5-minute padding on each side to capture setup/teardown activity.
-		startTime = startTime.Add(-5 * time.Minute)
-		endTime = endTime.Add(5 * time.Minute)
 
 		logger.Info("Gathering snapshot for test",
 			"test", test.Name,
 			"resourceGroup", test.ResourceGroup,
-			"startTime", startTime.Format(time.RFC3339),
-			"endTime", endTime.Format(time.RFC3339),
 			"outputDir", testOutputDir,
 		)
 
-		input := snapshotpkg.GatherInput{
-			ClusterURI:      kustoEndpoint.String(),
-			ServiceDatabase: jobConfig.ServiceDatabase,
-			HCPDatabase:     jobConfig.HCPDatabase,
-			ResourceGroup:   test.ResourceGroup,
-			TimeWindow: snapshotpkg.TimeWindow{
-				Start:           startTime,
-				End:             endTime,
-				SetupFinishTime: test.SetupFinishTime,
-			},
-			QueryTimeout:     o.queryTimeout,
-			Concurrency:      o.concurrency,
-			TestStartTime:    test.TestStartTime,
-			CleanupStartTime: test.CleanupStartTime,
-		}
-
-		manifest, _, err := gatherer.Gather(ctx, input, testOutputDir)
+		result, err := snapshotpkg.GatherForTest(ctx, snapshotpkg.GatherForTestOptions{
+			Gatherer:              gatherer,
+			Test:                  test,
+			ProwJobURL:            o.prowInfo.URL,
+			KustoEndpoint:         kustoEndpoint.String(),
+			ServiceDatabase:       jobConfig.ServiceDatabase,
+			HCPDatabase:           jobConfig.HCPDatabase,
+			ServiceClusterName:    jobConfig.ServiceClusterName,
+			ManagementClusterName: jobConfig.ManagementClusterName,
+			SiblingTests:          siblingTests,
+			OutputDir:             testOutputDir,
+			QueryTimeout:          o.queryTimeout,
+			Concurrency:           o.concurrency,
+		})
 		if err != nil {
 			logger.Error(err, "Failed to gather snapshot for test", "test", test.Name)
 			gatherErrors = append(gatherErrors, fmt.Errorf("test %q: %w", test.Name, err))
@@ -205,20 +191,9 @@ func (o *validatedFromProwJobOptions) run(ctx context.Context) error {
 			continue
 		}
 
-		// Set the test name in the manifest.
-		manifest.TestName = test.Name
-		manifest.ProwJobURL = o.prowInfo.URL
-
-		// Re-write the manifest with the test name populated.
-		if err := snapshotpkg.WriteManifest(testOutputDir, manifest); err != nil {
-			logger.Error(err, "Failed to write manifest", "test", test.Name)
-			gatherErrors = append(gatherErrors, fmt.Errorf("test %q: failed to write manifest: %w", test.Name, err))
-			continue
-		}
-
 		logger.Info("Snapshot complete for test",
 			"test", test.Name,
-			"phases", len(manifest.Phases),
+			"phases", len(result.Manifest.Phases),
 		)
 	}
 
@@ -236,10 +211,15 @@ func newFromProwJobCommand() (*cobra.Command, error) {
 	opts := defaultFromProwJobOptions()
 	cmd := &cobra.Command{
 		Use:   "from-prow-job",
-		Short: "Gather diagnostic snapshots for failed tests in a Prow job",
-		Long: `Gather structured diagnostic snapshots by downloading Prow job artifacts from
-GCS, parsing the job's config.yaml for Kusto connection info, identifying
-failed tests, and running the data gathering pipeline for each one.
+		Short: "Gather enriched diagnostic snapshots for tests in a Prow job",
+		Long: `Gather structured, enriched diagnostic snapshots by downloading Prow job
+artifacts from GCS, parsing the job's config.yaml for Kusto connection info,
+identifying failed tests, and running the full data gathering pipeline for
+each one.
+
+Each test snapshot includes Kusto query results, test logs (error and output),
+sibling test metadata, and a manifest.json index suitable for automated
+analysis via the analyze subcommand.
 
 The Kusto cluster, region, and database names are automatically extracted
 from the job's config.yaml artifact. The resource group and time window
@@ -247,16 +227,16 @@ are extracted from each test's output logs and metadata.
 
 Use --test to filter to a specific test by name substring.`,
 		Example: `  # Gather snapshots for all failed tests in a periodic job
-  hcpctl must-gather snapshot from-prow-job \
+  hcpctl snapshot from-prow-job \
     --url https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-aro-hcp-e2e-parallel/1234567890
 
   # Gather snapshot for a specific test
-  hcpctl must-gather snapshot from-prow-job \
+  hcpctl snapshot from-prow-job \
     --url https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-aro-hcp-e2e-parallel/1234567890 \
     --test TestNodePoolCreation
 
   # PR job
-  hcpctl must-gather snapshot from-prow-job \
+  hcpctl snapshot from-prow-job \
     --url https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/9999/pull-ci-Azure-ARO-HCP-main-aro-hcp-e2e-parallel/1234567890`,
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,

--- a/tooling/hcpctl/cmd/snapshot/from_resource_cmd.go
+++ b/tooling/hcpctl/cmd/snapshot/from_resource_cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Azure/azure-kusto-go/azkustodata"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 
 	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/kusto"
 	snapshotpkg "github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/snapshot"
@@ -121,8 +122,15 @@ type completedFromResourceOptions struct {
 }
 
 func (o *validatedFromResourceOptions) complete() (*completedFromResourceOptions, error) {
+	cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
+		AdditionallyAllowedTenants:   []string{"*"},
+		RequireAzureTokenCredentials: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Azure credential: %w", err)
+	}
 	kcsb := azkustodata.NewConnectionStringBuilder(o.kustoEndpoint.String())
-	kcsb = kcsb.WithDefaultAzureCredential()
+	kcsb = kcsb.WithTokenCredential(cred)
 	client, err := azkustodata.New(kcsb)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Kusto client: %w", err)

--- a/tooling/hcpctl/go.mod
+++ b/tooling/hcpctl/go.mod
@@ -8,10 +8,12 @@ require (
 	github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260515164928-09422e2febea
 	github.com/Azure/azure-kusto-go/azkustodata v1.2.1
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0
 	github.com/Azure/kubelogin v0.2.9
 	github.com/dusted-go/logging v1.3.0
+	github.com/github/copilot-sdk/go v0.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -42,7 +44,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.7.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
@@ -85,6 +86,7 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.28.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/tooling/hcpctl/go.sum
+++ b/tooling/hcpctl/go.sum
@@ -117,6 +117,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/github/copilot-sdk/go v0.3.0 h1:LPMpoJzUTfrPbr/5e7s5QKvi66PMmREnbZ9kRxPe6ls=
+github.com/github/copilot-sdk/go v0.3.0/go.mod h1:uGWkjVYcp2DV9DgtqYihh5tEoJjNqxIFaUNnrwY4FxM=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
@@ -153,6 +155,8 @@ github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7O
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
 github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/vP9vJGqPwcdqsWjOt+V8J7+bTc=

--- a/tooling/hcpctl/internal/tabular/table.go
+++ b/tooling/hcpctl/internal/tabular/table.go
@@ -1,0 +1,29 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tabular provides a structured representation of tabular data
+// with preserved column ordering. It is used to store Kusto query results
+// and other table-shaped data in a way that survives JSON round-tripping
+// without losing column order.
+package tabular
+
+// Table represents ordered tabular data with named columns and string cell values.
+type Table struct {
+	// Columns lists the column names in display order.
+	Columns []string `json:"columns"`
+
+	// Rows contains the data rows. Each row is a slice of cell values
+	// positionally corresponding to Columns.
+	Rows [][]string `json:"rows"`
+}

--- a/tooling/hcpctl/main.go
+++ b/tooling/hcpctl/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/hcpctl/cmd/mc"
 	mustgather "github.com/Azure/ARO-HCP/tooling/hcpctl/cmd/must-gather"
 	"github.com/Azure/ARO-HCP/tooling/hcpctl/cmd/sc"
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/cmd/snapshot"
 	"github.com/Azure/ARO-HCP/tooling/hcpctl/cmd/version"
 )
 
@@ -94,6 +95,7 @@ and hosted control plane services for operational and emergency scenarios.`,
 		hcp.NewCommand,
 		mustgather.NewCommand,
 		datadumptogit.NewCommand,
+		snapshot.NewCommand,
 	}
 	for _, newCmd := range mainCommands {
 		c, err := newCmd(mainGroupID)

--- a/tooling/hcpctl/pkg/agent/agent.go
+++ b/tooling/hcpctl/pkg/agent/agent.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
@@ -97,7 +98,7 @@ func NewCopilotClient(cfg *AgentConfig) (*CopilotClient, error) {
 		if err != nil {
 			return nil, fmt.Errorf("reading GitHub token from %s: %w", cfg.GitHubTokenFile, err)
 		}
-		clientOpts.GitHubToken = string(token)
+		clientOpts.GitHubToken = strings.TrimSpace(string(token))
 	case CopilotAuthModeBYOK:
 		// BYOK auth is configured per-session via ProviderConfig, not at the
 		// client level. Disable logged-in auth so the CLI doesn't try to

--- a/tooling/hcpctl/pkg/agent/agent.go
+++ b/tooling/hcpctl/pkg/agent/agent.go
@@ -1,0 +1,452 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package agent implements LLM-driven test failure analysis using the
+// GitHub Copilot SDK. It wraps the Copilot CLI process and provides a
+// structured session interface for analysis workflows.
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/go-logr/logr"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+const (
+	// CopilotAuthModeLoggedIn uses the developer's GitHub CLI session.
+	CopilotAuthModeLoggedIn = "logged-in"
+	// CopilotAuthModeToken reads a GitHub token from a file.
+	CopilotAuthModeToken = "token"
+	// CopilotAuthModeBYOK uses an Azure Entra token against a model endpoint.
+	CopilotAuthModeBYOK = "byok"
+)
+
+// AgentConfig configures the agent's auth and model settings.
+// This is the superset of configuration options — callers populate
+// only the fields relevant to their auth mode.
+type AgentConfig struct {
+	// AuthMode is one of "logged-in", "token", or "byok".
+	AuthMode string
+
+	// GitHubTokenFile is the path to a file containing a GitHub token (token mode).
+	GitHubTokenFile string
+
+	// ModelEndpoint is the Azure AI Foundry endpoint URL (byok mode).
+	ModelEndpoint string
+
+	// ModelDeployment is the model deployment name (byok mode).
+	ModelDeployment string
+
+	// AzureCredential is used to acquire Entra tokens for BYOK sessions.
+	AzureCredential azcore.TokenCredential
+
+	// Model overrides the default model for Copilot sessions.
+	Model string
+
+	// MaxRounds is the maximum number of tool-call rounds per session.
+	MaxRounds int
+
+	// Verbosity is the log verbosity level from the CLI. When >= 5,
+	// the Copilot CLI subprocess is started with --log-level=debug and
+	// all session events are traced.
+	Verbosity int
+}
+
+// CopilotClient wraps a copilot.Client that manages the Copilot CLI process.
+// One instance is created per process lifetime.
+type CopilotClient struct {
+	inner *copilot.Client
+	cfg   *AgentConfig
+}
+
+// NewCopilotClient creates a CopilotClient configured for the given auth mode.
+// The underlying CLI process is started lazily on first session creation
+// (AutoStart defaults to true).
+func NewCopilotClient(cfg *AgentConfig) (*CopilotClient, error) {
+	clientOpts := &copilot.ClientOptions{}
+
+	if cfg.Verbosity >= 5 {
+		clientOpts.LogLevel = "debug"
+	}
+
+	switch cfg.AuthMode {
+	case CopilotAuthModeLoggedIn, "":
+		// UseLoggedInUser defaults to true; no extra config needed.
+	case CopilotAuthModeToken:
+		token, err := os.ReadFile(cfg.GitHubTokenFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading GitHub token from %s: %w", cfg.GitHubTokenFile, err)
+		}
+		clientOpts.GitHubToken = string(token)
+	case CopilotAuthModeBYOK:
+		// BYOK auth is configured per-session via ProviderConfig, not at the
+		// client level. Disable logged-in auth so the CLI doesn't try to
+		// authenticate with GitHub.
+		clientOpts.UseLoggedInUser = copilot.Bool(false)
+	default:
+		return nil, fmt.Errorf("unsupported copilot auth mode: %q", cfg.AuthMode)
+	}
+
+	return &CopilotClient{
+		inner: copilot.NewClient(clientOpts),
+		cfg:   cfg,
+	}, nil
+}
+
+// Stop shuts down the Copilot CLI process and releases all resources.
+func (c *CopilotClient) Stop() error {
+	return c.inner.Stop()
+}
+
+// SessionConfig configures a new analysis session.
+type SessionConfig struct {
+	// WorkingDirectory is the workspace root for the Copilot session.
+	// Tool operations (read_file, grep, bash, glob) are relative to this directory.
+	WorkingDirectory string
+
+	// SystemMessage configures system prompt customization.
+	SystemMessage *copilot.SystemMessageConfig
+
+	// Tools are custom tools (e.g. kusto_query) registered on this session.
+	Tools []copilot.Tool
+
+	// Model overrides the default model for this session.
+	Model string
+}
+
+// Session wraps a copilot.Session for a single analysis run. It snapshots
+// the full conversation history after every successful SendAndWait so that
+// the conversation can be saved even if the CLI process is no longer
+// available (e.g. after ctrl-C kills the subprocess).
+type Session struct {
+	inner        *copilot.Session
+	client       *CopilotClient
+	logger       logr.Logger
+	lastMessages json.RawMessage
+}
+
+// CreateSession creates a new Copilot session for an analysis run.
+func (c *CopilotClient) CreateSession(ctx context.Context, logger logr.Logger, cfg SessionConfig) (*Session, error) {
+	sessionCfg := &copilot.SessionConfig{
+		Model:               cfg.Model,
+		SystemMessage:       cfg.SystemMessage,
+		Tools:               cfg.Tools,
+		WorkingDirectory:    cfg.WorkingDirectory,
+		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+		// Disable config discovery — we don't want to pick up .mcp.json or
+		// AGENTS.md from the analysis workspace.
+		EnableConfigDiscovery: false,
+	}
+
+	// Apply the configured model if the caller didn't override.
+	if sessionCfg.Model == "" && c.cfg.Model != "" {
+		sessionCfg.Model = c.cfg.Model
+	}
+
+	// Configure BYOK provider if applicable.
+	if c.cfg.AuthMode == CopilotAuthModeBYOK {
+		token, err := c.cfg.AzureCredential.GetToken(ctx, policy.TokenRequestOptions{
+			Scopes: []string{"https://cognitiveservices.azure.com/.default"},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("acquiring Entra token for BYOK copilot session: %w", err)
+		}
+		sessionCfg.Provider = &copilot.ProviderConfig{
+			Type:        "azure",
+			BaseURL:     c.cfg.ModelEndpoint,
+			BearerToken: token.Token,
+		}
+		if sessionCfg.Model == "" {
+			sessionCfg.Model = c.cfg.ModelDeployment
+		}
+	}
+
+	session, err := c.inner.CreateSession(ctx, sessionCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create copilot session: %w", err)
+	}
+
+	logger = logger.WithValues("sessionID", session.SessionID)
+	logger.Info("Created Copilot session.")
+
+	s := &Session{
+		inner:  session,
+		client: c,
+		logger: logger,
+	}
+
+	// When verbosity is high enough, trace every session event for debugging.
+	if c.cfg.Verbosity >= 5 {
+		s.traceEvents()
+	}
+
+	return s, nil
+}
+
+// SessionID returns the unique identifier for this session.
+func (s *Session) SessionID() string {
+	return s.inner.SessionID
+}
+
+// SendAndWait sends a prompt to the session and blocks until the agent is idle.
+// If ctx is cancelled, the in-flight work is aborted.
+// Returns the final assistant message content.
+func (s *Session) SendAndWait(ctx context.Context, prompt string) (string, error) {
+	s.logger.V(1).Info("Sending message to Copilot session.", "promptLength", len(prompt))
+
+	// The SDK applies a 60s default timeout when the context has no deadline.
+	// Analysis turns routinely take 10+ minutes, so set a generous deadline
+	// to prevent the SDK from timing out prematurely. The caller's context
+	// cancellation (via the abort path below) remains the real control.
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 30*time.Minute)
+		defer cancel()
+	}
+
+	// Run SendAndWait in a goroutine so we can select on ctx.Done() for abort.
+	type result struct {
+		event *copilot.SessionEvent
+		err   error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		ev, err := s.inner.SendAndWait(ctx, copilot.MessageOptions{
+			Prompt: prompt,
+		})
+		ch <- result{event: ev, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		s.logger.Info("Context cancelled, aborting Copilot session.")
+		if err := s.inner.Abort(context.Background()); err != nil {
+			s.logger.Error(err, "Failed to abort Copilot session.")
+		}
+		// Wait for SendAndWait to return after abort.
+		r := <-ch
+		if r.err != nil {
+			return "", fmt.Errorf("copilot session aborted: %w", r.err)
+		}
+		return "", ctx.Err()
+	case r := <-ch:
+		if r.err != nil {
+			return "", fmt.Errorf("copilot session failed: %w", r.err)
+		}
+		if r.event == nil {
+			return "", fmt.Errorf("copilot session returned no response")
+		}
+		data, ok := r.event.Data.(*copilot.AssistantMessageData)
+		if !ok {
+			return "", fmt.Errorf("copilot session returned unexpected event type %T", r.event.Data)
+		}
+		s.logger.V(1).Info("Copilot session responded.", "responseLength", len(data.Content))
+		s.snapshotMessages()
+		return data.Content, nil
+	}
+}
+
+// Disconnect releases in-memory session resources. Session state is preserved
+// on disk and can be resumed later.
+func (s *Session) Disconnect() error {
+	return s.inner.Disconnect()
+}
+
+// Delete permanently removes all session data from disk.
+func (s *Session) Delete(ctx context.Context) error {
+	return s.client.inner.DeleteSession(ctx, s.inner.SessionID)
+}
+
+// snapshotMessages fetches the full conversation history from the SDK and
+// caches it locally. If the RPC fails (e.g. process is dying), the last
+// successful snapshot is preserved.
+func (s *Session) snapshotMessages() {
+	events, err := s.inner.GetMessages(context.Background())
+	if err != nil {
+		s.logger.Error(err, "Failed to snapshot session messages.")
+		return
+	}
+	data, err := json.MarshalIndent(events, "", "  ")
+	if err != nil {
+		s.logger.Error(err, "Failed to marshal session messages for snapshot.")
+		return
+	}
+	s.lastMessages = data
+}
+
+// SaveConversation writes the most recent conversation snapshot to a JSON
+// file at the given path. Because messages are snapshotted after every
+// successful turn, this works even after the CLI subprocess has exited.
+// This is best-effort: errors are logged but not returned.
+func (s *Session) SaveConversation(path string) {
+	if s.lastMessages == nil {
+		s.logger.Info("No conversation messages to save.")
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		s.logger.Error(err, "Failed to create directory for conversation dump.", "path", path)
+		return
+	}
+
+	if err := os.WriteFile(path, s.lastMessages, 0644); err != nil {
+		s.logger.Error(err, "Failed to write conversation to disk.", "path", path)
+		return
+	}
+
+	s.logger.Info("Wrote conversation to disk.", "path", path, "size", len(s.lastMessages))
+}
+
+// traceEvents subscribes to all session events and logs them at V(5) for
+// debugging. This helps diagnose hangs by showing exactly what the Copilot
+// CLI subprocess is doing: tool calls, permission requests, errors, etc.
+func (s *Session) traceEvents() {
+	s.inner.On(func(event copilot.SessionEvent) {
+		switch d := event.Data.(type) {
+		case *copilot.AssistantMessageData:
+			s.logger.V(5).Info("Copilot event: AssistantMessage",
+				"contentLength", len(d.Content),
+			)
+		case *copilot.AssistantMessageDeltaData:
+			s.logger.V(5).Info("Copilot event: AssistantMessageDelta",
+				"deltaLength", len(d.DeltaContent),
+			)
+		case *copilot.AssistantTurnStartData:
+			s.logger.V(5).Info("Copilot event: AssistantTurnStart",
+				"turnID", d.TurnID,
+			)
+		case *copilot.AssistantTurnEndData:
+			s.logger.V(5).Info("Copilot event: AssistantTurnEnd",
+				"turnID", d.TurnID,
+			)
+		case *copilot.SessionIdleData:
+			s.logger.V(5).Info("Copilot event: SessionIdle")
+		case *copilot.SessionErrorData:
+			s.logger.V(5).Info("Copilot event: SessionError",
+				"message", d.Message,
+			)
+		case *copilot.SessionWarningData:
+			s.logger.V(5).Info("Copilot event: SessionWarning",
+				"message", d.Message,
+				"warningType", d.WarningType,
+			)
+		case *copilot.SessionStartData:
+			s.logger.V(5).Info("Copilot event: SessionStart")
+		case *copilot.SessionInfoData:
+			s.logger.V(5).Info("Copilot event: SessionInfo",
+				"infoType", d.InfoType,
+				"message", d.Message,
+			)
+		case *copilot.ToolExecutionStartData:
+			s.logger.V(5).Info("Copilot event: ToolExecutionStart",
+				"toolName", d.ToolName,
+				"toolCallID", d.ToolCallID,
+			)
+		case *copilot.ToolExecutionCompleteData:
+			s.logger.V(5).Info("Copilot event: ToolExecutionComplete",
+				"toolCallID", d.ToolCallID,
+				"success", d.Success,
+			)
+		case *copilot.ToolExecutionProgressData:
+			s.logger.V(5).Info("Copilot event: ToolExecutionProgress",
+				"toolCallID", d.ToolCallID,
+				"message", d.ProgressMessage,
+			)
+		case *copilot.ExternalToolRequestedData:
+			s.logger.V(5).Info("Copilot event: ExternalToolRequested",
+				"toolName", d.ToolName,
+				"requestID", d.RequestID,
+			)
+		case *copilot.ExternalToolCompletedData:
+			s.logger.V(5).Info("Copilot event: ExternalToolCompleted",
+				"requestID", d.RequestID,
+			)
+		case *copilot.PermissionRequestedData:
+			s.logger.V(5).Info("Copilot event: PermissionRequested",
+				"requestID", d.RequestID,
+			)
+		case *copilot.PermissionCompletedData:
+			s.logger.V(5).Info("Copilot event: PermissionCompleted",
+				"requestID", d.RequestID,
+			)
+		case *copilot.UserInputRequestedData:
+			s.logger.V(5).Info("Copilot event: UserInputRequested",
+				"question", d.Question,
+				"requestID", d.RequestID,
+			)
+		case *copilot.UserInputCompletedData:
+			s.logger.V(5).Info("Copilot event: UserInputCompleted",
+				"requestID", d.RequestID,
+			)
+		case *copilot.SessionModelChangeData:
+			s.logger.V(5).Info("Copilot event: SessionModelChange",
+				"newModel", d.NewModel,
+			)
+		case *copilot.SessionCompactionStartData:
+			s.logger.V(5).Info("Copilot event: SessionCompactionStart")
+		case *copilot.SessionCompactionCompleteData:
+			s.logger.V(5).Info("Copilot event: SessionCompactionComplete")
+		case *copilot.SessionTruncationData:
+			s.logger.V(5).Info("Copilot event: SessionTruncation")
+		case *copilot.SessionUsageInfoData:
+			s.logger.V(5).Info("Copilot event: SessionUsageInfo")
+		case *copilot.AssistantUsageData:
+			s.logger.V(5).Info("Copilot event: AssistantUsage",
+				"model", d.Model,
+				"inputTokens", d.InputTokens,
+				"outputTokens", d.OutputTokens,
+			)
+		case *copilot.SubagentStartedData:
+			s.logger.V(5).Info("Copilot event: SubagentStarted",
+				"agentName", d.AgentName,
+			)
+		case *copilot.SubagentCompletedData:
+			s.logger.V(5).Info("Copilot event: SubagentCompleted",
+				"agentName", d.AgentName,
+			)
+		case *copilot.SubagentFailedData:
+			s.logger.V(5).Info("Copilot event: SubagentFailed",
+				"agentName", d.AgentName,
+				"error", d.Error,
+			)
+		case *copilot.SessionShutdownData:
+			s.logger.V(5).Info("Copilot event: SessionShutdown",
+				"shutdownType", d.ShutdownType,
+			)
+		case *copilot.AbortData:
+			s.logger.V(5).Info("Copilot event: Abort",
+				"reason", d.Reason,
+			)
+		case *copilot.AssistantReasoningData:
+			s.logger.V(5).Info("Copilot event: AssistantReasoning")
+		case *copilot.AssistantIntentData:
+			s.logger.V(5).Info("Copilot event: AssistantIntent",
+				"intent", d.Intent,
+			)
+		default:
+			s.logger.V(5).Info("Copilot event: unknown",
+				"type", fmt.Sprintf("%T", event.Data),
+			)
+		}
+	})
+}

--- a/tooling/hcpctl/pkg/agent/analyze.go
+++ b/tooling/hcpctl/pkg/agent/analyze.go
@@ -83,7 +83,7 @@ func Analyze(ctx context.Context, logger logr.Logger, session *Session, kustoCli
 		maxValidationRounds = 10
 	}
 	reviewRounds := opts.ReviewRounds
-	if reviewRounds < 0 {
+	if reviewRounds <= 0 {
 		reviewRounds = 3
 	}
 

--- a/tooling/hcpctl/pkg/agent/analyze.go
+++ b/tooling/hcpctl/pkg/agent/analyze.go
@@ -1,0 +1,237 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-logr/logr"
+)
+
+// AnalyzeOptions configures a single analysis run.
+type AnalyzeOptions struct {
+	// Manifest is the raw manifest.json content.
+	Manifest []byte
+
+	// TestName is the name of the failed test (used for rendering).
+	TestName string
+
+	// TestError is the content of test_logs/error.log, or empty.
+	TestError string
+
+	// TestOutput is the content of test_logs/output.log, or empty.
+	TestOutput string
+
+	// SiblingTests is the content of sibling_tests.json, or empty.
+	SiblingTests string
+
+	// DataDir is the root of the structured data directory.
+	DataDir string
+
+	// WorktreePaths maps repository names to local filesystem paths.
+	WorktreePaths map[string]string
+
+	// KustoCluster is the Kusto cluster URI for hydration share links.
+	KustoCluster string
+
+	// KustoDatabase is the Kusto database name.
+	KustoDatabase string
+
+	// MaxValidationRounds is the maximum number of parse/validate correction
+	// rounds per validate-draft cycle. Zero defaults to 10.
+	MaxValidationRounds int
+
+	// ReviewRounds is the number of review passes. Zero defaults to 3.
+	ReviewRounds int
+}
+
+// AnalyzeResult contains the output of a successful analysis.
+type AnalyzeResult struct {
+	// HydratedChain is the fully validated and hydrated causal chain.
+	HydratedChain *HydratedChain
+
+	// DraftChain is the last validated draft before the final hydration.
+	DraftChain *DraftChain
+}
+
+// Analyze runs the full agentic analysis loop: initial prompt, validate-draft,
+// hydrate, and review rounds. It requires an already-created Session and
+// KustoClient. The caller is responsible for session lifecycle (create, save
+// conversation, delete/disconnect) and Kusto client lifecycle (create, close).
+//
+// The function sends the initial prompt, validates and corrects the agent's
+// output, hydrates proof items with real query results and code excerpts,
+// then runs review rounds where the agent sees its rendered output and can
+// refine it.
+func Analyze(ctx context.Context, logger logr.Logger, session *Session, kustoClient KustoClient, opts AnalyzeOptions) (*AnalyzeResult, error) {
+	maxValidationRounds := opts.MaxValidationRounds
+	if maxValidationRounds <= 0 {
+		maxValidationRounds = 10
+	}
+	reviewRounds := opts.ReviewRounds
+	if reviewRounds < 0 {
+		reviewRounds = 3
+	}
+
+	// Phase 1: Send initial prompt.
+	logger.Info("Sending initial analysis prompt.")
+	prompt := BuildInitialPrompt(string(opts.Manifest), opts.TestError, opts.TestOutput, opts.SiblingTests, opts.DataDir, opts.WorktreePaths)
+	output, err := session.SendAndWait(ctx, prompt)
+	if err != nil {
+		return nil, fmt.Errorf("agent analysis failed: %w", err)
+	}
+
+	// Build validation context.
+	validRepos := make(map[string]bool, len(opts.WorktreePaths))
+	for repo := range opts.WorktreePaths {
+		validRepos[repo] = true
+	}
+	vc := &ValidationContext{
+		ValidRepos:    validRepos,
+		WorktreePaths: opts.WorktreePaths,
+		DataDir:       opts.DataDir,
+		TestError:     opts.TestError,
+		TestOutput:    opts.TestOutput,
+	}
+
+	// Phase 2: Validate draft loop.
+	logger.Info("Validating agent output.")
+	draftChain, _, err := ValidateDraftLoop(ctx, logger, session, kustoClient, vc, output, maxValidationRounds)
+	if err != nil {
+		return nil, err
+	}
+
+	// Log the validated draft for exemplar collection.
+	if draftJSON, err := json.Marshal(draftChain); err != nil {
+		logger.Error(err, "Failed to marshal draft chain to JSON for logging.")
+	} else {
+		logger.V(1).Info("Validated draft chain.", "draft", string(draftJSON))
+	}
+
+	// Phase 3: Hydration.
+	logger.Info("Hydrating analysis.")
+	hydrator := NewHydrator(kustoClient, opts.KustoCluster, opts.KustoDatabase, opts.WorktreePaths, opts.TestError, opts.TestOutput, opts.DataDir)
+	hydratedChain, err := hydrator.Hydrate(ctx, draftChain)
+	if err != nil {
+		return nil, fmt.Errorf("hydration failed: %w", err)
+	}
+	if err := Validate(hydratedChain); err != nil {
+		return nil, fmt.Errorf("hydrated chain validation failed: %w", err)
+	}
+
+	// Phase 4: Review rounds.
+	for review := 0; review < reviewRounds; review++ {
+		logger.Info("Review pass.", "round", review+1)
+
+		rendered := RenderMarkdown(hydratedChain, opts.TestName)
+		reviewPrompt := BuildReviewPrompt(rendered)
+
+		output, err = session.SendAndWait(ctx, reviewPrompt)
+		if err != nil {
+			return nil, fmt.Errorf("agent review failed at round %d: %w", review+1, err)
+		}
+
+		draftChain, _, err = ValidateDraftLoop(ctx, logger, session, kustoClient, vc, output, maxValidationRounds)
+		if err != nil {
+			return nil, err
+		}
+
+		hydratedChain, err = hydrator.Hydrate(ctx, draftChain)
+		if err != nil {
+			return nil, fmt.Errorf("hydration failed after review round %d: %w", review+1, err)
+		}
+		if err := Validate(hydratedChain); err != nil {
+			return nil, fmt.Errorf("hydrated chain validation failed after review round %d: %w", review+1, err)
+		}
+	}
+
+	return &AnalyzeResult{
+		HydratedChain: hydratedChain,
+		DraftChain:    draftChain,
+	}, nil
+}
+
+// ValidateDraftLoop parses and validates the agent's output, sending correction
+// feedback for up to maxRounds iterations. It returns the validated draft chain
+// and the raw output string (which may have been updated by agent corrections).
+func ValidateDraftLoop(
+	ctx context.Context,
+	logger logr.Logger,
+	session *Session,
+	kustoClient KustoClient,
+	vc *ValidationContext,
+	output string,
+	maxRounds int,
+) (*DraftChain, string, error) {
+	var draftChain *DraftChain
+	var err error
+	for attempt := 0; ; attempt++ {
+		draftChain, err = ParseDraftChain(output)
+		if err != nil {
+			if attempt >= maxRounds {
+				return nil, output, fmt.Errorf("failed to parse agent output as draft chain after %d correction rounds: %w", attempt, err)
+			}
+			logger.Info("Failed to parse agent output as JSON; sending correction to agent.", "attempt", attempt+1, "error", err)
+			output, err = session.SendAndWait(ctx, fmt.Sprintf(
+				"Your output could not be parsed as valid JSON: %v\n\nPlease re-emit the complete JSON output.", err,
+			))
+			if err != nil {
+				return nil, output, fmt.Errorf("agent correction failed at attempt %d: %w", attempt+1, err)
+			}
+			continue
+		}
+
+		feedback := ValidateDraft(ctx, kustoClient, draftChain, vc)
+		if feedback == "" {
+			break // all validation passed
+		}
+
+		if attempt >= maxRounds {
+			logger.Info("Validation still has failures after max correction rounds; proceeding with best-effort.", "attempts", attempt)
+			break
+		}
+
+		logger.Info("Validation found errors; sending corrections to agent.", "attempt", attempt+1)
+		output, err = session.SendAndWait(ctx, feedback)
+		if err != nil {
+			return nil, output, fmt.Errorf("agent correction failed at attempt %d: %w", attempt+1, err)
+		}
+	}
+	return draftChain, output, nil
+}
+
+// BuildReviewPrompt constructs the prompt sent to the agent during review
+// rounds, asking it to review and re-emit the analysis.
+func BuildReviewPrompt(rendered string) string {
+	return fmt.Sprintf(
+		"Below is your analysis rendered as a complete document with query results.\n\n"+
+			"Review it for:\n"+
+			"1. **Narrative coherence** — does each answer directly and completely address its question? "+
+			"Does each subsequent question follow naturally from the previous answer? "+
+			"Do any answers 'jump' more than one layer down the stack, omitting crucial context?\n"+
+			"2. **Evidence quality** — do the query results actually support the answers? "+
+			"Are there unexpected results (empty tables, too many rows, irrelevant columns, repetitive output)?\n"+
+			"3. **Depth** — have you stopped the chain too early? Could you ask another \"why?\" to get deeper?\n"+
+			"4. **Accuracy** — now that you can see the actual query results, do any of your answers need revision?\n\n"+
+			"**Important:** The output you produce is the final document shown to readers. "+
+			"Do not mention the review process, do not add notes about what you changed or why, "+
+			"and do not reference these instructions. The document should read as if it were "+
+			"written correctly the first time.\n\n"+
+			"Re-emit the complete corrected JSON output (even if no changes are needed). "+
+			"---\n\n%s", rendered,
+	)
+}

--- a/tooling/hcpctl/pkg/agent/hydration.go
+++ b/tooling/hcpctl/pkg/agent/hydration.go
@@ -198,13 +198,9 @@ func (h *Hydrator) backfillAllDiscovery(ctx context.Context) []HydratedDiscovery
 		if !d.IsDir() || d.Name() != "discovery" {
 			return nil
 		}
-		relPath, relErr := filepath.Rel(h.dataDir, p)
-		if relErr != nil {
-			return nil
-		}
-		items, hydrateErr := h.hydrateDiscoveryDir(p, relPath)
+		items, hydrateErr := h.hydrateDiscoveryDir(p)
 		if hydrateErr != nil {
-			slog.WarnContext(ctx, "Failed to hydrate discovery directory; skipping.", "path", relPath, "error", hydrateErr)
+			slog.WarnContext(ctx, "Failed to hydrate discovery directory; skipping.", "path", p, "error", hydrateErr)
 			return filepath.SkipDir
 		}
 		result = append(result, items...)
@@ -284,77 +280,78 @@ func (h *Hydrator) extractLogExcerpt(source string, start, end int) (string, err
 	return strings.Join(allLines[start-1:end], "\n"), nil
 }
 
-// hydrateDiscoveryDir walks a discovery directory and produces a HydratedDiscovery
-// for each Markdown file in its immediate subdirectories that contains a KQL query.
-func (h *Hydrator) hydrateDiscoveryDir(absDir, relativeBase string) ([]HydratedDiscovery, error) {
+// hydrateDiscoveryDir recursively walks a discovery directory and produces a
+// HydratedDiscovery for every Markdown file that contains a KQL query block,
+// regardless of nesting depth.
+func (h *Hydrator) hydrateDiscoveryDir(absDir string) ([]HydratedDiscovery, error) {
 	var items []HydratedDiscovery
 
-	components, err := os.ReadDir(absDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read discovery directory: %w", err)
-	}
-
-	for _, component := range components {
-		if !component.IsDir() {
-			continue
-		}
-		componentDir := filepath.Join(absDir, component.Name())
-		files, err := os.ReadDir(componentDir)
+	err := filepath.WalkDir(absDir, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
-			slog.Warn("Failed to read discovery component directory; skipping.", "path", componentDir, "error", err)
-			continue
+			return nil
 		}
-		for _, file := range files {
-			if file.IsDir() || !strings.HasSuffix(file.Name(), ".md") {
-				continue
-			}
-			filePath := filepath.Join(componentDir, file.Name())
-			content, err := os.ReadFile(filePath)
-			if err != nil {
-				slog.Warn("Failed to read discovery markdown file; skipping.", "path", filePath, "error", err)
-				continue
-			}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
 
-			kql := extractMarkdownKQL(string(content))
-			if kql == "" {
-				continue // No KQL block — skip this file.
-			}
+		content, err := os.ReadFile(p)
+		if err != nil {
+			slog.Warn("Failed to read discovery markdown file; skipping.", "path", p, "error", err)
+			return nil
+		}
 
-			factName := strings.TrimSuffix(file.Name(), ".md")
-			leafRelPath := filepath.Join(relativeBase, component.Name(), factName)
+		kql := extractMarkdownKQL(string(content))
+		if kql == "" {
+			return nil // No KQL block — skip this file.
+		}
 
-			hd := HydratedDiscovery{
-				Directory: leafRelPath,
-				KQL:       kql,
-			}
+		relPath, err := filepath.Rel(filepath.Dir(absDir), p)
+		if err != nil {
+			slog.Warn("Failed to compute relative path for discovery file; skipping.", "path", p, "error", err)
+			return nil
+		}
+		// Strip the .md extension for the directory label.
+		relPath = strings.TrimSuffix(relPath, ".md")
 
-			// Extract label from ## Summary section.
-			hd.Label = extractReadmeSummary(string(content))
-			if hd.Label == "" {
-				hd.Label = component.Name() + " / " + factName
-			}
+		// Use the parent directory name and file stem as a fallback label.
+		parentDir := filepath.Base(filepath.Dir(p))
+		factName := strings.TrimSuffix(d.Name(), ".md")
 
-			// Generate share URI.
-			shareURI, err := queryToDeepLink(h.kustoEndpoint, h.kustoDatabase, hd.KQL)
-			if err != nil {
-				slog.Warn("Failed to generate share URI for discovery query; continuing.", "path", leafRelPath, "error", err)
+		hd := HydratedDiscovery{
+			Directory: relPath,
+			KQL:       kql,
+		}
+
+		// Extract label from ## Summary section.
+		hd.Label = extractReadmeSummary(string(content))
+		if hd.Label == "" {
+			hd.Label = parentDir + " / " + factName
+		}
+
+		// Generate share URI.
+		shareURI, err := queryToDeepLink(h.kustoEndpoint, h.kustoDatabase, hd.KQL)
+		if err != nil {
+			slog.Warn("Failed to generate share URI for discovery query; continuing.", "path", relPath, "error", err)
+		} else {
+			hd.ShareURI = shareURI
+		}
+
+		// Parse table from ## Results section.
+		resultsMarkdown := extractMarkdownResults(string(content))
+		if resultsMarkdown != "" {
+			table, parseErr := parseMarkdownTable(resultsMarkdown)
+			if parseErr != nil {
+				slog.Warn("Failed to parse results table; continuing.", "path", relPath, "error", parseErr)
 			} else {
-				hd.ShareURI = shareURI
+				hd.Table = table
 			}
-
-			// Parse table from ## Results section.
-			resultsMarkdown := extractMarkdownResults(string(content))
-			if resultsMarkdown != "" {
-				table, parseErr := parseMarkdownTable(resultsMarkdown)
-				if parseErr != nil {
-					slog.Warn("Failed to parse results table; continuing.", "path", leafRelPath, "error", parseErr)
-				} else {
-					hd.Table = table
-				}
-			}
-
-			items = append(items, hd)
 		}
+
+		items = append(items, hd)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk discovery directory: %w", err)
 	}
 
 	return items, nil

--- a/tooling/hcpctl/pkg/agent/hydration.go
+++ b/tooling/hcpctl/pkg/agent/hydration.go
@@ -1,0 +1,515 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/internal/tabular"
+)
+
+// Hydrator takes a draft chain produced by the agent and populates share URIs
+// and result tables for all Kusto proofs by re-running the queries deterministically.
+type Hydrator struct {
+	kustoClient   KustoClient
+	kustoEndpoint string
+	kustoDatabase string
+	worktreePaths map[string]string // repo name → local checkout path
+	testError     string            // contents of test error.log
+	testOutput    string            // contents of test output.log
+	dataDir       string            // root of the gathered data directory
+}
+
+// NewHydrator creates a Hydrator with the given Kusto client, cluster details,
+// worktree paths for resolving code proof excerpts, test log contents for
+// resolving log proof excerpts, and data directory for resolving discovery paths.
+func NewHydrator(kustoClient KustoClient, kustoEndpoint, kustoDatabase string, worktreePaths map[string]string, testError, testOutput, dataDir string) *Hydrator {
+	return &Hydrator{
+		kustoClient:   kustoClient,
+		kustoEndpoint: kustoEndpoint,
+		kustoDatabase: kustoDatabase,
+		worktreePaths: worktreePaths,
+		testError:     testError,
+		testOutput:    testOutput,
+		dataDir:       dataDir,
+	}
+}
+
+// queryToDeepLink compresses the input query with gzip and then encodes it to base64.
+// Necessary to compress long queries to fit in the default browser URI length limits.
+// Returns a Kusto deep link with encoded query and proper cluster/database.
+// See: https://learn.microsoft.com/en-us/kusto/api/rest/deeplink
+func queryToDeepLink(kustoEndpoint, kustoDatabase, query string) (string, error) {
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
+
+	if _, err := gzipWriter.Write([]byte(query)); err != nil {
+		return "", fmt.Errorf("failed to write to gzip writer: %w", err)
+	}
+
+	if err := gzipWriter.Close(); err != nil {
+		return "", fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+
+	encodedQuery := base64.StdEncoding.EncodeToString(buf.Bytes())
+	return fmt.Sprintf("%s/%s?query=%s", kustoEndpoint, kustoDatabase, encodedQuery), nil
+}
+
+// Hydrate takes a DraftChain and produces a HydratedChain by re-running all
+// KQL queries and generating share URIs.
+func (h *Hydrator) Hydrate(ctx context.Context, draft *DraftChain) (*HydratedChain, error) {
+	result := &HydratedChain{
+		RootCause:   draft.RootCause,
+		Summary:     draft.Summary,
+		Notes:       draft.Notes,
+		Suggestions: draft.Suggestions,
+	}
+
+	// Backfill all discovery directories from the data dir. All pre-gathered
+	// discovery data is included deterministically — the agent does not need
+	// to reference data-dir paths in its output.
+	backfillItems := h.backfillAllDiscovery(ctx)
+	result.Discovery = append(result.Discovery, backfillItems...)
+
+	// Hydrate agent-supplied discovery items (KQL only).
+	for _, item := range draft.Discovery {
+		if item.KQL == "" {
+			continue
+		}
+		hd, err := h.hydrateDiscoveryKQL(ctx, item)
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to hydrate agent-authored discovery query; continuing.", "label", item.Label, "error", err)
+			continue
+		}
+		result.Discovery = append(result.Discovery, *hd)
+	}
+
+	// Hydrate chain links.
+	for _, link := range draft.Chain {
+		hl := HydratedLink{
+			Question: link.Question,
+			Answer:   link.Answer,
+			Notes:    link.Notes,
+		}
+
+		for _, proof := range link.Proof {
+			hp := HydratedProofItem{
+				ProofItem: proof,
+			}
+
+			if proof.Type == "kusto" && proof.KQL != "" {
+				shareURI, err := queryToDeepLink(h.kustoEndpoint, h.kustoDatabase, proof.KQL)
+				if err != nil {
+					return nil, fmt.Errorf("failed to generate share URI for proof on %q: %w", link.Question, err)
+				}
+				hp.ShareURI = shareURI
+
+				tableRows, err := h.kustoClient.Query(ctx, proof.KQL)
+				if err != nil {
+					slog.WarnContext(ctx, "Failed to hydrate kusto proof query; continuing with empty table.", "question", link.Question, "error", err)
+				} else {
+					hp.Table = tableRows
+				}
+			}
+
+			if proof.Type == "code" && proof.Repo != "" && proof.File != "" {
+				excerpt, err := h.extractCodeExcerpt(proof.Repo, proof.File, proof.Lines[0], proof.Lines[1])
+				if err != nil {
+					slog.WarnContext(ctx, "Failed to extract code excerpt; continuing without excerpt.", "question", link.Question, "repo", proof.Repo, "file", proof.File, "error", err)
+				} else {
+					hp.CodeExcerpt = excerpt
+				}
+			}
+
+			if proof.Type == "log" && proof.Source != "" {
+				excerpt, err := h.extractLogExcerpt(proof.Source, proof.Lines[0], proof.Lines[1])
+				if err != nil {
+					slog.WarnContext(ctx, "Failed to extract log excerpt; continuing without excerpt.", "question", link.Question, "source", proof.Source, "error", err)
+				} else {
+					hp.LogExcerpt = excerpt
+				}
+			}
+
+			hl.Proof = append(hl.Proof, hp)
+		}
+
+		result.Chain = append(result.Chain, hl)
+	}
+
+	return result, nil
+}
+
+// hydrateDiscoveryKQL hydrates an agent-authored KQL discovery item by generating
+// a share URI and executing the query to produce a results table.
+func (h *Hydrator) hydrateDiscoveryKQL(ctx context.Context, item DiscoveryItem) (*HydratedDiscovery, error) {
+	hd := &HydratedDiscovery{
+		Label: item.Label,
+		KQL:   item.KQL,
+	}
+
+	shareURI, err := queryToDeepLink(h.kustoEndpoint, h.kustoDatabase, item.KQL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate share URI: %w", err)
+	}
+	hd.ShareURI = shareURI
+
+	table, err := h.kustoClient.Query(ctx, item.KQL)
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to execute discovery query; continuing without results.", "label", item.Label, "error", err)
+	} else {
+		hd.Table = table
+	}
+
+	return hd, nil
+}
+
+// backfillAllDiscovery walks the entire data directory for directories named
+// "discovery" and hydrates every Markdown file with a KQL block found within.
+// This ensures all pre-gathered discovery data is included in the final output
+// deterministically, without requiring the agent to reference paths.
+func (h *Hydrator) backfillAllDiscovery(ctx context.Context) []HydratedDiscovery {
+	var result []HydratedDiscovery
+
+	_ = filepath.WalkDir(h.dataDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() || d.Name() != "discovery" {
+			return nil
+		}
+		relPath, relErr := filepath.Rel(h.dataDir, p)
+		if relErr != nil {
+			return nil
+		}
+		items, hydrateErr := h.hydrateDiscoveryDir(p, relPath)
+		if hydrateErr != nil {
+			slog.WarnContext(ctx, "Failed to hydrate discovery directory; skipping.", "path", relPath, "error", hydrateErr)
+			return filepath.SkipDir
+		}
+		result = append(result, items...)
+		return filepath.SkipDir
+	})
+
+	return result
+}
+
+// extractCodeExcerpt reads lines [start, end] (1-indexed, inclusive) from the
+// given file in the repo's worktree. Returns empty string if the repo has no
+// worktree path configured.
+func (h *Hydrator) extractCodeExcerpt(repo, filePath string, start, end int) (string, error) {
+	worktreePath, ok := h.worktreePaths[repo]
+	if !ok || worktreePath == "" {
+		return "", fmt.Errorf("no worktree path for repo %q", repo)
+	}
+
+	absPath := filepath.Join(worktreePath, filePath)
+	f, err := os.Open(absPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open %s: %w", absPath, err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			slog.Warn("Failed to close file.", "path", absPath, "error", err)
+		}
+	}()
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		if lineNum >= start && lineNum <= end {
+			lines = append(lines, scanner.Text())
+		}
+		if lineNum > end {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to read %s: %w", absPath, err)
+	}
+	if len(lines) == 0 {
+		return "", fmt.Errorf("no lines found in range %d–%d of %s (file has %d lines)", start, end, absPath, lineNum)
+	}
+
+	return strings.Join(lines, "\n"), nil
+}
+
+// extractLogExcerpt extracts lines [start, end] (1-indexed, inclusive) from
+// the test error or output log held in memory.
+func (h *Hydrator) extractLogExcerpt(source string, start, end int) (string, error) {
+	var content string
+	switch source {
+	case "error":
+		content = h.testError
+	case "output":
+		content = h.testOutput
+	default:
+		return "", fmt.Errorf("unknown log source %q", source)
+	}
+
+	if content == "" {
+		return "", fmt.Errorf("test %s log is empty", source)
+	}
+
+	allLines := strings.Split(content, "\n")
+	if start < 1 || start > len(allLines) {
+		return "", fmt.Errorf("line_start %d is out of range (log has %d lines)", start, len(allLines))
+	}
+	if end < start || end > len(allLines) {
+		return "", fmt.Errorf("line_end %d is out of range (log has %d lines, start is %d)", end, len(allLines), start)
+	}
+
+	return strings.Join(allLines[start-1:end], "\n"), nil
+}
+
+// hydrateDiscoveryDir walks a discovery directory and produces a HydratedDiscovery
+// for each Markdown file in its immediate subdirectories that contains a KQL query.
+func (h *Hydrator) hydrateDiscoveryDir(absDir, relativeBase string) ([]HydratedDiscovery, error) {
+	var items []HydratedDiscovery
+
+	components, err := os.ReadDir(absDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read discovery directory: %w", err)
+	}
+
+	for _, component := range components {
+		if !component.IsDir() {
+			continue
+		}
+		componentDir := filepath.Join(absDir, component.Name())
+		files, err := os.ReadDir(componentDir)
+		if err != nil {
+			slog.Warn("Failed to read discovery component directory; skipping.", "path", componentDir, "error", err)
+			continue
+		}
+		for _, file := range files {
+			if file.IsDir() || !strings.HasSuffix(file.Name(), ".md") {
+				continue
+			}
+			filePath := filepath.Join(componentDir, file.Name())
+			content, err := os.ReadFile(filePath)
+			if err != nil {
+				slog.Warn("Failed to read discovery markdown file; skipping.", "path", filePath, "error", err)
+				continue
+			}
+
+			kql := extractMarkdownKQL(string(content))
+			if kql == "" {
+				continue // No KQL block — skip this file.
+			}
+
+			factName := strings.TrimSuffix(file.Name(), ".md")
+			leafRelPath := filepath.Join(relativeBase, component.Name(), factName)
+
+			hd := HydratedDiscovery{
+				Directory: leafRelPath,
+				KQL:       kql,
+			}
+
+			// Extract label from ## Summary section.
+			hd.Label = extractReadmeSummary(string(content))
+			if hd.Label == "" {
+				hd.Label = component.Name() + " / " + factName
+			}
+
+			// Generate share URI.
+			shareURI, err := queryToDeepLink(h.kustoEndpoint, h.kustoDatabase, hd.KQL)
+			if err != nil {
+				slog.Warn("Failed to generate share URI for discovery query; continuing.", "path", leafRelPath, "error", err)
+			} else {
+				hd.ShareURI = shareURI
+			}
+
+			// Parse table from ## Results section.
+			resultsMarkdown := extractMarkdownResults(string(content))
+			if resultsMarkdown != "" {
+				table, parseErr := parseMarkdownTable(resultsMarkdown)
+				if parseErr != nil {
+					slog.Warn("Failed to parse results table; continuing.", "path", leafRelPath, "error", parseErr)
+				} else {
+					hd.Table = table
+				}
+			}
+
+			items = append(items, hd)
+		}
+	}
+
+	return items, nil
+}
+
+// extractReadmeSummary extracts the first paragraph under the "## Summary"
+// heading from a README.md file. Returns empty string if not found.
+func extractReadmeSummary(readme string) string {
+	lines := strings.Split(readme, "\n")
+	inSummary := false
+	var summary []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "## Summary" {
+			inSummary = true
+			continue
+		}
+		if inSummary {
+			// Stop at the next heading or end of content.
+			if strings.HasPrefix(trimmed, "#") {
+				break
+			}
+			if trimmed == "" && len(summary) > 0 {
+				// End of first paragraph.
+				break
+			}
+			if trimmed != "" {
+				summary = append(summary, trimmed)
+			}
+		}
+	}
+	return strings.Join(summary, " ")
+}
+
+// extractMarkdownKQL extracts the content of the first fenced ```kql code block
+// found under a "## Query" heading in a machine-generated discovery Markdown file.
+// Returns empty string if no such block is found.
+func extractMarkdownKQL(md string) string {
+	lines := strings.Split(md, "\n")
+	inQuerySection := false
+	inCodeBlock := false
+	var kqlLines []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "## Query" {
+			inQuerySection = true
+			continue
+		}
+		if inQuerySection && !inCodeBlock {
+			// Stop at the next heading if we haven't entered a code block.
+			if strings.HasPrefix(trimmed, "## ") {
+				break
+			}
+			if trimmed == "```kql" {
+				inCodeBlock = true
+				continue
+			}
+		}
+		if inCodeBlock {
+			if trimmed == "```" {
+				// End of code block — we have our KQL.
+				return strings.Join(kqlLines, "\n")
+			}
+			kqlLines = append(kqlLines, line)
+		}
+	}
+	return ""
+}
+
+// extractMarkdownResults extracts the raw markdown table content under the
+// "## Results" heading in a machine-generated discovery Markdown file.
+// Returns empty string if no results section is found.
+func extractMarkdownResults(md string) string {
+	lines := strings.Split(md, "\n")
+	inResults := false
+	var resultLines []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "## Results" {
+			inResults = true
+			continue
+		}
+		if inResults {
+			if strings.HasPrefix(trimmed, "## ") {
+				break
+			}
+			resultLines = append(resultLines, line)
+		}
+	}
+	return strings.TrimSpace(strings.Join(resultLines, "\n"))
+}
+
+// parseMarkdownTable parses a pipe-delimited Markdown table into a tabular.Table.
+// It expects the standard format: header row, separator row, then data rows.
+// Returns nil (not an error) if the input is empty or has no table content.
+func parseMarkdownTable(md string) (*tabular.Table, error) {
+	lines := strings.Split(strings.TrimSpace(md), "\n")
+	if len(lines) < 2 {
+		return nil, nil
+	}
+
+	parseRow := func(line string) []string {
+		// Trim leading/trailing pipes and split by pipe.
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "|")
+		line = strings.TrimSuffix(line, "|")
+		parts := strings.Split(line, "|")
+		cells := make([]string, len(parts))
+		for i, p := range parts {
+			cells[i] = strings.TrimSpace(p)
+		}
+		return cells
+	}
+
+	columns := parseRow(lines[0])
+	if len(columns) == 0 {
+		return nil, nil
+	}
+
+	// Skip separator row (line 1), parse data rows.
+	var rows [][]string
+	for i := 2; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		row := parseRow(line)
+		// Pad or trim to match column count.
+		if len(row) < len(columns) {
+			padded := make([]string, len(columns))
+			copy(padded, row)
+			row = padded
+		} else if len(row) > len(columns) {
+			row = row[:len(columns)]
+		}
+		rows = append(rows, row)
+	}
+
+	return &tabular.Table{
+		Columns: columns,
+		Rows:    rows,
+	}, nil
+}
+
+// Validate checks hydration-specific requirements on a hydrated chain:
+// - Every kusto proof has a non-empty share URI (generated during hydration)
+// This is a lightweight post-hydration check; structural validation (non-empty
+// summary, claims, proof items, etc.) is performed earlier by ValidateDraft.
+func Validate(chain *HydratedChain) error {
+	for i, link := range chain.Chain {
+		for j, proof := range link.Proof {
+			if proof.Type == "kusto" && proof.ShareURI == "" {
+				return fmt.Errorf("chain link %d proof %d: kusto proof has empty share_uri after hydration", i, j)
+			}
+		}
+	}
+	return nil
+}

--- a/tooling/hcpctl/pkg/agent/prompt.go
+++ b/tooling/hcpctl/pkg/agent/prompt.go
@@ -1,0 +1,185 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+//go:embed prompts/*
+var promptFS embed.FS
+
+// BuildSystemMessageConfig assembles a SystemMessageConfig in "customize" mode.
+//
+// Section strategy (from design review):
+//   - SectionIdentity: replace with our domain identity
+//   - SectionTone: replace with our analysis tone
+//   - SectionCodeChangeRules: remove (agent doesn't write code)
+//   - SectionToolInstructions: keep (SDK manages tool descriptions)
+//   - SectionToolEfficiency: keep
+//   - SectionSafety: keep
+//   - SectionCustomInstructions: append domain content (references, exemplars, output schema)
+func BuildSystemMessageConfig() (*copilot.SystemMessageConfig, error) {
+	base, err := promptFS.ReadFile("prompts/system.md")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read system prompt: %w", err)
+	}
+
+	// Build the custom instructions content: base prompt + references + exemplars.
+	var sb strings.Builder
+	sb.Write(base)
+
+	// Append reference documents.
+	refs, err := readDir("prompts/references")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read reference documents: %w", err)
+	}
+	if len(refs) > 0 {
+		sb.WriteString("\n\n## Reference Material\n\n")
+		for _, content := range refs {
+			sb.WriteString(content)
+			sb.WriteString("\n\n")
+		}
+	}
+
+	// Append exemplars.
+	exemplars, err := readDir("prompts/exemplars")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read exemplar documents: %w", err)
+	}
+	if len(exemplars) > 0 {
+		sb.WriteString("\n\n## Exemplar Analyses\n\n")
+		sb.WriteString("The following are completed analyses demonstrating the expected quality, depth, and reasoning patterns.\n\n")
+		for _, content := range exemplars {
+			sb.WriteString(content)
+			sb.WriteString("\n\n---\n\n")
+		}
+	}
+
+	return &copilot.SystemMessageConfig{
+		Mode: "customize",
+		Sections: map[string]copilot.SectionOverride{
+			copilot.SectionIdentity: {
+				Action: copilot.SectionActionReplace,
+				Content: "You are a senior SRE specializing in Azure Red Hat OpenShift (ARO-HCP). " +
+					"Your task is to perform root-cause analysis on failed e2e tests by examining " +
+					"diagnostic data, querying Azure Data Explorer (Kusto), and reading source code.",
+			},
+			copilot.SectionTone: {
+				Action: copilot.SectionActionReplace,
+				Content: "Be precise, evidence-driven, and thorough. Every claim must be backed by " +
+					"data from tool calls. Prefer structured output over prose. When uncertain, " +
+					"investigate further rather than speculate.",
+			},
+			copilot.SectionCodeChangeRules: {
+				Action: copilot.SectionActionRemove,
+			},
+			copilot.SectionCustomInstructions: {
+				Action:  copilot.SectionActionAppend,
+				Content: sb.String(),
+			},
+		},
+	}, nil
+}
+
+// BuildInitialPrompt creates the initial user prompt for an analysis run,
+// including the manifest, test logs, and available source code worktrees.
+func BuildInitialPrompt(manifest, testError, testOutput, siblingTests, dataDir string, worktreePaths map[string]string) string {
+	var sb strings.Builder
+	sb.WriteString(`I need you to analyze a failed e2e test. Here is the gathered diagnostic data:
+
+## manifest.json
+
+`)
+	sb.WriteString(manifest)
+	sb.WriteString("\n\n## Test Error Log\n\n")
+	sb.WriteString(testError)
+	sb.WriteString("\n\n## Test Output Log\n\n")
+	sb.WriteString(testOutput)
+
+	if siblingTests != "" {
+		sb.WriteString("\n\n## Sibling Tests\n\n")
+		sb.WriteString("The following JSON lists all e2e tests (passing, failing, and skipped) from the same Prow job run. ")
+		sb.WriteString("Each entry includes the test name, result, resource group, and time window. ")
+		sb.WriteString("You can use the resource group and time window of a **passing** sibling test to query Kusto for known-good baseline logs, ")
+		sb.WriteString("then compare them against the failing test's logs to isolate what is different.\n\n")
+		sb.WriteString(siblingTests)
+	}
+
+	sb.WriteString("\n\n## Data Directory\n\n")
+	sb.WriteString(fmt.Sprintf("Pre-gathered diagnostic artifacts (traces, state files, logs) are available at: `%s`\n", dataDir))
+	sb.WriteString("Use the available tools to explore this directory and read files as needed.\n")
+	sb.WriteString("Reference findings from these data by re-evaluating the Kusto queries, not by referring to these files on disk.\n")
+
+	if len(worktreePaths) > 0 {
+		sb.WriteString("\n## Source Code Repositories\n\n")
+		sb.WriteString("The following repositories are checked out at the commits that were deployed when this test ran. ")
+		sb.WriteString("Use the available tools to read files from these directories when you need to understand the source code.\n\n")
+		for repo, path := range worktreePaths {
+			sb.WriteString(fmt.Sprintf("- **%s**: `%s`\n", repo, path))
+		}
+	}
+
+	sb.WriteString("\n\nPlease begin your analysis. Start by reading the manifest to understand what resources were involved, then examine the relevant trace data and state files. Use the available tools to explore the data directory and the kusto_query tool if you need additional data not present in the pre-gathered artifacts.")
+	sb.WriteString("\n\nWhen you are done, output your analysis as a JSON object conforming to the draft chain schema.")
+
+	return sb.String()
+}
+
+// BuildSummaryPrompt creates the user prompt for the job-level summary step.
+func BuildSummaryPrompt(testAnalyses []string) string {
+	var sb strings.Builder
+	sb.WriteString("The following per-test analyses have been completed for this job. ")
+	sb.WriteString("Please synthesize a job-level summary: are the failures related? Is there a common root cause?\n\n")
+
+	for i, analysis := range testAnalyses {
+		sb.WriteString(fmt.Sprintf("## Test %d\n\n%s\n\n", i+1, analysis))
+	}
+
+	sb.WriteString("Output your summary as a JSON object with fields: {\"summary\": \"...\", \"notes\": \"...\"}")
+
+	return sb.String()
+}
+
+// readDir reads all .md files from a directory in the embedded filesystem,
+// returning their contents sorted by filename for deterministic ordering.
+func readDir(dir string) ([]string, error) {
+	entries, err := fs.ReadDir(promptFS, dir)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+	var contents []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		data, err := promptFS.ReadFile(path.Join(dir, e.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s: %w", e.Name(), err)
+		}
+		contents = append(contents, string(data))
+	}
+	return contents, nil
+}

--- a/tooling/hcpctl/pkg/agent/prompts/exemplars/README
+++ b/tooling/hcpctl/pkg/agent/prompts/exemplars/README
@@ -1,0 +1,2 @@
+Place exemplar markdown files in this directory.
+They will be automatically embedded into the agent's system prompt.

--- a/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-cleanup-unknown-failure.md
+++ b/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-cleanup-unknown-failure.md
@@ -1,0 +1,303 @@
+This document shows a proof chain for a failure to delete a cluster during the test cleanup phase without any clear
+root-cause.
+
+# Root Cause
+
+An ARO HCP cluster failed to delete during a test's cleanup phase due to something blocking namespace cleanup; no
+obvious root-cause can be determined without more data.
+
+## Summary
+
+An end-to-end test for upgrading NodePool versions ran to completion and succeeded in all assertions; post-test cleanup
+failed to delete the ARO HCP cluster within five minutes. The deletion signal was propagated from the frontend to the
+backend and Clusters Service moved the cluster to `'uninstalling'` phase, but never finished removing it. HyperShift
+`HostedCluster` conditions showed no errors but the `hypershift-operator` indicated that cleanup was stuck on namespace
+removal. Without visibility into the namespace, no further root-cause can be determined.
+
+## Recursive 'Why' Chain
+
+### Why did the test fail?
+
+The test client timed out waiting for one of two ARO HCP clusters it created in a resource group to become ready.
+
+#### Proof 1: Test Error (lines 1-7)
+
+The proximal failure was a timeout while deleting an ARO HCP cluster while cleaning up the resource group:
+
+```
+fail [github.com/Azure/ARO-HCP/test/util/framework/per_test_framework.go:262] A node timeout occurred and then the following failure was recorded in the timedout node before it exited:
+Unexpected error:
+    <*errors.joinError | 0xc0013522e8>: 
+    failed to cleanup resource group: at least one hcp cluster failed to delete: failed waiting for hcpCluster="np-version-upgrade-cluster-rs22qw" in resourcegroup="rg-np-version-upgrade-rs22qw-sssr8k" to finish deleting: context canceled
+    ...
+occurred  
+fail [:0]: A node timeout occurred
+```
+
+#### Proof 2: Test Log (lines 32-34)
+
+We can see from the test log that we're in the `DeferCleanup (Each)` phase:
+
+```
+  [TIMEDOUT] in [DeferCleanup (Each)] - tear down test context | per_test_framework.go:195 @ 05/19/26 23:03:20.53
+"ts"="2026-05-19 23:03:20.531621" "msg"="at least one resource group failed to delete" "error"="failed to cleanup resource group: at least one hcp cluster failed to delete: failed waiting for hcpCluster=\"np-version-upgrade-cluster-rs22qw\" in resourcegroup=\"rg-np-version-upgrade-rs22qw-sssr8k\" to finish deleting: context canceled"
+```
+
+#### Proof 3: Code Snippet: ARO-HCP/test/util/framework/hcp_helper.go (lines 182-204)
+
+We can see the test client issues an ARM deletion call and polls to see it finish:
+
+```go
+poller, err := hcpClient.BeginDelete(ctx, resourceGroupName, hcpClusterName, nil)
+if err != nil {
+var respErr *azcore.ResponseError
+if errors.As(err, &respErr) && respErr.StatusCode == http.StatusConflict {
+resp, getErr := hcpClient.Get(ctx, resourceGroupName, hcpClusterName, nil)
+if getErr == nil && resp.Properties != nil && resp.Properties.ProvisioningState != nil && *resp.Properties.ProvisioningState == hcpsdk20240610preview.ProvisioningStateDeleting {
+ginkgo.GinkgoLogr.Info("cluster already deleting, waiting for completion",
+"cluster", hcpClusterName, "resourceGroup", resourceGroupName)
+return waitForHCPClusterDeletion(ctx, hcpClient, resourceGroupName, hcpClusterName)
+}
+}
+return err
+}
+
+operationResult, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
+Frequency: StandardPollInterval,
+})
+if err != nil {
+if errors.Is(err, context.DeadlineExceeded) {
+return fmt.Errorf("failed waiting for hcpCluster=%q in resourcegroup=%q to finish deleting, caused by: %w, error: %w", hcpClusterName, resourceGroupName, context.Cause(ctx), err)
+}
+return fmt.Errorf("failed waiting for hcpCluster=%q in resourcegroup=%q to finish deleting: %w", hcpClusterName, resourceGroupName, err)
+}
+```
+
+#### Proof 4: Log Snippet
+
+The test client polled on the async operation successfully but never saw it finish:
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('frontendLogs')
+| where timestamp between (datetime(2026-05-19T21:33:38Z) .. datetime(2026-05-19T23:03:20Z))
+| where log.path =~ '/subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54/providers/microsoft.redhatopenshift/locations/uksouth/hcpoperationstatuses/3ce3553b-8976-45c4-871e-0a5fc31b253e'
+| where log.msg == 'response complete'
+| summarize
+    first_occurrence = min(timestamp),
+    last_occurrence = max(timestamp),
+    occurrences = count()
+  by method=tostring(log.method), response_status_code=tostring(log.response_status_code), error=tostring(log.error)
+| order by first_occurrence asc
+```
+
+| method | response_status_code | error | first_occurrence         | last_occurrence         | occurrences |
+|--------|----------------------|-------|--------------------------|-------------------------|-------------|
+| get    | 200                  |       | 2026-05-19T22:18:22.374Z | 2026-05-19T23:03:19.97Z | 430         |
+
+### Why did the ARO HCP cluster deletion async operation never succeed?
+
+The RP frontend returns whatever state is current at the time of polling, and the RP backend computes async operation
+status based on Clusters Service state; the RP backend had no processing errors, but Clusters Service never moved the
+cluster past the `'uninstalling'` phase.
+
+#### Proof 1: Code Snippet: ARO-HCP/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go (lines 146-152)
+
+The RP backend simply computes cluster status based on what Clusters Service returns.
+
+```go
+newOperationStatus, newOperationError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus)
+if err != nil {
+return utils.TrackError(err)
+}
+
+err = UpdateOperationStatus(ctx, c.resourcesDBClient, operation, newOperationStatus, newOperationError, postAsyncNotificationFn(c.notificationClient))
+if err != nil {
+return utils.TrackError(err)
+}
+```
+
+#### Proof 2: Log Snippet
+
+The backend deletion controllers posted normal status during the cleanup time for this cluster:
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('backendLogs')
+| where timestamp between (datetime(2026-05-19T22:18:20Z) .. datetime(2026-05-19T23:03:20Z))
+| where container_name == 'aro-hcp-backend'
+| where log.controller_name == 'datadump'
+| where log.resource_group == 'rg-np-version-upgrade-rs22qw-sssr8k'
+| where log.resource_name == 'np-version-upgrade-cluster-rs22qw'
+| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/hcpopenshiftcontrollers'
+| where log.content.resourceID has 'np-version-upgrade-cluster-rs22qw'
+| summarize content=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| sort by tolong(content._ts) asc
+| extend content = parse_json(content)
+| extend controller_name = extract("/hcpOpenShiftControllers/([^\\/]+)", 1, tostring(content.resourceID))
+| where controller_name == 'OperationClusterDelete'
+| mv-expand condition = content.properties.status.conditions
+| project observedTime, lastTransitionTime=todatetime(condition.lastTransitionTime), controller_name, type=tostring(condition.type), status=tostring(condition.status), reason=tostring(condition.reason), message=tostring(condition.message)
+| summarize observedTime=min(observedTime) by lastTransitionTime, controller_name, type, status, reason, message
+| order by lastTransitionTime asc, observedTime asc
+```
+
+| lastTransitionTime     | controller_name        | type     | status | reason   | message      | observedTime               |
+|------------------------|------------------------|----------|--------|----------|--------------|----------------------------|
+| 5/19/2026, 10:19:22 PM | OperationClusterDelete | Degraded | False  | NoErrors | As expected. | 5/19/2026, 10:59:50.258 PM |
+
+#### Proof 3: Log Snippet
+
+Clusters Service never transitioned the cluster past the `'uninstalling'` phase:
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('clustersServiceLogs')
+| where timestamp between (datetime(2026-05-19T21:33:38Z) .. datetime(2026-05-19T23:03:20Z))
+| where log.aro_hcp_cluster_resource_id =~ '/subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54/resourcegroups/rg-np-version-upgrade-rs22qw-sssr8k/providers/microsoft.redhatopenshift/hcpopenshiftclusters/np-version-upgrade-cluster-rs22qw'
+| where isempty(log.aro_hcp_node_pool_resource_id)
+| where log has 'state to' or log has 'now in'
+| project timestamp, msg=tostring(log.msg)
+| order by timestamp asc
+```
+
+| timestamp                | msg                                                                           |
+|--------------------------|-------------------------------------------------------------------------------|
+| 2026-05-19T21:34:28.558Z | Cluster '2qd8ip08flgfav1pl5k2o8u23okgriqe' created, now in 'validating' state |
+| 2026-05-19T21:34:36.335Z | updating cluster '2qd8ip08flgfav1pl5k2o8u23okgriqe' state to 'pending'        |
+| 2026-05-19T21:51:55.55Z  | updating cluster '2qd8ip08flgfav1pl5k2o8u23okgriqe' state to 'installing'     |
+| 2026-05-19T21:55:56.942Z | updating cluster '2qd8ip08flgfav1pl5k2o8u23okgriqe' state to 'ready'          |
+| 2026-05-19T22:18:21.861Z | updating cluster '2qd8ip08flgfav1pl5k2o8u23okgriqe' state to 'uninstalling'   |
+
+### Why didn't Clusters Service move past the `'uninstalling'` phase?
+
+Clusters Service ran the deletion logic, but never saw the ManifestWork containing the HostedCluster finish deleting.
+
+#### Proof 1: Log Snippet
+
+Clusters Service repeated the cleanup logic 80+ times during the cleanup period:
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('clustersServiceLogs')
+| where timestamp between (datetime(2026-05-19T22:18:20Z) .. datetime(2026-05-19T23:03:20Z))
+| where log.aro_hcp_cluster_resource_id =~ '/subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54/resourcegroups/rg-np-version-upgrade-rs22qw-sssr8k/providers/microsoft.redhatopenshift/hcpopenshiftclusters/np-version-upgrade-cluster-rs22qw'
+| where isempty(log.aro_hcp_node_pool_resource_id)
+| summarize
+    first_occurrence = min(timestamp),
+    last_occurrence = max(timestamp),
+    occurrences = count()
+  by msg = tostring(log.msg)
+| order by first_occurrence asc
+| where occurrences > 80
+```
+
+| msg                                                                                                                                                                                                                                                                                                                                                                      | first_occurrence           | last_occurrence            | occurrences | 
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|----------------------------|-------------|
+| Running chain deletion to clean deleted cluster '2qd8ip08flgfav1pl5k2o8u23okgriqe'.                                                                                                                                                                                                                                                                                      | 5/19/2026, 10:18:46.945 PM | 5/19/2026, 11:03:19.594 PM | 86          | 
+| checking if config changed for shard '696d3cd6-199e-53cb-a6ab-49dffc54cb70'                                                                                                                                                                                                                                                                                              | 5/19/2026, 10:18:46.947 PM | 5/19/2026, 11:03:19.596 PM | 86          | 
+| Starting destruct chain for cluster                                                                                                                                                                                                                                                                                                                                      | 5/19/2026, 10:18:46.95 PM  | 5/19/2026, 11:03:19.598 PM | 86          | 
+| Running destructor 'hypershift-managed-cluster-destructor' for cluster                                                                                                                                                                                                                                                                                                   | 5/19/2026, 10:18:46.95 PM  | 5/19/2026, 11:03:19.598 PM | 86          | 
+| Not continuing to the next destructor for cluster                                                                                                                                                                                                                                                                                                                        | 5/19/2026, 10:18:48.332 PM | 5/19/2026, 11:02:48.985 PM | 85          | 
+| Finished destruct chain for cluster                                                                                                                                                                                                                                                                                                                                      | 5/19/2026, 10:18:48.332 PM | 5/19/2026, 11:02:48.985 PM | 85          | 
+| managed cluster does not exist for cluster '2qd8ip08flgfav1pl5k2o8u23okgriqe', skipping                                                                                                                                                                                                                                                                                  | 5/19/2026, 10:20:53.663 PM | 5/19/2026, 11:03:19.847 PM | 82          | 
+| Running destructor 'hypershift-manifest-work-destructor' for cluster                                                                                                                                                                                                                                                                                                     | 5/19/2026, 10:20:53.663 PM | 5/19/2026, 11:03:19.848 PM | 82          | 
+| list works with search=source='arohcpint-696d3cd6-199e-53cb-a6ab-49dffc54cb70' and consumer_name='hcp-underlay-ln-mgmt-1' and payload->'metadata'->'labels'@>'{"api.openshift.com/id":"2qd8ip08flgfav1pl5k2o8u23okgriqe","api.openshift.com/name":"np-version-upgrade-cluster-rs22qw","maestro.resource.type":"97b3a7e0-f995-5062-aba0-3410f2d257a2"}', page=1, size=400 | 5/19/2026, 10:20:53.663 PM | 5/19/2026, 11:03:19.85 PM  | 82          | 
+| list the work hcp-underlay-ln-mgmt-1/5c5d8c32-0497-5840-ac4c-4acb07e76a04 (source=arohcpint-696d3cd6-199e-53cb-a6ab-49dffc54cb70)                                                                                                                                                                                                                                        | 5/19/2026, 10:20:54.163 PM | 5/19/2026, 11:03:19.869 PM | 82          | 
+| list the work hcp-underlay-ln-mgmt-1/87c18c53-14b7-593d-a09c-80ef1d6ae157 (source=arohcpint-696d3cd6-199e-53cb-a6ab-49dffc54cb70)                                                                                                                                                                                                                                        | 5/19/2026, 10:20:54.163 PM | 5/19/2026, 11:03:19.87 PM  | 82          | 
+| list the work hcp-underlay-ln-mgmt-1/f40bac18-8f3f-5d0a-8044-2bb23f87ab1e (source=arohcpint-696d3cd6-199e-53cb-a6ab-49dffc54cb70)                                                                                                                                                                                                                                        | 5/19/2026, 10:20:54.163 PM | 5/19/2026, 11:03:19.87 PM  | 82          | 
+| Skipping ManifestWork 'local-cluster/2qd8ip08flgfav1pl5k2o8u23okgriqe-00-namespaces in this run as it contains namespaces                                                                                                                                                                                                                                                | 5/19/2026, 10:20:54.276 PM | 5/19/2026, 11:03:19.874 PM | 82          | 
+| Skipping ManifestWork 'local-cluster/2qd8ip08flgfav1pl5k2o8u23okgriqe-00-hcp-namespaces in this run as it contains namespaces                                                                                                                                                                                                                                            | 5/19/2026, 10:20:54.276 PM | 5/19/2026, 11:03:19.874 PM | 82          | 
+| deleting maestro bundle with maestro bundle name 'f40bac18-8f3f-5d0a-8044-2bb23f87ab1e' containing resource 'local-cluster/2qd8ip08flgfav1pl5k2o8u23okgriqe' with GVK 'work.open-cluster-management.io/v1, Kind=ManifestWork'                                                                                                                                            | 5/19/2026, 10:20:54.276 PM | 5/19/2026, 11:03:19.874 PM | 82          | 
+| get the work hcp-underlay-ln-mgmt-1/f40bac18-8f3f-5d0a-8044-2bb23f87ab1e (source=arohcpint-696d3cd6-199e-53cb-a6ab-49dffc54cb70)                                                                                                                                                                                                                                         | 5/19/2026, 10:20:54.288 PM | 5/19/2026, 11:02:48.936 PM | 81          | 
+| successfully sent delete request of maestro bundle name 'f40bac18-8f3f-5d0a-8044-2bb23f87ab1e' containing resource 'local-cluster/2qd8ip08flgfav1pl5k2o8u23okgriqe' with GVK 'work.open-cluster-management.io/v1, Kind=ManifestWork'                                                                                                                                     | 5/19/2026, 10:20:54.32 PM  | 5/19/2026, 11:02:48.985 PM | 81          | 
+| requested manifest work 'local-cluster/2qd8ip08flgfav1pl5k2o8u23okgriqe' deletion                                                                                                                                                                                                                                                                                        | 5/19/2026, 10:20:54.32 PM  | 5/19/2026, 11:02:48.985 PM | 81          |
+
+#### Proof 2: Log Snippet
+
+The ManifestWork `local-cluster/2qd8ip08flgfav1pl5k2o8u23okgriqe` contains the `HostedCluster`:
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('clustersServiceLogs')
+| where timestamp between (datetime(2026-05-19T22:18:20Z) .. datetime(2026-05-19T23:03:20Z))
+| where log.aro_hcp_cluster_resource_id =~ '/subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54/resourcegroups/rg-np-version-upgrade-rs22qw-sssr8k/providers/microsoft.redhatopenshift/hcpopenshiftclusters/np-version-upgrade-cluster-rs22qw'
+| where msg startswith "ManifestWork for cluster"
+| extend raw_content = extract("ManifestWork for cluster '[^']+':(.*)$", 1, tostring(msg))
+| extend manifest_work = parse_json(raw_content)
+| where manifest_work.metadata.namespace == 'local-cluster' and manifest_work.metadata.name == '2qd8ip08flgfav1pl5k2o8u23okgriqe'
+| mv-expand manifest = manifest_work.spec.workload.manifests
+| distinct tostring(manifest.apiVersion), tostring(manifest.kind), tostring(manifest.metadata.namespace), tostring(manifest.metadata.name)
+```
+
+| manifest_apiVersion             | manifest_kind       | manifest_metadata_namespace                    | manifest_metadata_name                                    | 
+|---------------------------------|---------------------|------------------------------------------------|-----------------------------------------------------------|
+| v1                              | Secret              | ocm-arohcpint-2qd8ip08flgfav1pl5k2o8u23okgriqe | l8c9m8n4d8e7g6i-pull                                      | 
+| secrets-store.csi.x-k8s.io/v1   | SecretProviderClass | ocm-arohcpint-2qd8ip08flgfav1pl5k2o8u23okgriqe | bound-service-account-signing-key                         | 
+| secret-sync.x-k8s.io/v1alpha1   | SecretSync          | ocm-arohcpint-2qd8ip08flgfav1pl5k2o8u23okgriqe | bound-service-account-signing-key                         | 
+| secrets-store.csi.x-k8s.io/v1   | SecretProviderClass | ocm-arohcpint-2qd8ip08flgfav1pl5k2o8u23okgriqe | kube-apiserver-tls-cert                                   | 
+| secret-sync.x-k8s.io/v1alpha1   | SecretSync          | ocm-arohcpint-2qd8ip08flgfav1pl5k2o8u23okgriqe | kube-apiserver-tls-cert                                   | 
+| secrets-store.csi.x-k8s.io/v1   | SecretProviderClass | open-cluster-management-policies               | default-ingress-tls-cert-2qd8ip08flgfav1pl5k2o8u23okgriqe | 
+| secret-sync.x-k8s.io/v1alpha1   | SecretSync          | open-cluster-management-policies               | default-ingress-tls-cert-2qd8ip08flgfav1pl5k2o8u23okgriqe | 
+| v1                              | ConfigMap           | open-cluster-management-policies               | default-ingress-config-2qd8ip08flgfav1pl5k2o8u23okgriqe   | 
+| hypershift.openshift.io/v1beta1 | HostedCluster       | ocm-arohcpint-2qd8ip08flgfav1pl5k2o8u23okgriqe | l8c9m8n4d8e7g6i                                           |
+
+### Why didn't the `ManifestWork` containing the `HostedCluster` finish deleting?
+
+The `HostedCluster` condition timeline after the deletion does not show anything out of the ordinary, but the
+`hypershift-operator` logs clearly show the namespace could not be deleted. We have no visibility into why the namespace
+never finished deleting, so our root-cause investigation stops here.
+
+#### Proof 1: Log Snippet
+
+The `HostedCluster` condition timeline after the test's cleanup start-time shows nothing out of the ordinary:
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('backendLogs')
+| where timestamp between (datetime(2026-05-19T22:18:20Z) .. datetime(2026-05-19T23:03:20Z))
+| where container_name == 'aro-hcp-backend'
+| where log.controller_name == 'datadump'
+| where log.resource_group == 'rg-np-version-upgrade-rs22qw-sssr8k'
+| where log.resource_name == 'np-version-upgrade-cluster-rs22qw'
+| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/managementclustercontents'
+| summarize content=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| sort by tolong(content._ts) asc
+| extend content = parse_json(content)
+| mv-expand manifest = content.properties.status.kubeContent.items
+| where manifest.kind == 'HostedCluster'
+| mv-expand condition = manifest.status.conditions
+| project observedTime, type=tostring(condition.type), status=tostring(condition.status), reason=tostring(condition.reason), message=tostring(condition.message), lastTransitionTime=todatetime(condition.lastTransitionTime)
+| summarize observedTime=min(observedTime) by type, status, reason, message, lastTransitionTime
+| order by lastTransitionTime asc, observedTime asc
+| where lastTransitionTime > datetime(2026-05-19T22:18:20Z)
+```
+
+| type                           | status | reason                  | message                               | lastTransitionTime     | observedTime               |
+|--------------------------------|--------|-------------------------|---------------------------------------|------------------------|----------------------------|
+| ReconciliationSucceeded        | True   | ReconciliatonSucceeded  | Reconciliation completed successfully | 5/19/2026, 10:27:12 PM | 5/19/2026, 10:28:36.047 PM |
+| AWSDefaultSecurityGroupDeleted | True   | AsExpected              | All is well                           | 5/19/2026, 10:27:29 PM | 5/19/2026, 10:59:50.257 PM |
+| CloudResourcesDestroyed        | True   | CloudResourcesDestroyed | All guest resources destroyed         | 5/19/2026, 10:27:47 PM | 5/19/2026, 10:59:50.257 PM |
+
+#### Proof 2: Log Snippet
+
+The `hypershift-operator` continues reconciling the `HostedCluster` after the test cleanup start-time and spends the
+entire period waiting on namespace deletion:
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('containerLogs')
+| where timestamp between (datetime(2026-05-19T22:18:20Z) .. datetime(2026-05-19T23:03:20Z))
+| where namespace_name == 'hypershift'
+| where container_name == 'operator'
+| where log.controllerKind == 'HostedCluster' and log.HostedCluster.namespace == 'ocm-arohcpint-2qd8ip08flgfav1pl5k2o8u23okgriqe'
+| summarize
+    first_occurrence = min(timestamp),
+    last_occurrence = max(timestamp),
+    occurrences = count()
+  by msg = tostring(log.msg)
+| order by first_occurrence asc
+| where occurrences > 10
+```
+
+| msg                                                | first_occurrence           | last_occurrence            | occurrences |
+|----------------------------------------------------|----------------------------|----------------------------|-------------|
+| reconciling                                        | 5/19/2026, 10:18:23.147 PM | 5/19/2026, 11:03:17.074 PM | 504         |
+| Reconciling                                        | 5/19/2026, 10:18:23.147 PM | 5/19/2026, 10:27:47.918 PM | 41          |
+| hostedcluster is being deleted, aborting reconcile | 5/19/2026, 10:27:12.175 PM | 5/19/2026, 10:27:47.834 PM | 16          |
+| hostedcluster is still deleting                    | 5/19/2026, 10:27:12.223 PM | 5/19/2026, 11:03:17.075 PM | 495         |
+| Waiting for cluster deletion                       | 5/19/2026, 10:27:12.223 PM | 5/19/2026, 10:27:48.05 PM  | 61          |
+| Waiting for namespace deletion                     | 5/19/2026, 10:27:48.183 PM | 5/19/2026, 11:03:17.075 PM | 434         |

--- a/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-installation-azure-disk-failure.md
+++ b/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-installation-azure-disk-failure.md
@@ -1,0 +1,403 @@
+This document shows a proof chain for a failure to install a cluster coming from deep in the stack.
+
+# Root Cause
+
+An ARO HCP cluster failed to install because an Azure Disk could not be mounted for an `etcd` pod in the hosted control
+plane due to internal Azure Disk errors.
+
+## Summary
+
+An end-to-end test installing two ARO HCP clusters in one resource group installed one without issue, but failed on the
+other. The test client polled ARM for the async operation without issue, but the status never proceeded. The RP backend
+posted no degraded controller status, but Clusters Service never progressed passed `'installing'` phase. The HyperShift
+`HostedCluster` never posted a `Available` condition with `status=True`, claiming that it was stuck on
+`reason=KubeconfigWaitingForCreate.` Furthermore, the `HostedCluster` claimed that `KubeAPIServerAvailable=False`
+because the `kube-apiserver` deployment could not be found. The `hypershift-operator`, however, logged that `etcd` was
+not fully available. Events for the `etcd` pods showed that one replica failed to mount its persistent volume due to an
+internal Azure Disk error. The node this replica was scheduled to failed its health-checks, and after the node
+auto-repair mechanism replaced this node, the `etcd` replica re-scheduled, mounted its persistent volume and ran without
+issue, but this happened too late to save the test from timing out.
+
+## Recursive 'Why' Chain
+
+### Why did the test fail?
+
+The test client timed out waiting for one of two ARO HCP clusters it created in a resource group to become ready.
+
+#### Proof 1: Test Error (lines 1-5)
+
+The test error is caused by a context deadline being exceeded:
+
+```
+fail [github.com/Azure/ARO-HCP/test/e2e/clusters_sharing_resgroup.go:132]: Unexpected error:
+    <context.deadlineExceededError>: 
+    context deadline exceeded
+    ...
+occurred
+```
+
+#### Proof 2: Test Log (lines 10-11)
+
+In the test log, we can see the step that failed was waiting on a cluster to become ready:
+
+```
+  STEP: waiting for first cluster to complete creation @ 05/19/26 20:58:52.976
+  [FAILED] in [It] - /opt/app-root/src/github.com/Azure/ARO-HCP/test/e2e/clusters_sharing_resgroup.go:132 @ 05/19/26 21:43:52.979 
+```
+
+#### Proof 3: Code Snippet: ARO-HCP/test/e2e/clusters_sharing_resgroup.go (lines 102-132)
+
+The test begins the creation of both clusters, then polls to see the first one complete.
+
+```go
+// Start first cluster creation
+poller1, err := framework.BeginCreateHCPCluster(
+ctx,
+GinkgoLogr,
+clusterClient,
+*customerResourceGroup.Name,
+clusterParams1.ClusterName,
+clusterParams1,
+tc.Location(),
+)
+Expect(err).NotTo(HaveOccurred())
+
+// Start second cluster creation
+poller2, err := framework.BeginCreateHCPCluster(
+ctx,
+GinkgoLogr,
+clusterClient,
+*customerResourceGroup.Name,
+clusterParams2.ClusterName,
+clusterParams2,
+tc.Location(),
+)
+Expect(err).NotTo(HaveOccurred())
+
+By("waiting for first cluster to complete creation")
+pollCtx, pollCancel := context.WithTimeout(ctx, 45*time.Minute)
+defer pollCancel()
+_, err = poller1.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
+Frequency: framework.StandardPollInterval,
+})
+Expect(err).NotTo(HaveOccurred())
+```
+
+### Proof 4: Log Snippet
+
+We can see the test client polling successfully for the entire time period:
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('frontendLogs')
+| where timestamp between (datetime(2026-05-19T20:52:10Z) .. datetime(2026-05-19T22:10:46Z))
+| where log.path =~ '/subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54/providers/microsoft.redhatopenshift/locations/uksouth/hcpoperationstatuses/a049288c-cdf3-4431-ab37-ba94acfedbd1'
+| where log.msg == 'response complete'
+| summarize
+    first_occurrence = min(timestamp),
+    last_occurrence = max(timestamp),
+    occurrences = count()
+  by method=tostring(log.method), response_status_code=tostring(log.response_status_code), error=tostring(log.error)
+| order by first_occurrence asc
+```
+
+| method | response_status_code | error | first_occurrence         | last_occurrence          | occurrences |
+|--------|----------------------|-------|--------------------------|--------------------------|-------------|
+| get    | 200                  |       | 2026-05-19T20:58:53.476Z | 2026-05-19T21:44:06.643Z | 432         |
+
+### Why did the async operation to create the cluster never finish?
+
+The RP frontend returns whatever state is current at the time of polling, and the RP backend computes async operation
+status based on Clusters Service state; the RP backend had no processing errors, but Clusters Service never moved the
+cluster past the `'installing'` phase.
+
+#### Proof 1: Code Snippet: ARO-HCP/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go (lines 140-155)
+
+The RP backend simply computes cluster status based on what Clusters Service returns.
+
+```go
+newOperationStatus, opError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus)
+if err != nil {
+return utils.TrackError(err)
+}
+logger.Info("new status via cluster-service", "newStatus", newOperationStatus, "newOperationError", opError)
+
+if newOperationStatus == arm.ProvisioningStateSucceeded && cosmosNewOperationState.provisioningState != arm.ProvisioningStateSucceeded {
+// we want to require that the cosmos view of cluster creation is also complete before we mark it.  This ensures (among other things)
+// that our ability to read maestro is successful.
+// Once we have confidence in our ability to determine that cluster is functional, we'll stop checking cluster-service at all.
+return fmt.Errorf("cosmos operation status is %q, but cluster-service operation status is %q", cosmosNewOperationState.provisioningState, newOperationStatus)
+}
+
+logger.Info("updating status")
+err = UpdateOperationStatus(ctx, c.resourcesDBClient, operation, newOperationStatus, opError, postAsyncNotificationFn(c.notificationClient))
+if err != nil {
+return utils.TrackError(err)
+}
+```
+
+#### Proof 2: Log Snippet
+
+No backend controllers posted unnatural status during the test run for this cluster.
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('backendLogs')
+| where timestamp between (datetime(2026-05-19T20:52:10Z) .. datetime(2026-05-19T21:43:55Z))
+| where container_name == 'aro-hcp-backend'
+| where log.controller_name == 'datadump'
+| where log.resource_group == 'customer-rg-crkv7p'
+| where log.resource_name == 'basic-hcp-cluster'
+| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/hcpopenshiftcontrollers'
+| where log.content.resourceID has 'basic-hcp-cluster'
+| summarize payload=take_any(log.content) by etag=tostring(log.content._etag)
+| extend payload = parse_json(payload)
+| extend controller_name = extract("/hcpOpenShiftControllers/([^\\/]+)", 1, tostring(payload.resourceID))
+| extend ts = tolong(payload._ts)
+| summarize arg_max(ts, payload) by controller_name
+| mv-expand condition = payload.properties.status.conditions
+| project lastTransitionTime=todatetime(condition.lastTransitionTime), controller_name, type=tostring(condition.type), status=tostring(condition.status), reason=tostring(condition.reason), message=tostring(condition.message)
+| summarize count = count() by type, status
+```
+
+| type         | status | count |
+|--------------|--------|-------|
+| Degraded     | False  | 22    |
+| IntentFailed | False  | 1     |
+
+#### Proof 3: Log Snippet
+
+Clusters Service never transitioned the cluster past the `'installing'` phase:
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('clustersServiceLogs')
+| where timestamp between (datetime(2026-05-19T20:52:10Z) .. datetime(2026-05-19T22:10:46Z))
+| where log.aro_hcp_cluster_resource_id =~ '/subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54/resourcegroups/customer-rg-crkv7p/providers/microsoft.redhatopenshift/hcpopenshiftclusters/basic-hcp-cluster'
+| where isempty(log.aro_hcp_node_pool_resource_id)
+| where log has 'state to' or log has 'now in'
+| project timestamp, msg=tostring(log.msg)
+| order by timestamp asc
+```
+
+| timestamp                | msg                                                                           |
+|--------------------------|-------------------------------------------------------------------------------|
+| 2026-05-19T20:58:51.188Z | Cluster '2qd822p7guniitr7ibsb7qjeccri0gdl' created, now in 'validating' state |
+| 2026-05-19T20:58:56.345Z | updating cluster '2qd822p7guniitr7ibsb7qjeccri0gdl' state to 'pending'        |
+| 2026-05-19T21:00:44.321Z | updating cluster '2qd822p7guniitr7ibsb7qjeccri0gdl' state to 'installing'     |
+| 2026-05-19T21:43:58.277Z | updating cluster '2qd822p7guniitr7ibsb7qjeccri0gdl' state to 'uninstalling'   |
+
+### Why didn't Clusters Service transition the cluster past the `'installing'` phase to `'ready'`?
+
+Clusters Service bubbles up the HyperShift `HostedCluster` status, and the `HostedCluster` never saw an `Available=true`
+condition.
+
+#### Proof 1: Code Snippet: aro-hcp-clusters-service/pkg/controller/manifestwork/cluster_status.go (lines 36-53)
+
+```go
+// syncInstallingClusterOnReady checks whether a hcp cluster in the "installing" phase is available.
+// Then it transitions to a final "ready" state.
+func (r *Reconciler) syncInstallingClusterOnReady(ctx context.Context, cluster *models.Cluster,
+values acm.HypershiftConditions) error {
+if condition, ok := values[hsv1beta1.HostedClusterAvailable]; !ok || condition.Status != v1.ConditionTrue {
+return nil
+}
+
+err := r.updateClusterStateReady(ctx, cluster)
+if err != nil {
+return errors.Wrapf(err, "Failed to update cluster state to Ready")
+}
+
+r.logReadyCluster(ctx, cluster)
+
+r.trackFinalClusterState(ctx, cluster, "")
+return nil
+}
+```
+
+#### Proof 2: Log Snippet
+
+The `Available` condition on the `HostedCluster` never had a `true` status:
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('backendLogs')
+| where timestamp between (datetime(2026-05-19T20:52:10Z) .. datetime(2026-05-19T22:10:46Z))
+| where container_name == 'aro-hcp-backend'
+| where log.controller_name == 'datadump'
+| where log.resource_group == 'customer-rg-crkv7p'
+| where log.resource_name == 'basic-hcp-cluster'
+| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/managementclustercontents'
+| summarize content=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| sort by tolong(content._ts) asc
+| extend content = parse_json(content)
+| mv-expand manifest = content.properties.status.kubeContent.items
+| where manifest.kind == 'HostedCluster'
+| mv-expand condition = manifest.status.conditions
+| project observedTime, type=tostring(condition.type), status=tostring(condition.status), reason=tostring(condition.reason), message=tostring(condition.message), lastTransitionTime=todatetime(condition.lastTransitionTime)
+| summarize observedTime=min(observedTime) by type, status, reason, message, lastTransitionTime
+| order by lastTransitionTime asc, observedTime asc
+| where type == 'Available'
+```
+
+| type      | status | reason                       | message                                                   | lastTransitionTime    | observedTime              |
+|-----------|--------|------------------------------|-----------------------------------------------------------|-----------------------|---------------------------| 
+| Available | False  | WaitingOnInfrastructureReady | Cluster infrastructure is still provisioning              | 5/19/2026, 9:00:45 PM | 5/19/2026, 9:01:42.891 PM |
+| Available | False  | KubeconfigWaitingForCreate   | Waiting for hosted control plane kubeconfig to be created | 5/19/2026, 9:00:45 PM | 5/19/2026, 9:02:06.346 PM |
+
+### Why did the `Available` condition on the `HostedCluster` never have a `true` status?
+
+The conditions on the `HostedCluster` claim that the `kube-apiserver` was not found, and the `kubeconfig` never created.
+The `hypershift-operator` complains that `etcd` is not fully available for the entire duration of the test.
+
+#### Proof 1: Log Snippet
+
+The last snapshot of the `HostedCluster` conditions before the test cleanup began shows that the `kubeconfig` was not
+present and the `kube-apiserver` deployment had not been found:
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('backendLogs')
+| where timestamp between (datetime(2026-05-19T20:52:10Z) .. datetime(2026-05-19T21:43:55Z))
+| where container_name == 'aro-hcp-backend'
+| where log.controller_name == 'datadump'
+| where log.resource_group == 'customer-rg-crkv7p'
+| where log.resource_name == 'basic-hcp-cluster'
+| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/managementclustercontents'
+| summarize content=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| top 1 by tolong(content._ts) desc
+| extend content = parse_json(content)
+| mv-expand manifest = content.properties.status.kubeContent.items
+| where manifest.kind == 'HostedCluster'
+| mv-expand condition = manifest.status.conditions
+| project observedTime, type=tostring(condition.type), status=tostring(condition.status), reason=tostring(condition.reason), message=tostring(condition.message), lastTransitionTime=todatetime(condition.lastTransitionTime)
+| where type in ('KubeAPIServerAvailable', 'Available')
+```
+
+| observedTime              | type                   | status | reason                     | message                                                   | lastTransitionTime    | 
+|---------------------------|------------------------|--------|----------------------------|-----------------------------------------------------------|-----------------------|
+| 5/19/2026, 9:43:08.978 PM | KubeAPIServerAvailable | False  | NotFound                   | Kube APIServer deployment not found                       | 5/19/2026, 9:01:01 PM | 
+| 5/19/2026, 9:43:08.978 PM | Available              | False  | KubeconfigWaitingForCreate | Waiting for hosted control plane kubeconfig to be created | 5/19/2026, 9:00:45 PM |
+
+#### Proof 2: Log Snippet
+
+The `hypershift-operator` is continually not finding `etcd` in a fully ready state during the entire test duration:
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('containerLogs')
+| where timestamp between (datetime(2026-05-19T20:52:10Z) .. datetime(2026-05-19T22:10:46Z))
+| where namespace_name == 'hypershift'
+| where container_name == 'operator'
+| where log.controllerKind == 'HostedCluster' and log.HostedCluster.namespace == 'ocm-arohcpint-2qd822p7guniitr7ibsb7qjeccri0gdl'
+| summarize
+    first_occurrence = min(timestamp),
+    last_occurrence = max(timestamp),
+    occurrences = count()
+  by msg = tostring(log.msg), err = tostring(log.error)
+| order by first_occurrence asc
+| where msg has 'etcd is not reporting fully available, need to watch'
+```
+
+| msg                                                  | err | first_occurrence         | last_occurrence           | occurrences |
+|------------------------------------------------------|-----|--------------------------|---------------------------|-------------|
+| etcd is not reporting fully available, need to watch |     | 5/19/2026, 9:01:12.96 PM | 5/19/2026, 9:46:11.032 PM | 311         |
+
+### Why was `etcd` not fully available?
+
+The persistent volume for the `etcd-0` replica failed to mount during the entire time the test was waiting on the
+cluster to install.
+
+#### Proof 1: Log Snippet
+
+Events for the `etcd` pods show that volumes mounted quickly for the other replicas, but we don't see a successful mount
+for `etcd-0` until after the test has timed out.
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('kubernetesEvents')
+| where timestamp between (datetime(2026-05-19T20:52:10Z) .. datetime(2026-05-19T22:10:46Z))
+| where eventNamespace == 'ocm-arohcpint-2qd822p7guniitr7ibsb7qjeccri0gdl-x0c2h7b6o1c1w1a'
+        and objectName contains 'etcd-'
+| where reason contains 'Volume' or message contains 'Volume'
+| summarize arg_max(count, firstSeen, lastSeen) by objectKind, objectName, reason, message
+| project objectKind, objectName, reason, message, firstSeen, lastSeen, count
+| order by firstSeen asc
+```
+
+| objectKind            | objectName  | reason                 | message                                                                                                                                                                                                                                    | firstSeen             | lastSeen              | count | 
+|-----------------------|-------------|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------|-----------------------|-------|
+| PersistentVolumeClaim | data-etcd-0 | Provisioning           | External provisioner is provisioning volume for claim "ocm-arohcpint-2qd822p7guniitr7ibsb7qjeccri0gdl-x0c2h7b6o1c1w1a/data-etcd-0"                                                                                                         | 5/19/2026, 9:01:13 PM | 5/19/2026, 9:01:13 PM | 1     | 
+| PersistentVolumeClaim | data-etcd-2 | Provisioning           | External provisioner is provisioning volume for claim "ocm-arohcpint-2qd822p7guniitr7ibsb7qjeccri0gdl-x0c2h7b6o1c1w1a/data-etcd-2"                                                                                                         | 5/19/2026, 9:01:13 PM | 5/19/2026, 9:01:13 PM | 1     | 
+| PersistentVolumeClaim | data-etcd-1 | Provisioning           | External provisioner is provisioning volume for claim "ocm-arohcpint-2qd822p7guniitr7ibsb7qjeccri0gdl-x0c2h7b6o1c1w1a/data-etcd-1"                                                                                                         | 5/19/2026, 9:01:13 PM | 5/19/2026, 9:01:13 PM | 1     | 
+| PersistentVolumeClaim | data-etcd-1 | ExternalProvisioning   | Waiting for a volume to be created either by the external provisioner 'disk.csi.azure.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered. | 5/19/2026, 9:01:13 PM | 5/19/2026, 9:01:16 PM | 2     | 
+| PersistentVolumeClaim | data-etcd-0 | ExternalProvisioning   | Waiting for a volume to be created either by the external provisioner 'disk.csi.azure.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered. | 5/19/2026, 9:01:13 PM | 5/19/2026, 9:01:16 PM | 3     | 
+| PersistentVolumeClaim | data-etcd-2 | ExternalProvisioning   | Waiting for a volume to be created either by the external provisioner 'disk.csi.azure.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered. | 5/19/2026, 9:01:13 PM | 5/19/2026, 9:01:16 PM | 3     | 
+| PersistentVolumeClaim | data-etcd-0 | ProvisioningSucceeded  | Successfully provisioned volume pvc-40f955d8-0d40-4d5f-a635-91ce592f6a2a                                                                                                                                                                   | 5/19/2026, 9:01:23 PM | 5/19/2026, 9:01:23 PM | 1     | 
+| PersistentVolumeClaim | data-etcd-1 | ProvisioningSucceeded  | Successfully provisioned volume pvc-4aef6076-7215-4e95-baf7-d39e98c719d5                                                                                                                                                                   | 5/19/2026, 9:01:23 PM | 5/19/2026, 9:01:23 PM | 1     | 
+| PersistentVolumeClaim | data-etcd-2 | ProvisioningSucceeded  | Successfully provisioned volume pvc-2f8b86e8-b48b-468d-a132-9263d78b774d                                                                                                                                                                   | 5/19/2026, 9:01:23 PM | 5/19/2026, 9:01:23 PM | 1     | 
+| Pod                   | etcd-2      | SuccessfulAttachVolume | AttachVolume.Attach succeeded for volume "pvc-2f8b86e8-b48b-468d-a132-9263d78b774d"                                                                                                                                                        | 5/19/2026, 9:01:31 PM | 5/19/2026, 9:01:31 PM | 1     | 
+| Pod                   | etcd-1      | SuccessfulAttachVolume | AttachVolume.Attach succeeded for volume "pvc-4aef6076-7215-4e95-baf7-d39e98c719d5"                                                                                                                                                        | 5/19/2026, 9:01:31 PM | 5/19/2026, 9:01:31 PM | 1     | 
+| Pod                   | etcd-0      | FailedMount            | MountVolume.MountDevice failed for volume "pvc-40f955d8-0d40-4d5f-a635-91ce592f6a2a" : rpc error: code = Internal desc = failed to find disk on lun 3. azureDisk - findDiskByLun(3) failed with error(failed to find disk by lun 3)        | 5/19/2026, 9:01:33 PM | 5/19/2026, 9:22:32 PM | 18    | 
+| Pod                   | etcd-0      | SuccessfulAttachVolume | AttachVolume.Attach succeeded for volume "pvc-40f955d8-0d40-4d5f-a635-91ce592f6a2a"                                                                                                                                                        | 5/19/2026, 9:46:04 PM | 5/19/2026, 9:46:04 PM | 1     | 
+
+### Why did the persistent volume fail to mount for the `etcd-0` replica in the first 45 minutes, but then succeed?
+
+The storage driver got an internal error from Azure disk for 15 minutes, at which point the node was marked unhealthy,
+and the auto-repair mechanism tried to reboot, reimage and redeploy the node to no avail, finally deleting the node and
+spinning up a new one. The `etcd-0` pod scheduled on the new node and mounted the persistent volume without issue.
+
+#### Proof 1: Log Snippet
+
+The direct error from Azure Disk is seen in the failed mount events:
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('kubernetesEvents')
+| where timestamp between (datetime(2026-05-19T20:52:10Z) .. datetime(2026-05-19T22:10:46Z))
+| where eventNamespace == 'ocm-arohcpint-2qd822p7guniitr7ibsb7qjeccri0gdl-x0c2h7b6o1c1w1a'
+        and objectName == 'etcd-0'
+| extend firstSeen = coalesce(firstSeen, todatetime(log.event_time)), lastSeen = coalesce(lastSeen, todatetime(log.event_time))
+| summarize arg_max(count, firstSeen, lastSeen) by objectKind, objectName, reason, message
+| project objectKind, objectName, reason, message, firstSeen, lastSeen, count
+| order by firstSeen asc
+```
+
+| objectKind | objectName | reason                 | message                                                                                           | firstSeen                                                                                                                                           | lastSeen                     | count                        | 
+|------------|------------|------------------------|---------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|------------------------------|
+| Pod        | etcd-0     | Scheduled              | Successfully assigned ocm-arohcpint-2qd822p7guniitr7ibsb7qjeccri0gdl-x0c2h7b6o1c1w1a/etcd-0 to    | aks-userswft3-15776247-vmss00000h                                                                                                                   | 5/19/2026, 9:01:24.073141 PM | 5/19/2026, 9:01:24.073141 PM 
+| Pod        | etcd-0     | FailedMount            | MountVolume.MountDevice failed for volume "pvc-40f955d8-0d40-4d5f-a635-91ce592f6a2a" : rpc error: | code = Internal desc = failed to find disk on lun 3. azureDisk - findDiskByLun(3) failed with error(failed to find disk by lun 3)                   | 5/19/2026, 9:01:33 PM        | 5/19/2026, 9:22:32 PM        | 18
+| Pod        | etcd-0     | TaintManagerEviction   | Marking for deletion Pod                                                                          | ocm-arohcpint-2qd822p7guniitr7ibsb7qjeccri0gdl-x0c2h7b6o1c1w1a/etcd-0                                                                               | 5/19/2026, 9:29:52 PM        | 5/19/2026, 9:29:52 PM        | 1
+| Pod        | etcd-0     | Scheduled              | Successfully assigned ocm-arohcpint-2qd822p7guniitr7ibsb7qjeccri0gdl-x0c2h7b6o1c1w1a/etcd-0 to    | aks-userswft3-15776247-vmss00000f                                                                                                                   | 5/19/2026, 9:45:57.993747 PM | 5/19/2026, 9:45:57.993747 PM 
+| Pod        | etcd-0     | SuccessfulAttachVolume | AttachVolume.Attach succeeded for volume "pvc-40f955d8-0d40-4d5f-a635-91ce592f6a2a"               |                                                                                                                                                     | 5/19/2026, 9:46:04 PM        | 5/19/2026, 9:46:04 PM        | 1
+| Pod        | etcd-0     | Pulling                | Pulling image "arohcpocpint.azurecr.io/openshift-release-dev/ocp-v4.                              | 0-art-dev@sha256:d8c2b75f4be30014e9d04f7edba6d9adbb4744d57b2938731860a66d66ac8c75"                                                                  | 5/19/2026, 9:46:12 PM        | 5/19/2026, 9:46:12 PM        | 1
+| Pod        | etcd-0     | Pulled                 | Successfully pulled image "arohcpocpint.azurecr.io/openshift-release-dev/ocp-v4.                  | 0-art-dev@sha256:d8c2b75f4be30014e9d04f7edba6d9adbb4744d57b2938731860a66d66ac8c75" in 101ms (101ms including waiting). Image size: 193214387 bytes. | 5/19/2026, 9:46:12 PM        | 5/19/2026, 9:46:12 PM        | 1
+| Pod        | etcd-0     | Created                | Container created                                                                                 | 5/19/2026, 9:46:12 PM                                                                                                                               | 5/19/2026, 9:46:12 PM        | 1                            | 
+| Pod        | etcd-0     | Started                | Container started                                                                                 | 5/19/2026, 9:46:12 PM                                                                                                                               | 5/19/2026, 9:46:12 PM        | 1                            | 
+| Pod        | etcd-0     | Pulling                | Pulling image "arohcpocpint.azurecr.io/openshift-release-dev/ocp-v4.                              | 0-art-dev@sha256:bab348336022bc9038541b0d2e902394ac4238864f3eff7d025810f40140e9d4"                                                                  | 5/19/2026, 9:46:23 PM        | 5/19/2026, 9:46:23 PM        | 1
+| Pod        | etcd-0     | Pulled                 | Successfully pulled image "arohcpocpint.azurecr.io/openshift-release-dev/ocp-v4.                  | 0-art-dev@sha256:bab348336022bc9038541b0d2e902394ac4238864f3eff7d025810f40140e9d4" in 68ms (68ms including waiting). Image size: 135157226 bytes.   | 5/19/2026, 9:46:23 PM        | 5/19/2026, 9:46:23 PM        | 1
+| Pod        | etcd-0     | Pulled                 | Container image "arohcpocpint.azurecr.io/openshift-release-dev/ocp-v4.                            | 0-art-dev@sha256:bab348336022bc9038541b0d2e902394ac4238864f3eff7d025810f40140e9d4" already present on machine and can be accessed by the pod        | 5/19/2026, 9:46:24 PM        | 5/19/2026, 9:46:24 PM        | 1
+| Pod        | etcd-0     | Pulling                | Pulling image "arohcpocpint.azurecr.io/openshift-release-dev/ocp-v4.                              | 0-art-dev@sha256:440ded05fd114f9d115896f8522886683953358f4c78a6a17d2ad0de77a93398"                                                                  | 5/19/2026, 9:46:24 PM        | 5/19/2026, 9:46:24 PM        | 1
+| Pod        | etcd-0     | Pulled                 | Successfully pulled image "arohcpocpint.azurecr.io/openshift-release-dev/ocp-v4.                  | 0-art-dev@sha256:440ded05fd114f9d115896f8522886683953358f4c78a6a17d2ad0de77a93398" in 92ms (92ms including waiting). Image size: 182879933 bytes.   | 5/19/2026, 9:46:24 PM        | 5/19/2026, 9:46:24 PM        | 1
+| Pod        | etcd-0     | Pulled                 | Container image "arohcpocpint.azurecr.io/openshift-release-dev/ocp-v4.                            | 0-art-dev@sha256:d8c2b75f4be30014e9d04f7edba6d9adbb4744d57b2938731860a66d66ac8c75" already present on machine and can be accessed by the pod        | 5/19/2026, 9:46:24 PM        | 5/19/2026, 9:46:24 PM        | 1
+| Pod        | etcd-0     | Killing                | Stopping container etcd                                                                           | 5/19/2026, 9:56:17 PM                                                                                                                               | 5/19/2026, 9:56:17 PM        | 1                            | 
+| Pod        | etcd-0     | Killing                | Stopping container etcd-metrics                                                                   | 5/19/2026, 9:56:17 PM                                                                                                                               | 5/19/2026, 9:56:17 PM        | 1                            | 
+| Pod        | etcd-0     | Killing                | Stopping container etcd-defrag                                                                    | 5/19/2026, 9:56:17 PM                                                                                                                               | 5/19/2026, 9:56:17 PM        | 1                            | 
+| Pod        | etcd-0     | Killing                | Stopping container healthz                                                                        | 5/19/2026, 9:56:17 PM                                                                                                                               | 5/19/2026, 9:56:17 PM        | 1                            | 
+
+#### Proof 2: Log Snippet
+
+```kql
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('kubernetesEvents')
+| where timestamp between (datetime(2026-05-19T20:52:10Z) .. datetime(2026-05-19T22:10:46Z))
+| where objectKind == 'Node' and objectName == 'aks-userswft3-15776247-vmss00000h'
+| extend firstSeen = coalesce(firstSeen, todatetime(log.event_time)), lastSeen = coalesce(lastSeen, todatetime(log.event_time))
+| summarize arg_max(count, firstSeen, lastSeen) by objectKind, objectName, reason, message
+| project objectKind, objectName, reason, message, firstSeen, lastSeen, count
+| order by firstSeen asc
+```
+
+| objectKind | objectName                        | reason            | message                                                                                                                                | firstSeen                                         | lastSeen                     | count                 |
+|------------|-----------------------------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|------------------------------|-----------------------|
+| Node       | aks-userswft3-15776247-vmss00000h | NodeNotReady      | Node aks-userswft3-15776247-vmss00000h status is now: NodeNotReady                                                                     | 5/19/2026, 9:24:51 PM                             | 5/19/2026, 9:24:51 PM        | 1                     |
+| Node       | aks-userswft3-15776247-vmss00000h | NodeRebootStart   | Node auto-repair is initiating a reboot action due to NotReady status persisting >5 minutes. Learn more: aka.ms/aks/node-auto-repair   | 5/19/2026, 9:34:43.708597 PM                      | 5/19/2026, 9:34:43.708597 PM |
+| Node       | aks-userswft3-15776247-vmss00000h | NodeRebootEnd     | Reboot action from node auto-repair has completed. Learn more: aka.ms/aks/node-auto-repair                                             | 5/19/2026, 9:34:43.847463 PM                      | 5/19/2026, 9:34:43.847463 PM |
+| Node       | aks-userswft3-15776247-vmss00000h | NodeReimageStart  | Node auto-repair is initiating a reimage action due to NotReady status persisting >5 minutes. Learn more: aka.ms/aks/node-auto-repair  | 5/19/2026, 9:39:43.281945 PM                      | 5/19/2026, 9:39:43.281945 PM |
+| Node       | aks-userswft3-15776247-vmss00000h | NodeReimageEnd    | Reimage action from node auto-repair has completed. Learn more: aka.ms/aks/node-auto-repair                                            | 5/19/2026, 9:39:43.573352 PM                      | 5/19/2026, 9:39:43.573352 PM |
+| Node       | aks-userswft3-15776247-vmss00000h | NodeRedeployStart | Node auto-repair is initiating a redeploy action due to NotReady status persisting >5 minutes. Learn more: aka.ms/aks/node-auto-repair | 5/19/2026, 9:44:43.632632 PM                      | 5/19/2026, 9:44:43.632632 PM |
+| Node       | aks-userswft3-15776247-vmss00000h | NodeRedeployEnd   | Redeploy action from node auto-repair has completed. Learn more: aka.ms/aks/node-auto-repair                                           | 5/19/2026, 9:44:43.752846 PM                      | 5/19/2026, 9:44:43.752846 PM |
+| Node       | aks-userswft3-15776247-vmss00000h | NodeRedeployError | Node auto-repair redeploy action failed due to an operation failure. Learn more: aka.ms/aks/node-auto-repair-errors                    | 5/19/2026, 9:44:43.752888 PM                      | 5/19/2026, 9:44:43.752888 PM |
+| Node       | aks-userswft3-15776247-vmss00000h | DeletingNode      | Deleting node aks-userswft3-15776247-vmss00000h because it does not exist in the cloud provider                                        | 5/19/2026, 9:45:00 PM                             | 5/19/2026, 9:45:00 PM        | 1                     |
+| Node       | aks-userswft3-15776247-vmss00000h | RemovingNode      | Node aks-userswft3-15776247-vmss00000h event: Removing Node                                                                            | aks-userswft3-15776247-vmss00000h from Controller | 5/19/2026, 9:45:03 PM        | 5/19/2026, 9:45:03 PM | 1 |

--- a/tooling/hcpctl/pkg/agent/prompts/references/architecture.md
+++ b/tooling/hcpctl/pkg/agent/prompts/references/architecture.md
@@ -1,0 +1,53 @@
+# ARO-HCP Architecture
+
+ARO-HCP (Azure Red Hat OpenShift — Hosted Control Planes) is a managed OpenShift service where customer
+cluster control planes run on shared management clusters rather than on the customer's own infrastructure.
+
+## Request Flow
+
+A customer operation (e.g. create cluster) flows through the following components in order:
+
+```
+Customer → ARM → Frontend → Backend (async) → Clusters Service → Maestro → HyperShift
+```
+
+1. **ARM** delivers the request to the **Frontend** (RP), which validates it and creates an async operation.
+2. The **Backend** picks up the async operation, translates it into Clusters Service API calls. Over time,
+   the backend will take over from CS; check the codebase for clear distinction of responsibilities.
+3. **Clusters Service** (CS) manages the cluster/nodepool lifecycle via its own state machine, producing
+   Maestro resource bundles that describe the desired state on the management cluster.
+4. **Maestro server** delivers those bundles to the management cluster as ManifestWork objects.
+5. **Maestro agent** applies the objects to the management cluster and pushes status back to the server. 
+5. **HyperShift** reconciles HostedCluster and NodePool custom resources on the management cluster,
+   creating the actual control plane pods in a hosted-control-plane namespace.
+
+## Topology
+
+- **Management clusters**: Run HyperShift, Maestro agent, and hosted control planes for many customers.
+- **Service clusters**: Run the Frontend, Backend, Clusters Service, and Maestro server.
+- Each environment has its own Kusto cluster with two databases:
+  - **Service database**: Frontend, Backend, and Clusters Service logs.
+  - **HCP database**: HyperShift, control-plane-operator, and per-cluster control plane logs.
+
+## Resource Types
+
+| ARM Resource Type | Description |
+|---|---|
+| `microsoft.redhatopenshift/hcpopenshiftclusters` | Top-level cluster resource |
+| `microsoft.redhatopenshift/hcpopenshiftclusters/nodepools` | Node pool (child of cluster) |
+| `microsoft.redhatopenshift/hcpopenshiftclusters/requestadmincredential` | Admin credential request |
+
+Each cluster resource maps to downstream objects:
+- A CS cluster ID (`cid`) (opaque string like `2iig1flm0pfjr9h8kkg6ggbjig1p3fpa`)
+- Maestro bundle IDs and ManifestWork names
+- A HyperShift HostedCluster in a namespace on the management cluster
+- A HyperShift HostedControlPlane in its own namespace (`<hc-namespace>-<hc-name>`)
+
+## Key Repositories
+
+| Repository | Contains |
+|---|---|
+| `ARO-HCP` | Frontend, Backend, Admin API, tooling |
+| `aro-hcp-clusters-service` | Clusters Service (private, mirrored from GitLab) |
+| `maestro` | Maestro server and agent |
+| `hypershift` | HyperShift operator |

--- a/tooling/hcpctl/pkg/agent/prompts/references/service-components.md
+++ b/tooling/hcpctl/pkg/agent/prompts/references/service-components.md
@@ -1,0 +1,75 @@
+# Service Components
+
+## Frontend (`arohcpfrontend`)
+
+The ARM-facing resource provider. Receives customer HTTP requests (PUT, POST, PATCH, DELETE) for
+clusters and node pools.
+
+**Responsibilities:**
+- Request validation and authentication
+- Creating async operations (returns `Azure-AsyncOperation` header with operation URL)
+- Proxying GET requests
+
+**Failure modes:** Validation errors (4xx), timeout creating async operation, panic/crash.
+
+## Backend (`arohcpbackend`)
+
+Processes async operations created by the Frontend. Runs as a set of controllers.
+
+**Responsibilities:**
+- Polling async operation status
+- Translating ARM operations into Clusters Service API calls
+- Dumping resource state periodically (the `datadump` and `csstatedump` controllers)
+
+**Failure modes:** CS API errors, stale state, controller crash loops, provisioning state stuck.
+
+## Clusters Service (`aro-hcp-clusters-service`)
+
+Red Hat-hosted service that manages the full cluster and node pool lifecycle.
+
+**Responsibilities:**
+- Maintains its own state machine for cluster/nodepool provisioning
+- Interacts with Azure to provision infrastructure required for a cluster
+- Produces Maestro resource bundles describing desired management-cluster state
+
+**Failure modes:** State machine stuck, bundle creation failure, internal errors, dependency on
+external services (e.g. DNS, certificate provisioning).
+
+## Maestro
+
+Resource delivery system. The **server** runs on the service cluster; the **agent** runs on each
+management cluster.
+
+**Responsibilities:**
+- Server: accepts resource bundles from CS, persists them, signals agents
+- Agent: watches for bundles, applies them as ManifestWork objects on the management cluster
+
+**Key identifiers:**
+- Bundle IDs (from CS logs)
+- ManifestWork names (applied on management cluster)
+
+**Failure modes:** Agent not connected, bundle apply failure, ManifestWork rejected, stale bundles.
+
+**Key Notes:** When reviewing Maestro transitions from logs, expect to see the spec and status
+sides equal - that is, if the server sees N client pings on spec, we should see the server send
+N specs to the broker, and the agent should get N specs from the broker and apply all of them to
+the cluster. If the agent sees X status updates from the cluster, we should see X status events
+to the broker, X status events processed by the server and at least X notifications to subscribers. 
+
+## HyperShift
+
+Operator running on management clusters that reconciles HostedCluster and NodePool custom resources
+into actual control plane infrastructure.
+
+**Responsibilities:**
+- Creating hosted control plane pods (kube-apiserver, etcd, etc.)
+- Managing NodePool machine sets
+- Reporting conditions on HostedCluster and NodePool objects
+
+**Key objects:**
+- `HostedCluster` in a namespace on the management cluster
+- `HostedControlPlane` in `<namespace>-<name>` namespace
+- `NodePool` in the same namespace as the HostedCluster
+
+**Failure modes:** Condition degraded/progressing stuck, pod crash loops, etcd issues, RBAC errors,
+resource quota exceeded, image pull failures.

--- a/tooling/hcpctl/pkg/agent/prompts/system.md
+++ b/tooling/hcpctl/pkg/agent/prompts/system.md
@@ -127,7 +127,7 @@ Your final output MUST be a valid JSON object with this structure:
 #### Output Schema Notes
 
 - The `log` proof type is *only* for referring to content from the test's stdout
-  or stderr logs, provided in the data directory under `test/{output,error}.log`
+  or stderr logs, provided in the data directory under `test_logs/{output,error}.log`
 - Use Markdown in all free-form text content to correctly format the output and
   improve communication efficacy.
 
@@ -150,7 +150,7 @@ Use standard CommonMark syntax:
 ## Debugging Methodology
 
 First, determine which phase of the test failed - some setup code runs before the spec,
-and some cleanup/teardown code runs after the code test finishes. Remember than more
+and some cleanup/teardown code runs after the code test finishes. Remember that more
 than one phase can fail, but if it's clear that only a particular phase failed, focus
 on debugging that, rather than investigating the other phases. For example, if only
 cleanup/teardown fails, don't focus on the core test phase. Review the correct phase
@@ -172,7 +172,7 @@ Markdown documents, where the following sections exist:
 - understanding the output section, which is a Markdown table-formatted version of the
   Kusto output
 
-Being by reviewing the Frontend requests in the data directory to find the mutating
+Begin by reviewing the Frontend requests in the data directory to find the mutating
 request(s) that correspond to the failures seen in the test. Determine which resources
 those relate to; trace the requests (along with asynchronous requests) to confirm
 the client interaction.

--- a/tooling/hcpctl/pkg/agent/prompts/system.md
+++ b/tooling/hcpctl/pkg/agent/prompts/system.md
@@ -1,0 +1,267 @@
+# Analysis Instructions
+
+## The Recursive Why Method
+
+Your analysis follows the "recursive why" method. Starting from the proximal
+failure, you recursively ask "why?" to drill deeper into the root cause.
+
+- The first question is always: **"Why did this test fail?"**
+- The answer to each question must be a direct, specific response that fully
+  describes one "layer" in our stack. For instance, explain fully the "why"
+  as it pertains to the test runner, but don't jump into the frontend.
+- **Make certain not to skip any "layers"** - for example, before talking
+  about CAPI, explain the "why" for the frontend, backend, Clusters Service,
+  and HyperShift.
+- Each answer naturally raises a follow-up "why?" question that becomes the
+  next link in the chain.
+- The chain stops when you reach a root cause you can prove, or when you run
+  out of evidence and must admit the trail ends.
+
+## Standards For Proof
+
+Every answer must be proven with verifiable evidence. Never speculate — always
+prefer to admit that the answer to a "why?" is unclear or that more data is
+necessary to understand the issue.
+
+Keep track of what kinds of claims are being made in an answer, and ensure
+**every single claim is proven**:
+
+*Descriptive claims* (what did happen) are relatively easy to prove: provide
+Kusto queries that clearly show the behavior in question.
+
+*Normative claims* (what ought to happen) are difficult to prove, and should
+be used with caution. A few common cases where they are permissible:
+
+- if a server or client logs what they expected to see, what they did see
+  and how the two did not match, both a normative and a descriptive claim
+  can be proven with Kusto query output
+- if the intent of the code is clear, a normative claim may be proven with
+  an excerpt of code from the repo in question
+- if neither of the above is possible, a normative claim may be supported
+  with Kusto query output from passing sibling tests - by inference, the
+  behavior seen in passing tests ought to happen
+
+## Output Schema
+
+Your final output MUST be a valid JSON object with this structure:
+
+```json
+{
+    "root_cause": "Terse, one-sentence description of the root cause, as best we can tell",
+    "summary": "Rich Markdown overview of the narrative that the chain links below will give full details over",
+    "notes": "Free-form rich markdown content to expand on the summary",
+    "chain": [
+        {
+            "question": "Why did this test fail?",
+            "answer": "A direct, specific answer to the question",
+            "notes": "Optional per-link commentary to flesh out the point",
+            "proof": [
+                {
+                    "type": "log",
+                    "source": "error",
+                    "lines": [
+                        1,
+                        15
+                    ],
+                    "note": "The test error log shows the failure"
+                },
+                {
+                    "type": "kusto",
+                    "kql": "Self-contained KQL query",
+                    "note": "Explain why this evidence supports the answer"
+                },
+                {
+                    "type": "code",
+                    "repo": "RepoName",
+                    "file": "path/to/file.go",
+                    "lines": [
+                        10,
+                        25
+                    ],
+                    "note": "Explain why this code is relevant to the answer"
+                }
+            ]
+        },
+        {
+            "question": "Follow-up why question prompted by the previous answer",
+            "answer": "...",
+            "proof": [
+                {
+                    "type": "kusto",
+                    "kql": "..."
+                }
+            ]
+        }
+    ],
+    "suggestions": [
+        "Actionable suggestion for improving debuggability, test resilience, adding logs, or preventing recurrence"
+    ],
+    "discovery": [
+        {
+            "label": "Derive the internal cluster ID from the correlation ID",
+            "kql": "Self-contained KQL query"
+        }
+    ]
+}
+```
+
+### Chain link rules
+
+- The first chain link's `question` MUST be exactly `"Why did this test fail?"`
+- The first chain link MUST include at least one `log` proof with `source` set
+  to `"error"` — this anchors the analysis in the actual test failure output
+- Each subsequent `question` must follow naturally from the previous `answer`
+- Every `answer` must be directly supported by the `proof` items in that link
+- Each `proof` item's optional `note` field should explain why that specific
+  piece of evidence supports the answer — this is especially useful when a link
+  has multiple proof items
+- Every `proof` item is reproducible - `kusto` proofs can have their queries
+  re-run, `code` proofs are rendered as links to hosted Git repositories from
+  which the local worktrees are cloned, `log` proofs reference line ranges in
+  the test error or output logs provided in the initial message
+- For normative claims, use `code` proofs or comparative `kusto` proofs from
+  passing sibling tests
+- For descriptive claims, use `kusto` proofs
+- **Proofs are mandatory for every single claim being made**
+
+#### Output Schema Notes
+
+- The `log` proof type is *only* for referring to content from the test's stdout
+  or stderr logs, provided in the data directory under `test/{output,error}.log`
+- Use Markdown in all free-form text content to correctly format the output and
+  improve communication efficacy.
+
+## Markdown Formatting Rules
+
+All free-form text fields (`root_cause`, `summary`, `notes`, `note`) are rendered as Markdown.
+Use standard CommonMark syntax:
+
+- **Lists:** Use `- item` or `1. item` syntax. Never use bullet characters like
+  `•`, `–`, or other Unicode symbols — these are not recognized as list markup
+  and will render as a single paragraph.
+- **Code:** Use `` `inline` `` for identifiers and ` ``` ` fenced blocks for
+  multi-line code or log excerpts. Always specify the language (e.g. `go`, `kql`,
+  `json`) on fenced blocks.
+- **Emphasis:** Use `**bold**` for key terms and `*italic*` for secondary emphasis.
+- **Line breaks:** Use blank lines between paragraphs. Do not rely on trailing
+  spaces or `\n` literals for line breaks within a JSON string — instead, use
+  actual newlines in the JSON string value.
+
+## Debugging Methodology
+
+First, determine which phase of the test failed - some setup code runs before the spec,
+and some cleanup/teardown code runs after the code test finishes. Remember than more
+than one phase can fail, but if it's clear that only a particular phase failed, focus
+on debugging that, rather than investigating the other phases. For example, if only
+cleanup/teardown fails, don't focus on the core test phase. Review the correct phase
+directory in the data dir.
+
+Then, determine which client/server relationship is failing in the test, some possible
+options are that the test client is failing when contacting:
+
+- the RP through ARM
+- the ARO HCP cluster's Kubernetes API
+- a workload deployed on the ARO HCP cluster
+
+When reviewing the data directory, you will encounter pre-canned queries provided in
+Markdown documents, where the following sections exist:
+
+- reviewing the "Summary" to understand the point of the query, "What To Look For" for
+  expected output and "Where to Go Next" for suggested follow-ups
+- reading the `.kql` query section to understand the query being executed
+- understanding the output section, which is a Markdown table-formatted version of the
+  Kusto output
+
+Being by reviewing the Frontend requests in the data directory to find the mutating
+request(s) that correspond to the failures seen in the test. Determine which resources
+those relate to; trace the requests (along with asynchronous requests) to confirm
+the client interaction.
+
+**Always** review the Maestro transitions output to see if service <-> management cluster
+communications are working correctly.
+
+## Discovery
+
+The `discovery` array serves as the **provenance section** of your analysis. It shows
+readers exactly how you derived the constants and context used in your proof queries.
+
+**All pre-gathered discovery data from the data directory is included automatically** in
+the final output — every resource-level, request-level, and cluster-level discovery
+directory is embedded deterministically. You do not need to reference any data directory
+paths in your discovery array.
+
+Each discovery item you provide is an **agent-authored query** (`{"label": "...", "kql": "..."}`):
+a KQL query you write to establish the provenance of a constant used in your proof queries
+that is NOT already covered by the pre-gathered data. The system executes the query, generates
+an ADX deep link, and renders the results alongside the label.
+
+**Provenance rule:** Any constant in a proof KQL query that is not self-evident (resource IDs,
+correlation IDs, container names, cluster names, internal IDs, async operation paths, etc.)
+must have its provenance traceable. If the constant is derived from pre-gathered discovery
+data (which is auto-included), no explicit discovery item is needed. If the constant comes
+from an ad-hoc investigation, add an agent-authored `{"label": "...", "kql": "..."}` item
+so a reader can trace every "magic string" in your proof back to its source.
+
+## KQL Quality Rules
+
+**When a pre-canned query from the data directory is applicable to the analysis, prefer
+to embed it directly (or add a few clauses to filter it before embedding).**
+
+- Prefer the style exemplified in the gathered data under manifest.json:
+    - always specify the full cluster, database, and table names unambiguously
+    - wherever possible, make sure to add timestamp bounds that match the test's runtime
+    - use new-lines liberally to keep the width of the query low
+- Queries must be self-contained stories — a reader should understand the intent from the KQL alone
+- Use `| summarize`, `| where`, `| project` to produce focused, unambiguous output
+- To demonstrate absence, use `| summarize count = count()` — never rely on empty result sets
+- Queries will be rendered verbatim alongside their results — write them as if presenting to a colleague
+
+### Kusto Reference
+
+Each regional Kusto cluster for ARO HCP has two databases:
+
+- `ServiceLogs`, which contains data for the microservices making up the ARO HCP control plane, mostly composed of
+  components running on the service cluster
+- `HostedControlPlaneLogs`, which contains data for the individual customer clusters in the ARO HCP data plane, as well
+  as logs for the management cluster components
+
+Review the ingest mappings and schemas used to set up these Kusto databases and tables in the ARO-HCP repository, at
+`dev-infrastructure/modules/logs/kusto/tables`.
+
+Remember that hosted cluster namespaces will take the form `ocm-arohcp<env>-<cid>-<id>`. Use
+`distinct pod_name, container_name` within a hosted cluster namespace to see the pods and containers for which we have
+logs; or, search the `database('HostedControlPlaneLogs').table('containerLogs')` with
+`| where namespace_name !contains 'ocm-arohcp'` to review other components on the management cluster for which we have
+logs.
+
+## Epistemological Rules
+
+- Never assert a cause without proof from Kusto queries or source code
+- Always dig in to the next causal layer - time-outs are a symptom, not a cause
+- When pre-gathered data is insufficient, formulate ad-hoc Kusto queries to investigate further
+- When you hit a dead end, state what you looked for and what you didn't find, with proof
+- Do not speculate beyond what the evidence supports. The chain stops where the proof stops.
+- Explore multiple hypotheses before committing to one — check alternatives
+
+## Methodology
+
+1. Read the test error log to understand what the test expected vs. what happened
+2. Read the test's source code in `Azure/ARO-HCP/test/e2e` to understand the test's intent
+3. Review the manifest.json in the data directory to learn facts about the test and an overview of pre-canned data
+   available
+4. Determine the resource(s) and request(s) pertinent to the test failure, review data dumped for these either to use
+   verbatim in the analysis or as inspiration for new queries with the kusto_query tool
+5. Check controller/resource status first, then dig into logs if that's not clear; finally, look at pod events to see if
+   the server(s) involved were healthy if the logs are inconclusive
+6. If contents in the data directory are useful as proof, include their KQL for Kusto proof items or edit it to fit the
+   narrative better - don't reference the data directory itself
+7. Use passing tests in the same Prow Job as comparison points for 'good' log traces if necessary
+8. Populate the `discovery` array: add agent-authored `{"label": "kql"}` items for any constant
+   whose provenance isn't covered by the pre-gathered data (which is auto-included in the final output).
+   Prefer to be broad.
+9. When the errant behavior is understood, use the source code in the worktrees to find the bug(s) that should be fixed
+   to avoid this kind of error in the future
+10. **Throughout the analysis**, whenever you make a claim about system behavior (e.g. "the controller does X", "the
+    timeout is Y", "this error is returned when Z"), read the relevant source code and include a `code` proof item with
+    the exact file and line range. Do not make claims about what the code does without citing it — readers need to see
+    the evidence, not just trust your assertion.

--- a/tooling/hcpctl/pkg/agent/render.go
+++ b/tooling/hcpctl/pkg/agent/render.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RenderMarkdown produces a low-fidelity markdown document from a hydrated
+// analysis chain. This is used to show the agent the full rendered output —
+// including query result tables — so it can review narrative coherence,
+// evidence quality, and depth before finalizing.
+func RenderMarkdown(chain *HydratedChain, testName string) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("# Test Failure Analysis: %s\n\n", testName))
+
+	// Root cause.
+	sb.WriteString("## Root Cause\n\n")
+	sb.WriteString(chain.RootCause)
+	sb.WriteString("\n\n")
+
+	// Summary.
+	sb.WriteString("## Summary\n\n")
+	sb.WriteString(chain.Summary)
+	sb.WriteString("\n\n")
+	if chain.Notes != "" {
+		sb.WriteString(chain.Notes)
+		sb.WriteString("\n\n")
+	}
+
+	// Causal chain.
+	if len(chain.Chain) > 0 {
+		sb.WriteString("## Causal Chain\n\n")
+		for i, link := range chain.Chain {
+			sb.WriteString(fmt.Sprintf("### %d. Q: %s\n\n", i+1, link.Question))
+			sb.WriteString(fmt.Sprintf("**A:** %s\n\n", link.Answer))
+
+			if link.Notes != "" {
+				sb.WriteString(link.Notes)
+				sb.WriteString("\n\n")
+			}
+
+			for j, proof := range link.Proof {
+				switch proof.Type {
+				case "kusto":
+					sb.WriteString(fmt.Sprintf("#### Proof %d (kusto)\n\n", j+1))
+					if proof.Note != "" {
+						sb.WriteString(proof.Note)
+						sb.WriteString("\n\n")
+					}
+					sb.WriteString("```kql\n")
+					sb.WriteString(proof.KQL)
+					sb.WriteString("\n```\n\n")
+					sb.WriteString(TableToMarkdown(proof.Table))
+					sb.WriteString("\n\n")
+				case "code":
+					sb.WriteString(fmt.Sprintf("#### Proof %d (code)\n\n", j+1))
+					if proof.Note != "" {
+						sb.WriteString(proof.Note)
+						sb.WriteString("\n\n")
+					}
+					sb.WriteString(fmt.Sprintf("`%s` — `%s` lines %d–%d:\n\n", proof.Repo, proof.File, proof.Lines[0], proof.Lines[1]))
+					sb.WriteString("```\n")
+					sb.WriteString(proof.CodeExcerpt)
+					sb.WriteString("\n```\n\n")
+				case "log":
+					sb.WriteString(fmt.Sprintf("#### Proof %d (log — %s)\n\n", j+1, proof.Source))
+					if proof.Note != "" {
+						sb.WriteString(proof.Note)
+						sb.WriteString("\n\n")
+					}
+					sb.WriteString(fmt.Sprintf("Test %s log, lines %d–%d:\n\n", proof.Source, proof.Lines[0], proof.Lines[1]))
+					sb.WriteString("```\n")
+					sb.WriteString(proof.LogExcerpt)
+					sb.WriteString("\n```\n\n")
+				}
+			}
+		}
+	}
+
+	// Suggestions.
+	if len(chain.Suggestions) > 0 {
+		sb.WriteString("## Suggestions\n\n")
+		for _, s := range chain.Suggestions {
+			sb.WriteString(fmt.Sprintf("- %s\n", s))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Facts (appendix).
+	if len(chain.Discovery) > 0 {
+		sb.WriteString("## Appendix: Discovered Facts\n\n")
+		for _, d := range chain.Discovery {
+			sb.WriteString(fmt.Sprintf("### %s\n\n", d.Label))
+			sb.WriteString("```kql\n")
+			sb.WriteString(d.KQL)
+			sb.WriteString("\n```\n\n")
+			sb.WriteString(TableToMarkdown(d.Table))
+			sb.WriteString("\n\n")
+		}
+	}
+
+	return sb.String()
+}

--- a/tooling/hcpctl/pkg/agent/schema.go
+++ b/tooling/hcpctl/pkg/agent/schema.go
@@ -1,0 +1,171 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"encoding/json"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/internal/tabular"
+)
+
+// DraftChain is the structured output the agent must produce as its final message.
+// This is the pre-hydration format — KQL queries have no share URIs or result tables yet.
+type DraftChain struct {
+	RootCause   string          `json:"root_cause"`
+	Summary     string          `json:"summary"`
+	Notes       string          `json:"notes,omitempty"`
+	Discovery   []DiscoveryItem `json:"discovery,omitempty"`
+	Chain       []ChainLink     `json:"chain"`
+	Suggestions []string        `json:"suggestions,omitempty"`
+}
+
+// DiscoveryItem is an agent-authored KQL query with a label, used to establish
+// provenance for constants in proof queries that are not already covered by the
+// pre-gathered data directory (which is embedded automatically during hydration).
+type DiscoveryItem struct {
+	// Label is a human-readable description of what this discovery item establishes.
+	Label string `json:"label"`
+
+	// KQL is an agent-authored Kusto query whose results establish provenance
+	// for constants used in proof queries.
+	KQL string `json:"kql"`
+}
+
+// ChainLink is one link in the causal why-chain. Each link poses a "why?"
+// question and provides an answer backed by proof. The first link's question
+// is always "Why did this test fail?"; subsequent questions follow naturally
+// from the previous answer.
+type ChainLink struct {
+	Question string      `json:"question"`
+	Answer   string      `json:"answer"`
+	Notes    string      `json:"notes,omitempty"`
+	Proof    []ProofItem `json:"proof"`
+}
+
+// ProofItem is evidence supporting a chain link claim.
+type ProofItem struct {
+	Type string `json:"type"` // "kusto", "code", "log"
+
+	// Kusto proof fields
+	KQL  string `json:"kql,omitempty"`
+	Note string `json:"note,omitempty"`
+
+	// Code proof fields
+	Repo  string `json:"repo,omitempty"`
+	File  string `json:"file,omitempty"`
+	Lines [2]int `json:"lines,omitempty"` // 1-indexed, inclusive; used by code and log proofs
+
+	// Log proof fields
+	Source string `json:"source,omitempty"` // "error" or "output"
+}
+
+// HydratedChain extends DraftChain with query results and share URIs.
+type HydratedChain struct {
+	RootCause   string              `json:"root_cause"`
+	Summary     string              `json:"summary"`
+	Notes       string              `json:"notes,omitempty"`
+	Discovery   []HydratedDiscovery `json:"discovery,omitempty"`
+	Chain       []HydratedLink      `json:"chain"`
+	Suggestions []string            `json:"suggestions,omitempty"`
+}
+
+// HydratedDiscovery is a single leaf query directory from a discovery path,
+// hydrated with its README summary, KQL, share URI, and parsed query results.
+type HydratedDiscovery struct {
+	Directory string         `json:"directory,omitempty"`
+	Label     string         `json:"label"`
+	KQL       string         `json:"kql"`
+	ShareURI  string         `json:"share_uri"`
+	Table     *tabular.Table `json:"table,omitempty"`
+}
+
+// HydratedLink is a chain link with hydrated proof items.
+type HydratedLink struct {
+	Question string              `json:"question"`
+	Answer   string              `json:"answer"`
+	Notes    string              `json:"notes,omitempty"`
+	Proof    []HydratedProofItem `json:"proof"`
+}
+
+// HydratedProofItem extends ProofItem with fields populated during hydration.
+type HydratedProofItem struct {
+	ProofItem
+
+	// Kusto proof fields populated during hydration
+	ShareURI string         `json:"share_uri,omitempty"`
+	Table    *tabular.Table `json:"table,omitempty"`
+
+	// Code proof field populated during hydration by reading the worktree
+	CodeExcerpt string `json:"code_excerpt,omitempty"`
+
+	// Log proof field populated during hydration by extracting lines from test logs
+	LogExcerpt string `json:"log_excerpt,omitempty"`
+}
+
+// ParseDraftChain parses the agent's final output as a DraftChain.
+func ParseDraftChain(output string) (*DraftChain, error) {
+	// Try to find JSON in the output — the agent may wrap it in markdown code fences.
+	jsonStr := extractJSON(output)
+
+	var chain DraftChain
+	if err := json.Unmarshal([]byte(jsonStr), &chain); err != nil {
+		return nil, err
+	}
+	return &chain, nil
+}
+
+// extractJSON attempts to extract a JSON object from text that may include
+// markdown code fences or surrounding prose.
+func extractJSON(s string) string {
+	// Look for ```json ... ``` fencing first.
+	start := -1
+	for i := 0; i < len(s)-3; i++ {
+		if s[i:i+3] == "```" {
+			// Skip the language tag line.
+			for j := i + 3; j < len(s); j++ {
+				if s[j] == '\n' {
+					start = j + 1
+					break
+				}
+			}
+			break
+		}
+	}
+
+	if start >= 0 {
+		// Find closing ```.
+		for i := start; i < len(s)-3; i++ {
+			if s[i:i+3] == "```" {
+				return s[start:i]
+			}
+		}
+	}
+
+	// Otherwise, find the first { and last }.
+	first := -1
+	last := -1
+	for i, c := range s {
+		if c == '{' && first == -1 {
+			first = i
+		}
+		if c == '}' {
+			last = i
+		}
+	}
+	if first >= 0 && last > first {
+		return s[first : last+1]
+	}
+	return s
+}

--- a/tooling/hcpctl/pkg/agent/tools_kusto.go
+++ b/tooling/hcpctl/pkg/agent/tools_kusto.go
@@ -1,0 +1,272 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	copilot "github.com/github/copilot-sdk/go"
+
+	"github.com/Azure/azure-kusto-go/azkustodata"
+	kustoerrors "github.com/Azure/azure-kusto-go/azkustodata/errors"
+	"github.com/Azure/azure-kusto-go/azkustodata/kql"
+	"github.com/Azure/azure-kusto-go/azkustodata/query"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/internal/tabular"
+)
+
+// KustoClient is the interface for executing KQL queries against Azure Data Explorer.
+type KustoClient interface {
+	// Query executes a KQL query and returns the result as a tabular.Table.
+	Query(ctx context.Context, kql string) (*tabular.Table, error)
+}
+
+// kustoQueryParams is the typed parameter struct for the kusto_query tool.
+type kustoQueryParams struct {
+	KQL string `json:"kql" jsonschema:"required" jsonschema_description:"The KQL query to execute."`
+}
+
+// maxToolResultRows is the maximum number of rows returned to the agent in a
+// tool call result. The full table is still cached (and used for hydration /
+// persistence); only the markdown rendered for the conversation is truncated.
+const maxToolResultRows = 100
+
+// NewKustoTool creates a kusto_query Copilot SDK tool backed by the given client.
+func NewKustoTool(client KustoClient) copilot.Tool {
+	return copilot.DefineTool(
+		"kusto_query",
+		`Execute a KQL query against Azure Data Explorer. Use this when the pre-gathered diagnostic data is insufficient and you need to investigate further. The query runs against the ARO-HCP logging cluster. Results are returned as a markdown table. Write queries that are self-contained and tell a story — they will be rendered verbatim in the final analysis.`,
+		func(params kustoQueryParams, inv copilot.ToolInvocation) (string, error) {
+			if params.KQL == "" {
+				return "", fmt.Errorf("kql must not be empty")
+			}
+
+			table, err := client.Query(inv.TraceContext, params.KQL)
+			if err != nil {
+				return "", fmt.Errorf("%s", summarizeKustoError(err))
+			}
+
+			totalRows := len(table.Rows)
+			if totalRows > maxToolResultRows {
+				truncated := &tabular.Table{
+					Columns: table.Columns,
+					Rows:    table.Rows[:maxToolResultRows],
+				}
+				return fmt.Sprintf("%s\n\n(showing %d of %d rows — add filters or aggregations to narrow results)",
+					TableToMarkdown(truncated), maxToolResultRows, totalRows), nil
+			}
+
+			return TableToMarkdown(table), nil
+		},
+	)
+}
+
+// ADXKustoClient wraps an Azure Data Explorer client to implement KustoClient.
+// It executes queries against a specific database and formats results as markdown.
+type ADXKustoClient struct {
+	client   *azkustodata.Client
+	database string
+}
+
+// NewADXKustoClient creates a KustoClient that queries a specific ADX cluster and database.
+// The client is created using the provided credential and cluster URI.
+// The caller is responsible for calling Close when done.
+func NewADXKustoClient(credential azcore.TokenCredential, clusterURI, database string) (*ADXKustoClient, error) {
+	kcsb := azkustodata.NewConnectionStringBuilder(clusterURI).
+		WithTokenCredential(credential)
+	client, err := azkustodata.New(kcsb)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kusto client for %q: %w", clusterURI, err)
+	}
+	return &ADXKustoClient{
+		client:   client,
+		database: database,
+	}, nil
+}
+
+// Close releases the underlying Kusto client resources.
+func (c *ADXKustoClient) Close() error {
+	return c.client.Close()
+}
+
+// CachingKustoClient wraps a KustoClient and caches successful query results
+// in memory, keyed by the KQL query string. This avoids re-running identical
+// queries across validation and hydration rounds. Only successful results are
+// cached; errors are always retried against the underlying client.
+type CachingKustoClient struct {
+	delegate KustoClient
+	cache    map[string]*tabular.Table
+}
+
+// NewCachingKustoClient wraps the given client with an in-memory query cache.
+func NewCachingKustoClient(delegate KustoClient) *CachingKustoClient {
+	return &CachingKustoClient{
+		delegate: delegate,
+		cache:    make(map[string]*tabular.Table),
+	}
+}
+
+// Query returns a cached result for the given KQL if available, otherwise
+// delegates to the underlying client and caches a successful result.
+func (c *CachingKustoClient) Query(ctx context.Context, kqlQuery string) (*tabular.Table, error) {
+	if table, ok := c.cache[kqlQuery]; ok {
+		return table, nil
+	}
+	table, err := c.delegate.Query(ctx, kqlQuery)
+	if err != nil {
+		return nil, err
+	}
+	c.cache[kqlQuery] = table
+	return table, nil
+}
+
+// Query executes a KQL query and returns the result as a tabular.Table.
+func (c *ADXKustoClient) Query(ctx context.Context, kqlQuery string) (*tabular.Table, error) {
+	dataset, err := c.client.IterativeQuery(ctx, c.database, kql.New("").AddUnsafe(kqlQuery))
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	return datasetToTable(dataset)
+}
+
+// datasetToTable converts a Kusto iterative dataset to a tabular.Table,
+// preserving the column order returned by the Kusto API.
+func datasetToTable(dataset query.IterativeDataset) (*tabular.Table, error) {
+	t := &tabular.Table{}
+
+	for tableResult := range dataset.Tables() {
+		table := tableResult.Table()
+		if table == nil {
+			if tableResult.Err() != nil {
+				return nil, tableResult.Err()
+			}
+			continue
+		}
+
+		// Skip non-primary tables (metadata, query stats, etc.)
+		if !table.IsPrimaryResult() {
+			for range table.Rows() {
+			}
+			continue
+		}
+
+		columns := table.Columns()
+		if t.Columns == nil {
+			t.Columns = make([]string, len(columns))
+			for i, col := range columns {
+				t.Columns[i] = col.Name()
+			}
+		}
+
+		for rowResult := range table.Rows() {
+			if rowResult.Err() != nil {
+				return t, rowResult.Err()
+			}
+			row := rowResult.Row()
+
+			cells := make([]string, len(columns))
+			for i := range columns {
+				val, err := row.Value(i)
+				if err != nil {
+					cells[i] = ""
+				} else {
+					cells[i] = fmt.Sprintf("%v", val)
+				}
+			}
+			t.Rows = append(t.Rows, cells)
+		}
+	}
+
+	return t, nil
+}
+
+// TableToMarkdown renders a tabular.Table as a markdown table.
+// If the table is nil or has no columns, the string "(no results)" is returned.
+func TableToMarkdown(t *tabular.Table) string {
+	if t == nil || len(t.Columns) == 0 {
+		return "(no results)"
+	}
+
+	var sb strings.Builder
+
+	// Header.
+	sb.WriteString("| ")
+	for i, col := range t.Columns {
+		if i > 0 {
+			sb.WriteString(" | ")
+		}
+		sb.WriteString(col)
+	}
+	sb.WriteString(" |\n")
+
+	// Separator.
+	sb.WriteString("| ")
+	for i := range t.Columns {
+		if i > 0 {
+			sb.WriteString(" | ")
+		}
+		sb.WriteString("---")
+	}
+	sb.WriteString(" |\n")
+
+	// Rows.
+	for _, row := range t.Rows {
+		sb.WriteString("| ")
+		for i := range t.Columns {
+			if i > 0 {
+				sb.WriteString(" | ")
+			}
+			if i < len(row) {
+				sb.WriteString(row[i])
+			}
+		}
+		sb.WriteString(" |\n")
+	}
+
+	return sb.String()
+}
+
+// summarizeKustoError extracts a concise error message from a Kusto SDK error.
+func summarizeKustoError(err error) string {
+	var kustoErr *kustoerrors.Error
+	if errors.As(err, &kustoErr) {
+		if rest := kustoErr.UnmarshalREST(); rest != nil {
+			if errObj, ok := rest["error"].(map[string]interface{}); ok {
+				code, _ := errObj["code"].(string)
+				msg, _ := errObj["message"].(string)
+				atMsg, _ := errObj["@message"].(string)
+				if code != "" {
+					summary := fmt.Sprintf("query failed: %s: %s", code, msg)
+					if atMsg != "" && atMsg != msg {
+						summary += " — " + atMsg
+					}
+					return summary
+				}
+			}
+		}
+	}
+	// Fallback: return the raw error but truncated to avoid context bloat.
+	s := err.Error()
+	const maxLen = 512
+	if len(s) > maxLen {
+		s = s[:maxLen] + "... (truncated)"
+	}
+	return s
+}

--- a/tooling/hcpctl/pkg/agent/validation.go
+++ b/tooling/hcpctl/pkg/agent/validation.go
@@ -1,0 +1,312 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// FirstChainQuestion is the required question for the first link in the causal chain.
+const FirstChainQuestion = "Why did this test fail?"
+
+// ValidationContext holds the data needed to validate a DraftChain beyond
+// structural checks — file system paths, log contents, and worktree locations.
+type ValidationContext struct {
+	// ValidRepos is the set of repository names that have source code worktrees available.
+	ValidRepos map[string]bool
+	// WorktreePaths maps repository names to local filesystem paths for their git worktrees.
+	WorktreePaths map[string]string
+	// DataDir is the root of the gathered data directory (for discovery path validation).
+	DataDir string
+	// TestError is the contents of the test error.log file.
+	TestError string
+	// TestOutput is the contents of the test output.log file.
+	TestOutput string
+}
+
+// ValidateDraft checks a DraftChain for structural problems and executes every
+// KQL snippet against the provided Kusto client. It validates log proof line
+// ranges against actual log contents, code proof line ranges against actual
+// source files, and discovery paths against the data directory.
+// It returns a human-readable feedback string describing all issues found,
+// suitable for sending back to the agent as a correction prompt. If everything
+// is valid, the returned string is empty.
+func ValidateDraft(ctx context.Context, client KustoClient, draft *DraftChain, vc *ValidationContext) string {
+	var problems []string
+
+	// Structural checks.
+	if draft.RootCause == "" {
+		problems = append(problems, "- The root_cause is empty. Every analysis must include a terse, one-sentence root cause.")
+	}
+	if draft.Summary == "" {
+		problems = append(problems, "- The summary is empty. Every analysis must include a non-empty summary.")
+	}
+	if len(draft.Chain) == 0 {
+		problems = append(problems, "- The chain is empty. Every analysis must include at least one causal chain link.")
+	}
+	for i, link := range draft.Chain {
+		if i == 0 && link.Question != FirstChainQuestion {
+			problems = append(problems, fmt.Sprintf(
+				"- The first chain link's question must be exactly %q, but got %q.",
+				FirstChainQuestion, link.Question,
+			))
+		} else if link.Question == "" {
+			problems = append(problems, fmt.Sprintf("- Chain link %d has an empty question.", i))
+		}
+		if link.Answer == "" {
+			problems = append(problems, fmt.Sprintf("- Chain link %d (%q) has an empty answer.", i, link.Question))
+		}
+		if len(link.Proof) == 0 {
+			problems = append(problems, fmt.Sprintf("- Chain link %d (%q) has no proof items.", i, link.Question))
+		}
+		for j, proof := range link.Proof {
+			switch proof.Type {
+			case "kusto":
+				if proof.KQL == "" {
+					problems = append(problems, fmt.Sprintf("- Chain link %d (%q), proof #%d: kusto proof has empty KQL.", i, link.Question, j+1))
+				}
+			case "code":
+				if proof.Repo == "" || proof.File == "" {
+					problems = append(problems, fmt.Sprintf("- Chain link %d (%q), proof #%d: code proof is missing repo or file.", i, link.Question, j+1))
+				} else if !vc.ValidRepos[proof.Repo] {
+					var available []string
+					for repo := range vc.ValidRepos {
+						available = append(available, fmt.Sprintf("%q", repo))
+					}
+					sort.Strings(available)
+					problems = append(problems, fmt.Sprintf(
+						"- Chain link %d (%q), proof #%d: code proof references repository %q which is not available as a worktree. "+
+							"Code proofs may only reference repositories with available source code. Available repositories: %s. "+
+							"Either use one of the available repositories or convert this proof to a different type.",
+						i, link.Question, j+1, proof.Repo, strings.Join(available, ", "),
+					))
+				} else if proof.Lines[0] < 1 || proof.Lines[1] < proof.Lines[0] {
+					problems = append(problems, fmt.Sprintf(
+						"- Chain link %d (%q), proof #%d: code proof has invalid line range [%d, %d] (must be 1-indexed with start <= end).",
+						i, link.Question, j+1, proof.Lines[0], proof.Lines[1],
+					))
+				} else if worktreePath, ok := vc.WorktreePaths[proof.Repo]; ok {
+					lineCount, err := countFileLines(filepath.Join(worktreePath, proof.File))
+					if err != nil {
+						problems = append(problems, fmt.Sprintf(
+							"- Chain link %d (%q), proof #%d: code proof references file %q in repo %q which cannot be read: %s",
+							i, link.Question, j+1, proof.File, proof.Repo, err.Error(),
+						))
+					} else if proof.Lines[1] > lineCount {
+						problems = append(problems, fmt.Sprintf(
+							"- Chain link %d (%q), proof #%d: code proof line range [%d, %d] exceeds the file length (%d lines) for %s in repo %q.",
+							i, link.Question, j+1, proof.Lines[0], proof.Lines[1], lineCount, proof.File, proof.Repo,
+						))
+					}
+				}
+			case "log":
+				if proof.Source != "error" && proof.Source != "output" {
+					problems = append(problems, fmt.Sprintf(
+						"- Chain link %d (%q), proof #%d: log proof has invalid source %q (must be \"error\" or \"output\").",
+						i, link.Question, j+1, proof.Source,
+					))
+				} else if proof.Lines[0] < 1 || proof.Lines[1] < proof.Lines[0] {
+					problems = append(problems, fmt.Sprintf(
+						"- Chain link %d (%q), proof #%d: log proof has invalid line range [%d, %d] (must be 1-indexed with start <= end).",
+						i, link.Question, j+1, proof.Lines[0], proof.Lines[1],
+					))
+				} else {
+					var logContent string
+					if proof.Source == "error" {
+						logContent = vc.TestError
+					} else {
+						logContent = vc.TestOutput
+					}
+					if logContent == "" {
+						problems = append(problems, fmt.Sprintf(
+							"- Chain link %d (%q), proof #%d: log proof references %s log, but the %s log is empty.",
+							i, link.Question, j+1, proof.Source, proof.Source,
+						))
+					} else {
+						lineCount := strings.Count(logContent, "\n") + 1
+						if proof.Lines[1] > lineCount {
+							problems = append(problems, fmt.Sprintf(
+								"- Chain link %d (%q), proof #%d: log proof line range [%d, %d] exceeds the %s log length (%d lines).",
+								i, link.Question, j+1, proof.Lines[0], proof.Lines[1], proof.Source, lineCount,
+							))
+						}
+					}
+				}
+			default:
+				problems = append(problems, fmt.Sprintf("- Chain link %d (%q), proof #%d: unknown proof type %q (expected \"kusto\", \"code\", or \"log\").", i, link.Question, j+1, proof.Type))
+			}
+		}
+
+		// The first chain link must include at least one log proof referencing
+		// the test error log, so readers always see the failure output.
+		if i == 0 {
+			hasErrorLog := false
+			for _, proof := range link.Proof {
+				if proof.Type == "log" && proof.Source == "error" {
+					hasErrorLog = true
+					break
+				}
+			}
+			if !hasErrorLog {
+				problems = append(problems, "- The first chain link must include at least one log proof with source \"error\" referencing the test error log.")
+			}
+		}
+	}
+
+	// Discovery validation — each item must be a KQL query with a label.
+	for i, item := range draft.Discovery {
+		if item.KQL == "" {
+			problems = append(problems, fmt.Sprintf(
+				"- Discovery item %d has empty kql.",
+				i,
+			))
+		}
+		if item.Label == "" {
+			problems = append(problems, fmt.Sprintf(
+				"- Discovery item %d: agent-authored KQL discovery must have a non-empty label.",
+				i,
+			))
+		}
+	}
+
+	// At least one code proof must exist somewhere in the chain — the agent must
+	// cite specific source code to back claims about intended behavior.
+	hasCodeProof := false
+	for _, link := range draft.Chain {
+		for _, proof := range link.Proof {
+			if proof.Type == "code" {
+				hasCodeProof = true
+				break
+			}
+		}
+		if hasCodeProof {
+			break
+		}
+	}
+	if !hasCodeProof && len(vc.ValidRepos) > 0 {
+		var repos []string
+		for repo := range vc.ValidRepos {
+			repos = append(repos, fmt.Sprintf("%q", repo))
+		}
+		sort.Strings(repos)
+		problems = append(problems, fmt.Sprintf(
+			"- The chain contains no code proof items. When source code worktrees are available (%s), "+
+				"the analysis must include at least one code proof citing the specific file and line range "+
+				"that implements the behavior under investigation. Use code proofs to show *why* the system "+
+				"behaves the way it does — for example, the code path that produces an error, the timeout "+
+				"constant that was exceeded, or the retry logic that should have recovered. Read the source "+
+				"code in the worktrees and add code proof items to the relevant chain links.",
+			strings.Join(repos, ", "),
+		))
+	}
+
+	// KQL execution checks — run every query to verify it is syntactically and
+	// semantically valid against the target cluster, and that it returns data.
+	for _, loc := range extractKQL(draft) {
+		table, err := client.Query(ctx, loc.KQL)
+
+		where := fmt.Sprintf("chain link %q, proof #%d", loc.Label, loc.ProofIndex+1)
+
+		if err != nil {
+			problems = append(problems, fmt.Sprintf(
+				"- %s: KQL query failed when executed against Kusto:\n  Error: %s\n  Query:\n  ```kql\n  %s\n  ```",
+				where, summarizeKustoError(err), loc.KQL,
+			))
+			continue
+		}
+
+		if table == nil || len(table.Rows) == 0 {
+			problems = append(problems, fmt.Sprintf(
+				"- %s: KQL query returned no rows. A query used as evidence must return data. "+
+					"If the point of the query is to show that something did NOT happen, "+
+					"use a `summarize count=count()` and explicitly show a zero count instead of an empty result set.\n"+
+					"  Query:\n  ```kql\n  %s\n  ```",
+				where, loc.KQL,
+			))
+		}
+	}
+
+	if len(problems) == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"Your output has %d %s that must be fixed. Please correct all issues and re-emit the complete JSON output.\n\n%s",
+		len(problems),
+		pluralize(len(problems), "problem", "problems"),
+		strings.Join(problems, "\n\n"),
+	)
+}
+
+// kqlLocation identifies where a KQL snippet came from in the draft chain.
+type kqlLocation struct {
+	Label      string // chain link question
+	ProofIndex int    // proof item index
+	KQL        string
+}
+
+// extractKQL collects all KQL snippets from chain link proofs with their locations.
+func extractKQL(draft *DraftChain) []kqlLocation {
+	var locs []kqlLocation
+	for _, link := range draft.Chain {
+		for j, proof := range link.Proof {
+			if proof.Type == "kusto" && proof.KQL != "" {
+				locs = append(locs, kqlLocation{
+					Label:      link.Question,
+					ProofIndex: j,
+					KQL:        proof.KQL,
+				})
+			}
+		}
+	}
+	return locs
+}
+
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}
+
+// countFileLines counts the number of lines in a file.
+func countFileLines(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			slog.Warn("Failed to close file.", "path", path, "error", err)
+		}
+	}()
+
+	count := 0
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		count++
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	return count, nil
+}

--- a/tooling/hcpctl/pkg/kusto/client.go
+++ b/tooling/hcpctl/pkg/kusto/client.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Azure/azure-kusto-go/azkustodata"
 	azkquery "github.com/Azure/azure-kusto-go/azkustodata/query"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 )
 
 type KustoClient interface {
@@ -76,8 +77,15 @@ func NewClient(endpoint *url.URL, queryTimeout time.Duration) (*Client, error) {
 	// Create connection string builder
 	kcsb := azkustodata.NewConnectionStringBuilder(endpoint.String())
 
-	// Use Azure default credential chain for authentication
-	kcsb = kcsb.WithDefaultAzureCredential()
+	// Use Azure default credential chain for authentication, which respects AZURE_CONFIG_DIR
+	cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
+		AdditionallyAllowedTenants:   []string{"*"},
+		RequireAzureTokenCredentials: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Azure credential: %w", err)
+	}
+	kcsb = kcsb.WithTokenCredential(cred)
 
 	// Create Kusto client with authentication
 	kustoClient, err := azkustodata.New(kcsb)

--- a/tooling/hcpctl/pkg/snapshot/analysis.go
+++ b/tooling/hcpctl/pkg/snapshot/analysis.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// TestSummary holds metadata about a single e2e test from a Prow job run.
+// This includes both passing and failing tests so the analysis agent can
+// compare errant logs against known-good exemplars from passing sibling tests.
+type TestSummary struct {
+	Name             string    `json:"name"`
+	Result           string    `json:"result"`
+	ResourceGroup    string    `json:"resource_group,omitempty"`
+	StartTime        time.Time `json:"start_time,omitempty"`
+	EndTime          time.Time `json:"end_time,omitempty"`
+	CleanupStartTime time.Time `json:"cleanup_start_time,omitempty"`
+}
+
+// ConvertTestResults transforms the raw test results returned by
+// FetchProwJobData into the TestSummary format used by the analysis agent.
+func ConvertTestResults(results []TestResult) []TestSummary {
+	summaries := make([]TestSummary, 0, len(results))
+	for _, r := range results {
+		result := "passed"
+		if r.Failed {
+			result = "failed"
+		}
+		ts := TestSummary{
+			Name:             r.Name,
+			Result:           result,
+			ResourceGroup:    r.ResourceGroup,
+			StartTime:        r.StartTime,
+			EndTime:          r.EndTime,
+			CleanupStartTime: r.CleanupStartTime,
+		}
+		summaries = append(summaries, ts)
+	}
+	return summaries
+}
+
+// WriteTestLogs writes the test's error and output logs to the test_logs/
+// subdirectory of the output directory. This provides the analysis agent with
+// the raw test output for inclusion in proof items.
+func WriteTestLogs(outputDir string, test *TestResult) error {
+	testDir := filepath.Join(outputDir, "test_logs")
+	if err := os.MkdirAll(testDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create test output dir: %w", err)
+	}
+	if test.Error != "" {
+		if err := os.WriteFile(filepath.Join(testDir, "error.log"), []byte(test.Error), 0o644); err != nil {
+			return fmt.Errorf("failed to write error log: %w", err)
+		}
+	}
+	if test.Output != "" {
+		if err := os.WriteFile(filepath.Join(testDir, "output.log"), []byte(test.Output), 0o644); err != nil {
+			return fmt.Errorf("failed to write output log: %w", err)
+		}
+	}
+	return nil
+}
+
+// WriteSiblingTests writes the sibling test summaries to sibling_tests.json
+// in the output directory. This provides the analysis agent with visibility
+// into all tests from the same Prow job run.
+func WriteSiblingTests(outputDir string, summaries []TestSummary) error {
+	if len(summaries) == 0 {
+		return nil
+	}
+	data, err := json.Marshal(summaries)
+	if err != nil {
+		return fmt.Errorf("failed to marshal sibling test summaries: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, "sibling_tests.json"), data, 0o644); err != nil {
+		return fmt.Errorf("failed to write sibling_tests.json: %w", err)
+	}
+	return nil
+}
+
+// RecoverTimeWindow reads sibling_tests.json from a previously gathered data
+// directory and returns the start/end/cleanup-start times for the named test.
+// This is used when reusing gathered data from a previous run where the time
+// window was not persisted separately. Returns zero times if the file is
+// missing or the test is not found.
+func RecoverTimeWindow(dataDir, testName string) (time.Time, time.Time, time.Time) {
+	siblingPath := filepath.Join(dataDir, "sibling_tests.json")
+	data, err := os.ReadFile(siblingPath)
+	if err != nil {
+		return time.Time{}, time.Time{}, time.Time{}
+	}
+	var summaries []TestSummary
+	if err := json.Unmarshal(data, &summaries); err != nil {
+		return time.Time{}, time.Time{}, time.Time{}
+	}
+	for _, s := range summaries {
+		if s.Name == testName {
+			return s.StartTime, s.EndTime, s.CleanupStartTime
+		}
+	}
+	return time.Time{}, time.Time{}, time.Time{}
+}

--- a/tooling/hcpctl/pkg/snapshot/gather_enriched.go
+++ b/tooling/hcpctl/pkg/snapshot/gather_enriched.go
@@ -1,0 +1,168 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// GatherForTestOptions configures a data gathering run for a single test case.
+// The caller is responsible for fetching Prow job data, creating the Kusto
+// client and Gatherer, and computing sibling test summaries — all of which are
+// per-job concerns. This function handles only per-test work: writing test
+// logs, running Kusto queries, enriching the manifest, and writing sibling
+// test metadata.
+type GatherForTestOptions struct {
+	// Gatherer is the pre-configured snapshot gatherer backed by a Kusto client.
+	Gatherer *Gatherer
+
+	// Test is the specific test result to gather data for.
+	Test *TestResult
+
+	// ProwJobURL is the original Prow job URL, written into the manifest.
+	ProwJobURL string
+
+	// KustoEndpoint is the Kusto cluster URI (e.g. "https://foo.eastus.kusto.windows.net").
+	KustoEndpoint string
+
+	// ServiceDatabase is the Kusto database name for service-side data.
+	ServiceDatabase string
+
+	// HCPDatabase is the Kusto database name for HCP-side data.
+	HCPDatabase string
+
+	// ServiceClusterName and ManagementClusterName are AKS cluster names
+	// used to filter Kusto queries to only relevant clusters for PR jobs.
+	ServiceClusterName    string
+	ManagementClusterName string
+
+	// SiblingTests contains metadata for all e2e tests from the same Prow job run.
+	SiblingTests []TestSummary
+
+	// OutputDir is the directory where the structured data should be written.
+	OutputDir string
+
+	// QueryTimeout is the timeout for individual Kusto queries.
+	// A zero value defaults to 10 minutes.
+	QueryTimeout time.Duration
+
+	// Concurrency is the maximum number of concurrent Kusto queries.
+	// A value of 0 defaults to 4 * runtime.NumCPU().
+	Concurrency int
+}
+
+// GatherForTestResult contains metadata about what was gathered.
+type GatherForTestResult struct {
+	// ManifestPath is the path to the manifest.json file in the output directory.
+	ManifestPath string
+
+	// DataDir is the root of the structured data directory.
+	DataDir string
+
+	// Manifest is the parsed manifest from the snapshot library.
+	Manifest *Manifest
+
+	// VerificationReport contains pass/fail/skip results for each query.
+	VerificationReport *VerificationReport
+
+	// StartTime is the start of the time window for the test execution.
+	StartTime time.Time
+
+	// EndTime is the end of the time window for the test execution.
+	EndTime time.Time
+
+	// CleanupStartTime is the time at which the test's cleanup phase began.
+	CleanupStartTime time.Time
+}
+
+// GatherForTest runs the per-test data gathering pipeline: it writes test
+// logs, queries Kusto for traces and state, enriches the manifest with test
+// metadata, and writes sibling test summaries.
+//
+// Per-job setup (Prow artifact download, Kusto client creation, sibling test
+// summary computation) must be done by the caller and passed in via opts.
+func GatherForTest(ctx context.Context, opts GatherForTestOptions) (*GatherForTestResult, error) {
+	test := opts.Test
+
+	if test.ResourceGroup == "" {
+		return nil, fmt.Errorf("test %q: no resource group found in test output", test.Name)
+	}
+	if test.StartTime.IsZero() || test.EndTime.IsZero() {
+		return nil, fmt.Errorf("test %q: no start/end time available", test.Name)
+	}
+
+	// Write test logs.
+	if err := WriteTestLogs(opts.OutputDir, test); err != nil {
+		return nil, fmt.Errorf("failed to write test logs: %w", err)
+	}
+
+	// Build the gather input with 5-minute padding.
+	startTime := test.StartTime.Add(-5 * time.Minute)
+	endTime := test.EndTime.Add(5 * time.Minute)
+
+	queryTimeout := opts.QueryTimeout
+	if queryTimeout == 0 {
+		queryTimeout = 10 * time.Minute
+	}
+
+	input := GatherInput{
+		ClusterURI:            opts.KustoEndpoint,
+		ServiceDatabase:       opts.ServiceDatabase,
+		HCPDatabase:           opts.HCPDatabase,
+		ResourceGroup:         test.ResourceGroup,
+		ServiceClusterName:    opts.ServiceClusterName,
+		ManagementClusterName: opts.ManagementClusterName,
+		TimeWindow: TimeWindow{
+			Start:           startTime,
+			End:             endTime,
+			SetupFinishTime: test.SetupFinishTime,
+		},
+		CleanupStartTime: test.CleanupStartTime,
+		QueryTimeout:     queryTimeout,
+		Concurrency:      opts.Concurrency,
+		TestStartTime:    test.TestStartTime,
+	}
+
+	// Run the snapshot gatherer.
+	manifest, report, err := opts.Gatherer.Gather(ctx, input, opts.OutputDir)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot gather failed: %w", err)
+	}
+
+	// Enrich manifest with test metadata.
+	manifest.TestName = test.Name
+	manifest.ProwJobURL = opts.ProwJobURL
+	if err := WriteManifest(opts.OutputDir, manifest); err != nil {
+		return nil, fmt.Errorf("failed to write manifest: %w", err)
+	}
+
+	// Write sibling test summaries.
+	if err := WriteSiblingTests(opts.OutputDir, opts.SiblingTests); err != nil {
+		slog.Warn("Failed to write sibling_tests.json; continuing.", "error", err)
+	}
+
+	return &GatherForTestResult{
+		ManifestPath:       fmt.Sprintf("%s/manifest.json", opts.OutputDir),
+		DataDir:            opts.OutputDir,
+		Manifest:           manifest,
+		VerificationReport: report,
+		StartTime:          test.StartTime,
+		EndTime:            test.EndTime,
+		CleanupStartTime:   test.CleanupStartTime,
+	}, nil
+}

--- a/tooling/hcpctl/pkg/snapshot/gatherer.go
+++ b/tooling/hcpctl/pkg/snapshot/gatherer.go
@@ -59,6 +59,13 @@ type GatherInput struct {
 	// CleanupStartTime is the time at which test cleanup (resource deletion)
 	// began. A zero value means no cleanup time is available.
 	CleanupStartTime time.Time
+
+	// ServiceClusterName and ManagementClusterName are AKS cluster names
+	// used to filter queries for PR jobs. When both are non-empty, queries
+	// include a "| where cluster in (...)" filter to scope results to only
+	// the relevant clusters.
+	ServiceClusterName    string
+	ManagementClusterName string
 }
 
 // concurrency returns the effective concurrency limit.
@@ -87,13 +94,13 @@ func computePhases(input GatherInput) []phaseSpec {
 
 	if input.CleanupStartTime.IsZero() {
 		return []phaseSpec{
-			{name: "test", start: testStart, end: input.TimeWindow.End},
+			{name: "test_phase", start: testStart, end: input.TimeWindow.End},
 		}
 	}
 
 	return []phaseSpec{
-		{name: "test", start: testStart, end: input.CleanupStartTime},
-		{name: "cleanup", start: input.CleanupStartTime, end: input.TimeWindow.End},
+		{name: "test_phase", start: testStart, end: input.CleanupStartTime},
+		{name: "cleanup_phase", start: input.CleanupStartTime, end: input.TimeWindow.End},
 	}
 }
 
@@ -138,7 +145,7 @@ func recordVerification(report *VerificationReport, suite string, q querySpec, d
 		return
 	}
 
-	// Render KQL for downstream consumers (e.g. HTML overview).
+	// Render KQL for consumers that display the query text (e.g. HTML overview).
 	var renderedKQL string
 	if rendered, err := renderQuery(q.templatePath, data); err == nil {
 		renderedKQL = rendered
@@ -208,12 +215,14 @@ func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir stri
 
 	// Build seed queryData for discovery (full time window).
 	seedData := queryData{
-		ClusterURI:      input.ClusterURI,
-		ServiceDatabase: input.ServiceDatabase,
-		HCPDatabase:     input.HCPDatabase,
-		ResourceGroup:   input.ResourceGroup,
-		FullStartTime:   input.TimeWindow.Start,
-		FullEndTime:     input.TimeWindow.End,
+		ClusterURI:            input.ClusterURI,
+		ServiceDatabase:       input.ServiceDatabase,
+		HCPDatabase:           input.HCPDatabase,
+		ResourceGroup:         input.ResourceGroup,
+		ServiceClusterName:    input.ServiceClusterName,
+		ManagementClusterName: input.ManagementClusterName,
+		FullStartTime:         input.TimeWindow.Start,
+		FullEndTime:           input.TimeWindow.End,
 		// Discovery queries use the full window for phase fields too.
 		PhaseStartTime: input.TimeWindow.Start,
 		PhaseEndTime:   input.TimeWindow.End,
@@ -364,7 +373,7 @@ func (g *Gatherer) runDiscovery(
 		}
 	}
 
-	logger.Info("Running request discovery", "requests", len(trackedReqs), "queries", len(pool1Items))
+	logger.V(1).Info("Running request discovery", "requests", len(trackedReqs), "queries", len(pool1Items))
 	pool.runPool(ctx, pool1Items)
 
 	// Populate cachedResults from pool1 items.
@@ -444,7 +453,7 @@ func (g *Gatherer) runDiscovery(
 		}
 	}
 
-	logger.Info("Running resource discovery", "items", len(pool2Items))
+	logger.V(1).Info("Running resource discovery", "items", len(pool2Items))
 	pool.runPool(ctx, pool2Items)
 
 	// Record verification for resource discovery.
@@ -656,15 +665,17 @@ func (g *Gatherer) gatherPhase(
 	// Service-level event queries for this phase.
 	serviceEventsDir := filepath.Join(phaseDir, "events")
 	serviceEventData := queryData{
-		ClusterURI:      input.ClusterURI,
-		ServiceDatabase: input.ServiceDatabase,
-		HCPDatabase:     input.HCPDatabase,
-		ResourceGroup:   input.ResourceGroup,
-		FullStartTime:   input.TimeWindow.Start,
-		FullEndTime:     input.TimeWindow.End,
-		PhaseStartTime:  phase.start,
-		PhaseEndTime:    phase.end,
-		PhaseName:       phase.name,
+		ClusterURI:            input.ClusterURI,
+		ServiceDatabase:       input.ServiceDatabase,
+		HCPDatabase:           input.HCPDatabase,
+		ResourceGroup:         input.ResourceGroup,
+		ServiceClusterName:    input.ServiceClusterName,
+		ManagementClusterName: input.ManagementClusterName,
+		FullStartTime:         input.TimeWindow.Start,
+		FullEndTime:           input.TimeWindow.End,
+		PhaseStartTime:        phase.start,
+		PhaseEndTime:          phase.end,
+		PhaseName:             phase.name,
 	}
 	serviceEventMu := &sync.Mutex{}
 	for _, q := range queriesByCategory(categoryEvents) {
@@ -676,7 +687,7 @@ func (g *Gatherer) gatherPhase(
 		})
 	}
 
-	logger.Info("Running phase queries", "phase", phase.name, "items", len(poolItems))
+	logger.V(1).Info("Running phase queries", "phase", phase.name, "items", len(poolItems))
 	pool.runPool(ctx, poolItems)
 
 	// Record verification results from phase pool items.
@@ -698,7 +709,7 @@ func (g *Gatherer) gatherPhase(
 // requestInPhase returns true if the request's timestamp falls within the phase window.
 func (g *Gatherer) requestInPhase(req frontendRequest, phase phaseSpec) bool {
 	if req.Timestamp.IsZero() {
-		return phase.name == "test" // default to test phase if timestamp unknown
+		return phase.name == "test_phase" // default to test phase if timestamp unknown
 	}
 	return !req.Timestamp.Before(phase.start) && req.Timestamp.Before(phase.end)
 }
@@ -861,7 +872,7 @@ func composeOutput(readme string, rendered string, rows []resultRow) string {
 }
 
 // executeQuery renders and executes a single query spec, writes a combined
-// output file (<queryName>.md), and returns the result rows for downstream
+// output file (<queryName>.md), and returns the result rows for
 // dependency resolution.
 func (g *Gatherer) executeQuery(ctx context.Context, q querySpec, data *queryData, baseDir string, input GatherInput) ([]resultRow, error) {
 	logger := logr.FromContextOrDiscard(ctx)
@@ -895,9 +906,9 @@ func (g *Gatherer) executeQuery(ctx context.Context, q querySpec, data *queryDat
 	}
 
 	if len(rows) > 0 {
-		logger.Info("Wrote query output", "query", q.key(), "rows", len(rows), "file", mdFile)
+		logger.V(1).Info("Wrote query output", "query", q.key(), "rows", len(rows), "file", mdFile)
 	} else {
-		logger.Info("Query returned no results", "query", q.key())
+		logger.V(1).Info("Query returned no results", "query", q.key())
 	}
 
 	return rows, nil
@@ -925,9 +936,9 @@ func (g *Gatherer) executeQueryToDir(ctx context.Context, q querySpec, data *que
 	}
 
 	if len(rows) > 0 {
-		logger.Info("Query returned results (deferred write)", "query", q.key(), "rows", len(rows))
+		logger.V(1).Info("Query returned results (deferred write)", "query", q.key(), "rows", len(rows))
 	} else {
-		logger.Info("Query returned no results", "query", q.key())
+		logger.V(1).Info("Query returned no results", "query", q.key())
 	}
 
 	return rows, nil

--- a/tooling/hcpctl/pkg/snapshot/gatherer.go
+++ b/tooling/hcpctl/pkg/snapshot/gatherer.go
@@ -46,18 +46,18 @@ type GatherInput struct {
 	HCPDatabase string
 	// ResourceGroup is the Azure resource group to scope queries to.
 	ResourceGroup string
-	// TimeWindow is the time range to query.
+	// TimeWindow is the full time range to query.
 	TimeWindow TimeWindow
 	// QueryTimeout is the timeout for individual Kusto queries.
 	QueryTimeout time.Duration
 	// Concurrency is the maximum number of concurrent Kusto queries.
 	// A value of 0 defaults to 4 * runtime.NumCPU().
 	Concurrency int
+	// TestStartTime is when the first non-setup test step began. Zero when
+	// no non-setup steps are present in the timing metadata.
+	TestStartTime time.Time
 	// CleanupStartTime is the time at which test cleanup (resource deletion)
-	// began. When set, queries that want a "point-in-time" snapshot of resource
-	// state will use this as the upper bound instead of EndTime, so that the
-	// snapshot reflects the resource as it existed before deletion.
-	// A zero value means no cleanup time is available and EndTime is used.
+	// began. A zero value means no cleanup time is available.
 	CleanupStartTime time.Time
 }
 
@@ -67,6 +67,34 @@ func (g GatherInput) concurrency() int {
 		return g.Concurrency
 	}
 	return 4 * runtime.NumCPU()
+}
+
+// phaseSpec describes a single phase (test or cleanup) with its time boundaries.
+type phaseSpec struct {
+	name  string
+	start time.Time
+	end   time.Time
+}
+
+// computePhases returns the phases to gather based on the input time boundaries.
+// If TestStartTime is zero, StartTime is used as the test phase start.
+// If CleanupStartTime is zero, only a test phase is returned spanning to EndTime.
+func computePhases(input GatherInput) []phaseSpec {
+	testStart := input.TestStartTime
+	if testStart.IsZero() {
+		testStart = input.TimeWindow.Start
+	}
+
+	if input.CleanupStartTime.IsZero() {
+		return []phaseSpec{
+			{name: "test", start: testStart, end: input.TimeWindow.End},
+		}
+	}
+
+	return []phaseSpec{
+		{name: "test", start: testStart, end: input.CleanupStartTime},
+		{name: "cleanup", start: input.CleanupStartTime, end: input.TimeWindow.End},
+	}
 }
 
 // Gatherer produces structured diagnostic data directories by running
@@ -88,13 +116,13 @@ func resourceKey(data queryData) string {
 	return sanitizePath(data.ResourceType) + "/" + sanitizePath(data.ResourceName)
 }
 
-// resourceDir returns the output directory for a resource within the snapshot.
+// resourceDir returns the output directory for a resource within a base directory.
 // When resource type is unknown, correlationID is used to produce a unique path.
-func resourceDir(outputDir string, data queryData, correlationID string) string {
+func resourceDir(baseDir string, data queryData, correlationID string) string {
 	if data.ResourceType == "" {
-		return filepath.Join(outputDir, "resources", "unknown", sanitizePath(correlationID))
+		return filepath.Join(baseDir, "resources", "unknown", sanitizePath(correlationID))
 	}
-	return filepath.Join(outputDir, "resources", sanitizePath(data.ResourceType), sanitizePath(data.ResourceName))
+	return filepath.Join(baseDir, "resources", sanitizePath(data.ResourceType), sanitizePath(data.ResourceName))
 }
 
 // trackedRequest holds per-request discovery data and the original frontend request.
@@ -160,8 +188,16 @@ func requestDiscoveryRowCount(q querySpec, data queryData) int {
 	return 0
 }
 
+// resourceState holds per-resource discovery data across requests.
+type resourceState struct {
+	data     queryData
+	mu       *sync.Mutex
+	requests []trackedRequest
+}
+
 // Gather runs the full diagnostic data gathering pipeline for a resource group
-// and writes structured output to outputDir.
+// and writes structured output to outputDir. It runs discovery queries once,
+// then per-phase (test and cleanup) queries with appropriate time boundaries.
 func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir string) (*Manifest, *VerificationReport, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 	report := &VerificationReport{}
@@ -170,22 +206,30 @@ func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir stri
 		return nil, nil, fmt.Errorf("failed to create output directory: %w", err)
 	}
 
+	// Build seed queryData for discovery (full time window).
 	seedData := queryData{
-		ClusterURI:       input.ClusterURI,
-		ServiceDatabase:  input.ServiceDatabase,
-		HCPDatabase:      input.HCPDatabase,
-		StartTime:        input.TimeWindow.Start,
-		EndTime:          input.TimeWindow.End,
-		ResourceGroup:    input.ResourceGroup,
-		CleanupStartTime: input.CleanupStartTime,
-		EffectiveEndTime: effectiveEndTime(input),
+		ClusterURI:      input.ClusterURI,
+		ServiceDatabase: input.ServiceDatabase,
+		HCPDatabase:     input.HCPDatabase,
+		ResourceGroup:   input.ResourceGroup,
+		FullStartTime:   input.TimeWindow.Start,
+		FullEndTime:     input.TimeWindow.End,
+		// Discovery queries use the full window for phase fields too.
+		PhaseStartTime: input.TimeWindow.Start,
+		PhaseEndTime:   input.TimeWindow.End,
 	}
 
 	pool := &queryPool{gatherer: g, input: input}
 
-	// Phase 1: Run initial context queries (frontendRequests) to discover all ARM requests.
+	// =========================================================================
+	// Phase-independent discovery
+	// =========================================================================
+
+	discoveryDir := filepath.Join(outputDir, "discovery")
+
+	// Run context queries (frontendRequests) to discover all ARM requests.
 	for _, q := range contextQueries {
-		if _, err := g.executeQuery(ctx, q, &seedData, outputDir, input); err != nil {
+		if _, err := g.executeQuery(ctx, q, &seedData, discoveryDir, input); err != nil {
 			return nil, nil, fmt.Errorf("context query %s failed: %w", q.key(), err)
 		}
 	}
@@ -197,10 +241,24 @@ func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir stri
 		requests = nil
 	}
 
+	// Run per-request and per-resource discovery.
+	trackedReqs, resources, resourceOrder := g.runDiscovery(ctx, pool, seedData, requests, discoveryDir, report, logger)
+
+	if ctx.Err() != nil {
+		return nil, nil, ctx.Err()
+	}
+
+	// =========================================================================
+	// Per-phase execution
+	// =========================================================================
+
+	phases := computePhases(input)
 	manifest := &Manifest{
 		TimeWindow: TimeWindow{
 			Start:            input.TimeWindow.Start,
 			End:              input.TimeWindow.End,
+			SetupFinishTime:  input.TimeWindow.SetupFinishTime,
+			TestStartTime:    input.TestStartTime,
 			CleanupStartTime: input.CleanupStartTime,
 		},
 		ResourceGroup:   input.ResourceGroup,
@@ -209,8 +267,57 @@ func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir stri
 		DirectoryLayout: directoryLayout(),
 	}
 
-	// Phase 2 (Pool 1): Per-request discovery — run requestDiscovery queries
-	// for each mutating request concurrently.
+	for _, phase := range phases {
+		if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
+
+		phaseDir := filepath.Join(outputDir, phase.name)
+		logger.Info("Gathering phase", "phase", phase.name, "start", phase.start.Format(time.RFC3339), "end", phase.end.Format(time.RFC3339))
+
+		phaseManifest := g.gatherPhase(ctx, pool, input, phase, phaseDir, resources, resourceOrder, trackedReqs, report, logger)
+		manifest.Phases = append(manifest.Phases, *phaseManifest)
+
+		if err := writePhaseManifest(phaseDir, phaseManifest); err != nil {
+			logger.Error(err, "Failed to write phase manifest", "phase", phase.name)
+		}
+	}
+
+	// Record verification for request discovery.
+	for _, key := range resourceOrder {
+		rs := resources[key]
+		for _, tr := range rs.requests {
+			reqSuite := key + "/" + tr.req.Method + "-" + tr.req.ClientRequestID
+			for _, q := range queriesByCategory(categoryRequestDiscovery) {
+				if q.ready != nil && !q.ready(tr.data) {
+					recordVerification(report, reqSuite, q, tr.data, 0, true)
+				} else {
+					rowCount := requestDiscoveryRowCount(q, tr.data)
+					recordVerification(report, reqSuite, q, tr.data, rowCount, false)
+				}
+			}
+		}
+	}
+
+	if err := WriteManifest(outputDir, manifest); err != nil {
+		return nil, nil, err
+	}
+
+	return manifest, report, nil
+}
+
+// runDiscovery executes request-level and resource-level discovery queries,
+// writing output to the discovery directory. Returns the tracked requests,
+// deduplicated resources, and resource ordering.
+func (g *Gatherer) runDiscovery(
+	ctx context.Context,
+	pool *queryPool,
+	seedData queryData,
+	requests []frontendRequest,
+	discoveryDir string,
+	report *VerificationReport,
+	logger logr.Logger,
+) ([]trackedRequest, map[string]*resourceState, []string) {
 	type trackedRequestWithMu struct {
 		trackedRequest
 		mu *sync.Mutex
@@ -245,8 +352,7 @@ func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir stri
 		})
 	}
 
-	// Build pool1 work items after the trackedReqs slice is finalized, so
-	// that pointers into the slice are stable (append may reallocate).
+	// Pool 1: Run request discovery queries concurrently.
 	var pool1Items []workItem
 	for idx := range trackedReqs {
 		for _, q := range discoveryQueries {
@@ -261,7 +367,7 @@ func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir stri
 	logger.Info("Running request discovery", "requests", len(trackedReqs), "queries", len(pool1Items))
 	pool.runPool(ctx, pool1Items)
 
-	// Populate cachedResults from pool1 items for later writing.
+	// Populate cachedResults from pool1 items.
 	itemIdx := 0
 	for i := range trackedReqs {
 		for range discoveryQueries {
@@ -271,12 +377,7 @@ func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir stri
 		}
 	}
 
-	// Sync point: Deduplicate resources and build Pool 2 work items.
-	type resourceState struct {
-		data     queryData
-		mu       *sync.Mutex
-		requests []trackedRequest
-	}
+	// Deduplicate resources.
 	resources := make(map[string]*resourceState)
 	var resourceOrder []string
 
@@ -295,7 +396,7 @@ func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir stri
 		resources[key].requests = append(resources[key].requests, tr.trackedRequest)
 	}
 
-	// Write cached request discovery output and build Pool 2 work items.
+	// Pool 2: Run resource discovery queries + write cached request discovery output.
 	var pool2Items []workItem
 
 	for _, key := range resourceOrder {
@@ -304,7 +405,7 @@ func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir stri
 		if len(rs.requests) > 0 {
 			fallbackID = rs.requests[0].req.ClientRequestID
 		}
-		resDir := resourceDir(outputDir, rs.data, fallbackID)
+		resDir := resourceDir(discoveryDir, rs.data, fallbackID)
 
 		allClientErrors := len(rs.requests) > 0
 		for _, tr := range rs.requests {
@@ -314,93 +415,192 @@ func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir stri
 			}
 		}
 
-		// Enqueue resource-level queries if not all client errors.
 		if !allClientErrors {
-			discoveryDir := filepath.Join(resDir, "discovery")
 			for _, q := range queriesByCategory(categoryResourceDiscovery) {
 				pool2Items = append(pool2Items, workItem{
 					query:             q,
 					data:              &rs.data,
 					mu:                rs.mu,
-					outputDir:         discoveryDir,
-					verificationSuite: key,
-				})
-			}
-
-			stateDir := filepath.Join(resDir, "state")
-			for _, q := range queriesByCategory(categoryState) {
-				pool2Items = append(pool2Items, workItem{
-					query:             q,
-					data:              &rs.data,
-					mu:                rs.mu,
-					outputDir:         stateDir,
-					verificationSuite: key,
-				})
-			}
-
-			conditionsDir := filepath.Join(resDir, "conditions")
-			for _, q := range queriesByCategory(categoryConditions) {
-				pool2Items = append(pool2Items, workItem{
-					query:             q,
-					data:              &rs.data,
-					mu:                rs.mu,
-					outputDir:         conditionsDir,
-					verificationSuite: key,
-				})
-			}
-
-			logsDir := filepath.Join(resDir, "logs")
-			for _, q := range queriesByCategory(categoryLogs) {
-				pool2Items = append(pool2Items, workItem{
-					query:             q,
-					data:              &rs.data,
-					mu:                rs.mu,
-					outputDir:         logsDir,
-					verificationSuite: key,
-				})
-			}
-
-			eventsDir := filepath.Join(resDir, "events")
-			for _, q := range queriesByCategory(categoryResourceEvents) {
-				pool2Items = append(pool2Items, workItem{
-					query:             q,
-					data:              &rs.data,
-					mu:                rs.mu,
-					outputDir:         eventsDir,
+					outputDir:         resDir,
 					verificationSuite: key,
 				})
 			}
 		}
 
-		// Enqueue per-request trace queries and write cached discovery output.
+		// Write cached request discovery output.
 		for i := range rs.requests {
 			tr := &rs.requests[i]
 			reqDir := filepath.Join(resDir, "requests", tr.req.Method+"-"+tr.req.ClientRequestID)
-			reqSuite := key + "/" + tr.req.Method + "-" + tr.req.ClientRequestID
-
-			// Write request discovery output now that we know the resource directory.
-			reqDiscoveryDir := filepath.Join(reqDir, "discovery")
 			traceData := tr.data
 			mergeResourceData(&traceData, rs.data)
 
 			for _, q := range queriesByCategory(categoryRequestDiscovery) {
 				cached := tr.cachedResults[q.key()]
-				if err := writeQueryOutput(q, traceData, reqDiscoveryDir, cached); err != nil {
+				if err := writeQueryOutput(q, traceData, reqDir, cached); err != nil {
 					logger.Error(err, "Failed to write request discovery output", "query", q.key())
 				}
 			}
-
-			// Store the traceData for this request so trace queries can use it.
-			// We need a stable pointer, so store it back.
 			tr.data = traceData
-			trMu := &sync.Mutex{}
+		}
+	}
+
+	logger.Info("Running resource discovery", "items", len(pool2Items))
+	pool.runPool(ctx, pool2Items)
+
+	// Record verification for resource discovery.
+	for i := range pool2Items {
+		item := &pool2Items[i]
+		if item.verificationSuite == "" {
+			continue
+		}
+		if !item.executed {
+			recordVerification(report, item.verificationSuite, item.query, *item.data, 0, true)
+		} else if !item.failed {
+			recordVerification(report, item.verificationSuite, item.query, *item.data, len(item.resultRows), false)
+		}
+	}
+
+	// Flatten trackedReqs for return.
+	flat := make([]trackedRequest, len(trackedReqs))
+	for i := range trackedReqs {
+		flat[i] = trackedReqs[i].trackedRequest
+	}
+
+	return flat, resources, resourceOrder
+}
+
+// gatherPhase runs all non-discovery queries for a single phase, writing output
+// to phaseDir. It partitions requests by timestamp into this phase and runs
+// state, conditions, logs, events, and trace queries.
+func (g *Gatherer) gatherPhase(
+	ctx context.Context,
+	pool *queryPool,
+	input GatherInput,
+	phase phaseSpec,
+	phaseDir string,
+	resources map[string]*resourceState,
+	resourceOrder []string,
+	allTrackedReqs []trackedRequest,
+	report *VerificationReport,
+	logger logr.Logger,
+) *PhaseManifest {
+
+	phaseManifest := &PhaseManifest{
+		Name:  phase.name,
+		Dir:   phase.name,
+		Start: phase.start,
+		End:   phase.end,
+	}
+
+	var poolItems []workItem
+
+	// For each resource, enqueue phase-scoped queries.
+	for _, key := range resourceOrder {
+		rs := resources[key]
+
+		allClientErrors := len(rs.requests) > 0
+		for _, tr := range rs.requests {
+			if tr.req.Status < 400 || tr.req.Status >= 500 {
+				allClientErrors = false
+				break
+			}
+		}
+
+		var fallbackID string
+		if len(rs.requests) > 0 {
+			fallbackID = rs.requests[0].req.ClientRequestID
+		}
+		resDir := resourceDir(phaseDir, rs.data, fallbackID)
+
+		// Build phase-scoped queryData for this resource.
+		phaseData := rs.data
+		phaseData.FullStartTime = input.TimeWindow.Start
+		phaseData.FullEndTime = input.TimeWindow.End
+		phaseData.PhaseStartTime = phase.start
+		phaseData.PhaseEndTime = phase.end
+		phaseData.PhaseName = phase.name
+
+		phaseDataPtr := &phaseData
+		phaseMu := &sync.Mutex{}
+
+		if !allClientErrors {
+			// State queries
+			stateDir := filepath.Join(resDir, "state")
+			for _, q := range queriesByCategory(categoryState) {
+				poolItems = append(poolItems, workItem{
+					query:             q,
+					data:              phaseDataPtr,
+					mu:                phaseMu,
+					outputDir:         stateDir,
+					verificationSuite: phase.name + "/" + key,
+				})
+			}
+
+			// Conditions queries
+			conditionsDir := filepath.Join(resDir, "conditions")
+			for _, q := range queriesByCategory(categoryConditions) {
+				poolItems = append(poolItems, workItem{
+					query:             q,
+					data:              phaseDataPtr,
+					mu:                phaseMu,
+					outputDir:         conditionsDir,
+					verificationSuite: phase.name + "/" + key,
+				})
+			}
+
+			// Logs queries
+			logsDir := filepath.Join(resDir, "logs")
+			for _, q := range queriesByCategory(categoryLogs) {
+				poolItems = append(poolItems, workItem{
+					query:             q,
+					data:              phaseDataPtr,
+					mu:                phaseMu,
+					outputDir:         logsDir,
+					verificationSuite: phase.name + "/" + key,
+				})
+			}
+
+			// Resource events queries
+			eventsDir := filepath.Join(resDir, "events")
+			for _, q := range queriesByCategory(categoryResourceEvents) {
+				poolItems = append(poolItems, workItem{
+					query:             q,
+					data:              phaseDataPtr,
+					mu:                phaseMu,
+					outputDir:         eventsDir,
+					verificationSuite: phase.name + "/" + key,
+				})
+			}
+		}
+
+		// Per-request trace queries — only for requests in this phase.
+		for i := range rs.requests {
+			tr := &rs.requests[i]
+			if !g.requestInPhase(tr.req, phase) {
+				continue
+			}
+
+			reqDir := filepath.Join(resDir, "requests", tr.req.Method+"-"+tr.req.ClientRequestID)
+			reqSuite := phase.name + "/" + key + "/" + tr.req.Method + "-" + tr.req.ClientRequestID
+
+			// Trace queries use full time window so we get the complete request lifecycle.
+			traceData := tr.data
+			mergeResourceData(&traceData, rs.data)
+			traceData.FullStartTime = input.TimeWindow.Start
+			traceData.FullEndTime = input.TimeWindow.End
+			traceData.PhaseStartTime = input.TimeWindow.Start
+			traceData.PhaseEndTime = input.TimeWindow.End
+			traceData.PhaseName = phase.name
+
+			traceDataPtr := &traceData
+			traceMu := &sync.Mutex{}
 
 			traceStateDir := filepath.Join(reqDir, "state")
 			for _, q := range queriesByCategory(categoryTraceState) {
-				pool2Items = append(pool2Items, workItem{
+				poolItems = append(poolItems, workItem{
 					query:             q,
-					data:              &tr.data,
-					mu:                trMu,
+					data:              traceDataPtr,
+					mu:                traceMu,
 					outputDir:         traceStateDir,
 					verificationSuite: reqSuite,
 				})
@@ -408,24 +608,67 @@ func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir stri
 
 			traceLogsDir := filepath.Join(reqDir, "logs")
 			for _, q := range queriesByCategory(categoryTraceLogs) {
-				pool2Items = append(pool2Items, workItem{
+				poolItems = append(poolItems, workItem{
 					query:             q,
-					data:              &tr.data,
-					mu:                trMu,
+					data:              traceDataPtr,
+					mu:                traceMu,
 					outputDir:         traceLogsDir,
 					verificationSuite: reqSuite,
 				})
 			}
 		}
+
+		// Build resource entry for phase manifest.
+		if rs.data.ResourceType != "" {
+			relDir, _ := filepath.Rel(phaseDir, resDir)
+			var requestInfos []RequestInfo
+			for _, tr := range rs.requests {
+				if !g.requestInPhase(tr.req, phase) {
+					continue
+				}
+				reqRelDir := filepath.Join(relDir, "requests", tr.req.Method+"-"+tr.req.ClientRequestID)
+				requestInfos = append(requestInfos, RequestInfo{
+					ClientRequestID: tr.req.ClientRequestID,
+					CorrelationID:   tr.req.CorrelationID,
+					Method:          tr.req.Method,
+					Path:            tr.req.Path,
+					Status:          tr.req.Status,
+					Timestamp:       tr.req.Timestamp,
+					Dir:             reqRelDir,
+				})
+			}
+			phaseManifest.Resources = append(phaseManifest.Resources, ResourceEntry{
+				Type:                        rs.data.ResourceType,
+				Name:                        rs.data.ResourceName,
+				Dir:                         relDir,
+				ResourceID:                  rs.data.ResourceID,
+				ClusterResourceID:           rs.data.ClusterResourceID,
+				ClusterResourceName:         rs.data.ClusterResourceName,
+				InternalID:                  rs.data.InternalID,
+				ClusterID:                   rs.data.ClusterID,
+				HostedClusterNamespace:      rs.data.HostedClusterNamespace,
+				HostedControlPlaneNamespace: rs.data.HostedControlPlaneNamespace,
+				Requests:                    requestInfos,
+			})
+		}
 	}
 
-	// Enqueue service-level event queries (scoped to the resource group, not
-	// to a specific ARM resource). These run once per snapshot.
-	serviceEventsDir := filepath.Join(outputDir, "events")
-	serviceEventData := seedData
+	// Service-level event queries for this phase.
+	serviceEventsDir := filepath.Join(phaseDir, "events")
+	serviceEventData := queryData{
+		ClusterURI:      input.ClusterURI,
+		ServiceDatabase: input.ServiceDatabase,
+		HCPDatabase:     input.HCPDatabase,
+		ResourceGroup:   input.ResourceGroup,
+		FullStartTime:   input.TimeWindow.Start,
+		FullEndTime:     input.TimeWindow.End,
+		PhaseStartTime:  phase.start,
+		PhaseEndTime:    phase.end,
+		PhaseName:       phase.name,
+	}
 	serviceEventMu := &sync.Mutex{}
 	for _, q := range queriesByCategory(categoryEvents) {
-		pool2Items = append(pool2Items, workItem{
+		poolItems = append(poolItems, workItem{
 			query:     q,
 			data:      &serviceEventData,
 			mu:        serviceEventMu,
@@ -433,86 +676,31 @@ func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir stri
 		})
 	}
 
-	logger.Info("Running resource and trace queries", "items", len(pool2Items))
-	pool.runPool(ctx, pool2Items)
+	logger.Info("Running phase queries", "phase", phase.name, "items", len(poolItems))
+	pool.runPool(ctx, poolItems)
 
-	// Record verification results from Pool 2 items.
-	for i := range pool2Items {
-		item := &pool2Items[i]
+	// Record verification results from phase pool items.
+	for i := range poolItems {
+		item := &poolItems[i]
 		if item.verificationSuite == "" {
 			continue
 		}
 		if !item.executed {
-			// Query was never ready — record as skipped.
 			recordVerification(report, item.verificationSuite, item.query, *item.data, 0, true)
 		} else if !item.failed {
 			recordVerification(report, item.verificationSuite, item.query, *item.data, len(item.resultRows), false)
 		}
 	}
 
-	// Record verification for request discovery (from Pool 1 cached results).
-	for _, key := range resourceOrder {
-		rs := resources[key]
-		for _, tr := range rs.requests {
-			reqSuite := key + "/" + tr.req.Method + "-" + tr.req.ClientRequestID
-			for _, q := range queriesByCategory(categoryRequestDiscovery) {
-				if q.ready != nil && !q.ready(tr.data) {
-					recordVerification(report, reqSuite, q, tr.data, 0, true)
-				} else {
-					rowCount := requestDiscoveryRowCount(q, tr.data)
-					recordVerification(report, reqSuite, q, tr.data, rowCount, false)
-				}
-			}
-		}
+	return phaseManifest
+}
+
+// requestInPhase returns true if the request's timestamp falls within the phase window.
+func (g *Gatherer) requestInPhase(req frontendRequest, phase phaseSpec) bool {
+	if req.Timestamp.IsZero() {
+		return phase.name == "test" // default to test phase if timestamp unknown
 	}
-
-	// Build manifest.
-	for _, key := range resourceOrder {
-		rs := resources[key]
-		var fallbackID string
-		if len(rs.requests) > 0 {
-			fallbackID = rs.requests[0].req.ClientRequestID
-		}
-		resDir := resourceDir(outputDir, rs.data, fallbackID)
-
-		if rs.data.ResourceType == "" {
-			logger.Info("Skipping manifest entry for unknown resource", "key", key)
-			continue
-		}
-		relDir, _ := filepath.Rel(outputDir, resDir)
-		var requestInfos []RequestInfo
-		for _, tr := range rs.requests {
-			reqRelDir := filepath.Join(relDir, "requests", tr.req.Method+"-"+tr.req.ClientRequestID)
-			requestInfos = append(requestInfos, RequestInfo{
-				ClientRequestID: tr.req.ClientRequestID,
-				CorrelationID:   tr.req.CorrelationID,
-				Method:          tr.req.Method,
-				Path:            tr.req.Path,
-				Status:          tr.req.Status,
-				Timestamp:       tr.req.Timestamp,
-				Dir:             reqRelDir,
-			})
-		}
-		manifest.Resources = append(manifest.Resources, ResourceEntry{
-			Type:                        rs.data.ResourceType,
-			Name:                        rs.data.ResourceName,
-			Dir:                         relDir,
-			ResourceID:                  rs.data.ResourceID,
-			ClusterResourceID:           rs.data.ClusterResourceID,
-			ClusterResourceName:         rs.data.ClusterResourceName,
-			InternalID:                  rs.data.InternalID,
-			ClusterID:                   rs.data.ClusterID,
-			HostedClusterNamespace:      rs.data.HostedClusterNamespace,
-			HostedControlPlaneNamespace: rs.data.HostedControlPlaneNamespace,
-			Requests:                    requestInfos,
-		})
-	}
-
-	if err := WriteManifest(outputDir, manifest); err != nil {
-		return nil, nil, err
-	}
-
-	return manifest, report, nil
+	return !req.Timestamp.Before(phase.start) && req.Timestamp.Before(phase.end)
 }
 
 // mergeResourceData copies resource-level discovered fields into a per-request

--- a/tooling/hcpctl/pkg/snapshot/manifest.go
+++ b/tooling/hcpctl/pkg/snapshot/manifest.go
@@ -52,9 +52,9 @@ type Manifest struct {
 	DirectoryLayout map[string]string `json:"directory_layout"`
 }
 
-// PhaseManifest describes the diagnostic data gathered for a single phase (test or cleanup).
+// PhaseManifest describes the diagnostic data gathered for a single phase (test_phase or cleanup_phase).
 type PhaseManifest struct {
-	// Name is the phase name ("test" or "cleanup").
+	// Name is the phase name ("test_phase" or "cleanup_phase").
 	Name string `json:"name"`
 
 	// Dir is the phase output directory, relative to the snapshot root.
@@ -152,8 +152,9 @@ type RequestInfo struct {
 func directoryLayout() map[string]string {
 	return map[string]string{
 		"discovery":      "discovery/ — phase-independent query results: frontend requests, resource IDs, cluster associations, etc.",
-		"test":           "test/ — diagnostic data from the test phase (between test start and cleanup start)",
-		"cleanup":        "cleanup/ — diagnostic data from the cleanup phase (between cleanup start and overall end)",
+		"test_logs":      "test_logs/ — the test's error.log and output.log from the Prow job",
+		"test_phase":     "test_phase/ — diagnostic data from the test phase (between test start and cleanup start)",
+		"cleanup_phase":  "cleanup_phase/ — diagnostic data from the cleanup phase (between cleanup start and overall end)",
 		"serviceEvents":  "<phase>/events/ — Kubernetes events for service-level components (frontend, backend, clusters-service, maestro) during the phase",
 		"resourceEvents": "<phase>/resources/<type>/<name>/events/ — Kubernetes events specific to a resource's control plane during the phase",
 		"state":          "<phase>/resources/<type>/<name>/state/ — time-windowed raw resource state dumps (ARM state, CS state, Maestro logs, etc.)",

--- a/tooling/hcpctl/pkg/snapshot/manifest.go
+++ b/tooling/hcpctl/pkg/snapshot/manifest.go
@@ -23,6 +23,8 @@ import (
 )
 
 // Manifest describes the complete set of diagnostic data gathered for a test or resource.
+// The top-level manifest provides an overview; per-phase manifests hold resource and
+// request details to avoid duplication.
 type Manifest struct {
 	// TestName is the name of the test that failed, if this snapshot was gathered
 	// from a test failure. Empty when gathered directly from a resource ID.
@@ -31,7 +33,7 @@ type Manifest struct {
 	// ProwJobURL is the URL to the Prow job that triggered this snapshot, if applicable.
 	ProwJobURL string `json:"prow_job_url,omitempty"`
 
-	// TimeWindow is the time range over which diagnostic data was gathered.
+	// TimeWindow is the full time range over which diagnostic data was gathered.
 	TimeWindow TimeWindow `json:"time_window"`
 
 	// ResourceGroup is the Azure resource group that was queried.
@@ -43,21 +45,46 @@ type Manifest struct {
 	// KustoDatabase is the Kusto database used for queries.
 	KustoDatabase string `json:"kusto_database"`
 
-	// Resources lists each ARM resource for which diagnostic data was gathered.
-	Resources []ResourceEntry `json:"resources"`
+	// Phases lists the per-phase manifests for the test and cleanup phases.
+	Phases []PhaseManifest `json:"phases"`
 
 	// DirectoryLayout describes the output directory structure.
 	DirectoryLayout map[string]string `json:"directory_layout"`
 }
 
-// TimeWindow represents a bounded time range for diagnostic queries.
+// PhaseManifest describes the diagnostic data gathered for a single phase (test or cleanup).
+type PhaseManifest struct {
+	// Name is the phase name ("test" or "cleanup").
+	Name string `json:"name"`
+
+	// Dir is the phase output directory, relative to the snapshot root.
+	Dir string `json:"dir"`
+
+	// Start is the phase start time.
+	Start time.Time `json:"start"`
+
+	// End is the phase end time.
+	End time.Time `json:"end"`
+
+	// Resources lists each ARM resource for which diagnostic data was gathered in this phase.
+	Resources []ResourceEntry `json:"resources"`
+}
+
+// TimeWindow represents the full bounded time range for diagnostic queries, including
+// phase boundary timestamps derived from test timing metadata.
 type TimeWindow struct {
 	Start time.Time `json:"start"`
 	End   time.Time `json:"end"`
 
-	// CleanupStartTime is when test cleanup began. Point-in-time condition
-	// snapshots use this (when non-zero) instead of End to capture state
-	// before teardown.
+	// SetupFinishTime is when identity container setup completed. Zero when
+	// no setup steps are present in the timing metadata.
+	SetupFinishTime time.Time `json:"setup_finish_time,omitempty"`
+
+	// TestStartTime is when the first non-setup step began. Zero when no
+	// non-setup steps are present in the timing metadata.
+	TestStartTime time.Time `json:"test_start_time,omitempty"`
+
+	// CleanupStartTime is when test cleanup began.
 	CleanupStartTime time.Time `json:"cleanup_start_time,omitempty"`
 }
 
@@ -124,14 +151,15 @@ type RequestInfo struct {
 // directoryLayout returns the static directory layout descriptions.
 func directoryLayout() map[string]string {
 	return map[string]string{
-		"frontendRequests": "frontend/frontendRequests.md — all ARM requests in the resource group during the time window; start your analysis here",
-		"serviceEvents":    "events/ — Kubernetes events for service-level components (frontend, backend, clusters-service, maestro) during the time window",
-		"resourceEvents":   "resources/<type>/<name>/events/ — Kubernetes events specific to a resource's control plane during the time window",
-		"discovery":        "resources/<type>/<name>/discovery/ — intermediate query results used to derive IDs, cluster associations, etc.",
-		"state":            "resources/<type>/<name>/state/ — time-windowed raw resource state dumps (ARM state, CS state, Maestro logs, etc.)",
-		"conditions":       "resources/<type>/<name>/conditions/ — status condition transition summaries (HyperShift conditions, controller conditions)",
-		"logs":             "resources/<type>/<name>/logs/ — filtered or aggregated container and audit logs (operator logs, Maestro server/agent logs)",
-		"requests":         "resources/<type>/<name>/requests/<METHOD>-<client_request_id>/ — per-request trace data with discovery/, state/, and logs/ subdirectories",
+		"discovery":      "discovery/ — phase-independent query results: frontend requests, resource IDs, cluster associations, etc.",
+		"test":           "test/ — diagnostic data from the test phase (between test start and cleanup start)",
+		"cleanup":        "cleanup/ — diagnostic data from the cleanup phase (between cleanup start and overall end)",
+		"serviceEvents":  "<phase>/events/ — Kubernetes events for service-level components (frontend, backend, clusters-service, maestro) during the phase",
+		"resourceEvents": "<phase>/resources/<type>/<name>/events/ — Kubernetes events specific to a resource's control plane during the phase",
+		"state":          "<phase>/resources/<type>/<name>/state/ — time-windowed raw resource state dumps (ARM state, CS state, Maestro logs, etc.)",
+		"conditions":     "<phase>/resources/<type>/<name>/conditions/ — status condition transition summaries (HyperShift conditions, controller conditions)",
+		"logs":           "<phase>/resources/<type>/<name>/logs/ — filtered or aggregated container and audit logs (operator logs, Maestro server/agent logs)",
+		"requests":       "<phase>/resources/<type>/<name>/requests/<METHOD>-<client_request_id>/ — per-request trace data with state/ and logs/ subdirectories",
 	}
 }
 
@@ -144,6 +172,22 @@ func WriteManifest(dir string, manifest *Manifest) error {
 	path := filepath.Join(dir, "manifest.json")
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		return fmt.Errorf("failed to write manifest to %s: %w", path, err)
+	}
+	return nil
+}
+
+// writePhaseManifest serializes a phase manifest to a manifest.json file.
+func writePhaseManifest(dir string, phase *PhaseManifest) error {
+	data, err := json.MarshalIndent(phase, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal phase manifest: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create phase directory %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, "manifest.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write phase manifest to %s: %w", path, err)
 	}
 	return nil
 }

--- a/tooling/hcpctl/pkg/snapshot/prow.go
+++ b/tooling/hcpctl/pkg/snapshot/prow.go
@@ -53,7 +53,12 @@ type ProwJobInfo struct {
 	JobName   string
 	ProwID    string
 	GCSPrefix string
-	IsPR      bool
+}
+
+// IsPullRequest reports whether the job is a pull-ci (PR) job,
+// determined by the job name prefix.
+func (p *ProwJobInfo) IsPullRequest() bool {
+	return strings.HasPrefix(p.JobName, "pull-ci")
 }
 
 // ProwJobConfig holds the Kusto connection info extracted from a Prow job's config.yaml.
@@ -62,6 +67,13 @@ type ProwJobConfig struct {
 	KustoName       string
 	HCPDatabase     string
 	ServiceDatabase string
+
+	// ServiceClusterName and ManagementClusterName are the AKS cluster names
+	// used to filter Kusto queries to only relevant clusters. These are only
+	// populated for PR (pull-ci) jobs where the shared Kusto database contains
+	// data from multiple clusters.
+	ServiceClusterName    string
+	ManagementClusterName string
 }
 
 // TestResult represents a single test with its metadata.
@@ -112,7 +124,6 @@ func ParseProwURL(rawURL string) (*ProwJobInfo, error) {
 				JobName:   segments[i+4],
 				ProwID:    prowID,
 				GCSPrefix: strings.Join(segments[i:i+6], "/"),
-				IsPR:      true,
 			}, nil
 		}
 		if seg == "logs" {
@@ -128,7 +139,6 @@ func ParseProwURL(rawURL string) (*ProwJobInfo, error) {
 				JobName:   segments[i+1],
 				ProwID:    prowID,
 				GCSPrefix: strings.Join(segments[i:i+3], "/"),
-				IsPR:      false,
 			}, nil
 		}
 	}
@@ -152,7 +162,7 @@ func FetchProwJobData(ctx context.Context, info *ProwJobInfo) (*ProwJobConfig, [
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to find artifact directory: %w", err)
 	}
-	logger.Info("Found artifact directory", "dir", artifactDir)
+	logger.V(1).Info("Found artifact directory", "dir", artifactDir)
 
 	artifactPrefix := fmt.Sprintf("%s/artifacts/%s", info.GCSPrefix, artifactDir)
 
@@ -163,11 +173,11 @@ func FetchProwJobData(ctx context.Context, info *ProwJobInfo) (*ProwJobConfig, [
 		return nil, nil, fmt.Errorf("failed to download config.yaml: %w", err)
 	}
 
-	jobConfig, err := parseConfig(configData, info.IsPR)
+	jobConfig, err := parseConfig(configData, info.JobName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse config.yaml: %w", err)
 	}
-	logger.Info("Parsed job config",
+	logger.V(1).Info("Parsed job config",
 		"region", jobConfig.Region,
 		"kusto", jobConfig.KustoName,
 		"serviceDB", jobConfig.ServiceDatabase,
@@ -176,7 +186,7 @@ func FetchProwJobData(ctx context.Context, info *ProwJobInfo) (*ProwJobConfig, [
 
 	// Download test results.
 	testStep := testStepPersistent
-	if info.IsPR {
+	if info.IsPullRequest() {
 		testStep = testStepLocal
 	}
 	testResultsPrefix := fmt.Sprintf("%s/%s/artifacts/extension_test_result_e2e_", artifactPrefix, testStep)
@@ -292,7 +302,7 @@ func deriveSetupTestBoundary(steps []timing.StepTimingMetadata) (setupFinishTime
 // container" are treated as setup; the remaining steps are the test itself.
 func fetchTestTimings(ctx context.Context, gcsClient *storage.Client, artifactPrefix string, logger logr.Logger) map[string]testTimingBoundaries {
 	prefix := fmt.Sprintf("%s/%stiming-metadata-", artifactPrefix, timingMetadataPath)
-	logger.Info("Fetching timing metadata", "prefix", prefix)
+	logger.V(1).Info("Fetching timing metadata", "prefix", prefix)
 	files, err := listObjects(ctx, gcsClient, prefix)
 	if err != nil {
 		logger.V(1).Info("Could not list timing metadata files, skipping timing enrichment", "err", err)
@@ -358,7 +368,7 @@ func fetchTestTimings(ctx context.Context, gcsClient *storage.Client, artifactPr
 		result[testName] = boundaries
 	}
 
-	logger.Info("Loaded test timing boundaries from timing metadata", "count", len(result))
+	logger.V(1).Info("Loaded test timing boundaries from timing metadata", "count", len(result))
 	return result
 }
 
@@ -381,6 +391,8 @@ func ExtractResourceGroup(output string) string {
 type sourceConfig struct {
 	Region string      `json:"region"`
 	Kusto  sourceKusto `json:"kusto"`
+	Svc    sourceAKS   `json:"svc"`
+	Mgmt   sourceAKS   `json:"mgmt"`
 }
 
 type sourceKusto struct {
@@ -389,23 +401,39 @@ type sourceKusto struct {
 	ServiceLogsDatabase            string `json:"serviceLogsDatabase"`
 }
 
-func parseConfig(data []byte, isPR bool) (*ProwJobConfig, error) {
+type sourceAKS struct {
+	AKS sourceAKSName `json:"aks"`
+}
+
+type sourceAKSName struct {
+	Name string `json:"name"`
+}
+
+func parseConfig(data []byte, jobName string) (*ProwJobConfig, error) {
 	var src sourceConfig
 	if err := yaml.Unmarshal(data, &src); err != nil {
 		return nil, fmt.Errorf("failed to parse YAML: %w", err)
 	}
 
 	region := src.Region
-	if isPR {
+	isPullRequest := strings.HasPrefix(jobName, "pull-ci")
+	if isPullRequest {
 		region = prKustoRegion
 	}
 
-	return &ProwJobConfig{
+	config := &ProwJobConfig{
 		Region:          region,
 		KustoName:       src.Kusto.KustoName,
 		HCPDatabase:     src.Kusto.HostedControlPlaneLogsDatabase,
 		ServiceDatabase: src.Kusto.ServiceLogsDatabase,
-	}, nil
+	}
+
+	if isPullRequest {
+		config.ServiceClusterName = src.Svc.AKS.Name
+		config.ManagementClusterName = src.Mgmt.AKS.Name
+	}
+
+	return config, nil
 }
 
 // findArtifactDir lists subdirectories under artifacts/ and returns the one

--- a/tooling/hcpctl/pkg/snapshot/prow.go
+++ b/tooling/hcpctl/pkg/snapshot/prow.go
@@ -73,6 +73,8 @@ type TestResult struct {
 	StartTime        time.Time
 	EndTime          time.Time
 	ResourceGroup    string // extracted from test output
+	SetupFinishTime  time.Time
+	TestStartTime    time.Time
 	CleanupStartTime time.Time
 }
 
@@ -226,11 +228,13 @@ func FetchProwJobData(ctx context.Context, info *ProwJobInfo) (*ProwJobConfig, [
 
 	logger.Info("Found test results", "total", len(tests), "failed", numFailed)
 
-	// Enrich test results with cleanup start times from timing metadata.
-	cleanupTimes := fetchCleanupStartTimes(ctx, gcsClient, artifactPrefix, logger)
+	// Enrich test results with timing boundaries from timing metadata.
+	testTimings := fetchTestTimings(ctx, gcsClient, artifactPrefix, logger)
 	for i := range tests {
-		if t, ok := cleanupTimes[tests[i].Name]; ok {
-			tests[i].CleanupStartTime = t
+		if t, ok := testTimings[tests[i].Name]; ok {
+			tests[i].SetupFinishTime = t.SetupFinishTime
+			tests[i].TestStartTime = t.TestStartTime
+			tests[i].CleanupStartTime = t.CleanupStartTime
 		}
 	}
 
@@ -239,16 +243,59 @@ func FetchProwJobData(ctx context.Context, info *ProwJobInfo) (*ProwJobConfig, [
 
 const timingMetadataPath = "aro-hcp-gather-test-visualization/artifacts/test-timing/"
 
-// fetchCleanupStartTimes downloads timing metadata files from the GCS bucket and
-// returns a map from test name to the cleanup start time. The top-level finishedAt
-// in each timing metadata file marks when the core test work completed and cleanup
-// began.
-func fetchCleanupStartTimes(ctx context.Context, gcsClient *storage.Client, artifactPrefix string, logger logr.Logger) map[string]time.Time {
+// testTimingBoundaries holds the derived phase boundaries for a single test.
+type testTimingBoundaries struct {
+	SetupFinishTime  time.Time
+	TestStartTime    time.Time
+	CleanupStartTime time.Time
+}
+
+// identityContainerStep reports whether a step name refers to identity container setup.
+func identityContainerStep(name string) bool {
+	return strings.Contains(strings.ToLower(name), "identity container")
+}
+
+// deriveSetupTestBoundary inspects the steps in the timing metadata and returns:
+//   - setupFinishTime: the latest FinishedAt among steps whose name contains
+//     "identity container" (setup steps).
+//   - testStartTime: the earliest StartedAt among steps whose name does NOT
+//     contain "identity container" (test steps).
+//
+// Either or both may be zero when the relevant steps are not present or their
+// timestamps cannot be parsed.
+func deriveSetupTestBoundary(steps []timing.StepTimingMetadata) (setupFinishTime, testStartTime time.Time) {
+	for _, step := range steps {
+		if identityContainerStep(step.Name) {
+			if step.FinishedAt != "" {
+				if t, err := time.Parse(time.RFC3339, step.FinishedAt); err == nil {
+					if setupFinishTime.IsZero() || t.After(setupFinishTime) {
+						setupFinishTime = t
+					}
+				}
+			}
+		} else {
+			if step.StartedAt != "" {
+				if t, err := time.Parse(time.RFC3339, step.StartedAt); err == nil {
+					if testStartTime.IsZero() || t.Before(testStartTime) {
+						testStartTime = t
+					}
+				}
+			}
+		}
+	}
+	return setupFinishTime, testStartTime
+}
+
+// fetchTestTimings downloads timing metadata files from the GCS bucket and
+// returns a map from test name to the derived timing boundaries. The top-level
+// finishedAt marks when cleanup began. Steps whose name contains "identity
+// container" are treated as setup; the remaining steps are the test itself.
+func fetchTestTimings(ctx context.Context, gcsClient *storage.Client, artifactPrefix string, logger logr.Logger) map[string]testTimingBoundaries {
 	prefix := fmt.Sprintf("%s/%stiming-metadata-", artifactPrefix, timingMetadataPath)
 	logger.Info("Fetching timing metadata", "prefix", prefix)
 	files, err := listObjects(ctx, gcsClient, prefix)
 	if err != nil {
-		logger.V(1).Info("Could not list timing metadata files, skipping cleanup time enrichment", "err", err)
+		logger.V(1).Info("Could not list timing metadata files, skipping timing enrichment", "err", err)
 		return nil
 	}
 	if len(files) == 0 {
@@ -256,7 +303,7 @@ func fetchCleanupStartTimes(ctx context.Context, gcsClient *storage.Client, arti
 		return nil
 	}
 
-	result := make(map[string]time.Time)
+	result := make(map[string]testTimingBoundaries)
 	for _, objPath := range files {
 		fileName := objPath[strings.LastIndex(objPath, "/")+1:]
 		if !strings.HasPrefix(fileName, "timing-metadata-") {
@@ -296,17 +343,22 @@ func fetchCleanupStartTimes(ctx context.Context, gcsClient *storage.Client, arti
 		}
 
 		testName := strings.Join(tm.Identifier, " ")
+		boundaries := testTimingBoundaries{}
+
 		if tm.FinishedAt != "" {
 			t, err := time.Parse(time.RFC3339, tm.FinishedAt)
 			if err == nil {
-				result[testName] = t
+				boundaries.CleanupStartTime = t
 			} else {
 				logger.Error(err, "Failed to parse finishedAt from timing metadata, skipping", "path", objPath)
 			}
 		}
+
+		boundaries.SetupFinishTime, boundaries.TestStartTime = deriveSetupTestBoundary(tm.Steps)
+		result[testName] = boundaries
 	}
 
-	logger.Info("Loaded cleanup start times from timing metadata", "count", len(result))
+	logger.Info("Loaded test timing boundaries from timing metadata", "count", len(result))
 	return result
 }
 

--- a/tooling/hcpctl/pkg/snapshot/queries.go
+++ b/tooling/hcpctl/pkg/snapshot/queries.go
@@ -98,7 +98,7 @@ type querySpec struct {
 	// empty results are always acceptable (it will not appear in verification output).
 	requiredWhen func(queryData) bool
 	// storeResult is called with the full result rows from the query.
-	// It stores discovered values for downstream queries. If the results
+	// It stores discovered values for dependent queries. If the results
 	// are ambiguous (e.g. multiple distinct values for a single-valued field),
 	// storeResult should return an error.
 	storeResult func(*queryData, []resultRow) error
@@ -116,6 +116,12 @@ type queryData struct {
 	ServiceDatabase string
 	HCPDatabase     string
 	ResourceGroup   string
+
+	// ServiceClusterName and ManagementClusterName are AKS cluster names
+	// used to filter queries for PR jobs. When both are non-empty, queries
+	// include a "| where cluster in (...)" filter.
+	ServiceClusterName    string
+	ManagementClusterName string
 
 	// FullStartTime and FullEndTime define the entire snapshot window. Use
 	// these for broad timestamp pre-filters (Kusto partition pruning) and

--- a/tooling/hcpctl/pkg/snapshot/queries.go
+++ b/tooling/hcpctl/pkg/snapshot/queries.go
@@ -115,18 +115,21 @@ type queryData struct {
 	ClusterURI      string
 	ServiceDatabase string
 	HCPDatabase     string
-	StartTime       time.Time
-	EndTime         time.Time
 	ResourceGroup   string
 
-	// CleanupStartTime is the time at which test cleanup began. A zero
-	// value means no cleanup time is available.
-	CleanupStartTime time.Time
+	// FullStartTime and FullEndTime define the entire snapshot window. Use
+	// these for broad timestamp pre-filters (Kusto partition pruning) and
+	// for discovery queries that must see the complete time range.
+	FullStartTime time.Time
+	FullEndTime   time.Time
 
-	// EffectiveEndTime is the cleanup start time if available, otherwise the
-	// test end time. Use this when queries need a point-in-time snapshot of
-	// state before teardown.
-	EffectiveEndTime time.Time
+	// PhaseStartTime and PhaseEndTime define the current phase (test or
+	// cleanup). Use these for queries that should be scoped to a single phase.
+	PhaseStartTime time.Time
+	PhaseEndTime   time.Time
+
+	// PhaseName is the human-readable name of the current phase ("test" or "cleanup").
+	PhaseName string
 
 	// Per-request context — set when tracing a specific request.
 	CorrelationID      string
@@ -712,15 +715,6 @@ func queriesByCategory(cat queryCategory) []querySpec {
 // kqlDatetime formats a time.Time as a KQL datetime literal.
 func kqlDatetime(t time.Time) string {
 	return fmt.Sprintf("datetime(%s)", t.UTC().Format(time.RFC3339))
-}
-
-// effectiveEndTime returns the cleanup start time if available, otherwise the
-// query window end time. This is used to populate EffectiveEndTime on queryData.
-func effectiveEndTime(input GatherInput) time.Time {
-	if !input.CleanupStartTime.IsZero() {
-		return input.CleanupStartTime
-	}
-	return input.TimeWindow.End
 }
 
 // templateFuncMap provides template functions available to KQL templates.

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/events/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/events/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where eventNamespace == 'aro-hcp'
 | where objectName has 'backend'
 | extend firstSeen = coalesce(firstSeen, todatetime(log.event_time)), lastSeen = coalesce(lastSeen, todatetime(log.event_time))

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/events/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/events/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where eventNamespace == 'aro-hcp'
 | where objectName has 'backend'
 | extend firstSeen = coalesce(firstSeen, todatetime(log.event_time)), lastSeen = coalesce(lastSeen, todatetime(log.event_time))

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditionTimeline/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditionTimeline/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'
@@ -12,5 +12,6 @@ cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLo
 | extend controller_name = extract("/hcpOpenShiftControllers/([^\\/]+)", 1, tostring(content.resourceID))
 | mv-expand condition = content.properties.status.conditions
 | project observedTime, lastTransitionTime=todatetime(condition.lastTransitionTime), controller_name, type=tostring(condition.type), status=tostring(condition.status), reason=tostring(condition.reason), message=tostring(condition.message)
+| where lastTransitionTime between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | summarize observedTime=min(observedTime) by lastTransitionTime, controller_name, type, status, reason, message
 | order by lastTransitionTime asc, observedTime asc

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditionTimeline/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditionTimeline/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditions/README.md
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditions/README.md
@@ -2,9 +2,12 @@
 
 ## Summary
 
-Extracts a point-in-time snapshot of HCP OpenShift controller conditions from the *last* datadump emission before
-cleanup/deletion began. When a cleanup start time is available, this shows each controller's condition state
-just before teardown; otherwise it uses the test end time.
+Extracts a point-in-time snapshot of HCP OpenShift controller conditions from the *last* datadump emission within
+the current phase's time window. In the `test/` phase this shows each controller's condition state just before
+cleanup began; in the `cleanup/` phase it shows the final state before the overall time window ended.
+
+The phase boundaries are derived from test timing metadata — see the phase's `manifest.json` for the
+exact `start` and `end` timestamps used to scope this query.
 
 Unlike `resourceControllerConditionTimeline`, which shows every condition transition over time, this query
 shows only the final state of each controller — making it easy to see whether controllers were healthy

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditions/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditions/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EffectiveEndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditions/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditions/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/resourceInternalId/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/resourceInternalId/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/resourceInternalId/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/resourceInternalId/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/resourceState/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/resourceState/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.content.resourceID =~ '{{ .ResourceID }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/resourceState/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/resourceState/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.content.resourceID =~ '{{ .ResourceID }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/serviceProviderState/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/serviceProviderState/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/serviceProviderState/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/serviceProviderState/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/cid/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/cid/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('clustersServiceLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where log.aro_hcp_cluster_resource_id =~ '{{ .ClusterResourceID }}'
 | where tostring(cid) != ''
 | distinct cid

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/cid/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/cid/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('clustersServiceLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where log.aro_hcp_cluster_resource_id =~ '{{ .ClusterResourceID }}'
 | where tostring(cid) != ''
 | distinct cid

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/clusterState/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/clusterState/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'csstatedump'
 | where log.msg == 'cluster-service state dump'

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/clusterState/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/clusterState/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'csstatedump'
 | where log.msg == 'cluster-service state dump'

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/events/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/events/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where eventNamespace == 'clusters-service'
 | where objectName has 'clusters-service'
 | extend firstSeen = coalesce(firstSeen, todatetime(log.event_time)), lastSeen = coalesce(lastSeen, todatetime(log.event_time))

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/events/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/events/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where eventNamespace == 'clusters-service'
 | where objectName has 'clusters-service'
 | extend firstSeen = coalesce(firstSeen, todatetime(log.event_time)), lastSeen = coalesce(lastSeen, todatetime(log.event_time))

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/logs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/logs/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('clustersServiceLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 {{- if eq (toLower .ResourceType) "microsoft.redhatopenshift/hcpopenshiftclusters" }}
 | where log.aro_hcp_cluster_resource_id =~ '{{ .ResourceID }}'
 | where isempty(log.aro_hcp_node_pool_resource_id)

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/logs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/logs/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('clustersServiceLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 {{- if eq (toLower .ResourceType) "microsoft.redhatopenshift/hcpopenshiftclusters" }}
 | where log.aro_hcp_cluster_resource_id =~ '{{ .ResourceID }}'
 | where isempty(log.aro_hcp_node_pool_resource_id)

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/nodePoolState/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/nodePoolState/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'csstatedump'
 | where log.msg == 'cluster-service node pool state dump'

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/nodePoolState/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/nodePoolState/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'csstatedump'
 | where log.msg == 'cluster-service node pool state dump'

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/phases/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/phases/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('clustersServiceLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 {{- if eq (toLower .ResourceType) "microsoft.redhatopenshift/hcpopenshiftclusters" }}
 | where log.aro_hcp_cluster_resource_id =~ '{{ .ResourceID }}'
 | where isempty(log.aro_hcp_node_pool_resource_id)

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/phases/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/phases/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('clustersServiceLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 {{- if eq (toLower .ResourceType) "microsoft.redhatopenshift/hcpopenshiftclusters" }}
 | where log.aro_hcp_cluster_resource_id =~ '{{ .ResourceID }}'
 | where isempty(log.aro_hcp_node_pool_resource_id)

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/asyncOperationId/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/asyncOperationId/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('frontendLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where log.client_request_id == '{{ .ClientRequestID }}'
 | where log.msg == 'response complete'
 | project asyncOperationId = replace_regex(tolower(tostring(parse_url(tostring(log["Header---Azure-AsyncOperation"])).Path)), @"/locations/[^/]+", "")

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/asyncOperationId/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/asyncOperationId/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('frontendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where log.client_request_id == '{{ .ClientRequestID }}'
 | where log.msg == 'response complete'
 | project asyncOperationId = replace_regex(tolower(tostring(parse_url(tostring(log["Header---Azure-AsyncOperation"])).Path)), @"/locations/[^/]+", "")

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/asyncOperationPath/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/asyncOperationPath/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('frontendLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where log.client_request_id == '{{ .ClientRequestID }}'
 | where log.msg == 'response complete'
 | project asyncOperationPath = tolower(tostring(parse_url(tostring(log["Header---Azure-AsyncOperation"])).Path))

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/asyncOperationPath/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/asyncOperationPath/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('frontendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where log.client_request_id == '{{ .ClientRequestID }}'
 | where log.msg == 'response complete'
 | project asyncOperationPath = tolower(tostring(parse_url(tostring(log["Header---Azure-AsyncOperation"])).Path))

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/asyncOperationRequests/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/asyncOperationRequests/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('frontendLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where log.path =~ '{{ .AsyncOperationPath }}'
 | where log.msg == 'response complete'
 | summarize

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/asyncOperationRequests/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/asyncOperationRequests/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('frontendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where log.path =~ '{{ .AsyncOperationPath }}'
 | where log.msg == 'response complete'
 | summarize

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/clientRequestId/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/clientRequestId/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('frontendLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where log.correlation_request_id == '{{ .CorrelationID }}'
 | where log.msg == 'response complete'
 | distinct client_request_id = tostring(log.client_request_id)

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/clientRequestId/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/clientRequestId/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('frontendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where log.correlation_request_id == '{{ .CorrelationID }}'
 | where log.msg == 'response complete'
 | distinct client_request_id = tostring(log.client_request_id)

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/events/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/events/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where eventNamespace == 'aro-hcp'
 | where objectName has 'frontend'
 | extend firstSeen = coalesce(firstSeen, todatetime(log.event_time)), lastSeen = coalesce(lastSeen, todatetime(log.event_time))

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/events/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/events/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where eventNamespace == 'aro-hcp'
 | where objectName has 'frontend'
 | extend firstSeen = coalesce(firstSeen, todatetime(log.event_time)), lastSeen = coalesce(lastSeen, todatetime(log.event_time))

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/frontendRequests/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/frontendRequests/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('frontendLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where log.resource_group =~ '{{ .ResourceGroup }}'
 | where log.msg == 'response complete'
 | summarize count() by

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/frontendRequests/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/frontendRequests/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('frontendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where log.resource_group =~ '{{ .ResourceGroup }}'
 | where log.msg == 'response complete'
 | summarize count() by

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/requestLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/requestLogs/query.kql
@@ -1,4 +1,4 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('frontendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where log.client_request_id == '{{ .ClientRequestID }}'
 | project timestamp, msg=tostring(log.msg), err=tostring(log.err), method=tostring(log.method), path=tostring(log.path)

--- a/tooling/hcpctl/pkg/snapshot/queries/frontend/requestLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/frontend/requestLogs/query.kql
@@ -1,4 +1,7 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('frontendLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where log.client_request_id == '{{ .ClientRequestID }}'
 | project timestamp, msg=tostring(log.msg), err=tostring(log.err), method=tostring(log.method), path=tostring(log.path)

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/clusterAPILogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/clusterAPILogs/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .HCPDatabase }}').table('containerLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where namespace_name == '{{ .HostedControlPlaneNamespace }}'
 | where pod_name has 'cluster-api-'
 | extend msg = extract(@']\s+"([^"]+)"', 1, tostring(log))

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/clusterAPILogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/clusterAPILogs/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .HCPDatabase }}').table('containerLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where namespace_name == '{{ .HostedControlPlaneNamespace }}'
 | where pod_name has 'cluster-api-'
 | extend msg = extract(@']\s+"([^"]+)"', 1, tostring(log))

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/clusterAPIProviderLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/clusterAPIProviderLogs/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .HCPDatabase }}').table('containerLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where namespace_name == '{{ .HostedControlPlaneNamespace }}'
 | where pod_name has 'capi-provider-'
 | extend msg = extract(@']\s+"([^"]+)"', 1, tostring(log))

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/clusterAPIProviderLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/clusterAPIProviderLogs/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .HCPDatabase }}').table('containerLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where namespace_name == '{{ .HostedControlPlaneNamespace }}'
 | where pod_name has 'capi-provider-'
 | extend msg = extract(@']\s+"([^"]+)"', 1, tostring(log))

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/controlPlaneEvents/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/controlPlaneEvents/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where eventNamespace == '{{ .HostedControlPlaneNamespace }}'
     and objectName !contains 'control-plane-pki-operator'
     and objectName !contains 'control-plane-operator'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/controlPlaneEvents/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/controlPlaneEvents/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where eventNamespace == '{{ .HostedControlPlaneNamespace }}'
     and objectName !contains 'control-plane-pki-operator'
     and objectName !contains 'control-plane-operator'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/controlPlaneOperatorLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/controlPlaneOperatorLogs/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .HCPDatabase }}').table('containerLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where namespace_name == '{{ .HostedControlPlaneNamespace }}'
 | where container_name == 'control-plane-operator'
 | summarize

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/controlPlaneOperatorLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/controlPlaneOperatorLogs/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .HCPDatabase }}').table('containerLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where namespace_name == '{{ .HostedControlPlaneNamespace }}'
 | where container_name == 'control-plane-operator'
 | summarize

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/events/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/events/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where eventNamespace == 'hypershift'
     or (eventNamespace == '{{ .HostedControlPlaneNamespace }}'
         and (objectName contains 'control-plane-pki-operator-'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/events/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/events/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where eventNamespace == 'hypershift'
     or (eventNamespace == '{{ .HostedControlPlaneNamespace }}'
         and (objectName contains 'control-plane-pki-operator-'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditionTimeline/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditionTimeline/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'
@@ -12,5 +12,6 @@ cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLo
 | where manifest.kind == 'HostedCluster'
 | mv-expand condition = manifest.status.conditions
 | project observedTime, type=tostring(condition.type), status=tostring(condition.status), reason=tostring(condition.reason), message=tostring(condition.message), lastTransitionTime=todatetime(condition.lastTransitionTime)
+| where lastTransitionTime between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | summarize observedTime=min(observedTime) by type, status, reason, message, lastTransitionTime
 | order by lastTransitionTime asc, observedTime asc

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditionTimeline/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditionTimeline/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditions/README.md
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditions/README.md
@@ -2,9 +2,12 @@
 
 ## Summary
 
-Extracts a point-in-time snapshot of HostedCluster conditions from the *last* datadump emission before
-cleanup/deletion began. When a cleanup start time is available, this shows the cluster's condition state
-just before teardown; otherwise it uses the test end time.
+Extracts a point-in-time snapshot of HostedCluster conditions from the *last* datadump emission within
+the current phase's time window. In the `test/` phase this shows the cluster's condition state just before
+cleanup began; in the `cleanup/` phase it shows the final state before the overall time window ended.
+
+The phase boundaries are derived from test timing metadata — see the phase's `manifest.json` for the
+exact `start` and `end` timestamps used to scope this query.
 
 Unlike `hostedClusterConditionTimeline`, which shows every condition transition over time, this query
 shows only the final state of each condition — making it easy to see whether the cluster was healthy

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditions/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditions/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EffectiveEndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditions/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditions/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterMetadata/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterMetadata/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterMetadata/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterMetadata/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/hypershiftOperatorLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/hypershiftOperatorLogs/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('containerLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where namespace_name == 'hypershift'
 | where container_name == 'operator'
 {{- if eq (toLower .ResourceType) "microsoft.redhatopenshift/hcpopenshiftclusters" }}

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/hypershiftOperatorLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/hypershiftOperatorLogs/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('containerLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where namespace_name == 'hypershift'
 | where container_name == 'operator'
 {{- if eq (toLower .ResourceType) "microsoft.redhatopenshift/hcpopenshiftclusters" }}

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditionTimeline/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditionTimeline/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditionTimeline/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditionTimeline/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'
@@ -13,5 +13,6 @@ cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLo
 | where manifest.kind == 'NodePool'
 | mv-expand condition = manifest.status.conditions
 | project observedTime, type=tostring(condition.type), status=tostring(condition.status), reason=tostring(condition.reason), message=tostring(condition.message), lastTransitionTime=todatetime(condition.lastTransitionTime)
+| where lastTransitionTime between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | summarize observedTime=min(observedTime) by type, status, reason, message, lastTransitionTime
 | order by lastTransitionTime asc, observedTime asc

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditions/README.md
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditions/README.md
@@ -2,9 +2,12 @@
 
 ## Summary
 
-Extracts a point-in-time snapshot of NodePool conditions from the *last* datadump emission before
-cleanup/deletion began. When a cleanup start time is available, this shows the node pool's condition state
-just before teardown; otherwise it uses the test end time.
+Extracts a point-in-time snapshot of NodePool conditions from the *last* datadump emission within
+the current phase's time window. In the `test/` phase this shows the node pool's condition state just before
+cleanup began; in the `cleanup/` phase it shows the final state before the overall time window ended.
+
+The phase boundaries are derived from test timing metadata — see the phase's `manifest.json` for the
+exact `start` and `end` timestamps used to scope this query.
 
 Unlike `nodePoolConditionTimeline`, which shows every condition transition over time, this query
 shows only the final state of each condition — making it easy to see whether the node pool was healthy

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditions/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditions/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EffectiveEndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditions/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditions/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/pkiOperatorEvents/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/pkiOperatorEvents/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where eventNamespace == '{{ .HostedControlPlaneNamespace }}'
 | where objectName == 'control-plane-pki-operator'
 | where reason contains 'CertificateSigningRequest'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/pkiOperatorEvents/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/pkiOperatorEvents/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where eventNamespace == '{{ .HostedControlPlaneNamespace }}'
 | where objectName == 'control-plane-pki-operator'
 | where reason contains 'CertificateSigningRequest'

--- a/tooling/hcpctl/pkg/snapshot/queries/maestro/agentLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/maestro/agentLogs/query.kql
@@ -1,6 +1,9 @@
 {{ template "bundleMap" . }}
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('containerLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where namespace_name == 'maestro'
 | where container_name == 'maestro-agent'
 | extend logs = tostring(log)

--- a/tooling/hcpctl/pkg/snapshot/queries/maestro/agentLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/maestro/agentLogs/query.kql
@@ -1,6 +1,6 @@
 {{ template "bundleMap" . }}
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('containerLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where namespace_name == 'maestro'
 | where container_name == 'maestro-agent'
 | extend logs = tostring(log)

--- a/tooling/hcpctl/pkg/snapshot/queries/maestro/events/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/maestro/events/query.kql
@@ -1,5 +1,5 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where eventNamespace == 'maestro'
 | where objectName has 'maestro'
 | extend firstSeen = coalesce(firstSeen, todatetime(log.event_time)), lastSeen = coalesce(lastSeen, todatetime(log.event_time))

--- a/tooling/hcpctl/pkg/snapshot/queries/maestro/events/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/maestro/events/query.kql
@@ -1,5 +1,8 @@
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesEvents')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where eventNamespace == 'maestro'
 | where objectName has 'maestro'
 | extend firstSeen = coalesce(firstSeen, todatetime(log.event_time)), lastSeen = coalesce(lastSeen, todatetime(log.event_time))

--- a/tooling/hcpctl/pkg/snapshot/queries/maestro/mgmtAuditLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/maestro/mgmtAuditLogs/query.kql
@@ -2,7 +2,7 @@
 let bundleResources = bundleMap
 | summarize groupVersion = take_any(groupVersion), resourceKind = take_any(resourceKind), label = take_any(label) by resourceNamespace, resourceName;
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('aksEvents')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where operationName == 'kube-audit'
 | extend event = parse_json(log)
 | where event.stage == 'ResponseComplete'

--- a/tooling/hcpctl/pkg/snapshot/queries/maestro/mgmtAuditLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/maestro/mgmtAuditLogs/query.kql
@@ -3,6 +3,9 @@ let bundleResources = bundleMap
 | summarize groupVersion = take_any(groupVersion), resourceKind = take_any(resourceKind), label = take_any(label) by resourceNamespace, resourceName;
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('aksEvents')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where operationName == 'kube-audit'
 | extend event = parse_json(log)
 | where event.stage == 'ResponseComplete'

--- a/tooling/hcpctl/pkg/snapshot/queries/maestro/serverLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/maestro/serverLogs/query.kql
@@ -1,6 +1,6 @@
 {{ template "bundleMap" . }}
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('containerLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where namespace_name == 'maestro'
 | where container_name == 'maestro-server'
 | extend logs = tostring(log)

--- a/tooling/hcpctl/pkg/snapshot/queries/maestro/serverLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/maestro/serverLogs/query.kql
@@ -1,6 +1,9 @@
 {{ template "bundleMap" . }}
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('containerLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where namespace_name == 'maestro'
 | where container_name == 'maestro-server'
 | extend logs = tostring(log)

--- a/tooling/hcpctl/pkg/snapshot/queries/maestro/transitions/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/maestro/transitions/query.kql
@@ -1,6 +1,9 @@
 {{ template "bundleMap" . }}
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('containerLogs')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where namespace_name == 'maestro'
 | where container_name in ('maestro-server', 'maestro-agent')
 | extend logs = tostring(log)

--- a/tooling/hcpctl/pkg/snapshot/queries/maestro/transitions/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/maestro/transitions/query.kql
@@ -1,6 +1,6 @@
 {{ template "bundleMap" . }}
 cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('containerLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 | where namespace_name == 'maestro'
 | where container_name in ('maestro-server', 'maestro-agent')
 | extend logs = tostring(log)

--- a/tooling/hcpctl/pkg/snapshot/queries/partials/bundleMap.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/partials/bundleMap.kql
@@ -1,7 +1,7 @@
 {{- define "bundleMapCS" -}}
 {{ if .ClusterID -}}
 let bundleMapCS = cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('clustersServiceLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where cid == '{{ .ClusterID }}'
 | where log.msg has 'successfully sent create request of maestro bundle' and log.msg has 'containing resource'
 | extend bundleId = extract("bundle id '([^']+)'", 1, tostring(log.msg))
@@ -19,7 +19,7 @@ let bundleMapCS = cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}'
 {{- define "bundleMapBackend" -}}
 {{ if and .ResourceGroup .ClusterResourceName .ServiceProviderResourceType -}}
 let bundleMapBackend = cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
-| where timestamp between ({{ kqlDatetime .StartTime }} .. {{ kqlDatetime .EndTime }})
+| where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'

--- a/tooling/hcpctl/pkg/snapshot/queries/partials/bundleMap.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/partials/bundleMap.kql
@@ -2,6 +2,9 @@
 {{ if .ClusterID -}}
 let bundleMapCS = cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('clustersServiceLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where cid == '{{ .ClusterID }}'
 | where log.msg has 'successfully sent create request of maestro bundle' and log.msg has 'containing resource'
 | extend bundleId = extract("bundle id '([^']+)'", 1, tostring(log.msg))
@@ -20,6 +23,9 @@ let bundleMapCS = cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}'
 {{ if and .ResourceGroup .ClusterResourceName .ServiceProviderResourceType -}}
 let bundleMapBackend = cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
 | where container_name == 'aro-hcp-backend'
 | where log.controller_name == 'datadump'
 | where log.resource_group == '{{ .ResourceGroup }}'


### PR DESCRIPTION
hcpctl: snapshot: separate queries by phase

When we know that a test failed during the normal phase, or during
cleanup, it's best to give agents a set of logs that start and stop
during the timestamps that are pertinent, so as to not lead them astray
with deletion-related content for normal analysis or vice versa.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

hcpctl: snapshot: add a local analysis CLI

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

hcpctl: snapshot: provide cluster filter in dev

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

