### PR TITLE
feat: enable nodepool delete from frontend to backend

### DIFF
--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -17,7 +17,6 @@ package frontend
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -30,8 +29,6 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
-
-	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/internal/admission"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -734,26 +731,6 @@ func (f *Frontend) DeleteNodePool(writer http.ResponseWriter, request *http.Requ
 		return utils.TrackError(err)
 	}
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the node
-	// pool has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete a node pool"))
-	}
-
-	err = f.clusterServiceClient.DeleteNodePool(ctx, *nodePool.ServiceProviderProperties.ClusterServiceID)
-	var ocmError *ocmerrors.Error
-	if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound {
-		// StatusNotFound means we have stale data in Cosmos DB.
-		// This can happen in test environments if a user bypasses
-		// the RP to delete a resource (e.g. "ocm delete"). It can
-		// also happen if an asynchronous deletion operation fails.
-		// we will fall through and cancel all operations and go through as normal a deletion flow as we can to avoid
-		// leaking data related to the resource, like controller status.
-		logger.Info("clusterService nodepool missing, trying to clean up", "err", err)
-	} else if err != nil {
-		return utils.TrackError(err)
-	}
-
 	transaction := f.resourcesDBClient.NewTransaction(nodePool.ID.SubscriptionID)
 	if err := f.addDeleteNodePoolToTransaction(ctx, writer, request, transaction, nodePool); err != nil {
 		return utils.TrackError(err)
@@ -784,21 +761,18 @@ func (f *Frontend) addDeleteNodePoolToTransaction(ctx context.Context, writer ht
 		return utils.TrackError(err)
 	}
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the node pool
-	// has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete a node pool"))
-	}
-
 	operationDoc := database.NewOperation(
 		database.OperationRequestDelete,
 		nodePool.ID,
-		*nodePool.ServiceProviderProperties.ClusterServiceID,
+		api.InternalID{},
 		f.azureLocation,
 		"",
 		"",
 		"",
 		correlationData)
+	// TODO remove this once migration of the new node pool deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	operationDoc.UsesNewNodePoolDeletionApproach = true
 	if request != nil {
 		// these are optional because when this is triggered via the subscription deletion flow, there is no
 		// deletion request containing these headers so these operations cannot be directly tracked.
@@ -817,6 +791,9 @@ func (f *Frontend) addDeleteNodePoolToTransaction(ctx context.Context, writer ht
 	}
 	nodePool.ServiceProviderProperties.ActiveOperationID = operationDoc.ResourceID.Name
 	nodePool.Properties.ProvisioningState = operationDoc.Status
+	// TODO remove this once migration of the new node pool deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach = true
 	_, err = f.resourcesDBClient.HCPClusters(nodePool.ID.SubscriptionID, nodePool.ID.ResourceGroupName).NodePools(nodePool.ID.Parent.Name).
 		AddReplaceToTransaction(ctx, transaction, nodePool, nil)
 	if err != nil {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
@@ -56,7 +56,7 @@
 				},
 				"serviceProviderProperties": {
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": true
 				},
 				"status": {},
 				"systemData": {
@@ -104,7 +104,7 @@
 			}
 		},
 		"serviceProviderProperties": {
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": true
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
@@ -6,7 +6,7 @@
 		"status": "Deleting",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
-		"usesNewNodePoolDeletionApproach": false
+		"usesNewNodePoolDeletionApproach": true
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
 	"ttl": 604800


### PR DESCRIPTION
This builds on top of https://github.com/Azure/ARO-HCP/pull/5440.

Move Cluster Service interaction out of the frontend delete path and
hand it off to the backend's async node pool deletion controllers.

The frontend now only:
- Creates a delete operation with UsesNewNodePoolDeletionApproach
  set to true
- Sets DeletionTimestamp and sets UsesNewNodePoolDeletionApproach to
  true in the NodePool
- Returns 202 Accepted immediately

Removed from the frontend:
- Direct clusterServiceClient.DeleteNodePool() call
- Requirement that ClusterServiceID must exist before delete is allowed
- Stale-data 404 handling, which is now handled in the backend side too

Node Pool Delete operations no longer set an InternalID as it is not
needed anymore when using the new node pool deletion approach in
backend.

Legacy deletion (operations without UsesNewNodePoolDeletionApproach) is
unchanged and still handled by OperationNodePoolDeleteController.