### PR TITLE
feat: persist IntentFailed for node pool version validation errors

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -628,6 +628,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		activeOperationLister,
 		backendInformers,
 		unionReadDesireLister,
+		subscriptionLister,
 	)
 	triggerNodePoolUpgradeController := upgradecontrollers.NewTriggerNodePoolUpgradeController(
 		b.options.ResourcesDBClient,

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
@@ -16,26 +16,36 @@ package operationcontrollers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	utilsclock "k8s.io/utils/clock"
+	"k8s.io/utils/lru"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/upgradecontrollers"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 type operationNodePoolUpdate struct {
-	clock                utilsclock.PassiveClock
-	resourcesDBClient    database.ResourcesDBClient
-	clusterServiceClient ocm.ClusterServiceClientSpec
-	notificationClient   *http.Client
+	resourcesDBClient               database.ResourcesDBClient
+	clusterServiceClient            ocm.ClusterServiceClientSpec
+	notificationClient              *http.Client
+	clock                           utilsclock.PassiveClock
+	desiredVersionMismatchFirstSeen *lru.Cache
 }
 
 // NewOperationNodePoolUpdateController returns a new Controller instance that
@@ -60,10 +70,11 @@ func NewOperationNodePoolUpdateController(
 	activeOperationInformer cache.SharedIndexInformer,
 ) controllerutils.Controller {
 	syncer := &operationNodePoolUpdate{
-		clock:                clock,
-		resourcesDBClient:    resourcesDBClient,
-		clusterServiceClient: clusterServiceClient,
-		notificationClient:   notificationClient,
+		resourcesDBClient:               resourcesDBClient,
+		clusterServiceClient:            clusterServiceClient,
+		notificationClient:              notificationClient,
+		clock:                           clock,
+		desiredVersionMismatchFirstSeen: lru.New(100000),
 	}
 
 	controller := NewGenericOperationController(
@@ -104,6 +115,156 @@ func (c *operationNodePoolUpdate) SynchronizeOperation(ctx context.Context, key 
 	if !c.ShouldProcess(ctx, operation) {
 		return nil // no work to do
 	}
+	if len(operation.InternalID.String()) == 0 {
+		// Cannot proceed yet
+		// TODO when we update to clusterservice node pool creation async, we need to handle this correctly.
+		return nil
+	}
 
-	return pollNodePoolStatus(ctx, c.clock, c.resourcesDBClient, c.clusterServiceClient, operation, c.notificationClient)
+	operationalState, err := c.determineOperationState(ctx, operation)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	var persistErr *arm.CloudErrorBody
+	if operationalState.provisioningState == arm.ProvisioningStateFailed {
+		persistErr = &arm.CloudErrorBody{
+			Code:    arm.CloudErrorCodeInvalidRequestContent,
+			Message: operationalState.message,
+		}
+	}
+
+	logger.Info("updating status")
+	if err := UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.provisioningState, persistErr, postAsyncNotificationFn(c.notificationClient)); err != nil {
+		return utils.TrackError(err)
+	}
+	return nil
+}
+
+func (c *operationNodePoolUpdate) determineOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {
+	logger := utils.LoggerFromContext(ctx)
+	errs := []error{}
+	operationStates := []*operationState{}
+
+	if operationState, err := c.desiredVersionResolutionOperationState(ctx, operation); err != nil {
+		errs = append(errs, utils.TrackError(err))
+	} else {
+		operationStates = append(operationStates, operationState)
+	}
+	if operationState, csErr := c.nodePoolServiceUpdateOperationState(ctx, operation); csErr != nil {
+		errs = append(errs, utils.TrackError(csErr))
+	} else {
+		operationStates = append(operationStates, operationState)
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+	if len(operationStates) == 0 {
+		return nil, errors.New("no operation states")
+	}
+	slices.SortStableFunc(operationStates, compareOperationState)
+	if operationStates[0] == nil {
+		return nil, errors.New("nil operation state")
+	}
+	logger.Info("determined node pool update operation status", "operationStates", operationStates)
+	picked, err := pickWorstOperationState(operationStates)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	logger.Info("picked node pool update operation status", "provisioningState", picked.provisioningState, "message", picked.message)
+	return picked, nil
+}
+
+func (c *operationNodePoolUpdate) desiredVersionResolutionOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {
+	existingNodePool, err := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).
+		NodePools(operation.ExternalID.Parent.Name).Get(ctx, operation.ExternalID.Name)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+
+	existingServiceProviderNodePool, err := c.resourcesDBClient.ServiceProviderNodePools(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Parent.Name, operation.ExternalID.Name).Get(ctx, api.ServiceProviderNodePoolResourceName)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+
+	resultingDesiredVersion := existingServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion
+	if resultingDesiredVersion == nil {
+		return nil, utils.TrackError(fmt.Errorf("service provider node pool has no desired version"))
+	}
+
+	customerDesiredVersion := semver.MustParse(existingNodePool.Properties.Version.ID)
+
+	operationID := strings.ToLower(operation.ResourceID.String())
+	// If the operation is cancelled, its desiredVersionMismatchFirstSeen entry is never
+	// explicitly removed. This is safe because operation.ResourceID is unique per operation,
+	// so stale entries won't cause false matches for newer operations and will eventually
+	// be evicted by the LRU.
+	if customerDesiredVersion.EQ(*resultingDesiredVersion) {
+		c.desiredVersionMismatchFirstSeen.Remove(operationID)
+		return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+	}
+
+	nodePoolKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    operation.ExternalID.SubscriptionID,
+		ResourceGroupName: operation.ExternalID.ResourceGroupName,
+		HCPClusterName:    operation.ExternalID.Parent.Name,
+		HCPNodePoolName:   operation.ExternalID.Name,
+	}
+
+	controllerCRUD := c.resourcesDBClient.HCPClusters(nodePoolKey.SubscriptionID, nodePoolKey.ResourceGroupName).NodePools(nodePoolKey.HCPClusterName).Controllers(nodePoolKey.HCPNodePoolName)
+	controllerDoc, getControllerErr := controllerCRUD.Get(ctx, upgradecontrollers.NodepoolVersionControllerName)
+	if getControllerErr != nil {
+		return nil, utils.TrackError(getControllerErr)
+	}
+
+	intentFailedCondition := apimeta.FindStatusCondition(controllerDoc.Status.Conditions, api.ControllerConditionTypeIntentFailed)
+
+	if intentFailedCondition == nil {
+		return newOperationState(arm.ProvisioningStateAccepted, "customer desired version not yet calculated"), nil
+	}
+	// Customer desired version differs from the service provider resolved version, and the
+	// NodePoolVersion controller has not yet set IntentFailed (VersionUpgradeNotAccepted)
+	// for this version. Stay Accepted while resolution runs; fail once elapsed exceeds
+	// 59s from the first time this process observed the mismatch for this operation.
+	// This avoids immediately failing long-running operations after controller restarts
+	// and is double the relistDuration of the nodepool and serviceProviderNodePool informers.
+	// This will not solve all the edge cases, but it will give enough time to the other controllers to act.
+	if intentFailedCondition.Status != metav1.ConditionTrue || intentFailedCondition.Reason != api.VersionUpgradeNotAcceptedReason {
+		pending := newOperationState(arm.ProvisioningStateAccepted, "customer desired version does not match resolved desired version")
+		firstSeen, ok := c.desiredVersionMismatchFirstSeen.Get(operationID)
+		if !ok {
+			c.desiredVersionMismatchFirstSeen.Add(operationID, c.clock.Now())
+			return pending, nil
+		}
+		if c.clock.Since(firstSeen.(time.Time)) <= 59*time.Second {
+			return pending, nil
+		}
+		msg := fmt.Sprintf(
+			"timed out after 59s waiting for resolution of desired version from '%s' node pool version",
+			existingNodePool.Properties.Version.ID,
+		)
+		c.desiredVersionMismatchFirstSeen.Remove(operationID)
+		return newOperationState(arm.ProvisioningStateFailed, msg), nil
+	}
+	c.desiredVersionMismatchFirstSeen.Remove(operationID)
+	return newOperationState(arm.ProvisioningStateFailed, intentFailedCondition.Message), nil
+}
+
+func (c *operationNodePoolUpdate) nodePoolServiceUpdateOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {
+	logger := utils.LoggerFromContext(ctx)
+	nodePoolStatus, err := c.clusterServiceClient.GetNodePoolStatus(ctx, operation.InternalID)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	newOperationStatus, opError, err := convertNodePoolStatus(operation, nodePoolStatus)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	logger.Info("new status via cluster-service", "newStatus", newOperationStatus, "newOperationError", opError)
+	msg := ""
+	if opError != nil {
+		msg = opError.Message
+	}
+	return newOperationState(newOperationStatus, msg), nil
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_test.go
@@ -17,16 +17,22 @@ package operationcontrollers
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	utilsclock "k8s.io/utils/clock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+	"k8s.io/utils/lru"
+	"k8s.io/utils/ptr"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
@@ -35,18 +41,46 @@ import (
 )
 
 func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
+	t.Parallel()
+	testClockNow := mustParseTime("2024-06-01T12:00:00Z")
+	fixture := newNodePoolTestFixture()
+	newNodePool := func(version string) *api.HCPOpenShiftClusterNodePool {
+		np := fixture.newNodePool()
+		np.Properties.Version.ID = version
+		return np
+	}
+	newServiceProviderNodePool := func(desiredVersion *semver.Version) *api.ServiceProviderNodePool {
+		sp := fixture.newServiceProviderNodePool()
+		sp.Spec.NodePoolVersion.DesiredVersion = desiredVersion
+		return sp
+	}
 	tests := []struct {
-		name          string
-		nodePoolState string
-		nodePoolMsg   string
-		expectError   bool
-		verify        func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture)
+		name                              string
+		mockCS                            func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec)
+		nodePool                          *api.HCPOpenShiftClusterNodePool
+		serviceProviderNodePool           *api.ServiceProviderNodePool
+		nodePoolVersionController         *api.Controller
+		desiredVersionMismatchFirstSeenAt time.Time
+		expectError                       bool
+		verifyDB                          func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture)
 	}{
 		{
-			name:          "node pool ready transitions to succeeded",
-			nodePoolState: string(NodePoolStateReady),
-			expectError:   false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name: "node pool ready transitions to succeeded",
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().
+					GetNodePoolStatus(gomock.Any(), gomock.Any()).
+					Return(nodePoolStatus, nil)
+			},
+			nodePool:                  newNodePool("4.19.0"),
+			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.19.0"))),
+			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
+			expectError:               false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
@@ -59,10 +93,22 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:          "node pool updating transitions to updating",
-			nodePoolState: string(NodePoolStateUpdating),
-			expectError:   false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name: "node pool updating transitions to updating",
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateUpdating))).
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().
+					GetNodePoolStatus(gomock.Any(), gomock.Any()).
+					Return(nodePoolStatus, nil)
+			},
+			nodePool:                  newNodePool("4.19.0"),
+			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.19.0"))),
+			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
+			expectError:               false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
@@ -75,31 +121,67 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:          "node pool validating_update stays accepted",
-			nodePoolState: string(NodePoolStateValidatingUpdate),
-			expectError:   false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name: "node pool validating_update stays accepted",
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateValidatingUpdate))).
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().
+					GetNodePoolStatus(gomock.Any(), gomock.Any()).
+					Return(nodePoolStatus, nil)
+			},
+			nodePool:                  newNodePool("4.19.0"),
+			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.19.0"))),
+			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
+			expectError:               false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
 			},
 		},
 		{
-			name:          "node pool pending_update stays accepted",
-			nodePoolState: string(NodePoolStatePendingUpdate),
-			expectError:   false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name: "node pool pending_update stays accepted",
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStatePendingUpdate))).
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().
+					GetNodePoolStatus(gomock.Any(), gomock.Any()).
+					Return(nodePoolStatus, nil)
+			},
+			nodePool:                  newNodePool("4.19.0"),
+			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.19.0"))),
+			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
+			expectError:               false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
 			},
 		},
 		{
-			name:          "node pool recoverable_error transitions to failed",
-			nodePoolState: string(NodePoolStateRecoverableError),
-			nodePoolMsg:   "temporary error occurred",
-			expectError:   false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name: "node pool recoverable_error transitions to failed",
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateRecoverableError))).
+					Message("temporary error occurred").
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().
+					GetNodePoolStatus(gomock.Any(), gomock.Any()).
+					Return(nodePoolStatus, nil)
+			},
+			nodePool:                  newNodePool("4.19.0"),
+			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.19.0"))),
+			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
+			expectError:               false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
@@ -107,41 +189,215 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 				assert.Equal(t, "temporary error occurred", op.Error.Message)
 			},
 		},
+		{
+			name: "node pool ready with exact version match transitions operation to succeeded",
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().
+					GetNodePoolStatus(gomock.Any(), gomock.Any()).
+					Return(nodePoolStatus, nil)
+			},
+			nodePool:                  newNodePool("4.20.5"),
+			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.20.5"))),
+			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
+			expectError:               false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
+
+				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateSucceeded, nodePool.Properties.ProvisioningState)
+				assert.Empty(t, nodePool.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
+		{
+			name: "node pool with version mismatch and IntentFailed condition marks operation failed",
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().
+					GetNodePoolStatus(gomock.Any(), gomock.Any()).
+					Return(nodePoolStatus, nil)
+			},
+			nodePool:                newNodePool("4.21.5"),
+			serviceProviderNodePool: newServiceProviderNodePool(ptr.To(semver.MustParse("4.20.5"))),
+			nodePoolVersionController: fixture.newNodePoolVersionController([]metav1.Condition{
+				{
+					Type:    api.ControllerConditionTypeIntentFailed,
+					Status:  metav1.ConditionTrue,
+					Reason:  api.VersionUpgradeNotAcceptedReason,
+					Message: "invalid node pool version 4.21.5: cannot exceed control plane version 4.20.5",
+				},
+			}),
+			expectError: false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
+				require.NotNil(t, op.Error)
+				assert.Equal(t, arm.CloudErrorCodeInvalidRequestContent, op.Error.Code)
+				assert.Contains(t, op.Error.Message, "cannot exceed control plane version")
+
+				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateFailed, nodePool.Properties.ProvisioningState)
+				assert.Empty(t, nodePool.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
+		{
+			name: "node pool with version mismatch without IntentFailed leaves operation accepted",
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().
+					GetNodePoolStatus(gomock.Any(), gomock.Any()).
+					Return(nodePoolStatus, nil)
+			},
+			nodePool:                  newNodePool("4.20.5"),
+			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.20.4"))),
+			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
+			expectError:               false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+				assert.Nil(t, op.Error)
+
+				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Equal(t, testOperationName, nodePool.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
+		{
+			name: "node pool with version mismatch without IntentFailed leaves operation accepted when first seen within 59s",
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().
+					GetNodePoolStatus(gomock.Any(), gomock.Any()).
+					Return(nodePoolStatus, nil)
+			},
+			nodePool:                          newNodePool("4.20.5"),
+			serviceProviderNodePool:           newServiceProviderNodePool(ptr.To(semver.MustParse("4.20.4"))),
+			nodePoolVersionController:         fixture.newNodePoolVersionController(nil),
+			desiredVersionMismatchFirstSeenAt: testClockNow.Add(-50 * time.Second),
+			expectError:                       false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+				assert.Nil(t, op.Error)
+
+				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Equal(t, testOperationName, nodePool.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
+		{
+			name: "node pool with version mismatch without IntentFailed stays accepted even after 59s",
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().
+					GetNodePoolStatus(gomock.Any(), gomock.Any()).
+					Return(nodePoolStatus, nil)
+			},
+			nodePool:                          newNodePool("4.20.5"),
+			serviceProviderNodePool:           newServiceProviderNodePool(ptr.To(semver.MustParse("4.20.4"))),
+			nodePoolVersionController:         fixture.newNodePoolVersionController(nil),
+			desiredVersionMismatchFirstSeenAt: testClockNow.Add(-60 * time.Second),
+			expectError:                       false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+				assert.Nil(t, op.Error)
+
+				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Equal(t, testOperationName, nodePool.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
+		{
+			name: "node pool with exact version match but cluster service still updating transitions operation to updating",
+			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
+				t.Helper()
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateUpdating))).
+					Build()
+				require.NoError(t, err)
+				mockCS.EXPECT().
+					GetNodePoolStatus(gomock.Any(), gomock.Any()).
+					Return(nodePoolStatus, nil)
+			},
+			nodePool:                  newNodePool("4.20.5"),
+			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.20.5"))),
+			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
+			expectError:               false,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
+
+				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, nodePool.Properties.ProvisioningState)
+				assert.Equal(t, testOperationName, nodePool.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			ctx = utils.ContextWithLogger(ctx, testr.New(t))
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
-			fixture := newNodePoolTestFixture()
 			cluster := fixture.newCluster()
-			nodePool := fixture.newNodePool()
 			operation := fixture.newOperation(database.OperationRequestUpdate)
 
-			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, nodePool, operation})
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, tt.nodePool, operation})
+			require.NoError(t, err)
+
+			_, err = mockResourcesDBClient.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).Create(ctx, tt.serviceProviderNodePool, nil)
+			require.NoError(t, err)
+
+			_, err = mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).
+				NodePools(testClusterName).Controllers(testNodePoolName).Create(ctx, tt.nodePoolVersionController, nil)
 			require.NoError(t, err)
 
 			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-			nodePoolStatusBuilder := arohcpv1alpha1.NewNodePoolStatus().
-				State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(tt.nodePoolState))
-			if tt.nodePoolMsg != "" {
-				nodePoolStatusBuilder = nodePoolStatusBuilder.Message(tt.nodePoolMsg)
-			}
-			nodePoolStatus, err := nodePoolStatusBuilder.Build()
-			require.NoError(t, err)
+			tt.mockCS(t, mockCSClient)
 
-			mockCSClient.EXPECT().
-				GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
-				Return(nodePoolStatus, nil)
-
+			fakeClock := clocktesting.NewFakeClock(testClockNow)
 			controller := &operationNodePoolUpdate{
-				clock:                utilsclock.RealClock{},
-				resourcesDBClient:    mockResourcesDBClient,
-				clusterServiceClient: mockCSClient,
-				notificationClient:   nil,
+				resourcesDBClient:               mockResourcesDBClient,
+				clusterServiceClient:            mockCSClient,
+				notificationClient:              nil,
+				clock:                           fakeClock,
+				desiredVersionMismatchFirstSeen: lru.New(100000),
+			}
+			if !tt.desiredVersionMismatchFirstSeenAt.IsZero() {
+				controller.desiredVersionMismatchFirstSeen.Add(operation.ResourceID.String(), tt.desiredVersionMismatchFirstSeenAt)
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
@@ -152,8 +408,8 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			if tt.verify != nil {
-				tt.verify(t, ctx, mockResourcesDBClient, fixture)
+			if tt.verifyDB != nil {
+				tt.verifyDB(t, ctx, mockResourcesDBClient, fixture)
 			}
 		})
 	}

--- a/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
+++ b/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
@@ -15,7 +15,10 @@
 package operationcontrollers
 
 import (
+	"fmt"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
@@ -197,6 +200,30 @@ func (f *nodePoolTestFixture) newNodePool() *api.HCPOpenShiftClusterNodePool {
 		ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
 			ClusterServiceID:  &f.nodePoolInternalID,
 			ActiveOperationID: testOperationName,
+		},
+	}
+}
+
+func (f *nodePoolTestFixture) newServiceProviderNodePool() *api.ServiceProviderNodePool {
+	resourceID := api.Must(azcorearm.ParseResourceID(fmt.Sprintf("%s/%s/%s",
+		f.nodePoolResourceID.String(),
+		api.ServiceProviderNodePoolResourceTypeName,
+		api.ServiceProviderNodePoolResourceName,
+	)))
+	return &api.ServiceProviderNodePool{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+	}
+}
+
+func (f *nodePoolTestFixture) newNodePoolVersionController(conditions []metav1.Condition) *api.Controller {
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		f.nodePoolResourceID.String() + "/hcpOpenShiftControllers/NodePoolVersion",
+	))
+	return &api.Controller{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+		ExternalID:     f.nodePoolResourceID,
+		Status: api.ControllerStatus{
+			Conditions: conditions,
 		},
 	}
 }

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
@@ -16,6 +16,7 @@ package upgradecontrollers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -23,14 +24,17 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
 
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/operation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cvocincinnati "github.com/openshift/cluster-version-operator/pkg/cincinnati"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
-	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/cincinnati"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
@@ -41,6 +45,9 @@ import (
 	"github.com/Azure/ARO-HCP/internal/validation"
 )
 
+// nodepoolVersionControllerName is the Cosmos controller document ID for this syncer.
+const NodepoolVersionControllerName = "NodePoolVersion"
+
 // nodePoolVersionSyncer is a nodePool syncer that synchronizes cluster information
 // from CS and internal and helps selecting a valid desiredVersion within the user's
 // desired
@@ -49,6 +56,7 @@ type nodePoolVersionSyncer struct {
 	readDesireLister     dblisters.ReadDesireLister
 	resourcesDBClient    database.ResourcesDBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
+	subscriptionLister   listers.SubscriptionLister
 
 	cincinnatiClientCache cincinnati.ClientCache
 }
@@ -64,6 +72,7 @@ func NewNodePoolVersionController(
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
 	readDesireLister dblisters.ReadDesireLister,
+	subscriptionLister listers.SubscriptionLister,
 ) controllerutils.Controller {
 	syncer := &nodePoolVersionSyncer{
 		cooldownChecker:       controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
@@ -71,10 +80,11 @@ func NewNodePoolVersionController(
 		resourcesDBClient:     resourcesDBClient,
 		clusterServiceClient:  clusterServiceClient,
 		cincinnatiClientCache: cincinnati.NewClientCache(),
+		subscriptionLister:    subscriptionLister,
 	}
 
 	controller := controllerutils.NewNodePoolWatchingController(
-		"NodePoolVersion",
+		NodepoolVersionControllerName,
 		resourcesDBClient,
 		informers,
 		5*time.Minute, // Check for upgrades every 5 minutes
@@ -209,14 +219,42 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 		return nil
 	}
 
-	subscription, err := c.resourcesDBClient.Subscriptions().Get(ctx, cluster.ID.SubscriptionID)
+	subscription, err := c.subscriptionLister.Get(ctx, cluster.ID.SubscriptionID)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get subscription: %w", err))
 	}
+	op := operation.Operation{
+		Type:    operation.Update,
+		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
+	}
 
 	// Validate the customer's desired version before setting it
-	if err := c.validateDesiredNodePoolVersion(ctx, &customerDesiredVersion, existingServiceProviderNodePool, existingServiceProviderCluster, subscription, nodePool.Properties.Version.ChannelGroup, clusterUUID); err != nil {
-		return utils.TrackError(fmt.Errorf("invalid desired version: %w", err))
+	err = c.validateDesiredNodePoolVersion(ctx, &customerDesiredVersion, existingServiceProviderNodePool, existingServiceProviderCluster, nodePool.Properties.Version.ChannelGroup, clusterUUID,
+		op.HasOption(api.FeatureExperimentalReleaseFeatures))
+
+	if err != nil {
+		// Persist IntentFailed on the controller document for Cincinnati VersionNotFound or any non-Cincinnati resolution error.
+		// Other Cincinnati errors are treated as transient graph or transport issues.
+		var cincinnatiErr *cvocincinnati.Error
+		persistIntentFailed := cincinnati.IsCincinnatiVersionNotFoundError(err) || !errors.As(err, &cincinnatiErr)
+		if persistIntentFailed {
+			logger.Error(err, "desired version resolution failed, persisting IntentFailed condition")
+			controllerCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).
+				NodePools(key.HCPClusterName).Controllers(key.HCPNodePoolName)
+			if writeErr := controllerutils.WriteController(ctx, controllerCRUD, NodepoolVersionControllerName, key.InitialController,
+				func(ctrl *api.Controller) {
+					apimeta.SetStatusCondition(&ctrl.Status.Conditions, metav1.Condition{
+						Type:    api.ControllerConditionTypeIntentFailed,
+						Status:  metav1.ConditionTrue,
+						Reason:  api.VersionUpgradeNotAcceptedReason,
+						Message: utils.ErrorMessageWithoutLineTracking(err),
+					})
+				}); writeErr != nil {
+				return utils.TrackError(writeErr)
+			}
+			return nil
+		}
+		return utils.TrackError(err)
 	}
 
 	// Update the serviceProviderNodePool DesiredVersion
@@ -225,8 +263,22 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool: %w", err))
 	}
-
 	logger.Info("Updated ServiceProviderNodePool with new desired version", "desiredVersion", customerDesiredVersion.String())
+
+	// Clear IntentFailed condition on successful validation
+	controllerCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).
+		NodePools(key.HCPClusterName).Controllers(key.HCPNodePoolName)
+	if err = controllerutils.WriteController(ctx, controllerCRUD, NodepoolVersionControllerName, key.InitialController,
+		func(ctrl *api.Controller) {
+			apimeta.SetStatusCondition(&ctrl.Status.Conditions, metav1.Condition{
+				Type:    api.ControllerConditionTypeIntentFailed,
+				Status:  metav1.ConditionFalse,
+				Reason:  api.ControllerConditionReasonAsExpected,
+				Message: "",
+			})
+		}); err != nil {
+		return utils.TrackError(err)
+	}
 
 	return nil
 }
@@ -266,15 +318,8 @@ func prependActiveVersionIfChanged(currentVersions []api.HCPNodePoolActiveVersio
 // See https://hypershift.pages.dev/reference/nodepool-rollouts/#upgrade-types
 //
 // Returns nil if the desired version is valid, or an error describing why it's invalid.
-func (c *nodePoolVersionSyncer) validateDesiredNodePoolVersion(
-	ctx context.Context,
-	desiredVersion *semver.Version,
-	spNodePool *api.ServiceProviderNodePool,
-	spCluster *api.ServiceProviderCluster,
-	subscription *arm.Subscription,
-	channelGroup string,
-	clusterUUID uuid.UUID,
-) error {
+func (c *nodePoolVersionSyncer) validateDesiredNodePoolVersion(ctx context.Context, desiredVersion *semver.Version, spNodePool *api.ServiceProviderNodePool, spCluster *api.ServiceProviderCluster,
+	channelGroup string, clusterUUID uuid.UUID, allowExperimentalReleaseFeatures bool) error {
 	if desiredVersion == nil {
 		return fmt.Errorf("customerDesiredVersion is nil, cannot evaluate upgrade")
 	}
@@ -286,13 +331,7 @@ func (c *nodePoolVersionSyncer) validateDesiredNodePoolVersion(
 	nodePoolActiveVersions := spNodePool.Status.NodePoolVersion.ActiveVersions
 	lowestCPVersion, highestCPVersion := apihelpers.FindLowestAndHighestClusterVersion(spCluster.Status.ControlPlaneVersion.ActiveVersions)
 
-	// This operation is added to normalize the use for the validations so they are shared
-	// between the frontend and the backend
-	op := operation.Operation{
-		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
-	}
-
-	if err := validation.ValidateNodePoolVersionChange(*desiredVersion, nodePoolActiveVersions, lowestCPVersion, highestCPVersion, op.HasOption(api.FeatureExperimentalReleaseFeatures)); err != nil {
+	if err := validation.ValidateNodePoolVersionChange(*desiredVersion, nodePoolActiveVersions, lowestCPVersion, highestCPVersion, allowExperimentalReleaseFeatures); err != nil {
 		return err
 	}
 

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -38,12 +39,14 @@ import (
 	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/cincinnati"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
 	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
@@ -142,7 +145,8 @@ func createTestNodePoolWithVersion(t *testing.T, ctx context.Context, mockResour
 		},
 		Properties: api.HCPOpenShiftClusterNodePoolProperties{
 			Version: api.NodePoolVersionProfile{
-				ID: desiredVersion,
+				ID:           desiredVersion,
+				ChannelGroup: api.DefaultClusterVersionChannelGroup,
 			},
 		},
 		ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
@@ -345,14 +349,233 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 	}
 }
 
-// assertSyncResult is a helper function that validates the result of SyncOnce
-func assertSyncResult(t *testing.T, err error, expectedError bool, expectedErrorContains string) {
-	t.Helper()
-	if expectedError {
-		assert.Error(t, err)
-		assert.ErrorContains(t, err, expectedErrorContains)
-	} else {
-		assert.NoError(t, err)
+func TestNodePoolVersionSyncer_SyncOnce_IntentFailed(t *testing.T) {
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+	subscriptionLister := newTestSubscriptionLister()
+
+	stableURI := api.Must(cincinnati.GetCincinnatiURI("stable"))
+
+	verifyDesiredVersion := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, wantVersion *semver.Version) {
+		t.Helper()
+		spNodePool, err := db.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).
+			Get(ctx, api.ServiceProviderNodePoolResourceName)
+		require.NoError(t, err)
+		if wantVersion != nil {
+			require.NotNil(t, spNodePool.Spec.NodePoolVersion.DesiredVersion)
+			assert.True(t, spNodePool.Spec.NodePoolVersion.DesiredVersion.EQ(*wantVersion),
+				"wanted desired version %s, got %s", wantVersion.String(), spNodePool.Spec.NodePoolVersion.DesiredVersion.String())
+		} else {
+			assert.Nil(t, spNodePool.Spec.NodePoolVersion.DesiredVersion)
+		}
+	}
+
+	verifyIntentFailed := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, want *metav1.Condition) {
+		t.Helper()
+		nodePoolVersionControllerDoc, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			NodePools(testClusterName).Controllers(testNodePoolName).Get(ctx, NodepoolVersionControllerName)
+		if want == nil {
+			assert.True(t, database.IsNotFoundError(err), "controller document should not exist for transient errors")
+			return
+		}
+		require.NoError(t, err)
+		got := apimeta.FindStatusCondition(nodePoolVersionControllerDoc.Status.Conditions, api.ControllerConditionTypeIntentFailed)
+		require.NotNil(t, got)
+		assert.Equal(t, want.Status, got.Status)
+		assert.Equal(t, want.Reason, got.Reason)
+		if want.Status == metav1.ConditionTrue {
+			require.NotEmpty(t, want.Message, "set want.Message to the exact persisted IntentFailed message")
+			assert.Equal(t, want.Message, got.Message)
+		} else {
+			assert.Empty(t, got.Message, "when want.Status is false, IntentFailed message must be empty")
+		}
+	}
+
+	tests := []struct {
+		name                string
+		customerVersion     string
+		nodePoolVersion     string
+		controlPlaneVersion string
+		setupCincinnati     func(*cincinnati.MockClient)
+		wantSyncErr         bool
+		wantErrContains     string
+		verifyDB            func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:                "successful resolution persists desired version and sets IntentFailed False",
+			customerVersion:     "4.19.20",
+			nodePoolVersion:     "4.19.15",
+			controlPlaneVersion: "4.19.22",
+			setupCincinnati: func(mc *cincinnati.MockClient) {
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.20")).Return(
+					configv1.Release{Version: "4.19.20"},
+					[]configv1.Release{},
+					nil,
+					nil,
+				).Times(1)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				verifyDesiredVersion(t, ctx, db, ptr.To(semver.MustParse("4.19.20")))
+				verifyIntentFailed(t, ctx, db, &metav1.Condition{
+					Status: metav1.ConditionFalse,
+					Reason: api.ControllerConditionReasonAsExpected,
+				})
+			},
+		},
+		{
+			name:                "downgrade within skew succeeds persists desired version and sets IntentFailed false",
+			customerVersion:     "4.19.5",
+			nodePoolVersion:     "4.19.10",
+			controlPlaneVersion: "4.20.0",
+			setupCincinnati: func(mc *cincinnati.MockClient) {
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.5")).Return(
+					configv1.Release{Version: "4.19.5"},
+					[]configv1.Release{},
+					nil,
+					nil,
+				).Times(1)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				verifyDesiredVersion(t, ctx, db, ptr.To(semver.MustParse("4.19.5")))
+				verifyIntentFailed(t, ctx, db, &metav1.Condition{
+					Status: metav1.ConditionFalse,
+					Reason: api.ControllerConditionReasonAsExpected,
+				})
+			},
+		},
+		{
+			name:                "downgrade outside skew succeed and sets IntentFailed true",
+			customerVersion:     "4.19.5",
+			nodePoolVersion:     "4.20.10",
+			controlPlaneVersion: "4.22.0",
+			setupCincinnati:     func(mc *cincinnati.MockClient) {},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				verifyDesiredVersion(t, ctx, db, nil)
+				verifyIntentFailed(t, ctx, db, &metav1.Condition{
+					Status:  metav1.ConditionTrue,
+					Reason:  api.VersionUpgradeNotAcceptedReason,
+					Message: "invalid node pool version 4.19.5: must be within 2 minor versions of control plane version 4.22.0",
+				})
+			},
+		},
+		{
+			name:                "Cincinnati VersionNotFound persists IntentFailed and does not set desired version",
+			customerVersion:     "4.19.20",
+			nodePoolVersion:     "4.19.15",
+			controlPlaneVersion: "4.19.30",
+			setupCincinnati: func(mc *cincinnati.MockClient) {
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.20")).Return(
+					configv1.Release{}, nil, nil, &cvocincinnati.Error{Reason: "VersionNotFound"},
+				).Times(1)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				verifyDesiredVersion(t, ctx, db, nil)
+				verifyIntentFailed(t, ctx, db, &metav1.Condition{
+					Status:  metav1.ConditionTrue,
+					Reason:  api.VersionUpgradeNotAcceptedReason,
+					Message: "version 4.19.20 not found in Cincinnati channel stable-4.19",
+				})
+			},
+		},
+		{
+			name:                "Cincinnati upstream error does not persist IntentFailed or desired version",
+			customerVersion:     "4.19.20",
+			nodePoolVersion:     "4.19.15",
+			controlPlaneVersion: "4.19.22",
+			setupCincinnati: func(mc *cincinnati.MockClient) {
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.20")).Return(
+					configv1.Release{}, nil, nil, &cvocincinnati.Error{Reason: "ServiceUnavailable", Message: "503 Service Unavailable"},
+				).Times(1)
+			},
+			wantSyncErr:     true,
+			wantErrContains: "503 Service Unavailable",
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				verifyDesiredVersion(t, ctx, db, nil)
+				verifyIntentFailed(t, ctx, db, nil)
+			},
+		},
+		{
+			name:                "desired version exceeds control plane persists IntentFailed",
+			customerVersion:     "4.19.20",
+			nodePoolVersion:     "4.19.15",
+			controlPlaneVersion: "4.19.15",
+			setupCincinnati:     func(mc *cincinnati.MockClient) {},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				verifyDesiredVersion(t, ctx, db, nil)
+				verifyIntentFailed(t, ctx, db, &metav1.Condition{
+					Status:  metav1.ConditionTrue,
+					Reason:  api.VersionUpgradeNotAcceptedReason,
+					Message: "invalid node pool version 4.19.20: cannot exceed control plane version 4.19.15",
+				})
+			},
+		},
+		{
+			name:                "skipping minor versions persists IntentFailed",
+			customerVersion:     "4.21.1",
+			nodePoolVersion:     "4.18.15",
+			controlPlaneVersion: "4.21.1",
+			setupCincinnati:     func(mc *cincinnati.MockClient) {},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				verifyDesiredVersion(t, ctx, db, nil)
+				verifyIntentFailed(t, ctx, db, &metav1.Condition{
+					Status:  metav1.ConditionTrue,
+					Reason:  api.VersionUpgradeNotAcceptedReason,
+					Message: "invalid upgrade path from 4.18.15 to 4.21.1: skipping more than 2 minor versions is not allowed",
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := utils.ContextWithLogger(context.Background(), logr.Discard())
+			ctrl := gomock.NewController(t)
+			mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+			mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+
+			createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, tt.customerVersion)
+			createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, tt.nodePoolVersion)
+			createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, tt.controlPlaneVersion)
+
+			csNodePool := newCSNodePoolWithVersion(t, tt.nodePoolVersion)
+			mockCS.EXPECT().
+				GetNodePool(gomock.Any(), gomock.Any()).
+				Return(csNodePool, nil).
+				Times(1)
+
+			mockCincinnati := cincinnati.NewMockClient(ctrl)
+			tt.setupCincinnati(mockCincinnati)
+
+			mockClientCache := cincinnati.NewMockClientCache(ctrl)
+			mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
+
+			syncer := &nodePoolVersionSyncer{
+				cooldownChecker:       &alwaysSyncCooldownChecker{},
+				readDesireLister:      newValidHostedClusterReadDesireLister(t),
+				resourcesDBClient:     mockResourcesDBClient,
+				clusterServiceClient:  mockCS,
+				subscriptionLister:    subscriptionLister,
+				cincinnatiClientCache: mockClientCache,
+			}
+
+			err := syncer.SyncOnce(ctx, testKey)
+			if tt.wantSyncErr {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErrContains)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tt.verifyDB != nil {
+				tt.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
 	}
 }
 
@@ -747,26 +970,14 @@ func TestNodePoolVersionSyncer_ValidateDesiredNodePoolVersion(t *testing.T) {
 				cincinnatiClientCache: mockClientCache,
 			}
 
-			// Create subscription based on allowMajorUpgrades flag
-			subscription := &arm.Subscription{
-				Properties: &arm.SubscriptionProperties{},
-			}
-
-			if tt.allowMajorUpgrades {
-				subscription.Properties.RegisteredFeatures = &[]arm.Feature{{
-					Name:  ptr.To(api.FeatureExperimentalReleaseFeatures),
-					State: ptr.To("Registered"),
-				}}
-			}
-
 			err := syncer.validateDesiredNodePoolVersion(
 				ctx,
 				&desiredVersion,
 				spNodePool,
 				spCluster,
-				subscription,
 				"stable",
 				[16]byte{}, // dummy UUID
+				tt.allowMajorUpgrades,
 			)
 
 			if tt.expectError {
@@ -777,438 +988,6 @@ func TestNodePoolVersionSyncer_ValidateDesiredNodePoolVersion(t *testing.T) {
 			}
 		})
 	}
-}
-
-// createServiceProviderClusterWithVersion creates a ServiceProviderCluster with the given control plane version.
-func createServiceProviderClusterWithVersion(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient, controlPlaneVersion string) {
-	t.Helper()
-
-	clusterResourceID := "/subscriptions/" + testSubscriptionID +
-		"/resourceGroups/" + testResourceGroupName +
-		"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName
-	// ServiceProviderCluster resource ID format: {clusterResourceID}/{resourceTypeName}/{resourceName}
-	spClusterResourceID := clusterResourceID + "/" + api.ServiceProviderClusterResourceTypeName + "/" + api.ServiceProviderClusterResourceName
-
-	cpVersion := semver.MustParse(controlPlaneVersion)
-	spCluster := &api.ServiceProviderCluster{
-		CosmosMetadata: api.CosmosMetadata{
-			ResourceID: api.Must(azcorearm.ParseResourceID(spClusterResourceID)),
-		},
-		Status: api.ServiceProviderClusterStatus{
-			ControlPlaneVersion: api.ServiceProviderClusterStatusVersion{
-				ActiveVersions: []api.HCPClusterActiveVersion{
-					{Version: &cpVersion, State: configv1.CompletedUpdate},
-				},
-			},
-		},
-	}
-	_, err := mockResourcesDBClient.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, spCluster, nil)
-	require.NoError(t, err)
-}
-
-// createServiceProviderNodePoolWithVersion creates a ServiceProviderNodePool with the given active version.
-func createServiceProviderNodePoolWithVersion(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient, activeVersion string) {
-	t.Helper()
-
-	nodePoolResourceID := "/subscriptions/" + testSubscriptionID +
-		"/resourceGroups/" + testResourceGroupName +
-		"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
-		"/nodePools/" + testNodePoolName
-	// ServiceProviderNodePool resource ID format: {nodePoolResourceID}/{resourceTypeName}/{resourceName}
-	spNodePoolResourceID := nodePoolResourceID + "/" + api.ServiceProviderNodePoolResourceTypeName + "/" + api.ServiceProviderNodePoolResourceName
-
-	version := semver.MustParse(activeVersion)
-	spNodePool := &api.ServiceProviderNodePool{
-		CosmosMetadata: api.CosmosMetadata{
-			ResourceID: api.Must(azcorearm.ParseResourceID(spNodePoolResourceID)),
-		},
-		Status: api.ServiceProviderNodePoolStatus{
-			NodePoolVersion: api.ServiceProviderNodePoolStatusVersion{
-				ActiveVersions: []api.HCPNodePoolActiveVersion{
-					{Version: &version},
-				},
-			},
-		},
-	}
-	_, err := mockResourcesDBClient.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).Create(ctx, spNodePool, nil)
-	require.NoError(t, err)
-}
-
-func newCSNodePoolWithVersion(t *testing.T, version string) *arohcpv1alpha1.NodePool {
-	t.Helper()
-
-	csNodePool, err := arohcpv1alpha1.NewNodePool().
-		ID(testNodePoolName).
-		Version(arohcpv1alpha1.NewVersion().RawID(version)).
-		Build()
-	require.NoError(t, err)
-	return csNodePool
-}
-
-func TestNodePoolVersionSyncer_SyncOnce_DesiredExceedsControlPlaneFails(t *testing.T) {
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-	mockClientCache := cincinnati.NewMockClientCache(ctrl)
-	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(cincinnati.NewMockClient(ctrl)).AnyTimes()
-
-	// Create node pool with desired version 4.19.15 (exceeds control plane 4.19.10)
-	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
-
-	// Create ServiceProviderCluster with control plane at 4.19.10 (lower than desired)
-	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.19.10")
-
-	// Create ServiceProviderNodePool with active version 4.19.5 (so desired is not already active)
-	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.5")
-
-	// CS returns node pool with current version 4.19.5
-	csNodePool := newCSNodePoolWithVersion(t, "4.19.5")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
-	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		cincinnatiClientCache: mockClientCache,
-	}
-
-	testKey := controllerutils.HCPNodePoolKey{
-		SubscriptionID:    testSubscriptionID,
-		ResourceGroupName: testResourceGroupName,
-		HCPClusterName:    testClusterName,
-		HCPNodePoolName:   testNodePoolName,
-	}
-
-	ctx = utils.ContextWithLogger(ctx, logr.Discard())
-	err := syncer.SyncOnce(ctx, testKey)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot exceed control plane version")
-}
-
-func TestNodePoolVersionSyncer_SyncOnce_SucceedsWithoutCincinnatiEdge(t *testing.T) {
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-	mockCincinnati := cincinnati.NewMockClient(ctrl)
-
-	// Create node pool with desired version 4.19.10
-	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.10")
-
-	// Create ServiceProviderCluster with control plane at 4.20.0 (allows the desired version)
-	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
-
-	// Create ServiceProviderNodePool with active version 4.19.7
-	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
-
-	// CS returns node pool with current version 4.19.7
-	csNodePool := newCSNodePoolWithVersion(t, "4.19.7")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
-	// Cincinnati: version exists, no candidates
-	mockCincinnati.EXPECT().
-		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.10"))).
-		Return(
-			configv1.Release{Version: "4.19.10"},
-			[]configv1.Release{},
-			nil,
-			nil,
-		).
-		Times(1)
-
-	mockClientCache := cincinnati.NewMockClientCache(ctrl)
-	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
-
-	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		cincinnatiClientCache: mockClientCache,
-	}
-
-	testKey := controllerutils.HCPNodePoolKey{
-		SubscriptionID:    testSubscriptionID,
-		ResourceGroupName: testResourceGroupName,
-		HCPClusterName:    testClusterName,
-		HCPNodePoolName:   testNodePoolName,
-	}
-
-	ctx = utils.ContextWithLogger(ctx, logr.Discard())
-	err := syncer.SyncOnce(ctx, testKey)
-
-	require.NoError(t, err)
-
-	// Verify the ServiceProviderNodePool DesiredVersion was updated
-	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
-		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
-	).Get(ctx, api.ServiceProviderNodePoolResourceName)
-	require.NoError(t, err)
-	require.NotNil(t, spnp.Spec.NodePoolVersion.DesiredVersion)
-	expectedDesiredVersion := semver.MustParse("4.19.10")
-	require.True(t, expectedDesiredVersion.EQ(*spnp.Spec.NodePoolVersion.DesiredVersion))
-}
-
-func TestNodePoolVersionSyncer_SyncOnce_VersionNotInCincinnatiFails(t *testing.T) {
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-	mockCincinnati := cincinnati.NewMockClient(ctrl)
-
-	// Create node pool with desired version 4.19.99 (does not exist in Cincinnati)
-	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.99")
-
-	// Create ServiceProviderCluster with control plane at 4.20.0
-	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
-
-	// Create ServiceProviderNodePool with active version 4.19.7
-	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
-
-	// CS returns node pool with current version 4.19.7
-	csNodePool := newCSNodePoolWithVersion(t, "4.19.7")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
-	// Cincinnati returns VersionNotFound for the desired version
-	mockCincinnati.EXPECT().
-		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.99"))).
-		Return(
-			configv1.Release{},
-			nil,
-			nil,
-			&cvocincinnati.Error{Reason: "VersionNotFound", Message: "version 4.19.99 not found"},
-		).
-		Times(1)
-
-	mockClientCache := cincinnati.NewMockClientCache(ctrl)
-	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
-
-	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		cincinnatiClientCache: mockClientCache,
-	}
-
-	testKey := controllerutils.HCPNodePoolKey{
-		SubscriptionID:    testSubscriptionID,
-		ResourceGroupName: testResourceGroupName,
-		HCPClusterName:    testClusterName,
-		HCPNodePoolName:   testNodePoolName,
-	}
-
-	ctx = utils.ContextWithLogger(ctx, logr.Discard())
-	err := syncer.SyncOnce(ctx, testKey)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found in Cincinnati")
-}
-
-func TestNodePoolVersionSyncer_SyncOnce_DowngradeVersionNotInCincinnatiFails(t *testing.T) {
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-	mockCincinnati := cincinnati.NewMockClient(ctrl)
-
-	// Create node pool with desired version 4.19.99 (does not exist in Cincinnati)
-	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.99")
-
-	// Create ServiceProviderCluster with control plane at 4.20.0
-	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
-
-	// Create ServiceProviderNodePool with active version 4.19.7
-	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
-
-	// CS returns node pool with current version 4.19.7
-	csNodePool := newCSNodePoolWithVersion(t, "4.19.7")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
-	// Cincinnati returns VersionNotFound for the desired version
-	mockCincinnati.EXPECT().
-		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.99"))).
-		Return(
-			configv1.Release{},
-			nil,
-			nil,
-			&cvocincinnati.Error{Reason: "VersionNotFound", Message: "version 4.19.99 not found"},
-		).
-		Times(1)
-
-	mockClientCache := cincinnati.NewMockClientCache(ctrl)
-	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
-
-	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		cincinnatiClientCache: mockClientCache,
-	}
-
-	testKey := controllerutils.HCPNodePoolKey{
-		SubscriptionID:    testSubscriptionID,
-		ResourceGroupName: testResourceGroupName,
-		HCPClusterName:    testClusterName,
-		HCPNodePoolName:   testNodePoolName,
-	}
-
-	ctx = utils.ContextWithLogger(ctx, logr.Discard())
-	err := syncer.SyncOnce(ctx, testKey)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found in Cincinnati")
-}
-
-func TestNodePoolVersionSyncer_SyncOnce_DowngradeWithinSkewSucceeds(t *testing.T) {
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-	mockCincinnati := cincinnati.NewMockClient(ctrl)
-
-	// Create node pool with desired version 4.19.5 (z-stream downgrade from 4.19.10)
-	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.5")
-
-	// Create ServiceProviderCluster with control plane at 4.20.0
-	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
-
-	// CS returns node pool with current version 4.19.10
-	csNodePool := newCSNodePoolWithVersion(t, "4.19.10")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
-	// Cincinnati: version exists
-	mockCincinnati.EXPECT().
-		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.5"))).
-		Return(
-			configv1.Release{Version: "4.19.5"},
-			[]configv1.Release{},
-			nil,
-			nil,
-		).
-		Times(1)
-
-	mockClientCache := cincinnati.NewMockClientCache(ctrl)
-	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
-
-	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		cincinnatiClientCache: mockClientCache,
-	}
-
-	testKey := controllerutils.HCPNodePoolKey{
-		SubscriptionID:    testSubscriptionID,
-		ResourceGroupName: testResourceGroupName,
-		HCPClusterName:    testClusterName,
-		HCPNodePoolName:   testNodePoolName,
-	}
-
-	ctx = utils.ContextWithLogger(ctx, logr.Discard())
-	err := syncer.SyncOnce(ctx, testKey)
-
-	require.NoError(t, err)
-
-	// Verify the ServiceProviderNodePool DesiredVersion was updated to the downgrade target
-	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
-		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
-	).Get(ctx, api.ServiceProviderNodePoolResourceName)
-	require.NoError(t, err)
-	require.NotNil(t, spnp.Spec.NodePoolVersion.DesiredVersion)
-	expectedDesiredVersion := semver.MustParse("4.19.5")
-	require.True(t, expectedDesiredVersion.EQ(*spnp.Spec.NodePoolVersion.DesiredVersion))
-}
-
-func TestNodePoolVersionSyncer_SyncOnce_ValidUpgradeSucceeds(t *testing.T) {
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-	mockCincinnati := cincinnati.NewMockClient(ctrl)
-
-	// Create node pool with desired version 4.19.15 (valid upgrade from 4.19.10)
-	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
-
-	// Create ServiceProviderCluster with control plane at 4.20.0
-	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
-
-	// CS returns node pool with current version 4.19.10
-	csNodePool := newCSNodePoolWithVersion(t, "4.19.10")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
-	// Cincinnati returns success for the desired version (version exists in the graph)
-	mockCincinnati.EXPECT().
-		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(
-			configv1.Release{Version: "4.19.15"},
-			[]configv1.Release{},
-			nil,
-			nil,
-		).
-		Times(1)
-
-	mockClientCache := cincinnati.NewMockClientCache(ctrl)
-	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
-
-	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		cincinnatiClientCache: mockClientCache,
-	}
-
-	testKey := controllerutils.HCPNodePoolKey{
-		SubscriptionID:    testSubscriptionID,
-		ResourceGroupName: testResourceGroupName,
-		HCPClusterName:    testClusterName,
-		HCPNodePoolName:   testNodePoolName,
-	}
-
-	ctx = utils.ContextWithLogger(ctx, logr.Discard())
-	err := syncer.SyncOnce(ctx, testKey)
-	require.NoError(t, err)
-
-	// Verify the ServiceProviderNodePool was updated correctly
-	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
-		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
-	).Get(ctx, api.ServiceProviderNodePoolResourceName)
-	require.NoError(t, err)
-
-	// Verify DesiredVersion was persisted
-	require.NotNil(t, spnp.Spec.NodePoolVersion.DesiredVersion)
-	expectedDesiredVersion := semver.MustParse("4.19.15")
-	require.True(t, expectedDesiredVersion.EQ(*spnp.Spec.NodePoolVersion.DesiredVersion))
 }
 
 func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_ChangedOnSuccess(t *testing.T) {
@@ -1249,6 +1028,7 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 		readDesireLister:      newValidHostedClusterReadDesireLister(t),
 		resourcesDBClient:     mockResourcesDBClient,
 		clusterServiceClient:  mockCS,
+		subscriptionLister:    newTestSubscriptionLister(),
 		cincinnatiClientCache: mockClientCache,
 	}
 
@@ -1314,10 +1094,9 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 		AnyTimes()
 	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnatiFailing).Times(1)
 
-	// SyncOnce should fail because the version doesn't exist in Cincinnati
+	// SyncOnce should succeed but persist IntentFailed (VersionNotFound is a user error, not transient)
 	err = syncer.SyncOnce(ctx, testKey)
-	require.Error(t, err, "SyncOnce should fail when version doesn't exist in Cincinnati")
-	assert.Contains(t, err.Error(), "not found in Cincinnati")
+	require.NoError(t, err, "SyncOnce should return nil after persisting IntentFailed for VersionNotFound")
 
 	// Verify that DesiredVersion was NOT changed (still 4.19.15)
 	spnp, err = mockResourcesDBClient.ServiceProviderNodePools(
@@ -1375,4 +1154,92 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	require.True(t, expectedNewDesiredVersion.EQ(*spnp.Spec.NodePoolVersion.DesiredVersion),
 		"DesiredVersion should have changed after successful validation, expected %s, got %s",
 		"4.19.20", spnp.Spec.NodePoolVersion.DesiredVersion)
+}
+
+// assertSyncResult is a helper function that validates the result of SyncOnce
+func assertSyncResult(t *testing.T, err error, expectedError bool, expectedErrorContains string) {
+	t.Helper()
+	if expectedError {
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, expectedErrorContains)
+	} else {
+		assert.NoError(t, err)
+	}
+}
+
+// createServiceProviderClusterWithVersion creates a ServiceProviderCluster with the given control plane version.
+func createServiceProviderClusterWithVersion(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient, controlPlaneVersion string) {
+	t.Helper()
+
+	clusterResourceID := "/subscriptions/" + testSubscriptionID +
+		"/resourceGroups/" + testResourceGroupName +
+		"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName
+	// ServiceProviderCluster resource ID format: {clusterResourceID}/{resourceTypeName}/{resourceName}
+	spClusterResourceID := clusterResourceID + "/" + api.ServiceProviderClusterResourceTypeName + "/" + api.ServiceProviderClusterResourceName
+
+	cpVersion := semver.MustParse(controlPlaneVersion)
+	spCluster := &api.ServiceProviderCluster{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID: api.Must(azcorearm.ParseResourceID(spClusterResourceID)),
+		},
+		Status: api.ServiceProviderClusterStatus{
+			ControlPlaneVersion: api.ServiceProviderClusterStatusVersion{
+				ActiveVersions: []api.HCPClusterActiveVersion{
+					{Version: &cpVersion, State: configv1.CompletedUpdate},
+				},
+			},
+		},
+	}
+	_, err := mockResourcesDBClient.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, spCluster, nil)
+	require.NoError(t, err)
+}
+
+// createServiceProviderNodePoolWithVersion creates a ServiceProviderNodePool with the given active version.
+func createServiceProviderNodePoolWithVersion(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient, activeVersion string) {
+	t.Helper()
+
+	nodePoolResourceID := "/subscriptions/" + testSubscriptionID +
+		"/resourceGroups/" + testResourceGroupName +
+		"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+		"/nodePools/" + testNodePoolName
+	// ServiceProviderNodePool resource ID format: {nodePoolResourceID}/{resourceTypeName}/{resourceName}
+	spNodePoolResourceID := nodePoolResourceID + "/" + api.ServiceProviderNodePoolResourceTypeName + "/" + api.ServiceProviderNodePoolResourceName
+
+	version := semver.MustParse(activeVersion)
+	spNodePool := &api.ServiceProviderNodePool{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID: api.Must(azcorearm.ParseResourceID(spNodePoolResourceID)),
+		},
+		Status: api.ServiceProviderNodePoolStatus{
+			NodePoolVersion: api.ServiceProviderNodePoolStatusVersion{
+				ActiveVersions: []api.HCPNodePoolActiveVersion{
+					{Version: &version},
+				},
+			},
+		},
+	}
+	_, err := mockResourcesDBClient.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).Create(ctx, spNodePool, nil)
+	require.NoError(t, err)
+}
+
+func newTestSubscriptionLister() *listertesting.SliceSubscriptionLister {
+	subResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscriptionID))
+	return &listertesting.SliceSubscriptionLister{
+		Subscriptions: []*arm.Subscription{{
+			CosmosMetadata: arm.CosmosMetadata{ResourceID: subResourceID},
+			ResourceID:     subResourceID,
+			Properties:     &arm.SubscriptionProperties{},
+		}},
+	}
+}
+
+func newCSNodePoolWithVersion(t *testing.T, version string) *arohcpv1alpha1.NodePool {
+	t.Helper()
+
+	csNodePool, err := arohcpv1alpha1.NewNodePool().
+		ID(testNodePoolName).
+		Version(arohcpv1alpha1.NewVersion().RawID(version)).
+		Build()
+	require.NoError(t, err)
+	return csNodePool
 }

--- a/internal/api/service_provider_conditions.go
+++ b/internal/api/service_provider_conditions.go
@@ -15,11 +15,12 @@
 package api
 
 const (
-	// DegradedCondition is True when the cluster is in a degraded state.
+	// DegradedCondition is True when the resource is in a degraded state.
+	// Applies to ServiceProviderCluster and ServiceProviderNodePool.
 	DegradedCondition = "Degraded"
 )
 
-// Known ServiceProviderCluster status condition Reason values (metav1.Condition.Reason).
+// Known ServiceProviderCluster and ServiceProviderNodePool status condition Reason values (metav1.Condition.Reason).
 const (
 	VersionUpgradeNotAcceptedReason string = "VersionUpgradeNotAccepted"
 	NoErrorsReason                  string = "NoErrors"


### PR DESCRIPTION
[ARO-26304](https://redhat.atlassian.net/browse/ARO-26304)

### What

Persist node pool version validation errors as `IntentFailed` conditions on the controller document instead of returning them as transient errors, and teach the operation controller to read those conditions to determine operation outcomes.

Similar work was done for control plane upgrade controller https://github.com/Azure/ARO-HCP/pull/5042

### Why

Previously, version validation errors (downgrades, Cincinnati `VersionNotFound`, missing upgrade paths, exceeding control plane version, skipping minor versions) were returned as errors from `SyncOnce`, causing the controller to retry them indefinitely. These are user errors that won't resolve on retry. By persisting them as `IntentFailed` conditions, the operation controller can detect them and fail the operation with a clear error message, while still retrying transient Cincinnati errors (e.g. 503).

### Testing

- Added new `TestNodePoolVersionSyncer_SyncOnce_IntentFailed` table with 6 test cases covering: successful resolution (IntentFailed=False), downgrade, Cincinnati VersionNotFound, Cincinnati upstream error (transient), exceeds control plane, and skipping minor versions
- Added operation controller tests covering: exact version match succeeds, IntentFailed marks operation failed, stale IntentFailed from previous version is ignored, 29s timeout for version resolution, and version mismatch without IntentFailed stays Accepted
- Updated `TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_ChangedOnSuccess` to reflect that VersionNotFound now returns nil (persists IntentFailed) instead of returning an error

### Special notes for your reviewer

- `service_provider_cluster_conditions.go` was renamed to `service_provider_conditions.go` since conditions now apply to both clusters and node pools
- The operation controller uses a `[version X.Y.Z]` prefix in the IntentFailed condition message to scope conditions to a specific customer version request, preventing stale errors from blocking new requests. There could be another approach to consider a dedicated field for cleaner version scoping. https://github.com/Azure/ARO-HCP/pull/5378#discussion_r3297706893
- The operation controller waits twice (59s timout) the informers relist period used by the nodepool version controller. This would cover most of the calculation edge cases in which the new desiredVersion has not yet calculated.
- `subscriptionLister` was added to the version controller for feature flag resolution (experimental release features)

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge