### PR TITLE
Retry OIDC storage static website enablement for RBAC propagation

### DIFF
--- a/dev-infrastructure/modules/oidc/region/storage.sh
+++ b/dev-infrastructure/modules/oidc/region/storage.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 
+MAX_RETRIES=15
+RETRY_INTERVAL=10
+
 echo "Enable static Website on storage account ${StorageAccountName}"
-az storage blob service-properties update --static-website true --account-name ${StorageAccountName} --auth-mode login
+for i in $(seq 1 ${MAX_RETRIES}); do
+  if az storage blob service-properties update --static-website true --account-name "${StorageAccountName}" --auth-mode login; then
+    echo "Static website enabled successfully"
+    exit 0
+  fi
+  echo "Attempt ${i}/${MAX_RETRIES} failed, retrying in ${RETRY_INTERVAL}s (waiting for RBAC propagation)..."
+  sleep ${RETRY_INTERVAL}
+done
+
+echo "Failed to enable static website after ${MAX_RETRIES} attempts"
+exit 1


### PR DESCRIPTION
### What

The OIDC storage deployment script can fail when the Storage Account Contributor role assignment has not yet propagated in Azure AD by the time the deployment script executes. ARM accepts the role assignment resource before enforcement is effective, causing a race condition.

Add a retry loop (15 attempts, 10s interval) to handle this transient RBAC propagation delay.

See: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/batch/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2059916834487930880

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
