### PR TITLE
feat: temp best-effort preventing deletion of last nodepool in frontend

### DIFF
--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -707,6 +707,30 @@ func (f *Frontend) DeleteNodePool(writer http.ResponseWriter, request *http.Requ
 		return utils.TrackError(err)
 	}
 
+	// We retrieve all node pools for the cluster, including the one we are attempting to
+	// delete, and we pass them to the delete admission validation.
+	// TODO once OCPBUGS-86702 is resolved, we should remove this retrieval and the check of last nodepool being
+	// deleted in the delete admission validation when we decide we want to allow the deletion of the last node pool.
+	nodePoolIterator, err := f.resourcesDBClient.HCPClusters(nodePool.ID.SubscriptionID, nodePool.ID.ResourceGroupName).NodePools(nodePool.ID.Parent.Name).List(ctx, nil)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	clusterNodePools := make([]*api.HCPOpenShiftClusterNodePool, 0)
+	for _, clusterNodePool := range nodePoolIterator.Items(ctx) {
+		clusterNodePools = append(clusterNodePools, clusterNodePool)
+	}
+	if err := nodePoolIterator.GetError(); err != nil {
+		return utils.TrackError(err)
+	}
+
+	nodePoolDeleteAdmissionContext := &admission.NodePoolDeleteAdmissionContext{
+		ClusterNodePools: clusterNodePools,
+	}
+	err = arm.CloudErrorFromFieldErrors(admission.AdmitNodePoolOnDelete(ctx, nodePoolDeleteAdmissionContext, nodePool))
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
 	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the node
 	// pool has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
 	if nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {

--- a/internal/admission/admit_nodepool.go
+++ b/internal/admission/admit_nodepool.go
@@ -71,6 +71,28 @@ func mutateNodePoolPlatform(ctx context.Context, admissionContext *NodePoolAdmis
 	return errs
 }
 
+// NodePoolDeleteAdmissionContext carries dependencies that node pool deletion admission needs.
+type NodePoolDeleteAdmissionContext struct {
+	// ClusterNodePools is a list of all node pools for the cluster, including the one being deleted.
+	ClusterNodePools []*api.HCPOpenShiftClusterNodePool
+}
+
+// AdmitNodePoolOnDelete performs non-static checks before deleting a node pool.
+func AdmitNodePoolOnDelete(ctx context.Context, admissionContext *NodePoolDeleteAdmissionContext, _ *api.HCPOpenShiftClusterNodePool) field.ErrorList {
+	errs := field.ErrorList{}
+
+	// We do a *best-effort* to check to see if we are the last node pool on the cluster and prevent deletion
+	// if we are. This is because as of now (2026-05-29) it is not possible to delete the last node pool from the cluster
+	// OCPBUGS-86702. This check won't fully prevent the last node pool deletion in all cases as there are edge cases
+	// where race conditions can occur, but it should be good enough to prevent the last node pool deletion in most cases.
+	// TODO once OCPBUGS-86702 is fixed, we should remove this check.
+	if len(admissionContext.ClusterNodePools) <= 1 {
+		errs = append(errs, field.Forbidden(field.NewPath("name"), "The last node pool can not be deleted from a cluster."))
+	}
+
+	return errs
+}
+
 // AdmitNodePool performs non-static checks of nodepool. Checks that require more information than is contained inside of
 // the nodepool instance itself. For update operations with version changes, include ServiceProviderNodePool and
 // ServiceProviderCluster in the admissionContext to enable version upgrade validation.

--- a/internal/admission/admit_nodepool_test.go
+++ b/internal/admission/admit_nodepool_test.go
@@ -618,3 +618,71 @@ func TestAdmitNodePool_IncludesChannelGroupCheck(t *testing.T) {
 
 	utils.VerifyErrorsMatch(t, expectedErrors, errs)
 }
+
+func TestAdmitNodePoolOnDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clusterResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster"))
+
+	makeTestNodePool := func(name string) *api.HCPOpenShiftClusterNodePool {
+		nodePoolResourceID := api.Must(azcorearm.ParseResourceID(clusterResourceID.String() + "/nodePools/" + name))
+		return &api.HCPOpenShiftClusterNodePool{
+			CosmosMetadata: arm.CosmosMetadata{
+				ResourceID: nodePoolResourceID,
+			},
+			TrackedResource: arm.NewTrackedResource(nodePoolResourceID, "eastus"),
+		}
+	}
+
+	makeDeletingNodePool := func(name string) *api.HCPOpenShiftClusterNodePool {
+		nodePool := makeTestNodePool(name)
+		nodePool.Properties.ProvisioningState = arm.ProvisioningStateDeleting
+		return nodePool
+	}
+
+	tests := []struct {
+		name                 string
+		existingNodePools    []*api.HCPOpenShiftClusterNodePool
+		nodePoolBeingDeleted *api.HCPOpenShiftClusterNodePool
+		expectErrors         []utils.ExpectedError
+	}{
+		{
+			name:                 "allows delete when another node pool exists",
+			existingNodePools:    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers"), makeTestNodePool("infra")},
+			nodePoolBeingDeleted: makeTestNodePool("workers"),
+			expectErrors:         []utils.ExpectedError{},
+		},
+		{
+			name: "allows delete when the only other remaining node pool is being deleted",
+			existingNodePools: []*api.HCPOpenShiftClusterNodePool{
+				makeDeletingNodePool("workers"),
+				makeTestNodePool("infra"),
+			},
+			nodePoolBeingDeleted: makeTestNodePool("infra"),
+			expectErrors:         []utils.ExpectedError{},
+		},
+		{
+			name:                 "rejects delete of last node pool",
+			existingNodePools:    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers")},
+			nodePoolBeingDeleted: makeTestNodePool("workers"),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "name", Message: "The last node pool can not be deleted from a cluster."},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			admissionContext := &NodePoolDeleteAdmissionContext{
+				ClusterNodePools: tt.existingNodePools,
+			}
+
+			errs := AdmitNodePoolOnDelete(ctx, admissionContext, tt.nodePoolBeingDeleted)
+			utils.VerifyErrorsMatch(t, tt.expectErrors, errs)
+		})
+	}
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/00-httpCreate-subscription/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/00-httpCreate-subscription/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "2f2d4ba3-1ee6-57b6-bde9-b61d09eaf989",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/00-httpCreate-subscription/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/00-httpCreate-subscription/subscription.json
@@ -1,0 +1,6 @@
+{
+	"properties": null,
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "793b5e4e-e763-55b9-a9dd-fdaa7b40d489",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/delete-not-last"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,50 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {}
+	},
+	"name": "delete-not-last",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/02-completeOperation-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/02-completeOperation-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "793b5e4e-e763-55b9-a9dd-fdaa7b40d489",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/delete-not-last"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/03-httpCreate-nodepoolone/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/03-httpCreate-nodepoolone/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "aa3d4156-537b-565c-b910-4d149ae11368",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/delete-not-last/nodePools/nodepoolone"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/03-httpCreate-nodepoolone/nodepoolone.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/03-httpCreate-nodepoolone/nodepoolone.json
@@ -1,0 +1,17 @@
+{
+	"name": "nodepoolone",
+	"properties": {
+		"autoRepair": true,
+		"autoScaling": {
+			"max": 5,
+			"min": 1
+		},
+		"platform": {
+			"vmSize": "large"
+		},
+		"version": {
+			"id": "4.20.8"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/04-httpCreate-nodepooltwo/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/04-httpCreate-nodepooltwo/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "aefc4159-c097-5ab9-b2e1-3397105887ea",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/delete-not-last/nodePools/nodepooltwo"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/04-httpCreate-nodepooltwo/nodepooltwo.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/04-httpCreate-nodepooltwo/nodepooltwo.json
@@ -1,0 +1,17 @@
+{
+	"name": "nodepooltwo",
+	"properties": {
+		"autoRepair": true,
+		"autoScaling": {
+			"max": 5,
+			"min": 1
+		},
+		"platform": {
+			"vmSize": "large"
+		},
+		"version": {
+			"id": "4.20.8"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/05-httpDelete-nodepooltwo/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/05-httpDelete-nodepooltwo/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "aefc4159-c097-5ab9-b2e1-3397105887ea",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/delete-not-last/nodePools/nodepooltwo"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/06-untypedDelete-nodepooltwo/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/06-untypedDelete-nodepooltwo/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/delete-not-last/nodePools/nodepooltwo"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/07-httpDelete-nodepoolone/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/07-httpDelete-nodepoolone/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "aa3d4156-537b-565c-b910-4d149ae11368",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/delete-not-last/nodePools/nodepoolone"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/07-httpDelete-nodepoolone/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/delete-not-last/07-httpDelete-nodepoolone/expected-error.txt
@@ -1,0 +1,1 @@
+The last node pool can not be deleted from a cluster.

--- a/test-integration/utils/integrationutils/cluster_service_mock.go
+++ b/test-integration/utils/integrationutils/cluster_service_mock.go
@@ -236,6 +236,18 @@ func (s *ClusterServiceMock) setupMockClusterService(t *testing.T) {
 		}
 		return ocm.NewSimpleNodePoolListIterator(allObjs, nil)
 	}).AnyTimes()
+	s.MockClusterServiceClient.EXPECT().DeleteNodePool(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, id ocm.InternalID) error {
+		_, exists := internalIDToNodePool[id.String()]
+		if !exists {
+			retErr, err := ocmerrors.NewError().Status(http.StatusNotFound).Build()
+			if err != nil {
+				return err
+			}
+			return retErr
+		}
+		delete(internalIDToNodePool, id.String())
+		return nil
+	}).AnyTimes()
 
 	s.MockClusterServiceClient.EXPECT().DeleteBreakGlassCredentials(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	s.MockClusterServiceClient.EXPECT().PostBreakGlassCredential(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, clusterID ocm.InternalID) (*cmv1.BreakGlassCredential, error) {


### PR DESCRIPTION
We are removing the validation that prevents the last nodepool from being deleted on the Cluster Service side. This has been done because we want to start allowing the deletion of the last nodepool. Unfortunately, we have detected that it's currently not possible to delete the last NodePool (OCPBUGS-86702) but at the same time we need the removal on Cluster Service side because even in that case we need to allow the triggering to allow moving the deletion of nodepools to be triggered asynchronously an in an ordered delete process on backend which includes a cluster deletion that will trigger the deletion of nodepools too on backend. At the same time and until OCPBUGS-86702 is resolved we want to prevent the last nodepool from being deleted in most cases. This commit adds a best-effort check in the form of a nodepool admission validation on delete.