### PR TITLE
Prepare slot-manager for rollout

### DIFF
--- a/test/cmd/aro-hcp-tests/slot-manager/DESIGN.md
+++ b/test/cmd/aro-hcp-tests/slot-manager/DESIGN.md
@@ -61,12 +61,22 @@ scale independently from the infrastructure-subscription work.
 - The canonical E2E slot inventory lives in ARO-HCP.
 - Runtime leasing is done through `aro-hcp-tests slot-manager` and the ci-operator Boskos proxy.
 - The E2E workflow in `openshift/release` uses dedicated acquire/release steps that wrap the CLI.
+- Pool selection is now driven by an explicit selector contract:
+  - `ALLOWED_SUBSCRIPTIONS`
+    - candidate-pool allowlist keyed by catalog `subscription_name`
+  - `ALLOWED_LOCATIONS`
+    - fixed-mode candidate-pool allowlist keyed by region
+  - `MULTISTAGE_PARAM_OVERRIDE_LOCATION`
+    - highest-precedence concrete runtime location
+    - when set it overrides `ALLOWED_LOCATIONS` for fixed-mode pool selection
+    - for runtime-selected pools it does not change pool identity, but it does become the concrete runtime location
 - The runtime env contract is intentionally narrow and non-secret:
   - `CUSTOMER_SUBSCRIPTION`
-  - `LOCATION`
+  - `SELECTED_LOCATION`
   - `LEASED_MSI_CONTAINERS`
   - `ARO_HCP_E2E_SLOT_NAME`
   - `ARO_HCP_E2E_SLOT_RESOURCE_TYPE`
+- Downstream `openshift/release` steps still mostly consume `LOCATION` today, so the release-side scripts map `SELECTED_LOCATION` back into `LOCATION` where needed.
 
 ### Coordinate model by environment
 
@@ -85,8 +95,8 @@ scale independently from the infrastructure-subscription work.
     - Prod has presence in many regions, so region is a real routing coordinate here.
     - `prod` also has periodic E2E jobs pinned to `uksouth` today, declared in `release/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml`.
     - Concurrency for a particular region is usually `1` (although it can be higher for `uksouth` due to periodics), but several customer subscriptions are still needed to run tests against multiple prod regions concurrently.
-    - The expectation is that Gangway-triggered prod gating jobs set `MULTISTAGE_PARAM_OVERRIDE_LOCATION` per target region when invoking the job. `slot-manager acquire` gives that override precedence over `LOCATION` during slot selection, and the leased slot then becomes the authoritative runtime `LOCATION` for downstream steps.
-    - This also means we need to watch for any step that bypasses that contract and accidentally uses a stale/default location instead of the leased one.
+    - The expectation is that Gangway-triggered prod gating jobs set `MULTISTAGE_PARAM_OVERRIDE_LOCATION` per target region when invoking the job. `slot-manager acquire` gives that override precedence over `ALLOWED_LOCATIONS` on the acquire side, and the leased slot then exports the authoritative runtime `SELECTED_LOCATION` for downstream steps.
+    - This also means we need to watch for any step that bypasses that contract and accidentally uses a stale/default `LOCATION` instead of the release-mapped `SELECTED_LOCATION`.
 
 ### Pool selection and lease acquisition flow
 
@@ -99,8 +109,8 @@ flowchart TD
 
     DetectMode --> IsFixed{region_mode?}
 
-    IsFixed -->|fixed| FixedFilter["Filter pools by:\n1. --subscription-name if set\n2. --region if set\nBoth narrow the candidate list"]
-    IsFixed -->|runtime-selected| RSFilter["Filter pools by:\n1. --subscription-name if set\n--region is ignored for filtering\nbecause region is chosen at runtime"]
+    IsFixed -->|fixed| FixedFilter["Fixed-mode filter:\n1. allowed subscriptions\n2. override location if set\n3. else allowed locations"]
+    IsFixed -->|runtime-selected| RSFilter["Runtime-selected filter:\n1. allowed subscriptions\n2. ignore allowed locations\nfor pool identity"]
 
     FixedFilter --> Candidates["Ordered candidate pool list"]
     RSFilter --> Candidates
@@ -111,8 +121,8 @@ flowchart TD
 
     LeaseResult -->|success| ResolveRegion{region_mode?}
     ResolveRegion -->|fixed| UsePoolRegion["Runtime region =\npool.Region"]
-    ResolveRegion -->|runtime-selected| HasOverride{--region set?}
-    HasOverride -->|yes| UseOverride["Runtime region =\n--region"]
+    ResolveRegion -->|runtime-selected| HasOverride{Override location set?}
+    HasOverride -->|yes| UseOverride["Runtime region =\noverride location"]
     HasOverride -->|no| UseFallback["Runtime region =\npool.Region as default"]
 
     UsePoolRegion --> Finalize
@@ -121,11 +131,12 @@ flowchart TD
 
     Finalize["Finalize:\n1. Verify subscription in cluster profile\n2. Write state file\n3. Write env file"]
 
-    LeaseResult -->|pool exhausted| MorePools{More candidate\npools?}
+    LeaseResult -->|no immediate lease| Unavailable["Temporarily unavailable now:\nproxy timeout,\nretry budget exhaustion,\nor retryable proxy response"]
+    Unavailable --> MorePools{More candidate\npools?}
     MorePools -->|yes| TryPool
     MorePools -->|no| WaitCheck{max_wait_for_lease\nexpired?}
     WaitCheck -->|no| Sleep["Sleep lease_wait_interval"] --> PassStart
-    WaitCheck -->|yes| Fail["Fail: all pools exhausted"]
+    WaitCheck -->|yes| Fail["Fail: no pool yielded an\nimmediate lease within budget"]
 
     LeaseResult -->|fatal error| Abort["Abort: non-retryable error"]
 ```
@@ -137,14 +148,21 @@ flowchart TD
   - `region_mode: fixed|runtime-selected` plus optional `identity_provisioning_region`,
   - Boskos managed-block sync/validation tooling,
   - release step wiring,
-  - formalized non-secret runtime contract.
+  - formalized non-secret runtime contract centered on `SELECTED_LOCATION`.
 - Multi-pool candidate selection and fallback are implemented:
-  - fixed-mode environments filter candidate pools by the requested runtime region and then try pools in catalog order,
-  - runtime-selected environments ignore region for pool identity and then try subscription-backed pools in catalog order,
-  - one full pass over the candidate pools is now the retry unit when every pool is exhausted.
-- Exhausted-pool waiting is now explicit and separated from transient proxy/network handling:
-  - per-request `lease-proxy-timeout` plus exponential backoff still only covers transient Boskos/proxy/network issues,
-  - all-pools-exhausted waiting now uses `lease_wait_interval` and `max_wait_for_lease`,
+  - fixed-mode environments filter candidate pools by `ALLOWED_SUBSCRIPTIONS` and either `ALLOWED_LOCATIONS` or `MULTISTAGE_PARAM_OVERRIDE_LOCATION`, then try pools in catalog order,
+  - runtime-selected environments use `ALLOWED_SUBSCRIPTIONS` for pool identity, ignore `ALLOWED_LOCATIONS` for candidate selection, and use `MULTISTAGE_PARAM_OVERRIDE_LOCATION` only as the concrete runtime location,
+  - current `openshift/release` dev rollout pins the normal `e2e-parallel` job to the first dev pool on `ARO HCP E2E Hosted Clusters (EA Subscription)` in `centralus`,
+  - the separate `e2e-parallel-multipool` job exercises only the additional pools on `ARO HCP E2E Hosted Clusters 2 (EA Subscription)` in `centralus` and `westus3`.
+- Pool fallback is now adapted to the Boskos proxy's blocking acquire behavior:
+  - the proxy does not reliably give `slot-manager` a distinct immediate "pool exhausted" signal for candidate failover,
+  - each candidate pool probe is therefore bounded by `lease-proxy-timeout` and interpreted through the client-side `ErrLeasePoolUnavailableNow` classification,
+  - timeout-budget exhaustion and retryable proxy/server failures now mean "this pool did not yield an immediate lease now; try the next candidate pool",
+  - one full pass over the candidate pools is the retry unit when every candidate is temporarily unavailable.
+- Waiting is now explicit and separated from transient proxy/network retry handling:
+  - per-request `lease-proxy-timeout` plus exponential backoff covers one bounded probe of a single candidate pool,
+  - repeated full-pass waiting now uses `lease_wait_interval` and `max_wait_for_lease`,
+  - the default per-pool `lease-proxy-timeout` is now `30s`,
   - the current defaults are `lease_wait_interval=1m` and `max_wait_for_lease=30m`,
   - `max_wait_for_lease=0` means wait forever,
   - `openshift/release` now exposes `ARO_HCP_SLOT_MANAGER_LEASE_WAIT_INTERVAL` and `ARO_HCP_SLOT_MANAGER_MAX_WAIT_FOR_LEASE` as optional per-job overrides.

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/Azure/ARO-HCP/test/cmd/aro-hcp-tests/slot-manager/slots"
 )
@@ -34,37 +35,57 @@ const (
 )
 
 func DefaultAcquireOptions() *RawAcquireOptions {
+	allowedSubscriptions, allowedLocations, selectedLocation := defaultAcquireSelectors()
 	return &RawAcquireOptions{
-		ClusterProfileDir: os.Getenv("CLUSTER_PROFILE_DIR"),
-		DeployEnv:         os.Getenv("ARO_HCP_DEPLOY_ENV"),
-		Region:            defaultAcquireRegion(),
-		SharedDir:         os.Getenv("SHARED_DIR"),
+		ClusterProfileDir:    strings.TrimSpace(os.Getenv("CLUSTER_PROFILE_DIR")),
+		DeployEnv:            strings.TrimSpace(os.Getenv("ARO_HCP_DEPLOY_ENV")),
+		AllowedSubscriptions: allowedSubscriptions,
+		AllowedLocations:     allowedLocations,
+		SelectedLocation:     selectedLocation,
+		SharedDir:            strings.TrimSpace(os.Getenv("SHARED_DIR")),
 
-		LeaseProxyServerURL: os.Getenv("LEASE_PROXY_SERVER_URL"),
+		LeaseProxyServerURL: strings.TrimSpace(os.Getenv("LEASE_PROXY_SERVER_URL")),
 		LeaseProxyTimeout:   slots.DefaultLeaseProxyTimeout,
 		MaxWaitForLease:     DefaultMaxWaitForLease,
 		LeaseWaitInterval:   DefaultLeaseWaitInterval,
 	}
 }
 
-func defaultAcquireRegion() string {
-	for _, value := range []string{
-		os.Getenv("MULTISTAGE_PARAM_OVERRIDE_LOCATION"),
-		os.Getenv("LOCATION"),
-	} {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
+func defaultAcquireSelectors() ([]string, []string, string) {
+	allowedSubscriptions := splitSelectorValues(os.Getenv("ALLOWED_SUBSCRIPTIONS"))
+	selectedLocation := strings.TrimSpace(os.Getenv("MULTISTAGE_PARAM_OVERRIDE_LOCATION"))
+	if selectedLocation != "" {
+		return allowedSubscriptions, nil, selectedLocation
 	}
 
-	return ""
+	return allowedSubscriptions, splitSelectorValues(os.Getenv("ALLOWED_LOCATIONS")), ""
+}
+
+func splitSelectorValues(raw string) []string {
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == '\n'
+	})
+	values := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+		if _, found := seen[value]; found {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	return values
 }
 
 func BindAcquireOptions(opts *RawAcquireOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.ClusterProfileDir, "cluster-profile-dir", opts.ClusterProfileDir, "Path to CLUSTER_PROFILE_DIR")
 	cmd.Flags().StringVar(&opts.DeployEnv, "deploy-env", opts.DeployEnv, "Deploy environment name (prow, ci01, int, stg, prod)")
-	cmd.Flags().StringVar(&opts.SubscriptionName, "subscription-name", opts.SubscriptionName, "Optional subscription name selector for environments with multiple pools.")
-	cmd.Flags().StringVar(&opts.Region, "region", opts.Region, "Optional runtime region selector. For fixed pools it also participates in pool selection.")
+	cmd.Flags().StringSliceVar(&opts.AllowedSubscriptions, "allowed-subscriptions", opts.AllowedSubscriptions, "Optional catalog subscription_name values allowed for candidate pool selection.")
+	cmd.Flags().StringSliceVar(&opts.AllowedLocations, "allowed-locations", opts.AllowedLocations, "Optional Azure regions allowed for fixed-mode candidate pool selection.")
 	cmd.Flags().StringVar(&opts.SharedDir, "shared-dir", opts.SharedDir, "Path to SHARED_DIR")
 	cmd.Flags().StringVar(&opts.CatalogPath, "slot-catalog", opts.CatalogPath, "Path to the canonical E2E slot catalog")
 	cmd.Flags().StringVar(&opts.LeaseProxyServerURL, "lease-proxy-server-url", opts.LeaseProxyServerURL, "Lease proxy server URL")
@@ -75,16 +96,17 @@ func BindAcquireOptions(opts *RawAcquireOptions, cmd *cobra.Command) error {
 }
 
 type RawAcquireOptions struct {
-	ClusterProfileDir   string
-	DeployEnv           string
-	SubscriptionName    string
-	Region              string
-	SharedDir           string
-	CatalogPath         string
-	LeaseProxyServerURL string
-	LeaseProxyTimeout   time.Duration
-	MaxWaitForLease     time.Duration
-	LeaseWaitInterval   time.Duration
+	ClusterProfileDir    string
+	DeployEnv            string
+	AllowedSubscriptions []string
+	AllowedLocations     []string
+	SelectedLocation     string
+	SharedDir            string
+	CatalogPath          string
+	LeaseProxyServerURL  string
+	LeaseProxyTimeout    time.Duration
+	MaxWaitForLease      time.Duration
+	LeaseWaitInterval    time.Duration
 }
 
 type validatedAcquireOptions struct {
@@ -103,11 +125,13 @@ type completedAcquireOptions struct {
 	LeaseProxyTimeout time.Duration
 	MaxWaitForLease   time.Duration
 	LeaseWaitInterval time.Duration
-	RequestedRegion   string
-	CandidatePools    []slots.Pool
-	PoolEnvironment   string
-	Now               func() time.Time
-	Sleep             func(context.Context, time.Duration) error
+	// RuntimeLocationOverride carries the concrete runtime region when pool
+	// identity is decoupled from region selection.
+	RuntimeLocationOverride string
+	CandidatePools          []slots.Pool
+	PoolEnvironment         string
+	Now                     func() time.Time
+	Sleep                   func(context.Context, time.Duration) error
 }
 
 type AcquireOptions struct {
@@ -145,13 +169,13 @@ func Acquire(ctx context.Context, opts *RawAcquireOptions) error {
 
 func (o *RawAcquireOptions) Validate() (*ValidatedAcquireOptions, error) {
 	switch {
-	case strings.TrimSpace(o.ClusterProfileDir) == "":
+	case o.ClusterProfileDir == "":
 		return nil, fmt.Errorf("--cluster-profile-dir must not be empty")
-	case strings.TrimSpace(o.DeployEnv) == "":
+	case o.DeployEnv == "":
 		return nil, fmt.Errorf("--deploy-env must not be empty")
-	case strings.TrimSpace(o.SharedDir) == "":
+	case o.SharedDir == "":
 		return nil, fmt.Errorf("--shared-dir must not be empty")
-	case strings.TrimSpace(o.LeaseProxyServerURL) == "":
+	case o.LeaseProxyServerURL == "":
 		return nil, fmt.Errorf("--lease-proxy-server-url must not be empty")
 	case o.LeaseProxyTimeout <= 0:
 		return nil, fmt.Errorf("--lease-proxy-timeout must be greater than zero")
@@ -177,25 +201,25 @@ func (o *ValidatedAcquireOptions) Complete(_ context.Context) (*AcquireOptions, 
 		return nil, err
 	}
 
-	candidatePools, err := catalog.CandidatePools(environment, o.SubscriptionName, o.Region)
+	candidatePools, err := catalog.CandidatePools(environment, sets.New(o.AllowedSubscriptions...), sets.New(o.AllowedLocations...), o.SelectedLocation)
 	if err != nil {
 		return nil, err
 	}
 
 	return &AcquireOptions{
 		completedAcquireOptions: &completedAcquireOptions{
-			ClusterProfileDir: o.ClusterProfileDir,
-			DeployEnvironment: o.DeployEnv,
-			SharedDir:         o.SharedDir,
-			LeaseProxyURL:     o.LeaseProxyServerURL,
-			LeaseProxyTimeout: o.LeaseProxyTimeout,
-			MaxWaitForLease:   o.MaxWaitForLease,
-			LeaseWaitInterval: o.LeaseWaitInterval,
-			RequestedRegion:   strings.TrimSpace(o.Region),
-			CandidatePools:    candidatePools,
-			PoolEnvironment:   environment,
-			Now:               time.Now,
-			Sleep:             sleepContext,
+			ClusterProfileDir:       o.ClusterProfileDir,
+			DeployEnvironment:       o.DeployEnv,
+			SharedDir:               o.SharedDir,
+			LeaseProxyURL:           o.LeaseProxyServerURL,
+			LeaseProxyTimeout:       o.LeaseProxyTimeout,
+			MaxWaitForLease:         o.MaxWaitForLease,
+			LeaseWaitInterval:       o.LeaseWaitInterval,
+			RuntimeLocationOverride: o.SelectedLocation,
+			CandidatePools:          candidatePools,
+			PoolEnvironment:         environment,
+			Now:                     time.Now,
+			Sleep:                   sleepContext,
 		},
 	}, nil
 }
@@ -316,8 +340,8 @@ func (o *AcquireOptions) Run(ctx context.Context) error {
 }
 
 func (o *AcquireOptions) runtimeRegionForPool(pool slots.Pool) string {
-	if requestedRegion := strings.TrimSpace(o.RequestedRegion); requestedRegion != "" {
-		return requestedRegion
+	if o.RuntimeLocationOverride != "" {
+		return o.RuntimeLocationOverride
 	}
 	return pool.Region
 }

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/Azure/ARO-HCP/test/cmd/aro-hcp-tests/slot-manager/slots"

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire.go
@@ -68,9 +68,9 @@ func BindAcquireOptions(opts *RawAcquireOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.SharedDir, "shared-dir", opts.SharedDir, "Path to SHARED_DIR")
 	cmd.Flags().StringVar(&opts.CatalogPath, "slot-catalog", opts.CatalogPath, "Path to the canonical E2E slot catalog")
 	cmd.Flags().StringVar(&opts.LeaseProxyServerURL, "lease-proxy-server-url", opts.LeaseProxyServerURL, "Lease proxy server URL")
-	cmd.Flags().DurationVar(&opts.LeaseProxyTimeout, "lease-proxy-timeout", opts.LeaseProxyTimeout, "Timeout per lease proxy request attempt")
-	cmd.Flags().DurationVar(&opts.MaxWaitForLease, "max-wait-for-lease", opts.MaxWaitForLease, "Maximum total time to keep retrying after full candidate-pool exhaustion. Zero waits forever.")
-	cmd.Flags().DurationVar(&opts.LeaseWaitInterval, "lease-wait-interval", opts.LeaseWaitInterval, "Wait between retries after a full exhausted pass across all candidate pools.")
+	cmd.Flags().DurationVar(&opts.LeaseProxyTimeout, "lease-proxy-timeout", opts.LeaseProxyTimeout, "Maximum time to spend probing a single candidate pool, including retryable proxy/network retries.")
+	cmd.Flags().DurationVar(&opts.MaxWaitForLease, "max-wait-for-lease", opts.MaxWaitForLease, "Maximum total time to keep retrying after full candidate-pool passes yield no immediate lease. Zero waits forever.")
+	cmd.Flags().DurationVar(&opts.LeaseWaitInterval, "lease-wait-interval", opts.LeaseWaitInterval, "Wait between retries after a full candidate-pool pass yields no immediate lease.")
 	return nil
 }
 
@@ -233,15 +233,15 @@ func (o *AcquireOptions) Run(ctx context.Context) error {
 	}
 
 	for pass := 1; ; pass++ {
-		exhaustedPools := make([]string, 0, len(o.CandidatePools))
+		unavailablePools := make([]string, 0, len(o.CandidatePools))
 
 		for _, pool := range o.CandidatePools {
 			leasedName, err := slots.AcquireLease(ctx, o.LeaseProxyURL, pool.ResourceType, o.LeaseProxyTimeout)
 			if err != nil {
-				if errors.Is(err, slots.ErrLeasePoolExhausted) {
-					exhaustedPools = append(exhaustedPools, describePool(pool))
+				if errors.Is(err, slots.ErrLeasePoolUnavailableNow) {
+					unavailablePools = append(unavailablePools, describePool(pool))
 					logger.Info(
-						"Candidate pool exhausted, trying next pool",
+						"Candidate pool did not yield an immediate lease, trying next pool",
 						"pass", pass,
 						"environment", o.PoolEnvironment,
 						"pool", describePool(pool),
@@ -265,47 +265,52 @@ func (o *AcquireOptions) Run(ctx context.Context) error {
 			return o.finalizeAcquiredLease(ctx, logger, pool, leasedName)
 		}
 
+		poolFailureSummary := strings.Join(unavailablePools, ", ")
+		waitMessage := "No candidate pool yielded an immediate lease, waiting before retrying full pass"
+
 		if o.MaxWaitForLease > 0 {
 			currentTime := now()
 			if !currentTime.Before(deadline) {
 				return fmt.Errorf(
-					"all candidate pools for environment %q were exhausted for %s across %d full pass(es): %s",
+					"no candidate pool for environment %q yielded an immediate lease for %s across %d full pass(es): %s",
 					o.PoolEnvironment,
 					o.MaxWaitForLease,
 					pass,
-					strings.Join(exhaustedPools, ", "),
+					poolFailureSummary,
 				)
 			}
 
 			remainingWait := deadline.Sub(currentTime)
 			sleepDuration := min(o.LeaseWaitInterval, deadline.Sub(currentTime))
 			logger.Info(
-				"All candidate pools exhausted, waiting before retrying full pass",
+				waitMessage,
 				"pass", pass,
 				"environment", o.PoolEnvironment,
 				"candidatePoolCount", len(o.CandidatePools),
+				"candidatePoolFailures", poolFailureSummary,
 				"sleepDuration", sleepDuration,
 				"leaseWaitInterval", o.LeaseWaitInterval,
 				"remainingWait", remainingWait,
 				"maxWaitForLease", o.MaxWaitForLease,
 			)
 			if err := sleep(ctx, sleepDuration); err != nil {
-				return fmt.Errorf("waiting to retry exhausted candidate pools: %w", err)
+				return fmt.Errorf("waiting to retry candidate pool pass: %w", err)
 			}
 			continue
 		}
 
 		logger.Info(
-			"All candidate pools exhausted, waiting before retrying full pass",
+			waitMessage,
 			"pass", pass,
 			"environment", o.PoolEnvironment,
 			"candidatePoolCount", len(o.CandidatePools),
+			"candidatePoolFailures", poolFailureSummary,
 			"sleepDuration", o.LeaseWaitInterval,
 			"leaseWaitInterval", o.LeaseWaitInterval,
 			"maxWaitForLease", o.MaxWaitForLease,
 		)
 		if err := sleep(ctx, o.LeaseWaitInterval); err != nil {
-			return fmt.Errorf("waiting to retry exhausted candidate pools: %w", err)
+			return fmt.Errorf("waiting to retry candidate pool pass: %w", err)
 		}
 	}
 }

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
@@ -187,6 +187,9 @@ func TestDefaultAcquireOptionsLeaseWaitDefaults(t *testing.T) {
 	t.Parallel()
 
 	opts := DefaultAcquireOptions()
+	if opts.LeaseProxyTimeout != slots.DefaultLeaseProxyTimeout {
+		t.Fatalf("expected default lease proxy timeout %s, got %s", slots.DefaultLeaseProxyTimeout, opts.LeaseProxyTimeout)
+	}
 	if opts.LeaseWaitInterval != DefaultLeaseWaitInterval {
 		t.Fatalf("expected default lease wait interval %s, got %s", DefaultLeaseWaitInterval, opts.LeaseWaitInterval)
 	}
@@ -229,7 +232,7 @@ environments:
 
 	server, acquireCalls, releaseCalls := newTestLeaseProxyServer(t, map[string][]leaseProxyReply{
 		"aro-hcp-dev-centralus-a-slot": {
-			exhaustedAcquireReply("aro-hcp-dev-centralus-a-slot"),
+			unavailableAcquireReply("aro-hcp-dev-centralus-a-slot"),
 		},
 		"aro-hcp-dev-centralus-b-slot": {
 			successAcquireReply("aro-hcp-dev-centralus-b-slot-00"),
@@ -245,7 +248,7 @@ environments:
 		SharedDir:           sharedDir,
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
-		LeaseProxyTimeout:   5 * time.Second,
+		LeaseProxyTimeout:   50 * time.Millisecond,
 		MaxWaitForLease:     DefaultMaxWaitForLease,
 		LeaseWaitInterval:   DefaultLeaseWaitInterval,
 	})
@@ -284,6 +287,73 @@ environments:
 	}
 }
 
+func TestAcquireRunFallsBackWhenCandidatePoolTimesOut(t *testing.T) {
+	t.Parallel()
+
+	clusterProfileDir := writeAcquireTestClusterProfiles(t, "dev-sub-b")
+	catalogPath := writeAcquireTestCatalogFromYAML(t, `version: 1
+environments:
+  dev:
+    deploy_envs: [ci01]
+    pools:
+      - subscription_name: dev-sub-a
+        region: centralus
+        region_mode: fixed
+        resource_type: aro-hcp-dev-centralus-a-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-a
+        identity_container_count: 2
+      - subscription_name: dev-sub-b
+        region: centralus
+        region_mode: fixed
+        resource_type: aro-hcp-dev-centralus-b-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-b
+        identity_container_count: 2
+`)
+
+	server, acquireCalls, releaseCalls := newTestLeaseProxyServer(t, map[string][]leaseProxyReply{
+		"aro-hcp-dev-centralus-a-slot": {
+			delayedLeaseProxyReply(200*time.Millisecond, successAcquireReply("aro-hcp-dev-centralus-a-slot-00")),
+		},
+		"aro-hcp-dev-centralus-b-slot": {
+			successAcquireReply("aro-hcp-dev-centralus-b-slot-00"),
+		},
+	})
+	defer server.Close()
+
+	sharedDir := t.TempDir()
+	err := Acquire(context.Background(), &RawAcquireOptions{
+		ClusterProfileDir:   clusterProfileDir,
+		DeployEnv:           "ci01",
+		Region:              "centralus",
+		SharedDir:           sharedDir,
+		CatalogPath:         catalogPath,
+		LeaseProxyServerURL: server.URL,
+		LeaseProxyTimeout:   50 * time.Millisecond,
+		MaxWaitForLease:     DefaultMaxWaitForLease,
+		LeaseWaitInterval:   DefaultLeaseWaitInterval,
+	})
+	if err != nil {
+		t.Fatalf("expected acquire to fall back after timeout: %v", err)
+	}
+
+	if got, want := *acquireCalls, []string{"aro-hcp-dev-centralus-a-slot", "aro-hcp-dev-centralus-b-slot"}; !equalStrings(got, want) {
+		t.Fatalf("unexpected acquire call order: got %v want %v", got, want)
+	}
+	if got := *releaseCalls; len(got) != 0 {
+		t.Fatalf("expected no release calls, got %v", got)
+	}
+
+	state, err := slots.LoadAcquiredSlotState(sharedDir)
+	if err != nil {
+		t.Fatalf("expected acquired slot state to load: %v", err)
+	}
+	if state.Slot.ResourceType != "aro-hcp-dev-centralus-b-slot" {
+		t.Fatalf("expected fallback pool resource type, got %q", state.Slot.ResourceType)
+	}
+}
+
 func TestAcquireRunRuntimeSelectedFallsBackAcrossSubscriptions(t *testing.T) {
 	t.Parallel()
 
@@ -311,7 +381,7 @@ environments:
 
 	server, acquireCalls, _ := newTestLeaseProxyServer(t, map[string][]leaseProxyReply{
 		"aro-hcp-prod-shard0-slot": {
-			exhaustedAcquireReply("aro-hcp-prod-shard0-slot"),
+			unavailableAcquireReply("aro-hcp-prod-shard0-slot"),
 		},
 		"aro-hcp-prod-shard1-slot": {
 			successAcquireReply("aro-hcp-prod-shard1-slot-00"),
@@ -327,7 +397,7 @@ environments:
 		SharedDir:           sharedDir,
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
-		LeaseProxyTimeout:   5 * time.Second,
+		LeaseProxyTimeout:   50 * time.Millisecond,
 		MaxWaitForLease:     DefaultMaxWaitForLease,
 		LeaseWaitInterval:   DefaultLeaseWaitInterval,
 	})
@@ -412,7 +482,7 @@ environments:
 	}
 }
 
-func TestAcquireRunRetriesAfterFullExhaustedPass(t *testing.T) {
+func TestAcquireRunRetriesAfterFullUnavailablePassAcrossPools(t *testing.T) {
 	t.Parallel()
 
 	clusterProfileDir := writeAcquireTestClusterProfiles(t, "dev-sub-b")
@@ -438,9 +508,9 @@ environments:
 `)
 
 	server, acquireCalls, _ := newTestLeaseProxyServer(t, map[string][]leaseProxyReply{
-		"aro-hcp-dev-centralus-a-slot": repeatLeaseProxyReply(exhaustedAcquireReply("aro-hcp-dev-centralus-a-slot"), 2),
+		"aro-hcp-dev-centralus-a-slot": repeatLeaseProxyReply(unavailableAcquireReply("aro-hcp-dev-centralus-a-slot"), 2),
 		"aro-hcp-dev-centralus-b-slot": {
-			exhaustedAcquireReply("aro-hcp-dev-centralus-b-slot"),
+			unavailableAcquireReply("aro-hcp-dev-centralus-b-slot"),
 			successAcquireReply("aro-hcp-dev-centralus-b-slot-00"),
 		},
 	})
@@ -453,7 +523,7 @@ environments:
 		SharedDir:           t.TempDir(),
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
-		LeaseProxyTimeout:   5 * time.Second,
+		LeaseProxyTimeout:   50 * time.Millisecond,
 		MaxWaitForLease:     2 * time.Minute,
 		LeaseWaitInterval:   1 * time.Minute,
 	})
@@ -469,6 +539,61 @@ environments:
 		"aro-hcp-dev-centralus-b-slot",
 		"aro-hcp-dev-centralus-a-slot",
 		"aro-hcp-dev-centralus-b-slot",
+	}; !equalStrings(got, want) {
+		t.Fatalf("unexpected acquire call order: got %v want %v", got, want)
+	}
+	if got, want := clock.slept, []time.Duration{1 * time.Minute}; !equalDurations(got, want) {
+		t.Fatalf("unexpected sleep durations: got %v want %v", got, want)
+	}
+}
+
+func TestAcquireRunRetriesAfterFullUnavailablePassAfterRetryableServerFailure(t *testing.T) {
+	t.Parallel()
+
+	clusterProfileDir := writeAcquireTestClusterProfiles(t, "dev-sub-a")
+	catalogPath := writeAcquireTestCatalogFromYAML(t, `version: 1
+environments:
+  dev:
+    deploy_envs: [ci01]
+    pools:
+      - subscription_name: dev-sub-a
+        region: centralus
+        region_mode: fixed
+        resource_type: aro-hcp-dev-centralus-a-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-a
+        identity_container_count: 2
+`)
+
+	server, acquireCalls, _ := newTestLeaseProxyServer(t, map[string][]leaseProxyReply{
+		"aro-hcp-dev-centralus-a-slot": {
+			{statusCode: http.StatusServiceUnavailable},
+			successAcquireReply("aro-hcp-dev-centralus-a-slot-00"),
+		},
+	})
+	defer server.Close()
+
+	completed := completeAcquireForTest(t, &RawAcquireOptions{
+		ClusterProfileDir:   clusterProfileDir,
+		DeployEnv:           "ci01",
+		Region:              "centralus",
+		SharedDir:           t.TempDir(),
+		CatalogPath:         catalogPath,
+		LeaseProxyServerURL: server.URL,
+		LeaseProxyTimeout:   50 * time.Millisecond,
+		MaxWaitForLease:     2 * time.Minute,
+		LeaseWaitInterval:   1 * time.Minute,
+	})
+	clock := newFakeClock(time.Unix(0, 0))
+	completed.Now = clock.Now
+	completed.Sleep = clock.Sleep
+
+	if err := completed.Run(context.Background()); err != nil {
+		t.Fatalf("expected acquire run to succeed after an unavailable pass retry: %v", err)
+	}
+	if got, want := *acquireCalls, []string{
+		"aro-hcp-dev-centralus-a-slot",
+		"aro-hcp-dev-centralus-a-slot",
 	}; !equalStrings(got, want) {
 		t.Fatalf("unexpected acquire call order: got %v want %v", got, want)
 	}
@@ -496,7 +621,7 @@ environments:
 `)
 
 	server, acquireCalls, _ := newTestLeaseProxyServer(t, map[string][]leaseProxyReply{
-		"aro-hcp-dev-centralus-a-slot": repeatLeaseProxyReply(exhaustedAcquireReply("aro-hcp-dev-centralus-a-slot"), 4),
+		"aro-hcp-dev-centralus-a-slot": repeatLeaseProxyReply(unavailableAcquireReply("aro-hcp-dev-centralus-a-slot"), 4),
 	})
 	defer server.Close()
 
@@ -507,7 +632,7 @@ environments:
 		SharedDir:           t.TempDir(),
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
-		LeaseProxyTimeout:   5 * time.Second,
+		LeaseProxyTimeout:   50 * time.Millisecond,
 		MaxWaitForLease:     3 * time.Minute,
 		LeaseWaitInterval:   1 * time.Minute,
 	})
@@ -519,8 +644,8 @@ environments:
 	if err == nil {
 		t.Fatal("expected acquire run to fail after max wait budget is exhausted")
 	}
-	if !strings.Contains(err.Error(), `were exhausted for 3m0s across 4 full pass(es)`) {
-		t.Fatalf("expected bounded exhaustion error, got %v", err)
+	if !strings.Contains(err.Error(), `yielded an immediate lease for 3m0s across 4 full pass(es)`) {
+		t.Fatalf("expected bounded no-immediate-lease error, got %v", err)
 	}
 	if got, want := *acquireCalls, []string{
 		"aro-hcp-dev-centralus-a-slot",
@@ -555,7 +680,7 @@ environments:
 
 	server, acquireCalls, _ := newTestLeaseProxyServer(t, map[string][]leaseProxyReply{
 		"aro-hcp-dev-centralus-a-slot": {
-			exhaustedAcquireReply("aro-hcp-dev-centralus-a-slot"),
+			unavailableAcquireReply("aro-hcp-dev-centralus-a-slot"),
 		},
 	})
 	defer server.Close()
@@ -567,7 +692,7 @@ environments:
 		SharedDir:           t.TempDir(),
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
-		LeaseProxyTimeout:   5 * time.Second,
+		LeaseProxyTimeout:   50 * time.Millisecond,
 		MaxWaitForLease:     0,
 		LeaseWaitInterval:   1 * time.Minute,
 	})
@@ -781,9 +906,10 @@ func completeAcquireForTest(t *testing.T, raw *RawAcquireOptions) *AcquireOption
 type leaseProxyReply struct {
 	statusCode int
 	body       string
+	delay      time.Duration
 }
 
-func exhaustedAcquireReply(resourceType string) leaseProxyReply {
+func unavailableAcquireReply(resourceType string) leaseProxyReply {
 	return leaseProxyReply{
 		statusCode: http.StatusInternalServerError,
 		body:       fmt.Sprintf("Failed to acquire lease %q: resources not found\n", resourceType),
@@ -799,6 +925,11 @@ func successAcquireReply(resourceName string) leaseProxyReply {
 		statusCode: http.StatusOK,
 		body:       string(body),
 	}
+}
+
+func delayedLeaseProxyReply(delay time.Duration, reply leaseProxyReply) leaseProxyReply {
+	reply.delay = delay
+	return reply
 }
 
 func repeatLeaseProxyReply(reply leaseProxyReply, count int) []leaseProxyReply {
@@ -834,6 +965,9 @@ func newTestLeaseProxyServer(t *testing.T, acquireReplies map[string][]leaseProx
 			}
 
 			reply := replies[replyIndex]
+			if reply.delay > 0 {
+				time.Sleep(reply.delay)
+			}
 			w.WriteHeader(reply.statusCode)
 			_, _ = w.Write([]byte(reply.body))
 		case "/lease/release":

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
@@ -250,8 +250,6 @@ func TestDefaultAcquireOptionsLeaseWaitDefaults(t *testing.T) {
 }
 
 func TestDefaultAcquireOptionsSelectorDefaults(t *testing.T) {
-	t.Parallel()
-
 	t.Setenv("ALLOWED_SUBSCRIPTIONS", "dev-sub-a, dev-sub-b, dev-sub-a")
 	t.Setenv("ALLOWED_LOCATIONS", "centralus, eastus2")
 
@@ -269,8 +267,6 @@ func TestDefaultAcquireOptionsSelectorDefaults(t *testing.T) {
 }
 
 func TestDefaultAcquireOptionsDoesNotUseLegacyLocationForSelection(t *testing.T) {
-	t.Parallel()
-
 	t.Setenv("LOCATION", "westus3")
 
 	opts := DefaultAcquireOptions()
@@ -281,8 +277,6 @@ func TestDefaultAcquireOptionsDoesNotUseLegacyLocationForSelection(t *testing.T)
 }
 
 func TestDefaultAcquireOptionsOverrideSuppressesAllowedLocationDefault(t *testing.T) {
-	t.Parallel()
-
 	t.Setenv("ALLOWED_LOCATIONS", "centralus, eastus2")
 	t.Setenv("MULTISTAGE_PARAM_OVERRIDE_LOCATION", "westus3")
 

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
@@ -89,52 +89,103 @@ func TestAcquireCompleteRegionModeMatrix(t *testing.T) {
 
 	type testCase struct {
 		regionMode         string
-		location           string
+		allowedLocations   string
 		override           string
 		wantRuntimeRegion  string
+		wantPoolRegion     string
 		wantErrorSubstring string
 	}
 
-	var cases []testCase
-	for _, regionMode := range []string{slots.RegionModeFixed, slots.RegionModeRuntimeSelected} {
-		for _, location := range []string{"", fixedRegion, alternateRegion} {
-			for _, override := range []string{"", fixedRegion, alternateRegion} {
-				effectiveRegion := override
-				if effectiveRegion == "" {
-					effectiveRegion = location
-				}
-
-				tc := testCase{
-					regionMode: regionMode,
-					location:   location,
-					override:   override,
-				}
-
-				switch regionMode {
-				case slots.RegionModeFixed:
-					if effectiveRegion == "" || effectiveRegion == fixedRegion {
-						tc.wantRuntimeRegion = fixedRegion
-					} else {
-						tc.wantErrorSubstring = "no pool found"
-					}
-				case slots.RegionModeRuntimeSelected:
-					if effectiveRegion == "" {
-						tc.wantRuntimeRegion = fixedRegion
-					} else {
-						tc.wantRuntimeRegion = effectiveRegion
-					}
-				}
-
-				cases = append(cases, tc)
-			}
-		}
+	cases := []testCase{
+		{
+			regionMode:        slots.RegionModeFixed,
+			allowedLocations:  "",
+			override:          "",
+			wantRuntimeRegion: fixedRegion,
+			wantPoolRegion:    fixedRegion,
+		},
+		{
+			regionMode:        slots.RegionModeFixed,
+			allowedLocations:  fixedRegion,
+			override:          "",
+			wantRuntimeRegion: fixedRegion,
+			wantPoolRegion:    fixedRegion,
+		},
+		{
+			regionMode:        slots.RegionModeFixed,
+			allowedLocations:  strings.Join([]string{fixedRegion, alternateRegion}, ","),
+			override:          "",
+			wantRuntimeRegion: fixedRegion,
+			wantPoolRegion:    fixedRegion,
+		},
+		{
+			regionMode:         slots.RegionModeFixed,
+			allowedLocations:   alternateRegion,
+			override:           "",
+			wantErrorSubstring: "no pool found",
+		},
+		{
+			regionMode:        slots.RegionModeFixed,
+			allowedLocations:  fixedRegion,
+			override:          fixedRegion,
+			wantRuntimeRegion: fixedRegion,
+			wantPoolRegion:    fixedRegion,
+		},
+		{
+			regionMode:         slots.RegionModeFixed,
+			allowedLocations:   fixedRegion,
+			override:           alternateRegion,
+			wantErrorSubstring: "no pool found",
+		},
+		{
+			regionMode:        slots.RegionModeRuntimeSelected,
+			allowedLocations:  "",
+			override:          "",
+			wantRuntimeRegion: fixedRegion,
+			wantPoolRegion:    fixedRegion,
+		},
+		{
+			regionMode:        slots.RegionModeRuntimeSelected,
+			allowedLocations:  fixedRegion,
+			override:          "",
+			wantRuntimeRegion: fixedRegion,
+			wantPoolRegion:    fixedRegion,
+		},
+		{
+			regionMode:        slots.RegionModeRuntimeSelected,
+			allowedLocations:  alternateRegion,
+			override:          "",
+			wantRuntimeRegion: fixedRegion,
+			wantPoolRegion:    fixedRegion,
+		},
+		{
+			regionMode:        slots.RegionModeRuntimeSelected,
+			allowedLocations:  strings.Join([]string{fixedRegion, alternateRegion}, ","),
+			override:          "",
+			wantRuntimeRegion: fixedRegion,
+			wantPoolRegion:    fixedRegion,
+		},
+		{
+			regionMode:        slots.RegionModeRuntimeSelected,
+			allowedLocations:  "",
+			override:          alternateRegion,
+			wantRuntimeRegion: alternateRegion,
+			wantPoolRegion:    fixedRegion,
+		},
+		{
+			regionMode:        slots.RegionModeRuntimeSelected,
+			allowedLocations:  fixedRegion,
+			override:          alternateRegion,
+			wantRuntimeRegion: alternateRegion,
+			wantPoolRegion:    fixedRegion,
+		},
 	}
 
 	for _, tc := range cases {
 		testName := fmt.Sprintf(
-			"regionMode=%s/location=%q/override=%q",
+			"regionMode=%s/allowedLocations=%q/override=%q",
 			tc.regionMode,
-			tc.location,
+			tc.allowedLocations,
 			tc.override,
 		)
 		t.Run(testName, func(t *testing.T) {
@@ -145,7 +196,7 @@ func TestAcquireCompleteRegionModeMatrix(t *testing.T) {
 			t.Setenv("ARO_HCP_DEPLOY_ENV", "ci01")
 			t.Setenv("SHARED_DIR", t.TempDir())
 			t.Setenv("LEASE_PROXY_SERVER_URL", "http://lease-proxy.example.com")
-			t.Setenv("LOCATION", tc.location)
+			t.Setenv("ALLOWED_LOCATIONS", tc.allowedLocations)
 			t.Setenv("MULTISTAGE_PARAM_OVERRIDE_LOCATION", tc.override)
 
 			opts := DefaultAcquireOptions()
@@ -176,8 +227,8 @@ func TestAcquireCompleteRegionModeMatrix(t *testing.T) {
 			if got := completed.runtimeRegionForPool(completed.CandidatePools[0]); got != tc.wantRuntimeRegion {
 				t.Fatalf("expected runtime region %q, got %q", tc.wantRuntimeRegion, got)
 			}
-			if completed.CandidatePools[0].Region != fixedRegion {
-				t.Fatalf("expected selected pool region %q, got %q", fixedRegion, completed.CandidatePools[0].Region)
+			if completed.CandidatePools[0].Region != tc.wantPoolRegion {
+				t.Fatalf("expected selected pool region %q, got %q", tc.wantPoolRegion, completed.CandidatePools[0].Region)
 			}
 		})
 	}
@@ -195,6 +246,53 @@ func TestDefaultAcquireOptionsLeaseWaitDefaults(t *testing.T) {
 	}
 	if opts.MaxWaitForLease != DefaultMaxWaitForLease {
 		t.Fatalf("expected default max wait for lease %s, got %s", DefaultMaxWaitForLease, opts.MaxWaitForLease)
+	}
+}
+
+func TestDefaultAcquireOptionsSelectorDefaults(t *testing.T) {
+	t.Parallel()
+
+	t.Setenv("ALLOWED_SUBSCRIPTIONS", "dev-sub-a, dev-sub-b, dev-sub-a")
+	t.Setenv("ALLOWED_LOCATIONS", "centralus, eastus2")
+
+	opts := DefaultAcquireOptions()
+
+	if got, want := opts.AllowedSubscriptions, []string{"dev-sub-a", "dev-sub-b"}; !equalStrings(got, want) {
+		t.Fatalf("unexpected allowed subscriptions: got %v want %v", got, want)
+	}
+	if got, want := opts.AllowedLocations, []string{"centralus", "eastus2"}; !equalStrings(got, want) {
+		t.Fatalf("unexpected allowed locations: got %v want %v", got, want)
+	}
+	if opts.SelectedLocation != "" {
+		t.Fatalf("expected empty selected location by default, got %q", opts.SelectedLocation)
+	}
+}
+
+func TestDefaultAcquireOptionsDoesNotUseLegacyLocationForSelection(t *testing.T) {
+	t.Parallel()
+
+	t.Setenv("LOCATION", "westus3")
+
+	opts := DefaultAcquireOptions()
+
+	if got := len(opts.AllowedLocations); got != 0 {
+		t.Fatalf("expected legacy LOCATION to be ignored for acquire-side selection, got %v", opts.AllowedLocations)
+	}
+}
+
+func TestDefaultAcquireOptionsOverrideSuppressesAllowedLocationDefault(t *testing.T) {
+	t.Parallel()
+
+	t.Setenv("ALLOWED_LOCATIONS", "centralus, eastus2")
+	t.Setenv("MULTISTAGE_PARAM_OVERRIDE_LOCATION", "westus3")
+
+	opts := DefaultAcquireOptions()
+
+	if opts.SelectedLocation != "westus3" {
+		t.Fatalf("expected selected location %q, got %q", "westus3", opts.SelectedLocation)
+	}
+	if got := len(opts.AllowedLocations); got != 0 {
+		t.Fatalf("expected allowed locations to be ignored when override is set, got %v", opts.AllowedLocations)
 	}
 }
 
@@ -244,7 +342,7 @@ environments:
 	err := Acquire(context.Background(), &RawAcquireOptions{
 		ClusterProfileDir:   clusterProfileDir,
 		DeployEnv:           "ci01",
-		Region:              "centralus",
+		AllowedLocations:    []string{"centralus"},
 		SharedDir:           sharedDir,
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
@@ -326,7 +424,7 @@ environments:
 	err := Acquire(context.Background(), &RawAcquireOptions{
 		ClusterProfileDir:   clusterProfileDir,
 		DeployEnv:           "ci01",
-		Region:              "centralus",
+		AllowedLocations:    []string{"centralus"},
 		SharedDir:           sharedDir,
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
@@ -393,7 +491,7 @@ environments:
 	err := Acquire(context.Background(), &RawAcquireOptions{
 		ClusterProfileDir:   clusterProfileDir,
 		DeployEnv:           "prod",
-		Region:              "eastus2",
+		SelectedLocation:    "eastus2",
 		SharedDir:           sharedDir,
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
@@ -463,7 +561,7 @@ environments:
 	err := Acquire(context.Background(), &RawAcquireOptions{
 		ClusterProfileDir:   clusterProfileDir,
 		DeployEnv:           "ci01",
-		Region:              "centralus",
+		AllowedLocations:    []string{"centralus"},
 		SharedDir:           sharedDir,
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
@@ -519,7 +617,7 @@ environments:
 	completed := completeAcquireForTest(t, &RawAcquireOptions{
 		ClusterProfileDir:   clusterProfileDir,
 		DeployEnv:           "ci01",
-		Region:              "centralus",
+		AllowedLocations:    []string{"centralus"},
 		SharedDir:           t.TempDir(),
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
@@ -576,7 +674,7 @@ environments:
 	completed := completeAcquireForTest(t, &RawAcquireOptions{
 		ClusterProfileDir:   clusterProfileDir,
 		DeployEnv:           "ci01",
-		Region:              "centralus",
+		AllowedLocations:    []string{"centralus"},
 		SharedDir:           t.TempDir(),
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
@@ -628,7 +726,7 @@ environments:
 	completed := completeAcquireForTest(t, &RawAcquireOptions{
 		ClusterProfileDir:   clusterProfileDir,
 		DeployEnv:           "ci01",
-		Region:              "centralus",
+		AllowedLocations:    []string{"centralus"},
 		SharedDir:           t.TempDir(),
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
@@ -688,7 +786,7 @@ environments:
 	completed := completeAcquireForTest(t, &RawAcquireOptions{
 		ClusterProfileDir:   clusterProfileDir,
 		DeployEnv:           "ci01",
-		Region:              "centralus",
+		AllowedLocations:    []string{"centralus"},
 		SharedDir:           t.TempDir(),
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
@@ -747,7 +845,7 @@ environments:
 	err := Acquire(context.Background(), &RawAcquireOptions{
 		ClusterProfileDir:   clusterProfileDir,
 		DeployEnv:           "ci01",
-		Region:              "centralus",
+		AllowedLocations:    []string{"centralus"},
 		SharedDir:           sharedDir,
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,
@@ -811,7 +909,7 @@ environments:
 	err = Acquire(context.Background(), &RawAcquireOptions{
 		ClusterProfileDir:   clusterProfileDir,
 		DeployEnv:           "ci01",
-		Region:              "centralus",
+		AllowedLocations:    []string{"centralus"},
 		SharedDir:           sharedDir,
 		CatalogPath:         catalogPath,
 		LeaseProxyServerURL: server.URL,

--- a/test/cmd/aro-hcp-tests/slot-manager/identity-pool/options.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/identity-pool/options.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -75,7 +74,7 @@ type ApplyOptions struct {
 }
 
 func (o *RawApplyOptions) Validate() (*ValidatedApplyOptions, error) {
-	if strings.TrimSpace(o.Environment) == "" {
+	if o.Environment == "" {
 		return nil, fmt.Errorf("--environment must not be empty")
 	}
 

--- a/test/cmd/aro-hcp-tests/slot-manager/release.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/release.go
@@ -30,8 +30,8 @@ import (
 
 func DefaultReleaseOptions() *RawReleaseOptions {
 	return &RawReleaseOptions{
-		SharedDir:           os.Getenv("SHARED_DIR"),
-		LeaseProxyServerURL: os.Getenv("LEASE_PROXY_SERVER_URL"),
+		SharedDir:           strings.TrimSpace(os.Getenv("SHARED_DIR")),
+		LeaseProxyServerURL: strings.TrimSpace(os.Getenv("LEASE_PROXY_SERVER_URL")),
 		LeaseProxyTimeout:   slots.DefaultLeaseProxyTimeout,
 	}
 }
@@ -98,9 +98,9 @@ func Release(ctx context.Context, opts *RawReleaseOptions) error {
 
 func (o *RawReleaseOptions) Validate() (*ValidatedReleaseOptions, error) {
 	switch {
-	case strings.TrimSpace(o.SharedDir) == "":
+	case o.SharedDir == "":
 		return nil, fmt.Errorf("--shared-dir must not be empty")
-	case strings.TrimSpace(o.LeaseProxyServerURL) == "":
+	case o.LeaseProxyServerURL == "":
 		return nil, fmt.Errorf("--lease-proxy-server-url must not be empty")
 	case o.LeaseProxyTimeout <= 0:
 		return nil, fmt.Errorf("--lease-proxy-timeout must be greater than zero")

--- a/test/cmd/aro-hcp-tests/slot-manager/release.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/release.go
@@ -39,7 +39,7 @@ func DefaultReleaseOptions() *RawReleaseOptions {
 func BindReleaseOptions(opts *RawReleaseOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.SharedDir, "shared-dir", opts.SharedDir, "Path to SHARED_DIR")
 	cmd.Flags().StringVar(&opts.LeaseProxyServerURL, "lease-proxy-server-url", opts.LeaseProxyServerURL, "Lease proxy server URL")
-	cmd.Flags().DurationVar(&opts.LeaseProxyTimeout, "lease-proxy-timeout", opts.LeaseProxyTimeout, "Timeout per lease proxy request attempt")
+	cmd.Flags().DurationVar(&opts.LeaseProxyTimeout, "lease-proxy-timeout", opts.LeaseProxyTimeout, "Maximum time to spend retrying a lease proxy request before failing.")
 	return nil
 }
 

--- a/test/cmd/aro-hcp-tests/slot-manager/release_repo.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/release_repo.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
@@ -58,7 +57,7 @@ type ReleaseRepoOptions struct {
 }
 
 func (o *RawReleaseRepoOptions) Validate() (*ValidatedReleaseRepoOptions, error) {
-	if strings.TrimSpace(o.ReleaseRepo) == "" {
+	if o.ReleaseRepo == "" {
 		return nil, fmt.Errorf("--release-repo must not be empty")
 	}
 	return &ValidatedReleaseRepoOptions{

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/catalog.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/catalog.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/catalog.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/catalog.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -105,7 +106,7 @@ func ResolveCatalogPathFrom(startDir string) (string, error) {
 }
 
 func resolveRepoFile(relPath, startDir string) (string, error) {
-	if strings.TrimSpace(startDir) == "" {
+	if startDir == "" {
 		wd, err := os.Getwd()
 		if err != nil {
 			return "", fmt.Errorf("failed to get current working directory: %w", err)
@@ -152,21 +153,28 @@ func (c *Catalog) Validate() error {
 		environmentRegionMode := ""
 		for i := range environment.Pools {
 			pool := &environment.Pools[i]
-			pool.RegionMode = pool.EffectiveRegionMode()
+			pool.SubscriptionName = strings.TrimSpace(pool.SubscriptionName)
+			pool.Region = strings.TrimSpace(pool.Region)
+			pool.RegionMode = strings.TrimSpace(pool.RegionMode)
+			if pool.RegionMode == "" {
+				pool.RegionMode = RegionModeFixed
+			}
 			pool.IdentityProvisioningRegion = strings.TrimSpace(pool.IdentityProvisioningRegion)
+			pool.ResourceType = strings.TrimSpace(pool.ResourceType)
+			pool.IdentityContainerPrefix = strings.TrimSpace(pool.IdentityContainerPrefix)
 
 			switch {
-			case strings.TrimSpace(pool.SubscriptionName) == "":
+			case pool.SubscriptionName == "":
 				return fmt.Errorf("environment %q has a pool with empty subscription_name", environmentName)
-			case strings.TrimSpace(pool.Region) == "":
+			case pool.Region == "":
 				return fmt.Errorf("environment %q has a pool with empty region", environmentName)
 			case pool.RegionMode != RegionModeFixed && pool.RegionMode != RegionModeRuntimeSelected:
 				return fmt.Errorf("environment %q pool %s has invalid region_mode %q", environmentName, describePool(*pool), pool.RegionMode)
-			case strings.TrimSpace(pool.ResourceType) == "":
+			case pool.ResourceType == "":
 				return fmt.Errorf("environment %q has a pool with empty resource_type", environmentName)
 			case pool.SlotCount <= 0:
 				return fmt.Errorf("environment %q pool %s has invalid slot_count %d", environmentName, describePool(*pool), pool.SlotCount)
-			case strings.TrimSpace(pool.IdentityContainerPrefix) == "":
+			case pool.IdentityContainerPrefix == "":
 				return fmt.Errorf("environment %q pool %s has empty identity_container_prefix", environmentName, describePool(*pool))
 			case pool.IdentityContainerCount <= 0:
 				return fmt.Errorf("environment %q pool %s has invalid identity_container_count %d", environmentName, describePool(*pool), pool.IdentityContainerCount)
@@ -211,7 +219,6 @@ func (c *Catalog) EnvironmentNames() []string {
 }
 
 func (c *Catalog) ResolveEnvironmentForDeployEnv(deployEnv string) (string, error) {
-	deployEnv = strings.TrimSpace(deployEnv)
 	if deployEnv == "" {
 		return "", errors.New("deploy environment is empty")
 	}
@@ -236,8 +243,8 @@ func (c *Catalog) ResolveEnvironmentForDeployEnv(deployEnv string) (string, erro
 	}
 }
 
-func (c *Catalog) ResolvePool(environment, subscriptionName, region string) (Pool, error) {
-	matches, err := c.CandidatePools(environment, subscriptionName, region)
+func (c *Catalog) ResolvePool(environment string, allowedSubscriptions, allowedLocations sets.Set[string], selectedLocation string) (Pool, error) {
+	matches, err := c.CandidatePools(environment, allowedSubscriptions, allowedLocations, selectedLocation)
 	if err != nil {
 		return Pool{}, err
 	}
@@ -251,13 +258,13 @@ func (c *Catalog) ResolvePool(environment, subscriptionName, region string) (Poo
 			return Pool{}, err
 		}
 		if environmentRegionMode == RegionModeRuntimeSelected {
-			return Pool{}, fmt.Errorf("environment %q has %d matching pools; specify --subscription-name to disambiguate runtime-selected pools", environment, len(matches))
+			return Pool{}, fmt.Errorf("environment %q has %d matching pools; narrow ALLOWED_SUBSCRIPTIONS to a single pool", environment, len(matches))
 		}
-		return Pool{}, fmt.Errorf("environment %q has %d matching pools; specify both --subscription-name and --region to disambiguate", environment, len(matches))
+		return Pool{}, fmt.Errorf("environment %q has %d matching pools; narrow ALLOWED_SUBSCRIPTIONS and/or ALLOWED_LOCATIONS to a single pool", environment, len(matches))
 	}
 }
 
-func (c *Catalog) CandidatePools(environment, subscriptionName, region string) ([]Pool, error) {
+func (c *Catalog) CandidatePools(environment string, allowedSubscriptions, allowedLocations sets.Set[string], selectedLocation string) ([]Pool, error) {
 	environmentConfig, found := c.Environments[environment]
 	if !found {
 		return nil, fmt.Errorf("unknown environment %q", environment)
@@ -268,16 +275,18 @@ func (c *Catalog) CandidatePools(environment, subscriptionName, region string) (
 		return nil, err
 	}
 
-	subscriptionName = strings.TrimSpace(subscriptionName)
-	region = strings.TrimSpace(region)
-
 	matches := make([]Pool, 0, len(environmentConfig.Pools))
 	for _, pool := range environmentConfig.Pools {
-		if subscriptionName != "" && pool.SubscriptionName != subscriptionName {
+		if allowedSubscriptions.Len() > 0 && !allowedSubscriptions.Has(pool.SubscriptionName) {
 			continue
 		}
-		if environmentRegionMode == RegionModeFixed && region != "" && pool.Region != region {
-			continue
+		if environmentRegionMode == RegionModeFixed {
+			if selectedLocation != "" && pool.Region != selectedLocation {
+				continue
+			}
+			if selectedLocation == "" && allowedLocations.Len() > 0 && !allowedLocations.Has(pool.Region) {
+				continue
+			}
 		}
 		matches = append(matches, pool)
 	}
@@ -287,11 +296,15 @@ func (c *Catalog) CandidatePools(environment, subscriptionName, region string) (
 	}
 
 	selectors := []string{}
-	if subscriptionName != "" {
-		selectors = append(selectors, fmt.Sprintf("subscription_name=%q", subscriptionName))
+	if allowedSubscriptions.Len() > 0 {
+		selectors = append(selectors, fmt.Sprintf("allowed_subscriptions=%q", strings.Join(sets.List(allowedSubscriptions), ",")))
 	}
-	if environmentRegionMode == RegionModeFixed && region != "" {
-		selectors = append(selectors, fmt.Sprintf("region=%q", region))
+	if environmentRegionMode == RegionModeFixed {
+		if selectedLocation != "" {
+			selectors = append(selectors, fmt.Sprintf("selected_location=%q", selectedLocation))
+		} else if allowedLocations.Len() > 0 {
+			selectors = append(selectors, fmt.Sprintf("allowed_locations=%q", strings.Join(sets.List(allowedLocations), ",")))
+		}
 	}
 	if len(selectors) == 0 {
 		return nil, fmt.Errorf("environment %q has no pools", environment)
@@ -366,17 +379,17 @@ func (c *Catalog) FindSlotByResourceName(resourceName string) (*ExpandedSlot, er
 }
 
 func (p Pool) EffectiveRegionMode() string {
-	if regionMode := strings.TrimSpace(p.RegionMode); regionMode != "" {
-		return regionMode
+	if p.RegionMode != "" {
+		return p.RegionMode
 	}
 	return RegionModeFixed
 }
 
 func (p Pool) EffectiveIdentityProvisioningRegion() string {
-	if region := strings.TrimSpace(p.IdentityProvisioningRegion); region != "" {
-		return region
+	if p.IdentityProvisioningRegion != "" {
+		return p.IdentityProvisioningRegion
 	}
-	return strings.TrimSpace(p.Region)
+	return p.Region
 }
 
 func (s ExpandedSlot) IdentityContainerNames() []string {
@@ -388,7 +401,7 @@ func (s ExpandedSlot) IdentityContainerNames() []string {
 }
 
 func SharedStateDir(sharedDir string) (string, error) {
-	if strings.TrimSpace(sharedDir) == "" {
+	if sharedDir == "" {
 		return "", errors.New("SHARED_DIR is empty")
 	}
 	return sharedDir, nil

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/catalog_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/catalog_test.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const syntheticCatalogYAML = `version: 1
@@ -114,7 +116,7 @@ func TestResolvePool(t *testing.T) {
 
 	catalog := loadSyntheticCatalog(t)
 
-	pool, err := catalog.ResolvePool("dev", "dev-shard-0", "westus3")
+	pool, err := catalog.ResolvePool("dev", sets.New("dev-shard-0"), sets.New("westus3"), "")
 	if err != nil {
 		t.Fatalf("expected pool resolution to succeed: %v", err)
 	}
@@ -128,7 +130,7 @@ func TestCandidatePoolsFixedPreservesCatalogOrder(t *testing.T) {
 
 	catalog := loadSyntheticCatalog(t)
 
-	pools, err := catalog.CandidatePools("dev", "", "")
+	pools, err := catalog.CandidatePools("dev", nil, nil, "")
 	if err != nil {
 		t.Fatalf("expected candidate pool resolution to succeed: %v", err)
 	}
@@ -143,12 +145,46 @@ func TestCandidatePoolsFixedPreservesCatalogOrder(t *testing.T) {
 	}
 }
 
-func TestCandidatePoolsFixedFiltersByRegion(t *testing.T) {
+func TestCandidatePoolsFixedFiltersByAllowedLocations(t *testing.T) {
 	t.Parallel()
 
 	catalog := loadSyntheticCatalog(t)
 
-	pools, err := catalog.CandidatePools("dev", "", "eastus2")
+	pools, err := catalog.CandidatePools("dev", nil, sets.New("eastus2"), "")
+	if err != nil {
+		t.Fatalf("expected candidate pool resolution to succeed: %v", err)
+	}
+	if len(pools) != 1 {
+		t.Fatalf("expected 1 candidate pool, got %d", len(pools))
+	}
+	if pools[0].ResourceType != "aro-hcp-dev-shard1-eastus2-slot" {
+		t.Fatalf("unexpected candidate resource type %q", pools[0].ResourceType)
+	}
+}
+
+func TestCandidatePoolsFiltersByAllowedSubscriptions(t *testing.T) {
+	t.Parallel()
+
+	catalog := loadSyntheticCatalog(t)
+
+	pools, err := catalog.CandidatePools("dev", sets.New("dev-shard-1"), nil, "")
+	if err != nil {
+		t.Fatalf("expected candidate pool resolution to succeed: %v", err)
+	}
+	if len(pools) != 1 {
+		t.Fatalf("expected 1 candidate pool, got %d", len(pools))
+	}
+	if pools[0].ResourceType != "aro-hcp-dev-shard1-eastus2-slot" {
+		t.Fatalf("unexpected candidate resource type %q", pools[0].ResourceType)
+	}
+}
+
+func TestCandidatePoolsFixedSelectedLocationOverrideTakesPrecedenceOverAllowedLocations(t *testing.T) {
+	t.Parallel()
+
+	catalog := loadSyntheticCatalog(t)
+
+	pools, err := catalog.CandidatePools("dev", nil, sets.New("westus3"), "eastus2")
 	if err != nil {
 		t.Fatalf("expected candidate pool resolution to succeed: %v", err)
 	}
@@ -255,7 +291,7 @@ environments:
         identity_container_count: 1
 `)
 
-	pool, err := catalog.ResolvePool("prod", "", "eastus2")
+	pool, err := catalog.ResolvePool("prod", nil, sets.New("eastus2"), "")
 	if err != nil {
 		t.Fatalf("expected runtime-selected pool resolution to ignore region: %v", err)
 	}
@@ -288,7 +324,7 @@ environments:
         identity_container_count: 1
 `)
 
-	pools, err := catalog.CandidatePools("prod", "", "eastus2")
+	pools, err := catalog.CandidatePools("prod", nil, sets.New("eastus2"), "")
 	if err != nil {
 		t.Fatalf("expected runtime-selected candidate pool resolution to ignore region: %v", err)
 	}
@@ -324,7 +360,7 @@ environments:
         identity_container_count: 1
 `)
 
-	_, err := catalog.ResolvePool("prod", "", "eastus2")
+	_, err := catalog.ResolvePool("prod", nil, sets.New("eastus2"), "")
 	if err == nil {
 		t.Fatal("expected runtime-selected pool resolution to require subscription selector when multiple pools exist")
 	}

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/leaseproxy.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/leaseproxy.go
@@ -29,9 +29,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-const DefaultLeaseProxyTimeout = 2 * time.Minute
+const DefaultLeaseProxyTimeout = 30 * time.Second
 
-var ErrLeasePoolExhausted = errors.New("lease pool exhausted")
+var ErrLeasePoolUnavailableNow = errors.New("lease pool temporarily unavailable")
 
 var leaseProxyRequestBackoff = wait.Backoff{
 	Duration: 2 * time.Second,
@@ -49,21 +49,39 @@ type releaseLeaseRequest struct {
 	Names []string `json:"names"`
 }
 
-type LeasePoolExhaustedError struct {
+type LeasePoolUnavailableError struct {
 	ResourceType string
-	Message      string
+	Cause        error
 }
 
-func (e *LeasePoolExhaustedError) Error() string {
-	message := strings.TrimSpace(e.Message)
-	if message == "" {
-		message = ErrLeasePoolExhausted.Error()
+func (e *LeasePoolUnavailableError) Error() string {
+	if e.Cause == nil {
+		return fmt.Sprintf("failed to immediately acquire lease type %q: %s", e.ResourceType, ErrLeasePoolUnavailableNow.Error())
 	}
-	return fmt.Sprintf("failed to acquire lease type %q: %s", e.ResourceType, message)
+	return fmt.Sprintf("failed to immediately acquire lease type %q within lease-proxy timeout budget: %v", e.ResourceType, e.Cause)
 }
 
-func (e *LeasePoolExhaustedError) Is(target error) bool {
-	return target == ErrLeasePoolExhausted
+func (e *LeasePoolUnavailableError) Is(target error) bool {
+	return target == ErrLeasePoolUnavailableNow
+}
+
+func (e *LeasePoolUnavailableError) Unwrap() error {
+	return e.Cause
+}
+
+type retryableLeaseProxyError struct {
+	Cause error
+}
+
+func (e *retryableLeaseProxyError) Error() string {
+	if e.Cause == nil {
+		return "lease proxy request did not succeed before retry budget expired"
+	}
+	return e.Cause.Error()
+}
+
+func (e *retryableLeaseProxyError) Unwrap() error {
+	return e.Cause
 }
 
 func AcquireLease(ctx context.Context, leaseProxyServerURL, resourceType string, timeout time.Duration) (string, error) {
@@ -85,12 +103,6 @@ func AcquireLease(ctx context.Context, leaseProxyServerURL, resourceType string,
 			if response.StatusCode >= 200 && response.StatusCode < 300 {
 				return true, nil
 			}
-			if isLeasePoolExhaustedResponse(response.StatusCode, responseBody) {
-				return false, &LeasePoolExhaustedError{
-					ResourceType: resourceType,
-					Message:      strings.TrimSpace(string(responseBody)),
-				}
-			}
 			if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500 {
 				return false, nil // retryable
 			}
@@ -98,6 +110,13 @@ func AcquireLease(ctx context.Context, leaseProxyServerURL, resourceType string,
 		},
 	)
 	if err != nil {
+		var retryableErr *retryableLeaseProxyError
+		if errors.As(err, &retryableErr) {
+			return "", &LeasePoolUnavailableError{
+				ResourceType: resourceType,
+				Cause:        retryableErr.Unwrap(),
+			}
+		}
 		return "", err
 	}
 	defer response.Body.Close()
@@ -148,36 +167,50 @@ func ReleaseLease(ctx context.Context, leaseProxyServerURL, name string, timeout
 }
 
 // doLeaseProxyRequestWithRetry executes an HTTP request with exponential
-// backoff. The classifyResponse callback inspects each response and signals
-// one of three outcomes:
+// backoff until it succeeds, returns a fatal response classification, the
+// parent context is canceled, or the provided timeout budget is exhausted.
+// The classifyResponse callback inspects each response and signals one of
+// three outcomes:
 //
 //   - success  (success=true,  fatal=nil)  → stop retrying, return the response
 //   - retry    (success=false, fatal=nil)  → wait and try again (transient: 429, 5xx, network errors)
 //   - fatal    (success=false, fatal=err)  → stop retrying, propagate the error immediately
 //
 // Network-level errors from requestFunc (connection refused, DNS failure, etc.)
-// are always treated as retryable. If all retry attempts are exhausted, the
-// last observed error is returned.
+// are always treated as retryable. If the retry budget is exhausted, the
+// helper returns the last observed retryable error wrapped in
+// retryableLeaseProxyError so callers can distinguish "did not succeed in
+// time" from fatal responses like type-not-found.
 func doLeaseProxyRequestWithRetry(
 	ctx context.Context,
 	timeout time.Duration,
 	requestFunc func(context.Context, *http.Client) (*http.Response, error),
 	classifyResponse func(*http.Response, []byte) (success bool, fatal error),
 ) (*http.Response, error) {
-	client := &http.Client{Timeout: timeout}
+	requestCtx := ctx
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		requestCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	client := &http.Client{}
 
 	var response *http.Response
 	var lastErr error
-	err := wait.ExponentialBackoffWithContext(ctx, leaseProxyRequestBackoff, func(ctx context.Context) (bool, error) {
-		currentResponse, err := requestFunc(ctx, client)
+	retryableFailure := false
+	err := wait.ExponentialBackoffWithContext(requestCtx, leaseProxyRequestBackoff, func(attemptCtx context.Context) (bool, error) {
+		currentResponse, err := requestFunc(attemptCtx, client)
 		if err != nil {
 			lastErr = err
+			retryableFailure = true
 			return false, nil // retry
 		}
 		responseBody, err := io.ReadAll(currentResponse.Body)
 		currentResponse.Body.Close()
 		if err != nil {
 			lastErr = fmt.Errorf("failed to read lease proxy response body: %w", err)
+			retryableFailure = true
 			return false, nil // retry
 		}
 		currentResponse.Body = io.NopCloser(bytes.NewReader(responseBody))
@@ -185,18 +218,30 @@ func doLeaseProxyRequestWithRetry(
 		success, fatal := classifyResponse(currentResponse, responseBody)
 		if fatal != nil {
 			lastErr = fatal
+			retryableFailure = false
 			return false, fatal // stop immediately
 		}
 		if !success {
 			lastErr = fmt.Errorf("retryable status %s", currentResponse.Status)
+			retryableFailure = true
 			return false, nil // retry
 		}
 
 		response = currentResponse
 		lastErr = nil
+		retryableFailure = false
 		return true, nil // done
 	})
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if retryableFailure {
+			if lastErr == nil {
+				lastErr = err
+			}
+			return nil, &retryableLeaseProxyError{Cause: lastErr}
+		}
 		if lastErr != nil {
 			return nil, lastErr
 		}
@@ -204,42 +249,6 @@ func doLeaseProxyRequestWithRetry(
 	}
 
 	return response, nil
-}
-
-// isLeasePoolExhaustedResponse determines whether a proxy response indicates
-// that all resources of the requested type are currently leased (pool
-// exhaustion) as opposed to the resource type not existing at all, or some
-// unrelated server error.
-//
-// The ci-tools lease proxy (pkg/lease/proxy) already encodes the distinction
-// via HTTP status codes:
-//   - 404 → lease.ErrTypeNotFound ("resource type not found")
-//   - 500 → lease.ErrNotFound     ("resources not found") or other errors
-//
-// For 500 responses, we additionally check the body against the known error
-// strings produced by the Boskos ecosystem to avoid false positives from
-// unrelated 500 errors (e.g. "Failed to get lease client"). The strings
-// originate from:
-//   - Boskos client sentinel: "resources not found"          (sigs.k8s.io/boskos/client.ErrNotFound)
-//   - Boskos server ranch:    "no available resource <name>" (sigs.k8s.io/boskos/ranch.ResourceNotFound)
-func isLeasePoolExhaustedResponse(statusCode int, responseBody []byte) bool {
-	if statusCode == http.StatusNotFound {
-		return false
-	}
-	if statusCode < http.StatusInternalServerError {
-		return false
-	}
-
-	message := strings.ToLower(strings.TrimSpace(string(responseBody)))
-
-	if strings.Contains(message, "resources not found") {
-		return true
-	}
-	if strings.Contains(message, "no available resource") {
-		return true
-	}
-
-	return false
 }
 
 func leaseProxyResponseMessage(status string, responseBody []byte) string {

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/leaseproxy_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/leaseproxy_test.go
@@ -109,7 +109,7 @@ func TestAcquireLeaseRejectsUnexpectedStatus(t *testing.T) {
 	}
 }
 
-func TestAcquireLeaseClassifiesPoolExhaustionWithoutRetry(t *testing.T) {
+func TestAcquireLeaseClassifiesRetryableServerResponsesAsTemporarilyUnavailable(t *testing.T) {
 	t.Parallel()
 
 	attempts := 0
@@ -120,89 +120,35 @@ func TestAcquireLeaseClassifiesPoolExhaustionWithoutRetry(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := AcquireLease(context.Background(), server.URL, "aro-hcp-dev-westus3-slot", 5*time.Second)
+	_, err := AcquireLease(context.Background(), server.URL, "aro-hcp-dev-westus3-slot", 50*time.Millisecond)
 	if err == nil {
-		t.Fatal("expected lease acquire to fail for an exhausted pool")
+		t.Fatal("expected lease acquire to fail when the pool does not yield an immediate lease")
 	}
-	if !errors.Is(err, ErrLeasePoolExhausted) {
-		t.Fatalf("expected exhausted-pool error classification, got %v", err)
+	if !errors.Is(err, ErrLeasePoolUnavailableNow) {
+		t.Fatalf("expected temporary-unavailability classification, got %v", err)
 	}
 	if attempts != 1 {
-		t.Fatalf("expected exactly 1 attempt for exhausted pool, got %d", attempts)
+		t.Fatalf("expected exactly 1 immediate probe attempt, got %d", attempts)
 	}
 }
 
-func TestIsLeasePoolExhaustedResponse(t *testing.T) {
-	t.Parallel()
-
-	for _, tc := range []struct {
-		name       string
-		statusCode int
-		body       string
-		want       bool
-	}{
-		{
-			name:       "ci-tools proxy: ErrNotFound wraps client sentinel",
-			statusCode: http.StatusInternalServerError,
-			body:       `Failed to acquire lease "aro-hcp-dev-westus3-slot": resources not found`,
-			want:       true,
-		},
-		{
-			name:       "Boskos server ranch.ResourceNotFound relayed as-is",
-			statusCode: http.StatusInternalServerError,
-			body:       `Acquire failed: no available resource aro-hcp-dev-westus3-slot, try again later.`,
-			want:       true,
-		},
-		{
-			name:       "ci-tools proxy: ErrTypeNotFound returns 404",
-			statusCode: http.StatusNotFound,
-			body:       `Failed to acquire lease "missing-type": resource type not found`,
-			want:       false,
-		},
-		{
-			name:       "unrelated 500 from proxy startup failure",
-			statusCode: http.StatusInternalServerError,
-			body:       `Failed to get lease client`,
-			want:       false,
-		},
-		{
-			name:       "4xx errors are never pool exhaustion",
-			statusCode: http.StatusBadRequest,
-			body:       `type is required`,
-			want:       false,
-		},
-		{
-			name:       "503 with no body is retryable, not pool exhaustion",
-			statusCode: http.StatusServiceUnavailable,
-			body:       ``,
-			want:       false,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			got := isLeasePoolExhaustedResponse(tc.statusCode, []byte(tc.body))
-			if got != tc.want {
-				t.Errorf("isLeasePoolExhaustedResponse(%d, %q) = %v, want %v", tc.statusCode, tc.body, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestAcquireLeaseDoesNotClassifyTypeNotFoundAsPoolExhausted(t *testing.T) {
+func TestAcquireLeaseClassifiesTimeoutBudgetExhaustionAsTemporarilyUnavailable(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`Failed to acquire lease "missing-type": resource type not found`))
+		time.Sleep(200 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"names": []string{"aro-hcp-dev-westus3-slot-00"},
+		})
 	}))
 	defer server.Close()
 
-	_, err := AcquireLease(context.Background(), server.URL, "missing-type", DefaultLeaseProxyTimeout)
+	_, err := AcquireLease(context.Background(), server.URL, "aro-hcp-dev-westus3-slot", 50*time.Millisecond)
 	if err == nil {
-		t.Fatal("expected lease acquire to fail for missing resource type")
+		t.Fatal("expected lease acquire to fail when the immediate-acquire budget is exhausted")
 	}
-	if errors.Is(err, ErrLeasePoolExhausted) {
-		t.Fatalf("expected missing resource type to remain a hard failure, got %v", err)
+	if !errors.Is(err, ErrLeasePoolUnavailableNow) {
+		t.Fatalf("expected temporary-unavailability classification, got %v", err)
 	}
 }
 

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/runtime_contract.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/runtime_contract.go
@@ -27,12 +27,10 @@ import (
 // It returns the validated name (not a subscription ID) because downstream
 // E2E steps expect the human-readable subscription name.
 func VerifyCustomerSubscriptionName(clusterProfileDir, slotSubscriptionName string) (string, error) {
-	clusterProfileDir = strings.TrimSpace(clusterProfileDir)
 	if clusterProfileDir == "" {
 		return "", errors.New("cluster profile dir is empty")
 	}
 
-	slotSubscriptionName = strings.TrimSpace(slotSubscriptionName)
 	if slotSubscriptionName == "" {
 		return "", errors.New("slot subscription name is empty")
 	}

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/state.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/state.go
@@ -140,7 +140,6 @@ func WriteEnvFile(sharedDir string, state *AcquiredSlotState, customerSubscripti
 	if err := state.Validate(); err != nil {
 		return err
 	}
-	customerSubscription = strings.TrimSpace(customerSubscription)
 	if customerSubscription == "" {
 		return errors.New("customer subscription is empty")
 	}
@@ -158,7 +157,7 @@ func WriteEnvFile(sharedDir string, state *AcquiredSlotState, customerSubscripti
 		"ARO_HCP_E2E_SLOT_RESOURCE_TYPE": state.Slot.ResourceType,
 		"CUSTOMER_SUBSCRIPTION":          customerSubscription,
 		"LEASED_MSI_CONTAINERS":          strings.Join(state.Slot.IdentityContainerNames(), " "),
-		"LOCATION":                       state.RuntimeRegion,
+		"SELECTED_LOCATION":              state.RuntimeRegion,
 	}
 
 	var builder strings.Builder

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/state_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/state_test.go
@@ -79,8 +79,8 @@ func TestWriteAndLoadAcquiredSlotStateAndEnvFile(t *testing.T) {
 	if !strings.Contains(content, `export LEASED_MSI_CONTAINERS='aro-hcp-msi-container-dev-00-00 aro-hcp-msi-container-dev-00-01 aro-hcp-msi-container-dev-00-02'`) {
 		t.Fatalf("expected env file to contain LEASED_MSI_CONTAINERS export, got %q", content)
 	}
-	if !strings.Contains(content, `export LOCATION='eastus2'`) {
-		t.Fatalf("expected env file to contain LOCATION export, got %q", content)
+	if !strings.Contains(content, `export SELECTED_LOCATION='eastus2'`) {
+		t.Fatalf("expected env file to contain SELECTED_LOCATION export, got %q", content)
 	}
 	if strings.Contains(content, "ARO_HCP_E2E_SLOT_REGION") {
 		t.Fatalf("expected env file to omit ARO_HCP_E2E_SLOT_REGION export, got %q", content)

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -8,13 +8,19 @@ environments:
     - subscription_name: "ARO HCP E2E Hosted Clusters (EA Subscription)"
       region: centralus
       resource_type: aro-hcp-dev-shard0-centralus-slot
+      slot_count: 15
+      identity_container_prefix: aro-hcp-msi-container-dev
+      identity_container_count: 20
+    - subscription_name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
+      region: canadacentral
+      resource_type: aro-hcp-dev-shard1-canadacentral-slot
       slot_count: 1
       identity_container_prefix: aro-hcp-msi-container-dev
       identity_container_count: 20
     - subscription_name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
       region: centralus
       resource_type: aro-hcp-dev-shard1-centralus-slot
-      slot_count: 7
+      slot_count: 6
       identity_container_prefix: aro-hcp-msi-container-dev
       identity_container_count: 20
 


### PR DESCRIPTION
## Summary

- Adapt `slot-manager acquire` to the Boskos proxy's blocking acquire behavior.
  - Bound each candidate-pool probe with `lease-proxy-timeout` instead of waiting for an explicit "pool exhausted" signal.
  - Treat proxy timeouts, retry-budget exhaustion, and retryable proxy/server responses as "temporarily unavailable now", then fall back to the next candidate pool.
  - Keep the outer `lease_wait_interval` / `max_wait_for_lease` loop as the retry unit after a full pass across all candidate pools.

- Implement explicit selector-based pool routing.
  - Add `ALLOWED_SUBSCRIPTIONS` and `ALLOWED_LOCATIONS` as the acquire-side selector contract.
  - Keep `MULTISTAGE_PARAM_OVERRIDE_LOCATION` as the highest-precedence concrete runtime location.
  - Update catalog selection, acquire logic, and unit coverage to reflect fixed vs runtime-selected pool behavior.
  - Export `SELECTED_LOCATION` in the slot runtime contract so the resolved runtime region is explicit.

- Refresh the dev slot inventory and docs for the staged rollout.
  - Reserve the first dev pool for the current CI dev jobs that are migrating from legacy Boskos leases to slot leases.
  - Use the additional pools on the second dev subscription for the multipool validation job.
  - Update the slot-manager design doc to reflect the selector contract and the proxy-aware failover model.

NOTE: slot-manager is yet unused by jobs in openshift/release.

## Test plan

- [x] `go test ./test/cmd/aro-hcp-tests/slot-manager/...`
- [x] Validate the paired `openshift/release` job selectors against the updated dev slot catalog. Tested via rehearsals in [PR #79042](https://github.com/openshift/release/pull/79042) . See job runs:
   - e2e-parallel (targets current dev e2esub): https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/79042/rehearse-79042-pull-ci-Azure-ARO-HCP-main-e2e-parallel/2060287893846364160
   - e2e-parallel-multipool (targets new dev e2e sub): https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/79042/rehearse-79042-pull-ci-Azure-ARO-HCP-main-e2e-parallel-multipool/2060096633210671104