### PR TITLE
fix(cleanup-pko): keep removal best-effort (AROSLSRE-969)

### DIFF
--- a/dev-infrastructure/scripts/cleanup-pko-resources/main.go
+++ b/dev-infrastructure/scripts/cleanup-pko-resources/main.go
@@ -103,8 +103,8 @@ func run(timeout time.Duration) error {
 		}
 		errors += cleanupPKOOperator(ctx, kubeClient)
 		if errors > 0 {
-			fmt.Printf("\n=== PKO cleanup completed with %d error(s) ===\n", errors)
-			return fmt.Errorf("PKO cleanup completed with %d error(s)", errors)
+			fmt.Printf("\n=== PKO cleanup completed best-effort with %d warning(s) ===\n", errors)
+			return nil
 		}
 		fmt.Println("\n=== PKO cleanup complete ===")
 		return nil
@@ -147,8 +147,8 @@ func run(timeout time.Duration) error {
 	errors += cleanupPKOOperator(ctx, kubeClient)
 
 	if errors > 0 {
-		fmt.Printf("\n=== PKO cleanup completed with %d error(s) ===\n", errors)
-		return fmt.Errorf("PKO cleanup completed with %d error(s)", errors)
+		fmt.Printf("\n=== PKO cleanup completed best-effort with %d warning(s) ===\n", errors)
+		return nil
 	}
 	fmt.Println("\n=== PKO cleanup complete ===")
 	return nil
@@ -198,6 +198,16 @@ func gvr(c crdInfo) schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: c.Group, Version: c.Version, Resource: c.Plural}
 }
 
+func isMissingResourceErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apierrors.IsNotFound(err) {
+		return true
+	}
+	return strings.Contains(err.Error(), "the server could not find the requested resource")
+}
+
 func deleteCRs(ctx context.Context, client dynamic.Interface, crds []crdInfo, timeout time.Duration) int {
 	errors := 0
 	for _, c := range crds {
@@ -213,6 +223,11 @@ func deleteCRs(ctx context.Context, client dynamic.Interface, crds []crdInfo, ti
 		if c.Scope == apiextensionsv1.NamespaceScoped {
 			list, err := client.Resource(gvr(c)).Namespace("").List(crdCtx, metav1.ListOptions{})
 			if err != nil {
+				if isMissingResourceErr(err) {
+					fmt.Fprintf(os.Stderr, "[WARNING] %s is already gone, skipping CR deletion\n", resource)
+					cancel()
+					continue
+				}
 				fmt.Fprintf(os.Stderr, "[ERROR] failed to list %s: %v\n", resource, err)
 				errors++
 				cancel()
@@ -226,12 +241,21 @@ func deleteCRs(ctx context.Context, client dynamic.Interface, crds []crdInfo, ti
 
 			for ns := range namespaces {
 				if err := client.Resource(gvr(c)).Namespace(ns).DeleteCollection(crdCtx, opts, metav1.ListOptions{}); err != nil {
+					if isMissingResourceErr(err) {
+						fmt.Fprintf(os.Stderr, "[WARNING] %s in namespace %s is already gone, skipping CR deletion\n", resource, ns)
+						continue
+					}
 					fmt.Fprintf(os.Stderr, "[ERROR] failed to delete %s in namespace %s: %v\n", resource, ns, err)
 					errors++
 				}
 			}
 		} else {
 			if err := client.Resource(gvr(c)).DeleteCollection(crdCtx, opts, metav1.ListOptions{}); err != nil {
+				if isMissingResourceErr(err) {
+					fmt.Fprintf(os.Stderr, "[WARNING] %s is already gone, skipping CR deletion\n", resource)
+					cancel()
+					continue
+				}
 				fmt.Fprintf(os.Stderr, "[ERROR] failed to delete %s: %v\n", resource, err)
 				errors++
 			}
@@ -254,6 +278,10 @@ func countCRs(ctx context.Context, client dynamic.Interface, c crdInfo) int {
 		list, err = client.Resource(gvr(c)).List(listCtx, metav1.ListOptions{})
 	}
 	if err != nil {
+		if isMissingResourceErr(err) {
+			fmt.Fprintf(os.Stderr, "[WARNING] %s.%s is already gone, counting as 0 remaining\n", c.Plural, c.Group)
+			return 0
+		}
 		fmt.Fprintf(os.Stderr, "[ERROR] failed to list %s.%s: %v\n", c.Plural, c.Group, err)
 		return -1
 	}
@@ -323,6 +351,10 @@ func stripFinalizersForCRD(ctx context.Context, client dynamic.Interface, c crdI
 		list, err = client.Resource(gvr(c)).List(ctx, metav1.ListOptions{})
 	}
 	if err != nil {
+		if isMissingResourceErr(err) {
+			fmt.Fprintf(os.Stderr, "[WARNING] %s is already gone, skipping finalizer removal\n", resource)
+			return 0
+		}
 		fmt.Fprintf(os.Stderr, "[ERROR] failed to list %s for finalizer removal: %v\n", resource, err)
 		return 1
 	}
@@ -349,7 +381,7 @@ func stripFinalizersForCRD(ctx context.Context, client dynamic.Interface, c crdI
 			fmt.Printf("  Patching finalizers on %s/%s\n", resource, name)
 			_, err = client.Resource(gvr(c)).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
 		}
-		if err != nil && !apierrors.IsNotFound(err) {
+		if err != nil && !isMissingResourceErr(err) {
 			if ns != "" {
 				fmt.Fprintf(os.Stderr, "[ERROR] failed to patch finalizers on %s/%s -n %s: %v\n", resource, name, ns, err)
 			} else {

--- a/dev-infrastructure/scripts/cleanup-pko-resources/main_test.go
+++ b/dev-infrastructure/scripts/cleanup-pko-resources/main_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func testCRD(scope apiextensionsv1.ResourceScope) crdInfo {
+	return crdInfo{
+		Name:    "objectsets.package-operator.run",
+		Plural:  "objectsets",
+		Group:   apiGroup,
+		Version: "v1alpha1",
+		Scope:   scope,
+	}
+}
+
+func missingResourceErr() error {
+	return apierrors.NewNotFound(schema.GroupResource{Group: apiGroup, Resource: "objectsets"}, "objectsets")
+}
+
+func dynamicClientReturning(err error) *dynamicfake.FakeDynamicClient {
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			gvr(testCRD(apiextensionsv1.ClusterScoped)): "ObjectSetList",
+		},
+	)
+	client.PrependReactor("*", "*", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, err
+	})
+	return client
+}
+
+func TestIsMissingResourceErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"api_not_found", missingResourceErr(), true},
+		{
+			"dynamic_resource_missing_text",
+			errors.New("the server could not find the requested resource"),
+			true,
+		},
+		{"other", errors.New("timeout"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isMissingResourceErr(tc.err); got != tc.want {
+				t.Fatalf("isMissingResourceErr(%v)=%t want %t", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCountCRs_MissingResourceReturnsZero(t *testing.T) {
+	got := countCRs(context.Background(), dynamicClientReturning(missingResourceErr()), testCRD(apiextensionsv1.ClusterScoped))
+	if got != 0 {
+		t.Fatalf("countCRs()=%d want 0 for missing resource", got)
+	}
+}
+
+func TestCountAllCRs_MissingResourceDoesNotAbort(t *testing.T) {
+	got := countAllCRs(context.Background(), dynamicClientReturning(missingResourceErr()), []crdInfo{
+		testCRD(apiextensionsv1.ClusterScoped),
+		testCRD(apiextensionsv1.NamespaceScoped),
+	})
+	if got != 0 {
+		t.Fatalf("countAllCRs()=%d want 0 for missing resources", got)
+	}
+}
+
+func TestStripFinalizersForCRD_MissingResourceIsWarningOnly(t *testing.T) {
+	got := stripFinalizersForCRD(
+		context.Background(),
+		dynamicClientReturning(missingResourceErr()),
+		testCRD(apiextensionsv1.ClusterScoped),
+		[]byte(`{"metadata":{"finalizers":[]}}`),
+	)
+	if got != 0 {
+		t.Fatalf("stripFinalizersForCRD()=%d want 0 for missing resource", got)
+	}
+}
+
+func TestDeleteCRs_MissingResourceIsWarningOnly(t *testing.T) {
+	got := deleteCRs(context.Background(), dynamicClientReturning(missingResourceErr()), []crdInfo{
+		testCRD(apiextensionsv1.ClusterScoped),
+		testCRD(apiextensionsv1.NamespaceScoped),
+	}, time.Second)
+	if got != 0 {
+		t.Fatalf("deleteCRs()=%d want 0 for missing resources", got)
+	}
+}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-969

### What

Make `dev-infrastructure/scripts/cleanup-pko-resources` truly best-effort when removing Package Operator resources from management clusters.

The script now treats missing PKO custom resources as already cleaned up in delete, count, and finalizer-removal paths, and exits successfully after best-effort cleanup warnings instead of failing the pipeline after resources have disappeared.

### Why

The PKO cleanup step is part of [ARO-23308](https://redhat.atlassian.net/browse/ARO-23308) / [AROSLSRE-782](https://redhat.atlassian.net/browse/AROSLSRE-782) removal work and is expected to unblock cluster deletion without blocking rollout. A production run on `prod-australiaeast-mgmt-1` failed after it had already deleted/removed multiple PKO resources because later dynamic list calls returned:

```text
the server could not find the requested resource
```

For a removal helper, that means the resource is already gone and should be treated as success/no-op, not as a hard failure.

### Testing

```text
go test ./dev-infrastructure/scripts/cleanup-pko-resources/...
go vet ./dev-infrastructure/scripts/cleanup-pko-resources/...
```

Added unit coverage for missing-resource behavior in:

```text
countCRs
countAllCRs
stripFinalizersForCRD
deleteCRs
```

### Special notes for your reviewer

Setup/client construction failures remain fatal. The best-effort behavior applies to cleanup execution failures after the script has started removing PKO resources, which matches the intended pipeline behavior.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
