### PR TITLE
fix(recreate-system-pool): widen NRP window and add forced-evidence trigger (AROSLSRE-924)

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -240,7 +240,7 @@ resourceGroups:
     - name: NRP_FAIL_THRESHOLD
       value: '10'
     - name: NRP_FAIL_WINDOW_MIN
-      value: '15'
+      value: '360'
     dependsOn:
     - resourceGroup: management
       step: cx-oncert-public-kv-issuer

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -129,6 +129,14 @@ const (
 	nrpKVSErrorCode    = "NetworkingInternalOperationError"
 	vmssWriteOperation = "Microsoft.Compute/virtualMachineScaleSets/write"
 
+	// systemVMSSPrefix is the activity-log filter for VMSS-write events
+	// scoped to the system pool's VMSS. AKS names node-pool VMSS using
+	// the convention "aks-<poolName>-<random>-vmss"; this constant is
+	// derived from systemPoolName so the two stay in sync if the system
+	// pool is ever renamed. Stable across all AKS API versions we run
+	// today (2024-10-01, 2025-07-02-preview).
+	systemVMSSPrefix = "aks-" + systemPoolName + "-"
+
 	activityLogAuthRetryTimeoutMin = 5
 	activityLogAuthRetryInitialSec = 10
 	activityLogAuthRetryMaxSec     = 60
@@ -889,7 +897,7 @@ func (c *clients) detect(ctx context.Context) (bool, string, error) {
 	if err != nil {
 		return false, "", fmt.Errorf("guard 1 activity-log query failed: %w", err)
 	}
-	hits, err := countNRPFailures(out, "aks-system-")
+	hits, err := countNRPFailures(out, systemVMSSPrefix)
 	if err != nil {
 		return false, "", fmt.Errorf("guard 1 activity-log parse failed: %w", err)
 	}
@@ -1287,7 +1295,7 @@ func (c *clients) pollForNRPEvidence(ctx context.Context, timeout time.Duration,
 		if err != nil {
 			return last, fmt.Errorf("forced-evidence activity-log query: %w", err)
 		}
-		hits, parseErr := countNRPFailures(out, "aks-system-")
+		hits, parseErr := countNRPFailures(out, systemVMSSPrefix)
 		if parseErr != nil {
 			return last, fmt.Errorf("forced-evidence activity-log parse: %w", parseErr)
 		}

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -132,6 +132,16 @@ const (
 	activityLogAuthRetryTimeoutMin = 5
 	activityLogAuthRetryInitialSec = 10
 	activityLogAuthRetryMaxSec     = 60
+
+	// triggerEvidence forces an AKS RP reconcile of the system pool when
+	// guards 2/3/4 PASS but guard 1 has no recent NRP-KVS events in the
+	// configured lookback window. The trigger gives the wedge a chance
+	// to produce fresh evidence (or to prove the wedge is not NRP-KVS).
+	// Times are short relative to the AKS RP retry cadence (~3 min) so
+	// threshold-many retries can accumulate during the wait window.
+	triggerEvidenceTimeoutMin      = 60 // wait at most this long for evidence
+	triggerEvidencePollIntervalSec = 60 // re-query activity log every poll
+	triggerEvidenceWindowMin       = 60 // activity-log lookback for the wait loop
 )
 
 func main() {
@@ -170,6 +180,9 @@ type orchestrator interface {
 	deletePool(ctx context.Context, pool string) error
 	recreateSystem(ctx context.Context, live *armcs.AgentPool) error
 	reconcileTagPut(ctx context.Context) error
+	triggerSystemReconcile(ctx context.Context, live *armcs.AgentPool) error
+	pollForNRPEvidence(ctx context.Context, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
+	abortSystemReconcile(ctx context.Context) error
 }
 
 func run() error {
@@ -215,6 +228,12 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 	act, reason, err := orch.detect(ctx)
 	if err != nil {
 		return fmt.Errorf("detection: %w", err)
+	}
+	if !act && !cfg.skipGuards && !cfg.dryRun && reasonIsGuard1Only(reason) {
+		act, reason, err = forcedEvidencePath(ctx, cfg, orch, reason)
+		if err != nil {
+			return err
+		}
 	}
 	if !act && !cfg.skipGuards {
 		logf("guards did not fire: %s. Exiting no-op.", reason)
@@ -320,6 +339,58 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 		logf("WARN: post-flight dump partial: %v", err)
 	}
 	return nil
+}
+
+// forcedEvidencePath triggers a no-op reconcile on the live system
+// pool so the AKS RP attempts a fresh VMSS write. It then polls the
+// activity log for NRP-KVS Failed events and aborts the LRO it started
+// once threshold-many hits are observed or the timeout elapses.
+//
+// Returns (act, reason, error). act=true means evidence reached the
+// threshold and the caller should proceed with the recreate flow.
+// act=false with no error means the trigger was inconclusive (the
+// cluster is wedged for a different reason) and the caller should
+// exit no-op.
+func forcedEvidencePath(ctx context.Context, cfg *config, orch orchestrator, initialReason string) (bool, string, error) {
+	logBanner("FORCED EVIDENCE :: triggering reconcile to verify NRP-KVS signature")
+	logf("initial guard 1 saw no NRP-KVS evidence in last %dm: %s", cfg.windowMin, initialReason)
+
+	live, err := orch.snapshotSystem(ctx)
+	if err != nil {
+		return false, initialReason, fmt.Errorf("forced evidence snapshot: %w", err)
+	}
+
+	if err := orch.triggerSystemReconcile(ctx, live); err != nil {
+		logf("WARN: triggerSystemReconcile failed: %v; treating as no-op", err)
+		return false, initialReason, nil
+	}
+
+	logf("triggered system pool reconcile; polling activity log every %ds for up to %dm",
+		triggerEvidencePollIntervalSec, triggerEvidenceTimeoutMin)
+	hits, pollErr := orch.pollForNRPEvidence(
+		ctx,
+		triggerEvidenceTimeoutMin*time.Minute,
+		triggerEvidencePollIntervalSec*time.Second,
+		triggerEvidenceWindowMin,
+		cfg.threshold,
+	)
+
+	// Always best-effort abort the LRO we started so the cluster doesn't
+	// keep retrying the wedged write after we're done observing.
+	if abortErr := orch.abortSystemReconcile(ctx); abortErr != nil {
+		logf("WARN: abortSystemReconcile failed: %v", abortErr)
+	}
+
+	if pollErr != nil {
+		return false, initialReason, fmt.Errorf("poll for NRP evidence: %w", pollErr)
+	}
+	if hits < cfg.threshold {
+		reason := fmt.Sprintf("forced evidence inconclusive: only %d NRP failures < %d after %dm", hits, cfg.threshold, triggerEvidenceTimeoutMin)
+		logf("%s. Exiting no-op.", reason)
+		return false, reason, nil
+	}
+	logf("forced evidence confirmed NRP-KVS (%d hits >= threshold %d) — proceeding with recreate", hits, cfg.threshold)
+	return true, "", nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1180,6 +1251,82 @@ func (c *clients) reconcileTagPut(ctx context.Context) error {
 }
 
 // ---------------------------------------------------------------------------
+// forced-evidence trigger (used only when guards 2/3/4 PASS and guard 1 FAILs
+// because the activity log has no recent NRP-KVS events)
+// ---------------------------------------------------------------------------
+
+// triggerSystemReconcile starts an AKS RP reconcile of the live system
+// pool by issuing a sanitized CreateOrUpdate with the snapshot spec.
+// It does not wait for the LRO to finish — the caller polls the activity
+// log for NRP-KVS evidence in parallel and aborts the LRO when done.
+func (c *clients) triggerSystemReconcile(ctx context.Context, live *armcs.AgentPool) error {
+	body, err := agentPoolForCreate(live, c.cfg.cpVersion)
+	if err != nil {
+		return fmt.Errorf("triggerSystemReconcile: %w", err)
+	}
+	logf("triggering AgentPool CreateOrUpdate on %q (no-op reconcile with live spec)", systemPoolName)
+	if _, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, systemPoolName, *body, nil); err != nil {
+		return fmt.Errorf("begin trigger system reconcile: %w", err)
+	}
+	return nil
+}
+
+// pollForNRPEvidence re-queries the activity log on a fixed interval
+// until the NRP-KVS Failed-event count reaches threshold or the timeout
+// elapses. windowMin controls how far back each poll looks (a window
+// equal to the timeout makes every poll see all events since the
+// trigger).
+func (c *clients) pollForNRPEvidence(ctx context.Context, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error) {
+	if pollInterval <= 0 {
+		pollInterval = 60 * time.Second
+	}
+	deadline := time.Now().Add(timeout)
+	last := 0
+	for {
+		out, err := c.activityLogJSON(ctx, c.cfg.nodeRG, fmt.Sprintf("%dm", windowMin))
+		if err != nil {
+			return last, fmt.Errorf("forced-evidence activity-log query: %w", err)
+		}
+		hits, parseErr := countNRPFailures(out, "aks-system-")
+		if parseErr != nil {
+			return last, fmt.Errorf("forced-evidence activity-log parse: %w", parseErr)
+		}
+		last = hits
+		logf("forced evidence poll: NRP-KVS hits=%d threshold=%d (window=%dm)", hits, threshold, windowMin)
+		if hits >= threshold {
+			return hits, nil
+		}
+		if !time.Now().Before(deadline) {
+			return hits, nil
+		}
+		sleep := pollInterval
+		if remaining := time.Until(deadline); remaining < sleep {
+			sleep = remaining
+		}
+		select {
+		case <-ctx.Done():
+			return last, ctx.Err()
+		case <-time.After(sleep):
+		}
+	}
+}
+
+// abortSystemReconcile aborts the latest LRO on the system pool, which
+// (when the forced-evidence trigger started one) cancels the in-flight
+// CreateOrUpdate. Best-effort: failures here are logged by the caller
+// but not propagated.
+func (c *clients) abortSystemReconcile(ctx context.Context) error {
+	poller, err := c.pools.BeginAbortLatestOperation(ctx, c.cfg.resourceGroup, c.cfg.clusterName, systemPoolName, nil)
+	if err != nil {
+		return fmt.Errorf("begin abort system reconcile: %w", err)
+	}
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		return fmt.Errorf("poll abort system reconcile: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
 
@@ -1240,6 +1387,17 @@ func isNodeSchedulableReady(n *corev1.Node) bool {
 		return false
 	}
 	return n.DeletionTimestamp == nil
+}
+
+// reasonIsGuard1Only reports whether a detect() reason string indicates
+// that guards 2/3/4 PASSed and only guard 1 (NRP-KVS storm) FAILed.
+// Used to gate the forced-evidence trigger path: the cluster is in a
+// wedge-compatible state, but the activity log has no recent NRP-KVS
+// events in the configured lookback window. The forced-evidence path
+// triggers a no-op reconcile on the live system pool to give AKS a
+// chance to re-attempt the failing VMSS write before deciding to act.
+func reasonIsGuard1Only(reason string) bool {
+	return strings.HasPrefix(strings.TrimSpace(reason), "guard 1 FAIL")
 }
 
 // activityLogJSON returns Activity Log events in the compact JSON shape used

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -42,29 +42,40 @@
 //   NRP_FAIL_WINDOW_MIN       Activity-log lookback window in min (default 15)
 //   DRY_RUN                   "true" to print intended actions but make no writes
 //
-// Detection guards (ALL must pass; otherwise exit 0 no-op)
+// Detection checks (ALL must pass; otherwise exit 0 no-op)
 // --------------------------------------------------------
-//   1. >= NRP_FAIL_THRESHOLD Failed VMSS-write events on an
-//      `aks-system-*` VMSS in the last NRP_FAIL_WINDOW_MIN whose inner
-//      error code is NetworkingInternalOperationError (the NRP-KVS
-//      signature). Other failure modes — quota/capacity/policy/image
-//      pull / etc — never satisfy this guard, so they cannot trigger
-//      a destructive pool recreation that would not address their
-//      actual root cause.
-//   2. Cluster provisioningState is recoverable: Succeeded, Canceled,
-//      Failed (settled) OR Updating, Upgrading (mid-LRO — the NRP-KVS
-//      wedge signature itself; step 2 decides whether to abort).
-//      Creating and Deleting are rejected; unknown states are
-//      rejected conservatively.
-//   3. Every non-system pool has count > 0.
-//   4. `system` pool's own provisioningState is NOT Succeeded —
-//      positive confirmation that this specific pool is wedged.
-//      Accepts Failed, Canceled, Updating, Upgrading: an NRP-KVS wedge
-//      typically leaves the pool in Updating while its parent cluster
-//      LRO retries forever (AROSLSRE-880), or in Failed/Canceled once
-//      that LRO finally times out or is aborted by an operator.
-//      Rejects Succeeded (no wedge) and Creating/Deleting/unknown
-//      (don't act on transitional / unrecognized states).
+// Names below are the check labels used in log lines and reason
+// strings throughout this binary. Checks run in the order listed
+// (cluster state -> non-system pools -> system wedge -> NRP-KVS storm)
+// so the cheap ARM checks short-circuit before we query Activity Log.
+//
+//   [cluster state]      cluster provisioningState is recoverable:
+//                        Succeeded, Canceled, Failed (settled) OR
+//                        Updating, Upgrading (mid-LRO — the NRP-KVS
+//                        wedge signature itself; step 2 decides
+//                        whether to abort the LRO). Creating and
+//                        Deleting are rejected; unknown states are
+//                        rejected conservatively.
+//   [non-system pools]   every non-system pool has count > 0.
+//   [system wedge]       system pool provisioningState is NOT
+//                        Succeeded — positive confirmation that this
+//                        specific pool is wedged. Accepts Failed,
+//                        Canceled, Updating, Upgrading (an NRP-KVS
+//                        wedge typically leaves the pool in Updating
+//                        while its parent cluster LRO retries forever
+//                        — AROSLSRE-880 — or in Failed/Canceled once
+//                        that LRO finally times out or is aborted).
+//                        Rejects Succeeded (no wedge) and
+//                        Creating/Deleting/unknown.
+//   [NRP-KVS storm]      >= NRP_FAIL_THRESHOLD Failed VMSS-write
+//                        events on the system pool's VMSS in the
+//                        last NRP_FAIL_WINDOW_MIN whose inner error
+//                        code is NetworkingInternalOperationError.
+//                        Other failure modes — quota/capacity/policy
+//                        / image pull / etc — never satisfy this
+//                        check, so they cannot trigger a destructive
+//                        pool recreation that would not address their
+//                        actual root cause.
 //
 // Action (only when all guards pass)
 // ----------------------------------
@@ -125,7 +136,8 @@ const (
 	pollIntervalSec   = 30
 	overallTimeoutMin = 60
 
-	// Guard 1 requires this code so other failure modes cannot trip the threshold.
+	// The NRP-KVS storm check requires this error code so other failure
+	// modes (quota / capacity / policy / etc) cannot trip the threshold.
 	nrpKVSErrorCode    = "NetworkingInternalOperationError"
 	vmssWriteOperation = "Microsoft.Compute/virtualMachineScaleSets/write"
 
@@ -142,7 +154,8 @@ const (
 	activityLogAuthRetryMaxSec     = 60
 
 	// triggerEvidence forces an AKS RP reconcile of the system pool when
-	// guards 2/3/4 PASS but guard 1 has no recent NRP-KVS events in the
+	// the cluster-state / non-system-pools / system-wedge checks PASS
+	// but the NRP-KVS-storm check has no recent NRP-KVS events in the
 	// configured lookback window. The trigger gives the wedge a chance
 	// to produce fresh evidence (or to prove the wedge is not NRP-KVS).
 	// Times are short relative to the AKS RP retry cadence (~3 min) so
@@ -237,7 +250,7 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 	if err != nil {
 		return fmt.Errorf("detection: %w", err)
 	}
-	if !act && !cfg.skipGuards && !cfg.dryRun && reasonIsGuard1Only(reason) {
+	if !act && !cfg.skipGuards && !cfg.dryRun && reasonIsNRPStormFail(reason) {
 		act, reason, err = forcedEvidencePath(ctx, cfg, orch, reason)
 		if err != nil {
 			return err
@@ -361,7 +374,7 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 // exit no-op.
 func forcedEvidencePath(ctx context.Context, cfg *config, orch orchestrator, initialReason string) (bool, string, error) {
 	logBanner("FORCED EVIDENCE :: triggering reconcile to verify NRP-KVS signature")
-	logf("initial guard 1 saw no NRP-KVS evidence in last %dm: %s", cfg.windowMin, initialReason)
+	logf("initial NRP-KVS storm check saw no evidence in last %dm: %s", cfg.windowMin, initialReason)
 
 	live, err := orch.snapshotSystem(ctx)
 	if err != nil {
@@ -534,7 +547,7 @@ func newAzureClients(cfg *config) (*clients, error) {
 // can no-op exit cleanly. On any other error returns (zero, false, error).
 // On success, it records nodeRG and cpVersion when ARM has populated them,
 // but deliberately does not require them yet: partially-created clusters can
-// be returned without these fields, and evalGuard2 should reject Creating as
+// be returned without these fields, and evalClusterState should reject Creating as
 // a no-op guard failure instead of failing the Shell step.
 func (c *clients) ensureCluster(ctx context.Context) (armcs.ManagedCluster, bool, error) {
 	resp, err := c.cluster.Get(ctx, c.cfg.resourceGroup, c.cfg.clusterName, nil)
@@ -739,18 +752,18 @@ func nodeInternalIP(n *corev1.Node) string {
 // detection
 // ---------------------------------------------------------------------------
 
-// evalGuard1 reports whether NRP failure count exceeds the threshold.
-func evalGuard1(failures, threshold int) (bool, string) {
+// evalNRPStorm reports whether NRP-KVS failure count exceeds the threshold.
+func evalNRPStorm(failures, threshold int) (bool, string) {
 	if threshold <= 0 {
-		return false, fmt.Sprintf("guard 1 FAIL: threshold=%d (invalid)", threshold)
+		return false, fmt.Sprintf("NRP-KVS storm FAIL: threshold=%d (invalid)", threshold)
 	}
 	if failures < threshold {
-		return false, fmt.Sprintf("guard 1 FAIL: only %d NRP failures < %d", failures, threshold)
+		return false, fmt.Sprintf("NRP-KVS storm FAIL: only %d NRP failures < %d", failures, threshold)
 	}
 	return true, ""
 }
 
-// evalGuard2 reports whether the cluster is in a state where we can act.
+// evalClusterState reports whether the cluster is in a state where we can act.
 //
 // Acceptable:
 //   - Succeeded / Canceled / Failed: settled, no LRO to fight, free to PUT.
@@ -766,27 +779,27 @@ func evalGuard1(failures, threshold int) (bool, string) {
 //     pool we'd want to recreate doesn't exist in a stable form.
 //   - Deleting: someone is tearing the cluster down; do not interfere.
 //   - empty / unknown future states: be conservative.
-func evalGuard2(provisioningState string) (bool, string) {
+func evalClusterState(provisioningState string) (bool, string) {
 	switch provisioningState {
 	case "Succeeded", "Canceled", "Failed", "Updating", "Upgrading":
 		return true, ""
 	case "Creating":
-		return false, "guard 2 FAIL: cluster provisioningState=\"Creating\" (cluster not fully provisioned)"
+		return false, "cluster state FAIL: provisioningState=\"Creating\" (cluster not fully provisioned)"
 	case "Deleting":
-		return false, "guard 2 FAIL: cluster provisioningState=\"Deleting\" (cluster is being torn down)"
+		return false, "cluster state FAIL: provisioningState=\"Deleting\" (cluster is being torn down)"
 	case "":
-		return false, "guard 2 FAIL: cluster provisioningState is empty"
+		return false, "cluster state FAIL: provisioningState is empty"
 	}
-	return false, fmt.Sprintf("guard 2 FAIL: cluster provisioningState=%q is not a recognized recoverable state", provisioningState)
+	return false, fmt.Sprintf("cluster state FAIL: provisioningState=%q is not a recognized recoverable state", provisioningState)
 }
 
-// evalGuard3 reports whether all non-system pools have count > 0 and a
-// system pool exists. Also reports the system pool's minCount and
-// provisioningState back to the caller so the latter can be fed into
-// evalGuard4 without a second list-pools API call.
+// evalNonSystemPools reports whether all non-system pools have count > 0
+// and a system pool exists. Also reports the system pool's minCount
+// and provisioningState back to the caller so the latter can be fed
+// into evalSystemWedge without a second list-pools API call.
 //
 // Returns (pass, systemMin, systemProvState, reason).
-func evalGuard3(pools []*armcs.AgentPool) (bool, int32, string, string) {
+func evalNonSystemPools(pools []*armcs.AgentPool) (bool, int32, string, string) {
 	var systemMin int32
 	var systemProvState string
 	systemFound := false
@@ -810,18 +823,18 @@ func evalGuard3(pools []*armcs.AgentPool) (bool, int32, string, string) {
 			cnt = *p.Properties.Count
 		}
 		if cnt == 0 {
-			return false, 0, "", fmt.Sprintf("guard 3 FAIL: non-system pool %q has count=0", name)
+			return false, 0, "", fmt.Sprintf("non-system pools FAIL: pool %q has count=0", name)
 		}
 	}
 	if !systemFound {
-		return false, 0, "", "guard 3 FAIL: no system pool found"
+		return false, 0, "", "non-system pools FAIL: no system pool found"
 	}
 	return true, systemMin, systemProvState, ""
 }
 
-// evalGuard4 reports whether the system pool itself is in a wedge-
-// compatible state. Refines guard 1 (NRP failure storm) with a positive
-// signal scoped to this exact agent-pool resource.
+// evalSystemWedge reports whether the system pool itself is in a
+// wedge-compatible state. Refines the NRP-KVS storm check with a
+// positive signal scoped to this exact agent-pool resource.
 //
 // Accepts:
 //   - Failed   — RP gave up retrying the VMSS write chain.
@@ -837,76 +850,76 @@ func evalGuard3(pools []*armcs.AgentPool) (bool, int32, string, string) {
 //   - Creating  — pool not fully created yet; do not interfere.
 //   - Deleting  — pool being torn down; do not interfere.
 //   - empty / unknown — fail conservatively.
-func evalGuard4(systemProvState string) (bool, string) {
+func evalSystemWedge(systemProvState string) (bool, string) {
 	switch systemProvState {
 	case "Failed", "Canceled", "Updating", "Upgrading":
 		return true, ""
 	case "Succeeded":
-		return false, "guard 4 FAIL: system pool provisioningState=\"Succeeded\" (no wedge)"
+		return false, "system wedge FAIL: provisioningState=\"Succeeded\" (no wedge)"
 	case "Creating":
-		return false, "guard 4 FAIL: system pool provisioningState=\"Creating\" (not fully created)"
+		return false, "system wedge FAIL: provisioningState=\"Creating\" (not fully created)"
 	case "Deleting":
-		return false, "guard 4 FAIL: system pool provisioningState=\"Deleting\" (being torn down)"
+		return false, "system wedge FAIL: provisioningState=\"Deleting\" (being torn down)"
 	case "":
-		return false, "guard 4 FAIL: system pool provisioningState is empty"
+		return false, "system wedge FAIL: provisioningState is empty"
 	}
-	return false, fmt.Sprintf("guard 4 FAIL: system pool provisioningState=%q is not a recognized wedge-compatible state", systemProvState)
+	return false, fmt.Sprintf("system wedge FAIL: provisioningState=%q is not a recognized wedge-compatible state", systemProvState)
 }
 
 func (c *clients) detect(ctx context.Context) (bool, string, error) {
-	// Guard 2: cluster provisioning state
+	// Cluster state check
 	mc, err := c.cluster.Get(ctx, c.cfg.resourceGroup, c.cfg.clusterName, nil)
 	if err != nil {
-		return false, "", fmt.Errorf("guard 2 cluster get: %w", err)
+		return false, "", fmt.Errorf("cluster state get: %w", err)
 	}
 	cs := ""
 	if mc.Properties != nil && mc.Properties.ProvisioningState != nil {
 		cs = *mc.Properties.ProvisioningState
 	}
-	logf("guard 2 :: cluster provisioningState=%s (accept: Succeeded/Canceled/Failed/Updating/Upgrading; reject: Creating/Deleting/unknown)", cs)
-	if pass, reason := evalGuard2(cs); !pass {
+	logf("cluster state :: provisioningState=%s (accept: Succeeded/Canceled/Failed/Updating/Upgrading; reject: Creating/Deleting/unknown)", cs)
+	if pass, reason := evalClusterState(cs); !pass {
 		return false, reason, nil
 	}
-	logf("guard 2 PASS")
+	logf("cluster state PASS")
 
-	// Guard 3: non-system pools healthy, plus discover system minCount.
+	// Non-system pools check (also discovers system minCount and state).
 	pager := c.pools.NewListPager(c.cfg.resourceGroup, c.cfg.clusterName, nil)
 	var allPools []*armcs.AgentPool
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return false, "", fmt.Errorf("guard 3 list pools: %w", err)
+			return false, "", fmt.Errorf("non-system pools list: %w", err)
 		}
 		allPools = append(allPools, page.Value...)
 	}
-	pass, systemMin, systemProvState, reason := evalGuard3(allPools)
+	pass, systemMin, systemProvState, reason := evalNonSystemPools(allPools)
 	if !pass {
 		return false, reason, nil
 	}
-	logf("guard 3 PASS (system minCount=%d systemProvState=%q)", systemMin, systemProvState)
+	logf("non-system pools PASS (system minCount=%d systemProvState=%q)", systemMin, systemProvState)
 
-	// Guard 4: system pool itself is in a wedge-compatible state.
-	if pass, reason := evalGuard4(systemProvState); !pass {
+	// System wedge check (system pool itself is in a wedge-compatible state).
+	if pass, reason := evalSystemWedge(systemProvState); !pass {
 		return false, reason, nil
 	}
-	logf("guard 4 PASS (system pool provisioningState=%q)", systemProvState)
+	logf("system wedge PASS (system pool provisioningState=%q)", systemProvState)
 
-	// Guard 1: NRP retry loop on aks-system-* VMSS
-	logf("guard 1 :: checking activity log on %s for last %d min", c.cfg.nodeRG, c.cfg.windowMin)
+	// NRP-KVS storm check (activity log on aks-system-* VMSS)
+	logf("NRP-KVS storm :: checking activity log on %s for last %d min", c.cfg.nodeRG, c.cfg.windowMin)
 	out, err := c.activityLogJSON(ctx, c.cfg.nodeRG, fmt.Sprintf("%dm", c.cfg.windowMin))
 	if err != nil {
-		return false, "", fmt.Errorf("guard 1 activity-log query failed: %w", err)
+		return false, "", fmt.Errorf("NRP-KVS storm activity-log query failed: %w", err)
 	}
 	hits, err := countNRPFailures(out, systemVMSSPrefix)
 	if err != nil {
-		return false, "", fmt.Errorf("guard 1 activity-log parse failed: %w", err)
+		return false, "", fmt.Errorf("NRP-KVS storm activity-log parse failed: %w", err)
 	}
-	logf("guard 1 :: NRP-KVS (%s) Failed events on aks-system-* in window: %d (threshold %d)",
+	logf("NRP-KVS storm :: NRP-KVS (%s) Failed events on aks-system-* in window: %d (threshold %d)",
 		nrpKVSErrorCode, hits, c.cfg.threshold)
-	if pass, reason := evalGuard1(hits, c.cfg.threshold); !pass {
+	if pass, reason := evalNRPStorm(hits, c.cfg.threshold); !pass {
 		return false, reason, nil
 	}
-	logf("guard 1 PASS")
+	logf("NRP-KVS storm PASS")
 
 	return true, "", nil
 }
@@ -1259,7 +1272,8 @@ func (c *clients) reconcileTagPut(ctx context.Context) error {
 }
 
 // ---------------------------------------------------------------------------
-// forced-evidence trigger (used only when guards 2/3/4 PASS and guard 1 FAILs
+// forced-evidence trigger (used only when cluster-state, non-system-pools,
+// and system-wedge checks PASS and the NRP-KVS-storm check FAILs
 // because the activity log has no recent NRP-KVS events)
 // ---------------------------------------------------------------------------
 
@@ -1397,15 +1411,16 @@ func isNodeSchedulableReady(n *corev1.Node) bool {
 	return n.DeletionTimestamp == nil
 }
 
-// reasonIsGuard1Only reports whether a detect() reason string indicates
-// that guards 2/3/4 PASSed and only guard 1 (NRP-KVS storm) FAILed.
+// reasonIsNRPStormFail reports whether a detect() reason string
+// indicates that the cluster-state, non-system-pools, and system-wedge
+// checks all PASSed and only the NRP-KVS-storm check FAILed.
 // Used to gate the forced-evidence trigger path: the cluster is in a
 // wedge-compatible state, but the activity log has no recent NRP-KVS
 // events in the configured lookback window. The forced-evidence path
 // triggers a no-op reconcile on the live system pool to give AKS a
 // chance to re-attempt the failing VMSS write before deciding to act.
-func reasonIsGuard1Only(reason string) bool {
-	return strings.HasPrefix(strings.TrimSpace(reason), "guard 1 FAIL")
+func reasonIsNRPStormFail(reason string) bool {
+	return strings.HasPrefix(strings.TrimSpace(reason), "NRP-KVS storm FAIL")
 }
 
 // activityLogJSON returns Activity Log events in the compact JSON shape used
@@ -1560,8 +1575,8 @@ type activityEvent struct {
 
 // hasNRPKVSSignature reports whether an activity-log event's inner ARM
 // error body carries the NetworkingInternalOperationError code. Returns
-// false on any parse error or missing field — guard 1 must fail closed
-// rather than over-count.
+// false on any parse error or missing field — the NRP-KVS-storm
+// check must fail closed rather than over-count.
 func hasNRPKVSSignature(e activityEvent) bool {
 	msg := strings.TrimSpace(e.Properties.StatusMessage)
 	if msg == "" {

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -163,6 +163,15 @@ const (
 	triggerEvidenceTimeoutMin      = 60 // wait at most this long for evidence
 	triggerEvidencePollIntervalSec = 60 // re-query activity log every poll
 	triggerEvidenceWindowMin       = 60 // activity-log lookback for the wait loop
+
+	// abortTriggerTimeoutMin caps the wait for cleanup of the LRO that
+	// forcedEvidencePath itself triggered. The abort runs with a fresh
+	// context derived from context.Background so it executes even when
+	// the parent run context has already expired (overall script timeout
+	// or pollForNRPEvidence consuming the full triggerEvidenceTimeoutMin
+	// budget). Without this, a cancelled parent context would silently
+	// skip the abort and leave the AKS RP retrying the wedged write.
+	abortTriggerTimeoutMin = 5
 )
 
 func main() {
@@ -397,8 +406,14 @@ func forcedEvidencePath(ctx context.Context, cfg *config, orch orchestrator, ini
 	)
 
 	// Always best-effort abort the LRO we started so the cluster doesn't
-	// keep retrying the wedged write after we're done observing.
-	if abortErr := orch.abortSystemReconcile(ctx); abortErr != nil {
+	// keep retrying the wedged write after we're done observing. Use a
+	// fresh context.Background-rooted context so the abort still runs
+	// when the parent ctx is already cancelled (overall script timeout
+	// or pollForNRPEvidence consuming its full budget) — the LRO we
+	// triggered here is our responsibility to tear down.
+	abortCtx, abortCancel := context.WithTimeout(context.Background(), abortTriggerTimeoutMin*time.Minute)
+	defer abortCancel()
+	if abortErr := orch.abortSystemReconcile(abortCtx); abortErr != nil {
 		logf("WARN: abortSystemReconcile failed: %v", abortErr)
 	}
 

--- a/dev-infrastructure/scripts/recreate-system-pool/main_test.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main_test.go
@@ -1335,17 +1335,20 @@ type mockOrchestrator struct {
 	calls       []string
 	detectCount int
 
-	ensureClusterFn   func(ctx context.Context) (armcs.ManagedCluster, bool, error)
-	bootstrapKubeFn   func(ctx context.Context, mc armcs.ManagedCluster) error
-	detectFn          func(ctx context.Context, n int) (bool, string, error)
-	preflightChecksFn func(ctx context.Context) error
-	snapshotSystemFn  func(ctx context.Context) (*armcs.AgentPool, error)
-	maybeAbortLROFn   func(ctx context.Context) (bool, error)
-	addSystmpFn       func(ctx context.Context, live *armcs.AgentPool) error
-	drainPoolFn       func(ctx context.Context, pool string, timeout time.Duration) error
-	deletePoolFn      func(ctx context.Context, pool string) error
-	recreateSystemFn  func(ctx context.Context, live *armcs.AgentPool) error
-	reconcileTagPutFn func(ctx context.Context) error
+	ensureClusterFn          func(ctx context.Context) (armcs.ManagedCluster, bool, error)
+	bootstrapKubeFn          func(ctx context.Context, mc armcs.ManagedCluster) error
+	detectFn                 func(ctx context.Context, n int) (bool, string, error)
+	preflightChecksFn        func(ctx context.Context) error
+	snapshotSystemFn         func(ctx context.Context) (*armcs.AgentPool, error)
+	maybeAbortLROFn          func(ctx context.Context) (bool, error)
+	addSystmpFn              func(ctx context.Context, live *armcs.AgentPool) error
+	drainPoolFn              func(ctx context.Context, pool string, timeout time.Duration) error
+	deletePoolFn             func(ctx context.Context, pool string) error
+	recreateSystemFn         func(ctx context.Context, live *armcs.AgentPool) error
+	reconcileTagPutFn        func(ctx context.Context) error
+	triggerSystemReconcileFn func(ctx context.Context, live *armcs.AgentPool) error
+	pollForNRPEvidenceFn     func(ctx context.Context, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
+	abortSystemReconcileFn   func(ctx context.Context) error
 }
 
 func (m *mockOrchestrator) record(name string) { m.calls = append(m.calls, name) }
@@ -1449,6 +1452,30 @@ func (m *mockOrchestrator) reconcileTagPut(ctx context.Context) error {
 	return nil
 }
 
+func (m *mockOrchestrator) triggerSystemReconcile(ctx context.Context, live *armcs.AgentPool) error {
+	m.record("triggerSystemReconcile")
+	if m.triggerSystemReconcileFn != nil {
+		return m.triggerSystemReconcileFn(ctx, live)
+	}
+	return nil
+}
+
+func (m *mockOrchestrator) pollForNRPEvidence(ctx context.Context, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error) {
+	m.record("pollForNRPEvidence")
+	if m.pollForNRPEvidenceFn != nil {
+		return m.pollForNRPEvidenceFn(ctx, timeout, pollInterval, windowMin, threshold)
+	}
+	return threshold, nil
+}
+
+func (m *mockOrchestrator) abortSystemReconcile(ctx context.Context) error {
+	m.record("abortSystemReconcile")
+	if m.abortSystemReconcileFn != nil {
+		return m.abortSystemReconcileFn(ctx)
+	}
+	return nil
+}
+
 func TestRunWith(t *testing.T) {
 	dummyErr := errors.New("boom")
 
@@ -1492,14 +1519,82 @@ func TestRunWith(t *testing.T) {
 			wantCalls: []string{"ensureCluster"},
 		},
 		{
-			name: "guards_do_not_fire",
+			name: "guards_do_not_fire_non_guard1",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0"},
 			setup: func(m *mockOrchestrator) {
 				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "guard 1 FAIL", nil
+					return false, "guard 2 FAIL: not recoverable", nil
 				}
 			},
 			wantCalls: []string{"ensureCluster", "dumpPreflight", "detect:1"},
+		},
+		{
+			name: "guard1_fail_dry_run_skips_forced_evidence",
+			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", dryRun: true},
+			setup: func(m *mockOrchestrator) {
+				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
+					return false, "guard 1 FAIL: only 0 NRP failures < 10", nil
+				}
+			},
+			wantCalls: []string{"ensureCluster", "dumpPreflight", "detect:1"},
+		},
+		{
+			name: "guard1_fail_forced_evidence_inconclusive",
+			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10},
+			setup: func(m *mockOrchestrator) {
+				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
+					return false, "guard 1 FAIL: only 0 NRP failures < 10", nil
+				}
+				m.pollForNRPEvidenceFn = func(context.Context, time.Duration, time.Duration, int, int) (int, error) {
+					return 3, nil
+				}
+			},
+			wantCalls: []string{
+				"ensureCluster", "dumpPreflight", "detect:1",
+				"snapshotSystem", "triggerSystemReconcile", "pollForNRPEvidence", "abortSystemReconcile",
+			},
+		},
+		{
+			name: "guard1_fail_forced_evidence_confirms_nrp",
+			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10},
+			setup: func(m *mockOrchestrator) {
+				m.detectFn = func(_ context.Context, n int) (bool, string, error) {
+					if n == 1 {
+						return false, "guard 1 FAIL: only 0 NRP failures < 10", nil
+					}
+					return true, "", nil
+				}
+				m.pollForNRPEvidenceFn = func(context.Context, time.Duration, time.Duration, int, int) (int, error) {
+					return 12, nil
+				}
+			},
+			wantCalls: []string{
+				"ensureCluster", "dumpPreflight", "detect:1",
+				"snapshotSystem", "triggerSystemReconcile", "pollForNRPEvidence", "abortSystemReconcile",
+				"bootstrapKube", "dumpPreflight", "preflightChecks",
+				"snapshotSystem", "maybeAbortLRO", "detect:2", "snapshotSystem",
+				"addSystmp",
+				"drainPool:system", "deletePool:system",
+				"recreateSystem",
+				"drainPool:systmp", "deletePool:systmp",
+				"reconcileTagPut", "dumpPostflight",
+			},
+		},
+		{
+			name: "guard1_fail_trigger_failure_exits_noop",
+			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10},
+			setup: func(m *mockOrchestrator) {
+				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
+					return false, "guard 1 FAIL: only 0 NRP failures < 10", nil
+				}
+				m.triggerSystemReconcileFn = func(context.Context, *armcs.AgentPool) error {
+					return errors.New("conflict")
+				}
+			},
+			wantCalls: []string{
+				"ensureCluster", "dumpPreflight", "detect:1",
+				"snapshotSystem", "triggerSystemReconcile",
+			},
 		},
 		{
 			name: "detect_error",

--- a/dev-infrastructure/scripts/recreate-system-pool/main_test.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main_test.go
@@ -197,10 +197,10 @@ func TestParseEnvConfig_DryRunFlag(t *testing.T) {
 }
 
 // =============================================================================
-// evalGuard1..4
+// evalNRPStorm..4
 // =============================================================================
 
-func TestEvalGuard1(t *testing.T) {
+func TestEvalNRPStorm(t *testing.T) {
 	cases := []struct {
 		name                string
 		failures, threshold int
@@ -215,7 +215,7 @@ func TestEvalGuard1(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			pass, reason := evalGuard1(tc.failures, tc.threshold)
+			pass, reason := evalNRPStorm(tc.failures, tc.threshold)
 			if pass != tc.wantPass {
 				t.Errorf("failures=%d threshold=%d: pass=%t want %t (%s)", tc.failures, tc.threshold, pass, tc.wantPass, reason)
 			}
@@ -226,7 +226,7 @@ func TestEvalGuard1(t *testing.T) {
 	}
 }
 
-func TestEvalGuard2(t *testing.T) {
+func TestEvalClusterState(t *testing.T) {
 	cases := []struct {
 		name  string
 		state string
@@ -258,7 +258,7 @@ func TestEvalGuard2(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			pass, reason := evalGuard2(tc.state)
+			pass, reason := evalClusterState(tc.state)
 			if pass != tc.want {
 				t.Errorf("state=%q: pass=%t want %t (%s)", tc.state, pass, tc.want, reason)
 			}
@@ -290,12 +290,12 @@ func mkPoolWithState(name string, count, minCount *int32, provState string) *arm
 	return p
 }
 
-func TestEvalGuard3_AllHealthy(t *testing.T) {
+func TestEvalNonSystemPools_AllHealthy(t *testing.T) {
 	pools := []*armcs.AgentPool{
 		mkPoolWithState("system", ptr(int32(2)), ptr(int32(2)), "Succeeded"),
 		mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
 	}
-	pass, sysMin, sysState, reason := evalGuard3(pools)
+	pass, sysMin, sysState, reason := evalNonSystemPools(pools)
 	if !pass {
 		t.Fatalf("expected pass, got fail: %s", reason)
 	}
@@ -307,12 +307,12 @@ func TestEvalGuard3_AllHealthy(t *testing.T) {
 	}
 }
 
-func TestEvalGuard3_NonSystemPoolEmpty(t *testing.T) {
+func TestEvalNonSystemPools_NonSystemPoolEmpty(t *testing.T) {
 	pools := []*armcs.AgentPool{
 		mkPool("system", ptr(int32(2)), ptr(int32(2))),
 		mkPool("userswft3", ptr(int32(0)), ptr(int32(0))),
 	}
-	pass, _, _, reason := evalGuard3(pools)
+	pass, _, _, reason := evalNonSystemPools(pools)
 	if pass {
 		t.Fatal("expected fail when non-system pool has count=0")
 	}
@@ -321,11 +321,11 @@ func TestEvalGuard3_NonSystemPoolEmpty(t *testing.T) {
 	}
 }
 
-func TestEvalGuard3_NoSystemPool(t *testing.T) {
+func TestEvalNonSystemPools_NoSystemPool(t *testing.T) {
 	pools := []*armcs.AgentPool{
 		mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
 	}
-	pass, _, _, reason := evalGuard3(pools)
+	pass, _, _, reason := evalNonSystemPools(pools)
 	if pass {
 		t.Fatal("expected fail when no system pool")
 	}
@@ -334,13 +334,13 @@ func TestEvalGuard3_NoSystemPool(t *testing.T) {
 	}
 }
 
-func TestEvalGuard3_SystemPoolWithZeroCount_OK(t *testing.T) {
+func TestEvalNonSystemPools_SystemPoolWithZeroCount_OK(t *testing.T) {
 	// System pool itself can have count=0 (that's the whole point of this script).
 	pools := []*armcs.AgentPool{
 		mkPool("system", ptr(int32(0)), ptr(int32(2))),
 		mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
 	}
-	pass, sysMin, _, reason := evalGuard3(pools)
+	pass, sysMin, _, reason := evalNonSystemPools(pools)
 	if !pass {
 		t.Fatalf("system pool with count=0 should not fail guard 4: %s", reason)
 	}
@@ -349,45 +349,45 @@ func TestEvalGuard3_SystemPoolWithZeroCount_OK(t *testing.T) {
 	}
 }
 
-func TestEvalGuard3_NilPoolsSkipped(t *testing.T) {
+func TestEvalNonSystemPools_NilPoolsSkipped(t *testing.T) {
 	pools := []*armcs.AgentPool{
 		nil,
 		mkPool("system", ptr(int32(2)), ptr(int32(2))),
 		nil,
 		mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
 	}
-	pass, _, _, reason := evalGuard3(pools)
+	pass, _, _, reason := evalNonSystemPools(pools)
 	if !pass {
 		t.Fatalf("nil pools should be skipped: %s", reason)
 	}
 }
 
-func TestEvalGuard3_PoolMissingFieldsSkipped(t *testing.T) {
+func TestEvalNonSystemPools_PoolMissingFieldsSkipped(t *testing.T) {
 	pools := []*armcs.AgentPool{
 		{Name: ptr("orphan")}, // no properties
 		{Properties: &armcs.ManagedClusterAgentPoolProfileProperties{Count: ptr(int32(3))}}, // no name
 		mkPool("system", ptr(int32(1)), ptr(int32(2))),
 		mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
 	}
-	pass, _, _, reason := evalGuard3(pools)
+	pass, _, _, reason := evalNonSystemPools(pools)
 	if !pass {
 		t.Fatalf("malformed pool entries should be skipped: %s", reason)
 	}
 }
 
-func TestEvalGuard3_SystemMissingMinCount_DefaultsZero(t *testing.T) {
+func TestEvalNonSystemPools_SystemMissingMinCount_DefaultsZero(t *testing.T) {
 	pools := []*armcs.AgentPool{
 		mkPool("system", ptr(int32(1)), nil),
 		mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
 	}
-	pass, sysMin, _, _ := evalGuard3(pools)
+	pass, sysMin, _, _ := evalNonSystemPools(pools)
 	if !pass || sysMin != 0 {
 		t.Errorf("systemMin=%d pass=%t (want 0/true)", sysMin, pass)
 	}
 }
 
-func TestEvalGuard3_EmptyList(t *testing.T) {
-	pass, _, _, reason := evalGuard3(nil)
+func TestEvalNonSystemPools_EmptyList(t *testing.T) {
+	pass, _, _, reason := evalNonSystemPools(nil)
 	if pass {
 		t.Fatal("empty pool list must fail")
 	}
@@ -396,7 +396,7 @@ func TestEvalGuard3_EmptyList(t *testing.T) {
 	}
 }
 
-func TestEvalGuard3_ExtractsSystemProvState(t *testing.T) {
+func TestEvalNonSystemPools_ExtractsSystemProvState(t *testing.T) {
 	cases := []struct {
 		name  string
 		state string
@@ -412,7 +412,7 @@ func TestEvalGuard3_ExtractsSystemProvState(t *testing.T) {
 				mkPoolWithState("system", ptr(int32(0)), ptr(int32(2)), tc.state),
 				mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
 			}
-			pass, _, gotState, _ := evalGuard3(pools)
+			pass, _, gotState, _ := evalNonSystemPools(pools)
 			if !pass {
 				t.Fatal("expected pass")
 			}
@@ -1290,10 +1290,10 @@ func TestIsActivityLogAuthorizationError(t *testing.T) {
 }
 
 // =============================================================================
-// evalGuard4  (system pool provisioningState == "Failed")
+// evalSystemWedge  (system pool provisioningState == "Failed")
 // =============================================================================
 
-func TestEvalGuard4(t *testing.T) {
+func TestEvalSystemWedge(t *testing.T) {
 	cases := []struct {
 		name  string
 		state string
@@ -1316,7 +1316,7 @@ func TestEvalGuard4(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			pass, reason := evalGuard4(tc.state)
+			pass, reason := evalSystemWedge(tc.state)
 			if pass != tc.want {
 				t.Errorf("state=%q: pass=%t want %t (%s)", tc.state, pass, tc.want, reason)
 			}
@@ -1523,7 +1523,7 @@ func TestRunWith(t *testing.T) {
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0"},
 			setup: func(m *mockOrchestrator) {
 				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "guard 2 FAIL: not recoverable", nil
+					return false, "cluster state FAIL: not recoverable", nil
 				}
 			},
 			wantCalls: []string{"ensureCluster", "dumpPreflight", "detect:1"},
@@ -1533,7 +1533,7 @@ func TestRunWith(t *testing.T) {
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", dryRun: true},
 			setup: func(m *mockOrchestrator) {
 				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "guard 1 FAIL: only 0 NRP failures < 10", nil
+					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
 				}
 			},
 			wantCalls: []string{"ensureCluster", "dumpPreflight", "detect:1"},
@@ -1543,7 +1543,7 @@ func TestRunWith(t *testing.T) {
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10},
 			setup: func(m *mockOrchestrator) {
 				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "guard 1 FAIL: only 0 NRP failures < 10", nil
+					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
 				}
 				m.pollForNRPEvidenceFn = func(context.Context, time.Duration, time.Duration, int, int) (int, error) {
 					return 3, nil
@@ -1560,7 +1560,7 @@ func TestRunWith(t *testing.T) {
 			setup: func(m *mockOrchestrator) {
 				m.detectFn = func(_ context.Context, n int) (bool, string, error) {
 					if n == 1 {
-						return false, "guard 1 FAIL: only 0 NRP failures < 10", nil
+						return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
 					}
 					return true, "", nil
 				}
@@ -1585,7 +1585,7 @@ func TestRunWith(t *testing.T) {
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10},
 			setup: func(m *mockOrchestrator) {
 				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "guard 1 FAIL: only 0 NRP failures < 10", nil
+					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
 				}
 				m.triggerSystemReconcileFn = func(context.Context, *armcs.AgentPool) error {
 					return errors.New("conflict")
@@ -1640,7 +1640,7 @@ func TestRunWith(t *testing.T) {
 					if n == 1 {
 						return true, "", nil
 					}
-					return false, "guard 4 FAIL after LRO", nil
+					return false, "system wedge FAIL after LRO", nil
 				}
 			},
 			wantCalls: []string{


### PR DESCRIPTION
[AROSLSRE-951](https://issues.redhat.com/browse/AROSLSRE-951) (story) · [AROSLSRE-958](https://issues.redhat.com/browse/AROSLSRE-958) (sub-task) · follow-up to [#5397](https://github.com/Azure/ARO-HCP/pull/5397)

### What

Make `recreate-system-pool-if-broken` work on sparse-rollout environments (Stage daily, Prod weekly+), plus follow-up cleanups from review:

1. Widen the initial activity-log lookback in `mgmt-pipeline.yaml`: `NRP_FAIL_WINDOW_MIN: 15 -> 360` (6h).
2. Add a forced-evidence trigger in the Go binary: when the cluster-state, non-system-pools, and system-wedge checks PASS but the NRP-KVS-storm check finds no events in the 6h window, trigger a no-op `AgentPool` CreateOrUpdate on the live `system` pool, poll the activity log for up to 1h, abort the triggered LRO, and only proceed with the destructive recreate flow if NRP-KVS hits reach threshold.
3. `aks-system-` magic string is now a `systemVMSSPrefix` constant derived from `systemPoolName`, documenting the AKS VMSS naming convention.
4. Dropped the `guard 1/2/3/4` numbering. Helper functions, log lines, and reason strings use semantic labels: `NRP-KVS storm`, `cluster state`, `non-system pools`, `system wedge`.
5. The forced-evidence path now aborts the LRO it triggered with a fresh `context.Background`-rooted context, so cleanup runs even when the parent run context has been cancelled by the overall script timeout.

### Why

The first Stage rollout of #5397 confirmed the wedge but exited no-op because the AKS RP retry storm started ~4 minutes after the script ran:

```text
script ran: 2026-05-28T03:56:26Z (window 03:41:28Z..03:56:28Z)  -> 0 NRP failures
NRP storm:  04:00:53Z..04:32:58Z (12 VMSS-write failures, correlationId 35996c36)
```

A wider window helps daily-rollout environments but not Prod, where the prior storm may be days old and AKS RP has stopped retrying. The forced-evidence trigger re-issues the failing VMSS write itself, watches for the NRP-KVS signature, and aborts cleanly — so the script can detect the wedge in the same rollout without depending on history.

### Testing

- `go test -count=1 ./dev-infrastructure/scripts/recreate-system-pool` — green locally. New table-driven cases cover dry-run skip, trigger-failure, inconclusive evidence, and confirmed evidence paths.
- `make lint`, `make verify`, `make validate-changed-config-pipelines` — green locally.

### Special notes for your reviewer

- The forced-evidence path issues `AgentPoolsClient.BeginCreateOrUpdate` (with the sanitized live spec, so a no-op) on the `system` pool, then `AgentPoolsClient.BeginAbortLatestOperation` on a fresh context regardless of outcome. Both are gated behind the structural checks (cluster state, non-system pools, system wedge) PASSing.
- The trigger path is skipped under `DRY_RUN=true`. Trigger failures (e.g. RP conflict) log a warning and exit no-op; they never fall through to destructive recreate.
- Detection signature is unchanged: exact `Microsoft.Compute/virtualMachineScaleSets/write` op with `NetworkingInternalOperationError` on `aks-system-*` (now `systemVMSSPrefix`), threshold ≥ 10.
- `overallTimeoutMin` is still 60m, the same as the forced-evidence wait. Operators may want to bump it in a follow-up if both phases need to run in the same execution; the abort cleanup runs on its own short-lived `abortTriggerTimeoutMin` budget so a hit overall timeout still tears down the triggered LRO.
- Deeper technical detail lives in [AROSLSRE-958](https://issues.redhat.com/browse/AROSLSRE-958).

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — n/a
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable) — n/a
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
