### PR TITLE
fix(kube-applier): look up CosmosDB in svc subscription

### DIFF
--- a/dev-infrastructure/configurations/kube-applier-lookup.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/kube-applier-lookup.tmpl.bicepparam
@@ -2,5 +2,3 @@ using '../templates/kube-applier-lookup.bicep'
 
 param imagePullerMsiName = 'image-puller'
 param kubeApplierMsiName = '{{ .kubeApplier.managedIdentityName }}'
-param regionalResourceGroup = '{{ .regionRG }}'
-param rpCosmosDbName = '{{ .frontend.cosmosDB.name }}'

--- a/dev-infrastructure/templates/kube-applier-lookup.bicep
+++ b/dev-infrastructure/templates/kube-applier-lookup.bicep
@@ -4,12 +4,6 @@ param imagePullerMsiName string
 @description('The name of the Kube Applier MSI')
 param kubeApplierMsiName string
 
-@description('The resourcegroup for regional infrastructure')
-param regionalResourceGroup string
-
-@description('The name of the CosmosDB account')
-param rpCosmosDbName string
-
 //
 //   I M A G E   P U L L E R   L O O K U P
 //
@@ -33,14 +27,3 @@ resource kubeApplierIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2
 
 output kubeApplierMsiClientId string = kubeApplierIdentity.properties.clientId
 output kubeApplierMsiTenantId string = kubeApplierIdentity.properties.tenantId
-
-//
-//   C O S M O S D B   L O O K U P
-//
-
-resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' existing = {
-  scope: resourceGroup(regionalResourceGroup)
-  name: rpCosmosDbName
-}
-
-output cosmosDBDocumentEndpoint string = cosmosDbAccount.properties.documentEndpoint

--- a/dev-infrastructure/templates/output-region.bicep
+++ b/dev-infrastructure/templates/output-region.bicep
@@ -48,3 +48,4 @@ resource rpCosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' ex
 }
 
 output rpCosmosDbAccountId string = rpCosmosDbAccount.id
+output cosmosDBDocumentEndpoint string = rpCosmosDbAccount.properties.documentEndpoint

--- a/kube-applier/pipeline.yaml
+++ b/kube-applier/pipeline.yaml
@@ -48,6 +48,16 @@ resourceGroups:
     parameters: ../dev-infrastructure/configurations/kusto-lookup.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
+- name: region
+  resourceGroup: '{{ .regionRG }}'
+  subscription: '{{ .svc.subscription.key }}'
+  steps:
+  - name: output
+    action: ARM
+    template: ./../dev-infrastructure/templates/output-region.bicep
+    parameters: ./../dev-infrastructure/configurations/output-region.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
 - name: management
   resourceGroup: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
@@ -91,7 +101,7 @@ resourceGroups:
         step: output
         name: kubeApplierMsiTenantId
       cosmosDBDocumentEndpoint:
-        resourceGroup: management
+        resourceGroup: region
         step: output
         name: cosmosDBDocumentEndpoint
     dependsOn:

--- a/kube-applier/pipeline.yaml
+++ b/kube-applier/pipeline.yaml
@@ -48,7 +48,7 @@ resourceGroups:
     parameters: ../dev-infrastructure/configurations/kusto-lookup.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: region
+- name: regional
   resourceGroup: '{{ .regionRG }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
@@ -101,7 +101,7 @@ resourceGroups:
         step: output
         name: kubeApplierMsiTenantId
       cosmosDBDocumentEndpoint:
-        resourceGroup: region
+        resourceGroup: regional
         step: output
         name: cosmosDBDocumentEndpoint
     dependsOn:


### PR DESCRIPTION
### What

The kube-applier-lookup bicep ran in the management cluster subscription, but CosmosDB lives in the service cluster subscription. This caused the CosmosDB lookup to fail in environments with separate subscriptions.

Move the CosmosDB endpoint lookup to output-region.bicep (which runs in the svc subscription) and add a region resource group step to the kube-applier pipeline to consume it.

https://redhat.atlassian.net/browse/ARO-27358

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
