### PR TITLE
fix(observability): restore organize transforms on etcd dashboard tables

### DIFF
--- a/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
+++ b/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
@@ -754,6 +754,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "P99 Fsync (ms)",
+              "cluster": "Cluster"
+            }
+          }
         }
       ],
       "type": "table"
@@ -841,6 +855,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "P99 Commit (ms)",
+              "cluster": "Cluster"
+            }
+          }
         }
       ],
       "type": "table"
@@ -928,6 +956,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "P99 RTT (ms)",
+              "cluster": "Cluster"
+            }
+          }
         }
       ],
       "type": "table"
@@ -1020,6 +1062,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Changes/Hour",
+              "cluster": "Cluster"
+            }
+          }
         }
       ],
       "type": "table"
@@ -1120,6 +1176,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Leader Changes (24h)",
+              "cluster": "Cluster Name"
+            }
+          }
         }
       ],
       "type": "table"
@@ -1220,6 +1290,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Leader Changes (24h)",
+              "cluster": "Cluster Name"
+            }
+          }
         }
       ],
       "type": "table"
@@ -1380,6 +1464,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Stable (\u22645 changes/24h)",
+              "Value #B": "High Churn (>10 changes/24h)",
+              "Value #C": "Unstable (>5 changes/24h)"
+            }
+          }
         }
       ],
       "type": "table"
@@ -1688,6 +1786,20 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "DB Size (bytes)",
+              "cluster": "Cluster Name"
+            }
+          }
         }
       ],
       "type": "table"


### PR DESCRIPTION
Follow-up to #5241 per [review feedback](https://github.com/Azure/ARO-HCP/pull/5241#pullrequestreview-4383149170) from @raelga.

Restores the `organize` transforms (column renaming + Time column hiding) on all 8 violator/summary tables that were dropped during the fleet summary rebuild.

| Table | Column renames |
|-------|---------------|
| WAL Fsync SLO Violations | cluster -> Cluster, Value -> P99 Fsync (ms) |
| Backend Commit SLO Violations | cluster -> Cluster, Value -> P99 Commit (ms) |
| Peer RTT SLO Violations | cluster -> Cluster, Value -> P99 RTT (ms) |
| Leader Instability (Hourly) | cluster -> Cluster, Value -> Changes/Hour |
| Clusters with High Leader Churn | cluster -> Cluster Name, Value -> Leader Changes (24h) |
| Clusters with Unstable Leaders | cluster -> Cluster Name, Value -> Leader Changes (24h) |
| Etcd Health Distribution | Value #A/B/C -> Stable/High Churn/Unstable |
| Clusters with Large DB Size | cluster -> Cluster Name, Value -> DB Size (bytes) |

All tables also hide the `Time` column (not useful for instant queries).