### PR TITLE
test: preserve ARM error when cluster delete/update retries are interrupted

### DIFF
--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -182,6 +182,7 @@ func DeleteHCPCluster(
 	defer cancel()
 
 	var attempt int
+	var lastTransientErr error
 	retryErr := wait.ExponentialBackoffWithContext(ctx, stateConflictBackoff, func(ctx context.Context) (bool, error) {
 		attempt++
 		err := deleteHCPClusterAttempt(ctx, hcpClient, resourceGroupName, hcpClusterName)
@@ -189,6 +190,7 @@ func DeleteHCPCluster(
 			return true, nil
 		}
 		if isTransientDeleteError(err) {
+			lastTransientErr = err
 			ginkgo.GinkgoLogr.Info("transient conflict during cluster delete, retrying",
 				"cluster", hcpClusterName, "resourceGroup", resourceGroupName,
 				"attempt", attempt, "error", err.Error())
@@ -197,10 +199,8 @@ func DeleteHCPCluster(
 		return false, err
 	})
 
-	if retryErr != nil && attempt > 1 {
-		ginkgo.GinkgoLogr.Info("cluster delete failed after retries",
-			"cluster", hcpClusterName, "resourceGroup", resourceGroupName,
-			"attempts", attempt, "error", retryErr.Error())
+	if wait.Interrupted(retryErr) && lastTransientErr != nil {
+		return fmt.Errorf("delete interrupted for hcpCluster=%q in resourcegroup=%q after %d attempts, last transient error: %w, interrupt cause: %w", hcpClusterName, resourceGroupName, attempt, lastTransientErr, retryErr)
 	}
 
 	return retryErr
@@ -291,6 +291,7 @@ func UpdateHCPCluster(
 	defer cancel()
 
 	var hcpOpenShiftCluster *hcpsdk20240610preview.HcpOpenShiftCluster
+	var lastTransientErr error
 	attempt := 0
 
 	err := wait.ExponentialBackoffWithContext(ctx, stateConflictBackoff, func(ctx context.Context) (bool, error) {
@@ -304,6 +305,7 @@ func UpdateHCPCluster(
 		poller, err := hcpClient.BeginUpdate(ctx, resourceGroupName, hcpClusterName, update, nil)
 		if err != nil {
 			if isTransientUpdateError(err) {
+				lastTransientErr = err
 				return false, nil
 			}
 			return false, err
@@ -314,6 +316,7 @@ func UpdateHCPCluster(
 		})
 		if err != nil {
 			if isTransientUpdateError(err) {
+				lastTransientErr = err
 				return false, nil
 			}
 			if errors.Is(err, context.DeadlineExceeded) {
@@ -341,12 +344,8 @@ func UpdateHCPCluster(
 		}
 	})
 
-	if err != nil && attempt > 1 {
-		ginkgo.GinkgoLogr.Info("Cluster update failed after retries",
-			"cluster", hcpClusterName,
-			"resourceGroup", resourceGroupName,
-			"attempts", attempt,
-			"error", err.Error())
+	if wait.Interrupted(err) && lastTransientErr != nil {
+		return hcpOpenShiftCluster, fmt.Errorf("update interrupted for hcpCluster=%q in resourcegroup=%q after %d attempts, last transient error: %w, interrupt cause: %w", hcpClusterName, resourceGroupName, attempt, lastTransientErr, err)
 	}
 
 	return hcpOpenShiftCluster, err
@@ -416,6 +415,7 @@ func UpdateHCPCluster20251223(
 	defer cancel()
 
 	var hcpOpenShiftCluster *hcpsdk20251223preview.HcpOpenShiftCluster
+	var lastTransientErr error
 	attempt := 0
 
 	err := wait.ExponentialBackoffWithContext(ctx, stateConflictBackoff, func(ctx context.Context) (bool, error) {
@@ -429,6 +429,7 @@ func UpdateHCPCluster20251223(
 		poller, err := hcpClient.BeginUpdate(ctx, resourceGroupName, hcpClusterName, update, nil)
 		if err != nil {
 			if isTransientUpdateError(err) {
+				lastTransientErr = err
 				return false, nil
 			}
 			return false, err
@@ -439,6 +440,7 @@ func UpdateHCPCluster20251223(
 		})
 		if err != nil {
 			if isTransientUpdateError(err) {
+				lastTransientErr = err
 				return false, nil
 			}
 			if errors.Is(err, context.DeadlineExceeded) {
@@ -454,12 +456,8 @@ func UpdateHCPCluster20251223(
 		return true, nil
 	})
 
-	if err != nil && attempt > 1 {
-		ginkgo.GinkgoLogr.Info("Cluster update failed after retries",
-			"cluster", hcpClusterName,
-			"resourceGroup", resourceGroupName,
-			"attempts", attempt,
-			"error", err.Error())
+	if wait.Interrupted(err) && lastTransientErr != nil {
+		return hcpOpenShiftCluster, fmt.Errorf("update interrupted for hcpCluster=%q in resourcegroup=%q after %d attempts, last transient error: %w, interrupt cause: %w", hcpClusterName, resourceGroupName, attempt, lastTransientErr, err)
 	}
 
 	return hcpOpenShiftCluster, err


### PR DESCRIPTION
### What

When `DeleteHCPCluster`, `UpdateHCPCluster`, or `UpdateHCPCluster20251223` retry loops are interrupted — whether by backoff exhaustion, context cancellation, or deadline exceeded — the returned error loses the original ARM error details. Track the last transient error and wrap it alongside the interrupt cause, so both are preserved in the error chain.

### Why

The retry callbacks return `(false, nil)` on transient errors, so if all attempts fail transiently, `wait.ExponentialBackoffWithContext` returns a generic message with no ARM status code, error code, or response details. This makes interrupted-retry failures hard to diagnose. The fix preserves the real (transient) error (for example `ConflictingConcurrentWriteNotAllowed`, Cosmos ETag conflict) so test output remains actionable.

### Testing

No tests — the change only affects the error return path when retries are interrupted. The logic is straightforward: track last error, check for interruption, wrap and return.

### Special notes for your reviewer

- This is a follow-up to #5386 which added the delete retry logic.
- The redundant "failed after retries" log lines are removed — the error is returned to the caller where it surfaces.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue (no ticket)
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
