### PR TITLE
Add stamp approval endpoint to admin API

### DIFF
--- a/admin/server/cmd/server/options.go
+++ b/admin/server/cmd/server/options.go
@@ -138,6 +138,7 @@ type completedOptions struct {
 	Location                string
 	ResourcesDBClient       database.ResourcesDBClient
 	BillingDBClient         database.BillingDBClient
+	FleetDBClient           database.FleetDBClient
 	ClusterServiceClient    ocm.ClusterServiceClientSpec
 	KustoClient             *kusto.Client
 	FpaCredentialRetriever  fpa.FirstPartyApplicationTokenCredentialRetriever
@@ -221,6 +222,10 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the billing database client: %w", err)
 	}
+	fleetDBClient, err := database.NewFleetDBClient(cosmosDatabaseClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the fleet database client: %w", err)
+	}
 
 	// Create Kusto client
 	var kustoClient *kusto.Client
@@ -290,6 +295,7 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 			Location:                o.Location,
 			ResourcesDBClient:       resourcesDBClient,
 			BillingDBClient:         billingDBClient,
+			FleetDBClient:           fleetDBClient,
 			ClusterServiceClient:    csClient,
 			KustoClient:             kustoClient,
 			FpaCredentialRetriever:  fpaCredentialRetriever,
@@ -345,6 +351,7 @@ func (opts *Options) Run(ctx context.Context) error {
 		metricsListener,
 		opts.ResourcesDBClient,
 		opts.BillingDBClient,
+		opts.FleetDBClient,
 		opts.ClusterServiceClient,
 		opts.KustoClient,
 		opts.FpaCredentialRetriever,

--- a/admin/server/handlers/stamp/stamp_approval.go
+++ b/admin/server/handlers/stamp/stamp_approval.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stamp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/fleet"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+type stampApprovalRequest struct {
+	Approved bool   `json:"approved"`
+	Reason   string `json:"reason"`
+	Message  string `json:"message"`
+}
+
+type StampApprovalHandler struct {
+	fleetDBClient database.FleetDBClient
+}
+
+func NewStampApprovalHandler(fleetDBClient database.FleetDBClient) *StampApprovalHandler {
+	return &StampApprovalHandler{
+		fleetDBClient: fleetDBClient,
+	}
+}
+
+func (h *StampApprovalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	stampIdentifier := r.PathValue("stampIdentifier")
+
+	var body stampApprovalRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return arm.NewCloudError(
+			http.StatusBadRequest,
+			arm.CloudErrorCodeInvalidRequestContent, "",
+			"The request content was invalid and could not be deserialized: %q", err,
+		)
+	}
+
+	if err := validateApprovalRequest(body); err != nil {
+		return err
+	}
+
+	if _, err := fleet.ToStampResourceID(stampIdentifier); err != nil {
+		return arm.NewCloudError(
+			http.StatusBadRequest,
+			arm.CloudErrorCodeInvalidRequestContent, "stampIdentifier",
+			"Invalid stamp identifier: %q", stampIdentifier,
+		)
+	}
+
+	stampsCRUD := h.fleetDBClient.Stamps()
+	existing, err := stampsCRUD.Get(ctx, stampIdentifier)
+	if err != nil {
+		if database.IsNotFoundError(err) {
+			return arm.NewCloudError(http.StatusNotFound, arm.CloudErrorCodeNotFound, "", "Stamp %q not found", stampIdentifier)
+		}
+		return utils.TrackError(fmt.Errorf("failed to get stamp: %w", err))
+	}
+
+	conditionStatus := metav1.ConditionFalse
+	if body.Approved {
+		conditionStatus = metav1.ConditionTrue
+	}
+
+	// Check if this is a no-op (idempotent)
+	existingCondition := apimeta.FindStatusCondition(existing.Status.Conditions, string(fleet.StampConditionApproved))
+	if existingCondition != nil &&
+		existingCondition.Status == conditionStatus &&
+		existingCondition.Reason == body.Reason &&
+		existingCondition.Message == body.Message {
+		w.WriteHeader(http.StatusNoContent)
+		return nil
+	}
+
+	updated := existing.DeepCopy()
+	apimeta.SetStatusCondition(&updated.Status.Conditions, metav1.Condition{
+		Type:               string(fleet.StampConditionApproved),
+		Status:             conditionStatus,
+		Reason:             body.Reason,
+		Message:            body.Message,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	})
+
+	if _, err := stampsCRUD.Replace(ctx, updated, existing, nil); err != nil {
+		if database.IsPreconditionFailedError(err) {
+			return arm.NewCloudError(http.StatusConflict, arm.CloudErrorCodeConflict, "", "ETag conflict, retry the operation")
+		}
+		return utils.TrackError(err)
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+	return nil
+}
+
+func validateApprovalRequest(body stampApprovalRequest) error {
+	var details []arm.CloudErrorBody
+
+	if len(body.Reason) == 0 {
+		details = append(details, arm.CloudErrorBody{
+			Code:    arm.CloudErrorCodeInvalidRequestContent,
+			Target:  "reason",
+			Message: "reason is required",
+		})
+	}
+	if len(body.Message) == 0 {
+		details = append(details, arm.CloudErrorBody{
+			Code:    arm.CloudErrorCodeInvalidRequestContent,
+			Target:  "message",
+			Message: "message is required",
+		})
+	}
+
+	if len(details) == 0 {
+		return nil
+	}
+	return arm.NewContentValidationError(details)
+}

--- a/admin/server/handlers/stamp/stamp_approval_test.go
+++ b/admin/server/handlers/stamp/stamp_approval_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stamp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/fleet"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func newStamp(stampIdentifier string) *fleet.Stamp {
+	stampResourceID, _ := fleet.ToStampResourceID(stampIdentifier)
+	return &fleet.Stamp{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID: stampResourceID,
+		},
+		ResourceID: stampResourceID,
+	}
+}
+
+func newStampWithConditions(stampIdentifier string, conditions ...metav1.Condition) *fleet.Stamp {
+	stampResourceID, _ := fleet.ToStampResourceID(stampIdentifier)
+	return &fleet.Stamp{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID: stampResourceID,
+		},
+		ResourceID: stampResourceID,
+		Status: fleet.StampStatus{
+			Conditions: conditions,
+		},
+	}
+}
+
+func TestStampApprovalHandler(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name               string
+		stampIdentifier    string
+		body               string
+		setupResources     []any
+		expectedStatusCode int
+		expectedError      string
+		verifyState        func(*testing.T, *databasetesting.MockFleetDBClient)
+	}{
+		{
+			name:               "approve stamp",
+			stampIdentifier:    "a1",
+			body:               `{"approved":true,"reason":"ManuallyApproved","message":"Approved by SRE"}`,
+			setupResources:     []any{newStamp("a1")},
+			expectedStatusCode: http.StatusNoContent,
+			verifyState: func(t *testing.T, mock *databasetesting.MockFleetDBClient) {
+				ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+				stamp, err := mock.Stamps().Get(ctx, "a1")
+				require.NoError(t, err)
+				cond := apimeta.FindStatusCondition(stamp.Status.Conditions, string(fleet.StampConditionApproved))
+				require.NotNil(t, cond)
+				require.Equal(t, metav1.ConditionTrue, cond.Status)
+				require.Equal(t, "ManuallyApproved", cond.Reason)
+				require.Equal(t, "Approved by SRE", cond.Message)
+			},
+		},
+		{
+			name:            "revoke approval",
+			stampIdentifier: "a1",
+			body:            `{"approved":false,"reason":"ApprovalRevoked","message":"Revoked for maintenance"}`,
+			setupResources: []any{
+				newStampWithConditions("a1", metav1.Condition{
+					Type:   string(fleet.StampConditionApproved),
+					Status: metav1.ConditionTrue,
+					Reason: string(fleet.StampConditionReasonManuallyApproved),
+				}),
+			},
+			expectedStatusCode: http.StatusNoContent,
+			verifyState: func(t *testing.T, mock *databasetesting.MockFleetDBClient) {
+				ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+				stamp, err := mock.Stamps().Get(ctx, "a1")
+				require.NoError(t, err)
+				cond := apimeta.FindStatusCondition(stamp.Status.Conditions, string(fleet.StampConditionApproved))
+				require.NotNil(t, cond)
+				require.Equal(t, metav1.ConditionFalse, cond.Status)
+				require.Equal(t, "ApprovalRevoked", cond.Reason)
+			},
+		},
+		{
+			name:            "idempotent approval is no-op",
+			stampIdentifier: "a1",
+			body:            `{"approved":true,"reason":"ManuallyApproved","message":"Approved by SRE"}`,
+			setupResources: []any{
+				newStampWithConditions("a1", metav1.Condition{
+					Type:   string(fleet.StampConditionApproved),
+					Status: metav1.ConditionTrue,
+					Reason: string(fleet.StampConditionReasonManuallyApproved),
+				}),
+			},
+			expectedStatusCode: http.StatusNoContent,
+		},
+		{
+			name:            "idempotent revocation is no-op",
+			stampIdentifier: "a1",
+			body:            `{"approved":false,"reason":"ApprovalRevoked","message":"Revoked"}`,
+			setupResources: []any{
+				newStampWithConditions("a1", metav1.Condition{
+					Type:   string(fleet.StampConditionApproved),
+					Status: metav1.ConditionFalse,
+					Reason: string(fleet.StampConditionReasonApprovalRevoked),
+				}),
+			},
+			expectedStatusCode: http.StatusNoContent,
+		},
+		{
+			name:               "stamp not found returns 404",
+			stampIdentifier:    "a1",
+			body:               `{"approved":true,"reason":"ManuallyApproved","message":"Approved"}`,
+			expectedStatusCode: http.StatusNotFound,
+			expectedError:      "not found",
+		},
+		{
+			name:               "missing reason returns 400",
+			stampIdentifier:    "a1",
+			body:               `{"approved":true,"reason":"","message":"Approved"}`,
+			setupResources:     []any{newStamp("a1")},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedError:      "reason is required",
+		},
+		{
+			name:               "missing message returns 400",
+			stampIdentifier:    "a1",
+			body:               `{"approved":true,"reason":"ManuallyApproved","message":""}`,
+			setupResources:     []any{newStamp("a1")},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedError:      "message is required",
+		},
+		{
+			name:               "invalid JSON body",
+			stampIdentifier:    "a1",
+			body:               `{invalid`,
+			setupResources:     []any{newStamp("a1")},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedError:      "could not be deserialized",
+		},
+		{
+			name:               "missing both reason and message returns 400",
+			stampIdentifier:    "a1",
+			body:               `{"approved":true,"reason":"","message":""}`,
+			setupResources:     []any{newStamp("a1")},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedError:      "reason is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			var mockFleetDB *databasetesting.MockFleetDBClient
+			var err error
+			if len(tt.setupResources) > 0 {
+				mockFleetDB, err = databasetesting.NewMockFleetDBClientWithResources(ctx, tt.setupResources)
+				require.NoError(t, err)
+			} else {
+				mockFleetDB = databasetesting.NewMockFleetDBClient()
+			}
+
+			handler := NewStampApprovalHandler(mockFleetDB)
+
+			req := httptest.NewRequest(http.MethodPost, "/admin/v1/stamps/"+tt.stampIdentifier+"/approval", strings.NewReader(tt.body))
+			req.SetPathValue("stampIdentifier", tt.stampIdentifier)
+			req = req.WithContext(ctx)
+			recorder := httptest.NewRecorder()
+
+			handlerErr := handler.ServeHTTP(recorder, req)
+
+			if len(tt.expectedError) > 0 {
+				require.Error(t, handlerErr)
+				var cloudErr *arm.CloudError
+				require.True(t, errors.As(handlerErr, &cloudErr), "expected CloudError but got %T: %v", handlerErr, handlerErr)
+				require.Equal(t, tt.expectedStatusCode, cloudErr.StatusCode)
+				require.Contains(t, cloudErr.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, handlerErr)
+				require.Equal(t, tt.expectedStatusCode, recorder.Code)
+			}
+
+			if tt.verifyState != nil {
+				tt.verifyState(t, mockFleetDB)
+			}
+		})
+	}
+}

--- a/admin/server/server/admin.go
+++ b/admin/server/server/admin.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Azure/ARO-HCP/admin/server/handlers/cosmosdump"
 	"github.com/Azure/ARO-HCP/admin/server/handlers/hcp"
 	breakglasshandlers "github.com/Azure/ARO-HCP/admin/server/handlers/hcp/breakglass"
+	stamphandlers "github.com/Azure/ARO-HCP/admin/server/handlers/stamp"
 	"github.com/Azure/ARO-HCP/admin/server/middleware"
 	"github.com/Azure/ARO-HCP/internal/audit"
 	"github.com/Azure/ARO-HCP/internal/database"
@@ -49,6 +50,7 @@ import (
 type AdminAPI struct {
 	clustersServiceClient  ocm.ClusterServiceClientSpec
 	resourcesDBClient      database.ResourcesDBClient
+	fleetDBClient          database.FleetDBClient
 	kustoClient            *kusto.Client
 	fpaCredentialRetriever fpa.FirstPartyApplicationTokenCredentialRetriever
 
@@ -67,6 +69,7 @@ func NewAdminAPI(
 	metricsListener net.Listener,
 	resourcesDBClient database.ResourcesDBClient,
 	billingDBClient database.BillingDBClient,
+	fleetDBClient database.FleetDBClient,
 	clustersServiceClient ocm.ClusterServiceClientSpec,
 	kustoClient *kusto.Client,
 	fpaCredentialRetriever fpa.FirstPartyApplicationTokenCredentialRetriever,
@@ -122,6 +125,10 @@ func NewAdminAPI(
 	// Non-HCP admin routes
 	middlewareMux.Handle("GET /admin/helloworld", handlers.HelloWorldHandler())
 
+	// Stamp management routes
+	middlewareMux.Handle("POST /admin/v1/stamps/{stampIdentifier}/approval",
+		errorutils.ReportError(stamphandlers.NewStampApprovalHandler(fleetDBClient).ServeHTTP))
+
 	// Top-level mux (healthz bypasses all middleware)
 	apiMux := http.NewServeMux()
 	apiMux.HandleFunc("GET /healthz/ready", healthzReadyHandler)
@@ -154,6 +161,7 @@ func NewAdminAPI(
 			Handler: metricsMux,
 		},
 		resourcesDBClient:      resourcesDBClient,
+		fleetDBClient:          fleetDBClient,
 		clustersServiceClient:  clustersServiceClient,
 		kustoClient:            kustoClient,
 		fpaCredentialRetriever: fpaCredentialRetriever,

--- a/test-integration/utils/integrationutils/cosmos_testinfo.go
+++ b/test-integration/utils/integrationutils/cosmos_testinfo.go
@@ -48,6 +48,7 @@ type CosmosIntegrationTestInfo struct {
 	resourcesDBClient    database.ResourcesDBClient
 	billingDBClient      database.BillingDBClient
 	locksDBClient        database.LocksDBClient
+	fleetDBClient        database.FleetDBClient
 	cosmosClient         *azcosmos.Client
 }
 
@@ -72,6 +73,10 @@ func NewCosmosFromTestingEnv(ctx context.Context, t *testing.T) (StorageIntegrat
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the locks database client: %w", err)
 	}
+	fleetDBClient, err := database.NewFleetDBClient(cosmosDatabaseClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the fleet database client: %w", err)
+	}
 
 	testInfo := &CosmosIntegrationTestInfo{
 		ArtifactsDir:         path.Join(getArtifactDir(), t.Name()),
@@ -79,6 +84,7 @@ func NewCosmosFromTestingEnv(ctx context.Context, t *testing.T) (StorageIntegrat
 		resourcesDBClient:    resourcesDBClient,
 		billingDBClient:      billingDBClient,
 		locksDBClient:        locksDBClient,
+		fleetDBClient:        fleetDBClient,
 		cosmosClient:         cosmosClient,
 	}
 	return testInfo, nil
@@ -124,6 +130,10 @@ func (s *CosmosIntegrationTestInfo) BillingDBClient() database.BillingDBClient {
 
 func (s *CosmosIntegrationTestInfo) LocksDBClient() database.LocksDBClient {
 	return s.locksDBClient
+}
+
+func (s *CosmosIntegrationTestInfo) FleetDBClient() database.FleetDBClient {
+	return s.fleetDBClient
 }
 
 func LoadCosmosContent(ctx context.Context, cosmosContainer *azcosmos.ContainerClient, content []byte) error {
@@ -450,6 +460,7 @@ func initializeCosmosDBForFrontend(ctx context.Context, cosmosClient *azcosmos.C
 		{"Resources", "/partitionKey", nil},
 		{"Billing", "/subscriptionId", nil},
 		{"Locks", "/id", &[]int32{10}[0]}, // 10 second TTL for locks
+		{"Fleet", "/partitionKey", nil},
 	}
 
 	start := time.Now()

--- a/test-integration/utils/integrationutils/frontend_testinfo.go
+++ b/test-integration/utils/integrationutils/frontend_testinfo.go
@@ -44,6 +44,7 @@ type StorageIntegrationTestInfo interface {
 	ResourcesDBClient() database.ResourcesDBClient
 	BillingDBClient() database.BillingDBClient
 	LocksDBClient() database.LocksDBClient
+	FleetDBClient() database.FleetDBClient
 
 	Cleanup(ctx context.Context)
 }

--- a/test-integration/utils/integrationutils/mock_cosmos_testinfo.go
+++ b/test-integration/utils/integrationutils/mock_cosmos_testinfo.go
@@ -30,18 +30,21 @@ type MockCosmosIntegrationTestInfo struct {
 	mockResourcesDBClient *databasetesting.MockResourcesDBClient
 	mockBillingDBClient   *databasetesting.MockBillingDBClient
 	mockLocksDBClient     *databasetesting.MockLocksDBClient
+	mockFleetDBClient     *databasetesting.MockFleetDBClient
 }
 
 func NewMockCosmosFromTestingEnv(ctx context.Context, t *testing.T) (StorageIntegrationTestInfo, error) {
 	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
 	mockBillingDBClient := databasetesting.NewMockBillingDBClient()
 	mockLocksDBClient := databasetesting.NewMockLocksDBClient()
+	mockFleetDBClient := databasetesting.NewMockFleetDBClient()
 
 	testInfo := &MockCosmosIntegrationTestInfo{
 		ArtifactsDir:          path.Join(getArtifactDir(), t.Name()),
 		mockResourcesDBClient: mockResourcesDBClient,
 		mockBillingDBClient:   mockBillingDBClient,
 		mockLocksDBClient:     mockLocksDBClient,
+		mockFleetDBClient:     mockFleetDBClient,
 	}
 	return testInfo, nil
 }
@@ -56,6 +59,10 @@ func (m *MockCosmosIntegrationTestInfo) BillingDBClient() database.BillingDBClie
 
 func (m *MockCosmosIntegrationTestInfo) LocksDBClient() database.LocksDBClient {
 	return m.mockLocksDBClient
+}
+
+func (m *MockCosmosIntegrationTestInfo) FleetDBClient() database.FleetDBClient {
+	return m.mockFleetDBClient
 }
 
 func (m *MockCosmosIntegrationTestInfo) LoadContent(ctx context.Context, content []byte) error {

--- a/test-integration/utils/integrationutils/utils.go
+++ b/test-integration/utils/integrationutils/utils.go
@@ -149,6 +149,7 @@ func NewIntegrationTestInfoFromEnv(ctx context.Context, t *testing.T, withMock b
 		adminMetricsListener,
 		storageIntegrationTestInfo.ResourcesDBClient(),
 		storageIntegrationTestInfo.BillingDBClient(),
+		storageIntegrationTestInfo.FleetDBClient(),
 		clusterServiceMockInfo.MockClusterServiceClient,
 		nil,
 		nil,


### PR DESCRIPTION
### What

Introduces POST /admin/v1/stamps/{stampIdentifier}/approval to approve or revoke stamp approval via the Approved condition. Wires FleetDBClient through the admin server and test infrastructure.

Ref: https://redhat.atlassian.net/browse/ARO-27316

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
