### PR TITLE
feat(fleet): add dedicated Kusto table for fleet controller logs

### DIFF
--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -497,7 +497,7 @@ mgmt.dev.permissions: mgmt.kv.permission
 # Monitoring
 #
 kusto: configurations/kusto.bicepparam
-	make -C .. pipeline/HCP.Geography DEPLOY_ENV=$(DEPLOY_ENV) EXTRA_ARGS="--region eastus2"
+	make -C .. pipeline/Geography DEPLOY_ENV=$(DEPLOY_ENV) EXTRA_ARGS="--region eastus2"
 	az tag create --resource-id /subscriptions/$(DEV_TESTING_SUBSCRIPTION_ID)/resourceGroups/hcp-kusto-us --tags persist=true
 .PHONY: kusto
 
@@ -643,4 +643,3 @@ clean: svc.clean mgmt.clean region.clean
 
 local-cs-permissions: svc.dev.permissions mgmt.dev.permissions
 .PHONY: local-cs-permissions
-

--- a/dev-infrastructure/modules/logs/kusto/main.bicep
+++ b/dev-infrastructure/modules/logs/kusto/main.bicep
@@ -56,6 +56,7 @@ var dummyScript = '.create-or-alter function with (docstring = \'dummy function 
 var allServiceLogsTablesKQL = {
   backendLogs: loadTextContent('tables/backendLogs.kql')
   containerlogs: loadTextContent('tables/containerLogs.kql')
+  fleetLogs: loadTextContent('tables/fleetLogs.kql')
   frontendLogs: loadTextContent('tables/frontendLogs.kql')
   clustersServiceLogs: loadTextContent('tables/clustersServiceLogs.kql')
   kubernetesEvents: loadTextContent('tables/kubernetesEvents.kql')

--- a/dev-infrastructure/modules/logs/kusto/tables/fleetLogs.kql
+++ b/dev-infrastructure/modules/logs/kusto/tables/fleetLogs.kql
@@ -1,0 +1,46 @@
+.create-merge table fleetLogs (
+  timestamp: datetime,
+  log: dynamic,
+  environment: string,
+  cluster: string,
+  namespace_name: string,
+  container_name: string,
+  container_image: string,           // fluentbit: kubernetes.container_image
+  host: string,
+  labels: string,
+  pod_name: string,
+  region: string,
+  level: string,
+  msg: string,
+  controller_name: string,
+  resource_name: string,
+  resource_id: string,
+  resource_type: string,
+  tag: string,                       // fluentbit: tag routing identifier
+  container_status_image_id: string  // fluentbit: kubernetes.container_hash (k8s status.containerStatuses.imageID)
+)
+
+.create-or-alter table fleetLogs ingestion json mapping 'ingestionMapping'
+```
+[
+  {"column":"timestamp","Properties":{"path":"$.timestamp"}},
+  {"column":"log","Properties":{"path":"$.log.log"}},
+  {"column":"environment","Properties":{"path":"$.log.environment"}},
+  {"column":"region","Properties":{"path":"$.log.region"}},
+  {"column":"cluster","Properties":{"path":"$.log.cluster"}},
+  {"column":"namespace_name","Properties":{"path":"$.log.kubernetes.namespace_name"}},
+  {"column":"container_name","Properties":{"path":"$.log.kubernetes.container_name"}},
+  {"column":"container_image","Properties":{"path":"$.log.kubernetes.container_image"}},
+  {"column":"host","Properties":{"path":"$.log.kubernetes.host"}},
+  {"column":"labels","Properties":{"path":"$.log.kubernetes.labels"}},
+  {"column":"pod_name","Properties":{"path":"$.log.kubernetes.pod_name"}},
+  {"column":"tag","Properties":{"path":"$.tag"}},
+  {"column":"level","Properties":{"path":"$.log.level"}},
+  {"column":"msg","Properties":{"path":"$.log.msg"}},
+  {"column":"controller_name","Properties":{"path":"$.log.controller_name"}},
+  {"column":"resource_name","Properties":{"path":"$.log.resource_name"}},
+  {"column":"resource_id","Properties":{"path":"$.log.resource_id"}},
+  {"column":"resource_type","Properties":{"path":"$.log.resourceType"}},
+  {"column":"container_status_image_id","Properties":{"path":"$.log.kubernetes.container_hash"}}
+]
+```

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -153,6 +153,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-frontend* aro-hcp-frontend.logs true
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs true
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs true
+        Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs true
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs true
         Emitter_Name    re_emitted_container_name_router
         Emitter_Mem_Buf_Limit  20M
@@ -161,7 +162,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -236,6 +237,31 @@ data:
         Table_Name backendLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key backendLogs
+        buffer_dir "/var/kusto"
+        buffering_enabled           true 
+        upload_timeout              1m
+        upload_file_size            16M
+        buffer_file_delete_early    false
+        unify_tag                   true
+        store_dir_limit_size        1.8GB
+        blob_uri_length             128
+        scheduler_max_retries       9
+        delete_on_max_upload_error  true
+        io_timeout                  60s
+
+    [OUTPUT]
+        Match fleet-controller.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name fleetLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key fleetLogs
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
@@ -451,7 +477,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: daa48c40fc3f117b2650ffc65f9606a93231c8ba30f24e21bb4f8b598167c84b
+        checksum/configmap: 17967358ee186f2e0492f99e6bfa4911f9a5d64121fb14d58af9dd529e2a75e3
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -153,6 +153,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-frontend* aro-hcp-frontend.logs true
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs true
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs true
+        Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs true
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs true
         Emitter_Name    re_emitted_container_name_router
         Emitter_Mem_Buf_Limit  20M
@@ -161,7 +162,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -212,6 +213,31 @@ data:
         Table_Name backendLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key backendLogs
+        buffer_dir "/var/kusto"
+        buffering_enabled           true 
+        upload_timeout              1m
+        upload_file_size            16M
+        buffer_file_delete_early    false
+        unify_tag                   true
+        store_dir_limit_size        1.8GB
+        blob_uri_length             128
+        scheduler_max_retries       9
+        delete_on_max_upload_error  true
+        io_timeout                  60s
+
+    [OUTPUT]
+        Match fleet-controller.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name fleetLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key fleetLogs
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
@@ -427,7 +453,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 2a4cfa99e01402601797b5e385a0c40bcef5ef8a62a1266d2ac2589a62874f97
+        checksum/configmap: 77fb271608b0242f0986409e3a7cf9cc9fc6c627ba40a77054f3083da6869c3d
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/docs/ai/kusto-debugging.md
+++ b/docs/ai/kusto-debugging.md
@@ -18,6 +18,7 @@
 - `frontendLogs` — ARM API request/response logs: HTTP method, path, status code, duration, request/correlation IDs, subscription/resource identifiers
 - `backendLogs` — backend service logs: async operations, controller state dumps, cluster lifecycle, error codes, correlation IDs
 - `clustersServiceLogs` — Cluster Service logs: cluster provisioning phases, operation IDs, cluster correlation IDs
+- `fleetLogs` — fleet controller logs: fleet reconciliation events, fleet data dumps
 - `aksEvents` / `kubeAudit` — AKS management cluster events and extracted K8s API audit logs: API verbs, request URIs, user agents, response status
 - `systemdLogs` — node-level systemd unit logs: hostname, systemd unit, message
 
@@ -30,4 +31,3 @@
 - `backendLogs` links to `frontendLogs` via `correlation_request_id` and contains state dumps from controllers.
 - `containerLogs` is filtered by `namespace_name` and `container_name` to isolate maestro/hypershift logs.
 - Maestro bundle tracking joins `containerLogs` + `backendLogs`/`clustersServiceLogs` via bundle ID extraction.
-

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -46,8 +46,9 @@ Table schemas are defined in KQL files under [`dev-infrastructure/modules/logs/k
 1. **`frontendLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/frontendLogs.kql)): Frontend service logs with HTTP request/response details and tracking IDs
 2. **`backendLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/backendLogs.kql)): Backend service logs with operation tracking and error codes
 3. **`clustersServiceLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/clustersServiceLogs.kql)): Clusters-service logs with cluster resource IDs
-4. **`containerLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/containerLogs.kql)): General container logs from non-OCM namespaces
-5. **`kubernetesEvents`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/kubernetesEvents.kql)): Kubernetes events from all clusters
+4. **`fleetLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/fleetLogs.kql)): Fleet controller logs with controller name, resource identifiers, and resource type
+5. **`containerLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/containerLogs.kql)): General container logs from non-OCM namespaces
+6. **`kubernetesEvents`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/kubernetesEvents.kql)): Kubernetes events from all clusters
 
 ### HostedControlPlaneLogs Database
 
@@ -77,6 +78,7 @@ Fluent Bit authenticates using **Azure Workload Identity** (MSI client ID, token
 | Frontend | Non-OCM | `aro-hcp-frontend*` | ServiceLogs | `frontendLogs` |
 | Backend | Non-OCM | `aro-hcp-backend*` | ServiceLogs | `backendLogs` |
 | Clusters Service | Non-OCM | `clusters-service*` | ServiceLogs | `clustersServiceLogs` |
+| Fleet | Non-OCM | `fleet-controller*` | ServiceLogs | `fleetLogs` |
 | Kubernetes Events | Any | `kube-events*` | ServiceLogs | `kubernetesEvents` |
 | General Containers | Non-OCM | Other | ServiceLogs | `containerLogs` |
 | HCP Containers | `ocm-*` | Any | HostedControlPlaneLogs | `containerLogs` |

--- a/fleet/pipeline.yaml
+++ b/fleet/pipeline.yaml
@@ -72,7 +72,7 @@ resourceGroups:
       step: kusto-lookup
       name: kustoUri
     kustoDatabase: '{{ .kusto.serviceLogsDatabase }}'
-    kustoTable: 'containerLogs'
+    kustoTable: 'fleetLogs'
     inputVariables:
       cosmosUrl:
         resourceGroup: service

--- a/observability/arobit/deploy/templates/forwarder-configmap.yaml
+++ b/observability/arobit/deploy/templates/forwarder-configmap.yaml
@@ -159,6 +159,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-frontend* aro-hcp-frontend.logs true
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs true
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs true
+        Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs true
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs true
         Emitter_Name    re_emitted_container_name_router
         Emitter_Mem_Buf_Limit  20M
@@ -167,7 +168,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -377,6 +378,24 @@ data:
         Table_Name backendLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key backendLogs
+        buffer_dir "{{ .Values.forwarder.kusto.buffer_dir }}"
+{{- if .Values.forwarder.kusto.buffering }}
+        {{- template "buffer_settings" . }}
+{{- end }}
+
+    [OUTPUT]
+        Match fleet-controller.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id {{ .Values.forwarder.tenantId }}
+        client_id {{ .Values.forwarder.msiClientId }}
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint {{ .Values.forwarder.kusto.ingestionEndpoint }}
+        Database_Name {{ .Values.forwarder.kusto.serviceLogsDatabase }}
+        Table_Name fleetLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key fleetLogs
         buffer_dir "{{ .Values.forwarder.kusto.buffer_dir }}"
 {{- if .Values.forwarder.kusto.buffering }}
         {{- template "buffer_settings" . }}

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
@@ -153,6 +153,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-frontend* aro-hcp-frontend.logs true
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs true
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs true
+        Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs true
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs true
         Emitter_Name    re_emitted_container_name_router
         Emitter_Mem_Buf_Limit  20M
@@ -161,7 +162,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -201,6 +202,21 @@ data:
         Table_Name backendLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key backendLogs
+        buffer_dir "/var/kusto"
+
+    [OUTPUT]
+        Match fleet-controller.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name fleetLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key fleetLogs
         buffer_dir "/var/kusto"
 
     [OUTPUT]
@@ -366,7 +382,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 0125c22a6f97225ef8815fec4a047ee67b7f0dff1b518abcf3232fc8d1a39f1d
+        checksum/configmap: 7c67a38bc1288295508fbaad623fae887102d323c74774f7b229cd591c9de18f
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -152,6 +152,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-frontend* aro-hcp-frontend.logs true
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs true
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs true
+        Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs true
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs true
         Emitter_Name    re_emitted_container_name_router
         Emitter_Mem_Buf_Limit  20M
@@ -160,7 +161,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -211,6 +212,31 @@ data:
         Table_Name backendLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key backendLogs
+        buffer_dir "/var/kusto"
+        buffering_enabled           true 
+        upload_timeout              1m
+        upload_file_size            16M
+        buffer_file_delete_early    false
+        unify_tag                   true
+        store_dir_limit_size        1.8GB
+        blob_uri_length             128
+        scheduler_max_retries       9
+        delete_on_max_upload_error  true
+        io_timeout                  60s
+
+    [OUTPUT]
+        Match fleet-controller.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name fleetLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key fleetLogs
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
@@ -426,7 +452,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 6596e05b3e7afcd127f75c1de0a178a0ef2338ad9b6c8d19c9671095345c1deb
+        checksum/configmap: 370716c172289dfb0bb64b09fbe253ea82038a1e4e51dd017c109201feaea992
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
@@ -153,6 +153,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-frontend* aro-hcp-frontend.logs true
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs true
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs true
+        Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs true
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs true
         Emitter_Name    re_emitted_container_name_router
         Emitter_Mem_Buf_Limit  20M
@@ -161,7 +162,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -212,6 +213,31 @@ data:
         Table_Name backendLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key backendLogs
+        buffer_dir "/var/kusto"
+        buffering_enabled           true 
+        upload_timeout              1m
+        upload_file_size            16M
+        buffer_file_delete_early    false
+        unify_tag                   true
+        store_dir_limit_size        1.8GB
+        blob_uri_length             128
+        scheduler_max_retries       9
+        delete_on_max_upload_error  true
+        io_timeout                  60s
+
+    [OUTPUT]
+        Match fleet-controller.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name fleetLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key fleetLogs
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
@@ -427,7 +453,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: d0af69bf42ceeb8edd628b7ced7cfd5834bdb283b5fd6525fbad4d0e75977eda
+        checksum/configmap: dcc0bff9fa4ad3ee12f15a66f21197381af10bb8e90518397c8dd41b5b69aa9a
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -155,6 +155,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-frontend* aro-hcp-frontend.logs true
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs true
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs true
+        Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs true
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs true
         Emitter_Name    re_emitted_container_name_router
         Emitter_Mem_Buf_Limit  20M
@@ -163,7 +164,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -383,6 +384,31 @@ data:
         Table_Name backendLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key backendLogs
+        buffer_dir "/var/kusto"
+        buffering_enabled           true 
+        upload_timeout              1m
+        upload_file_size            16M
+        buffer_file_delete_early    false
+        unify_tag                   true
+        store_dir_limit_size        1.8GB
+        blob_uri_length             128
+        scheduler_max_retries       9
+        delete_on_max_upload_error  true
+        io_timeout                  60s
+
+    [OUTPUT]
+        Match fleet-controller.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name fleetLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key fleetLogs
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
@@ -639,7 +665,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: bcc43b17958a9e5ecb2765877be2145fc8deb5f8e3c2974fe0beb84ee0d34694
+        checksum/configmap: 9be464c4b82dcc5d6893049517be8b45dcad3f049bce2bf75ffa60a2989524b6
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -153,6 +153,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-frontend* aro-hcp-frontend.logs true
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs true
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs true
+        Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs true
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs true
         Emitter_Name    re_emitted_container_name_router
         Emitter_Mem_Buf_Limit  20M
@@ -161,7 +162,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -212,6 +213,31 @@ data:
         Table_Name backendLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key backendLogs
+        buffer_dir "/var/kusto"
+        buffering_enabled           true 
+        upload_timeout              1m
+        upload_file_size            16M
+        buffer_file_delete_early    false
+        unify_tag                   true
+        store_dir_limit_size        1.8GB
+        blob_uri_length             128
+        scheduler_max_retries       9
+        delete_on_max_upload_error  true
+        io_timeout                  60s
+
+    [OUTPUT]
+        Match fleet-controller.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name fleetLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key fleetLogs
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
@@ -427,7 +453,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: adfb75e40455e9c78550952a0d0c570120d30fdc28229331d9ccf1bf4e20d489
+        checksum/configmap: ff7fda314b102dd057ff3cd576386e1e111ebf8e9152abf9dbd2d0f6ff60edb3
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/tooling/hcpctl/pkg/mustgather/queries.go
+++ b/tooling/hcpctl/pkg/mustgather/queries.go
@@ -21,6 +21,7 @@ import (
 var ServicesTables = []string{
 	"containerLogs",
 	"clustersServiceLogs",
+	"fleetLogs",
 	"frontendLogs",
 	"backendLogs",
 }

--- a/tooling/hcpctl/pkg/mustgather/queries_test.go
+++ b/tooling/hcpctl/pkg/mustgather/queries_test.go
@@ -33,7 +33,7 @@ func TestGetServicesQueries(t *testing.T) {
 
 	queries, err := serviceLogs(factory, "serviceLogs", opts, []string{"cluster1"})
 	require.NoError(t, err)
-	assert.Len(t, queries, 4)
+	assert.Len(t, queries, 5)
 }
 
 func TestGetHostedControlPlaneLogsQuery(t *testing.T) {


### PR DESCRIPTION
### What

Add a dedicated fleetLogs Kusto table with fleet-specific columns (controller_name, resource_name, resource_id, resource_type) and wire up fluentbit routing to direct fleet-controller container logs into it.

https://redhat.atlassian.net/browse/ARO-27359

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
