### PR TITLE
charts: set runAsUser/runAsGroup=65532 on container securityContext (6 components) (AROSLSRE-929)

### DIFF
--- a/admin/deploy/templates/admin.deployment.yaml
+++ b/admin/deploy/templates/admin.deployment.yaml
@@ -89,6 +89,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         livenessProbe:

--- a/admin/testdata/zz_fixture_TestHelmTemplate_admin_api_mise_enabled.yaml
+++ b/admin/testdata/zz_fixture_TestHelmTemplate_admin_api_mise_enabled.yaml
@@ -145,6 +145,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         livenessProbe:

--- a/admin/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_admin_api.yaml
+++ b/admin/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_admin_api.yaml
@@ -145,6 +145,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         livenessProbe:

--- a/backend/deploy/templates/backend.deployment.yaml
+++ b/backend/deploy/templates/backend.deployment.yaml
@@ -140,6 +140,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         readinessProbe:

--- a/backend/testdata/zz_fixture_TestHelmTemplate_backend_clstr_scoped_identities_role_set_name_public.yaml
+++ b/backend/testdata/zz_fixture_TestHelmTemplate_backend_clstr_scoped_identities_role_set_name_public.yaml
@@ -233,6 +233,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         readinessProbe:

--- a/backend/testdata/zz_fixture_TestHelmTemplate_backend_mi_mock_and_arm_perms_mgr_identities_unset.yaml
+++ b/backend/testdata/zz_fixture_TestHelmTemplate_backend_mi_mock_and_arm_perms_mgr_identities_unset.yaml
@@ -216,6 +216,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         readinessProbe:

--- a/backend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_backend_dev.yaml
+++ b/backend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_backend_dev.yaml
@@ -233,6 +233,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         readinessProbe:

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_exporter.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_exporter.yaml
@@ -100,6 +100,8 @@ spec:
           privileged: false
           allowPrivilegeEscalation: false
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
           capabilities:

--- a/frontend/deploy/templates/_helpers.tpl
+++ b/frontend/deploy/templates/_helpers.tpl
@@ -87,6 +87,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         {{- if .Values.audit.connectSocket }}

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
@@ -182,6 +182,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
@@ -299,6 +301,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
@@ -182,6 +182,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         startupProbe:
@@ -291,6 +293,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         startupProbe:

--- a/frontend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
+++ b/frontend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
@@ -182,6 +182,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         startupProbe:
@@ -291,6 +293,8 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
         startupProbe:

--- a/mgmt-agent/deploy/templates/deployment.yaml
+++ b/mgmt-agent/deploy/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
           name: health
         securityContext:
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
           allowPrivilegeEscalation: false

--- a/mgmt-agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mgmt_agent.yaml
+++ b/mgmt-agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mgmt_agent.yaml
@@ -156,6 +156,8 @@ spec:
           name: health
         securityContext:
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
           allowPrivilegeEscalation: false

--- a/sessiongate/deploy/templates/deployment.yaml
+++ b/sessiongate/deploy/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
           name: sessions
         securityContext:
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
           allowPrivilegeEscalation: false

--- a/sessiongate/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_sessiongate.yaml
+++ b/sessiongate/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_sessiongate.yaml
@@ -485,6 +485,8 @@ spec:
           name: sessions
         securityContext:
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
           allowPrivilegeEscalation: false

--- a/tooling/aro-hcp-exporter/deploy/templates/deployment.yaml
+++ b/tooling/aro-hcp-exporter/deploy/templates/deployment.yaml
@@ -67,6 +67,8 @@ spec:
           privileged: false
           allowPrivilegeEscalation: false
           runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
           capabilities:


### PR DESCRIPTION
## What

Add `runAsUser: 65532` and `runAsGroup: 65532` to the container `securityContext` of every ARO-HCP-owned chart that currently sets `runAsNonRoot: true` without an explicit user.

## Why

On 2026-05-24, the `kube-applier` deployment failed for 72+ minutes on `int-uksouth-mgmt-1` with `CreateContainerConfigError: container has runAsNonRoot and image will run as root` (fix shipped via #5373, [AROSLSRE-926](https://redhat.atlassian.net/browse/AROSLSRE-926)). Root cause was the same anti-pattern across the repo: chart says `runAsNonRoot: true`, no `runAsUser`, so kubelet validates against the image OCI config `User` field. When that field is empty on the registry (as it was for `arohcpsvcint.azurecr.io/kube-applier@sha256:9378a76…` — likely a buildkit / multi-stage cache artefact), the pod is rejected.

Audit ([AROSLSRE-929](https://redhat.atlassian.net/browse/AROSLSRE-929) / closed [AROSLSRE-927](https://redhat.atlassian.net/browse/AROSLSRE-927)) identified 6 ARO-HCP-owned charts with the same anti-pattern. Each Dockerfile already sets `USER 65532:65532` so the fix is purely additive in the chart and matches established behavior. Making the UID/GID explicit in the pod spec removes the dependency on registry-side metadata being preserved through future buildkit changes.

## Components covered

| Component | Dockerfile USER | File patched |
|---|---|---|
| admin | `65532:65532` | `admin/deploy/templates/admin.deployment.yaml` |
| backend | `65532:65532` | `backend/deploy/templates/backend.deployment.yaml` |
| frontend | `65532:65532` | `frontend/deploy/templates/_helpers.tpl` (define `frontend.deployment`) |
| mgmt-agent | `65532:65532` | `mgmt-agent/deploy/templates/deployment.yaml` |
| sessiongate | `65532:65532` | `sessiongate/deploy/templates/deployment.yaml` |
| tooling/aro-hcp-exporter | `65532:65532` | `tooling/aro-hcp-exporter/deploy/templates/deployment.yaml` |

The diff is identical in every chart:

```yaml
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
          runAsNonRoot: true
+         runAsUser: 65532
+         runAsGroup: 65532
          seccompProfile:
            type: RuntimeDefault
```

## Out of scope

- `kube-applier` — already fixed in #5373.
- `acrpull`, `observability/prometheus`, `route-monitor-operator` — already declare `runAsUser` in their charts.
- ACM-bundled upstream charts (4 files with the same anti-pattern) — should be raised against `open-cluster-management` upstream, not patched here.
- `frontend/deploy/templates/frontend.secret-refresher.yaml` — busybox sidecar, no `securityContext` at all (separate hardening item).
- `image-sync/oc-mirror` Dockerfile has no `USER`; only used in CI pipeline shell, not k8s-deployed.
- Root-cause investigation of the OCI `User` field disappearing on registry push (buildkit / multi-stage cache). Chart-side fix here is the safest backstop regardless.

## Validation

- `cd tooling/helmtest && UPDATE=true go test ./...` — fixtures regenerated for all 6 components (and downstream frontend fixtures that include the helper template)
- `cd tooling/helmtest && go test ./...` — green without UPDATE flag
- Diff: 17 files, +40/-0 (6 chart templates + 11 fixture files)
- Spot-checked rendered output (e.g. `frontend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml`): both containers in the rendered Deployment now carry `runAsUser: 65532` / `runAsGroup: 65532`

## Refs

- Story: [AROSLSRE-929](https://redhat.atlassian.net/browse/AROSLSRE-929) — Harden ARO-HCP charts: enforce explicit runAsUser/runAsGroup matching Dockerfile USER
- Sub-tasks: [AROSLSRE-930](https://redhat.atlassian.net/browse/AROSLSRE-930) (admin), -931 (backend), -932 (frontend), -933 (mgmt-agent), -934 (sessiongate), -935 (aro-hcp-exporter)
- Reference fix (same pattern, kube-applier): #5373
- Originating incident: [AROSLSRE-926](https://redhat.atlassian.net/browse/AROSLSRE-926)