### PR TITLE
fix(hcpctl): use standard K8s groups for HCP breakglass

### DIFF
--- a/tooling/hcpctl/README.md
+++ b/tooling/hcpctl/README.md
@@ -114,7 +114,7 @@ hcpctl hcp breakglass 12345678-1234-1234-1234-123456789abc
 # Access using Azure resource ID
 hcpctl hcp breakglass /subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpClusters/cluster-name
 
-# Privileged access (uses aro-sre-cluster-admin role instead of aro-sre)
+# Privileged access (uses system:masters group instead of system:cluster-readers)
 hcpctl hcp breakglass 12345678-1234-1234-1234-123456789abc --privileged
 ```
 

--- a/tooling/hcpctl/cmd/hcp/options.go
+++ b/tooling/hcpctl/cmd/hcp/options.go
@@ -149,7 +149,7 @@ type RawBreakglassHCPOptions struct {
 	SessionTimeout    time.Duration // Certificate/session timeout duration
 	NoPortForward     bool          // Disable port forwarding after kubeconfig generation
 	NoShell           bool          // Disable shell mode (shell is default when port-forwarding is enabled)
-	Privileged        bool          // Use privileged access role (aro-sre-cluster-admin instead of aro-sre)
+	Privileged        bool          // Use privileged access group (system:masters instead of system:cluster-readers)
 	ExecCommand       string        // Command to execute directly instead of spawning interactive shell
 }
 
@@ -176,7 +176,7 @@ func BindBreakglassHCPOptions(opts *RawBreakglassHCPOptions, cmd *cobra.Command)
 	cmd.Flags().DurationVar(&opts.SessionTimeout, "session-timeout", opts.SessionTimeout, "certificate/session expiration time")
 	cmd.Flags().BoolVar(&opts.NoPortForward, "no-port-forward", opts.NoPortForward, "do not start port forwarding after generating kubeconfig")
 	cmd.Flags().BoolVar(&opts.NoShell, "no-shell", opts.NoShell, "do not spawn a shell; instead wait for Ctrl+C to terminate (default: spawn shell with KUBECONFIG set)")
-	cmd.Flags().BoolVar(&opts.Privileged, "privileged", opts.Privileged, "use privileged access role (aro-sre-cluster-admin instead of aro-sre)")
+	cmd.Flags().BoolVar(&opts.Privileged, "privileged", opts.Privileged, "use privileged access group (system:masters instead of system:cluster-readers)")
 	cmd.Flags().StringVar(&opts.ExecCommand, "exec", opts.ExecCommand, "execute command directly instead of spawning interactive shell")
 
 	return nil

--- a/tooling/hcpctl/internal/e2e/e2e_test.go
+++ b/tooling/hcpctl/internal/e2e/e2e_test.go
@@ -545,14 +545,14 @@ func TestHCPBreakglassRole(t *testing.T) {
 			name:           "HCP breakglass regular access role validation",
 			cluster:        hcpCluster.ID,
 			privileged:     false,
-			expectedGroups: []string{"aro-sre"},
+			expectedGroups: []string{"system:cluster-readers"},
 			expectError:    false,
 		},
 		{
 			name:           "HCP breakglass privileged access role validation",
 			cluster:        hcpCluster.ID,
 			privileged:     true,
-			expectedGroups: []string{"aro-sre-cluster-admin"},
+			expectedGroups: []string{"system:masters"},
 			expectError:    false,
 		},
 		{

--- a/tooling/hcpctl/pkg/breakglass/certs/generator.go
+++ b/tooling/hcpctl/pkg/breakglass/certs/generator.go
@@ -74,9 +74,9 @@ func EncodePrivateKey(key *rsa.PrivateKey) []byte {
 
 // BuildSubject creates the certificate subject for SRE breakglass
 func BuildSubject(user string, privileged bool) pkix.Name {
-	organization := "aro-sre"
+	organization := "system:cluster-readers"
 	if privileged {
-		organization = "aro-sre-cluster-admin"
+		organization = "system:masters"
 	}
 
 	return pkix.Name{

--- a/tooling/hcpctl/pkg/breakglass/certs/generator_test.go
+++ b/tooling/hcpctl/pkg/breakglass/certs/generator_test.go
@@ -167,7 +167,7 @@ func TestBuildSubject(t *testing.T) {
 			privileged: false,
 			expected: pkix.Name{
 				CommonName:   "system:sre-break-glass:b-user@microsoft.com",
-				Organization: []string{"aro-sre"},
+				Organization: []string{"system:cluster-readers"},
 			},
 		},
 		{
@@ -176,7 +176,7 @@ func TestBuildSubject(t *testing.T) {
 			privileged: true,
 			expected: pkix.Name{
 				CommonName:   "system:sre-break-glass:b-user@microsoft.com",
-				Organization: []string{"aro-sre-cluster-admin"},
+				Organization: []string{"system:masters"},
 			},
 		},
 	}

--- a/tooling/hcpctl/testdata/zz_fixture_TestGenerateCSR_privileged_session.txt
+++ b/tooling/hcpctl/testdata/zz_fixture_TestGenerateCSR_privileged_session.txt
@@ -1,7 +1,7 @@
 Certificate Request:
     Data:
         Version: 0
-        Subject: CN=system:sre-break-glass:b-user@microsoft.com,O=aro-sre-cluster-admin
+        Subject: CN=system:sre-break-glass:b-user@microsoft.com,O=system:masters
         Subject Public Key Info:
             Public Key Algorithm: RSA
                 Public-Key: (2048 bit)

--- a/tooling/hcpctl/testdata/zz_fixture_TestGenerateCSR_unprivileged_session.txt
+++ b/tooling/hcpctl/testdata/zz_fixture_TestGenerateCSR_unprivileged_session.txt
@@ -1,7 +1,7 @@
 Certificate Request:
     Data:
         Version: 0
-        Subject: CN=system:sre-break-glass:b-user@microsoft.com,O=aro-sre
+        Subject: CN=system:sre-break-glass:b-user@microsoft.com,O=system:cluster-readers
         Subject Public Key Info:
             Public Key Algorithm: RSA
                 Public-Key: (2048 bit)


### PR DESCRIPTION
### What

The sre-breakglass-role ACM policy was removed in #4700, so the aro-sre and aro-sre-cluster-admin groups no longer have RBAC bindings on HCPs. Replace them with the same groups that adminapi breakglass and sessiongate use:

- aro-sre → system:cluster-readers
- aro-sre-cluster-admin → system:masters

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
