### PR TITLE
Revert "fix: disable VAP/VAPB check in image registry policy test case for MSFT environments"

### DIFF
--- a/test/e2e/image_registry_policy.go
+++ b/test/e2e/image_registry_policy.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 )
 
@@ -126,18 +125,15 @@ var _ = Describe("Image Registry Policy", func() {
 		labels.CoreInfraService,
 		labels.DevelopmentOnly,
 		func(ctx context.Context) {
-			// INT, STG and PROD do not have cluster-scoped RBAC to verify the policy exists
-			if framework.IsDevelopmentEnvironment() {
-				By("verifying the ValidatingAdmissionPolicy exists")
-				_, err := kubeClient.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(
-					ctx, "image-registry-allowlist-policy", metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred(), "ValidatingAdmissionPolicy should exist")
+			By("verifying the ValidatingAdmissionPolicy exists")
+			_, err := kubeClient.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(
+				ctx, "image-registry-allowlist-policy", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "ValidatingAdmissionPolicy should exist")
 
-				By("verifying the ValidatingAdmissionPolicyBinding exists")
-				_, err = kubeClient.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(
-					ctx, "image-registry-allowlist-policy-binding", metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred(), "ValidatingAdmissionPolicyBinding should exist")
-			}
+			By("verifying the ValidatingAdmissionPolicyBinding exists")
+			_, err = kubeClient.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(
+				ctx, "image-registry-allowlist-policy-binding", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "ValidatingAdmissionPolicyBinding should exist")
 
 			By("verifying the ConfigMap allowlist is non-empty and contains required registries")
 			cm, err := kubeClient.CoreV1().ConfigMaps("image-registry-policy").Get(


### PR DESCRIPTION
Reverts Azure/ARO-HCP#5385 as it is no longer necessary due to the whole test spec being scoped to dev only in https://github.com/Azure/ARO-HCP/pull/5391 