### PR TITLE
Fix complete_cluster_create_multiversion.go test by not hardcoding nightly channel group

### DIFF
--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -43,22 +43,19 @@ import (
 var TestArtifactsFS embed.FS
 
 var _ = Describe("ARO-HCP", func() {
-	// Use channel group from environment variable, or default to stable
-	var channelGroup = framework.DefaultOpenshiftChannelGroup()
-	var nodePoolChannelGroup = framework.DefaultOpenshiftNodePoolChannelGroup()
 
 	DescribeTable("should be able to perform a control plane and node pool install with OCP "+framework.DefaultOpenshiftChannelGroup()+" channel",
 		func(ctx context.Context, version string) {
+			clusterParams := framework.NewDefaultClusterParams20251223()
 
-			customerNetworkSecurityGroupName := "customer-nsg-" + channelGroup + "-"
-			customerVnetName := "customer-vnet-" + channelGroup + "-"
-			customerVnetSubnetName := "customer-vnet-subnet-" + channelGroup + "-"
-			customerClusterNamePrefix := "cluster-" + channelGroup + "-"
+			customerNetworkSecurityGroupName := "customer-nsg-" + clusterParams.ChannelGroup + "-"
+			customerVnetName := "customer-vnet-" + clusterParams.ChannelGroup + "-"
+			customerVnetSubnetName := "customer-vnet-subnet-" + clusterParams.ChannelGroup + "-"
+			customerClusterNamePrefix := "cluster-" + clusterParams.ChannelGroup + "-"
 
 			versionLabel := strings.ReplaceAll(version, ".", "-") // e.g. "4.20" -> "4-20"
 			suffix := rand.String(6)
 			clusterName := customerClusterNamePrefix + versionLabel + "-" + suffix
-			clusterParams := framework.NewDefaultClusterParams20251223()
 			clusterParams.ClusterName = clusterName
 			clusterParams.OpenshiftVersionId = version
 			openShiftControlPlaneVersion, err := framework.GetLatestInstallVersion(ctx, clusterParams.ChannelGroup, version)
@@ -78,10 +75,10 @@ var _ = Describe("ARO-HCP", func() {
 			}
 
 			By("creating resource group")
-			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-"+channelGroup+"-"+versionLabel, tc.Location())
+			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-"+clusterParams.ChannelGroup+"-"+versionLabel, tc.Location())
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for version %s", version)
 
-			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name+"-"+channelGroup+"-"+suffix, "-managed", 64)
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name+"-"+clusterParams.ChannelGroup+"-"+suffix, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
 			By("creating customer resources")
@@ -98,7 +95,7 @@ var _ = Describe("ARO-HCP", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for cluster %q", clusterName)
 
-			By(fmt.Sprintf("creating the HCP cluster with version '%s' on %s channel", clusterParams.OpenshiftVersionId, channelGroup))
+			By(fmt.Sprintf("creating the HCP cluster with version '%s' on %s channel", clusterParams.OpenshiftVersionId, clusterParams.ChannelGroup))
 			err = tc.CreateHCPClusterFromParam20251223(
 				ctx,
 				GinkgoLogr,
@@ -146,11 +143,11 @@ var _ = Describe("ARO-HCP", func() {
 				return vi.LT(vj)
 			})
 			if len(parseableVersions) == 0 {
-				Skip(fmt.Sprintf("No node pool install version found for %s in %s channel", version, nodePoolChannelGroup))
+				Skip(fmt.Sprintf("No node pool install version found for %s in %s channel", version, nodePoolParams.ChannelGroup))
 			}
 			nodePoolParams.OpenshiftVersionId = parseableVersions[0]
 
-			By(fmt.Sprintf("creating node pool %q with version '%s' on %s channel", nodePoolName, nodePoolParams.OpenshiftVersionId, nodePoolChannelGroup))
+			By(fmt.Sprintf("creating node pool %q with version '%s' on %s channel", nodePoolName, nodePoolParams.OpenshiftVersionId, nodePoolParams.ChannelGroup))
 			err = tc.CreateNodePoolFromParam20240610(
 				ctx,
 				GinkgoLogr,

--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -98,38 +98,16 @@ var _ = Describe("ARO-HCP", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for cluster %q", clusterName)
 
-			// OCP 4.23 and 5.0 use v20251223preview to create Swift-based clusters so we can validate
-			// Swift NIC scheduling end-to-end: Hypershift sets aro.openshift.io/swift-nic limits overrides
-			// (https://github.com/openshift/hypershift/pull/8552), and Cluster Service applies the matching
-			// NIC resource request (https://redhat.atlassian.net/browse/ARO-27209).
-			if version == "4.23" || version == "5.0" {
-				By(fmt.Sprintf("creating a Swift cluster on version '%s' and channel group '%s'", clusterParams.OpenshiftVersionId, channelGroup))
-				clusterResource, err := framework.BuildHCPClusterFromParams20251223(clusterParams, tc.Location(), nil)
-				Expect(err).NotTo(HaveOccurred(), "Swift cluster resource for %s should build from params", clusterName)
-				clientFactory, err := tc.Get20251223ClientFactory(ctx)
-				Expect(err).NotTo(HaveOccurred(), "Get20251223ClientFactory: client factory should be obtained for Swift cluster %s", clusterName)
-				_, err = framework.CreateHCPClusterAndWait20251223(
-					ctx,
-					GinkgoLogr,
-					clientFactory.NewHcpOpenShiftClustersClient(),
-					*resourceGroup.Name,
-					clusterName,
-					clusterResource,
-					framework.ClusterCreationTimeout,
-				)
-				Expect(err).NotTo(HaveOccurred(), "Swift cluster %s/%s should provision", *resourceGroup.Name, clusterName)
-			} else {
-				By(fmt.Sprintf("creating the HCP cluster with version '%s' on %s channel", clusterParams.OpenshiftVersionId, channelGroup))
-				err = tc.CreateHCPClusterFromParam20251223(
-					ctx,
-					GinkgoLogr,
-					*resourceGroup.Name,
-					clusterParams,
-					nil,
-					framework.ClusterCreationTimeout,
-				)
-				Expect(err).NotTo(HaveOccurred(), "HCP cluster %s/%s should provision", *resourceGroup.Name, clusterName)
-			}
+			By(fmt.Sprintf("creating the HCP cluster with version '%s' on %s channel", clusterParams.OpenshiftVersionId, channelGroup))
+			err = tc.CreateHCPClusterFromParam20251223(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				nil,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "HCP cluster %s/%s should provision", *resourceGroup.Name, clusterName)
 
 			By("verifying the cluster is viable")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(

--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -43,19 +43,13 @@ import (
 var TestArtifactsFS embed.FS
 
 var _ = Describe("ARO-HCP", func() {
+	// Use channel group from environment variable, or default to stable
+	var channelGroup = framework.DefaultOpenshiftChannelGroup()
+	var nodePoolChannelGroup = framework.DefaultOpenshiftNodePoolChannelGroup()
 
 	DescribeTable("should be able to perform a control plane and node pool install with OCP "+framework.DefaultOpenshiftChannelGroup()+" channel",
 		func(ctx context.Context, version string) {
-			// Use channel group from environment variable, or default to stable
-			var channelGroup = framework.DefaultOpenshiftChannelGroup()
-			var nodePoolChannelGroup = framework.DefaultOpenshiftNodePoolChannelGroup()
 
-			if version == "4.23" || version == "5.0" {
-				// Nightly channel picks up the Hypershift fix for Swift NIC scheduling overrides
-				// (https://github.com/openshift/hypershift/pull/8552) and test it against the CS bump.
-				channelGroup = "nightly"
-				nodePoolChannelGroup = "nightly"
-			}
 			customerNetworkSecurityGroupName := "customer-nsg-" + channelGroup + "-"
 			customerVnetName := "customer-vnet-" + channelGroup + "-"
 			customerVnetSubnetName := "customer-vnet-subnet-" + channelGroup + "-"
@@ -67,7 +61,6 @@ var _ = Describe("ARO-HCP", func() {
 			clusterParams := framework.NewDefaultClusterParams20251223()
 			clusterParams.ClusterName = clusterName
 			clusterParams.OpenshiftVersionId = version
-			clusterParams.ChannelGroup = channelGroup
 			openShiftControlPlaneVersion, err := framework.GetLatestInstallVersion(ctx, clusterParams.ChannelGroup, version)
 			if err != nil {
 				if errors.Is(err, framework.ErrNightlyReleaseStreamNotFound) || errors.Is(err, framework.ErrNoAcceptedNightlyTags) || errors.Is(err, framework.ErrVersionNotFound) {
@@ -154,7 +147,6 @@ var _ = Describe("ARO-HCP", func() {
 			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
 			nodePoolParams.ClusterName = clusterName
 			nodePoolParams.NodePoolName = nodePoolName
-			nodePoolParams.ChannelGroup = nodePoolChannelGroup
 			// Calculate the node pool version
 			configClient, err := configv1client.NewForConfig(adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to create OpenShift config client for cluster %q", clusterName)


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Fix complete_cluster_create_multiversion.go test by not hardcoding nightly channel group

### Why

In https://amd64.ocp.releases.ci.openshift.org/#5-dev-preview there is a recent ec.2 version that hopeful should contain the NIC fix. Let's pick it and see if it works and remove the channel hardcoding.

In passage, have one way of create swift clusters

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
