### PR TITLE
improve error checking and logging

### DIFF
--- a/test/e2e/admin_api.go
+++ b/test/e2e/admin_api.go
@@ -335,12 +335,11 @@ var _ = Describe("SRE", func() {
 			By(fmt.Sprintf("retrieving serial console logs for VM %s", vmName))
 			logs, err := tc.GetSerialConsoleLogs(ctx, hcpResourceID, vmName, currentIdentity)
 			Expect(err).NotTo(HaveOccurred(), "failed to retrieve serial console logs for VM %q", vmName)
-			Expect(logs).NotTo(BeEmpty(), "serial console logs for VM %q should not be empty", vmName)
 
 			By("verifying serial console logs contain boot information")
 			// Serial console logs typically contain boot messages, kernel output, or systemd logs
 			// We just verify that we got some content back
-			Expect(len(logs)).To(BeNumerically(">", 0), "serial console logs length should be greater than 0")
+			Expect(len(logs)).To(BeNumerically(">", 0), "serial console logs for VM %q should have length greater than 0", vmName)
 
 			By("testing error case: non-existent VM name")
 			_, err = tc.GetSerialConsoleLogs(ctx, hcpResourceID, "non-existent-vm-12345", currentIdentity)


### PR DESCRIPTION
### What

Drops extraneous check and improves logging in the following check.

### Why

When console logs are fetched without error (err value returned from tc.GetSerialConsoleLogs is nil), but their content is empty, there is no reason to check this 2 times, since the first check will fail and the rest of the test won't be executed.

### Testing

Via pull-ci job.

### Special notes for your reviewer

Follow up for https://github.com/Azure/ARO-HCP/pull/5330#discussion_r3274415445

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] Summary explains the "Why" behind the change
- [X] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
