### PR TITLE
fix: build cleanup-pko-resources based on machine architecture

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -19,7 +19,7 @@ buildStep:
     set -o pipefail
     tmp="$(mktemp ./scripts/cleanup-pko-resources/cleanup-pko-resources.XXXXXX)"
     trap 'rm -f "${tmp}"' EXIT
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "${tmp}" ./scripts/cleanup-pko-resources
+    CGO_ENABLED=0 go build -o "${tmp}" ./scripts/cleanup-pko-resources
     chmod 0755 "${tmp}"
     mv "${tmp}" ./scripts/cleanup-pko-resources/cleanup-pko-resources
     trap - EXIT


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Builds cleanup-pko-resources based on the current machine architecture.

### Why

So that cleanup-pko-resources binary is compatible on macOS arm.  

Deployment error:
```
  "err": "errors occurred during execution: [error running Shell Step, failed to execute shell command: /bin/bash: line 1: ./scripts/cleanup-pko-resources/cleanup-pko-resources: cannot execute binary file
```

### Testing

I was able to create a personal dev environment after this change.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
