### PR TITLE
ARO-27344: Filter pre-release versions from E2E test version selection

### DIFF
--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -101,6 +101,9 @@ func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string
 	if err != nil {
 		return "", false, err
 	}
+	if len(candidates) == 0 {
+		return "", false, &cvocincinnati.Error{Reason: "VersionNotFound", Message: fmt.Sprintf("no versions found for %s", configuredVersionID)}
+	}
 	if len(candidates) == 1 {
 		return candidates[0].String(), false, nil
 	}
@@ -132,9 +135,9 @@ func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string
 // parse-tolerant (e.g. "4.20", "4.20.0", "4.20.1"). Results are sorted descending (latest first).
 //
 // If semver.Parse succeeds, only that version is used as the Cincinnati graph root for GetUpdates. When semver.Parse
-// fails (major.minor only), discovery queries ParseTolerant dot-zero, X.Y.0-rc.0, and X.Y.0-ec.0 in turn when GA z0 may
-// not yet be a graph node. Each successful response is merged into the result; VersionNotFound skips to the next root;
-// any other error fails immediately.
+// fails (major.minor only), discovery queries the GA dot-zero anchor and, for non-nightly channels, also X.Y.0-rc.0
+// and X.Y.0-ec.0 (RC/EC don't exist in CS as nightly builds). Each successful response is merged into the result;
+// VersionNotFound skips to the next root; any other error fails immediately.
 func GetAllVersionsInMinorStartingWith(ctx context.Context, channelGroup string, version string) ([]semver.Version, error) {
 	var getUpdatesGraphRoots []semver.Version
 	if parsed, err := semver.Parse(version); err != nil {
@@ -142,11 +145,14 @@ func GetAllVersionsInMinorStartingWith(ctx context.Context, channelGroup string,
 		if err != nil {
 			return nil, err
 		}
-		// Major.minor only (e.g. "4.20"): discover the minor by querying each dot-zero anchor (GA z0, RC, EC).
-		getUpdatesGraphRoots = []semver.Version{
-			versionToDiscover,
-			semver.MustParse(fmt.Sprintf("%d.%d.0-rc.0", versionToDiscover.Major, versionToDiscover.Minor)),
-			semver.MustParse(fmt.Sprintf("%d.%d.0-ec.0", versionToDiscover.Major, versionToDiscover.Minor)),
+		// Major.minor only (e.g. "4.20"): discover the minor by querying each dot-zero anchor.
+		// For nightly, only use the GA z0 anchor — RC/EC versions don't exist in CS as nightly builds.
+		getUpdatesGraphRoots = []semver.Version{versionToDiscover}
+		if channelGroup != "nightly" {
+			getUpdatesGraphRoots = append(getUpdatesGraphRoots,
+				semver.MustParse(fmt.Sprintf("%d.%d.0-rc.0", versionToDiscover.Major, versionToDiscover.Minor)),
+				semver.MustParse(fmt.Sprintf("%d.%d.0-ec.0", versionToDiscover.Major, versionToDiscover.Minor)),
+			)
 		}
 	} else {
 		getUpdatesGraphRoots = []semver.Version{parsed}


### PR DESCRIPTION
(updated)

RC/EC versions returned by Cincinnati don't exist in CS as nightly builds. Skip RC/EC discovery anchors on the nightly channel to prevent E2E tests from selecting unusable versions.

[ARO-27344](https://issues.redhat.com/browse/ARO-27344)

### What

When `channelGroup == "nightly"`, `GetAllVersionsInMinorStartingWith` no longer generates `X.Y.0-rc.0` and `X.Y.0-ec.0` as Cincinnati graph query anchors. Only the GA dot-zero anchor is used. Non-nightly channels (candidate, stable, fast) are unchanged.

Also adds a defensive empty-candidates guard in `GetInstallVersionForZStreamUpgrade`.

### Why

On the nightly channel, `GetAllVersionsInMinorStartingWith` generated RC/EC roots to discover versions in Cincinnati. These roots (and versions reachable from them) were added to results, but RC/EC versions don't exist in CS as nightly builds. Tests would select them, CS would reject them, and tests would fail.

### Testing

- Verified through E2E test coverage

### Special notes for your reviewer

- Only test infrastructure code is changed (`test/util/framework/`), no production code
- Candidate channel keeps RC/EC versions — they are valid in CS
- The `getVersionPairWithoutUpgradeEdge` filter (PR #5153) is unchanged

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge
