### PR TITLE
Add PrometheusMetricsAbsent alert (sev 3)

### DIFF
--- a/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
+++ b/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
@@ -10,10 +10,50 @@ param actionGroups array
 @description('Whether alerts are enabled')
 param enabled bool
 
+@description('Runbook URL for Prometheus metrics absent alert')
+param prometheusRunbookUrl string = 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/prometheus.html'
+
 var amwName = last(split(azureMonitorWorkspaceId, '/'))
 
 // Severity 4 (Informational): approaching limits — capacity planning signal
 // Severity 3 (Warning): high risk of throttling — matches all other production alerts in the repo
+
+resource prometheusMetricsAbsent 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'PrometheusMetricsAbsent - ${workspaceLabel} - ${amwName}'
+  location: resourceGroup().location
+  properties: {
+    enabled: enabled
+    scopes: [
+      azureMonitorWorkspaceId
+    ]
+    rules: [
+      {
+        alert: 'PrometheusMetricsAbsent'
+        expression: 'absent(up{job="prometheus/prometheus",namespace="prometheus"})'
+        for: 'PT10M'
+        severity: 3
+        enabled: true
+        annotations: {
+          description: 'The up metric for Prometheus in the prometheus namespace has been absent for the past 10 minutes. This indicates that Prometheus is not reporting any metrics, which means no data is being sent to the Azure Monitor Workspace. Check the status of the Prometheus pods, verify scrape configurations, and ensure remote write is functioning.'
+          runbook_url: prometheusRunbookUrl
+          summary: 'Prometheus up metric is absent.'
+        }
+        labels: {
+          severity: 'warning'
+        }
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+          }
+        ]
+      }
+    ]
+  }
+}
 
 resource approachingActiveTimeSeries 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: 'AMW Approaching Active TimeSeries Limit - ${workspaceLabel} - ${amwName}'


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-948

### What

Add a new warning-severity alert that fires when the Prometheus up metric is completely absent for 10 minutes, indicating no metrics data is reaching the Azure Monitor Workspace.

This complements the existing PrometheusJobUp alert which detects Prometheus being down (up=0). PrometheusMetricsAbsent catches a different failure mode where the scrape target itself is missing or remote write has stopped entirely — the up metric does not exist at all rather than reporting an unhealthy value.
