### PR TITLE
fix: manual kube-applier bump to fix int

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -184,7 +184,7 @@ defaults:
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: kube-applier
-      digest: sha256:9378a7668d2f67d0e7ea316113626539c75687556f99fff6a9dd9ae1bc830ba2 # f64835f (2026-05-18 15:45)
+      digest: sha256:c8526efb6a13bb3da45cfdfb406de9badccf8014cd12a41e5338c89dfd555b0f # 00ddf2b (2026-05-25 22:32)
     cosmosContainerName: "Manifests-MC-{{ .ctx.stamp }}"
     partitionKey: "/providers/microsoft.redhatopenshift/stamps/{{ .ctx.stamp }}/managementclusters/default"
     cosmosContainerMaxScale: 4000

--- a/config/rendered/dev/ci01/westus3.yaml
+++ b/config/rendered/dev/ci01/westus3.yaml
@@ -443,7 +443,7 @@ kubeApplier:
   cosmosContainerMaxScale: 4000
   cosmosContainerName: Manifests-MC-1
   image:
-    digest: sha256:9378a7668d2f67d0e7ea316113626539c75687556f99fff6a9dd9ae1bc830ba2
+    digest: sha256:c8526efb6a13bb3da45cfdfb406de9badccf8014cd12a41e5338c89dfd555b0f
     registry: arohcpsvcdev.azurecr.io
     repository: kube-applier
   k8s:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -443,7 +443,7 @@ kubeApplier:
   cosmosContainerMaxScale: 4000
   cosmosContainerName: Manifests-MC-1
   image:
-    digest: sha256:9378a7668d2f67d0e7ea316113626539c75687556f99fff6a9dd9ae1bc830ba2
+    digest: sha256:c8526efb6a13bb3da45cfdfb406de9badccf8014cd12a41e5338c89dfd555b0f
     registry: arohcpsvcdev.azurecr.io
     repository: kube-applier
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -443,7 +443,7 @@ kubeApplier:
   cosmosContainerMaxScale: 4000
   cosmosContainerName: Manifests-MC-1
   image:
-    digest: sha256:9378a7668d2f67d0e7ea316113626539c75687556f99fff6a9dd9ae1bc830ba2
+    digest: sha256:c8526efb6a13bb3da45cfdfb406de9badccf8014cd12a41e5338c89dfd555b0f
     registry: arohcpsvcdev.azurecr.io
     repository: kube-applier
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -443,7 +443,7 @@ kubeApplier:
   cosmosContainerMaxScale: 4000
   cosmosContainerName: Manifests-MC-1
   image:
-    digest: sha256:9378a7668d2f67d0e7ea316113626539c75687556f99fff6a9dd9ae1bc830ba2
+    digest: sha256:c8526efb6a13bb3da45cfdfb406de9badccf8014cd12a41e5338c89dfd555b0f
     registry: arohcpsvcdev.azurecr.io
     repository: kube-applier
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -443,7 +443,7 @@ kubeApplier:
   cosmosContainerMaxScale: 4000
   cosmosContainerName: Manifests-MC-1
   image:
-    digest: sha256:9378a7668d2f67d0e7ea316113626539c75687556f99fff6a9dd9ae1bc830ba2
+    digest: sha256:c8526efb6a13bb3da45cfdfb406de9badccf8014cd12a41e5338c89dfd555b0f
     registry: arohcpsvcdev.azurecr.io
     repository: kube-applier
   k8s:

--- a/config/rendered/dev/prow/westus3.yaml
+++ b/config/rendered/dev/prow/westus3.yaml
@@ -443,7 +443,7 @@ kubeApplier:
   cosmosContainerMaxScale: 4000
   cosmosContainerName: Manifests-MC-1
   image:
-    digest: sha256:9378a7668d2f67d0e7ea316113626539c75687556f99fff6a9dd9ae1bc830ba2
+    digest: sha256:c8526efb6a13bb3da45cfdfb406de9badccf8014cd12a41e5338c89dfd555b0f
     registry: arohcpsvcdev.azurecr.io
     repository: kube-applier
   k8s:


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

manual bump of kube-applier image

### Why

int is blocked by this broken image, opening this PR just in case the bot PR with all the image bumps fails e2e again so we can unblock int and beyond deployments

### Testing

e2e


### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
