### PR TITLE
Dockerfiles temporary change to 1.25.10-1-azurelinux3.0-amd64 mcr golang image

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 as builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 as builder
 COPY internal/go.mod internal/go.sum internal/
 COPY test-integration/go.mod test-integration/
 COPY sessiongate/go.mod sessiongate/go.sum sessiongate/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 ARG PLATFORM
 
 # Builder image installs tools needed to build aro-hcp-backend
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY test-integration/go.mod test-integration/
 COPY backend/go.mod backend/go.sum backend/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY test-integration/go.mod test-integration/
 COPY frontend/go.mod frontend/go.sum frontend/

--- a/kube-applier/Dockerfile
+++ b/kube-applier/Dockerfile
@@ -1,7 +1,7 @@
 ARG PLATFORM
 
 # Builder image installs tools needed to build kube-applier
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY kube-applier/go.mod kube-applier/go.sum kube-applier/
 RUN cd kube-applier && go mod download

--- a/mgmt-agent/Dockerfile
+++ b/mgmt-agent/Dockerfile
@@ -1,7 +1,7 @@
 ARG PLATFORM
 
 # Builder image installs tools needed to build mgmt-agent
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
 COPY mgmt-agent/go.mod mgmt-agent/go.sum mgmt-agent/
 RUN cd mgmt-agent && go mod download
 WORKDIR /app

--- a/sessiongate/Dockerfile
+++ b/sessiongate/Dockerfile
@@ -1,7 +1,7 @@
 ARG PLATFORM
 
 # Builder image installs tools needed to build aro-hcp-backend
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
 COPY sessiongate/go.mod sessiongate/go.sum sessiongate/
 RUN cd sessiongate && go mod download
 WORKDIR /app

--- a/tooling/aro-hcp-exporter/Dockerfile
+++ b/tooling/aro-hcp-exporter/Dockerfile
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
 WORKDIR /app
 COPY ./hcpctl/ hcpctl/
 COPY ./aro-hcp-exporter/ aro-hcp-exporter/

--- a/tooling/tenant-quota/Dockerfile
+++ b/tooling/tenant-quota/Dockerfile
@@ -1,7 +1,7 @@
 ARG PLATFORM
 
 # Builder image
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY tooling/tenant-quota/go.mod tooling/tenant-quota/go.sum tooling/tenant-quota/
 RUN cd tooling/tenant-quota && go mod download


### PR DESCRIPTION
### What

Update MCR golang image to latest fixed version for amd64.

### Why

We are experiencing Docker build failures. The build cannot pull the 1.25-azurelinux3.0 image for platform linux/amd64.

### Testing

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
