### PR TITLE
mgmt-agent: embed commit SHA and use local internal module

### DIFF
--- a/mgmt-agent/Dockerfile
+++ b/mgmt-agent/Dockerfile
@@ -2,18 +2,19 @@ ARG PLATFORM
 
 # Builder image installs tools needed to build mgmt-agent
 FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
+COPY internal/go.mod internal/go.sum internal/
 COPY mgmt-agent/go.mod mgmt-agent/go.sum mgmt-agent/
 RUN cd mgmt-agent && go mod download
 WORKDIR /app
 COPY . .
-
+ARG ARO_HCP_REVISION
 # https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips#build-option-to-require-fips-mode
 # NOTE: starting with go 1.27, GODEBUG=fips140=only can be used at runtime to also reject
 # non-FIPS algorithms. See https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 ENV CGO_ENABLED=1 GOFIPS140=latest
 RUN --mount=type=cache,target=/go/cache \
     GOCACHE=/go/cache \
-    make --directory mgmt-agent build
+    make --directory mgmt-agent build ARO_HCP_REVISION=${ARO_HCP_REVISION}
 
 FROM --platform=${PLATFORM} mcr.microsoft.com/azurelinux/distroless/base:3.0
 USER 65532:65532

--- a/mgmt-agent/Makefile
+++ b/mgmt-agent/Makefile
@@ -16,7 +16,8 @@ HELMCHART_DIR = deploy
 CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || echo docker)
 BINARY = bin/mgmt-agent
 MGMT_AGENT_SOURCES = $(shell find . -name '*.go' -o -name 'go.mod' -o -name 'go.sum')
-LDFLAGS = -ldflags ""
+LDFLAGS = -ldflags "\
+	-X github.com/Azure/ARO-HCP/internal/version.CommitSHA=${ARO_HCP_REVISION}"
 
 # Default target
 .DEFAULT_GOAL := build

--- a/mgmt-agent/go.mod
+++ b/mgmt-agent/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/ARO-HCP/mgmt-agent
 go 1.25.7
 
 require (
-	github.com/Azure/ARO-HCP/internal v0.0.0-20260512110147-2543c657a16a
+	github.com/Azure/ARO-HCP/internal v0.0.0-00010101000000-000000000000
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.3.0
@@ -73,3 +73,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/Azure/ARO-HCP/internal => ../internal

--- a/mgmt-agent/go.sum
+++ b/mgmt-agent/go.sum
@@ -1,5 +1,3 @@
-github.com/Azure/ARO-HCP/internal v0.0.0-20260512110147-2543c657a16a h1:oKfIPkuyXIBtQTjq9Hmf+ZWUINbkcpk9C6HbiwDeaJY=
-github.com/Azure/ARO-HCP/internal v0.0.0-20260512110147-2543c657a16a/go.mod h1:b6BnaL0zkBnAvIwUebsZgB+J+N6m6FXwrsaZRNh5UG8=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzUOPYN9KEUUuC0Yd0/vC0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1/go.mod h1:pzBXCYn05zvYIrwLgtK8Ap8QcjRg+0i76tMQdWN6wOk=


### PR DESCRIPTION
### What

Wire ARO_HCP_REVISION through the Dockerfile and Makefile ldflags to set internal/version.CommitSHA at build time. Switch the internal module dependency to a local replace directive so the build uses source from the monorepo instead of a pinned remote version.

### Why

* by having the commit sha in code, we can leverage it for agent string in azure arm communication
* for internal: we always want to use the current state of internal

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
