### PR TITLE
Fix kusto exporter log freshness

### DIFF
--- a/test/cmd/aro-hcp-tests/custom-link-tools/options.go
+++ b/test/cmd/aro-hcp-tests/custom-link-tools/options.go
@@ -307,12 +307,11 @@ func (o Options) Run(ctx context.Context) error {
 			if err != nil {
 				return utils.TrackError(fmt.Errorf("failed to create query factory: %w", err))
 			}
-			queryOpts := kusto.QueryOptions{
-				ResourceGroupName: rg,
-				TimestampMin:      ti.StartTime,
-				TimestampMax:      ti.EndTime,
-				Limit:             -1,
-			}
+			queryOpts := kusto.NewQueryOptions()
+			queryOpts.ResourceGroupName = rg
+			queryOpts.TimestampMin = ti.StartTime
+			queryOpts.TimestampMax = ti.EndTime
+			queryOpts.Limit = -1
 			templateData := kusto.NewTemplateDataFromOptions(queryOpts)
 
 			var links []LinkDetails
@@ -488,12 +487,11 @@ func getServiceLogLinks(tw timing.TimeWindow, svcClusterName, mgmtClusterName st
 	if err != nil {
 		return nil, fmt.Errorf("failed to create query factory: %w", err)
 	}
-	svcOpts := kusto.QueryOptions{
-		InfraClusterName: svcClusterName,
-		TimestampMin:     tw.Start,
-		TimestampMax:     tw.End,
-		Limit:            -1,
-	}
+	svcOpts := kusto.NewQueryOptions()
+	svcOpts.InfraClusterName = svcClusterName
+	svcOpts.TimestampMin = tw.Start
+	svcOpts.TimestampMax = tw.End
+	svcOpts.Limit = -1
 
 	// Service cluster queries: one per service log table + one merged link per custom query definition
 	infraServiceLogsDef, err := factory.GetBuiltinQueryDefinition("infraServiceLogs")
@@ -540,12 +538,11 @@ func getServiceLogLinks(tw timing.TimeWindow, svcClusterName, mgmtClusterName st
 	}
 
 	// Management cluster queries
-	mgmtOpts := kusto.QueryOptions{
-		InfraClusterName: mgmtClusterName,
-		TimestampMin:     tw.Start,
-		TimestampMax:     tw.End,
-		Limit:            -1,
-	}
+	mgmtOpts := kusto.NewQueryOptions()
+	mgmtOpts.InfraClusterName = mgmtClusterName
+	mgmtOpts.TimestampMin = tw.Start
+	mgmtOpts.TimestampMax = tw.End
+	mgmtOpts.Limit = -1
 	mgmtTables := []struct {
 		table       string
 		displayName string

--- a/test/util/verifiers/kusto.go
+++ b/test/util/verifiers/kusto.go
@@ -74,14 +74,12 @@ func (v verifyMustGatherLogsImpl) Verify(ctx context.Context) error {
 
 	queryClient := mustgather.NewQueryClientWithFileWriter(kustoClient, v.config.QueryTimeout, "", nil)
 
-	queryOptions := kusto.QueryOptions{
-		SubscriptionId:    v.config.SubscriptionID,
-		ResourceGroupName: v.config.ResourceGroup,
-		InfraClusterName:  "",
-		TimestampMin:      time.Now().Add(-24 * time.Hour),
-		TimestampMax:      time.Now(),
-		Limit:             -1,
-	}
+	queryOptions := kusto.NewQueryOptions()
+	queryOptions.SubscriptionId = v.config.SubscriptionID
+	queryOptions.ResourceGroupName = v.config.ResourceGroup
+	queryOptions.TimestampMin = time.Now().Add(-24 * time.Hour)
+	queryOptions.TimestampMax = time.Now()
+	queryOptions.Limit = -1
 
 	foundLogSources := make(map[string]bool)
 	var foundMutex sync.Mutex

--- a/tooling/aro-hcp-exporter/go.mod
+++ b/tooling/aro-hcp-exporter/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
-	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/prometheus/client_golang v1.23.2

--- a/tooling/aro-hcp-exporter/go.sum
+++ b/tooling/aro-hcp-exporter/go.sum
@@ -27,8 +27,6 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dusted-go/logging v1.3.0 h1:SL/EH1Rp27oJQIte+LjWvWACSnYDTqNx5gZULin0XRY=
-github.com/dusted-go/logging v1.3.0/go.mod h1:s58+s64zE5fxSWWZfp+b8ZV0CHyKHjamITGyuY1wzGg=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=

--- a/tooling/aro-hcp-exporter/internal/metrics/kusto_logs_current.go
+++ b/tooling/aro-hcp-exporter/internal/metrics/kusto_logs_current.go
@@ -103,13 +103,13 @@ func (c *KustoLogsCurrentCollector) CollectMetricValues(ctx context.Context) {
 
 		queryClient := mustgather.NewQueryClientWithFileWriter(c.kustoClient, KustoLogsCurrentQueryTimeout, "", nil)
 
-		queryOptions := kusto.QueryOptions{
-			InfraClusterName: clusterName,
-			TimestampMin:     time.Now().Add(-120 * time.Minute),
-			TimestampMax:     time.Now(),
-			// Use magic number for now, will change to specific limit for each table, once kql generater is done
-			Limit: 100,
-		}
+		queryOptions := kusto.NewQueryOptions()
+		queryOptions.InfraClusterName = clusterName
+		queryOptions.TimestampMin = time.Now().Add(-120 * time.Minute)
+		queryOptions.TimestampMax = time.Now()
+		// Use magic number for now, will change to specific limit for each table, once kql generater is done
+		queryOptions.Limit = 100
+		queryOptions.OrderBy = kusto.OrderByDesc
 
 		foundLogSources := make(map[string]time.Time)
 		var foundMutex sync.Mutex

--- a/tooling/aro-hcp-exporter/main.go
+++ b/tooling/aro-hcp-exporter/main.go
@@ -21,7 +21,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/dusted-go/logging/prettylog"
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 
@@ -74,10 +73,8 @@ This tool exposes metrics via HTTP that can be scraped by Prometheus.`,
 }
 
 func createLogger(verbosity int) logr.Logger {
-	prettyHandler := prettylog.NewHandler(&slog.HandlerOptions{
-		Level:       slog.Level(verbosity * -1),
-		AddSource:   false,
-		ReplaceAttr: nil,
+	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.Level(verbosity * -1),
 	})
-	return logr.FromSlogHandler(prettyHandler)
+	return logr.FromSlogHandler(handler)
 }

--- a/tooling/hcpctl/cmd/must-gather/query_infra_cmd.go
+++ b/tooling/hcpctl/cmd/must-gather/query_infra_cmd.go
@@ -69,14 +69,15 @@ func (opts *CompletedInfraQueryOptions) RunInfra(ctx context.Context) error {
 	for _, clusterName := range opts.InfraClusters {
 		logger.V(1).Info("Gathering infrastructure logs", "cluster", clusterName)
 
+		queryOptions := kusto.NewQueryOptions()
+		queryOptions.InfraClusterName = clusterName
+		queryOptions.TimestampMin = opts.TimestampMin
+		queryOptions.TimestampMax = opts.TimestampMax
+		queryOptions.Limit = opts.Limit
+		queryOptions.SplitByPod = opts.SplitByPod
+
 		gatherer := mustgather.NewCliGatherer(opts.QueryClient, opts.OutputPath, ServicesLogDirectory, HostedControlPlaneLogDirectory, CustomLogsDirectory, mustgather.GathererOptions{
-			QueryOptions: &kusto.QueryOptions{
-				InfraClusterName: clusterName,
-				TimestampMin:     opts.TimestampMin,
-				TimestampMax:     opts.TimestampMax,
-				Limit:            opts.Limit,
-				SplitByPod:       opts.SplitByPod,
-			},
+			QueryOptions: &queryOptions,
 		}, true)
 
 		if err := gatherer.GatherLogs(ctx); err != nil {

--- a/tooling/hcpctl/cmd/must-gather/query_options.go
+++ b/tooling/hcpctl/cmd/must-gather/query_options.go
@@ -122,19 +122,20 @@ func (o *RawQueryOptions) Validate(ctx context.Context) (*ValidatedQueryOptions,
 		resourceGroupName = res.ResourceGroupName
 	}
 
+	queryOptions := kusto.NewQueryOptions()
+	queryOptions.SubscriptionId = subscriptionID
+	queryOptions.ResourceGroupName = resourceGroupName
+	queryOptions.TimestampMin = o.TimestampMin
+	queryOptions.TimestampMax = o.TimestampMax
+	queryOptions.Limit = o.Limit
+	queryOptions.SplitByPod = o.SplitByPod
+	queryOptions.ClusterNames = o.ClusterNames
+	queryOptions.ClusterIds = o.ClusterIds
+
 	return &ValidatedQueryOptions{
 		RawQueryOptions: o,
 		KustoEndpoint:   kustoEndpoint,
-		QueryOptions: kusto.QueryOptions{
-			SubscriptionId:    subscriptionID,
-			ResourceGroupName: resourceGroupName,
-			ClusterIds:        o.ClusterIds,
-			ClusterNames:      o.ClusterNames,
-			TimestampMin:      o.TimestampMin,
-			TimestampMax:      o.TimestampMax,
-			Limit:             o.Limit,
-			SplitByPod:        o.SplitByPod,
-		},
+		QueryOptions:    queryOptions,
 	}, nil
 }
 

--- a/tooling/hcpctl/pkg/kusto/query.go
+++ b/tooling/hcpctl/pkg/kusto/query.go
@@ -24,6 +24,22 @@ import (
 	"github.com/Azure/azure-kusto-go/azkustodata/kql"
 )
 
+type OrderBy int
+
+const (
+	OrderByAsc OrderBy = iota
+	OrderByDesc
+)
+
+func (o OrderBy) String() string {
+	switch o {
+	case OrderByDesc:
+		return "desc"
+	default:
+		return "asc"
+	}
+}
+
 // QueryOptions contains the parameters needed to construct queries.
 type QueryOptions struct {
 	SubscriptionId    string
@@ -35,6 +51,13 @@ type QueryOptions struct {
 	TimestampMax      time.Time
 	Limit             int
 	SplitByPod        bool
+	OrderBy           OrderBy
+}
+
+func NewQueryOptions() QueryOptions {
+	return QueryOptions{
+		OrderBy: OrderByAsc,
+	}
 }
 
 // Query represents a ready-to-execute KQL query with all its metadata.
@@ -116,6 +139,7 @@ type TemplateData struct {
 	FilterClusterName  string
 	HCPNamespacePrefix string
 	SplitByPod         bool
+	OrderBy            string
 }
 
 type TemplateDataOptions func(*TemplateData)
@@ -181,6 +205,7 @@ func NewTemplateDataFromOptions(queryOptions QueryOptions, options ...TemplateDa
 		SubResourceGroupId: fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", kqlEscStr(queryOptions.SubscriptionId), kqlEscStr(queryOptions.ResourceGroupName)),
 		ResourceGroupName:  kqlEscStr(queryOptions.ResourceGroupName),
 		SplitByPod:         queryOptions.SplitByPod,
+		OrderBy:            queryOptions.OrderBy.String(),
 	}
 	defaults := []TemplateDataOptions{
 		WithClusterName(queryOptions.InfraClusterName),

--- a/tooling/hcpctl/pkg/kusto/query_test.go
+++ b/tooling/hcpctl/pkg/kusto/query_test.go
@@ -41,14 +41,14 @@ func queryToFixture(q Query) queryFixture {
 }
 
 func baseOptions() QueryOptions {
-	return QueryOptions{
-		SubscriptionId:    "test-sub",
-		ResourceGroupName: "test-rg",
-		InfraClusterName:  "test-cluster",
-		TimestampMin:      time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-		TimestampMax:      time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
-		Limit:             100,
-	}
+	opts := NewQueryOptions()
+	opts.SubscriptionId = "test-sub"
+	opts.ResourceGroupName = "test-rg"
+	opts.InfraClusterName = "test-cluster"
+	opts.TimestampMin = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	opts.TimestampMax = time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+	opts.Limit = 100
+	return opts
 }
 
 func TestInfraKubernetesEvents(t *testing.T) {
@@ -67,10 +67,9 @@ func TestInfraKubernetesEvents(t *testing.T) {
 func TestInfraKubernetesEvents_NoTruncation(t *testing.T) {
 	f, err := NewQueryFactory()
 	require.NoError(t, err)
-	opts := QueryOptions{
-		InfraClusterName: "test-cluster",
-		Limit:            -1,
-	}
+	opts := NewQueryOptions()
+	opts.InfraClusterName = "test-cluster"
+	opts.Limit = -1
 	def, err := f.GetBuiltinQueryDefinition("kubernetesEvents")
 	require.NoError(t, err)
 	queries, err := f.Build(*def, NewTemplateDataFromOptions(opts))
@@ -96,10 +95,9 @@ func TestKubernetesEventsSvc(t *testing.T) {
 func TestKubernetesEventsMgmt(t *testing.T) {
 	f, err := NewQueryFactory()
 	require.NoError(t, err)
-	opts := QueryOptions{
-		InfraClusterName: "test-cluster",
-		Limit:            50,
-	}
+	opts := NewQueryOptions()
+	opts.InfraClusterName = "test-cluster"
+	opts.Limit = 50
 	def, err := f.GetBuiltinQueryDefinition("kubernetesEventsMgmt")
 	require.NoError(t, err)
 	queries, err := f.Build(*def, NewTemplateDataFromOptions(opts,
@@ -141,11 +139,10 @@ func TestInfraServiceLogs(t *testing.T) {
 func TestServiceLogs(t *testing.T) {
 	f, err := NewQueryFactory()
 	require.NoError(t, err)
-	opts := QueryOptions{
-		SubscriptionId:    "sub",
-		ResourceGroupName: "rg",
-		Limit:             10,
-	}
+	opts := NewQueryOptions()
+	opts.SubscriptionId = "sub"
+	opts.ResourceGroupName = "rg"
+	opts.Limit = 10
 	def, err := f.GetBuiltinQueryDefinition("serviceLogs")
 	require.NoError(t, err)
 	queries, err := f.Build(*def, NewTemplateDataFromOptions(opts,
@@ -161,11 +158,10 @@ func TestServiceLogs(t *testing.T) {
 func TestServiceLogs_NoClusterIds(t *testing.T) {
 	f, err := NewQueryFactory()
 	require.NoError(t, err)
-	opts := QueryOptions{
-		SubscriptionId:    "sub",
-		ResourceGroupName: "rg",
-		Limit:             10,
-	}
+	opts := NewQueryOptions()
+	opts.SubscriptionId = "sub"
+	opts.ResourceGroupName = "rg"
+	opts.Limit = 10
 	def, err := f.GetBuiltinQueryDefinition("serviceLogs")
 	require.NoError(t, err)
 	queries, err := f.Build(*def, NewTemplateDataFromOptions(opts, WithTable("containerLogs")))
@@ -178,7 +174,8 @@ func TestServiceLogs_NoClusterIds(t *testing.T) {
 func TestHostedControlPlaneLogs(t *testing.T) {
 	f, err := NewQueryFactory()
 	require.NoError(t, err)
-	opts := QueryOptions{Limit: 100}
+	opts := NewQueryOptions()
+	opts.Limit = 100
 	def, err := f.GetBuiltinQueryDefinition("hostedControlPlaneLogs")
 	require.NoError(t, err)
 	queries, err := f.Build(*def, NewTemplateDataFromOptions(opts, WithClusterId("cid1")))
@@ -242,12 +239,11 @@ func TestBuildMerged_SingleTemplate(t *testing.T) {
 func TestBuildMerged_MultipleChildren(t *testing.T) {
 	f, err := NewQueryFactory()
 	require.NoError(t, err)
-	opts := QueryOptions{
-		ResourceGroupName: "test-rg",
-		TimestampMin:      time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-		TimestampMax:      time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
-		Limit:             -1,
-	}
+	opts := NewQueryOptions()
+	opts.ResourceGroupName = "test-rg"
+	opts.TimestampMin = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	opts.TimestampMax = time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+	opts.Limit = -1
 
 	var detailedDef *QueryDefinition
 	for _, def := range f.customQueryDefinitions {
@@ -266,12 +262,11 @@ func TestBuildMerged_MultipleChildren(t *testing.T) {
 }
 
 func TestTemplateDataOptions(t *testing.T) {
-	opts := QueryOptions{
-		SubscriptionId:    "sub",
-		ResourceGroupName: "rg",
-		InfraClusterName:  "cluster",
-		Limit:             100,
-	}
+	opts := NewQueryOptions()
+	opts.SubscriptionId = "sub"
+	opts.ResourceGroupName = "rg"
+	opts.InfraClusterName = "cluster"
+	opts.Limit = 100
 
 	td := NewTemplateDataFromOptions(opts,
 		WithClusterId("cid1"),
@@ -286,7 +281,8 @@ func TestTemplateDataOptions(t *testing.T) {
 }
 
 func TestTemplateDataOptions_NoTruncation(t *testing.T) {
-	opts := QueryOptions{Limit: -1}
+	opts := NewQueryOptions()
+	opts.Limit = -1
 	td := NewTemplateDataFromOptions(opts)
 
 	testutil.CompareWithFixture(t, td)

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/hcp/hcp_logs.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/hcp/hcp_logs.kql.gotmpl
@@ -9,7 +9,7 @@ containerLogs
 {{- end}}
 | where timestamp between({{ .TimestampMin }} .. {{ .TimestampMax }})
 | where namespace_name has '{{.ClusterId}}'
+| order by timestamp {{.OrderBy}}
 {{- if gt .Limit 0}}
 | limit {{.Limit}}
 {{- end}}
-| order by timestamp asc

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/infra/kubernetes_events.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/infra/kubernetes_events.kql.gotmpl
@@ -4,7 +4,7 @@ kubernetesEvents
 | project timestamp, log, cluster
 | where timestamp between({{ .TimestampMin }} .. {{ .TimestampMax }})
 | where cluster == '{{.ClusterName}}'
+| order by timestamp {{.OrderBy}}
 {{- if gt .Limit 0}}
 | limit {{.Limit}}
 {{- end}}
-| order by timestamp asc

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/infra/service_logs.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/infra/service_logs.kql.gotmpl
@@ -9,7 +9,7 @@
 {{- end}}
 | where timestamp between({{ .TimestampMin }} .. {{ .TimestampMax }})
 | where cluster == '{{.ClusterName}}'
+| order by timestamp {{.OrderBy}}
 {{- if gt .Limit 0}}
 | limit {{.Limit}}
 {{- end}}
-| order by timestamp asc

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/infra/systemd_logs.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/infra/systemd_logs.kql.gotmpl
@@ -5,7 +5,7 @@ systemdLogs
 | project timestamp, log, cluster
 | where cluster == '{{.ClusterName}}'
 | where timestamp between({{ .TimestampMin }} .. {{ .TimestampMax }})
+| order by timestamp {{.OrderBy}}
 {{- if gt .Limit 0}}
 | limit {{.Limit}}
 {{- end}}
-| order by timestamp asc

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/kubernetes-events/mgmt.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/kubernetes-events/mgmt.kql.gotmpl
@@ -5,7 +5,7 @@ kubernetesEvents
 | where cluster == '{{.ClusterName}}'
 | where eventNamespace !hasprefix '{{.HCPNamespacePrefix}}' or eventNamespace has_any ({{.ClusterIds}})
 | project timestamp, log, cluster
+| order by timestamp {{.OrderBy}}
 {{- if gt .Limit 0}}
 | limit {{.Limit}}
 {{- end}}
-| order by timestamp asc

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/kubernetes-events/svc.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/kubernetes-events/svc.kql.gotmpl
@@ -4,7 +4,7 @@ kubernetesEvents
 | project timestamp, log, cluster
 | where timestamp between({{ .TimestampMin }} .. {{ .TimestampMax }})
 | where cluster == '{{.ClusterName}}'
+| order by timestamp {{.OrderBy}}
 {{- if gt .Limit 0}}
 | limit {{.Limit}}
 {{- end}}
-| order by timestamp asc

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/services/service_logs.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/services/service_logs.kql.gotmpl
@@ -14,7 +14,7 @@
 {{- else}}
 | project timestamp, log, cluster, namespace_name, container_name
 {{- end}}
+| order by timestamp {{.OrderBy}}
 {{- if gt .Limit 0}}
 | limit {{.Limit}}
 {{- end}}
-| order by timestamp asc

--- a/tooling/hcpctl/pkg/kusto/templates/custom/detailed_api_layer_logs.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/custom/detailed_api_layer_logs.kql.gotmpl
@@ -26,4 +26,4 @@ union
         | where resource_group == '{{.ResourceGroupName}}'
         | project timestamp, container_name, msg, log
     )
-| order by timestamp asc
+| order by timestamp {{.OrderBy}}

--- a/tooling/hcpctl/pkg/kusto/templates/custom/detailed_cluster_mgmt_logs.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/custom/detailed_cluster_mgmt_logs.kql.gotmpl
@@ -23,4 +23,4 @@ union
         | summarize arg_min(timestamp, *) by status_name, status_message
         | project timestamp, container_name = "clusters-service (status)", msg = strcat(status_name, ": ", status_message), log = bag_pack("status_name", status_name, "status_message", status_message)
     )
-| order by timestamp asc
+| order by timestamp {{.OrderBy}}

--- a/tooling/hcpctl/pkg/kusto/templates/custom/detailed_infra_orchestration_logs.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/custom/detailed_infra_orchestration_logs.kql.gotmpl
@@ -52,4 +52,4 @@ union
         | where logStr has cluster_id
         | project timestamp, container_name, msg = logStr, log
     )
-| order by timestamp asc
+| order by timestamp {{.OrderBy}}

--- a/tooling/hcpctl/pkg/mustgather/gather_test.go
+++ b/tooling/hcpctl/pkg/mustgather/gather_test.go
@@ -90,13 +90,18 @@ func makeTestRow(t *testing.T, colDefs []struct {
 	return kusto.TaggedRow{Row: azkquery.NewRow(bt, 0, vals), QueryName: "test"}
 }
 
+func testQueryOptions(subID, rg, infraCluster string) *kusto.QueryOptions {
+	q := kusto.NewQueryOptions()
+	q.SubscriptionId = subID
+	q.ResourceGroupName = rg
+	q.InfraClusterName = infraCluster
+	return &q
+}
+
 func TestNewGatherer(t *testing.T) {
 	mockQueryClient := &MockQueryClient{}
 	opts := GathererOptions{
-		QueryOptions: &kusto.QueryOptions{
-			SubscriptionId:    "test-sub",
-			ResourceGroupName: "test-rg",
-		},
+		QueryOptions: testQueryOptions("test-sub", "test-rg", ""),
 	}
 
 	// Test CLI gatherer
@@ -122,10 +127,7 @@ func TestGatherer_GatherLogs(t *testing.T) {
 		QueryClient: mockQueryClient,
 		opts: GathererOptions{
 			SkipKubernetesEventsLogs: true,
-			QueryOptions: &kusto.QueryOptions{
-				SubscriptionId:    "test-sub",
-				ResourceGroupName: "test-rg",
-			},
+			QueryOptions:             testQueryOptions("test-sub", "test-rg", ""),
 		},
 		outputFunc:    mockOutputFunc,
 		outputOptions: RowOutputOptions{"outputPath": "/test"},
@@ -176,10 +178,7 @@ func TestGatherer_GatherLogs_WithKubernetesEventsAndSystemdLogs(t *testing.T) {
 		opts: GathererOptions{
 			SkipKubernetesEventsLogs: false,
 			CollectSystemdLogs:       true,
-			QueryOptions: &kusto.QueryOptions{
-				SubscriptionId:    "test-sub",
-				ResourceGroupName: "test-rg",
-			},
+			QueryOptions:             testQueryOptions("test-sub", "test-rg", ""),
 		},
 		outputFunc:    mockOutputFunc,
 		outputOptions: RowOutputOptions{"outputPath": "/test"},
@@ -202,10 +201,7 @@ func TestGatherer_GatherLogs_SkipOnlySystemdLogs(t *testing.T) {
 		QueryClient: mockQueryClient,
 		opts: GathererOptions{
 			SkipKubernetesEventsLogs: false,
-			QueryOptions: &kusto.QueryOptions{
-				SubscriptionId:    "test-sub",
-				ResourceGroupName: "test-rg",
-			},
+			QueryOptions:             testQueryOptions("test-sub", "test-rg", ""),
 		},
 		outputFunc:    mockOutputFunc,
 		outputOptions: RowOutputOptions{"outputPath": "/test"},
@@ -230,9 +226,7 @@ func TestGatherer_GatherInfraLogs(t *testing.T) {
 		QueryClient: mockQueryClient,
 		opts: GathererOptions{
 			GatherInfraLogs: true,
-			QueryOptions: &kusto.QueryOptions{
-				InfraClusterName: "test-infra-cluster",
-			},
+			QueryOptions:    testQueryOptions("", "", "test-infra-cluster"),
 		},
 		outputFunc:    mockOutputFunc,
 		outputOptions: RowOutputOptions{"outputPath": "/test"},
@@ -254,9 +248,7 @@ func TestGatherer_GatherInfraLogs_Error(t *testing.T) {
 		QueryClient: mockQueryClient,
 		opts: GathererOptions{
 			GatherInfraLogs: true,
-			QueryOptions: &kusto.QueryOptions{
-				InfraClusterName: "test-infra-cluster",
-			},
+			QueryOptions:    testQueryOptions("", "", "test-infra-cluster"),
 		},
 		outputFunc:    mockOutputFunc,
 		outputOptions: RowOutputOptions{"outputPath": "/test"},
@@ -281,10 +273,7 @@ func TestGatherer_GatherLogs_ContextCancellation(t *testing.T) {
 		QueryClient: mockQueryClient,
 		opts: GathererOptions{
 			SkipKubernetesEventsLogs: true,
-			QueryOptions: &kusto.QueryOptions{
-				SubscriptionId:    "test-sub",
-				ResourceGroupName: "test-rg",
-			},
+			QueryOptions:             testQueryOptions("test-sub", "test-rg", ""),
 		},
 		outputFunc:    mockOutputFunc,
 		outputOptions: RowOutputOptions{"outputPath": "/test"},

--- a/tooling/hcpctl/pkg/mustgather/queries_test.go
+++ b/tooling/hcpctl/pkg/mustgather/queries_test.go
@@ -26,10 +26,9 @@ import (
 func TestGetServicesQueries(t *testing.T) {
 	factory, err := kusto.NewQueryFactory()
 	require.NoError(t, err)
-	opts := kusto.QueryOptions{
-		SubscriptionId:    "test-sub",
-		ResourceGroupName: "test-rg",
-	}
+	opts := kusto.NewQueryOptions()
+	opts.SubscriptionId = "test-sub"
+	opts.ResourceGroupName = "test-rg"
 
 	queries, err := serviceLogs(factory, "serviceLogs", opts, []string{"cluster1"})
 	require.NoError(t, err)
@@ -39,7 +38,7 @@ func TestGetServicesQueries(t *testing.T) {
 func TestGetHostedControlPlaneLogsQuery(t *testing.T) {
 	factory, err := kusto.NewQueryFactory()
 	require.NoError(t, err)
-	opts := kusto.QueryOptions{}
+	opts := kusto.NewQueryOptions()
 
 	// With cluster IDs
 	queries, err := hostedControlPlaneLogs(factory, opts, []string{"cluster1", "cluster2"})
@@ -55,10 +54,9 @@ func TestGetHostedControlPlaneLogsQuery(t *testing.T) {
 func TestGetClusterIdQuery(t *testing.T) {
 	factory, err := kusto.NewQueryFactory()
 	require.NoError(t, err)
-	opts := kusto.QueryOptions{
-		SubscriptionId:    "test-sub",
-		ResourceGroupName: "test-rg",
-	}
+	opts := kusto.NewQueryOptions()
+	opts.SubscriptionId = "test-sub"
+	opts.ResourceGroupName = "test-rg"
 
 	clusterIdDef, err := factory.GetBuiltinQueryDefinition("clusterId")
 	require.NoError(t, err)

--- a/tooling/hcpctl/testdata/zz_fixture_TestBuildMerged_SingleTemplate.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestBuildMerged_SingleTemplate.yaml
@@ -4,7 +4,7 @@ kql: |-
   | project timestamp, log, cluster
   | where timestamp between(datetime(2025-01-01T00:00:00.0000000Z) .. datetime(2025-01-02T00:00:00.0000000Z))
   | where cluster == 'test-cluster'
-  | limit 100
   | order by timestamp asc
+  | limit 100
 name: kubernetesEvents
 unlimited: false

--- a/tooling/hcpctl/testdata/zz_fixture_TestHostedControlPlaneLogs.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestHostedControlPlaneLogs.yaml
@@ -4,7 +4,7 @@ kql: |-
   | project timestamp, log, cluster, namespace_name, container_name
   | where timestamp between(datetime(0001-01-01T00:00:00.0000000Z) .. datetime(0001-01-01T00:00:00.0000000Z))
   | where namespace_name has 'cid1'
-  | limit 100
   | order by timestamp asc
+  | limit 100
 name: hostedControlPlaneLogs
 unlimited: false

--- a/tooling/hcpctl/testdata/zz_fixture_TestInfraKubernetesEvents.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestInfraKubernetesEvents.yaml
@@ -4,7 +4,7 @@ kql: |-
   | project timestamp, log, cluster
   | where timestamp between(datetime(2025-01-01T00:00:00.0000000Z) .. datetime(2025-01-02T00:00:00.0000000Z))
   | where cluster == 'test-cluster'
-  | limit 100
   | order by timestamp asc
+  | limit 100
 name: kubernetesEvents
 unlimited: false

--- a/tooling/hcpctl/testdata/zz_fixture_TestInfraServiceLogs.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestInfraServiceLogs.yaml
@@ -4,7 +4,7 @@ kql: |-
   | project timestamp, log, cluster, namespace_name, container_name
   | where timestamp between(datetime(2025-01-01T00:00:00.0000000Z) .. datetime(2025-01-02T00:00:00.0000000Z))
   | where cluster == 'test-cluster'
-  | limit 100
   | order by timestamp asc
+  | limit 100
 name: infraServiceLogs
 unlimited: false

--- a/tooling/hcpctl/testdata/zz_fixture_TestInfraSystemdLogs.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestInfraSystemdLogs.yaml
@@ -5,7 +5,7 @@ kql: |-
   | project timestamp, log, cluster
   | where cluster == 'test-cluster'
   | where timestamp between(datetime(2025-01-01T00:00:00.0000000Z) .. datetime(2025-01-02T00:00:00.0000000Z))
-  | limit 100
   | order by timestamp asc
+  | limit 100
 name: systemdLogs
 unlimited: false

--- a/tooling/hcpctl/testdata/zz_fixture_TestKubernetesEventsMgmt.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestKubernetesEventsMgmt.yaml
@@ -5,7 +5,7 @@ kql: |-
   | where cluster == 'test-cluster'
   | where eventNamespace !hasprefix 'ocm-arohcp' or eventNamespace has_any ('cid1', 'cid2')
   | project timestamp, log, cluster
-  | limit 50
   | order by timestamp asc
+  | limit 50
 name: kubernetesEventsMgmt
 unlimited: false

--- a/tooling/hcpctl/testdata/zz_fixture_TestKubernetesEventsSvc.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestKubernetesEventsSvc.yaml
@@ -4,7 +4,7 @@ kql: |-
   | project timestamp, log, cluster
   | where timestamp between(datetime(2025-01-01T00:00:00.0000000Z) .. datetime(2025-01-02T00:00:00.0000000Z))
   | where cluster == 'test-cluster'
-  | limit 100
   | order by timestamp asc
+  | limit 100
 name: kubernetesEventsSvc
 unlimited: false

--- a/tooling/hcpctl/testdata/zz_fixture_TestServiceLogs.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestServiceLogs.yaml
@@ -5,7 +5,7 @@ kql: |
   | where column_ifexists("cid", "") in ('cid1')
       or (log has '/subscriptions/sub/resourceGroups/rg' and log has_any ('cid1'))
   | project timestamp, log, cluster, namespace_name, container_name
-  | limit 10
   | order by timestamp asc
+  | limit 10
 name: serviceLogs
 unlimited: false

--- a/tooling/hcpctl/testdata/zz_fixture_TestServiceLogs_NoClusterIds.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestServiceLogs_NoClusterIds.yaml
@@ -4,7 +4,7 @@ kql: |
   | where timestamp between(datetime(0001-01-01T00:00:00.0000000Z) .. datetime(0001-01-01T00:00:00.0000000Z))
   | where log has '/subscriptions/sub/resourceGroups/rg'
   | project timestamp, log, cluster, namespace_name, container_name
-  | limit 10
   | order by timestamp asc
+  | limit 10
 name: serviceLogs
 unlimited: false

--- a/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions.yaml
@@ -6,6 +6,7 @@ FilterClusterName: ""
 HCPNamespacePrefix: ocm-arohcp
 Limit: 100
 NoTruncation: false
+OrderBy: asc
 ResourceGroupName: rg
 SplitByPod: false
 SubResourceGroupId: /subscriptions/sub/resourceGroups/rg

--- a/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions_NoTruncation.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions_NoTruncation.yaml
@@ -6,6 +6,7 @@ FilterClusterName: ""
 HCPNamespacePrefix: ""
 Limit: 0
 NoTruncation: true
+OrderBy: asc
 ResourceGroupName: ""
 SplitByPod: false
 SubResourceGroupId: /subscriptions//resourceGroups/


### PR DESCRIPTION


https://redhat.atlassian.net/browse/AROSLSRE-962

### What/Why

Fix kusto exporter log freshness: sort before limit, make order configurable

  The exporter checks log freshness by querying Kusto and inspecting the
  first returned row's timestamp. Previously, queries applied `limit`
  before `order by`, returning an arbitrary subset that was then sorted —
  so the exporter was measuring the age of a random log, not the most
  recent one.

  - Add OrderBy type (string enum: asc/desc) to QueryOptions with a NewQueryOptions() constructor that defaults to asc
  - Templatize `| order by timestamp` direction in all 10 KQL templates
  - Move `| order by` before `| limit` so sorting happens before truncation
  - Set OrderBy to desc in the exporter so it sees the newest log first
  - Replace prettylog with slog.TextHandler for plain text CLI logging
  - Migrate all QueryOptions call sites to use NewQueryOptions()

