### PR TITLE
feat: introduce asynchronous node pool deletion in backend in a disabled state

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -43,6 +43,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/managementclustercontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/metricscontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/mismatchcontrollers"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/nodepooldeletion"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/operationcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/upgradecontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/validationcontrollers"
@@ -629,6 +630,30 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		unionKubeApplierInformers,
 	)
 
+	nodePoolDeletionClusterServiceDeleteDispatchController := nodepooldeletion.NewNodePoolClusterServiceDeleteDispatchController(
+		utilsclock.RealClock{},
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
+	nodePoolClusterServiceIDClearerController := nodepooldeletion.NewNodePoolClusterServiceIDClearerController(
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
+	nodePoolChildResourcesCleanupController := nodepooldeletion.NewNodePoolChildResourcesCleanupController(
+		b.options.ResourcesDBClient,
+		activeOperationLister,
+		backendInformers,
+	)
+	nodePoolDeletionController := nodepooldeletion.NewNodePoolDeletionController(
+		b.options.ResourcesDBClient,
+		activeOperationLister,
+		backendInformers,
+	)
+
 	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
 		Lock:          b.options.LeaderElectionLock,
 		LeaseDuration: leaderElectionLeaseDuration,
@@ -688,6 +713,10 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go maestroDeleteOrphanedReadonlyBundlesController.Run(ctx, 20)
 				go cleanupLegacyMaestroReadonlyBundlesController.Run(ctx, 1)
 				go triggerNodePoolUpgradeController.Run(ctx, 20)
+				go nodePoolDeletionClusterServiceDeleteDispatchController.Run(ctx, 20)
+				go nodePoolClusterServiceIDClearerController.Run(ctx, 20)
+				go nodePoolChildResourcesCleanupController.Run(ctx, 20)
+				go nodePoolDeletionController.Run(ctx, 20)
 				go operationPhaseMetricsController.Run(ctx, 1)
 				go clusterMetricsController.Run(ctx, 1)
 				go nodePoolMetricsController.Run(ctx, 1)

--- a/backend/pkg/controllers/managementclustercontrollers/management_cluster_placement_sync_test.go
+++ b/backend/pkg/controllers/managementclustercontrollers/management_cluster_placement_sync_test.go
@@ -166,7 +166,7 @@ func TestManagementClusterPlacementSyncer_SyncOnce(t *testing.T) {
 			cachedSPC:   newTestSPC(),
 			existingSPC: newTestSPC(),
 			cachedCluster: newTestHCPCluster(func(c *api.HCPOpenShiftCluster) {
-				c.ServiceProviderProperties.ClusterServiceID = &api.InternalID{}
+				c.ServiceProviderProperties.ClusterServiceID = nil
 			}),
 			expectCSCall:                        false,
 			expectError:                         false,

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolChildResourcesCleanupController deletes child resources scoped
+// under a NodePool (e.g. ManagementClusterContent documents) recursively once
+// the NodePool is marked for deletion and Cluster Service has confirmed the
+// delete on its side. Controller status documents (NodePoolControllerResourceType)
+// are left alone. The orphan scraper handles those after the NodePool document
+// itself is removed.
+type nodePoolChildResourcesCleanupController struct {
+	cooldownChecker   controllerutil.CooldownChecker
+	nodePoolLister    listers.NodePoolLister
+	resourcesDBClient database.ResourcesDBClient
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolChildResourcesCleanupController)(nil)
+
+func NewNodePoolChildResourcesCleanupController(
+	resourcesDBClient database.ResourcesDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	syncer := &nodePoolChildResourcesCleanupController{
+		cooldownChecker:   controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:    nodePoolLister,
+		resourcesDBClient: resourcesDBClient,
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		"NodePoolChildResourcesCleanupController",
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *nodePoolChildResourcesCleanupController) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *nodePoolChildResourcesCleanupController) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
+	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
+		return false
+	}
+
+	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceID == nil
+}
+
+func (c *nodePoolChildResourcesCleanupController) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedNodePool) {
+		return nil
+	}
+
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName)
+	nodePool, err := nodePoolCRUD.Get(ctx, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
+	}
+	if !c.NeedsWork(nodePool) {
+		return nil
+	}
+
+	nodePoolResourceID := key.GetResourceID()
+	untypedCRUD, err := c.resourcesDBClient.UntypedCRUD(*nodePoolResourceID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to create untyped CRUD for node pool children: %w", err))
+	}
+
+	// extraDeleteGates is a map of resource types to extra delete gates that are used to determine if a resource should be deleted.
+	// Keys are strings.ToLower(api resource type strings) so lookups match TypedDocument.resourceType regardless of casing.
+	// The value of the map is a function that takes a context and a resource ID and returns a boolean indicating if the resource should be deleted, or
+	// an error.
+	// If the resource type is not in the map, the resource is deleted.
+	extraDeleteGates := map[string]func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error){
+		strings.ToLower(api.ServiceProviderNodePoolResourceType.String()): c.extraDeleteGateShouldDeleteServiceProviderNodePool,
+		// We never delete node pool controllers here, as there might be controllers still running for the NodePool until the very
+		// end of the deletion process
+		strings.ToLower(api.NodePoolControllerResourceType.String()): func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error) { return false, nil },
+	}
+
+	childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to list node pool child resources: %w", err))
+	}
+	for _, childResource := range childIterator.Items(ctx) {
+		if childResource.ResourceID == nil {
+			return utils.TrackError(fmt.Errorf("child resource at cosmosID %q has no resourceID; refusing to delete", childResource.ID))
+		}
+
+		extraDeleteGate, ok := extraDeleteGates[strings.ToLower(childResource.ResourceType)]
+		if ok {
+			shouldDelete, err := extraDeleteGate(ctx, childResource.ResourceID)
+			if err != nil {
+				return utils.TrackError(err)
+			}
+			if !shouldDelete {
+				continue
+			}
+		}
+
+		logger.Info("deleting child resource", "childResourceID", childResource.ResourceID)
+		if err := untypedCRUD.Delete(ctx, childResource.ResourceID); err != nil {
+			return utils.TrackError(err)
+		}
+	}
+	if err := childIterator.GetError(); err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}
+
+// extraDeleteGateShouldDeleteServiceProviderNodePool is an extra delete gate that checks if the ServiceProviderNodePool has any Maestro readonly bundles.
+// serviceProviderNodePoolResourceID is the child's ARM resource ID (serviceProviderNodePools/default).
+// If there are bundles it returns false, otherwise it returns true.
+func (c *nodePoolChildResourcesCleanupController) extraDeleteGateShouldDeleteServiceProviderNodePool(ctx context.Context, serviceProviderNodePoolResourceID *azcorearm.ResourceID) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	if serviceProviderNodePoolResourceID.Parent == nil || serviceProviderNodePoolResourceID.Parent.Parent == nil {
+		return false, utils.TrackError(fmt.Errorf(
+			"service provider node pool resource ID missing cluster or node pool parent: %s",
+			serviceProviderNodePoolResourceID.String()))
+	}
+
+	clusterName := serviceProviderNodePoolResourceID.Parent.Parent.Name
+	nodePoolName := serviceProviderNodePoolResourceID.Parent.Name
+
+	spnp, err := c.resourcesDBClient.ServiceProviderNodePools(serviceProviderNodePoolResourceID.SubscriptionID, serviceProviderNodePoolResourceID.ResourceGroupName, clusterName, nodePoolName).Get(ctx, api.ServiceProviderNodePoolResourceName)
+	if database.IsNotFoundError(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool: %w", err))
+	}
+
+	if len(spnp.Status.MaestroReadonlyBundles) > 0 {
+		logger.Info("waiting for nodepool-scoped Maestro readonly bundles to be deleted before removing Cosmos entry",
+			"serviceProviderNodePoolResourceID", spnp.ResourceID.String(), "remainingBundles", len(spnp.Status.MaestroReadonlyBundles))
+		return false, nil
+	}
+	return true, nil
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller_test.go
@@ -1,0 +1,304 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func newTestManagementClusterContent(t *testing.T, name string) *api.ManagementClusterContent {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName +
+			"/managementClusterContents/" + name))
+	return &api.ManagementClusterContent{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+	}
+}
+
+func newTestNodePoolController(t *testing.T, name string) *api.Controller {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName +
+			"/hcpOpenShiftControllers/" + name))
+	return &api.Controller{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+		ExternalID: api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + testSubscriptionID +
+				"/resourceGroups/" + testResourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+				"/nodePools/" + testNodePoolName)),
+		Status: api.ControllerStatus{
+			Conditions: []metav1.Condition{},
+		},
+	}
+}
+
+func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	readyToDeleteNodePoolOptsFunc := func(np *api.HCPOpenShiftClusterNodePool) {
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+		np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+		np.ServiceProviderProperties.ClusterServiceID = nil
+	}
+
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	testCases := []struct {
+		name             string
+		existingNodePool *api.HCPOpenShiftClusterNodePool
+		childResources   []any
+		wantErr          bool
+		verifyDB         func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:             "when no DeletionTimestamp, no ClusterServiceDeletionTimestamp are set and ClusterServiceID is set performs a no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, nil),
+			childResources:   []any{newTestManagementClusterContent(t, "untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name: "when no ClusterServiceDeletionTimestamp is set performs a no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = nil
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			childResources: []any{newTestManagementClusterContent(t, "untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name: "when ClusterServiceID is set performs a no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+			}),
+			childResources: []any{newTestManagementClusterContent(t, "untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name:             "when all conditions met and there are no children performs a no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+		},
+		{
+			name:             "when there is a children resource it deletes it",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestManagementClusterContent(t, "test-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				nodePoolResourceID := testKey.GetResourceID()
+				untypedCRUD, err := db.UntypedCRUD(*nodePoolResourceID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var remainingCount int
+				for range childIterator.Items(ctx) {
+					remainingCount++
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 0, remainingCount, "expected no children to remain")
+			},
+		},
+		{
+			name:             "deletion of node pool controllers is skipped",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestNodePoolController(t, "test-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				nodePoolResourceID := testKey.GetResourceID()
+				untypedCRUD, err := db.UntypedCRUD(*nodePoolResourceID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var controllerCount int
+				for _, child := range childIterator.Items(ctx) {
+					if strings.EqualFold(child.ResourceType, api.NodePoolControllerResourceType.String()) {
+						controllerCount++
+					}
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 1, controllerCount, "expected controller child to remain")
+			},
+		},
+		{
+			name:             "when there are nodepool controller and non nodepool controller children it deletes the non nodepool controller children",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestManagementClusterContent(t, "test-mcc"), newTestNodePoolController(t, "test-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				nodePoolResourceID := testKey.GetResourceID()
+				untypedCRUD, err := db.UntypedCRUD(*nodePoolResourceID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var remainingCount int
+				var controllerCount int
+				for _, child := range childIterator.Items(ctx) {
+					remainingCount++
+					if strings.EqualFold(child.ResourceType, api.NodePoolControllerResourceType.String()) {
+						controllerCount++
+					}
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 1, remainingCount, "expected only controller child to remain")
+				assert.Equal(t, 1, controllerCount, "expected the remaining child to be a controller")
+			},
+		},
+		{
+			name: "when the node pool is not found performs a no-op",
+		},
+		{
+			name:             "when there is a child ServiceProviderNodePool and it does not have Maestro bundle references it deletes it",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestSPNP(t, nil)},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.True(t, database.IsNotFoundError(err), "expected SPNP to be deleted")
+			},
+		},
+		{
+			name:             "when there is a child ServiceProviderNodePool and it has Maestro bundle references it does not delete it",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{newTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundle-a", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+			})},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err, "expected SPNP to still exist")
+			},
+		},
+		{
+			name:             "when there are child resources including a ServiceProviderNodePool with Maestro bundle references it deletes them excluding it",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{
+				newTestManagementClusterContent(t, "gate-mcc"),
+				newTestSPNP(t, api.MaestroBundleReferenceList{
+					{Name: "bundle-a", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+				}),
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
+				_, err := mccCRUD.Get(ctx, "gate-mcc")
+				require.True(t, database.IsNotFoundError(err), "expected MCC gate-mcc to be deleted")
+
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err = spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err, "expected SPNP to still exist")
+			},
+		},
+		{
+			name:             "UsesNewNodePoolDeletionApproach false -- no-op even when all cleanup conditions met and children exist",
+			existingNodePool: newTestNodePoolWithOldDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestManagementClusterContent(t, "untouched-mcc"), newTestSPNP(t, nil)},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err = spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err, "expected SPNP to still exist")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			resources := []any{}
+			if tc.existingNodePool != nil {
+				resources = append(resources, tc.existingNodePool)
+			}
+			resources = append(resources, tc.childResources...)
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			nodePoolsForLister := []*api.HCPOpenShiftClusterNodePool{}
+			if tc.existingNodePool != nil {
+				nodePoolsForLister = append(nodePoolsForLister, tc.existingNodePool)
+			}
+
+			syncer := &nodePoolChildResourcesCleanupController{
+				cooldownChecker:   &alwaysSyncCooldownChecker{},
+				nodePoolLister:    &listertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
+				resourcesDBClient: mockResourcesDBClient,
+			}
+
+			err = syncer.SyncOnce(ctx, testKey)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilsclock "k8s.io/utils/clock"
+	"k8s.io/utils/lru"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// missingClusterServiceIDTimeout is how long we wait after first observing
+// DeletionTimestamp for the ClusterServiceID to appear before concluding
+// that the corresponding Cluster Service Node Pool was never created and we have
+// no work to do (or before treating a 404 from Cluster Service as definitive).
+const missingClusterServiceIDTimeout = 120 * time.Second
+
+// nodePoolClusterServiceDeleteDispatchSyncer issues a Cluster Service delete for any
+// NodePool whose DeletionTimestamp has been set. The frontend records the
+// timestamp on the NodePool when DeleteNodePool is invoked, this controller
+// picks it up and calls Cluster Service out-of-band so the frontend never has
+// to block on it. Once the controller has issued the delete (or given up
+// waiting for a ClusterServiceID), it stamps ClusterServiceDeletionTimestamp
+// on the NodePool to record that this step is complete and avoid re-issuing
+// the delete on subsequent syncs.
+// The controller also caches the time the controller has first seen the
+// serviceProviderProperties.deletionTimestamp being set for a nodepool. This
+// is used to avoid immediately triggering deletion in scenarios where the
+// nodepool was marked for deletion but the controllers were not available for
+// some reason until some time afterwards.
+type nodePoolClusterServiceDeleteDispatchSyncer struct {
+	clock                utilsclock.PassiveClock
+	cooldownChecker      controllerutil.CooldownChecker
+	nodePoolLister       listers.NodePoolLister
+	resourcesDBClient    database.ResourcesDBClient
+	clusterServiceClient ocm.ClusterServiceClientSpec
+	// firstSeenDeletionTimestampCache is a cache that contains the time the controller
+	// has first seen the serviceProviderProperties.deletionTimestamp being set
+	// for a nodepool. The cache key is the lowercased node pool's resource ID and
+	// the value is a time.Time in UTC indicating the first seen deletion timestamp.
+	firstSeenDeletionTimestampCache *lru.Cache
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolClusterServiceDeleteDispatchSyncer)(nil)
+
+func NewNodePoolClusterServiceDeleteDispatchController(
+	clock utilsclock.PassiveClock,
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
+		clock:                           clock,
+		cooldownChecker:                 controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:                  nodePoolLister,
+		resourcesDBClient:               resourcesDBClient,
+		clusterServiceClient:            clusterServiceClient,
+		firstSeenDeletionTimestampCache: lru.New(50000),
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		"NodePoolClusterServiceDeleteDispatch",
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *nodePoolClusterServiceDeleteDispatchSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether the deleter has unfinished business for the given
+// NodePool: DeletionTimestamp must be set and ClusterServiceDeletionTimestamp
+// must not yet be set.
+func (c *nodePoolClusterServiceDeleteDispatchSyncer) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
+	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
+		return false
+	}
+
+	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp == nil
+}
+
+// SyncOnce calls Cluster Service to delete the NodePool when its DeletionTimestamp is set.
+//
+// If the NodePool has no ClusterServiceID yet, we may have raced cluster-service NodePool
+// creation. We wait for missingClusterServiceIDTimeout from when we first observed
+// DeletionTimestamp before concluding the cluster-service NodePool was never created.
+//
+// In either terminal case - CS delete issued or wait abandoned - we stamp
+// ClusterServiceDeletionTimestamp so the next sync short-circuits.
+func (c *nodePoolClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedNodePool) {
+		return nil
+	}
+
+	// Confirm against the live document. The cache can lag behind a write that
+	// just set DeletionTimestamp, populated ClusterServiceID, or stamped
+	// ClusterServiceDeletionTimestamp.
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName)
+	nodePool, err := nodePoolCRUD.Get(ctx, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
+	}
+	if !c.NeedsWork(nodePool) {
+		return nil
+	}
+
+	// We check if we have seen the deletion marker being set for this node pool.
+	// If we don't we start tracking it in the cache.
+	nodePoolDeletionTimestamp := nodePool.ServiceProviderProperties.DeletionTimestamp.Time
+	cacheKey := strings.ToLower(nodePool.ID.String())
+	var firstSeenNodePoolDeletionTimestamp time.Time
+	firstSeenEntry, ok := c.firstSeenDeletionTimestampCache.Get(cacheKey)
+	if ok {
+		firstSeenNodePoolDeletionTimestamp = firstSeenEntry.(time.Time)
+	} else {
+		firstSeenNodePoolDeletionTimestamp = c.clock.Now().UTC()
+		c.firstSeenDeletionTimestampCache.Add(cacheKey, firstSeenNodePoolDeletionTimestamp)
+	}
+
+	csID := nodePool.ServiceProviderProperties.ClusterServiceID
+	if csID == nil || len(csID.String()) == 0 {
+		elapsed := c.clock.Since(firstSeenNodePoolDeletionTimestamp)
+		if elapsed < missingClusterServiceIDTimeout {
+			// The frontend may still be in the middle of creating the cluster-service
+			// NodePool, or the controller that does so hasn't run yet. Re-check on the
+			// next sync. The resync interval and informer change events drive retries.
+			return nil
+		}
+		logger.Info("giving up on cluster-service NodePool delete - ClusterServiceID never appeared",
+			"nodePoolDeletionTimestamp", nodePoolDeletionTimestamp, "nodePoolFirstSeenDeletionTimestamp", firstSeenNodePoolDeletionTimestamp)
+	} else if err := c.clusterServiceClient.DeleteNodePool(ctx, *csID); err != nil {
+		var ocmError *ocmerrors.Error
+
+		switch {
+		case errors.As(err, &ocmError) && ocmError.Status() == http.StatusBadRequest &&
+			strings.Contains(ocmError.Reason(), "Cannot delete node pool: its parent cluster must be in a deletable state") &&
+			strings.Contains(ocmError.Reason(), "Parent cluster state: 'uninstalling'"):
+			// If the error is indicating that the parent cluster is already being
+			// uninstalled we consider that the the nodepool is already being deleted
+			// because Cluster Service on cluster deletion will end up deleting the
+			// nodepools as well.
+			// Matching an error message is brittle, but Clusters Service
+			// returns 400 Bad Request for a wide range of errors and there
+			// is no other information in the response to distinguish them.
+			logger.Info("NodePool already being deleted by cluster-service via parent cluster deletion", "clusterServiceID", csID.String())
+		case errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound:
+			// OCM error 404 - could be a stale CSID or a race against an in-flight CS
+			// create. Wait before treating the NodePool as definitively gone
+			elapsed := c.clock.Since(firstSeenNodePoolDeletionTimestamp)
+			if elapsed < missingClusterServiceIDTimeout {
+				return nil
+			}
+			logger.Info("cluster-service NodePool already deleted or race against in-flight CS create", "clusterServiceID", csID.String())
+		default:
+			return utils.TrackError(fmt.Errorf("failed to delete cluster-service NodePool: %w", err))
+		}
+	} else {
+		logger.Info("requested cluster-service NodePool delete", "clusterServiceID", csID.String())
+	}
+
+	nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: c.clock.Now().UTC()}
+	_, err = nodePoolCRUD.Replace(ctx, nodePool, nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to stamp ClusterServiceDeletionTimestamp: %w", err))
+	}
+	c.firstSeenDeletionTimestampCache.Remove(cacheKey)
+
+	return nil
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller_test.go
@@ -1,0 +1,475 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+	"k8s.io/utils/lru"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	testSubscriptionID      = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName   = "test-rg"
+	testClusterName         = "test-cluster"
+	testNodePoolName        = "test-nodepool"
+	testClusterServiceIDStr = "/api/aro_hcp/v1alpha1/clusters/abc123"
+	testNodePoolCSIDStr     = testClusterServiceIDStr + "/node_pools/" + testNodePoolName
+)
+
+type alwaysSyncCooldownChecker struct{}
+
+func (c *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
+	return true
+}
+
+func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	verifyClusterServiceDeletionTimestampIsNil := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			NodePools(testClusterName).Get(ctx, testNodePoolName)
+		require.NoError(t, err)
+		assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+	}
+
+	verifyClusterServiceDeletionTimestampStamped := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			NodePools(testClusterName).Get(ctx, testNodePoolName)
+		require.NoError(t, err)
+		require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp, "expected ClusterServiceDeletionTimestamp to be stamped")
+		assert.True(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time.Equal(fixedClockTime),
+			"expected ClusterServiceDeletionTimestamp to equal fixedClockTime, got %v", stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time)
+	}
+
+	newFakeOCMParentClusterUninstallingError := func() error {
+		e, _ := ocmerrors.NewError().
+			Status(http.StatusBadRequest).
+			Reason("Cannot delete node pool: its parent cluster must be in a deletable state. Parent cluster state: 'uninstalling'").
+			Build()
+		return e
+	}
+
+	testCases := []struct {
+		name                string
+		existingNodePool    *api.HCPOpenShiftClusterNodePool
+		firstSeenDeletionAt time.Time
+		setupMockCSClient   func(mock *ocm.MockClusterServiceClientSpec)
+		wantErr             bool
+		wantErrContain      string
+		verifyDB            func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:             "when no DeletionTimestamp no-op is performed",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, nil),
+			verifyDB:         verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when ClusterServiceDeletionTimestamp is set no-op is performed",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Minute)}
+			}),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+				assert.True(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time.Equal(fixedClockTime.Add(-30*time.Minute)),
+					"expected ClusterServiceDeletionTimestamp unchanged")
+			},
+		},
+		{
+			name: "when ClusterServiceID is not set and deletion is first observed then first seen is recorded and no-op is performed",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			verifyDB: verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when ClusterServiceID is not set and first seen within missing cluster service id is within timeout no-op is performed",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			verifyDB:            verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when ClusterServiceID is not set and first seen older than missing cluster service id timeout then we give up and set ClusterServiceDeletionTimestamp",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout - time.Second),
+			verifyDB:            verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "when ClusterServiceID is set we trigger CS nodepool deletion and set ClusterServiceDeletionTimestamp",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(nil)
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "when CS nodepool deletion returns 404 and first seen is within the missing cluster service id timeout no-op is performed",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(fakeOCMNotFoundError())
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when CS nodepool deletion returns 404 and first seen is older than the missing cluster service id timeout then we give up and set ClusterServiceDeletionTimestamp",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout - time.Second),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(fakeOCMNotFoundError())
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "when CS nodepool deletion returns one of the not handled errors we propagate it without setting ClusterServiceDeletionTimestamp",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(errors.New("boom"))
+			},
+			wantErr:        true,
+			wantErrContain: "failed to delete cluster-service NodePool",
+		},
+		{
+			name: "when CS nodepool deletion returns parent cluster is uninstalling we set ClusterServiceDeletionTimestamp immediately",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Second)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(newFakeOCMParentClusterUninstallingError())
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "UsesNewNodePoolDeletionApproach false -- no-op even when DeletionTimestamp is set",
+			existingNodePool: newTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+			}),
+			verifyDB: verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "node pool not found no-op is performed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
+
+			resources := []any{}
+			if tc.existingNodePool != nil {
+				resources = append(resources, tc.existingNodePool)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
+
+			nodePoolsForLister := []*api.HCPOpenShiftClusterNodePool{}
+			if tc.existingNodePool != nil {
+				nodePoolsForLister = append(nodePoolsForLister, tc.existingNodePool)
+			}
+
+			firstSeenDeletionTimestampCache := lru.New(10)
+			if !tc.firstSeenDeletionAt.IsZero() {
+				firstSeenDeletionTimestampCache.Add(
+					strings.ToLower(tc.existingNodePool.ID.String()),
+					tc.firstSeenDeletionAt,
+				)
+			}
+
+			syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
+				clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+				cooldownChecker:                 &alwaysSyncCooldownChecker{},
+				nodePoolLister:                  &listertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
+				resourcesDBClient:               mockResourcesDBClient,
+				clusterServiceClient:            mockCSClient,
+				firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
+			}
+
+			err = syncer.SyncOnce(ctx, testKey)
+			if tc.wantErr {
+				require.Error(t, err)
+				if len(tc.wantErrContain) > 0 {
+					require.ErrorContains(t, err, tc.wantErrContain)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}
+
+func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_cacheShortCircuit(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+
+	nodePoolInDB := newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+	})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{nodePoolInDB})
+	require.NoError(t, err)
+
+	// Here the cached node pool does not have a DeletionTimestamp set, so the syncer will short-circuit.
+	cachedNodePool := newTestNodePoolWithNewDeletionApproach(t, nil)
+
+	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
+		clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+		cooldownChecker:                 &alwaysSyncCooldownChecker{},
+		nodePoolLister:                  &listertesting.SliceNodePoolLister{NodePools: []*api.HCPOpenShiftClusterNodePool{cachedNodePool}},
+		resourcesDBClient:               mockResourcesDBClient,
+		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		firstSeenDeletionTimestampCache: lru.New(10),
+	}
+
+	key := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	require.NoError(t, syncer.SyncOnce(ctx, key))
+
+	stored, err := mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).
+		NodePools(testClusterName).Get(ctx, testNodePoolName)
+	require.NoError(t, err)
+	assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+}
+
+func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCachePopulation(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+
+	nodePool := newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+		np.ServiceProviderProperties.ClusterServiceID = nil
+	})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{nodePool})
+	require.NoError(t, err)
+
+	firstSeenDeletionTimestampCache := lru.New(10)
+	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
+		clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+		cooldownChecker:                 &alwaysSyncCooldownChecker{},
+		nodePoolLister:                  &listertesting.SliceNodePoolLister{NodePools: []*api.HCPOpenShiftClusterNodePool{nodePool}},
+		resourcesDBClient:               mockResourcesDBClient,
+		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
+	}
+
+	key := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	require.NoError(t, syncer.SyncOnce(ctx, key))
+
+	cacheKey := strings.ToLower(nodePool.ID.String())
+	firstSeenEntry, ok := firstSeenDeletionTimestampCache.Get(cacheKey)
+	require.True(t, ok, "expected first seen deletion timestamp to be cached")
+	assert.True(t, firstSeenEntry.(time.Time).Equal(fixedClockTime))
+}
+
+func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCacheCleared(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+
+	nodePool := newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+	})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{nodePool})
+	require.NoError(t, err)
+
+	cacheKey := strings.ToLower(nodePool.ID.String())
+	firstSeenDeletionTimestampCache := lru.New(10)
+	firstSeenDeletionTimestampCache.Add(cacheKey, fixedClockTime.Add(-missingClusterServiceIDTimeout/2))
+
+	mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+	mockCSClient.EXPECT().
+		DeleteNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+		Return(nil)
+
+	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
+		clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+		cooldownChecker:                 &alwaysSyncCooldownChecker{},
+		nodePoolLister:                  &listertesting.SliceNodePoolLister{NodePools: []*api.HCPOpenShiftClusterNodePool{nodePool}},
+		resourcesDBClient:               mockResourcesDBClient,
+		clusterServiceClient:            mockCSClient,
+		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
+	}
+
+	key := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	require.NoError(t, syncer.SyncOnce(ctx, key))
+
+	_, ok := firstSeenDeletionTimestampCache.Get(cacheKey)
+	assert.False(t, ok, "expected first seen deletion cache entry to be removed after terminal sync")
+
+	stored, err := mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).
+		NodePools(testClusterName).Get(ctx, testNodePoolName)
+	require.NoError(t, err)
+	require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+	assert.True(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time.Equal(fixedClockTime))
+}
+
+func fakeOCMNotFoundError() error {
+	e, _ := ocmerrors.NewError().Status(http.StatusNotFound).Reason("not found").Build()
+	return e
+}
+
+// TODO rename this to newTestNodePoolWithNewDeletionApproach and remove the newTestNodePoolWithOldDeletionApproach function once
+// the new deletion approach is fully rolled out in all ARO-HCP permanent environments, for all regions.
+func newTestNodePoolWithNewDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName))
+	nodePoolInternalID := api.Ptr(api.Must(api.NewInternalID(testNodePoolCSIDStr)))
+	np := &api.HCPOpenShiftClusterNodePool{
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testNodePoolName,
+				Type: api.NodePoolResourceType.String(),
+			},
+			Location: "eastus",
+		},
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Platform: api.NodePoolPlatformProfile{
+				OSDisk: api.OSDiskProfile{
+					DiskStorageAccountType: api.DiskStorageAccountTypePremium_LRS,
+					DiskType:               api.OsDiskTypeManaged,
+				},
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+			ClusterServiceID:                nodePoolInternalID,
+			UsesNewNodePoolDeletionApproach: true,
+		},
+	}
+	if opts != nil {
+		opts(np)
+	}
+	return np
+}
+
+// TODO remove this once the new deletion approach is fully rolled out in all ARO-HCP permanent environments, for all regions.
+func newTestNodePoolWithOldDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
+	np := newTestNodePoolWithNewDeletionApproach(t, opts)
+	np.ServiceProviderProperties.UsesNewNodePoolDeletionApproach = false
+	return np
+}
+
+func newTestSPNP(t *testing.T, bundles api.MaestroBundleReferenceList) *api.ServiceProviderNodePool {
+	t.Helper()
+	spnpResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName +
+			"/serviceProviderNodePools/default"))
+	return &api.ServiceProviderNodePool{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
+		Status: api.ServiceProviderNodePoolStatus{
+			MaestroReadonlyBundles: bundles,
+		},
+	}
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolClusterServiceIDClearer clears ClusterServiceID after the
+// cluster-service NodePool itself has been confirmed gone. This runs after the
+// delete dispatch controller has already issued the delete request
+// (ClusterServiceDeletionTimestamp is set). We poll cluster-service for the
+// NodePool and, on 404, zero out the stored ClusterServiceID so downstream
+// code knows the CS resource is fully gone.
+type nodePoolClusterServiceIDClearer struct {
+	cooldownChecker      controllerutil.CooldownChecker
+	nodePoolLister       listers.NodePoolLister
+	resourcesDBClient    database.ResourcesDBClient
+	clusterServiceClient ocm.ClusterServiceClientSpec
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolClusterServiceIDClearer)(nil)
+
+func NewNodePoolClusterServiceIDClearerController(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	syncer := &nodePoolClusterServiceIDClearer{
+		cooldownChecker:      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:       nodePoolLister,
+		resourcesDBClient:    resourcesDBClient,
+		clusterServiceClient: clusterServiceClient,
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		"NodePoolDeletionClusterServiceIDClearer",
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *nodePoolClusterServiceIDClearer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether this controller has unfinished business for the
+// given NodePool: deletion has been started (DeletionTimestamp), the deleter
+// has already issued the CS delete (ClusterServiceDeletionTimestamp), and a
+// ClusterServiceID is still recorded that needs verification before clearing.
+func (c *nodePoolClusterServiceIDClearer) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
+	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
+		return false
+	}
+
+	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceID != nil && len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) > 0
+}
+
+// SyncOnce reads the NodePool from cluster-service. If cluster-service reports
+// 404, the deletion has finished and we zero out ClusterServiceID. Any other
+// state means cluster-service is still draining the NodePool. We retry on the
+// next sync.
+func (c *nodePoolClusterServiceIDClearer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedNodePool) {
+		return nil
+	}
+
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName)
+	nodePool, err := nodePoolCRUD.Get(ctx, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
+	}
+	if !c.NeedsWork(nodePool) {
+		return nil
+	}
+
+	csID := nodePool.ServiceProviderProperties.ClusterServiceID
+	_, err = c.clusterServiceClient.GetNodePool(ctx, *csID)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+		if !errors.As(err, &ocmError) || ocmError.Status() != http.StatusNotFound {
+			return utils.TrackError(fmt.Errorf("failed to get cluster-service NodePool: %w", err))
+		}
+		// 404 - cluster-service has finished deleting the NodePool, clear the CS ID.
+		logger.Info("cluster-service NodePool gone. Clearing ClusterServiceID", "clusterServiceID", csID.String())
+		nodePool.ServiceProviderProperties.ClusterServiceID = nil
+		if _, err := nodePoolCRUD.Replace(ctx, nodePool, nil); err != nil {
+			return utils.TrackError(fmt.Errorf("failed to clear ClusterServiceID: %w", err))
+		}
+		return nil
+	}
+
+	// NodePool still exists in cluster-service. Nothing to do yet.
+	return nil
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestNodePoolClusterServiceIDClearer_SyncOnce(t *testing.T) {
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	withDeletionStampsNodePoolOptsFunc := func(np *api.HCPOpenShiftClusterNodePool) {
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+		np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+	}
+
+	verifyClusterServiceIDUnchanged := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			NodePools(testClusterName).Get(ctx, testNodePoolName)
+		require.NoError(t, err)
+		require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceID, "ClusterServiceID should not be nil")
+		assert.Equal(t, testNodePoolCSIDStr, stored.ServiceProviderProperties.ClusterServiceID.String(),
+			"ClusterServiceID should be unchanged")
+	}
+
+	testCases := []struct {
+		name              string
+		existingNodePool  *api.HCPOpenShiftClusterNodePool
+		setupMockCSClient func(mock *ocm.MockClusterServiceClientSpec)
+		wantErr           bool
+		wantErrContain    string
+		verifyDB          func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:             "no DeletionTimestamp -- no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, nil),
+			verifyDB:         verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "DeletionTimestamp set but ClusterServiceDeletionTimestamp not yet -- no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+			}),
+			verifyDB: verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "ClusterServiceID already cleared -- no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				withDeletionStampsNodePoolOptsFunc(np)
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceID, "ClusterServiceID should remain nil")
+			},
+		},
+		{
+			name: "CS NodePool still present -- wait",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				withDeletionStampsNodePoolOptsFunc(np)
+			}),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(newCSNodePool(t), nil)
+			},
+			verifyDB: verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "CS returns 404 -- clear ClusterServiceID",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				withDeletionStampsNodePoolOptsFunc(np)
+			}),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(nil, fakeOCMNotFoundError())
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceID, "expected ClusterServiceID to be cleared")
+			},
+		},
+		{
+			name: "CS returns one of the not handled errors -- propagated, no clear",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				withDeletionStampsNodePoolOptsFunc(np)
+			}),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(nil, errors.New("boom"))
+			},
+			wantErr:        true,
+			wantErrContain: "failed to get cluster-service NodePool",
+		},
+		{
+			name: "UsesNewNodePoolDeletionApproach false -- no-op even when all clear conditions met",
+			existingNodePool: newTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				withDeletionStampsNodePoolOptsFunc(np)
+			}),
+			verifyDB: verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "node pool not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
+
+			resources := []any{}
+			if tc.existingNodePool != nil {
+				resources = append(resources, tc.existingNodePool)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
+
+			nodePoolsForLister := []*api.HCPOpenShiftClusterNodePool{}
+			if tc.existingNodePool != nil {
+				nodePoolsForLister = append(nodePoolsForLister, tc.existingNodePool)
+			}
+
+			syncer := &nodePoolClusterServiceIDClearer{
+				cooldownChecker:      &alwaysSyncCooldownChecker{},
+				nodePoolLister:       &listertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
+				resourcesDBClient:    mockResourcesDBClient,
+				clusterServiceClient: mockCSClient,
+			}
+
+			key := controllerutils.HCPNodePoolKey{
+				SubscriptionID:    testSubscriptionID,
+				ResourceGroupName: testResourceGroupName,
+				HCPClusterName:    testClusterName,
+				HCPNodePoolName:   testNodePoolName,
+			}
+
+			err = syncer.SyncOnce(ctx, key)
+			if tc.wantErr {
+				require.Error(t, err)
+				if len(tc.wantErrContain) > 0 {
+					require.ErrorContains(t, err, tc.wantErrContain)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}
+
+func newCSNodePool(t *testing.T) *arohcpv1alpha1.NodePool {
+	t.Helper()
+	np, err := arohcpv1alpha1.NewNodePool().ID(testNodePoolName).Build()
+	require.NoError(t, err)
+	return np
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolDeletionController issues a Cosmos nodepool delete
+// for the Node Pools that have their DeletionTimestamp and ClusterServiceDeletionTimestamp set,
+// their ClusterServiceID has been cleared, and all nodepool-scoped Maestro readonly bundles
+// have been deleted from the ServiceProviderNodePool.
+type nodePoolDeletionController struct {
+	cooldownChecker               controllerutil.CooldownChecker
+	nodePoolLister                listers.NodePoolLister
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
+	resourcesDBClient             database.ResourcesDBClient
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolDeletionController)(nil)
+
+func NewNodePoolDeletionController(
+	resourcesDBClient database.ResourcesDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	_, serviceProviderNodePoolLister := informers.ServiceProviderNodePools()
+	syncer := &nodePoolDeletionController{
+		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:                nodePoolLister,
+		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
+		resourcesDBClient:             resourcesDBClient,
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		"NodePoolDeletionController",
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *nodePoolDeletionController) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether the deleter has unfinished business for the given
+// NodePool. All the following conditions must be met:
+// - DeletionTimestamp must be set
+// - ClusterServiceDeletionTimestamp must be set
+// - ClusterServiceID must be nil
+func (c *nodePoolDeletionController) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
+	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
+		return false
+	}
+
+	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceID == nil
+}
+
+// SyncOnce calls Cosmos to delete the NodePool when the NeedsWork condition is met and
+// all the delete preconditions are met.
+func (c *nodePoolDeletionController) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedNodePool) {
+		return nil
+	}
+
+	// We do a quick check to see if the ServiceProviderNodePool has any Maestro readonly bundles.
+	// If it does, we return early as we need to wait for the bundles to be deleted.
+	cachedSPNP, spnpCacheErr := c.serviceProviderNodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if spnpCacheErr == nil && len(cachedSPNP.Status.MaestroReadonlyBundles) > 0 {
+		return nil
+	}
+
+	// Confirm against the live document. The cache can lag behind a write that
+	// modified one of the NeedsWork conditions.
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName)
+	nodePool, err := nodePoolCRUD.Get(ctx, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
+	}
+	if !c.NeedsWork(nodePool) {
+		return nil
+	}
+
+	// We do not proceed until we know that all the maestro readonly bundles have been eliminated
+	preconditionMet, err := c.deletePreconditionAllMaestroNodePoolScopedReadonlyBundlesCleared(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
+	// We do not proceed until we know that the cosmos child resources have been eliminated
+	preconditionMet, err = c.deletePreconditionCosmosChildResourcesDeleted(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
+	logger.Info("deleting node pool from Cosmos")
+	err = nodePoolCRUD.Delete(ctx, key.HCPNodePoolName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to delete node pool from Cosmos: %w", err))
+	}
+	logger.Info("node pool deleted from Cosmos")
+
+	return nil
+}
+
+// deletePreconditionAllMaestroNodePoolScopedReadonlyBundlesCleared checks if the ServiceProviderNodePool has any Maestro readonly bundles.
+// If it does, it returns false, otherwise it returns true.
+func (c *nodePoolDeletionController) deletePreconditionAllMaestroNodePoolScopedReadonlyBundlesCleared(ctx context.Context, key controllerutils.HCPNodePoolKey) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	spnpCRUD := c.resourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	spnp, spnpErr := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+	if spnpErr != nil && !database.IsNotFoundError(spnpErr) {
+		return false, utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool: %w", spnpErr))
+	}
+	if spnp != nil && len(spnp.Status.MaestroReadonlyBundles) > 0 {
+		logger.Info("waiting for nodepool-scoped Maestro readonly bundles to be deleted before removing Cosmos entry",
+			"remainingBundles", len(spnp.Status.MaestroReadonlyBundles))
+		return false, nil
+	}
+	return true, nil
+}
+
+// deletePreconditionCosmosChildResourcesDeleted checks if the cosmos child resources have been deleted.
+// If they have, it returns true, otherwise it returns false.
+// It ignores node pool controllers here, as there might be controllers still running for the NodePool until the very
+// end of the deletion process.
+func (c *nodePoolDeletionController) deletePreconditionCosmosChildResourcesDeleted(ctx context.Context, key controllerutils.HCPNodePoolKey) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	nodePoolResourceID := key.GetResourceID()
+	untypedCRUD, err := c.resourcesDBClient.UntypedCRUD(*nodePoolResourceID)
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to create untyped CRUD for child check: %w", err))
+	}
+	childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to list child resources: %w", err))
+	}
+	for _, childResource := range childIterator.Items(ctx) {
+		// We ignore node pool controllers here, as there might be controllers still running for the NodePool until the very
+		// end of the deletion process
+		if strings.EqualFold(childResource.ResourceType, api.NodePoolControllerResourceType.String()) {
+			continue
+		}
+		logger.Info("child resource still exists, waiting for cleanup", "childResourceID", childResource.ResourceID)
+		return false, nil
+	}
+	if err := childIterator.GetError(); err != nil {
+		return false, utils.TrackError(fmt.Errorf("error iterating child resources: %w", err))
+	}
+
+	return true, nil
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestNodePoolDeletionController_SyncOnce(t *testing.T) {
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	readyToDeleteNodePoolOptsFunc := func(np *api.HCPOpenShiftClusterNodePool) {
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+		np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+		np.ServiceProviderProperties.ClusterServiceID = nil
+	}
+
+	verifyNodePoolStillExists := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		_, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			NodePools(testClusterName).Get(ctx, testNodePoolName)
+		require.NoError(t, err, "expected nodepool to still exist in Cosmos")
+	}
+
+	verifyNodePoolDeleted := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		_, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			NodePools(testClusterName).Get(ctx, testNodePoolName)
+		assert.True(t, database.IsNotFoundError(err), "expected nodepool to be deleted from Cosmos")
+	}
+
+	testCases := []struct {
+		name             string
+		existingNodePool *api.HCPOpenShiftClusterNodePool
+		childResources   []any
+		wantErr          bool
+		verifyDB         func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:             "no DeletionTimestamp -- no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, nil),
+			verifyDB:         verifyNodePoolStillExists,
+		},
+		{
+			name: "DeletionTimestamp set but ClusterServiceDeletionTimestamp not -- no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+			}),
+			verifyDB: verifyNodePoolStillExists,
+		},
+		{
+			name: "ClusterServiceID still set -- no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+			}),
+			verifyDB: verifyNodePoolStillExists,
+		},
+		{
+			name:             "all conditions met, no children -- deletes nodepool from Cosmos",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			verifyDB:         verifyNodePoolDeleted,
+		},
+		{
+			name:             "all conditions met, SPNP has remaining bundles -- backs off",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{newTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "readonly-bundle-1"},
+			})},
+			verifyDB: verifyNodePoolStillExists,
+		},
+		{
+			name:             "all conditions met, SPNP with no bundles -- backs off until SPNP removed",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestSPNP(t, nil)},
+			verifyDB:         verifyNodePoolStillExists,
+		},
+		{
+			name:             "all conditions met, a non node pool controller cosmos child exists -- backs off",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestManagementClusterContent(t, "test-mcc")},
+			verifyDB:         verifyNodePoolStillExists,
+		},
+		{
+			name:             "all conditions met, only controller children -- deletes nodepool",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestNodePoolController(t, "test-controller")},
+			verifyDB:         verifyNodePoolDeleted,
+		},
+		{
+			name:             "UsesNewNodePoolDeletionApproach false -- no-op even when all delete conditions met",
+			existingNodePool: newTestNodePoolWithOldDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestNodePoolController(t, "test-controller")},
+			verifyDB:         verifyNodePoolStillExists,
+		},
+		{
+			name: "node pool not found -- no-op",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			resources := []any{}
+			if tc.existingNodePool != nil {
+				resources = append(resources, tc.existingNodePool)
+			}
+			resources = append(resources, tc.childResources...)
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			nodePoolsForLister := []*api.HCPOpenShiftClusterNodePool{}
+			if tc.existingNodePool != nil {
+				nodePoolsForLister = append(nodePoolsForLister, tc.existingNodePool)
+			}
+			spnpForLister := []*api.ServiceProviderNodePool{}
+			for _, child := range tc.childResources {
+				if spnp, ok := child.(*api.ServiceProviderNodePool); ok {
+					spnpForLister = append(spnpForLister, spnp)
+				}
+			}
+
+			syncer := &nodePoolDeletionController{
+				cooldownChecker:               &alwaysSyncCooldownChecker{},
+				nodePoolLister:                &listertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
+				serviceProviderNodePoolLister: &listertesting.SliceServiceProviderNodePoolLister{ServiceProviderNodePools: spnpForLister},
+				resourcesDBClient:             mockResourcesDBClient,
+			}
+
+			key := controllerutils.HCPNodePoolKey{
+				SubscriptionID:    testSubscriptionID,
+				ResourceGroupName: testResourceGroupName,
+				HCPClusterName:    testClusterName,
+				HCPNodePoolName:   testNodePoolName,
+			}
+
+			err = syncer.SyncOnce(ctx, key)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
@@ -116,10 +116,31 @@ func (c *operationClusterDelete) SynchronizeOperation(ctx context.Context, key c
 		// TODO when we update to make clusterserice creation async, we need to handle this correctly.
 		return nil
 	}
+
 	clusterStatus, err := c.clusterServiceClient.GetClusterStatus(ctx, operation.InternalID)
 	var ocmGetClusterError *ocmerrors.Error
 	if err != nil && errors.As(err, &ocmGetClusterError) && ocmGetClusterError.Status() == http.StatusNotFound {
 		logger.Info("cluster was deleted")
+
+		// Some nodepool controllers require of the Cosmos document to do their cleanup work so we block
+		// the cluster cosmos deletion until the nodepools are gone.
+		nodePoolIterator, err := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).NodePools(operation.ExternalID.Name).List(ctx, nil)
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		foundAtLeastOneNodePool := false
+		for range nodePoolIterator.Items(ctx) {
+			foundAtLeastOneNodePool = true
+			break
+		}
+		err = nodePoolIterator.GetError()
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		if foundAtLeastOneNodePool {
+			logger.Info("cluster still has cosmos nodepools")
+			return nil
+		}
 
 		// Update the Cosmos DB billing document with a deletion timestamp.
 		// Do this before calling setDeleteOperationAsCompleted so that in

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete_test.go
@@ -29,6 +29,7 @@ import (
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
@@ -42,6 +43,7 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 
 	tests := []struct {
 		name        string
+		nodePools   []*api.HCPOpenShiftClusterNodePool
 		setupMock   func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec
 		expectError bool
 		verify      func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture)
@@ -66,6 +68,30 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 				// Verify cluster document was deleted
 				_, err = db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				assert.Error(t, err, "cluster should have been deleted")
+			},
+		},
+		{
+			name: "cluster not found does not remove cluster while nodepools exist",
+			nodePools: []*api.HCPOpenShiftClusterNodePool{
+				newNodePoolTestFixture().newNodePool(),
+			},
+			setupMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				notFoundErr, _ := ocmerrors.NewError().Status(http.StatusNotFound).Build()
+				mockCSClient.EXPECT().
+					GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
+					Return(nil, notFoundErr)
+				return mockCSClient
+			},
+			expectError: false,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.NotNil(t, cluster)
 			},
 		},
 		{
@@ -163,11 +189,16 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 			billingDoc.CreationTime = createdAt
 			billingDoc.Location = testAzureLocation
 			billingDoc.TenantID = testTenantID
-
-			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, operation})
-			require.NoError(t, err)
 			mockBillingDBClient := databasetesting.NewMockBillingDBClient()
-			err = mockBillingDBClient.BillingDocs(fixture.clusterResourceID.SubscriptionID).Create(ctx, billingDoc)
+			err := mockBillingDBClient.BillingDocs(fixture.clusterResourceID.SubscriptionID).Create(ctx, billingDoc)
+			require.NoError(t, err)
+
+			// Mock resources DB client with cluster, operation, and node pools
+			resources := []any{cluster, operation}
+			for _, nodePool := range tt.nodePools {
+				resources = append(resources, nodePool)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)
 
 			mockCSClient := tt.setupMock(ctrl, fixture)
@@ -181,7 +212,6 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
-
 			if tt.expectError {
 				require.Error(t, err)
 			} else {

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete.go
@@ -45,16 +45,25 @@ type operationNodePoolDelete struct {
 // follows an asynchronous node pool deletion operation to completion and updates
 // the corresponding operation document in Cosmos DB.
 //
-// Operation documents relevant to this controller will have the following values:
-//
-//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools
-//	     Request: Delete
-//	      Status: any non-terminal value
+// The controller has the following responsibilities:
+//   - While the NodePool Cosmos document is present, it reconciles the
+//     operation and the node pool status.
+//   - When the NodePool Cosmos document is deleted (by the nodePoolDeletionController),
+//     it marks the operation as Succeeded. It also cleans up child
+//     resources. TODO Note: This last part is handled by other controllers too but
+//     because the SetDeleteOperationAsCompleted is still reused by other operations
+//     that have not been migrated to asynchronous flow yet this remains.
 //
 // Note that "to completion" does not imply success. An operation is considered
 // complete when its status field reaches what Azure defines as a terminal value;
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools
+//	     Request: Delete
+//	      Status: any non-terminal value
 func NewOperationNodePoolDeleteController(
 	clock utilsclock.PassiveClock,
 	resourcesDBClient database.ResourcesDBClient,
@@ -93,18 +102,23 @@ func (c *operationNodePoolDelete) ShouldProcess(ctx context.Context, operation *
 	return true
 }
 
-func (c *operationNodePoolDelete) SynchronizeOperation(ctx context.Context, key controllerutils.OperationKey) error {
-	logger := utils.LoggerFromContext(ctx)
-	logger.Info("checking operation")
+func (c *operationNodePoolDelete) legacyShouldProcess(ctx context.Context, operation *api.Operation) bool {
+	if operation.Status.IsTerminal() {
+		return false
+	}
+	if operation.Request != database.OperationRequestDelete {
+		return false
+	}
+	if operation.ExternalID == nil || !strings.EqualFold(operation.ExternalID.ResourceType.String(), api.NodePoolResourceType.String()) {
+		return false
+	}
+	return true
+}
 
-	operation, err := c.resourcesDBClient.Operations(key.SubscriptionID).Get(ctx, key.OperationName)
-	if database.IsNotFoundError(err) {
-		return nil // no work to do
-	}
-	if err != nil {
-		return fmt.Errorf("failed to get active operation: %w", err)
-	}
-	if !c.ShouldProcess(ctx, operation) {
+func (c *operationNodePoolDelete) legacySynchronizeOperation(ctx context.Context, operation *api.Operation) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	if !c.legacyShouldProcess(ctx, operation) {
 		return nil // no work to do
 	}
 
@@ -121,6 +135,96 @@ func (c *operationNodePoolDelete) SynchronizeOperation(ctx context.Context, key 
 	}
 	if err != nil {
 		return utils.TrackError(err)
+	}
+
+	newOperationStatus, newOperationError, err := convertNodePoolStatus(operation, nodePoolStatus)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, newOperationStatus, newOperationError, postAsyncNotificationFn(c.notificationClient))
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}
+
+func (c *operationNodePoolDelete) SynchronizeOperation(ctx context.Context, key controllerutils.OperationKey) error {
+	logger := utils.LoggerFromContext(ctx)
+	logger.Info("checking operation")
+
+	operation, err := c.resourcesDBClient.Operations(key.SubscriptionID).Get(ctx, key.OperationName)
+	if database.IsNotFoundError(err) {
+		return nil // no work to do
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get active operation: %w", err)
+	}
+
+	// TODO remove this once migration of node pool deletion from frontend to backend is fully completed.
+	if !operation.UsesNewNodePoolDeletionApproach {
+		return c.legacySynchronizeOperation(ctx, operation)
+	}
+
+	// From here, we know it uses the new deletion approach.
+
+	if !c.ShouldProcess(ctx, operation) {
+		return nil // no work to do
+	}
+
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).NodePools(operation.ExternalID.Parent.Name)
+	nodePool, err := nodePoolCRUD.Get(ctx, operation.ExternalID.Name)
+	if database.IsNotFoundError(err) {
+		logger.Info("node pool document deleted - completing operation")
+		err = SetDeleteOperationAsCompleted(ctx, c.clock, c.resourcesDBClient, operation, postAsyncNotificationFn(c.notificationClient))
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
+	}
+
+	if !c.shouldReconcileOperationAndResourceStatus(nodePool) {
+		return nil
+	}
+	err = c.reconcileOperationAndResourceStatus(ctx, operation, nodePool)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}
+
+func (c *operationNodePoolDelete) shouldReconcileOperationAndResourceStatus(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceID != nil
+}
+
+func (c *operationNodePoolDelete) reconcileOperationAndResourceStatus(ctx context.Context, operation *api.Operation, nodePool *api.HCPOpenShiftClusterNodePool) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	nodePoolCSID := nodePool.ServiceProviderProperties.ClusterServiceID
+
+	nodePoolStatus, err := c.clusterServiceClient.GetNodePoolStatus(ctx, *nodePoolCSID)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+		if !errors.As(err, &ocmError) || ocmError.Status() != http.StatusNotFound {
+			return utils.TrackError(fmt.Errorf("failed to get cluster-service NodePool status: %w", err))
+		}
+		// 404 - CS has finished deleting. nodePoolClusterServiceIDClearer will clear the ID.
+		logger.Info("cluster-service NodePool gone - skipping operation update", "clusterServiceID", nodePoolCSID.String())
+		return nil
+	}
+
+	// If the node pool is in the Ready state from CS side, we wait until the Cosmos NodePool document is deleted, which
+	// will be picked up by a next reconciliation of this controller and we will update the operation to Succeeded.
+	if nodePoolStatus.State().NodePoolStateValue() == string(NodePoolStateReady) {
+		logger.Info("cluster-service NodePool in Ready state. Waiting until Cosmos NodePool document is deleted.")
+		return nil
 	}
 
 	newOperationStatus, newOperationError, err := convertNodePoolStatus(operation, nodePoolStatus)

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete_test.go
@@ -18,17 +18,20 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilsclock "k8s.io/utils/clock"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
@@ -37,15 +40,92 @@ import (
 )
 
 func TestOperationNodePoolDelete_SynchronizeOperation(t *testing.T) {
-	tests := []struct {
-		name        string
-		setupMock   func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec
-		expectError bool
-		verify      func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture)
+	fixture := newNodePoolTestFixture()
+
+	nodePoolPassingExtraReconcileGate := func() *api.HCPOpenShiftClusterNodePool {
+		now := time.Now()
+		np := fixture.newNodePool()
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: now}
+		np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: now}
+		return np
+	}
+
+	testCases := []struct {
+		name                    string
+		existingNodePool        *api.HCPOpenShiftClusterNodePool
+		wantErr                 bool
+		verifyDB                func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+		usesNewDeletionApproach bool
+		setupCSMock             func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec
 	}{
 		{
-			name: "node pool not found marks operation succeeded and removes node pool",
-			setupMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
+			name: "node pool document gone completes operation",
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
+			},
+			usesNewDeletionApproach: true,
+		},
+		{
+			name: "shouldReconcile gate not passed skips cluster service",
+			existingNodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				return np
+			}(),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+			usesNewDeletionApproach: true,
+		},
+		{
+			name:             "extra reconcilegate passed and CS Ready waits without updating operation",
+			existingNodePool: nodePoolPassingExtraReconcileGate(),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
+					Build()
+				require.NoError(t, err)
+				mockCSClient.EXPECT().
+					GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
+					Return(nodePoolStatus, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+			usesNewDeletionApproach: true,
+		},
+		{
+			name:             "extra reconcile gate passed and CS uninstalling updates operation to deleting",
+			existingNodePool: nodePoolPassingExtraReconcileGate(),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateUninstalling))).
+					Build()
+				require.NoError(t, err)
+				mockCSClient.EXPECT().
+					GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
+					Return(nodePoolStatus, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateDeleting, op.Status)
+			},
+			usesNewDeletionApproach: true,
+		},
+		{
+			name: "legacy approach: node pool gone in cluster service marks operation succeeded",
+			setupCSMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 				notFoundErr, _ := ocmerrors.NewError().Status(http.StatusNotFound).Build()
 				mockCSClient.EXPECT().
@@ -53,110 +133,57 @@ func TestOperationNodePoolDelete_SynchronizeOperation(t *testing.T) {
 					Return(nil, notFoundErr)
 				return mockCSClient
 			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
-
-				// Verify node pool document was deleted
-				_, err = db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
-				assert.Error(t, err, "node pool should have been deleted")
 			},
+			usesNewDeletionApproach: false,
 		},
 		{
-			name: "node pool uninstalling updates operation to deleting",
-			setupMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
+			name: "legacy approach: node pool still exists in cluster service keeps operation accepted",
+			setupCSMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-				nodePoolStatus, _ := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateUninstalling))).
-					Build()
-				mockCSClient.EXPECT().
-					GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
-					Return(nodePoolStatus, nil)
-				return mockCSClient
-			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
-				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
-				require.NoError(t, err)
-				assert.Equal(t, arm.ProvisioningStateDeleting, op.Status)
-
-				// Node pool should still exist during uninstalling
-				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
-				require.NoError(t, err)
-				assert.NotNil(t, nodePool)
-			},
-		},
-		{
-			name: "node pool ready during delete stays at current status",
-			setupMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
-				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-				nodePoolStatus, _ := arohcpv1alpha1.NewNodePoolStatus().
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
 					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
 					Build()
+				require.NoError(t, err)
 				mockCSClient.EXPECT().
 					GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
 					Return(nodePoolStatus, nil)
 				return mockCSClient
 			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
-				// When node pool is Ready during delete, operation stays at Accepted
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
-
-				// Node pool should still exist
-				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
-				require.NoError(t, err)
-				assert.NotNil(t, nodePool)
 			},
-		},
-		{
-			name: "node pool error during delete transitions to failed",
-			setupMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
-				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-				nodePoolStatus, _ := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateError))).
-					Message("delete failed").
-					Build()
-				mockCSClient.EXPECT().
-					GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
-					Return(nodePoolStatus, nil)
-				return mockCSClient
-			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
-				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
-				require.NoError(t, err)
-				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
-				assert.NotNil(t, op.Error)
-
-				// Node pool should still exist on failure
-				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
-				require.NoError(t, err)
-				assert.NotNil(t, nodePool)
-			},
+			usesNewDeletionApproach: false,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			ctx = utils.ContextWithLogger(ctx, testr.New(t))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			fixture := newNodePoolTestFixture()
-			cluster := fixture.newCluster()
-			nodePool := fixture.newNodePool()
 			operation := fixture.newOperation(database.OperationRequestDelete)
+			// TODO remove this once the new deletion approach is fully rolled out in all ARO-HCP permanent environments, for all regions.
+			operation.UsesNewNodePoolDeletionApproach = tc.usesNewDeletionApproach
 
-			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, nodePool, operation})
+			resources := []any{operation}
+			if tc.existingNodePool != nil {
+				resources = append(resources, tc.existingNodePool)
+			}
+
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)
 
-			mockCSClient := tt.setupMock(ctrl, fixture)
+			var mockCSClient ocm.ClusterServiceClientSpec
+			if tc.setupCSMock != nil {
+				mockCSClient = tc.setupCSMock(ctrl, fixture)
+			}
 
 			controller := &operationNodePoolDelete{
 				clock:                utilsclock.RealClock{},
@@ -166,15 +193,14 @@ func TestOperationNodePoolDelete_SynchronizeOperation(t *testing.T) {
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
-
-			if tt.expectError {
+			if tc.wantErr {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+				return
 			}
+			require.NoError(t, err)
 
-			if tt.verify != nil {
-				tt.verify(t, ctx, mockResourcesDBClient, fixture)
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
 			}
 		})
 	}

--- a/backend/pkg/controllers/operationcontrollers/utils.go
+++ b/backend/pkg/controllers/operationcontrollers/utils.go
@@ -385,7 +385,6 @@ func notifyOperationOwner(ctx context.Context, resourcesDBClient database.Resour
 	}
 }
 
-// PostAsyncNotification submits an POST request with status payload to the given URL.
 func postAsyncNotificationFn(notificationClient *http.Client) PostAsyncNotificationFunc {
 	return func(ctx context.Context, operation *api.Operation) error {
 		return PostAsyncNotification(ctx, notificationClient, operation)

--- a/backend/pkg/listertesting/helpers.go
+++ b/backend/pkg/listertesting/helpers.go
@@ -55,3 +55,22 @@ func managementClusterContentMatchesCluster(resourceID *azcorearm.ResourceID, cl
 	}
 	return strings.EqualFold(resourceID.Parent.Name, clusterName)
 }
+
+// serviceProviderNodePoolMatchesNodePool checks if a service provider node pool's resource ID belongs to the given node pool.
+// Service provider node pools are grandchild resources: .../nodePools/<np>/serviceProviderNodePools/default
+// so we check the parent (nodePool) name.
+func serviceProviderNodePoolMatchesNodePool(resourceID *azcorearm.ResourceID, nodePoolName string) bool {
+	if resourceID == nil || resourceID.Parent == nil {
+		return false
+	}
+	return strings.EqualFold(resourceID.Parent.Name, nodePoolName)
+}
+
+// serviceProviderNodePoolMatchesCluster checks if a service provider node pool's resource ID belongs to the given cluster.
+// The cluster name is the grandparent: .../hcpOpenShiftClusters/<cluster>/nodePools/<np>/serviceProviderNodePools/default
+func serviceProviderNodePoolMatchesCluster(resourceID *azcorearm.ResourceID, clusterName string) bool {
+	if resourceID == nil || resourceID.Parent == nil || resourceID.Parent.Parent == nil {
+		return false
+	}
+	return strings.EqualFold(resourceID.Parent.Parent.Name, clusterName)
+}

--- a/backend/pkg/listertesting/slice_listers.go
+++ b/backend/pkg/listertesting/slice_listers.go
@@ -253,6 +253,50 @@ func (l *SliceServiceProviderClusterLister) ListForCluster(ctx context.Context, 
 	return result, nil
 }
 
+// SliceServiceProviderNodePoolLister implements listers.ServiceProviderNodePoolLister backed by a slice.
+type SliceServiceProviderNodePoolLister struct {
+	ServiceProviderNodePools []*api.ServiceProviderNodePool
+}
+
+var _ listers.ServiceProviderNodePoolLister = &SliceServiceProviderNodePoolLister{}
+
+func (l *SliceServiceProviderNodePoolLister) List(ctx context.Context) ([]*api.ServiceProviderNodePool, error) {
+	return l.ServiceProviderNodePools, nil
+}
+
+func (l *SliceServiceProviderNodePoolLister) Get(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName string) (*api.ServiceProviderNodePool, error) {
+	for _, spnp := range l.ServiceProviderNodePools {
+		resourceID := spnp.GetResourceID()
+		if resourceID == nil {
+			continue
+		}
+		if strings.EqualFold(resourceID.SubscriptionID, subscriptionID) &&
+			strings.EqualFold(resourceID.ResourceGroupName, resourceGroupName) &&
+			serviceProviderNodePoolMatchesCluster(resourceID, clusterName) &&
+			serviceProviderNodePoolMatchesNodePool(resourceID, nodePoolName) {
+			return spnp, nil
+		}
+	}
+	return nil, database.NewNotFoundError()
+}
+
+func (l *SliceServiceProviderNodePoolLister) ListForNodePool(ctx context.Context, subscriptionName, resourceGroupName, clusterName, nodePoolName string) ([]*api.ServiceProviderNodePool, error) {
+	var result []*api.ServiceProviderNodePool
+	for _, spnp := range l.ServiceProviderNodePools {
+		resourceID := spnp.GetResourceID()
+		if resourceID == nil {
+			continue
+		}
+		if strings.EqualFold(resourceID.SubscriptionID, subscriptionName) &&
+			strings.EqualFold(resourceID.ResourceGroupName, resourceGroupName) &&
+			serviceProviderNodePoolMatchesCluster(resourceID, clusterName) &&
+			serviceProviderNodePoolMatchesNodePool(resourceID, nodePoolName) {
+			result = append(result, spnp)
+		}
+	}
+	return result, nil
+}
+
 // SliceManagementClusterContentLister implements listers.ManagementClusterContentLister backed by a slice.
 type SliceManagementClusterContentLister struct {
 	Contents []*api.ManagementClusterContent

--- a/internal/api/types_serviceprovider_cluster.go
+++ b/internal/api/types_serviceprovider_cluster.go
@@ -229,6 +229,26 @@ func (l *MaestroBundleReferenceList) Set(maestroBundleReference *MaestroBundleRe
 	return nil
 }
 
+// Remove removes the Maestro Bundle reference for a given Maestro Bundle internal name.
+// If the Maestro Bundle reference identified by name does not exist, it is a no-op.
+// If multiple Maestro Bundle references are found for the same internal name, it returns an error.
+func (l *MaestroBundleReferenceList) Remove(name MaestroBundleInternalName) error {
+	filtered := make(MaestroBundleReferenceList, 0, len(*l))
+	matched := 0
+	for _, bundle := range *l {
+		if bundle.Name == name {
+			matched++
+		} else {
+			filtered = append(filtered, bundle)
+		}
+	}
+	if matched > 1 {
+		return utils.TrackError(fmt.Errorf("multiple Maestro Bundle references found for the same internal name: %s", name))
+	}
+	*l = filtered
+	return nil
+}
+
 // MaestroBundleInternalName is a type that represents the internal name of a Maestro Bundle.
 // It is used to identify the Maestro Bundle internally and to retrieve it from the MaestroBundleReferenceList.
 type MaestroBundleInternalName string


### PR DESCRIPTION
This PR builds on top of https://github.com/Azure/ARO-HCP/pull/5429.

The backend logic to perform asynchronous node pool deletion is disabled
for now: all new controllers and the updated node pool delete operation
controller branch on UsesNewNodePoolDeletionApproach, which is not
set by the frontend yet. Legacy synchronous deletion behavior is preserved
via legacySynchronizeOperation in operation_node_pool_delete.

Changes:
- Add NodePoolClusterServiceDeleteDispatchController to call Cluster Service
  DeleteNodePool after DeletionTimestamp is set. It also stamps
  ClusterServiceDeletionTimestamp
- Add NodePoolClusterServiceIDClearerController to clear ClusterServiceID
  once from the NodePool's serviceProviderProperties when Cluster Service
  reports the node pool is gone
- Add NodePoolChildResourcesCleanupController to recursively delete Cosmos
  child resources under the node pool (with gates for Maestro bundles cleanup
  as they depend on ServiceProviderNodepool, and ignoring controllers
  documents
- Add NodePoolDeletionController to delete the NodePool Cosmos document once
  CS cleanup, Maestro bundles cleanup and child resources cleanup are completed
- Update OperationNodePoolDeleteController to complete operations when the
  NodePool Cosmos document is removed (new path), as well as keep CS polling
  to update the node pool delete operation and the nodepool delete
  status from CS state. The controller also keeps the legacy node pool delete
  operation controller behavior by branching depending on UsesNewNodePoolDeletionApproach
- Block cluster Cosmos deletion in OperationClusterDeleteController until all
  node pool documents are removed
- Add MaestroBundleReferenceList.Remove() helper and lister testing utilities

This PR can only be rolled out once https://github.com/Azure/ARO-HCP/pull/5429 has been rolled out to all prod regions