### PR TITLE
Rawo/uncouple event hub provisioning from manage instance

### DIFF
--- a/dev-infrastructure/configurations/audit-logs-data-connection.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/audit-logs-data-connection.tmpl.bicepparam
@@ -6,7 +6,6 @@ param auditLogsKustoConsumerGroupName = '{{ .auditLogsEventHub.kustoConsumerGrou
 param auditLogsEventHubId = '__auditLogsEventHubId__'
 param databaseName = '{{ .kusto.serviceLogsDatabase }}'
 param kustoDataConnectionName = '{{ .auditLogsEventHub.kustoDataConnectionName }}'
-param manageInstance = {{ .kusto.manageInstance }}
 param kustoEnabled = {{ .arobit.kusto.enabled }}
 param eventhubEnabled = {{ .auditLogsEventHub.enabled }}
 

--- a/dev-infrastructure/configurations/audit-logs-eventhub.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/audit-logs-eventhub.tmpl.bicepparam
@@ -4,6 +4,6 @@ param auditLogsKustoConsumerGroupName = '{{ .auditLogsEventHub.kustoConsumerGrou
 param auditLogsDiagnosticSettingsRuleName = '{{ .auditLogsEventHub.authRuleName }}'
 param auditLogsEventHubName = '{{ .auditLogsEventHub.name }}'
 param auditLogsEventHubNamespaceName = '{{ .auditLogsEventHub.namespace }}'
-param manageInstance = {{ .kusto.manageInstance }}
 param eventhubEnabled = {{ .auditLogsEventHub.enabled }}
 param kustoPrincipalId = '__kustoPrincipalId__'
+param kustoEnabled = {{ .arobit.kusto.enabled }}

--- a/dev-infrastructure/templates/audit-logs-data-connection.bicep
+++ b/dev-infrastructure/templates/audit-logs-data-connection.bicep
@@ -22,15 +22,12 @@ param kustoEnabled bool
 @description('Whether the audit logs Event Hub is enabled in this region')
 param eventhubEnabled bool
 
-@description('When true, create resources managed by this deployment')
-param manageInstance bool = true
-
 resource kustoCluster 'Microsoft.Kusto/clusters@2024-04-13' existing = if (kustoEnabled) {
   name: kustoName
 }
 
 // Kusto Event Hub data connection for AKS audit logs
-resource kustoDataConnection 'Microsoft.Kusto/clusters/databases/dataConnections@2024-04-13' = if (kustoEnabled && eventhubEnabled && manageInstance) {
+resource kustoDataConnection 'Microsoft.Kusto/clusters/databases/dataConnections@2024-04-13' = if (kustoEnabled && eventhubEnabled) {
   name: '${kustoName}/${databaseName}/${kustoDataConnectionName}'
   location: location
   kind: 'EventHub'

--- a/dev-infrastructure/templates/audit-logs-eventhub.bicep
+++ b/dev-infrastructure/templates/audit-logs-eventhub.bicep
@@ -13,14 +13,14 @@ param auditLogsDiagnosticSettingsRuleName string
 @description('Principal ID of the Kusto cluster managed identity')
 param kustoPrincipalId string
 
-@description('When true, deploy managed audit logs Event Hub resources')
-param manageInstance bool = true
+@description('Whether arobit Kusto is enabled in this region')
+param kustoEnabled bool = true
 
 @description('Whether the audit logs Event Hub is enabled in this region')
 param eventhubEnabled bool
 
 // Event Hub namespace for AKS audit logs
-resource eventHubNamespace 'Microsoft.EventHub/namespaces@2024-01-01' = if (manageInstance && eventhubEnabled) {
+resource eventHubNamespace 'Microsoft.EventHub/namespaces@2024-01-01' = if (kustoEnabled && eventhubEnabled) {
   name: auditLogsEventHubNamespaceName
   location: resourceGroup().location
   sku: {
@@ -69,7 +69,7 @@ resource eventHubNamespace 'Microsoft.EventHub/namespaces@2024-01-01' = if (mana
 }
 
 var eventHubDataReceiverRole = 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde'
-resource eventHubDataReceiverRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (manageInstance && eventhubEnabled && kustoPrincipalId != '') {
+resource eventHubDataReceiverRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (kustoEnabled && eventhubEnabled && kustoPrincipalId != '') {
   scope: eventHubNamespace::eventHub
   name: guid(eventHubNamespace::eventHub.id, kustoPrincipalId, eventHubDataReceiverRole)
   properties: {
@@ -79,7 +79,7 @@ resource eventHubDataReceiverRoleAssignment 'Microsoft.Authorization/roleAssignm
   }
 }
 
-output auditLogsEventHubId string = manageInstance && eventhubEnabled ? eventHubNamespace::eventHub.id : ''
-output auditLogsEventHubAuthRuleId string = manageInstance && eventhubEnabled
+output auditLogsEventHubId string = kustoEnabled && eventhubEnabled ? eventHubNamespace::eventHub.id : ''
+output auditLogsEventHubAuthRuleId string = kustoEnabled && eventhubEnabled
   ? eventHubNamespace::diagnosticSettingsAuthRule.id
   : ''


### PR DESCRIPTION
[ARO-27351](https://redhat.atlassian.net/browse/ARO-27351)

### What

Audit log eventhub provisioning to look at kusto.enabled instead of kusto.manageinstance

### Why

I want to be able to use the kusto.manageInstance flag instead of execution constraints in HCP.Geography to determine whether a Kusto cluster is provisioned in a given region, but first I have to decouple manageInstance from the audit log eventhub bicep. Even if a given region/environment isn't deploying the Kusto Cluster, an audit log eventhub can still be created to forward logs to the kusto as long as arobit.kusto.enabled and auditLogsEventHub.enabled is true.

### Testing

Tested by e2e parallel deployment

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
