### PR TITLE
api: Add Conditions to ARM Resource Types

### DIFF
--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
@@ -129,6 +129,11 @@ model HcpOpenShiftClusterProperties {
   /** OpenShift internal image registry */
   @visibility(Lifecycle.Read, Lifecycle.Create)
   clusterImageRegistry?: ClusterImageRegistryProfile;
+
+  /** Status of the cluster resource */
+  @visibility(Lifecycle.Read)
+  @added(Versions.v2026_06_30_preview)
+  status?: ResourceStatus;
 }
 
 /** The resource provisioning state. */
@@ -716,6 +721,11 @@ model NodePoolProperties {
    */
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   nodeDrainTimeoutMinutes?: int32;
+
+  /** Status of the node pool resource */
+  @visibility(Lifecycle.Read)
+  @added(Versions.v2026_06_30_preview)
+  status?: ResourceStatus;
 }
 
 /** The taint effect the same as in Kubernetes */
@@ -963,6 +973,11 @@ model ExternalAuthProperties {
   @removed(Versions.v2026_06_30_preview)
   condition?: ExternalAuthCondition;
 
+  /** Status of the external auth resource */
+  @visibility(Lifecycle.Read)
+  @added(Versions.v2026_06_30_preview)
+  status?: ResourceStatus;
+
   /** Token Issuer profile */
   issuer: TokenIssuerProfile;
 
@@ -977,6 +992,73 @@ model ExternalAuthProperties {
    * This configures how claims are validated and applied.
    */
   claim: ExternalAuthClaimProfile;
+}
+
+/** ResourceStatus represents the observed status of the resource. */
+@added(Versions.v2026_06_30_preview)
+model ResourceStatus {
+  /** The conditions on the resource */
+  @visibility(Lifecycle.Read)
+  @identifiers(#["type"])
+  @maxItems(10)
+  conditions?: Condition[];
+}
+
+/** Condition represents an observation of a resource's state. */
+@added(Versions.v2026_06_30_preview)
+model Condition {
+  /** Type of the condition.
+   * This is a PascalCase identifier representing the type of the condition.
+   */
+  @visibility(Lifecycle.Read)
+  @maxLength(316)
+  @pattern(
+    "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)$",
+    "Condition type format following Kubernetes condition type conventions."
+  )
+  type: ConditionType;
+
+  /** The status of the condition. */
+  @visibility(Lifecycle.Read)
+  status: StatusType;
+
+  /** The last time the condition transitioned from one status to another. */
+  @visibility(Lifecycle.Read)
+  lastTransitionTime: utcDateTime;
+
+  /** A programmatic identifier indicating the reason for the condition's last transition.
+   * This value should be a CamelCase string.
+   */
+  @visibility(Lifecycle.Read)
+  @minLength(1)
+  @maxLength(1024)
+  @pattern(
+    "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+    "Reason must be a CamelCase string."
+  )
+  reason: string;
+
+  /** A human readable message indicating details about the transition.
+   * This may be an empty string.
+   */
+  @visibility(Lifecycle.Read)
+  @maxLength(32768)
+  message: string;
+}
+
+/** Representation of the possible condition types. */
+@added(Versions.v2026_06_30_preview)
+union ConditionType {
+  string,
+
+  /** Indicates that the resource is available. */
+  Available: "Available",
+
+  /** Indicates that the resource is in a degraded state. */
+  Degraded: "Degraded",
+
+  /** Indicates that the resource is in a progressing state. */
+  Progressing: "Progressing",
 }
 
 /** Condition defines an observation of the external auth state. */
@@ -1004,7 +1086,7 @@ model ExternalAuthCondition {
   message: string;
 }
 
-/** Representation of the possible values of a external auths condition status. */
+/** Representation of the possible values of a condition status. */
 union StatusType {
   string,
 

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
@@ -3294,7 +3294,7 @@
     },
     "StatusType": {
       "type": "string",
-      "description": "Representation of the possible values of a external auths condition status.",
+      "description": "Representation of the possible values of a condition status.",
       "enum": [
         "True",
         "False",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
@@ -3457,7 +3457,7 @@
     },
     "StatusType": {
       "type": "string",
-      "description": "Representation of the possible values of a external auths condition status.",
+      "description": "Representation of the possible values of a condition status.",
       "enum": [
         "True",
         "False",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
@@ -1568,6 +1568,81 @@
         }
       }
     },
+    "Condition": {
+      "type": "object",
+      "description": "Condition represents an observation of a resource's state.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/ConditionType",
+          "description": "Type of the condition.\nThis is a PascalCase identifier representing the type of the condition.",
+          "maxLength": 316,
+          "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)$",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/StatusType",
+          "description": "The status of the condition.",
+          "readOnly": true
+        },
+        "lastTransitionTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The last time the condition transitioned from one status to another.",
+          "readOnly": true
+        },
+        "reason": {
+          "type": "string",
+          "description": "A programmatic identifier indicating the reason for the condition's last transition.\nThis value should be a CamelCase string.",
+          "minLength": 1,
+          "maxLength": 1024,
+          "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "A human readable message indicating details about the transition.\nThis may be an empty string.",
+          "maxLength": 32768,
+          "readOnly": true
+        }
+      },
+      "required": [
+        "type",
+        "status",
+        "lastTransitionTime",
+        "reason",
+        "message"
+      ]
+    },
+    "ConditionType": {
+      "type": "string",
+      "description": "Representation of the possible condition types.",
+      "enum": [
+        "Available",
+        "Degraded",
+        "Progressing"
+      ],
+      "x-ms-enum": {
+        "name": "ConditionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Available",
+            "value": "Available",
+            "description": "Indicates that the resource is available."
+          },
+          {
+            "name": "Degraded",
+            "value": "Degraded",
+            "description": "Indicates that the resource is in a degraded state."
+          },
+          {
+            "name": "Progressing",
+            "value": "Progressing",
+            "description": "Indicates that the resource is in a progressing state."
+          }
+        ]
+      }
+    },
     "ConsoleProfile": {
       "type": "object",
       "description": "Configuration of the cluster web console",
@@ -1905,6 +1980,11 @@
         "provisioningState": {
           "$ref": "#/definitions/ExternalAuthProvisioningState",
           "description": "Provisioning state",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/ResourceStatus",
+          "description": "Status of the external auth resource",
           "readOnly": true
         },
         "issuer": {
@@ -2251,6 +2331,11 @@
             "read",
             "create"
           ]
+        },
+        "status": {
+          "$ref": "#/definitions/ResourceStatus",
+          "description": "Status of the cluster resource",
+          "readOnly": true
         }
       },
       "required": [
@@ -2925,6 +3010,11 @@
             "update",
             "create"
           ]
+        },
+        "status": {
+          "$ref": "#/definitions/ResourceStatus",
+          "description": "Status of the node pool resource",
+          "readOnly": true
         }
       },
       "required": [
@@ -3397,6 +3487,24 @@
       },
       "readOnly": true
     },
+    "ResourceStatus": {
+      "type": "object",
+      "description": "ResourceStatus represents the observed status of the resource.",
+      "properties": {
+        "conditions": {
+          "type": "array",
+          "description": "The conditions on the resource",
+          "maxItems": 10,
+          "items": {
+            "$ref": "#/definitions/Condition"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "type"
+          ]
+        }
+      }
+    },
     "RoleDefinition": {
       "type": "object",
       "description": "A single role definition required by a given operator",
@@ -3426,6 +3534,36 @@
             "scopes": [
               "Tenant"
             ]
+          }
+        ]
+      }
+    },
+    "StatusType": {
+      "type": "string",
+      "description": "Representation of the possible values of a condition status.",
+      "enum": [
+        "True",
+        "False",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "StatusType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "True",
+            "value": "True",
+            "description": "Indicates that the condition status is True."
+          },
+          {
+            "name": "False",
+            "value": "False",
+            "description": "Indicates that the condition status is False."
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Indicates that the condition status is unknown."
           }
         ]
       }

--- a/internal/api/v20260630preview/external_auth_methods.go
+++ b/internal/api/v20260630preview/external_auth_methods.go
@@ -304,6 +304,7 @@ func (v version) NewHCPOpenShiftClusterExternalAuth(from *api.HCPOpenShiftCluste
 			SystemData: api.PtrOrNil(newSystemData(from.SystemData)),
 			Properties: &generated.ExternalAuthProperties{
 				ProvisioningState: api.PtrOrNil(generated.ExternalAuthProvisioningState(from.Properties.ProvisioningState)),
+				Status:            newResourceStatus(from.Status.Conditions),
 				Issuer:            api.PtrOrNil(newTokenIssuerProfile(&from.Properties.Issuer)),
 				Claim:             api.PtrOrNil(newExternalAuthClaimProfile(&from.Properties.Claim)),
 			},

--- a/internal/api/v20260630preview/generated/constants.go
+++ b/internal/api/v20260630preview/generated/constants.go
@@ -39,6 +39,27 @@ func PossibleClusterImageRegistryStateValues() []ClusterImageRegistryState {
 	}
 }
 
+// ConditionType - Representation of the possible condition types.
+type ConditionType string
+
+const (
+	// ConditionTypeAvailable - Indicates that the resource is available.
+	ConditionTypeAvailable ConditionType = "Available"
+	// ConditionTypeDegraded - Indicates that the resource is in a degraded state.
+	ConditionTypeDegraded ConditionType = "Degraded"
+	// ConditionTypeProgressing - Indicates that the resource is in a progressing state.
+	ConditionTypeProgressing ConditionType = "Progressing"
+)
+
+// PossibleConditionTypeValues returns the possible values for the ConditionType const type.
+func PossibleConditionTypeValues() []ConditionType {
+	return []ConditionType{
+		ConditionTypeAvailable,
+		ConditionTypeDegraded,
+		ConditionTypeProgressing,
+	}
+}
+
 // CreatedByType - The type of identity that created the resource.
 type CreatedByType string
 
@@ -375,6 +396,27 @@ func PossibleProvisioningStateValues() []ProvisioningState {
 		ProvisioningStateProvisioning,
 		ProvisioningStateSucceeded,
 		ProvisioningStateUpdating,
+	}
+}
+
+// StatusType - Representation of the possible values of a condition status.
+type StatusType string
+
+const (
+	// StatusTypeFalse - Indicates that the condition status is False.
+	StatusTypeFalse StatusType = "False"
+	// StatusTypeTrue - Indicates that the condition status is True.
+	StatusTypeTrue StatusType = "True"
+	// StatusTypeUnknown - Indicates that the condition status is unknown.
+	StatusTypeUnknown StatusType = "Unknown"
+)
+
+// PossibleStatusTypeValues returns the possible values for the StatusType const type.
+func PossibleStatusTypeValues() []StatusType {
+	return []StatusType{
+		StatusTypeFalse,
+		StatusTypeTrue,
+		StatusTypeUnknown,
 	}
 }
 

--- a/internal/api/v20260630preview/generated/models.go
+++ b/internal/api/v20260630preview/generated/models.go
@@ -68,6 +68,25 @@ type ClusterImageRegistryProfile struct {
 	State *ClusterImageRegistryState
 }
 
+// Condition represents an observation of a resource's state.
+type Condition struct {
+	// READ-ONLY; The last time the condition transitioned from one status to another.
+	LastTransitionTime *time.Time
+
+	// READ-ONLY; A human readable message indicating details about the transition. This may be an empty string.
+	Message *string
+
+	// READ-ONLY; A programmatic identifier indicating the reason for the condition's last transition. This value should be a
+	// CamelCase string.
+	Reason *string
+
+	// READ-ONLY; The status of the condition.
+	Status *StatusType
+
+	// READ-ONLY; Type of the condition. This is a PascalCase identifier representing the type of the condition.
+	Type *ConditionType
+}
+
 // ConsoleProfile - Configuration of the cluster web console
 type ConsoleProfile struct {
 	// READ-ONLY; The cluster web console URL endpoint
@@ -199,6 +218,9 @@ type ExternalAuthProperties struct {
 
 	// READ-ONLY; Provisioning state
 	ProvisioningState *ExternalAuthProvisioningState
+
+	// READ-ONLY; Status of the external auth resource
+	Status *ResourceStatus
 }
 
 // ExternalAuthPropertiesUpdate - External Auth profile
@@ -348,6 +370,9 @@ type HcpOpenShiftClusterProperties struct {
 
 	// READ-ONLY; The status of the last operation.
 	ProvisioningState *ProvisioningState
+
+	// READ-ONLY; Status of the cluster resource
+	Status *ResourceStatus
 }
 
 // HcpOpenShiftClusterPropertiesUpdate - HCP cluster properties
@@ -695,6 +720,9 @@ type NodePoolProperties struct {
 
 	// READ-ONLY; Provisioning state
 	ProvisioningState *ProvisioningState
+
+	// READ-ONLY; Status of the node pool resource
+	Status *ResourceStatus
 }
 
 // NodePoolPropertiesUpdate - Represents the node pool properties
@@ -909,6 +937,12 @@ type PlatformProfile struct {
 type PlatformProfileUpdate struct {
 	// The configuration that the operators of the cluster have to authenticate to Azure
 	OperatorsAuthentication *OperatorsAuthenticationProfileUpdate
+}
+
+// ResourceStatus represents the observed status of the resource.
+type ResourceStatus struct {
+	// READ-ONLY; The conditions on the resource
+	Conditions []*Condition
 }
 
 // RoleDefinition - A single role definition required by a given operator

--- a/internal/api/v20260630preview/generated/models_serde.go
+++ b/internal/api/v20260630preview/generated/models_serde.go
@@ -152,6 +152,51 @@ func (c *ClusterImageRegistryProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type Condition.
+func (c Condition) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populateDateTimeRFC3339(objectMap, "lastTransitionTime", c.LastTransitionTime)
+	populate(objectMap, "message", c.Message)
+	populate(objectMap, "reason", c.Reason)
+	populate(objectMap, "status", c.Status)
+	populate(objectMap, "type", c.Type)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type Condition.
+func (c *Condition) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", c, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "lastTransitionTime":
+			err = unpopulateDateTimeRFC3339(val, "LastTransitionTime", &c.LastTransitionTime)
+			delete(rawMsg, key)
+		case "message":
+			err = unpopulate(val, "Message", &c.Message)
+			delete(rawMsg, key)
+		case "reason":
+			err = unpopulate(val, "Reason", &c.Reason)
+			delete(rawMsg, key)
+		case "status":
+			err = unpopulate(val, "Status", &c.Status)
+			delete(rawMsg, key)
+		case "type":
+			err = unpopulate(val, "Type", &c.Type)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", c, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", c, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type ConsoleProfile.
 func (c ConsoleProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -534,6 +579,7 @@ func (e ExternalAuthProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "clients", e.Clients)
 	populate(objectMap, "issuer", e.Issuer)
 	populate(objectMap, "provisioningState", e.ProvisioningState)
+	populate(objectMap, "status", e.Status)
 	return json.Marshal(objectMap)
 }
 
@@ -557,6 +603,9 @@ func (e *ExternalAuthProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "provisioningState":
 			err = unpopulate(val, "ProvisioningState", &e.ProvisioningState)
+			delete(rawMsg, key)
+		case "status":
+			err = unpopulate(val, "Status", &e.Status)
 			delete(rawMsg, key)
 		default:
 			err = fmt.Errorf("unmarshalling type %T, unknown field %q", e, key)
@@ -854,6 +903,7 @@ func (h HcpOpenShiftClusterProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "nodeDrainTimeoutMinutes", h.NodeDrainTimeoutMinutes)
 	populate(objectMap, "platform", h.Platform)
 	populate(objectMap, "provisioningState", h.ProvisioningState)
+	populate(objectMap, "status", h.Status)
 	populate(objectMap, "version", h.Version)
 	return json.Marshal(objectMap)
 }
@@ -902,6 +952,9 @@ func (h *HcpOpenShiftClusterProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "provisioningState":
 			err = unpopulate(val, "ProvisioningState", &h.ProvisioningState)
+			delete(rawMsg, key)
+		case "status":
+			err = unpopulate(val, "Status", &h.Status)
 			delete(rawMsg, key)
 		case "version":
 			err = unpopulate(val, "Version", &h.Version)
@@ -1669,6 +1722,7 @@ func (n NodePoolProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "platform", n.Platform)
 	populate(objectMap, "provisioningState", n.ProvisioningState)
 	populate(objectMap, "replicas", n.Replicas)
+	populate(objectMap, "status", n.Status)
 	populate(objectMap, "taints", n.Taints)
 	populate(objectMap, "version", n.Version)
 	return json.Marshal(objectMap)
@@ -1703,6 +1757,9 @@ func (n *NodePoolProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "replicas":
 			err = unpopulate(val, "Replicas", &n.Replicas)
+			delete(rawMsg, key)
+		case "status":
+			err = unpopulate(val, "Status", &n.Status)
 			delete(rawMsg, key)
 		case "taints":
 			err = unpopulate(val, "Taints", &n.Taints)
@@ -2220,6 +2277,35 @@ func (p *PlatformProfileUpdate) UnmarshalJSON(data []byte) error {
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", p, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ResourceStatus.
+func (r ResourceStatus) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "conditions", r.Conditions)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ResourceStatus.
+func (r *ResourceStatus) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", r, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "conditions":
+			err = unpopulate(val, "Conditions", &r.Conditions)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", r, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", r, err)
 		}
 	}
 	return nil

--- a/internal/api/v20260630preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20260630preview/hcpopenshiftclusters_methods.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/uuid"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
@@ -261,6 +262,18 @@ func newKmsKey(from *api.KmsKey) generated.KmsKey {
 	}
 }
 
+func newConditions(from []metav1.Condition) []*generated.Condition {
+	// TODO (bvesel): propose a method for how we want to translate our internal metav1.Conditions type to this external
+	// type.  Until then, we'll plumb it with empty data.
+	return []*generated.Condition{}
+}
+
+func newResourceStatus(from []metav1.Condition) *generated.ResourceStatus {
+	return &generated.ResourceStatus{
+		Conditions: newConditions(from),
+	}
+}
+
 func newClusterImageRegistryProfile(from *api.ClusterImageRegistryProfile) generated.ClusterImageRegistryProfile {
 	if from == nil {
 		return generated.ClusterImageRegistryProfile{}
@@ -368,6 +381,7 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 				ClusterImageRegistry:    api.PtrOrNil(newClusterImageRegistryProfile(&from.CustomerProperties.ClusterImageRegistry)),
 				Etcd:                    api.PtrOrNil(newEtcdProfile(&from.CustomerProperties.Etcd)),
 				ImageDigestMirrors:      newImageDigestMirrors(from.CustomerProperties.ImageDigestMirrors),
+				Status:                  newResourceStatus(from.Status.Conditions),
 			},
 			Identity: newManagedServiceIdentity(from.Identity),
 		},

--- a/internal/api/v20260630preview/nodepools_methods.go
+++ b/internal/api/v20260630preview/nodepools_methods.go
@@ -325,6 +325,7 @@ func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNod
 				// Use Ptr (not PtrOrNil) to ensure int32 zero value is preserved in JSON response.
 				Replicas:                api.Ptr(from.Properties.Replicas),
 				NodeDrainTimeoutMinutes: from.Properties.NodeDrainTimeoutMinutes,
+				Status:                  newResourceStatus(from.Status.Conditions),
 			},
 			Identity: newManagedServiceIdentity(from.Identity),
 		},

--- a/internal/conversion/readonly_cluster.go
+++ b/internal/conversion/readonly_cluster.go
@@ -45,6 +45,7 @@ func CopyReadOnlyClusterValues(dest, src *api.HCPOpenShiftCluster) {
 	}
 
 	dest.ServiceProviderProperties = *src.ServiceProviderProperties.DeepCopy()
+	dest.Status = *src.Status.DeepCopy()
 }
 
 func copyReadOnlyManagedServiceIdentityValues(dest, src *arm.ManagedServiceIdentity) {

--- a/internal/conversion/readonly_externalauth.go
+++ b/internal/conversion/readonly_externalauth.go
@@ -35,4 +35,5 @@ func CopyReadOnlyExternalAuthValues(dest, src *api.HCPOpenShiftClusterExternalAu
 
 	dest.Properties.ProvisioningState = src.Properties.ProvisioningState
 	dest.ServiceProviderProperties = *src.ServiceProviderProperties.DeepCopy()
+	dest.Status = *src.Status.DeepCopy()
 }

--- a/internal/conversion/readonly_nodepool.go
+++ b/internal/conversion/readonly_nodepool.go
@@ -38,4 +38,5 @@ func CopyReadOnlyNodePoolValues(dest, src *api.HCPOpenShiftClusterNodePool) {
 
 	dest.Properties.ProvisioningState = src.Properties.ProvisioningState
 	dest.ServiceProviderProperties = *src.ServiceProviderProperties.DeepCopy()
+	dest.Status = *src.Status.DeepCopy()
 }

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/basic-cluster/expected/get/2026-06-30-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/basic-cluster/expected/get/2026-06-30-preview.json
@@ -40,6 +40,9 @@
 			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
 		},
 		"provisioningState": "Succeeded",
+		"status": {
+			"conditions": []
+		},
 		"version": {
 			"channelGroup": "stable",
 			"id": "4.20"

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/basic-cluster/expected/list/2026-06-30-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/basic-cluster/expected/list/2026-06-30-preview.json
@@ -40,6 +40,9 @@
 			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
 		},
 		"provisioningState": "Succeeded",
+		"status": {
+			"conditions": []
+		},
 		"version": {
 			"channelGroup": "stable",
 			"id": "4.20"

--- a/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/get/2026-06-30-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/get/2026-06-30-preview.json
@@ -20,6 +20,9 @@
 		},
 		"provisioningState": "Succeeded",
 		"replicas": 0,
+		"status": {
+			"conditions": []
+		},
 		"version": {
 			"channelGroup": "stable",
 			"id": "4.20.8"

--- a/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/list/2026-06-30-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/list/2026-06-30-preview.json
@@ -20,6 +20,9 @@
 		},
 		"provisioningState": "Succeeded",
 		"replicas": 0,
+		"status": {
+			"conditions": []
+		},
 		"version": {
 			"channelGroup": "stable",
 			"id": "4.20.8"


### PR DESCRIPTION
### What

Adds a read-only conditions API field to our resource types to expose status information and the addition of a new api version 2026-06-30-preview.  

### Why

We can leverage this to expose read-only information similar to k8s conditions which tell the customer if the cluster is degraded.  Because of the controller implementation of the backend, and the fact that customers can make changes to permissions, infra, etc. which can result in degradation of functionality on the cluster, this allows us to expose that information without requiring an ongoing customer operation to do so to move the resource type into a failed state. 

### Testing

The e2e test, integration test, and unit test additions should cover this use case.  

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
