### PR TITLE
fix: disable VAP/VAPB check in image registry policy test case for MSFT environments

### DIFF
--- a/test/e2e/image_registry_policy.go
+++ b/test/e2e/image_registry_policy.go
@@ -124,16 +124,6 @@ var _ = Describe("Image Registry Policy", func() {
 		labels.Positive,
 		labels.CoreInfraService,
 		func(ctx context.Context) {
-			By("verifying the ValidatingAdmissionPolicy exists")
-			_, err := kubeClient.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(
-				ctx, "image-registry-allowlist-policy", metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), "ValidatingAdmissionPolicy should exist")
-
-			By("verifying the ValidatingAdmissionPolicyBinding exists")
-			_, err = kubeClient.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(
-				ctx, "image-registry-allowlist-policy-binding", metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), "ValidatingAdmissionPolicyBinding should exist")
-
 			By("verifying the ConfigMap allowlist is non-empty and contains required registries")
 			cm, err := kubeClient.CoreV1().ConfigMaps("image-registry-policy").Get(
 				ctx, "image-registry-allowlist-config", metav1.GetOptions{})

--- a/test/e2e/image_registry_policy.go
+++ b/test/e2e/image_registry_policy.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 )
 
@@ -124,6 +125,19 @@ var _ = Describe("Image Registry Policy", func() {
 		labels.Positive,
 		labels.CoreInfraService,
 		func(ctx context.Context) {
+			// INT, STG and PROD do not have cluster-scoped RBAC to verify the policy exists
+			if framework.IsDevelopmentEnvironment() {
+				By("verifying the ValidatingAdmissionPolicy exists")
+				_, err := kubeClient.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(
+					ctx, "image-registry-allowlist-policy", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred(), "ValidatingAdmissionPolicy should exist")
+
+				By("verifying the ValidatingAdmissionPolicyBinding exists")
+				_, err = kubeClient.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(
+					ctx, "image-registry-allowlist-policy-binding", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred(), "ValidatingAdmissionPolicyBinding should exist")
+			}
+
 			By("verifying the ConfigMap allowlist is non-empty and contains required registries")
 			cm, err := kubeClient.CoreV1().ConfigMaps("image-registry-policy").Get(
 				ctx, "image-registry-allowlist-config", metav1.GetOptions{})


### PR DESCRIPTION
[ARO-27298](https://redhat.atlassian.net/browse/ARO-27298)

### What

Remove object existence check for ValidationAdmissionPolicy and ValidatingAdmissionPolicyBinding

### Why

- The e2e service account in STG/PROD lacks RBAC to get cluster-scoped VAP and VAPB, causing the test to fail consistently
- Since the policy is audit only in those environments there is no denial behavior to assert, only that the     
  deployment happened. The namespaced ConfigMap check covers that already

### Testing

This is a test bug fix. 

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
