### PR TITLE
Check if resources got deleted

### DIFF
--- a/dev-infrastructure/scripts/cleanup-pko-resources/main.go
+++ b/dev-infrastructure/scripts/cleanup-pko-resources/main.go
@@ -254,6 +254,10 @@ func countCRs(ctx context.Context, client dynamic.Interface, c crdInfo) int {
 		list, err = client.Resource(gvr(c)).List(listCtx, metav1.ListOptions{})
 	}
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			fmt.Printf("  CRD %s.%s no longer exists, skipping.\n", c.Plural, c.Group)
+			return 0
+		}
 		fmt.Fprintf(os.Stderr, "[ERROR] failed to list %s.%s: %v\n", c.Plural, c.Group, err)
 		return -1
 	}
@@ -323,6 +327,10 @@ func stripFinalizersForCRD(ctx context.Context, client dynamic.Interface, c crdI
 		list, err = client.Resource(gvr(c)).List(ctx, metav1.ListOptions{})
 	}
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			fmt.Printf("  CRD %s no longer exists, skipping finalizer removal.\n", resource)
+			return 0
+		}
 		fmt.Fprintf(os.Stderr, "[ERROR] failed to list %s for finalizer removal: %v\n", resource, err)
 		return 1
 	}


### PR DESCRIPTION


<!-- Link to Jira issue -->

### What/Wh
We want to delete resources, crds/crs; if things get deleted while running, this is fine. Log and ignore

This fixes errors like:
```
2026-05-29 09:18:13.309178: [WARNING] 9 CR(s) stuck after 180s \N{EM DASH} removing finalizers.
2026-05-29 09:18:13.959855:   Patching finalizers on clusterobjectsets.package-operator.run/package-operator-59b98749f5
2026-05-29 09:18:14.445601:   Patching finalizers on clusterobjectsets.package-operator.run/package-operator-5fb86b57b5
2026-05-29 09:18:14.814796:   Patching finalizers on clusterobjectsets.package-operator.run/package-operator-6bb49d7d5c
2026-05-29 09:18:15.123110:   Patching finalizers on clusterobjectsets.package-operator.run/package-operator-748f58fc76
2026-05-29 09:18:15.295193: [ERROR] failed to list clusterobjectslices.package-operator.run for finalizer removal: the server could not find the requested resource
2026-05-29 09:18:15.311568: [ERROR] failed to list clusterobjecttemplates.package-operator.run for finalizer removal: the server could not find the requested resource
```
