### PR TITLE
test: retry ConflictingConcurrentWriteNotAllowed on HCP cluster delete

### DIFF
--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -168,7 +168,9 @@ func (tc *perItOrDescribeTestContext) RevokeCredentialsAndWait(
 	}
 }
 
-// DeleteHCPCluster deletes an hcp cluster and waits for the operation to complete
+// DeleteHCPCluster deletes an hcp cluster and waits for the operation to complete.
+// Transient ConflictingConcurrentWriteNotAllowed (409) errors are retried automatically
+// with exponential backoff.
 func DeleteHCPCluster(
 	ctx context.Context,
 	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
@@ -179,6 +181,38 @@ func DeleteHCPCluster(
 	ctx, cancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded during DeleteHCPCluster for cluster %s in resource group %s", timeout.Minutes(), hcpClusterName, resourceGroupName))
 	defer cancel()
 
+	var attempt int
+	retryErr := wait.ExponentialBackoffWithContext(ctx, stateConflictBackoff, func(ctx context.Context) (bool, error) {
+		attempt++
+		err := deleteHCPClusterAttempt(ctx, hcpClient, resourceGroupName, hcpClusterName)
+		if err == nil {
+			return true, nil
+		}
+		if isTransientDeleteError(err) {
+			ginkgo.GinkgoLogr.Info("transient conflict during cluster delete, retrying",
+				"cluster", hcpClusterName, "resourceGroup", resourceGroupName,
+				"attempt", attempt, "error", err.Error())
+			return false, nil
+		}
+		return false, err
+	})
+
+	if retryErr != nil && attempt > 1 {
+		ginkgo.GinkgoLogr.Info("cluster delete failed after retries",
+			"cluster", hcpClusterName, "resourceGroup", resourceGroupName,
+			"attempts", attempt, "error", retryErr.Error())
+	}
+
+	return retryErr
+}
+
+// deleteHCPClusterAttempt performs a single delete attempt for an HCP cluster.
+func deleteHCPClusterAttempt(
+	ctx context.Context,
+	hcpClient *hcpsdk20240610preview.HcpOpenShiftClustersClient,
+	resourceGroupName string,
+	hcpClusterName string,
+) error {
 	poller, err := hcpClient.BeginDelete(ctx, resourceGroupName, hcpClusterName, nil)
 	if err != nil {
 		var respErr *azcore.ResponseError
@@ -329,6 +363,21 @@ var stateConflictBackoff = wait.Backoff{
 // csStateConflictPattern matches the cluster-service error message format:
 // "Cluster '<id>' is in state '<state>', can't update"
 var csStateConflictPattern = regexp.MustCompile(`is in state '[^']+', can't update`)
+
+// isTransientDeleteError detects transient write conflicts during cluster deletion.
+// Only matches ConflictingConcurrentWriteNotAllowed, which is caused by optimistic
+// concurrency control in the backend and resolves on retry.
+func isTransientDeleteError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var responseError *azcore.ResponseError
+	if !errors.As(err, &responseError) {
+		return false
+	}
+	return responseError.StatusCode == http.StatusConflict &&
+		responseError.ErrorCode == "ConflictingConcurrentWriteNotAllowed"
+}
 
 // isTransientUpdateError detects errors worth retrying during cluster updates:
 //   - HTTP 500: e.g. Cosmos DB ETag conflict after cluster-service commit


### PR DESCRIPTION
[ARO-26433](https://redhat.atlassian.net/browse/ARO-26433)

### What

Add retry logic to `DeleteHCPCluster` for transient `ConflictingConcurrentWriteNotAllowed` (409) errors during E2E test cleanup. A new `isTransientDeleteError` helper detects this specific ARM error code, and the delete logic is wrapped in `wait.ExponentialBackoffWithContext` using the existing `stateConflictBackoff` config (up to 5 attempts with exponential backoff).


### Why

The backend uses optimistic concurrency control, which can produce transient 409 conflicts during concurrent writes. The test cleanup code did not retry on this error, causing functionally passing tests to be reported as failed. This creates noise in test results and masks the true pass rate.

### Testing

No unit tests added -- `isTransientDeleteError` is a trivial function (nil check, type assertion, two field comparisons), consistent with the untested sibling `isTransientUpdateError`. The fix will be validated by the E2E test suite itself, where the flaky cleanup failures should stop occurring.

### Special notes for your reviewer

- The retry uses the same `stateConflictBackoff` config already used by `UpdateHCPCluster` (5 attempts, 1m/2m/4m/8m backoff), well within the 60-minute cleanup timeout.
- The existing "already deleting" 409 handler is preserved unchanged inside `deleteHCPClusterAttempt`.
- Only `ConflictingConcurrentWriteNotAllowed` is retried -- deliberately narrower than the update path which retries all 409s and 500s.


### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge
