### PR TITLE
Revert fix cilium connect

### DIFF
--- a/test/e2e/cluster_create_cni_cilium.go
+++ b/test/e2e/cluster_create_cni_cilium.go
@@ -166,9 +166,9 @@ var _ = Describe("Customer", func() {
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodesReady(), verifiers.VerifyCiliumOperational(ciliumNamespace, "k8s-app=cilium"))
 			Expect(errors.Join(err, nodePoolErr)).NotTo(HaveOccurred(), "failed to verify cilium is running and nodes are Ready for cluster %q", customerClusterName)
 
-			By("verifying a simple web app can run with cilium")
-			err = verifiers.VerifySimpleWebApp().Verify(ctx, adminRESTConfig)
-			Expect(err).NotTo(HaveOccurred(), "failed to verify simple web app runs with cilium CNI")
+			By("checking that network works via a simple web app and connectivity checks")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifySimpleWebApp(), verifiers.VerifyCiliumConnectivityChecks("1.19.2"))
+			Expect(err).NotTo(HaveOccurred(), "failed to run simple web app and connectivity check app with cilium CNI")
 		},
 	)
 })

--- a/test/e2e/cluster_create_complex_cilium_kv.go
+++ b/test/e2e/cluster_create_complex_cilium_kv.go
@@ -190,9 +190,9 @@ var _ = Describe("Customer", func() {
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodesReady(), verifiers.VerifyCiliumOperational("kube-system", "k8s-app=cilium"))
 			Expect(errors.Join(err, nodePoolErr, consoleLogErr)).NotTo(HaveOccurred(), "failed to verify nodes are Ready with Cilium CNI for cluster %q", customerClusterName)
 
-			By("verifying a simple web app can run with cilium")
-			err = verifiers.VerifySimpleWebApp().Verify(ctx, adminRESTConfig)
-			Expect(err).NotTo(HaveOccurred(), "failed to verify simple web app runs with cilium CNI")
+			By("checking that network works via a simple web app and connectivity checks")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifySimpleWebApp(), verifiers.VerifyCiliumConnectivityChecks("1.19.2"))
+			Expect(err).NotTo(HaveOccurred(), "failed to run simple web app and connectivity check with cilium CNI")
 		},
 	)
 })

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0000.scc.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0000.scc.yaml
@@ -1,0 +1,25 @@
+# from https://github.com/openshift/hypershift/blob/dc7b179/docs/content/how-to/sdn/other-sdn-providers.md
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: cilium-test
+allowHostPorts: true
+allowHostNetwork: true
+users:
+  - system:serviceaccount:cilium-test:default
+priority: null
+readOnlyRootFilesystem: false
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+volumes: null
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostPID: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+requiredDropCapabilities: null
+groups: null

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0000.scc.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0000.scc.yaml
@@ -6,7 +6,7 @@ metadata:
 allowHostPorts: true
 allowHostNetwork: true
 users:
-  - system:serviceaccount:cilium-connectivity-check:default
+- system:serviceaccount:cilium-connectivity-check:default
 priority: null
 readOnlyRootFilesystem: false
 runAsUser:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0000.scc.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0000.scc.yaml
@@ -2,11 +2,11 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: cilium-test
+  name: cilium-connectivity-check
 allowHostPorts: true
 allowHostNetwork: true
 users:
-  - system:serviceaccount:cilium-test:default
+  - system:serviceaccount:cilium-connectivity-check:default
 priority: null
 readOnlyRootFilesystem: false
 runAsUser:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0001.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0001.yaml
@@ -1,0 +1,57 @@
+---
+metadata:
+  name: echo-a
+  labels:
+    name: echo-a
+    topology: any
+    component: network-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: echo-a
+    spec:
+      hostNetwork: false
+      containers:
+      - name: echo-a-container
+        env:
+        - name: PORT
+          value: "8080"
+        ports:
+        - containerPort: 8080
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:8080
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:8080
+  selector:
+    matchLabels:
+      name: echo-a
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0001.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0001.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-a
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0002.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0002.yaml
@@ -1,0 +1,58 @@
+---
+metadata:
+  name: echo-b
+  labels:
+    name: echo-b
+    topology: any
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: echo-b
+    spec:
+      hostNetwork: false
+      containers:
+      - name: echo-b-container
+        env:
+        - name: PORT
+          value: "8080"
+        ports:
+        - containerPort: 8080
+          hostPort: 40000
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:8080
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:8080
+  selector:
+    matchLabels:
+      name: echo-b
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0002.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0002.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-b
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0003.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0003.yaml
@@ -1,0 +1,66 @@
+---
+metadata:
+  name: echo-b-host
+  labels:
+    name: echo-b-host
+    topology: any
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: echo-b-host
+    spec:
+      hostNetwork: true
+      containers:
+      - name: echo-b-host-container
+        env:
+        - name: PORT
+          value: "21000"
+        ports: []
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:21000
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:21000
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: echo-b-host
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0003.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0003.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-b-host
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0004.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0004.yaml
@@ -1,0 +1,57 @@
+---
+metadata:
+  name: pod-to-a
+  labels:
+    name: pod-to-a
+    topology: any
+    component: network-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-a
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-a-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-a:8080/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-a:8080/public
+  selector:
+    matchLabels:
+      name: pod-to-a
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0004.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0004.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-a
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0005.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0005.yaml
@@ -1,0 +1,47 @@
+---
+metadata:
+  name: pod-to-a-denied-cnp
+  labels:
+    name: pod-to-a-denied-cnp
+    topology: any
+    component: policy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-a-denied-cnp
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-a-denied-cnp-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - ash
+            - -c
+            - '! curl -s --fail --connect-timeout 5 -o /dev/null echo-a:8080/private'
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - ash
+            - -c
+            - '! curl -s --fail --connect-timeout 5 -o /dev/null echo-a:8080/private'
+  selector:
+    matchLabels:
+      name: pod-to-a-denied-cnp
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0005.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0005.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-a-denied-cnp
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0006.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0006.yaml
@@ -1,0 +1,57 @@
+---
+metadata:
+  name: pod-to-a-allowed-cnp
+  labels:
+    name: pod-to-a-allowed-cnp
+    topology: any
+    component: policy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-a-allowed-cnp
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-a-allowed-cnp-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-a:8080/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-a:8080/public
+  selector:
+    matchLabels:
+      name: pod-to-a-allowed-cnp
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0006.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0006.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-a-allowed-cnp
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0007.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0007.yaml
@@ -1,0 +1,67 @@
+---
+metadata:
+  name: pod-to-b-multi-node-clusterip
+  labels:
+    name: pod-to-b-multi-node-clusterip
+    topology: multi-node
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-clusterip
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-b-multi-node-clusterip-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b:8080/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b:8080/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-clusterip
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0007.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0007.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-b-multi-node-clusterip
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0008.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0008.yaml
@@ -1,0 +1,67 @@
+---
+metadata:
+  name: pod-to-b-multi-node-headless
+  labels:
+    name: pod-to-b-multi-node-headless
+    topology: multi-node
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-headless
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-b-multi-node-headless-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-headless:8080/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-headless:8080/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-headless
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0008.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0008.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-b-multi-node-headless
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0009.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0009.yaml
@@ -1,0 +1,68 @@
+---
+metadata:
+  name: host-to-b-multi-node-clusterip
+  labels:
+    name: host-to-b-multi-node-clusterip
+    topology: multi-node
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: host-to-b-multi-node-clusterip
+    spec:
+      hostNetwork: true
+      containers:
+      - name: host-to-b-multi-node-clusterip-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b:8080/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b:8080/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      dnsPolicy: ClusterFirstWithHostNet
+  selector:
+    matchLabels:
+      name: host-to-b-multi-node-clusterip
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0009.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0009.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: host-to-b-multi-node-clusterip
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0010.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0010.yaml
@@ -1,0 +1,68 @@
+---
+metadata:
+  name: host-to-b-multi-node-headless
+  labels:
+    name: host-to-b-multi-node-headless
+    topology: multi-node
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: host-to-b-multi-node-headless
+    spec:
+      hostNetwork: true
+      containers:
+      - name: host-to-b-multi-node-headless-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-headless:8080/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-headless:8080/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      dnsPolicy: ClusterFirstWithHostNet
+  selector:
+    matchLabels:
+      name: host-to-b-multi-node-headless
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0010.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0010.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: host-to-b-multi-node-headless
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0011.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0011.yaml
@@ -1,0 +1,67 @@
+---
+metadata:
+  name: pod-to-b-multi-node-nodeport
+  labels:
+    name: pod-to-b-multi-node-nodeport
+    topology: multi-node
+    component: nodeport-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-nodeport
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-b-multi-node-nodeport-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-host-headless:31414/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-host-headless:31414/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-nodeport
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0011.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0011.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-b-multi-node-nodeport
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0012.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0012.yaml
@@ -1,0 +1,67 @@
+---
+metadata:
+  name: pod-to-b-intra-node-nodeport
+  labels:
+    name: pod-to-b-intra-node-nodeport
+    topology: intra-node
+    component: nodeport-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-intra-node-nodeport
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-b-intra-node-nodeport-container
+        ports: []
+        image: quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-host-headless:31414/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-host-headless:31414/public
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: pod-to-b-intra-node-nodeport
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0012.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0012.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-b-intra-node-nodeport
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0013.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0013.yaml
@@ -1,0 +1,19 @@
+---
+metadata:
+  name: echo-a
+  labels:
+    name: echo-a
+    topology: any
+    component: network-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports:
+  - name: http
+    port: 8080
+  type: ClusterIP
+  selector:
+    name: echo-a
+apiVersion: v1
+kind: Service

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0013.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0013.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-a
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0014.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0014.yaml
@@ -1,0 +1,20 @@
+---
+metadata:
+  name: echo-b
+  labels:
+    name: echo-b
+    topology: any
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports:
+  - name: http
+    port: 8080
+    nodePort: 31414
+  type: NodePort
+  selector:
+    name: echo-b
+apiVersion: v1
+kind: Service

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0014.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0014.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-b
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0015.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0015.yaml
@@ -1,0 +1,20 @@
+---
+metadata:
+  name: echo-b-headless
+  labels:
+    name: echo-b-headless
+    topology: any
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports:
+  - name: http
+    port: 8080
+  type: ClusterIP
+  selector:
+    name: echo-b
+  clusterIP: None
+apiVersion: v1
+kind: Service

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0015.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0015.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-b-headless
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0016.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0016.yaml
@@ -1,0 +1,18 @@
+---
+metadata:
+  name: echo-b-host-headless
+  labels:
+    name: echo-b-host-headless
+    topology: any
+    component: services-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports: []
+  type: ClusterIP
+  selector:
+    name: echo-b-host
+  clusterIP: None
+apiVersion: v1
+kind: Service

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0016.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0016.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: echo-b-host-headless
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0017.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0017.yaml
@@ -1,0 +1,36 @@
+---
+metadata:
+  name: pod-to-a-denied-cnp
+  labels:
+    name: pod-to-a-denied-cnp
+    topology: any
+    component: policy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  endpointSelector:
+    matchLabels:
+      name: pod-to-a-denied-cnp
+  egress:
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
+  - toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: openshift-dns
+        k8s:dns.operator.openshift.io/daemonset-dns: default
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0017.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0017.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-a-denied-cnp
   labels:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0018.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0018.yaml
@@ -1,0 +1,43 @@
+---
+metadata:
+  name: pod-to-a-allowed-cnp
+  labels:
+    name: pod-to-a-allowed-cnp
+    topology: any
+    component: policy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  endpointSelector:
+    matchLabels:
+      name: pod-to-a-allowed-cnp
+  egress:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        name: echo-a
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
+  - toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: openshift-dns
+        k8s:dns.operator.openshift.io/daemonset-dns: default
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0018.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0018.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   name: pod-to-a-allowed-cnp
   labels:

--- a/test/util/verifiers/cilium.go
+++ b/test/util/verifiers/cilium.go
@@ -276,6 +276,23 @@ func (v verifyCiliumConnectivityChecks) Verify(ctx context.Context, adminRESTCon
 			return scheduled >= 2, nil
 		})
 		if waitErr != nil {
+			events, eventsErr := kubeClient.CoreV1().Events(namespaceName).List(ctx, metav1.ListOptions{})
+			if eventsErr != nil {
+				logger.Error(eventsErr, "failed to list events for debugging", "namespace", namespaceName)
+			} else {
+				logger.Info("listing events for debugging echo scheduling failure", "namespace", namespaceName, "eventCount", len(events.Items))
+				for _, event := range events.Items {
+					logger.Info("event",
+						"type", event.Type,
+						"reason", event.Reason,
+						"message", event.Message,
+						"object", fmt.Sprintf("%s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Name),
+						"count", event.Count,
+						"firstTimestamp", event.FirstTimestamp,
+						"lastTimestamp", event.LastTimestamp,
+					)
+				}
+			}
 			return fmt.Errorf("echo-a/echo-b pods were not scheduled in time: %w", waitErr)
 		}
 		logger.Info("echo-a and echo-b pods are scheduled, deploying remaining resources")

--- a/test/util/verifiers/cilium.go
+++ b/test/util/verifiers/cilium.go
@@ -185,7 +185,15 @@ func (v verifyCiliumConnectivityChecks) Verify(ctx context.Context, adminRESTCon
 		}
 	}()
 
-	// Deploy all YAML files from the connectivity check directory
+	// Deploy all YAML files from the connectivity check directory.
+	// Several connectivity check deployments use requiredDuringScheduling
+	// podAntiAffinity against the echo-b label to enforce cross-node
+	// placement. Because this constraint is bidirectional, the scheduler
+	// also blocks echo-b from landing on a node that already hosts one of
+	// those anti-affinity pods. When all deployments are created at once,
+	// a scheduling race can prevent echo-b from ever being placed.
+	// To avoid this, we deploy echo-a and echo-b first and wait for their
+	// pods to be scheduled before creating the remaining resources.
 	expectedPodCount := 0
 	checkDir := fmt.Sprintf("artifacts/cilium-connectivity-check-%s", v.ciliumVersion)
 	entries, err := fs.ReadDir(staticFiles, checkDir)
@@ -193,11 +201,10 @@ func (v verifyCiliumConnectivityChecks) Verify(ctx context.Context, adminRESTCon
 		return fmt.Errorf("failed to read connectivity check artifacts directory: %w", err)
 	}
 
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
-			continue
-		}
+	echoDeploymentNames := map[string]bool{"echo-a": true, "echo-b": true}
+	echoDeploymentsCreated := 0
 
+	createResource := func(entry fs.DirEntry) error {
 		filePath := filepath.Join(checkDir, entry.Name())
 		deploymentYAML, err := staticFiles.ReadFile(filePath)
 		if err != nil {
@@ -213,12 +220,16 @@ func (v verifyCiliumConnectivityChecks) Verify(ctx context.Context, adminRESTCon
 		}
 		if resource.GetKind() == "Deployment" {
 			replicas := int64(1)
-			if spec, ok := resource.Object["spec"].(map[string]interface{}); ok {
+			if spec, ok := resource.Object["spec"].(map[string]any); ok {
 				if r, ok := spec["replicas"].(int64); ok {
 					replicas = r
 				}
 			}
 			expectedPodCount += int(replicas)
+
+			if echoDeploymentNames[resource.GetName()] {
+				echoDeploymentsCreated++
+			}
 		}
 
 		logger.Info("created resource",
@@ -227,7 +238,57 @@ func (v verifyCiliumConnectivityChecks) Verify(ctx context.Context, adminRESTCon
 			"name", resource.GetName(),
 			"namespace", resource.GetNamespace(),
 		)
+		return nil
+	}
 
+	// Phase 1: create resources up to and including both echo deployments.
+	phase2Start := 0
+	for i, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		if err := createResource(entry); err != nil {
+			return err
+		}
+		if echoDeploymentsCreated >= len(echoDeploymentNames) {
+			phase2Start = i + 1
+			break
+		}
+	}
+
+	// Wait for echo-a and echo-b pods to be assigned to nodes before
+	// creating resources with anti-affinity rules against them.
+	if echoDeploymentsCreated >= len(echoDeploymentNames) {
+		logger.Info("waiting for echo-a and echo-b pods to be scheduled")
+		waitErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			pods, listErr := kubeClient.CoreV1().Pods(namespaceName).List(ctx, metav1.ListOptions{
+				LabelSelector: "name in (echo-a, echo-b)",
+			})
+			if listErr != nil {
+				return false, nil
+			}
+			scheduled := 0
+			for _, pod := range pods.Items {
+				if pod.Spec.NodeName != "" {
+					scheduled++
+				}
+			}
+			return scheduled >= 2, nil
+		})
+		if waitErr != nil {
+			return fmt.Errorf("echo-a/echo-b pods were not scheduled in time: %w", waitErr)
+		}
+		logger.Info("echo-a and echo-b pods are scheduled, deploying remaining resources")
+	}
+
+	// Phase 2: create remaining resources.
+	for _, entry := range entries[phase2Start:] {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		if err := createResource(entry); err != nil {
+			return err
+		}
 	}
 
 	// Wait for all test pods to be running and ready. Any unhealthy pod

--- a/test/util/verifiers/cilium.go
+++ b/test/util/verifiers/cilium.go
@@ -14,16 +14,26 @@
 
 package verifiers
 
+// NOTE: This file depends on the staticFiles embed.FS variable defined in
+// serving_app.go, which embeds the artifacts directory containing the
+// cilium-connectivity-check YAML files.
+
 import (
 	"context"
 	"fmt"
+	"io/fs"
+	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -119,4 +129,244 @@ func (v verifyCiliumOperational) Verify(ctx context.Context, adminRESTConfig *re
 // Verifies that all Cilium pods are running in given namespace.
 func VerifyCiliumOperational(ciliumNamespace string, ciliumLabelSelector string) HostedClusterVerifier {
 	return verifyCiliumOperational{ciliumNamespace: ciliumNamespace, ciliumLabelSelector: ciliumLabelSelector}
+}
+
+type verifyCiliumConnectivityChecks struct {
+	ciliumVersion string
+}
+
+func (v verifyCiliumConnectivityChecks) Name() string {
+	return "VerifyCiliumConnectivityChecks"
+}
+
+func (v verifyCiliumConnectivityChecks) Verify(ctx context.Context, adminRESTConfig *rest.Config) error {
+	logger := ginkgo.GinkgoLogr
+
+	kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	// Create namespace for the connectivity check
+	namespaceName := "cilium-connectivity-check"
+	namespace, err := kubeClient.CoreV1().Namespaces().Create(
+		ctx,
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespaceName,
+			},
+		},
+		metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create test namespace: %w", err)
+	}
+	logger.Info("namespace for connectivity check was created", "namespace", namespaceName)
+
+	// Ensure namespace and SCCs cleanup on exit, SCCs are cluster-scoped so
+	// must be deleted explicitly
+	sccNames := []string{}
+	sccGVR := schema.GroupVersionResource{Group: "security.openshift.io", Version: "v1", Resource: "securitycontextconstraints"}
+	defer func() {
+		deleteCtx := context.Background()
+		for _, sccName := range sccNames {
+			err := dynamicClient.Resource(sccGVR).Delete(deleteCtx, sccName, metav1.DeleteOptions{})
+			if err != nil {
+				logger.Error(err, "failed to delete SCC", "name", sccName)
+			}
+		}
+		err := kubeClient.CoreV1().Namespaces().Delete(deleteCtx, namespaceName, metav1.DeleteOptions{})
+		if err != nil {
+			logger.Error(err, "failed to delete test namespace", "namespace", namespaceName)
+		}
+	}()
+
+	// Deploy all YAML files from the connectivity check directory
+	expectedPodCount := 0
+	checkDir := fmt.Sprintf("artifacts/cilium-connectivity-check-%s", v.ciliumVersion)
+	entries, err := fs.ReadDir(staticFiles, checkDir)
+	if err != nil {
+		return fmt.Errorf("failed to read connectivity check artifacts directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+
+		filePath := filepath.Join(checkDir, entry.Name())
+		deploymentYAML, err := staticFiles.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", filePath, err)
+		}
+
+		resource, err := createArbitraryResource(ctx, dynamicClient, namespace.Name, deploymentYAML)
+		if err != nil {
+			return fmt.Errorf("failed to create test resource from %s: %w", filePath, err)
+		}
+		if resource.GetKind() == "SecurityContextConstraints" {
+			sccNames = append(sccNames, resource.GetName())
+		}
+		if resource.GetKind() == "Deployment" {
+			replicas := int64(1)
+			if spec, ok := resource.Object["spec"].(map[string]interface{}); ok {
+				if r, ok := spec["replicas"].(int64); ok {
+					replicas = r
+				}
+			}
+			expectedPodCount += int(replicas)
+		}
+
+		logger.Info("created resource",
+			"file", entry.Name(),
+			"kind", resource.GetKind(),
+			"name", resource.GetName(),
+			"namespace", resource.GetNamespace(),
+		)
+
+	}
+
+	// Wait for all test pods to be running and ready. Any unhealthy pod
+	// indicates a failed connectivity check.
+	var lastErr error
+	logger.Info("expecting pods from deployed Deployments", "count", expectedPodCount)
+	var lastNotReadyPods []string
+	err = wait.PollUntilContextTimeout(ctx, 30*time.Second, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pods, err := kubeClient.CoreV1().Pods(namespaceName).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("failed to list pods in %s namespace: %w", namespaceName, err)
+			return false, nil
+		}
+
+		if len(pods.Items) < expectedPodCount {
+			lastErr = fmt.Errorf("expected %d pods in %s namespace, found %d", expectedPodCount, namespaceName, len(pods.Items))
+			return false, nil
+		}
+
+		notReadyPods := []string{}
+		for _, pod := range pods.Items {
+			// Check if the pod is running, any other state (including
+			// succeeded) indicates an error reported by a connectivity check
+			if pod.Status.Phase != corev1.PodRunning {
+				notReadyPods = append(notReadyPods, fmt.Sprintf("%s (phase: %s)", pod.Name, pod.Status.Phase))
+				continue
+			}
+
+			// Check if pod is ready - this is critical for connectivity checks
+			// as readiness probes are used to indicate test success/failure
+			podReady := false
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == corev1.PodReady {
+					if condition.Status == corev1.ConditionTrue {
+						podReady = true
+					}
+					break
+				}
+			}
+
+			// Detect liveness probe failures: a failing liveness probe kills
+			// and restarts the container, leaving it in Waiting state
+			// (e.g. CrashLoopBackOff) while the pod phase stays Running.
+			livenessFailure := ""
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
+					livenessFailure = fmt.Sprintf("container %s waiting: %s", cs.Name, cs.State.Waiting.Reason)
+					podReady = false
+					break
+				}
+			}
+
+			if !podReady {
+				if livenessFailure != "" {
+					notReadyPods = append(notReadyPods, fmt.Sprintf("%s (%s)", pod.Name, livenessFailure))
+				} else {
+					notReadyPods = append(notReadyPods, fmt.Sprintf("%s (running but not ready)", pod.Name))
+				}
+			}
+		}
+
+		if len(notReadyPods) > 0 {
+			// We are logging only status changes
+			slices.Sort(notReadyPods)
+			if !slices.Equal(notReadyPods, lastNotReadyPods) {
+				logger.Info("waiting for test pods to be ready", "notReady", notReadyPods)
+			}
+			lastErr = fmt.Errorf("test pods not yet ready: %v", notReadyPods)
+			lastNotReadyPods = notReadyPods
+			return false, nil
+		}
+
+		logger.Info("all connectivity check test pods are ready")
+
+		lastNotReadyPods = []string{}
+		return true, nil
+	})
+
+	// If the waiting failed on a timeout, some connectivity check pod must
+	// have failed, so we need to report what failed exactly.
+	if err != nil {
+		// Log all events in the test namespace to help with debugging, as
+		// failures in liveness or readiness probes will be visible there
+		events, eventsErr := kubeClient.CoreV1().Events(namespaceName).List(ctx, metav1.ListOptions{})
+		if eventsErr != nil {
+			logger.Error(eventsErr, "failed to list k8s events", "namespace", namespaceName)
+		} else {
+			logger.Info("listing k8s events", "namespace", namespaceName, "eventCount", len(events.Items))
+			for _, event := range events.Items {
+				logger.Info("event",
+					"type", event.Type,
+					"reason", event.Reason,
+					"message", event.Message,
+					"object", fmt.Sprintf("%s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Name),
+					"count", event.Count,
+					"firstTimestamp", event.FirstTimestamp,
+					"lastTimestamp", event.LastTimestamp,
+				)
+			}
+		}
+		// The pods use "terminationMessagePolicy: FallbackToLogsOnError"
+		// to report errors, so we log termination messages
+		pods, podsErr := kubeClient.CoreV1().Pods(namespaceName).List(ctx, metav1.ListOptions{})
+		if podsErr != nil {
+			logger.Error(podsErr, "failed to list pods for error reporting purposes", "namespace", namespaceName)
+		} else {
+			for _, pod := range pods.Items {
+				for _, cs := range pod.Status.ContainerStatuses {
+					if t := cs.State.Terminated; t != nil {
+						logger.Info("terminated container",
+							"pod", pod.Name,
+							"container", cs.Name,
+							"exitCode", t.ExitCode,
+							"message", t.Message,
+						)
+					}
+					if t := cs.LastTerminationState.Terminated; t != nil {
+						logger.Info("last terminated container",
+							"pod", pod.Name,
+							"container", cs.Name,
+							"exitCode", t.ExitCode,
+							"message", t.Message,
+						)
+					}
+				}
+			}
+		}
+		if lastErr != nil {
+			return fmt.Errorf("connectivity check failed, not all pods in %s namespace are ready: %w", namespaceName, lastErr)
+		}
+		return fmt.Errorf("connectivity check failed waiting for pods in %s namespace: %w", namespaceName, err)
+	}
+
+	return nil
+}
+
+// Deploy and run Cilium Connectivity Checks, set of deployments that will
+// perform a series of connectivity checks via liveness and readiness checks.
+// An unhealthy/unready pod indicates a problem.
+func VerifyCiliumConnectivityChecks(ciliumVersion string) HostedClusterVerifier {
+	return verifyCiliumConnectivityChecks{ciliumVersion: ciliumVersion}
 }

--- a/test/util/verifiers/helper.go
+++ b/test/util/verifiers/helper.go
@@ -124,6 +124,16 @@ var defaultRESTMappings = []meta.RESTMapping{
 		Scope:            meta.RESTScopeRoot,
 		Resource:         schema.GroupVersionResource{Group: "security.openshift.io", Version: "v1", Resource: "securitycontextconstraints"},
 	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "cilium.io", Version: "v1alpha1", Kind: "CiliumConfig"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "cilium.io", Version: "v1alpha1", Resource: "ciliumconfigs"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "cilium.io", Version: "v2", Kind: "CiliumNetworkPolicy"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "cilium.io", Version: "v2", Resource: "ciliumnetworkpolicies"},
+	},
 }
 
 var localRESTMapper = newHardcodedRESTMapper()


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-27342

### What

Bring back changes revert in #5408 and add fix to it from #5407.

The fix updates the Cilium connectivity check verifier to reduce a scheduler race by deploying the echo-a/echo-b Deployments first, waiting for their pods to be scheduled, and then creating the remaining connectivity-check resources.
