### PR TITLE
deps: bump typespec packages to 0.68.x / 1.12.x

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -24,7 +24,7 @@
         "autorest": "^3.7.2"
       },
       "engines": {
-        "node": ">=20.12.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5,22 +5,22 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-tools/typespec-autorest": "^0.67.0",
-        "@azure-tools/typespec-azure-core": "^0.67.1",
-        "@azure-tools/typespec-azure-resource-manager": "^0.67.1",
-        "@azure-tools/typespec-azure-rulesets": "0.67.0",
-        "@azure-tools/typespec-client-generator-core": "^0.67.4",
-        "@typespec/http": "~1.11.0",
-        "@typespec/openapi": "~1.11.0",
-        "@typespec/openapi3": "~1.11.0",
-        "@typespec/rest": "~0.81.0",
-        "@typespec/versioning": "~0.81.0",
+        "@azure-tools/typespec-autorest": "^0.68.0",
+        "@azure-tools/typespec-azure-core": "^0.68.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.68.0",
+        "@azure-tools/typespec-azure-rulesets": "^0.68.0",
+        "@azure-tools/typespec-client-generator-core": "^0.68.1",
+        "@typespec/http": "^1.12.0",
+        "@typespec/openapi": "^1.12.0",
+        "@typespec/openapi3": "^1.12.0",
+        "@typespec/rest": "^0.82.0",
+        "@typespec/versioning": "^0.82.0",
         "oav": "^4.0.4"
       },
       "devDependencies": {
         "@microsoft.azure/openapi-validator": "2.2.4",
         "@microsoft.azure/openapi-validator-rulesets": "2.2.6",
-        "@typespec/compiler": "~1.11.0",
+        "@typespec/compiler": "^1.12.0",
         "autorest": "^3.7.2"
       },
       "engines": {
@@ -159,23 +159,23 @@
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.67.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.67.0.tgz",
-      "integrity": "sha512-RP0TZB46tnYGfN5FKaaXDP5/rDff0PEERKz4epoYsm4RmXeRDYXVcOjw7DXLbcgFpMLTLBf/w/5dqJZBx03KpQ==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.68.0.tgz",
+      "integrity": "sha512-ywcB68x0jOuplKg1u9ZpjOamHbIEEgAaMuXTP72cvWXE7q1eGLCN1DQx1Uk5ME8VLJKAX6cMOMHK4hcmg9tvuw==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.67.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.67.0",
-        "@azure-tools/typespec-client-generator-core": "^0.67.0",
-        "@typespec/compiler": "~1.11.0",
-        "@typespec/http": "~1.11.0",
-        "@typespec/openapi": "~1.11.0",
-        "@typespec/rest": "~0.81.0",
-        "@typespec/versioning": "~0.81.0",
-        "@typespec/xml": "^0.81.0"
+        "@azure-tools/typespec-azure-core": "^0.68.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.68.0",
+        "@azure-tools/typespec-client-generator-core": "^0.68.0",
+        "@typespec/compiler": "^1.12.0",
+        "@typespec/http": "^1.12.0",
+        "@typespec/openapi": "^1.12.0",
+        "@typespec/rest": "^0.82.0",
+        "@typespec/versioning": "^0.82.0",
+        "@typespec/xml": "^0.82.0"
       },
       "peerDependenciesMeta": {
         "@typespec/xml": {
@@ -184,79 +184,79 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.67.1.tgz",
-      "integrity": "sha512-HBvigwr8Ub7rsg4RDpTO3WTHS+CIqAw32X3RzxsDNb8NfLoSLSZDANz05VPiDTzAXO7eMfEP42RXkKPV0tlZLg==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.68.0.tgz",
+      "integrity": "sha512-p0qUkRZav5fdQvGe2gSCvlgsvpM0y9xVhgH2GpXi5ZzpYfNGzxd8oZr8VOCP8mjMVfGQ3AtnowbmrHALEZgz7Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~1.11.0",
-        "@typespec/http": "~1.11.0",
-        "@typespec/rest": "~0.81.0"
+        "@typespec/compiler": "^1.12.0",
+        "@typespec/http": "^1.12.0",
+        "@typespec/rest": "^0.82.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.67.1.tgz",
-      "integrity": "sha512-cIPVscR29WgUOk6NDWco95Fc0swSe1jmJz+5G24cCqt6iR/mgIiNdT7D+Njg0VkANoI1AaCT69eIa6yWpAaOIg==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.68.0.tgz",
+      "integrity": "sha512-1zgXpOb/fGfB7SrFqawKasSOTIi9cZPWyK8V3RHyNWFZVQclEMGBzSvBHi6an4AEChqcjCSMh5MEr4BSujW4Ew==",
       "license": "MIT",
       "dependencies": {
-        "change-case": "~5.4.4",
+        "change-case": "^5.4.4",
         "pluralize": "^8.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.67.0",
-        "@typespec/compiler": "~1.11.0",
-        "@typespec/http": "~1.11.0",
-        "@typespec/openapi": "~1.11.0",
-        "@typespec/rest": "~0.81.0",
-        "@typespec/versioning": "~0.81.0"
+        "@azure-tools/typespec-azure-core": "^0.68.0",
+        "@typespec/compiler": "^1.12.0",
+        "@typespec/http": "^1.12.0",
+        "@typespec/openapi": "^1.12.0",
+        "@typespec/rest": "^0.82.0",
+        "@typespec/versioning": "^0.82.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.67.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.67.0.tgz",
-      "integrity": "sha512-YCkyTm090xQR0Gb3CnIdbEd+SbVUY1TRtuPXrBPTsNu3MJwvlaESnkJ7bt9zkP94mAFTNoSTuZlAUKDfPrFaFA==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.68.0.tgz",
+      "integrity": "sha512-cXZ3jiDNqJgpBQLguNgXjvAsvYo7VwtlQxFMzTr96gpoAiuBViH+3eOhVd5HA4H96NgAWSddTMHXZJZzcsnE5A==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.67.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.67.0",
-        "@azure-tools/typespec-client-generator-core": "^0.67.0",
-        "@typespec/compiler": "~1.11.0"
+        "@azure-tools/typespec-azure-core": "^0.68.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.68.0",
+        "@azure-tools/typespec-client-generator-core": "^0.68.0",
+        "@typespec/compiler": "^1.12.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.67.4",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.67.4.tgz",
-      "integrity": "sha512-Q9mlU5wZzPCFtdwVKKgqb6Nw4PM0taOeRsr7Aj9WkRYx7n9B8Y+ITtMLYaJWd3OQVkpZoiFOgq+0ZnrcC3IjCw==",
+      "version": "0.68.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.68.1.tgz",
+      "integrity": "sha512-b27LO6KW3rE/SrLdMgsLKcIQ9tTglGLVQF2zv1cgHO5CWh/OeJhP6R2Cw5R0HPbDIcfpoLD6te++GlveL1VtVg==",
       "license": "MIT",
       "dependencies": {
-        "change-case": "~5.4.4",
+        "change-case": "^5.4.4",
         "pluralize": "^8.0.0",
-        "yaml": "~2.8.2"
+        "yaml": "^2.8.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.67.1",
-        "@typespec/compiler": "^1.11.0",
-        "@typespec/events": "^0.81.0",
-        "@typespec/http": "^1.11.0",
-        "@typespec/openapi": "^1.11.0",
-        "@typespec/rest": "^0.81.0",
-        "@typespec/sse": "^0.81.0",
-        "@typespec/streams": "^0.81.0",
-        "@typespec/versioning": "^0.81.0",
-        "@typespec/xml": "^0.81.0"
+        "@azure-tools/typespec-azure-core": "^0.68.0",
+        "@typespec/compiler": "^1.12.0",
+        "@typespec/events": "^0.82.0",
+        "@typespec/http": "^1.12.0",
+        "@typespec/openapi": "^1.12.0",
+        "@typespec/rest": "^0.82.0",
+        "@typespec/sse": "^0.82.0",
+        "@typespec/streams": "^0.82.0",
+        "@typespec/versioning": "^0.82.0",
+        "@typespec/xml": "^0.82.0"
       }
     },
     "node_modules/@azure-tools/uri": {
@@ -884,74 +884,39 @@
         "node": ">=20"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@scalar/helpers": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.2.18.tgz",
-      "integrity": "sha512-w1d4tpNEVZ293oB2BAgLrS0kVPUtG3eByNmOCJA5eK9vcT4D3cmsGtWjUaaqit0BQCsBFHK51rasGvSWnApYTw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.8.0.tgz",
+      "integrity": "sha512-gmOC6VravNB9VDl6wnt/GOj4K/hn48tj5bpW4AM4MhH8Ubil6uu7g1DSoKHwltu8Ks79KEtR6JmOrROi9R7jaQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/json-magic": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.11.7.tgz",
-      "integrity": "sha512-GVz9E0vXu+ecypkdn0biK1gbQVkK4QTTX1Hq3eMgxlLQC91wwiqWfCqwfhuX0LRu+Z5OmYhLhufDJEEh56rVgA==",
+      "version": "0.12.14",
+      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.14.tgz",
+      "integrity": "sha512-dWrCy3ew1r7OQ1pu2r4ZjiKEVy0yVd66kXdmsl41bteOG2F2I2IBlPjmPV6p8ckjImQHxtNBIntFaQfNrdBhJg==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.2.18",
+        "@scalar/helpers": "0.8.0",
         "pathe": "^2.0.3",
-        "yaml": "^2.8.0"
+        "yaml": "^2.8.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/openapi-parser": {
-      "version": "0.24.17",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.24.17.tgz",
-      "integrity": "sha512-aM9UVrzlMreC3X/sZbyj+7XDZmat3ecGC3RpU8dqEO/HIH+CEX0xMLuP+41DhePCYg5+9TtDomSfWuMq4x1Z1A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.25.12.tgz",
+      "integrity": "sha512-1hajBAbc7cbEcsSZEQxaPXZyCjMf6h6hObV+SO32jkC6rrxinPXQIucDu9HTu/jm/FaaMnNhc8/XDWz5/E49cQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.2.18",
-        "@scalar/json-magic": "0.11.7",
-        "@scalar/openapi-types": "0.5.4",
-        "@scalar/openapi-upgrader": "0.1.11",
+        "@scalar/helpers": "0.5.2",
+        "@scalar/json-magic": "0.12.8",
+        "@scalar/openapi-types": "0.8.0",
+        "@scalar/openapi-upgrader": "0.2.6",
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
         "ajv-formats": "^3.0.1",
@@ -960,7 +925,39 @@
         "yaml": "^2.8.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/openapi-parser/node_modules/@scalar/helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-Pi1GAl8jO6ungmGj2sjDfCfqiBNrKW6HXDZmminV94ybGU/KtRLOqHwd0n9FIhY3j0RYGpGC0VCuniCICfQPHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/openapi-parser/node_modules/@scalar/json-magic": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.8.tgz",
+      "integrity": "sha512-a559iO8tmFeA90JJAAM3U5x1Asf3mr0Z8uDC1PmyLTDjdSOfajP7EY9VzNoXE2cM48ilf9qrjmkbw/d4VCFjQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.5.2",
+        "pathe": "^2.0.3",
+        "yaml": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/openapi-parser/node_modules/@scalar/openapi-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.8.0.tgz",
+      "integrity": "sha512-WmaxVSfvY5K/TwcG2B2TU1WOe1As1uc2s7myswtP6dBlcjU3hM08SApxv/jmyGaCE8t4gO5BBhmHY4pDUfmr2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/openapi-parser/node_modules/ajv-formats": {
@@ -993,39 +990,33 @@
       }
     },
     "node_modules/@scalar/openapi-types": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.5.4.tgz",
-      "integrity": "sha512-2pEbhprh8lLGDfUI6mNm9EV104pjb3+aJsXrFaqfgOSre7r6NlgM5HcSbsLjzDAnTikjJhJ3IMal1Rz8WVwiOw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.7.0.tgz",
+      "integrity": "sha512-kN0PwlJW0de4bwQ4ib+mBHzKJUvBCyR/gwU4zLEq6SCbj+GfgYUh+2a0/yl1WYVUiSkkwFsHjfmQ8KjhR3HK0Q==",
       "license": "MIT",
-      "dependencies": {
-        "zod": "^4.3.5"
-      },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/openapi-upgrader": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-upgrader/-/openapi-upgrader-0.1.11.tgz",
-      "integrity": "sha512-ngJcHGoCHmpWgYtNy08vmzFfLdQEkMpvaCQqNPPMNKq0QEXOv89e/rn+TZJZgPnRlY7fDIoIhn9lNgr+azBW+w==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-upgrader/-/openapi-upgrader-0.2.6.tgz",
+      "integrity": "sha512-pvEmfSCDNYR4+lygidUqfo+shzyp4OSh9+UgK110rzA8Oot6WbJBM03Fuq3M255G7G6R9iXyfsebB7MBUocPkw==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/openapi-types": "0.5.4"
+        "@scalar/openapi-types": "0.8.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
-    "node_modules/@sindresorhus/merge-streams": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+    "node_modules/@scalar/openapi-upgrader/node_modules/@scalar/openapi-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.8.0.tgz",
+      "integrity": "sha512-WmaxVSfvY5K/TwcG2B2TU1WOe1As1uc2s7myswtP6dBlcjU3hM08SApxv/jmyGaCE8t4gO5BBhmHY4pDUfmr2g==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=22"
       }
     },
     "node_modules/@so-ric/colorspace": {
@@ -1589,61 +1580,60 @@
       "license": "MIT"
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.11.0.tgz",
-      "integrity": "sha512-4vuWtoepc4rYJ81K+P7xn2ByXIRhBM40rfzAGnpagNuGSVHuKEC6lqJqs3ePvhCpnxiYAC8XWpaOi+BEDzyhnQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.12.0.tgz",
+      "integrity": "sha512-hKCkHEEDdCpXFyOU8ln+TzBBwonFMbkeUV0zIc+vBETyO8p/Upui3XvEyLOyB4CpKUReHzGeGm3gcFjNc73ygg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "~7.29.0",
-        "@inquirer/prompts": "^8.3.0",
-        "ajv": "~8.18.0",
-        "change-case": "~5.4.4",
+        "@babel/code-frame": "^7.29.0",
+        "@inquirer/prompts": "^8.4.1",
+        "ajv": "^8.18.0",
+        "change-case": "^5.4.4",
         "env-paths": "^4.0.0",
-        "globby": "~16.1.1",
         "is-unicode-supported": "^2.1.0",
-        "mustache": "~4.2.0",
-        "picocolors": "~1.1.1",
-        "prettier": "~3.8.1",
+        "mustache": "^4.2.0",
+        "picocolors": "^1.1.1",
+        "prettier": "^3.8.1",
         "semver": "^7.7.4",
-        "tar": "^7.5.11",
+        "tar": "^7.5.13",
         "temporal-polyfill": "^0.3.2",
-        "vscode-languageserver": "~9.0.1",
-        "vscode-languageserver-textdocument": "~1.0.12",
-        "yaml": "~2.8.2",
-        "yargs": "~18.0.0"
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "yaml": "^2.8.3",
+        "yargs": "^18.0.0"
       },
       "bin": {
         "tsp": "cmd/tsp.js",
         "tsp-server": "cmd/tsp-server.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.81.0.tgz",
-      "integrity": "sha512-ee9QSBL+k6ccPlbJICZzaGt4iC1nTIl+J9sELY9yJNISvOvUEzY5MU8c7HaISB10cUESRJW+oaLWwyc8XjwHng==",
+      "version": "0.82.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.82.0.tgz",
+      "integrity": "sha512-4gxwWndMVmYF6e5ETrwW6b77h1DsSc2ZiIbNo98XePaynD6yz/ooHKKtNKacjC2gmWhfRz1ArPioYn0YHvQkxw==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~1.11.0"
+        "@typespec/compiler": "^1.12.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.11.0.tgz",
-      "integrity": "sha512-/DOkN2+MUZyLdmqYmSMZDjxikJTOuNxikTeOwG2fVOibnu8e6S1jzPAuN/mn6YyQBKeBCItMPmUOXIj61Wy8Bg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.12.0.tgz",
+      "integrity": "sha512-3Bb1M6VSuEVPWOecXj3h3I/ddMpb9cmKRQQq34oq7LatiK4fwVBp+EdWbqzEzaRUGHm9mZtqsMsxZf5FndT8dg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~1.11.0",
-        "@typespec/streams": "^0.81.0"
+        "@typespec/compiler": "^1.12.0",
+        "@typespec/streams": "^0.82.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -1652,45 +1642,45 @@
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.11.0.tgz",
-      "integrity": "sha512-xUQrHExKBh0XSP4cn+HcondDXjHJM5HCq2Xfy9tB1QflsFh5uP1JJt1+67g73VmHlhZVSUDcoFrnU95pfjyubg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.12.0.tgz",
+      "integrity": "sha512-XtkCMPpzXFfuIzmx/BQrCMUCCk7d37lkqZe5ubJmvJ02Fr7yvAbofrgtNUZ1BbFe3TBBUS2nB3E3mjT3tE4zCQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~1.11.0",
-        "@typespec/http": "^1.11.0"
+        "@typespec/compiler": "^1.12.0",
+        "@typespec/http": "^1.12.0"
       }
     },
     "node_modules/@typespec/openapi3": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-1.11.0.tgz",
-      "integrity": "sha512-AjMpTkIUy8+YlRaqUyQ1NZxbmVbWyT4fPpztVzclyX+TXyvxo9gqLEdqoMfvQ9KUjcU0nsOjfPdaYb5rj25oIA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-1.12.0.tgz",
+      "integrity": "sha512-r2CechzwGyr+BtLo7ApoaaTsrYybaE0gsGCLVWbkfH9Fs2KTu0ilpMKGxXjhKRS6cWHMkGGuB3hM0OJjFyFydw==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/json-magic": "^0.11.5",
-        "@scalar/openapi-parser": "^0.24.1",
-        "@scalar/openapi-types": "^0.5.0",
+        "@scalar/json-magic": "^0.12.5",
+        "@scalar/openapi-parser": "^0.25.8",
+        "@scalar/openapi-types": "^0.7.0",
         "@typespec/asset-emitter": "^0.79.1",
-        "yaml": "~2.8.2"
+        "yaml": "^2.8.3"
       },
       "bin": {
         "tsp-openapi3": "cmd/tsp-openapi3.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~1.11.0",
-        "@typespec/events": "^0.81.0",
-        "@typespec/http": "^1.11.0",
-        "@typespec/json-schema": "^1.11.0",
-        "@typespec/openapi": "^1.11.0",
-        "@typespec/sse": "^0.81.0",
-        "@typespec/streams": "^0.81.0",
-        "@typespec/versioning": "~0.81.0"
+        "@typespec/compiler": "^1.12.0",
+        "@typespec/events": "^0.82.0",
+        "@typespec/http": "^1.12.0",
+        "@typespec/json-schema": "^1.12.0",
+        "@typespec/openapi": "^1.12.0",
+        "@typespec/sse": "^0.82.0",
+        "@typespec/streams": "^0.82.0",
+        "@typespec/versioning": "^0.82.0"
       },
       "peerDependenciesMeta": {
         "@typespec/events": {
@@ -1726,70 +1716,70 @@
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.81.0.tgz",
-      "integrity": "sha512-qQXZRKEvq5aNlDFEUqBiiXXPIFyr/+PWgBY0kIrnhyZzMjfUqPInkB12QgXpVp2O2Wm3jmETJD45SaLHTCYBbg==",
+      "version": "0.82.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.82.0.tgz",
+      "integrity": "sha512-cKjKEd8lgE3EdU9b5xXLoSdKBcifITOhHS2n9LPbEG9w6APfWDWGdtUe4UKV3wxWq9HlT143wpECW7IjrPhjnA==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~1.11.0",
-        "@typespec/http": "^1.11.0"
+        "@typespec/compiler": "^1.12.0",
+        "@typespec/http": "^1.12.0"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.81.0.tgz",
-      "integrity": "sha512-VinoeN+5ClKlGXf77fWayAQna8SaYtvEBhnLR8t8FdvmMsL6ce1LghR2kAL3ARbNXfwMZRmQiq+ajKKebDLIng==",
+      "version": "0.82.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.82.0.tgz",
+      "integrity": "sha512-4jBByfLsS7yQAIqmbLkfrw4XoPm9kOqawvW5gVXmKtnMMDYR0RmfBhsnAXBqhUXGbnFq0bDJGEw3GX+6k3mKnA==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~1.11.0",
-        "@typespec/events": "^0.81.0",
-        "@typespec/http": "^1.11.0",
-        "@typespec/streams": "^0.81.0"
+        "@typespec/compiler": "^1.12.0",
+        "@typespec/events": "^0.82.0",
+        "@typespec/http": "^1.12.0",
+        "@typespec/streams": "^0.82.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.81.0.tgz",
-      "integrity": "sha512-IIEKq18aqAtM65f8ZLs3Kzua97wjkr8fTehqPs/Q4neWo2UkDJp64LfA37iXJzaku8xMFSwXdVu4EW8wo+KV8w==",
+      "version": "0.82.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.82.0.tgz",
+      "integrity": "sha512-cr/6h6VV/6OJeG8RNcSd0SDes5iEXiuGUcKGrMN6wF8qKTTrY2hXNhfqCCn3lamDOg00wbi7ke+laz6pHWN3tg==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~1.11.0"
+        "@typespec/compiler": "^1.12.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.81.0.tgz",
-      "integrity": "sha512-5bha4t64xA85zLY8VGm/6jNd2kwPHzjPq/dlCUjtgGfGXv2R6Ow/YIukqhqZnwnIgNAIlZ7nguekRMRx+2oO2w==",
+      "version": "0.82.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.82.0.tgz",
+      "integrity": "sha512-s8giuYQTQPniy2YxNfKXYpAU2Vm4L74TdOsbFWe0tG+jnOy/9tt7kKTH4QF1sB8nRvmjv8h31EoHtZYOPe1GvA==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~1.11.0"
+        "@typespec/compiler": "^1.12.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.81.0.tgz",
-      "integrity": "sha512-4docnAcV1a8gE4c4TmYuirZf2PEzS4xHUH4QjHFU6hk6J2M6OMU6YG4iSq9tmlUzQ/2DraVcWNO/fsG8Lt383A==",
+      "version": "0.82.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.82.0.tgz",
+      "integrity": "sha512-/Bwlt7HwSltojSbalkh7hGRh/lB5aMJllnb7gAAf3xRPMlnmu5VJqDFFcbZKqDvkwgGXZX/xHo458c4kott5Ug==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~1.11.0"
+        "@typespec/compiler": "^1.12.0"
       }
     },
     "node_modules/abort-controller": {
@@ -2019,18 +2009,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/call-bind": {
@@ -2653,22 +2631,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2722,15 +2684,6 @@
         "fast-string-width": "^3.0.2"
       }
     },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
     "node_modules/fecha": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
@@ -2753,18 +2706,6 @@
       "integrity": "sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
       "engines": {
         "node": ">=8"
       }
@@ -3030,18 +2971,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3093,26 +3022,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/globby": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.1.tgz",
-      "integrity": "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "fast-glob": "^3.3.3",
-        "ignore": "^7.0.5",
-        "is-path-inside": "^4.0.0",
-        "slash": "^5.1.0",
-        "unicorn-magic": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -3235,15 +3144,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/immer": {
@@ -3408,15 +3308,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
@@ -3462,18 +3353,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -3500,15 +3379,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/is-number-object": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
@@ -3524,18 +3394,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -3920,28 +3778,6 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "license": "MIT"
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -4427,18 +4263,6 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
-    "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -4515,26 +4339,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/readable-stream": {
       "version": "1.1.14",
@@ -4630,39 +4434,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-array-concat": {
@@ -4922,18 +4693,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/slash": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -5131,18 +4890,6 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/toposort": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
@@ -5272,18 +5019,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
-    },
-    "node_modules/unicorn-magic": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
-      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -5673,15 +5408,6 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "oav": "^4.0.4"
   },
   "engines": {
-    "node": ">=20.12.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "format": "prettier --write --plugin @typespec/compiler/internals/prettier-formatter \"redhatopenshift/**/*.tsp\"",

--- a/api/package.json
+++ b/api/package.json
@@ -16,8 +16,8 @@
     "node": ">=20.12.0"
   },
   "scripts": {
-    "format": "tsp format \"**/*.tsp\"",
-    "format-check": "tsp format --check \"**/*.tsp\"",
+    "format": "prettier --write --plugin @typespec/compiler/internals/prettier-formatter \"redhatopenshift/**/*.tsp\"",
+    "format-check": "prettier --check --plugin @typespec/compiler/internals/prettier-formatter \"redhatopenshift/**/*.tsp\"",
     "compile": "tsp compile redhatopenshift/HcpCluster.Management --warn-as-error",
     "models": "autorest readme.md --verbose --tag=${VERSION}",
     "testsdk": "autorest testsdk.md --verbose --tag=${VERSION}"

--- a/api/package.json
+++ b/api/package.json
@@ -1,15 +1,15 @@
 {
   "dependencies": {
-    "@azure-tools/typespec-autorest": "^0.67.0",
-    "@azure-tools/typespec-azure-core": "^0.67.1",
-    "@azure-tools/typespec-azure-resource-manager": "^0.67.1",
-    "@azure-tools/typespec-azure-rulesets": "0.67.0",
-    "@azure-tools/typespec-client-generator-core": "^0.67.4",
-    "@typespec/http": "~1.11.0",
-    "@typespec/openapi": "~1.11.0",
-    "@typespec/openapi3": "~1.11.0",
-    "@typespec/rest": "~0.81.0",
-    "@typespec/versioning": "~0.81.0",
+    "@azure-tools/typespec-autorest": "^0.68.0",
+    "@azure-tools/typespec-azure-core": "^0.68.0",
+    "@azure-tools/typespec-azure-resource-manager": "^0.68.0",
+    "@azure-tools/typespec-azure-rulesets": "^0.68.0",
+    "@azure-tools/typespec-client-generator-core": "^0.68.1",
+    "@typespec/http": "^1.12.0",
+    "@typespec/openapi": "^1.12.0",
+    "@typespec/openapi3": "^1.12.0",
+    "@typespec/rest": "^0.82.0",
+    "@typespec/versioning": "^0.82.0",
     "oav": "^4.0.4"
   },
   "engines": {
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@microsoft.azure/openapi-validator": "2.2.4",
     "@microsoft.azure/openapi-validator-rulesets": "2.2.6",
-    "@typespec/compiler": "~1.11.0",
+    "@typespec/compiler": "^1.12.0",
     "autorest": "^3.7.2"
   },
   "overrides": {

--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -1,7 +1,6 @@
 import "@typespec/rest";
 import "@typespec/versioning";
 import "@typespec/http";
-import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@azure-tools/typespec-client-generator-core";

--- a/api/redhatopenshift/HcpCluster.Management/hcpOperatorIdentityRoleSet.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpOperatorIdentityRoleSet.tsp
@@ -22,7 +22,8 @@ model HcpOperatorIdentityRoleSet
     NamePattern = "^[a-zA-Z0-9-\\.]{3,24}$"
   >;
 }
-@@doc(HcpOperatorIdentityRoleSet.name,
+@@doc(
+  HcpOperatorIdentityRoleSet.name,
   "The OpenShift minor version these identities are required for."
 );
 


### PR DESCRIPTION
[AROSLSRE-949](https://redhat.atlassian.net/browse/AROSLSRE-949)

### What

Bump typespec packages from 0.67.x / 1.11.x to 0.68.x / 1.12.x in `/api`.

**Packages updated:**
- `@azure-tools/typespec-autorest`: `0.67.0` -> `0.68.0`
- `@azure-tools/typespec-azure-core`: `0.67.1` -> `0.68.0`
- `@azure-tools/typespec-azure-resource-manager`: `0.67.1` -> `0.68.0`
- `@azure-tools/typespec-azure-rulesets`: `0.67.0` -> `0.68.0`
- `@azure-tools/typespec-client-generator-core`: `0.67.4` -> `0.68.1`
- `@typespec/http`: `1.11.0` -> `1.12.0`
- `@typespec/openapi`: `1.11.0` -> `1.12.0`
- `@typespec/openapi3`: `1.11.0` -> `1.12.0`
- `@typespec/rest`: `0.81.0` -> `0.82.0`
- `@typespec/versioning`: `0.81.0` -> `0.82.0`
- `@typespec/compiler`: `1.11.0` -> `1.12.0`

### Why

Dependency update.

### Testing

- [x] `npm install --package-lock-only` passes

Closes #5301