### PR TITLE
fix(image-updater): use short-SHA tag for clusters-service pin (AROSLSRE-954)

### DIFF
--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -47,7 +47,7 @@ images:
     group: cs
     source:
       image: quay.io/app-sre/aro-hcp-clusters-service
-      tag: "dbb022a3dd3f0533ae1c8eebd4e6929ba1ca1ede" # pinned: latest includes swift-nic annotation without CPO override (AROSLSRE-944, unpin: AROSLSRE-946)
+      tag: "dbb022a" # pinned: latest includes swift-nic annotation without CPO override (AROSLSRE-944, unpin: AROSLSRE-946). Quay publishes 7-char short SHAs; full SHA is dbb022a3dd3f0533ae1c8eebd4e6929ba1ca1ede.
       versionLabel: "vcs-ref"
       useAuth: true
       keyVault:


### PR DESCRIPTION
https://issues.redhat.com/browse/AROSLSRE-954

### What

Change the `clusters-service` pin in `tooling/image-updater/config.yaml` from the full 40-character git SHA to the 7-character short SHA that `quay.io/app-sre/aro-hcp-clusters-service` actually publishes:

```diff
-      tag: "dbb022a3dd3f0533ae1c8eebd4e6929ba1ca1ede" # pinned (AROSLSRE-944, unpin: AROSLSRE-946)
+      tag: "dbb022a" # pinned (AROSLSRE-944, unpin: AROSLSRE-946). Quay publishes 7-char short SHAs; full SHA is dbb022a3dd3f0533ae1c8eebd4e6929ba1ca1ede.
```

### Why

PR #5371 pinned `clusters-service` to the full git SHA, but the upstream `quay.io/app-sre/aro-hcp-clusters-service` repository only publishes **7-character short-SHA tags** (e.g. `dbb022a`, `b8a87db`, `e2d2136`). The full-SHA tag does not exist in quay, so every periodic `image-updater` run fails.

#### Failing prow job
[periodic-ci-Azure-ARO-HCP-main-image-updater-image-updater-tooling/2059635834981715968](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-image-updater-image-updater-tooling/2059635834981715968) — 2026-05-27 14:32:49 UTC:

#### Before (current `main`)

```
[14:32:48.870] ERROR: command failed {
  "err": "failed to fetch latest value for clusters-service: failed to fetch image descriptor for tag dbb022a3dd3f0533ae1c8eebd4e6929ba1ca1ede: GET https://quay.io/v2/app-sre/aro-hcp-clusters-service/manifests/dbb022a3dd3f0533ae1c8eebd4e6929ba1ca1ede: MANIFEST_UNKNOWN: manifest unknown; map[]"
}
make[1]: *** [Makefile:25: update] Error 1
make: *** [Makefile:584: image-updater] Error 2
```

Direct `podman pull` of the full-SHA tag returns the same `manifest unknown`. Quay's UI confirms the repo only has the short-tag form `dbb022a` (9 days old, digest `sha256:c7c3d1b499fb…`, 149 MiB).

#### After (this PR)

```
$ AZURE_TOKEN_CREDENTIALS=dev ./image-updater update \
    --config config.yaml --components clusters-service --verbosity 2 --tags

[17:28:13.736] DEBUG+3: starting image updates { "totalImages": 1 }
[17:28:13.736] DEBUG+2: processing image {
  "name": "clusters-service",
  "source": "quay.io/app-sre/aro-hcp-clusters-service",
  "tag": "dbb022a"
}
[17:28:13.736] DEBUG+2: fetching digest for specific tag {
  "repository": "app-sre/aro-hcp-clusters-service",
  "tag": "dbb022a",
  "useAuth": true,
  "versionLabel": "vcs-ref"
}
[17:28:14.576] DEBUG+2: extracted version from label {
  "label": "vcs-ref",
  "tag": "dbb022a",
  "version": "dbb022a3dd3f0533ae1c8eebd4e6929ba1ca1ede"
}
[17:28:14.643] DEBUG+2: found matching image {
  "arch": "amd64",
  "digest": "sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5",
  "repository": "app-sre/aro-hcp-clusters-service",
  "tag": "dbb022a"
}
[17:28:14.644] DEBUG+2: Current digest {
  "currentDigest": "sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5",
  "name": "clusters-service"
}
[17:28:14.644] DEBUG+2: No update needed - digests match { "name": "clusters-service" }
[17:28:14.644] DEBUG+3: No updates to report {}
```

The short tag `dbb022a` resolves to digest `sha256:c7c3d1b499fbc29760eda173fa1a8c4eb2cd2b0aa3a872c7fe3aacfc2ff8abe5` with `vcs-ref` label `dbb022a3dd3f0533ae1c8eebd4e6929ba1ca1ede` — the exact commit [AROSLSRE-944](https://redhat.atlassian.net/browse/AROSLSRE-944) intended to pin, and the digest already present in `config/config.yaml`. No drift.

`versionLabel: "vcs-ref"` continues to validate the resolved image matches the intended full commit SHA, so the short-tag form is safe against accidental tag reuse.

### Testing

- `AZURE_TOKEN_CREDENTIALS=dev ./image-updater update --config config.yaml --components clusters-service --verbosity 2 --tags` succeeds and reports "No update needed — digests match".
- `podman pull quay.io/app-sre/aro-hcp-clusters-service:dbb022a` resolves to the same digest currently in `config/config.yaml`.
- `make -C config detect-change` passes.

### Special notes for your reviewer

- This is a one-line config fix to restore image-updater functionality. The underlying image and digest do not change.
- Permanent unpin (`tag: "latest"`) remains tracked in [AROSLSRE-946](https://issues.redhat.com/browse/AROSLSRE-946) and is gated on [openshift/hypershift#8610](https://github.com/openshift/hypershift/pull/8610) merging and rolling out to int.