### PR TITLE
kube-applier: set runAsUser/runAsGroup=65532 on container securityContext (AROSLSRE-926)

### DIFF
--- a/kube-applier/deploy/templates/deployment.yaml
+++ b/kube-applier/deploy/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         resources:

--- a/kube-applier/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_kube_applier.yaml
+++ b/kube-applier/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_kube_applier.yaml
@@ -222,6 +222,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         resources:


### PR DESCRIPTION
## What

Add `runAsUser: 65532` and `runAsGroup: 65532` to the kube-applier container `securityContext` so the pod can start.

## Why

Today the kube-applier deployment template declares:

```yaml
securityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop:
    - ALL
  runAsNonRoot: true
  seccompProfile:
    type: RuntimeDefault
```

With `runAsNonRoot: true` and **no** `runAsUser`, kubelet validates the image's OCI config `User` field. The Dockerfile correctly sets `USER 65532:65532`:

```dockerfile
FROM mcr.microsoft.com/azurelinux/distroless/base:3.0
USER 65532:65532
WORKDIR /
COPY --from=builder /app/kube-applier/kube-applier .
```

But the resulting image config in `arohcpsvcint.azurecr.io/kube-applier@sha256:9378a7668d2f67d0e7ea316113626539c75687556f99fff6a9dd9ae1bc830ba2` does not propagate the `USER` directive into the OCI manifest config — likely a buildkit / multi-stage cache artefact. Kubelet therefore sees `User: ""` and refuses to start the container.

This regressed today on `int-uksouth-mgmt-1` via [EV2 pipeline 428766 build 165402808](https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=165402808), step `KubeApplier.management.deploy-uksouth-1`, with:

```
Helm release "kube-applier" failed:
resource Deployment/kube-applier/kube-applier not ready.
status: InProgress, message: Available: 0/1
context deadline exceeded
```

Live pod state on the cluster (still ongoing at PR time):

```
NAME                           READY   STATUS                       AGE
kube-applier-dc749466f-2fm9j   0/1     CreateContainerConfigError   72m
```

```
Error: container has runAsNonRoot and image will run as root
(pod: kube-applier-dc749466f-2fm9j_kube-applier, container: kube-applier)
```

## Approach

Set `runAsUser` and `runAsGroup` explicitly in the chart so the pod spec is **self-sufficient** and does not depend on registry-side image metadata. 65532 is the conventional `nonroot` UID used by distroless base images and matches the existing Dockerfile.

Not reverting [#5255](https://github.com/Azure/ARO-HCP/pull/5255) because the chart is otherwise correct; this is a 2-line completeness fix.

## Changes

- `kube-applier/deploy/templates/deployment.yaml` — add `runAsUser: 65532`, `runAsGroup: 65532` to the container `securityContext`.
- `kube-applier/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_kube_applier.yaml` — regenerated fixture.

## Validation

- `cd tooling/helmtest && go test ./... -run TestHelmTemplate -v` → all pass, including `dev-westus3-mgmt-1-kube-applier` ✅
- `cd kube-applier && go test ./...` → all pass ✅
- Once merged + image bumper picks it up, the next pipeline run on `int-uksouth-mgmt-1` should land the helm release successfully (deployment pod transitions `CreateContainerConfigError → Running`).

## Refs

- [AROSLSRE-926](https://redhat.atlassian.net/browse/AROSLSRE-926) — Jira bug
- Original deployment commit: cefb652f0 from [#5255](https://github.com/Azure/ARO-HCP/pull/5255)
- EV2 failure build: [165402808](https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=165402808)
- Sibling on-call work mitigating the NRP KVS issue on the same cluster: [AROSLSRE-880](https://redhat.atlassian.net/browse/AROSLSRE-880) / -922 / -923 / -924 / -925.