### PR TITLE
revert: restore MCR golang floating tag (AROSLSRE-939)

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 as builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 as builder
 COPY internal/go.mod internal/go.sum internal/
 COPY test-integration/go.mod test-integration/
 COPY sessiongate/go.mod sessiongate/go.sum sessiongate/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 ARG PLATFORM
 
 # Builder image installs tools needed to build aro-hcp-backend
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY test-integration/go.mod test-integration/
 COPY backend/go.mod backend/go.sum backend/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY test-integration/go.mod test-integration/
 COPY frontend/go.mod frontend/go.sum frontend/

--- a/kube-applier/Dockerfile
+++ b/kube-applier/Dockerfile
@@ -1,7 +1,7 @@
 ARG PLATFORM
 
 # Builder image installs tools needed to build kube-applier
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY kube-applier/go.mod kube-applier/go.sum kube-applier/
 RUN cd kube-applier && go mod download

--- a/mgmt-agent/Dockerfile
+++ b/mgmt-agent/Dockerfile
@@ -1,7 +1,7 @@
 ARG PLATFORM
 
 # Builder image installs tools needed to build mgmt-agent
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
 COPY mgmt-agent/go.mod mgmt-agent/go.sum mgmt-agent/
 RUN cd mgmt-agent && go mod download
 WORKDIR /app

--- a/sessiongate/Dockerfile
+++ b/sessiongate/Dockerfile
@@ -1,7 +1,7 @@
 ARG PLATFORM
 
 # Builder image installs tools needed to build aro-hcp-backend
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
 COPY sessiongate/go.mod sessiongate/go.sum sessiongate/
 RUN cd sessiongate && go mod download
 WORKDIR /app

--- a/tooling/aro-hcp-exporter/Dockerfile
+++ b/tooling/aro-hcp-exporter/Dockerfile
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
 WORKDIR /app
 COPY ./hcpctl/ hcpctl/
 COPY ./aro-hcp-exporter/ aro-hcp-exporter/

--- a/tooling/tenant-quota/Dockerfile
+++ b/tooling/tenant-quota/Dockerfile
@@ -1,7 +1,7 @@
 ARG PLATFORM
 
 # Builder image
-FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-azurelinux3.0-amd64 AS builder
+FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY tooling/tenant-quota/go.mod tooling/tenant-quota/go.sum tooling/tenant-quota/
 RUN cd tooling/tenant-quota && go mod download


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://redhat.atlassian.net/browse/AROSLSRE-939

### What

Reverts PR #5379 which pinned Dockerfiles to `1.25.10-1-azurelinux3.0-amd64` as a workaround for the MCR golang floating tag missing its amd64 manifest.

### Why

PR #5379 was a temporary fix. Once the MCR `1.25-azurelinux3.0` floating tag is restored with amd64, we should revert to the floating tag to continue receiving patch updates automatically.

**Do NOT merge until `docker manifest inspect mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0` confirms amd64 is back.**

### Testing

- `make verify-yamlfmt` — passes
- `make -C config detect-change` — passes

### Special notes for your reviewer

This PR should remain open until MCR confirms the floating tag is fixed. Check with:
```
docker manifest inspect mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0
```